### PR TITLE
[Performance] Optimize fused Ring Indexer communication and scheduling

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -811,7 +811,7 @@ class TtIndexer:
         # Causality is fused inside indexer_score (future columns -> -inf from chunk_start_idx), so no triu
         # mask here. All H_idx heads are resident on-chip (wq_b replicated), so head_group_size=0 reads the
         # key cache ONCE — but that needs L1 headroom, so k_chunk is bounded by resident head count
-        # (DSA_INDEXER_CONFIG, measured per model: DeepSeek@64h=64, GLM@32h=224; larger OOMs).
+        # (DSA_INDEXER_CONFIG, measured per model: DeepSeek@64h=64, GLM@32h=320).
         k_chunk = get_indexer_key_chunk(a.index_n_heads)
         # Keyed on end_pos, NOT valid_pos: the program config is hashed, so keying it on a per-chunk
         # runtime quantity would compile a second program. The valid extent travels in hash-excluded kv_len.

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -592,12 +592,13 @@ def get_sdpa_config(seq_len_local: int) -> dict | list | None:
 
 # DSA lightning-indexer scoring config, keyed by resident index-head count (index_n_heads). The
 # indexer runs indexer_score with head_group_size=0, so ALL index heads stay on-chip and the key
-# chunk is L1-bound, scaling ~1/heads. Values are the measured per-model optima (k_chunk sweep on
-# LoudBox / Blackhole at Sq=640, T=56320): a larger k_chunk OOMs L1 (DeepSeek@64h fits <=96,
-# GLM@32h fits <=256). DeepSeek is flat so 64 is optimal and L1-safe; GLM is ~8% faster at 224.
+# chunk is L1-bound, scaling ~1/heads. Values are measured per-model optima on Blackhole.
+# DeepSeek is flat at 64. GLM's fused ring path uses five-tile block-cyclic runs, so KC=10 avoids
+# splitting a run across work units while remaining fast at both 55K and 512K prefixes. The 320 value
+# is L1-validated for the fused 32-head Ring Indexer; revalidate L1 before reusing it in a classic path.
 DSA_INDEXER_CONFIG: dict[int, dict[str, int]] = {
     64: {"k_chunk_size": 64},  # DeepSeek V3.2
-    32: {"k_chunk_size": 224},  # GLM 5.1 / 5.2
+    32: {"k_chunk_size": 320},  # GLM 5.1 / 5.2
 }
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
@@ -854,9 +854,8 @@ def test_indexer_score_full_mesh_rejects_invalid_contracts(expect_error):
 def test_indexer_score_ring8_partial_readiness_reference_cache_hit(mesh_device):
     """Reference-check the production Ring two-marker protocol, including its cache-hit runtime patch.
 
-    The smaller correctness shapes above intentionally use the legacy packet schedule. This test keeps query
-    work small but makes the BF16 K capacity large enough that forwarded payload exceeds the 20 MiB bank-owned
-    threshold. Two runtime prefixes then exercise different midpoint/completion locations on one cached program.
+    This test keeps query work small while using a large BF16 K capacity to exercise the bank-owned schedule's
+    midpoint/completion protocol. Two runtime prefixes exercise different marker locations on one cached program.
     Sampled first/last rows on every rank cover both directions without constructing a capacity-sized CPU score.
     """
     sp = mesh_device.shape[0]
@@ -866,10 +865,6 @@ def test_indexer_score_ring8_partial_readiness_reference_cache_hit(mesh_device):
     k_capacity = 128 * 1024
     kv_lens = (56320, 112640)
     dim = 128
-    bf16_bytes = 2
-    forwarded_capacity_bytes = k_capacity // sp * dim * bf16_bytes * (sp - 1)
-    assert forwarded_capacity_bytes > 20 * 1024 * 1024, "test capacity must activate bank-owned partial readiness"
-
     grid = mesh_device.compute_with_storage_grid_size()
     worker_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
     subdevice_id = ttnn.SubDeviceId(0)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
@@ -60,6 +60,21 @@ pytestmark = [
 ]
 
 
+def _ring8_partial_router_config():
+    config = ttnn.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = 14 * 1024
+    return config
+
+
+_RING8_PARTIAL_DEVICE_PARAMS = {
+    "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+    "reliability_mode": ttnn.FabricReliabilityMode.STRICT_INIT,
+    "fabric_tensix_config": ttnn.FabricTensixConfig.DISABLED,
+    "fabric_router_config": _ring8_partial_router_config(),
+    "require_exact_physical_num_devices": True,
+}
+
+
 def _fused_dev_inputs(submesh, q_g, w_g, k_host, *, k_dtype=ttnn.bfloat16):
     """Fused op inputs: SP-shard q/w (bf16) on dim 2, SP-shard k_local (the AG input), and a zero-seeded
     gathered buffer (AG fills remote bands; zeros prove the reader dual-sources the local band). k_dtype sets
@@ -831,6 +846,119 @@ def test_indexer_score_full_mesh_rejects_invalid_contracts(expect_error):
             _call(k=nonreplicated_k)
     finally:
         _close_full_mesh_ccl(mesh)
+
+
+@pytest.mark.requires_host_iommu
+@pytest.mark.parametrize("mesh_device", [(8, 1)], ids=["ring8"], indirect=True)
+@pytest.mark.parametrize("device_params", [_RING8_PARTIAL_DEVICE_PARAMS], indirect=True)
+def test_indexer_score_ring8_partial_readiness_reference_cache_hit(mesh_device):
+    """Reference-check the production Ring two-marker protocol, including its cache-hit runtime patch.
+
+    The smaller correctness shapes above intentionally use the legacy packet schedule. This test keeps query
+    work small but makes the BF16 K capacity large enough that forwarded payload exceeds the 20 MiB bank-owned
+    threshold. Two runtime prefixes then exercise different midpoint/completion locations on one cached program.
+    Sampled first/last rows on every rank cover both directions without constructing a capacity-sized CPU score.
+    """
+    sp = mesh_device.shape[0]
+    heads = 4
+    q_per_rank = 32
+    chunk_global = sp * q_per_rank
+    k_capacity = 128 * 1024
+    kv_lens = (56320, 112640)
+    dim = 128
+    bf16_bytes = 2
+    forwarded_capacity_bytes = k_capacity // sp * dim * bf16_bytes * (sp - 1)
+    assert forwarded_capacity_bytes > 20 * 1024 * 1024, "test capacity must activate bank-owned partial readiness"
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    worker_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    subdevice_id = ttnn.SubDeviceId(0)
+    stall_group = [subdevice_id]
+    manager = mesh_device.create_sub_device_manager([ttnn.SubDevice([worker_cores])], 0)
+    mesh_device.load_sub_device_manager(manager)
+    mesh_device.set_sub_device_stall_group(stall_group)
+    ccl_semaphores = [ttnn.create_global_semaphore(mesh_device, worker_cores, 0) for _ in range(2)]
+    try:
+        q_g, k_nat, w_g = _global_inputs(heads, chunk_global, k_capacity, seed=4242)
+        k_bc = _to_slab(k_nat, sp, chunk_global)
+        sp_shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(sp, 1), dims=(2, None))
+        q_dev = ttnn.from_torch(
+            q_g, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard
+        )
+        w_dev = ttnn.from_torch(
+            w_g, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard
+        )
+        k_local = ttnn.from_torch(
+            k_bc,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=sp_shard,
+        )
+        k_gathered = ttnn.from_torch(
+            torch.zeros_like(k_nat),
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        program_config = ttnn.IndexerScoreProgramConfig(
+            q_chunk_size=32,
+            k_chunk_size=320,
+            head_group_size=0,
+        )
+
+        def _score(kv_len):
+            chunk_start = kv_len - chunk_global
+            out = ttnn.experimental.ring_indexer_score_dsa(
+                q_dev,
+                k_gathered,
+                w_dev,
+                k_local,
+                ccl_semaphores,
+                cluster_axis=0,
+                topology=ttnn.Topology.Ring,
+                num_links=2,
+                ag_sub_device_id=subdevice_id,
+                chunk_start_idx=chunk_start,
+                kv_len=kv_len,
+                block_cyclic_sp_axis=0,
+                block_cyclic_chunk_local=q_per_rank,
+                program_config=program_config,
+            )
+            ttnn.synchronize_device(mesh_device, sub_device_ids=stall_group)
+            out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+            ttnn.deallocate(out)
+            return out_t, chunk_start
+
+        entries_before = mesh_device.num_program_cache_entries()
+        for dispatch, kv_len in enumerate(kv_lens):
+            out_t, chunk_start = _score(kv_len)
+            if dispatch == 0:
+                entries_after_compile = mesh_device.num_program_cache_entries()
+                assert entries_after_compile > entries_before
+            else:
+                assert (
+                    mesh_device.num_program_cache_entries() == entries_after_compile
+                ), "changing kv_len/midpoint recompiled instead of patching the cached Ring program"
+
+            for rank in range(sp):
+                for local_row in (0, q_per_rank - 1):
+                    global_row = rank * q_per_rank + local_row
+                    row = slice(global_row, global_row + 1)
+                    ref = indexer_score_dsa_ref(
+                        q_g[:, :, row, :],
+                        k_nat[:, :, :kv_len, :],
+                        w_g[:, :, row, :],
+                        chunk_start + global_row,
+                    )
+                    assert_indexer_match(out_t[:, :, row, :kv_len], ref, sq=1, t=kv_len, check_neg=False)
+        logger.info("Ring-8 partial readiness matched sampled reference across a kv_len cache hit")
+    finally:
+        mesh_device.reset_sub_device_stall_group()
+        mesh_device.clear_loaded_sub_device_manager()
 
 
 def test_indexer_score_ring4_fused_rejects_head_streaming(expect_error):

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py
@@ -44,17 +44,17 @@ DRAM = ttnn.DRAM_MEMORY_CONFIG
 
 pytestmark = [
     pytest.mark.skipif(not ttnn.device.is_blackhole(), reason="indexer_score is Blackhole-only"),
-    pytest.mark.skipif(ttnn.get_num_devices() < 4, reason="needs a 4-device Blackhole box"),
+    pytest.mark.skipif(ttnn.get_num_devices() != 4, reason="needs an exact 4-device Blackhole box"),
 ]
 
 
-def _open_ccl(mesh_shape):
+def _open_ccl(mesh_shape, *, fabric_config=ttnn.FabricConfig.FABRIC_1D):
     """Open `mesh_shape` directly (no parent carve), load a worker sub-device, make 2 ccl semaphores (the two
     ring directions). Mirrors ring_indexer_score_test_utils._open_ring4_ccl without the (2,4)->(1,4) submesh
     step, so it
     runs on a 4-chip box. Returns (mesh, ccl_semaphores, worker_sub_device_id, stall_group)."""
     ttnn.set_fabric_config(
-        ttnn.FabricConfig.FABRIC_1D,
+        fabric_config,
         ttnn.FabricReliabilityMode.STRICT_INIT,
         None,
         ttnn.FabricTensixConfig.DISABLED,
@@ -150,6 +150,188 @@ def test_indexer_score_ring4_fused_4d(case_id, heads, block_cyclic):
         assert_indexer_match(out_t, ref, CHUNK4, T4, check_neg=True)
         layout = "block_cyclic" if block_cyclic else "contiguous"
         logger.info(f"4d ring4 fused {layout} (heads={heads}): matched reference")
+    finally:
+        _close_ccl(mesh)
+
+
+@pytest.mark.requires_host_iommu
+def test_indexer_score_ring4_true_ring_bfp8_bank_owned_reference_cache_hit():
+    """Reference-check the production BFP8 bank-owned path on a true QuietBox Ring.
+
+    The large BFP8 K capacity exercises the bank-owned schedule's midpoint/completion protocol. Two runtime
+    prefixes exercise distinct marker locations through one cached program.
+    Sampled boundary rows on every rank cover both ring directions without constructing a capacity-sized CPU
+    score tensor.
+    """
+    sp = 4
+    sp_axis = 0
+    heads = 4
+    q_per_rank = 32
+    chunk_global = sp * q_per_rank
+    k_capacity = 256 * 1024
+    kv_lens = (56320, 112640)
+    dim = 128
+    mesh, ccl_semaphores, subdevice_id, stall_group = _open_ccl(
+        (sp, 1), fabric_config=ttnn.FabricConfig.FABRIC_2D_TORUS_XY
+    )
+    try:
+        q_g, k_nat, w_g = _global_inputs(heads, chunk_global, k_capacity, seed=4343)
+        k_bc = _to_slab(k_nat, sp, chunk_global)
+        sp_shard = ttnn.ShardTensor2dMesh(mesh, mesh_shape=(sp, 1), dims=(2, None))
+        q_dev = ttnn.from_torch(q_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
+        w_dev = ttnn.from_torch(w_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
+        k_local = ttnn.from_torch(
+            k_bc,
+            device=mesh,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=sp_shard,
+        )
+        k_gathered = ttnn.from_torch(
+            torch.zeros_like(k_nat),
+            device=mesh,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh),
+        )
+        program_config = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=320, head_group_size=0)
+
+        def _score(kv_len):
+            chunk_start = kv_len - chunk_global
+            out = ttnn.experimental.ring_indexer_score_dsa(
+                q_dev,
+                k_gathered,
+                w_dev,
+                k_local,
+                ccl_semaphores,
+                cluster_axis=sp_axis,
+                topology=ttnn.Topology.Ring,
+                num_links=2,
+                ag_sub_device_id=subdevice_id,
+                chunk_start_idx=chunk_start,
+                kv_len=kv_len,
+                block_cyclic_sp_axis=sp_axis,
+                block_cyclic_chunk_local=q_per_rank,
+                program_config=program_config,
+            )
+            ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+            out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh, dim=2))
+            ttnn.deallocate(out)
+            return out_t, chunk_start
+
+        entries_before = mesh.num_program_cache_entries()
+        saw_negative_reference = False
+        for dispatch, kv_len in enumerate(kv_lens):
+            out_t, chunk_start = _score(kv_len)
+            if dispatch == 0:
+                entries_after_compile = mesh.num_program_cache_entries()
+                assert entries_after_compile > entries_before
+            else:
+                assert (
+                    mesh.num_program_cache_entries() == entries_after_compile
+                ), "changing kv_len/midpoint recompiled instead of patching the cached Ring program"
+
+            for rank in range(sp):
+                for local_row in (0, q_per_rank - 1):
+                    global_row = rank * q_per_rank + local_row
+                    row = slice(global_row, global_row + 1)
+                    ref = indexer_score_dsa_ref(
+                        q_g[:, :, row, :],
+                        k_nat[:, :, :kv_len, :],
+                        w_g[:, :, row, :],
+                        chunk_start + global_row,
+                    )
+                    visible_ref = ref[ref != float("-inf")]
+                    saw_negative_reference |= bool((visible_ref < 0).any())
+                    assert_indexer_match(out_t[:, :, row, :kv_len], ref, sq=1, t=kv_len, check_neg=False)
+        assert saw_negative_reference, "sampled rows must include a negative valid score"
+        logger.info("True Ring-4 BFP8 bank-owned partial readiness matched sampled reference across a cache hit")
+    finally:
+        _close_ccl(mesh)
+
+
+@pytest.mark.requires_host_iommu
+def test_indexer_score_ring4_small_capacity_has_no_empty_lane_deadlock():
+    """Keep every multicast participant productive when one shard has fewer KC units than the full grid.
+
+    Eleven query groups force multiple phases while eighteen KC units per shard are too few for the old
+    ring-wide lane sizing. An empty compute lane would return while its reader blocks on the next single-buffered
+    q/w multicast phase, hanging the row. The sampled reference checks that the reduced nonempty lane geometry
+    also preserves semantics.
+    """
+    sp = 4
+    sp_axis = 0
+    heads = 4
+    q_per_rank = 352  # 11 tiles; prime group count exceeds the 10-row QuietBox grid.
+    chunk_global = sp * q_per_rank
+    k_capacity = 22_528  # 5,632 tokens/rank = 18 KC units, below the physical lane count.
+    assert (k_capacity // sp + 10 * 32 - 1) // (10 * 32) == 18
+
+    mesh, ccl_semaphores, subdevice_id, stall_group = _open_ccl(
+        (sp, 1), fabric_config=ttnn.FabricConfig.FABRIC_2D_TORUS_XY
+    )
+    try:
+        q_g, k_nat, w_g = _global_inputs(heads, chunk_global, k_capacity, seed=4444)
+        k_bc = _to_slab(k_nat, sp, chunk_global)
+        sp_shard = ttnn.ShardTensor2dMesh(mesh, mesh_shape=(sp, 1), dims=(2, None))
+        q_dev = ttnn.from_torch(q_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
+        w_dev = ttnn.from_torch(w_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
+        k_local = ttnn.from_torch(
+            k_bc,
+            device=mesh,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=sp_shard,
+        )
+        k_gathered = ttnn.from_torch(
+            torch.zeros_like(k_nat),
+            device=mesh,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh),
+        )
+        out = ttnn.experimental.ring_indexer_score_dsa(
+            q_dev,
+            k_gathered,
+            w_dev,
+            k_local,
+            ccl_semaphores,
+            cluster_axis=sp_axis,
+            topology=ttnn.Topology.Ring,
+            num_links=2,
+            ag_sub_device_id=subdevice_id,
+            chunk_start_idx=0,
+            kv_len=k_capacity,
+            block_cyclic_sp_axis=sp_axis,
+            block_cyclic_chunk_local=q_per_rank,
+            program_config=ttnn.IndexerScoreProgramConfig(
+                q_chunk_size=32,
+                k_chunk_size=320,
+                head_group_size=0,
+            ),
+        )
+        ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+        out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh, dim=2))
+
+        for rank in range(sp):
+            # Start at the end of the first query tile: row zero has only one visible causal score, for which
+            # correlation is undefined. This still samples both ends of every rank while keeping the PCC check
+            # meaningful.
+            for local_row in (31, q_per_rank - 1):
+                global_row = rank * q_per_rank + local_row
+                row = slice(global_row, global_row + 1)
+                ref = indexer_score_dsa_ref(
+                    q_g[:, :, row, :],
+                    k_nat,
+                    w_g[:, :, row, :],
+                    global_row,
+                )
+                assert_indexer_match(out_t[:, :, row, :], ref, sq=1, t=k_capacity, check_neg=True)
+        logger.info("True Ring-4 small-capacity multi-phase schedule matched sampled reference without a hang")
     finally:
         _close_ccl(mesh)
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
@@ -78,10 +78,10 @@ RING_INDEXER_PERF_MARGIN = 0.02
 RING_INDEXER_PERF_REPLAYS = 3
 RING_INDEXER_EXPECTED_FPU_UTIL = {
     # (SP ranks, KV prefix): expected fused-program FPU utilization, percent.
-    (4, GLM52_KV_55K): 46.26,
+    (4, GLM52_KV_55K): 52.22,
     (4, GLM52_KV_512K): 62.99,
-    (8, GLM52_KV_55K): 58.07,
-    (8, GLM52_KV_512K): 60.15,
+    (8, GLM52_KV_55K): 58.10,
+    (8, GLM52_KV_512K): 60.39,
 }
 
 _FABRIC_2D_TORUS_DEVICE_PARAMS = {
@@ -134,10 +134,10 @@ def _largest_divisor_leq(value, cap):
 def _ring_indexer_ideal_compute_cycles(mesh_device, kv_len, chunk_start):
     """Mirror the fused op's Blackhole ideal-compute-cycle performance model.
 
-    This is intentionally test-local until op-performance-model fields are
-    directly exposed to the realtime-profiler API. The calculation is
-    fusion-aware: two links reserve four all-gather worker cores, so score
-    math is credited only to the remaining compute rectangle.
+    This is intentionally test-local until the op-performance-model fields
+    are directly exposed to Python. The calculation is fusion-aware: two
+    links reserve four all-gather worker cores, so score math is credited
+    only to the remaining compute rectangle.
     """
     q_tiles = GLM52_Q_PER_CHIP // 32
     k_tiles = GLM52_K_CACHE_CAPACITY // 32
@@ -145,7 +145,7 @@ def _ring_indexer_ideal_compute_cycles(mesh_device, kv_len, chunk_start):
     chunk_start_tiles = chunk_start // 32
     valid_tiles = sum(min(kv_tiles, chunk_start_tiles + row + 1) for row in range(q_tiles))
 
-    # IndexerScoreProgramConfig(q_chunk=32, k_chunk=224) maps q groups by
+    # IndexerScoreProgramConfig(q_chunk=32, k_chunk=GLM52_K_CHUNK) maps q groups by
     # grid rows and K bands by columns. This is the same banded_core_count()
     # arithmetic as the C++ program factory/perf model.
     q_groups = q_tiles

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
@@ -18,6 +18,7 @@ Run (requires an IOMMU-enabled Blackhole runner):
 """
 
 import math
+import statistics
 
 import pytest
 import torch
@@ -57,25 +58,37 @@ GLM52_K_CHUNK = get_indexer_key_chunk(GLM52_INDEX_HEADS)
 # 4x1 on QuietBox and 8x1 on LoudBox.
 RING_PERF_MESHES = ((4, 1), (8, 1))
 RING_PERF_MESH_IDS = ("quietbox_4x1", "loudbox_8x1")
+# The 14 KiB router limit carries 13 complete 1088-byte BFP8 tile pages
+# (14144 bytes); the remaining 192 bytes cannot hold another complete page.
+RING_INDEXER_FABRIC_PAYLOAD_BYTES = 14 * 1024
+
+
+def _ring_indexer_fabric_router_config():
+    config = ttnn.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = RING_INDEXER_FABRIC_PAYLOAD_BYTES
+    return config
+
 
 # Match the indexer_score perf gate: expected FPU utilization is compared with
-# a symmetric +/-2% relative band.  These are warm trace-replay realtime-profiler
+# a symmetric relative band. These are warm trace-replay realtime-profiler
 # baselines taken on the complete physical boxes.  A value is deliberately per
 # SKU: the proxy retains the box's actual fabric path rather than treating a 4x1
 # subset of an 8x1 box as equivalent.
 RING_INDEXER_PERF_MARGIN = 0.02
+RING_INDEXER_PERF_REPLAYS = 3
 RING_INDEXER_EXPECTED_FPU_UTIL = {
     # (SP ranks, KV prefix): expected fused-program FPU utilization, percent.
-    (4, GLM52_KV_55K): 37.16,
-    (4, GLM52_KV_512K): 39.31,
-    (8, GLM52_KV_55K): 38.48,
-    (8, GLM52_KV_512K): 42.72,
+    (4, GLM52_KV_55K): 43.74,
+    (4, GLM52_KV_512K): 47.26,
+    (8, GLM52_KV_55K): 51.82,
+    (8, GLM52_KV_512K): 55.12,
 }
 
 _FABRIC_2D_TORUS_DEVICE_PARAMS = {
     "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
     "reliability_mode": ttnn.FabricReliabilityMode.STRICT_INIT,
     "fabric_tensix_config": ttnn.FabricTensixConfig.DISABLED,
+    "fabric_router_config": _ring_indexer_fabric_router_config(),
     "require_exact_physical_num_devices": True,
 }
 
@@ -169,7 +182,7 @@ def _ring_perf_config():
 @pytest.mark.parametrize("kv_len", RING_PERF_KV_LENS, ids=RING_PERF_KV_IDS)
 @pytest.mark.timeout(0)
 def test_ring_indexer_score_dsa_perf(mesh_device, kv_len):
-    """Profile one warm fused ring score at a 55K or 512K KV prefix.
+    """Profile the median warm fused ring score at a 55K or 512K KV prefix.
 
     The realtime profiler's fused-program critical path is converted to FPU
     utilization using a test-local mirror of the op's fusion-aware
@@ -266,16 +279,22 @@ def test_ring_indexer_score_dsa_perf(mesh_device, kv_len):
         trace_capture_ended = True
         ttnn.synchronize_device(mesh_device, sub_device_ids=[subdevice_id])
 
-        # Warm the trace replay outside the profiler window, then measure the
-        # identical captured command stream without first-replay jitter.
-        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
-        ttnn.synchronize_device(mesh_device, sub_device_ids=[subdevice_id])
-
         def replay_once():
             ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
 
-        _, programs = profile_realtime_program_merged(mesh_device, replay_once, record_timeout_seconds=30.0)
-        duration_ns = _ring_indexer_duration_ns(programs)
+        # Profile and discard the warm replay. Realtime-profiler records arrive asynchronously, so an
+        # unprofiled warm replay can otherwise leak into the measured callback below. Trace replays reuse
+        # their runtime ID, causing the merge helper to take the slower of the stale and measured records.
+        _, warm_programs = profile_realtime_program_merged(mesh_device, replay_once, record_timeout_seconds=30.0)
+        _ring_indexer_duration_ns(warm_programs)
+
+        # Use separate profiler windows because captured trace replays share a runtime ID and would be merged
+        # into one maximum if queued in a single window.
+        measured_durations_ns = []
+        for _ in range(RING_INDEXER_PERF_REPLAYS):
+            _, programs = profile_realtime_program_merged(mesh_device, replay_once, record_timeout_seconds=30.0)
+            measured_durations_ns.append(_ring_indexer_duration_ns(programs))
+        duration_ns = statistics.median(measured_durations_ns)
         ideal_compute_cycles = _ring_indexer_ideal_compute_cycles(mesh_device, kv_len, chunk_start)
         fpu_utilization = ideal_compute_cycles / (duration_ns * _BH_CLOCK_GHZ) * 100
         expected_fpu_utilization = RING_INDEXER_EXPECTED_FPU_UTIL[(sp, kv_len)]

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
@@ -78,10 +78,10 @@ RING_INDEXER_PERF_MARGIN = 0.02
 RING_INDEXER_PERF_REPLAYS = 3
 RING_INDEXER_EXPECTED_FPU_UTIL = {
     # (SP ranks, KV prefix): expected fused-program FPU utilization, percent.
-    (4, GLM52_KV_55K): 43.74,
-    (4, GLM52_KV_512K): 47.26,
-    (8, GLM52_KV_55K): 51.82,
-    (8, GLM52_KV_512K): 55.12,
+    (4, GLM52_KV_55K): 46.26,
+    (4, GLM52_KV_512K): 62.99,
+    (8, GLM52_KV_55K): 58.07,
+    (8, GLM52_KV_512K): 60.15,
 }
 
 _FABRIC_2D_TORUS_DEVICE_PARAMS = {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
@@ -26,6 +26,11 @@ struct LinkPageRange {
     uint32_t end;
 };
 
+// Row-aligned prefix exposed by the midpoint readiness marker.
+FORCE_INLINE uint32_t midpoint_prefix_pages(uint32_t valid_pages, uint32_t row_pages) {
+    return ((valid_pages / row_pages + 1) / 2) * row_pages;
+}
+
 struct BankOwnedSlice {
     uint32_t first_page_offset;
     uint32_t page_count;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -23,6 +24,71 @@ namespace ring_attention_all_gather {
 struct LinkPageRange {
     uint32_t start;
     uint32_t end;
+};
+
+struct BankOwnedSlice {
+    uint32_t first_page_offset;
+    uint32_t page_count;
+};
+
+FORCE_INLINE BankOwnedSlice
+get_bank_owned_slice(uint32_t output_page_base, uint32_t valid_pages, uint32_t bank, uint32_t num_dram_banks) {
+    const uint32_t base_bank = output_page_base % num_dram_banks;
+    const uint32_t first_page_offset = (bank + num_dram_banks - base_bank) % num_dram_banks;
+    const uint32_t page_count =
+        first_page_offset < valid_pages ? 1 + (valid_pages - 1 - first_page_offset) / num_dram_banks : 0;
+    return {first_page_offset, page_count};
+}
+
+// Keep each packet physically contiguous within one owned bank, but rotate banks between packets so one reader
+// prefetch window preserves DRAM-bank parallelism.
+template <size_t NumDramBanks>
+struct BankOwnedPacketSchedule {
+    std::array<BankOwnedSlice, NumDramBanks> slices{};
+    std::array<uint32_t, NumDramBanks> pages_consumed{};
+    uint32_t first_bank;
+    uint32_t bank_stride;
+    uint32_t next_bank;
+    uint32_t packet_pages;
+    uint32_t packets_remaining = 0;
+
+    FORCE_INLINE BankOwnedPacketSchedule(
+        uint32_t output_page_base,
+        uint32_t valid_pages,
+        uint32_t worker_first_bank,
+        uint32_t worker_bank_stride,
+        uint32_t packet_size_in_pages) :
+        first_bank(worker_first_bank),
+        bank_stride(worker_bank_stride),
+        next_bank(worker_first_bank),
+        packet_pages(packet_size_in_pages) {
+        for (uint32_t bank = first_bank; bank < NumDramBanks; bank += bank_stride) {
+            slices[bank] = get_bank_owned_slice(output_page_base, valid_pages, bank, NumDramBanks);
+            packets_remaining += (slices[bank].page_count + packet_size_in_pages - 1) / packet_size_in_pages;
+        }
+    }
+
+    FORCE_INLINE bool next_packet(uint32_t& first_page_offset, uint32_t& page_count) {
+        if (packets_remaining == 0) {
+            return false;
+        }
+        for (uint32_t candidate = 0; candidate < NumDramBanks; ++candidate) {
+            const uint32_t bank = next_bank;
+            next_bank += bank_stride;
+            if (next_bank >= NumDramBanks) {
+                next_bank = first_bank;
+            }
+            if (pages_consumed[bank] == slices[bank].page_count) {
+                continue;
+            }
+            page_count = std::min(packet_pages, slices[bank].page_count - pages_consumed[bank]);
+            first_page_offset = slices[bank].first_page_offset + pages_consumed[bank] * NumDramBanks;
+            pages_consumed[bank] += page_count;
+            --packets_remaining;
+            return true;
+        }
+        return false;
+    }
 };
 
 // Partition a valid page prefix as evenly as possible across links. Earlier links receive one
@@ -48,13 +114,14 @@ inline uint32_t compute_gather_valid_Ht(uint32_t kv_actual_isl, uint32_t chunk_l
 }
 
 // Clamp each input to the valid slab prefix, then repartition that prefix across links. Reader and
-// writer must update both range endpoints identically or their cb_output page counts can diverge.
+// writer must update the effective page count and both range endpoints identically or their cb_output
+// page counts can diverge. The bank-owned path consumes the effective page count directly.
 template <size_t NumInputs>
 inline void update_link_page_ranges_for_gather_extent(
     uint32_t gather_valid_Ht,
     uint32_t num_links,
     const std::array<uint32_t, NumInputs>& input_tensor_Wt,
-    const std::array<uint32_t, NumInputs>& input_valid_pages,
+    std::array<uint32_t, NumInputs>& input_valid_pages,
     const std::array<uint32_t, NumInputs>& worker_link,
     std::array<uint32_t, NumInputs>& input_tile_id_start,
     std::array<uint32_t, NumInputs>& input_tile_id_end) {
@@ -62,6 +129,7 @@ inline void update_link_page_ranges_for_gather_extent(
         const uint32_t gather_valid_pages = gather_valid_Ht * input_tensor_Wt[input_idx];
         const uint32_t valid_pages =
             input_valid_pages[input_idx] < gather_valid_pages ? input_valid_pages[input_idx] : gather_valid_pages;
+        input_valid_pages[input_idx] = valid_pages;
         const auto link_page_range = compute_link_page_range(valid_pages, num_links, worker_link[input_idx]);
         input_tile_id_start[input_idx] = link_page_range.start;
         input_tile_id_end[input_idx] = link_page_range.end;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_metadata.hpp
@@ -6,11 +6,11 @@
 // Both kernels must clamp the gather to the SAME slab prefix or the cb_output producer/consumer page
 // counts drift apart, so the formula lives here in one place instead of being duplicated per kernel.
 //
-// KEEP IN SYNC with the host reference, `compute_gather_valid_Ht`
-// (ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp): on the scalar
-// path the host computes the extent and passes it as a runtime arg, on the metadata path these kernels
-// recompute it on-device from kv_actual_isl. The metadata==scalar bit-exact tests only guard the points
-// they exercise, so a change to one side that is not mirrored in the other diverges silently elsewhere.
+// KEEP IN SYNC with the host references in ring_joint_sdpa_program_factory.cpp and
+// indexer_score/device/ring_indexer_score_dsa_program_factory.cpp. On the scalar path the host computes the
+// extent and passes it as a runtime arg; on the metadata path these kernels recompute it on-device from
+// kv_actual_isl. The fused Indexer reader also derives the same gathered-shard extent before applying
+// midpoint readiness. Tests only guard the points they exercise, so drift elsewhere would be silent.
 
 #pragma once
 
@@ -26,7 +26,8 @@ struct LinkPageRange {
     uint32_t end;
 };
 
-// Row-aligned prefix exposed by the midpoint readiness marker.
+// Row-aligned prefix exposed by the midpoint readiness marker. Round the valid row count up before halving so
+// the prefix covers the first half of the rows (including the middle row when odd) without splitting a row.
 FORCE_INLINE uint32_t midpoint_prefix_pages(uint32_t valid_pages, uint32_t row_pages) {
     return ((valid_pages / row_pages + 1) / 2) * row_pages;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -73,6 +73,14 @@ constexpr bool partial_readiness_enabled = get_compile_time_arg_val(kPartialRead
 constexpr bool output_bank_owned_schedule = get_compile_time_arg_val(kOutputBankOwnedSchedule);
 constexpr uint32_t num_dram_banks = get_compile_time_arg_val(kNumDramBanks);
 
+static_assert(!partial_readiness_enabled || num_inputs == 1, "partial readiness requires one gathered input");
+static_assert(
+    !partial_readiness_enabled || !split_forwarding_enabled,
+    "partial readiness and split forwarding are mutually exclusive");
+static_assert(
+    !partial_readiness_enabled || (num_targets_forward_direction > 0 && num_targets_backward_direction > 0),
+    "partial readiness requires both ring directions");
+
 // Prefetch: batch multiple packets of DRAM reads before a single barrier.
 // This keeps more reads in flight across interleaved DRAM banks, hiding latency.
 // CB depth must be >= 2 * prefetch_packets * packet_size_in_pages (see program_factory cb_num_pages).
@@ -131,6 +139,9 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
+    // KEEP IN SYNC with kReaderRuntimeArgHeaderCount/kTensorDescriptorFieldCount and field offsets in
+    // ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp. Fused consumers patch
+    // selected fields through that shared host-side layout.
     uint32_t arg_idx = 0;
     // Load the input tensor spec
     uint32_t gather_dim = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -41,6 +41,7 @@ enum CompileTimeArg : uint32_t {
     kSnakeOrientation,
     kMeshRows,
     kMeshCols,
+    kPartialReadinessEnabled,
     kOutputBankOwnedSchedule,
     kNumDramBanks,
     kPrefetchPackets,
@@ -68,6 +69,7 @@ constexpr auto snake_orientation =
     static_cast<ttnn::ccl::snake_ring::Orientation>(get_compile_time_arg_val(kSnakeOrientation));
 constexpr uint32_t mesh_rows = get_compile_time_arg_val(kMeshRows);
 constexpr uint32_t mesh_cols = get_compile_time_arg_val(kMeshCols);
+constexpr bool partial_readiness_enabled = get_compile_time_arg_val(kPartialReadinessEnabled);
 constexpr bool output_bank_owned_schedule = get_compile_time_arg_val(kOutputBankOwnedSchedule);
 constexpr uint32_t num_dram_banks = get_compile_time_arg_val(kNumDramBanks);
 
@@ -228,17 +230,44 @@ void kernel_main() {
                 const uint32_t input_page_base = input_batch_base[input_idx] + bh_idx * input_pages_per_batch_head;
                 const uint32_t output_page_base =
                     bh_idx * output_pages_per_batch_head + my_tensor_rank * input_pages_per_batch_head;
-                prefetch_bank_owned_slices<false>(
-                    noc_obj,
-                    cb_output,
-                    cb_fifo_limit,
-                    cb_fifo_size,
-                    input_tensor_addrgens[input_idx],
-                    input_page_base,
-                    output_page_base,
-                    input_valid_pages[input_idx],
-                    worker_link[input_idx],
-                    num_links);
+                if constexpr (partial_readiness_enabled) {
+                    const uint32_t first_pages = ring_attention_all_gather::midpoint_prefix_pages(
+                        input_valid_pages[input_idx], input_tensor_Wt[input_idx]);
+                    prefetch_bank_owned_slices<false>(
+                        noc_obj,
+                        cb_output,
+                        cb_fifo_limit,
+                        cb_fifo_size,
+                        input_tensor_addrgens[input_idx],
+                        input_page_base,
+                        output_page_base,
+                        first_pages,
+                        worker_link[input_idx],
+                        num_links);
+                    prefetch_bank_owned_slices<false>(
+                        noc_obj,
+                        cb_output,
+                        cb_fifo_limit,
+                        cb_fifo_size,
+                        input_tensor_addrgens[input_idx],
+                        input_page_base + first_pages,
+                        output_page_base + first_pages,
+                        input_valid_pages[input_idx] - first_pages,
+                        worker_link[input_idx],
+                        num_links);
+                } else {
+                    prefetch_bank_owned_slices<false>(
+                        noc_obj,
+                        cb_output,
+                        cb_fifo_limit,
+                        cb_fifo_size,
+                        input_tensor_addrgens[input_idx],
+                        input_page_base,
+                        output_page_base,
+                        input_valid_pages[input_idx],
+                        worker_link[input_idx],
+                        num_links);
+                }
             }
         } else {
             // For a single-slot gather this starts at the sliced batch slot; otherwise 0 (full batch).
@@ -307,19 +336,22 @@ void kernel_main() {
         // Device 2.0: legacy primitive retained, out_ready_sem is the address of a GlobalSemaphore
         // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
         // GlobalSemaphore.
-        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), slices_received + 1);
-        // Got it
-        slices_received++;
+        const uint32_t next_slice = slices_received + 1;
+        if constexpr (partial_readiness_enabled) {
+            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), next_slice * 2 - 1);
+        } else {
+            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), next_slice);
+        }
 
         int sender_transport_rank_signed;
         uint32_t sender_transport_rank;
         if constexpr (direction == 1) {
-            sender_transport_rank_signed = my_transport_rank + slices_received;
+            sender_transport_rank_signed = my_transport_rank + next_slice;
             sender_transport_rank = (sender_transport_rank_signed >= (int)ring_size)
                                         ? sender_transport_rank_signed - ring_size
                                         : sender_transport_rank_signed;
         } else {
-            sender_transport_rank_signed = my_transport_rank - slices_received;
+            sender_transport_rank_signed = my_transport_rank - next_slice;
             sender_transport_rank = (sender_transport_rank_signed < 0) ? ring_size + sender_transport_rank_signed
                                                                        : sender_transport_rank_signed;
         }
@@ -328,9 +360,16 @@ void kernel_main() {
                 sender_transport_rank, mesh_rows, mesh_cols, snake_orientation);
 
         if constexpr (fuse_op) {
-            // Signal matmul to go
+            // In partial mode this first signal exposes the completed prefix of the shard.
             op_signaler.synchronize_workers_and_signal_op(sender_transport_rank);
         }
+        if constexpr (partial_readiness_enabled) {
+            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), next_slice * 2);
+            if constexpr (fuse_op) {
+                op_signaler.synchronize_workers_and_signal_op(sender_transport_rank);
+            }
+        }
+        slices_received = next_slice;
         // Direction == backward: Should I forward what I got from the left to my right?
         // In the linear case, if I have any targets to my right, always forward
         // In the ring case, if I have received on the left less than my targets on the right, forward
@@ -354,17 +393,44 @@ void kernel_main() {
                     for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; ++bh_idx) {
                         const uint32_t output_page_base =
                             bh_idx * output_pages_per_batch_head + sender_tensor_rank * input_pages_per_batch_head;
-                        prefetch_bank_owned_slices<true>(
-                            noc_obj,
-                            cb_output,
-                            cb_fifo_limit,
-                            cb_fifo_size,
-                            output_tensor_addrgens[input_idx],
-                            output_page_base,
-                            output_page_base,
-                            input_valid_pages[input_idx],
-                            first_bank,
-                            bank_stride);
+                        if constexpr (partial_readiness_enabled) {
+                            const uint32_t first_pages = ring_attention_all_gather::midpoint_prefix_pages(
+                                input_valid_pages[input_idx], input_tensor_Wt[input_idx]);
+                            prefetch_bank_owned_slices<true>(
+                                noc_obj,
+                                cb_output,
+                                cb_fifo_limit,
+                                cb_fifo_size,
+                                output_tensor_addrgens[input_idx],
+                                output_page_base,
+                                output_page_base,
+                                first_pages,
+                                first_bank,
+                                bank_stride);
+                            prefetch_bank_owned_slices<true>(
+                                noc_obj,
+                                cb_output,
+                                cb_fifo_limit,
+                                cb_fifo_size,
+                                output_tensor_addrgens[input_idx],
+                                output_page_base + first_pages,
+                                output_page_base + first_pages,
+                                input_valid_pages[input_idx] - first_pages,
+                                first_bank,
+                                bank_stride);
+                        } else {
+                            prefetch_bank_owned_slices<true>(
+                                noc_obj,
+                                cb_output,
+                                cb_fifo_limit,
+                                cb_fifo_size,
+                                output_tensor_addrgens[input_idx],
+                                output_page_base,
+                                output_page_base,
+                                input_valid_pages[input_idx],
+                                first_bank,
+                                bank_stride);
+                        }
                     }
                 } else {
                     // Packet-aligned midpoint of this worker's page range (matches the writer).

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -17,49 +17,111 @@
 #include <cstdint>
 #include <utility>
 
-using address_t = uint32_t;
 using ttnn::ccl::Topology;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
-constexpr uint32_t my_transport_rank = get_compile_time_arg_val(0);
-constexpr uint32_t cb_output_id = get_compile_time_arg_val(1);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(2);  // 2
-constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(3);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(4);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(5);
-constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(6));
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(7);  // 2
-constexpr uint32_t num_inputs = get_compile_time_arg_val(8);
-constexpr bool direction = get_compile_time_arg_val(9);  // 1 is forward, 0 is backward
-constexpr bool fuse_op = get_compile_time_arg_val(10);
-constexpr bool has_metadata = get_compile_time_arg_val(11);
-constexpr uint32_t cb_meta_id = get_compile_time_arg_val(12);
-constexpr uint32_t num_links = get_compile_time_arg_val(13);
-// Host-derived even-ring split-forwarding gate: the parent fused op owns this protocol decision and
-// passes the same flag to both all-gather directions and its own receiver, so producer and consumer
-// cannot disagree. Standalone (non-fused) callers get the legacy even-ring topology gate from the host.
-constexpr bool split_forwarding_enabled = get_compile_time_arg_val(14);
-constexpr bool full_mesh_rank_mapping = get_compile_time_arg_val(15);
-constexpr auto snake_orientation = static_cast<ttnn::ccl::snake_ring::Orientation>(get_compile_time_arg_val(16));
-constexpr uint32_t mesh_rows = get_compile_time_arg_val(17);
-constexpr uint32_t mesh_cols = get_compile_time_arg_val(18);
+enum CompileTimeArg : uint32_t {
+    kMyTransportRank,
+    kCbOutputId,
+    kPacketSizeInPages,
+    kInputTensorPageSize,
+    kNumTargetsForwardDirection,
+    kNumTargetsBackwardDirection,
+    kTopology,
+    kContigPagesAdvanced,
+    kNumInputs,
+    kDirection,
+    kFuseOp,
+    kHasMetadata,
+    kNumLinks,
+    kSplitForwardingEnabled,
+    kFullMeshRankMapping,
+    kSnakeOrientation,
+    kMeshRows,
+    kMeshCols,
+    kOutputBankOwnedSchedule,
+    kNumDramBanks,
+    kPrefetchPackets,
+    kNumFixedCompileTimeArgs,
+};
+
+constexpr uint32_t my_transport_rank = get_compile_time_arg_val(kMyTransportRank);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(kCbOutputId);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(kPacketSizeInPages);
+constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(kInputTensorPageSize);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(kNumTargetsForwardDirection);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(kNumTargetsBackwardDirection);
+constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(kTopology));
+constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(kContigPagesAdvanced);
+constexpr uint32_t num_inputs = get_compile_time_arg_val(kNumInputs);
+constexpr bool direction = get_compile_time_arg_val(kDirection);  // 1 is forward, 0 is backward
+constexpr bool fuse_op = get_compile_time_arg_val(kFuseOp);
+constexpr bool has_metadata = get_compile_time_arg_val(kHasMetadata);
+constexpr uint32_t num_links = get_compile_time_arg_val(kNumLinks);
+// The parent fused op owns this protocol decision and passes the same flag to both
+// all-gather directions and its receiver, keeping producer and consumer in sync.
+constexpr bool split_forwarding_enabled = get_compile_time_arg_val(kSplitForwardingEnabled);
+constexpr bool full_mesh_rank_mapping = get_compile_time_arg_val(kFullMeshRankMapping);
+constexpr auto snake_orientation =
+    static_cast<ttnn::ccl::snake_ring::Orientation>(get_compile_time_arg_val(kSnakeOrientation));
+constexpr uint32_t mesh_rows = get_compile_time_arg_val(kMeshRows);
+constexpr uint32_t mesh_cols = get_compile_time_arg_val(kMeshCols);
+constexpr bool output_bank_owned_schedule = get_compile_time_arg_val(kOutputBankOwnedSchedule);
+constexpr uint32_t num_dram_banks = get_compile_time_arg_val(kNumDramBanks);
 
 // Prefetch: batch multiple packets of DRAM reads before a single barrier.
 // This keeps more reads in flight across interleaved DRAM banks, hiding latency.
-// CB depth must be >= 2 * PREFETCH_PACKETS * packet_size_in_pages (see program_factory cb_num_pages).
-constexpr uint32_t PREFETCH_PACKETS = 4;
+// CB depth must be >= 2 * prefetch_packets * packet_size_in_pages (see program_factory cb_num_pages).
+constexpr uint32_t prefetch_packets = get_compile_time_arg_val(kPrefetchPackets);
+
+template <bool physically_contiguous, typename Accessor>
+FORCE_INLINE void prefetch_bank_owned_slices(
+    const Noc& noc,
+    CircularBuffer& cb_output,
+    uint32_t cb_fifo_limit,
+    uint32_t cb_fifo_size,
+    const Accessor& accessor,
+    uint32_t accessor_page_base,
+    uint32_t output_page_base,
+    uint32_t valid_pages,
+    uint32_t first_bank,
+    uint32_t bank_stride) {
+    ring_attention_all_gather::BankOwnedPacketSchedule<num_dram_banks> schedule(
+        output_page_base, valid_pages, first_bank, bank_stride, packet_size_in_pages);
+    const auto next_packet = [&](uint32_t& pages_to_read) {
+        uint32_t first_page_offset = 0;
+        schedule.next_packet(first_page_offset, pages_to_read);
+        return accessor_page_base + first_page_offset;
+    };
+    if constexpr (physically_contiguous) {
+        prefetch_batch_read_physically_contiguous_packets<
+            input_tensor_page_size,
+            packet_size_in_pages,
+            prefetch_packets>(
+            noc, cb_output, schedule.packets_remaining, cb_fifo_limit, cb_fifo_size, accessor, next_packet);
+    } else {
+        prefetch_batch_read_packets<input_tensor_page_size, packet_size_in_pages, prefetch_packets>(
+            noc,
+            cb_output,
+            schedule.packets_remaining,
+            cb_fifo_limit,
+            cb_fifo_size,
+            accessor,
+            next_packet,
+            [](uint32_t first_page_id, uint32_t page) { return first_page_id + page * num_dram_banks; });
+    }
+}
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = ttnn::ring_attention_all_gather::kReaderFixedCompileTimeArgCount;
-    constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
+    constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, kNumFixedCompileTimeArgs + num_inputs>();
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<
         num_inputs,
         std::get<num_inputs - 1>(inputs_args).next_compile_time_args_offset()>();
     constexpr uint32_t kMetaArgsOffset = has_metadata
                                              ? std::get<num_inputs - 1>(outputs_args).next_compile_time_args_offset()
-                                             : (page_size_base_idx + num_inputs);
+                                             : (kNumFixedCompileTimeArgs + num_inputs);
     constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
     constexpr uint32_t kKvMetaArgsOffset = has_metadata ? meta_args.next_compile_time_args_offset() : kMetaArgsOffset;
     constexpr auto kv_meta_args = TensorAccessorArgs<kKvMetaArgsOffset>();
@@ -82,7 +144,7 @@ void kernel_main() {
     std::array<uint32_t, num_inputs> input_tile_id_end;
     std::array<uint32_t, num_inputs> input_valid_pages;
     std::array<uint32_t, num_inputs> worker_link;
-    // Phase-1 input page base: nonzero only for single-slot gather (skip to the sliced input slot).
+    // Nonzero only for a single-slot gather, where it skips to the selected input slot.
     // The slice is always emitted into output slot 0, whatever the output batch size.
     std::array<uint32_t, num_inputs> input_batch_base;
 
@@ -92,10 +154,8 @@ void kernel_main() {
         output_tensor_Wt[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         output_tensor_Ht[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_batch_head_count[input_idx] = get_arg_val<uint32_t>(arg_idx++);
-        (void)get_arg_val<uint32_t>(arg_idx++);  // structural tile_id_start placeholder
-        (void)get_arg_val<uint32_t>(arg_idx++);  // structural tile_id_end placeholder
         input_batch_base[input_idx] = get_arg_val<uint32_t>(arg_idx++);
-        // valid_pages_per_batch_head (slot 8): clamp the gather to the logical_n-valid slab prefix so
+        // valid_pages_per_batch_head (slot 6): clamp the gather to the logical_n-valid slab prefix so
         // only kv_actual-sized data moves. Uniform across cores/devices, so producer/consumer page
         // counts and the ring slice protocol stay matched. Default (full input) leaves it unchanged.
         const uint32_t valid_pages = get_arg_val<uint32_t>(arg_idx++);
@@ -155,34 +215,55 @@ void kernel_main() {
 
     Noc noc_obj;
     CircularBuffer cb_output(cb_output_id);
+    constexpr uint32_t my_tensor_rank =
+        ttnn::ring_attention_all_gather::tensor_rank_from_transport_rank<full_mesh_rank_mapping>(
+            my_transport_rank, mesh_rows, mesh_cols, snake_orientation);
 
-    // Push out our local slice
-    // For a single-slot gather this starts at the sliced batch slot; otherwise 0 (full batch).
-    uint32_t output_tile_id_start = 0;
-    // Read local slice to our buffers, before sending them over
+    // Read the local slice into the packet CB before sending it over Fabric.
     for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-        output_tile_id_start = input_batch_base[input_idx];
-        uint32_t tiles_read = input_tile_id_start[input_idx];
-        uint32_t tiles_to_read = input_tile_id_end[input_idx];
-        for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-            prefetch_batch_read_tiles<
-                input_tensor_page_size,
-                packet_size_in_pages,
-                PREFETCH_PACKETS,
-                contig_pages_advanced>(
-                noc_obj,
-                cb_output,
-                tiles_read,
-                tiles_to_read,
-                cb_fifo_limit,
-                cb_fifo_size,
-                input_tensor_addrgens[input_idx],
-                [&](uint32_t tr) { return output_tile_id_start + tr; });
-            tiles_read = input_tile_id_start[input_idx];
-            tiles_to_read = input_tile_id_end[input_idx];
-            output_tile_id_start += input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
+        const uint32_t input_pages_per_batch_head = input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
+        const uint32_t output_pages_per_batch_head = output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
+        if constexpr (output_bank_owned_schedule) {
+            for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; ++bh_idx) {
+                const uint32_t input_page_base = input_batch_base[input_idx] + bh_idx * input_pages_per_batch_head;
+                const uint32_t output_page_base =
+                    bh_idx * output_pages_per_batch_head + my_tensor_rank * input_pages_per_batch_head;
+                prefetch_bank_owned_slices<false>(
+                    noc_obj,
+                    cb_output,
+                    cb_fifo_limit,
+                    cb_fifo_size,
+                    input_tensor_addrgens[input_idx],
+                    input_page_base,
+                    output_page_base,
+                    input_valid_pages[input_idx],
+                    worker_link[input_idx],
+                    num_links);
+            }
+        } else {
+            // For a single-slot gather this starts at the sliced batch slot; otherwise 0 (full batch).
+            uint32_t input_page_base = input_batch_base[input_idx];
+            uint32_t tiles_read = input_tile_id_start[input_idx];
+            uint32_t tiles_to_read = input_tile_id_end[input_idx];
+            for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
+                prefetch_batch_read_tiles<
+                    input_tensor_page_size,
+                    packet_size_in_pages,
+                    prefetch_packets,
+                    contig_pages_advanced>(
+                    noc_obj,
+                    cb_output,
+                    tiles_read,
+                    tiles_to_read,
+                    cb_fifo_limit,
+                    cb_fifo_size,
+                    input_tensor_addrgens[input_idx],
+                    [&](uint32_t tr) { return input_page_base + tr; });
+                tiles_read = input_tile_id_start[input_idx];
+                tiles_to_read = input_tile_id_end[input_idx];
+                input_page_base += input_pages_per_batch_head;
+            }
         }
-        output_tile_id_start = 0;
     }
 
     uint32_t slices_received = 0;
@@ -261,61 +342,85 @@ void kernel_main() {
             // The last slice we relay is the diametric shard of our downstream neighbor
             const bool is_split_forwarded_slice = split_forwarding_enabled && (slices_received == writes_expected);
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-                uint32_t slice_Wt = input_tensor_Wt[input_idx];
-                uint32_t stride_Wt = output_tensor_Wt[input_idx];
-
-                // Packet-aligned midpoint of this input's per-batch-head page range (matches the writer)
-                const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
-                const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
-                const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
-                const bool split_this_input = is_split_forwarded_slice;
-                uint32_t relay_start = input_tile_id_start[input_idx];
-                uint32_t relay_end = input_tile_id_end[input_idx];
-                if (split_this_input) {
-                    if (direction == 0) {
-                        relay_end = input_tile_id_start[input_idx] + first_half_pages;
-                    } else {
-                        relay_start = input_tile_id_start[input_idx] + first_half_pages;
+                const uint32_t input_pages_per_batch_head = input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
+                const uint32_t output_pages_per_batch_head = output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
+                if constexpr (output_bank_owned_schedule) {
+                    // Split the diametric slice by DRAM-bank ownership. Both directions together still
+                    // cover every bank, while each direction forwards roughly half the traffic.
+                    const uint32_t split_factor = is_split_forwarded_slice ? 2 : 1;
+                    const uint32_t first_bank =
+                        worker_link[input_idx] + (is_split_forwarded_slice ? direction * num_links : 0);
+                    const uint32_t bank_stride = num_links * split_factor;
+                    for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; ++bh_idx) {
+                        const uint32_t output_page_base =
+                            bh_idx * output_pages_per_batch_head + sender_tensor_rank * input_pages_per_batch_head;
+                        prefetch_bank_owned_slices<true>(
+                            noc_obj,
+                            cb_output,
+                            cb_fifo_limit,
+                            cb_fifo_size,
+                            output_tensor_addrgens[input_idx],
+                            output_page_base,
+                            output_page_base,
+                            input_valid_pages[input_idx],
+                            first_bank,
+                            bank_stride);
                     }
-                }
-
-                uint32_t tiles_read = relay_start;
-                uint32_t tiles_to_read = relay_end;
-                uint32_t output_tile_id_start = 0;
-                uint32_t pages_read_in_row = relay_start % slice_Wt;
-                uint32_t row_offset = (relay_start / slice_Wt) * stride_Wt;
-                if (gather_dim == 3) {
-                    output_tile_id_start = sender_tensor_rank * input_tensor_Wt[input_idx];
                 } else {
-                    output_tile_id_start = sender_tensor_rank * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
-                }
-                for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-                    prefetch_batch_read_tiles<
-                        input_tensor_page_size,
-                        packet_size_in_pages,
-                        PREFETCH_PACKETS,
-                        contig_pages_advanced>(
-                        noc_obj,
-                        cb_output,
-                        tiles_read,
-                        tiles_to_read,
-                        cb_fifo_limit,
-                        cb_fifo_size,
-                        output_tensor_addrgens[input_idx],
-                        [&](uint32_t /* tiles_read */) {
-                            const uint32_t pid = output_tile_id_start + row_offset + pages_read_in_row;
-                            pages_read_in_row++;
-                            if (pages_read_in_row >= slice_Wt) {
-                                row_offset += stride_Wt;
-                                pages_read_in_row = 0;
-                            }
-                            return pid;
-                        });
-                    pages_read_in_row = relay_start % slice_Wt;
-                    row_offset = (relay_start / slice_Wt) * stride_Wt;
-                    tiles_read = relay_start;
-                    tiles_to_read = relay_end;
-                    output_tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
+                    // Packet-aligned midpoint of this worker's page range (matches the writer).
+                    const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
+                    const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+                    const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+                    uint32_t relay_start = input_tile_id_start[input_idx];
+                    uint32_t relay_end = input_tile_id_end[input_idx];
+                    if (is_split_forwarded_slice) {
+                        if constexpr (direction == 0) {
+                            relay_end = relay_start + first_half_pages;
+                        } else {
+                            relay_start += first_half_pages;
+                        }
+                    }
+
+                    uint32_t tiles_read = relay_start;
+                    uint32_t tiles_to_read = relay_end;
+                    uint32_t output_tile_id_start = 0;
+                    const uint32_t slice_Wt = input_tensor_Wt[input_idx];
+                    const uint32_t stride_Wt = output_tensor_Wt[input_idx];
+                    uint32_t pages_read_in_row = relay_start % slice_Wt;
+                    uint32_t row_offset = (relay_start / slice_Wt) * stride_Wt;
+                    if (gather_dim == 3) {
+                        output_tile_id_start = sender_tensor_rank * slice_Wt;
+                    } else {
+                        output_tile_id_start = sender_tensor_rank * input_pages_per_batch_head;
+                    }
+                    for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
+                        prefetch_batch_read_tiles<
+                            input_tensor_page_size,
+                            packet_size_in_pages,
+                            prefetch_packets,
+                            contig_pages_advanced>(
+                            noc_obj,
+                            cb_output,
+                            tiles_read,
+                            tiles_to_read,
+                            cb_fifo_limit,
+                            cb_fifo_size,
+                            output_tensor_addrgens[input_idx],
+                            [&](uint32_t /* tiles_read */) {
+                                const uint32_t pid = output_tile_id_start + row_offset + pages_read_in_row;
+                                pages_read_in_row++;
+                                if (pages_read_in_row >= slice_Wt) {
+                                    row_offset += stride_Wt;
+                                    pages_read_in_row = 0;
+                                }
+                                return pid;
+                            });
+                        pages_read_in_row = relay_start % slice_Wt;
+                        row_offset = (relay_start / slice_Wt) * stride_Wt;
+                        tiles_read = relay_start;
+                        tiles_to_read = relay_end;
+                        output_tile_id_start += output_pages_per_batch_head;
+                    }
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -84,6 +84,14 @@ constexpr bool partial_readiness_enabled = get_compile_time_arg_val(kPartialRead
 constexpr bool output_bank_owned_schedule = get_compile_time_arg_val(kOutputBankOwnedSchedule);
 constexpr uint32_t num_dram_banks = get_compile_time_arg_val(kNumDramBanks);
 
+static_assert(!partial_readiness_enabled || num_inputs == 1, "partial readiness requires one gathered input");
+static_assert(
+    !partial_readiness_enabled || !split_forwarding_enabled,
+    "partial readiness and split forwarding are mutually exclusive");
+static_assert(
+    !partial_readiness_enabled || (num_targets_forward_direction > 0 && num_targets_backward_direction > 0),
+    "partial readiness requires both ring directions");
+
 template <typename AddrGenType, typename FabricSender>
 FORCE_INLINE void write_bank_owned_slices(
     CircularBuffer& cb_output,
@@ -137,6 +145,9 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
+    // KEEP IN SYNC with kWriterRuntimeArgHeaderCount/kTensorDescriptorFieldCount and field offsets in
+    // ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp. Fused consumers patch
+    // selected fields through that shared host-side layout.
     uint32_t arg_idx = 0;
     uint32_t gather_dim = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
@@ -338,8 +349,7 @@ void kernel_main() {
                 while (tiles_read < tiles_to_read) {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
                     cb_output.wait_front(packet_size_in_pages);
-                    const size_t l1_read_addr_base = cb_output.get_read_ptr();
-                    size_t l1_read_addr = l1_read_addr_base;
+                    size_t l1_read_addr = cb_output.get_read_ptr();
 
                     uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -48,6 +48,7 @@ enum CompileTimeArg : uint32_t {
     kSnakeOrientation,
     kMeshRows,
     kMeshCols,
+    kPartialReadinessEnabled,
     kOutputBankOwnedSchedule,
     kNumDramBanks,
     kNumFixedCompileTimeArgs,
@@ -79,6 +80,7 @@ constexpr auto snake_orientation =
     static_cast<ttnn::ccl::snake_ring::Orientation>(get_compile_time_arg_val(kSnakeOrientation));
 constexpr uint32_t mesh_rows = get_compile_time_arg_val(kMeshRows);
 constexpr uint32_t mesh_cols = get_compile_time_arg_val(kMeshCols);
+constexpr bool partial_readiness_enabled = get_compile_time_arg_val(kPartialReadinessEnabled);
 constexpr bool output_bank_owned_schedule = get_compile_time_arg_val(kOutputBankOwnedSchedule);
 constexpr uint32_t num_dram_banks = get_compile_time_arg_val(kNumDramBanks);
 
@@ -246,6 +248,20 @@ void kernel_main() {
     constexpr uint32_t num_targets_in_direction =
         direction == 1 ? num_targets_backward_direction : num_targets_forward_direction;
 
+    const uint64_t out_ready_sem_noc_addr_in_pkt =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
+    auto* pkt_hdr_sem_inc = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
+    pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(
+        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});
+    ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
+    const auto signal_output_ready = [&]() {
+        if constexpr (num_targets_in_direction) {
+            fabric_direction_connection->wait_for_empty_write_slot();
+            fabric_direction_connection->send_payload_flush_blocking_from_address(
+                packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+        }
+    };
+
     uint32_t slice_writes = 0;
     constexpr uint32_t my_tensor_rank =
         ttnn::ring_attention_all_gather::tensor_rank_from_transport_rank<full_mesh_rank_mapping>(
@@ -267,15 +283,39 @@ void kernel_main() {
                 const uint32_t output_page_base =
                     bh_idx * output_pages_per_batch_head + my_tensor_rank * input_pages_per_batch_head;
                 if constexpr (num_targets_in_direction) {
-                    write_bank_owned_slices(
-                        cb_output,
-                        output_addrgens[input_idx],
-                        pkt_hdr,
-                        *fabric_direction_connection,
-                        output_page_base,
-                        input_valid_pages[input_idx],
-                        worker_link[input_idx],
-                        num_links);
+                    if constexpr (partial_readiness_enabled) {
+                        const uint32_t first_pages = ring_attention_all_gather::midpoint_prefix_pages(
+                            input_valid_pages[input_idx], input_tensor_Wt[input_idx]);
+                        write_bank_owned_slices(
+                            cb_output,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            output_page_base,
+                            first_pages,
+                            worker_link[input_idx],
+                            num_links);
+                        signal_output_ready();
+                        write_bank_owned_slices(
+                            cb_output,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            output_page_base + first_pages,
+                            input_valid_pages[input_idx] - first_pages,
+                            worker_link[input_idx],
+                            num_links);
+                    } else {
+                        write_bank_owned_slices(
+                            cb_output,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            output_page_base,
+                            input_valid_pages[input_idx],
+                            worker_link[input_idx],
+                            num_links);
+                    }
                 } else {
                     discard_bank_owned_slices(
                         cb_output, output_page_base, input_valid_pages[input_idx], worker_link[input_idx], num_links);
@@ -367,22 +407,9 @@ void kernel_main() {
         op_signaler_sender.synchronize_workers_and_signal_op(my_transport_rank);
     }
 
-    // 2. unicast output ready semaphore
-    uint64_t out_ready_sem_noc_addr_in_pkt =
-        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
-    auto* pkt_hdr_sem_inc = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
-    pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-        out_ready_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
-
-    // Write the unicast packet. num_hops=1 is correct under both topologies: 1D ring-AG always
-    // targets the immediate neighbor; 2D ignores num_hops (HybridMesh::to_chip_unicast is a no-op
-    // and route_info carries the 2D destination).
-    if constexpr (num_targets_in_direction) {
-        fabric_direction_connection->wait_for_empty_write_slot();
-        ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
-        fabric_direction_connection->send_payload_flush_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
-    }
+    // The completion marker is the only marker in the legacy protocol and the second marker in
+    // partial-readiness mode. num_hops=1 is correct for both supported Fabric topologies.
+    signal_output_ready();
 
     uint32_t writes_expected = 0;
     if constexpr (topology == Topology::Linear) {
@@ -444,15 +471,39 @@ void kernel_main() {
                 for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; ++bh_idx) {
                     const uint32_t output_page_base =
                         bh_idx * output_pages_per_batch_head + slice_tensor_rank * input_pages_per_batch_head;
-                    write_bank_owned_slices(
-                        cb_output,
-                        output_addrgens[input_idx],
-                        pkt_hdr,
-                        *fabric_direction_connection,
-                        output_page_base,
-                        input_valid_pages[input_idx],
-                        first_bank,
-                        bank_stride);
+                    if constexpr (partial_readiness_enabled) {
+                        const uint32_t first_pages = ring_attention_all_gather::midpoint_prefix_pages(
+                            input_valid_pages[input_idx], input_tensor_Wt[input_idx]);
+                        write_bank_owned_slices(
+                            cb_output,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            output_page_base,
+                            first_pages,
+                            first_bank,
+                            bank_stride);
+                        signal_output_ready();
+                        write_bank_owned_slices(
+                            cb_output,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            output_page_base + first_pages,
+                            input_valid_pages[input_idx] - first_pages,
+                            first_bank,
+                            bank_stride);
+                    } else {
+                        write_bank_owned_slices(
+                            cb_output,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            output_page_base,
+                            input_valid_pages[input_idx],
+                            first_bank,
+                            bank_stride);
+                    }
                 }
             } else {
                 const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
@@ -531,12 +582,7 @@ void kernel_main() {
             }
         }
 
-        // 2. unicast output ready semaphore forward — route was set once on pkt_hdr_sem_inc
-        // before the writes loop above; unicast_route_info is constexpr, so no need to
-        // re-set it each iteration.
-        fabric_direction_connection->wait_for_empty_write_slot();
-        fabric_direction_connection->send_payload_flush_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+        signal_output_ready();
 
         slice_writes++;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -20,53 +20,118 @@
 #include <cstdint>
 #include <utility>
 
-using address_t = uint32_t;
 using ttnn::ccl::Topology;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
 
-constexpr uint32_t my_transport_rank = get_compile_time_arg_val(0);
-constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
-constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
-constexpr uint32_t cb_output_id = get_compile_time_arg_val(3);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
-constexpr uint32_t output_page_size = get_compile_time_arg_val(5);
-constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
-constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
-constexpr bool dynamic_alternate = get_compile_time_arg_val(8);
-constexpr bool fuse_op = get_compile_time_arg_val(9);
-constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(10));
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(11);
-constexpr uint32_t num_inputs = get_compile_time_arg_val(12);
-constexpr bool direction = get_compile_time_arg_val(13);  // 1 is forward, 0 is backward
-constexpr uint32_t unicast_route_arg0 = get_compile_time_arg_val(14);
-constexpr uint32_t unicast_route_arg1 = get_compile_time_arg_val(15);
+enum CompileTimeArg : uint32_t {
+    kMyTransportRank,
+    kReservedPacketHeaderCbId,
+    kCbOutputId,
+    kPacketSizeInPages,
+    kOutputPageSize,
+    kNumTargetsForwardDirection,
+    kNumTargetsBackwardDirection,
+    kFuseOp,
+    kTopology,
+    kNumInputs,
+    kDirection,
+    kUnicastRouteArg0,
+    kUnicastRouteArg1,
+    kHasMetadata,
+    kCbMetaId,
+    kNumLinks,
+    kSplitForwardingEnabled,
+    kFullMeshRankMapping,
+    kSnakeOrientation,
+    kMeshRows,
+    kMeshCols,
+    kOutputBankOwnedSchedule,
+    kNumDramBanks,
+    kNumFixedCompileTimeArgs,
+};
+
+constexpr uint32_t my_transport_rank = get_compile_time_arg_val(kMyTransportRank);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(kReservedPacketHeaderCbId);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(kCbOutputId);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(kPacketSizeInPages);
+constexpr uint32_t output_page_size = get_compile_time_arg_val(kOutputPageSize);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(kNumTargetsForwardDirection);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(kNumTargetsBackwardDirection);
+constexpr bool fuse_op = get_compile_time_arg_val(kFuseOp);
+constexpr Topology topology = static_cast<Topology>(get_compile_time_arg_val(kTopology));
+constexpr uint32_t num_inputs = get_compile_time_arg_val(kNumInputs);
+constexpr bool direction = get_compile_time_arg_val(kDirection);  // 1 is forward, 0 is backward
+constexpr uint32_t unicast_route_arg0 = get_compile_time_arg_val(kUnicastRouteArg0);
+constexpr uint32_t unicast_route_arg1 = get_compile_time_arg_val(kUnicastRouteArg1);
 // Trace-safe metadata path: when set, the writer recomputes the gather extent (valid_pages) on-device
 // from kv_actual_isl[0] (a 1-element uint32 DRAM tensor) so it stays matched to the reader's on-device
 // recompute (else they desync under a placeholder host logical_n). When false neither this nor the
 // metadata accessor is emitted.
-constexpr bool has_metadata = get_compile_time_arg_val(16);
-constexpr uint32_t cb_meta_id = get_compile_time_arg_val(17);
-constexpr uint32_t num_links = get_compile_time_arg_val(18);
-// Host-derived even-ring split-forwarding gate; see ring_attention_all_gather_reader.cpp for semantics.
-constexpr bool split_forwarding_enabled = get_compile_time_arg_val(19);
-constexpr bool full_mesh_rank_mapping = get_compile_time_arg_val(20);
-constexpr auto snake_orientation = static_cast<ttnn::ccl::snake_ring::Orientation>(get_compile_time_arg_val(21));
-constexpr uint32_t mesh_rows = get_compile_time_arg_val(22);
-constexpr uint32_t mesh_cols = get_compile_time_arg_val(23);
+constexpr bool has_metadata = get_compile_time_arg_val(kHasMetadata);
+constexpr uint32_t cb_meta_id = get_compile_time_arg_val(kCbMetaId);
+constexpr uint32_t num_links = get_compile_time_arg_val(kNumLinks);
+constexpr bool split_forwarding_enabled = get_compile_time_arg_val(kSplitForwardingEnabled);
+constexpr bool full_mesh_rank_mapping = get_compile_time_arg_val(kFullMeshRankMapping);
+constexpr auto snake_orientation =
+    static_cast<ttnn::ccl::snake_ring::Orientation>(get_compile_time_arg_val(kSnakeOrientation));
+constexpr uint32_t mesh_rows = get_compile_time_arg_val(kMeshRows);
+constexpr uint32_t mesh_cols = get_compile_time_arg_val(kMeshCols);
+constexpr bool output_bank_owned_schedule = get_compile_time_arg_val(kOutputBankOwnedSchedule);
+constexpr uint32_t num_dram_banks = get_compile_time_arg_val(kNumDramBanks);
+
+template <typename AddrGenType, typename FabricSender>
+FORCE_INLINE void write_bank_owned_slices(
+    CircularBuffer& cb_output,
+    AddrGenType& output_addrgen,
+    volatile PACKET_HEADER_TYPE* pkt_hdr,
+    FabricSender& fabric_direction_connection,
+    uint32_t output_page_base,
+    uint32_t valid_pages,
+    uint32_t first_bank,
+    uint32_t bank_stride) {
+    ring_attention_all_gather::BankOwnedPacketSchedule<num_dram_banks> schedule(
+        output_page_base, valid_pages, first_bank, bank_stride, packet_size_in_pages);
+    uint32_t first_page_offset = 0;
+    uint32_t batch = 0;
+    while (schedule.next_packet(first_page_offset, batch)) {
+        cb_output.wait_front(packet_size_in_pages);
+        fabric_write_unidir(
+            output_page_base + first_page_offset,
+            output_addrgen,
+            pkt_hdr,
+            fabric_direction_connection,
+            cb_output.get_read_ptr(),
+            batch * output_page_size);
+        cb_output.pop_front(packet_size_in_pages);
+    }
+}
+
+FORCE_INLINE void discard_bank_owned_slices(
+    CircularBuffer& cb_output,
+    uint32_t output_page_base,
+    uint32_t valid_pages,
+    uint32_t first_bank,
+    uint32_t bank_stride) {
+    for (uint32_t bank = first_bank; bank < num_dram_banks; bank += bank_stride) {
+        const uint32_t page_count =
+            ring_attention_all_gather::get_bank_owned_slice(output_page_base, valid_pages, bank, num_dram_banks)
+                .page_count;
+        for (uint32_t pages_discarded = 0; pages_discarded < page_count; pages_discarded += packet_size_in_pages) {
+            cb_output.wait_front(packet_size_in_pages);
+            cb_output.pop_front(packet_size_in_pages);
+        }
+    }
+}
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = ttnn::ring_attention_all_gather::kWriterFixedCompileTimeArgCount;
-    constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
-    // Metadata accessor follows the output accessors (metadata path only); fall back to a valid (unused)
-    // accessor offset when absent so TensorAccessorArgs<> never names a non-accessor compile arg.
+    constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, kNumFixedCompileTimeArgs + num_inputs>();
     constexpr uint32_t kMetaArgsOffset = has_metadata
                                              ? std::get<num_inputs - 1>(outputs_args).next_compile_time_args_offset()
-                                             : (page_size_base_idx + num_inputs);
+                                             : (kNumFixedCompileTimeArgs + num_inputs);
     constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
-
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
@@ -93,12 +158,10 @@ void kernel_main() {
         output_tensor_Wt[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         output_tensor_Ht[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_batch_head_count[input_idx] = get_arg_val<uint32_t>(arg_idx++);
-        (void)get_arg_val<uint32_t>(arg_idx++);  // structural tile_id_start placeholder
-        (void)get_arg_val<uint32_t>(arg_idx++);  // structural tile_id_end placeholder
-        // input_batch_base: reader-only (phase-1 input offset). The writer always targets output
+        // input_batch_base is reader-only. The writer always targets output
         // slot 0, so it reads the arg here only for alignment.
         (void)get_arg_val<uint32_t>(arg_idx++);
-        // valid_pages_per_batch_head (slot 8): clamp the gather to the logical_n-valid slab prefix (must
+        // valid_pages_per_batch_head (slot 6): clamp the gather to the logical_n-valid slab prefix (must
         // match the reader's clamp so cb_output producer/consumer page counts stay aligned). Default
         // (full input) leaves the range unchanged.
         const uint32_t valid_pages = get_arg_val<uint32_t>(arg_idx++);
@@ -176,7 +239,6 @@ void kernel_main() {
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, unicast_route_info);
 
     fabric_connection.open();
-
     tt::tt_fabric::WorkerToFabricEdmSender* fabric_direction_connection =
         fabric_connection.is_logically_connected() ? (direction == 1 ? &fabric_connection.get_backward_connection()
                                                                      : &fabric_connection.get_forward_connection())
@@ -189,7 +251,6 @@ void kernel_main() {
         ttnn::ring_attention_all_gather::tensor_rank_from_transport_rank<full_mesh_rank_mapping>(
             my_transport_rank, mesh_rows, mesh_cols, snake_orientation);
 
-    uint32_t row_offset = 0;
     for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
         /**
          * Write out the local slice to forward and backward devices
@@ -199,76 +260,98 @@ void kernel_main() {
          * to remove startup latency from the fused op.
          */
 
-        uint32_t tile_id_start = my_tensor_rank * input_tensor_Wt[input_idx];
-        uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-        uint32_t row_offset =
-            (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
-        uint32_t tiles_read = input_tile_id_start[input_idx];
-        uint32_t tiles_to_read = input_tile_id_end[input_idx];
-        if (gather_dim == 3) {
-            tile_id_start = my_tensor_rank * input_tensor_Wt[input_idx];
-        } else {
-            tile_id_start = my_tensor_rank * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
-        }
-
-        for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-            while (tiles_read < tiles_to_read) {
-                uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                cb_output.wait_front(packet_size_in_pages);
-                const size_t l1_read_addr_base = cb_output.get_read_ptr();
-                size_t l1_read_addr = l1_read_addr_base;
-
-                // for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
-                uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
-
-                pages_read_in_row++;
-                if (pages_read_in_row >= input_tensor_Wt[input_idx]) {
-                    row_offset += output_tensor_Wt[input_idx];
-                    pages_read_in_row = 0;
+        const uint32_t input_pages_per_batch_head = input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
+        const uint32_t output_pages_per_batch_head = output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
+        if constexpr (output_bank_owned_schedule) {
+            for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; ++bh_idx) {
+                const uint32_t output_page_base =
+                    bh_idx * output_pages_per_batch_head + my_tensor_rank * input_pages_per_batch_head;
+                if constexpr (num_targets_in_direction) {
+                    write_bank_owned_slices(
+                        cb_output,
+                        output_addrgens[input_idx],
+                        pkt_hdr,
+                        *fabric_direction_connection,
+                        output_page_base,
+                        input_valid_pages[input_idx],
+                        worker_link[input_idx],
+                        num_links);
+                } else {
+                    discard_bank_owned_slices(
+                        cb_output, output_page_base, input_valid_pages[input_idx], worker_link[input_idx], num_links);
                 }
+            }
+        } else {
+            uint32_t tile_id_start = my_tensor_rank * input_tensor_Wt[input_idx];
+            uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+            uint32_t row_offset =
+                (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
+            uint32_t tiles_read = input_tile_id_start[input_idx];
+            uint32_t tiles_to_read = input_tile_id_end[input_idx];
+            if (gather_dim == 3) {
+                tile_id_start = my_tensor_rank * input_tensor_Wt[input_idx];
+            } else {
+                tile_id_start = my_tensor_rank * input_pages_per_batch_head;
+            }
 
-                if (num_pages_to_read == 2) {
-                    uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+            for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
+                while (tiles_read < tiles_to_read) {
+                    uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
+                    cb_output.wait_front(packet_size_in_pages);
+                    const size_t l1_read_addr_base = cb_output.get_read_ptr();
+                    size_t l1_read_addr = l1_read_addr_base;
 
-                    if constexpr (num_targets_in_direction) {
-                        scatter_fabric_write_unidir(
-                            tile_id,
-                            second_tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
-                    }
+                    uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
 
                     pages_read_in_row++;
                     if (pages_read_in_row >= input_tensor_Wt[input_idx]) {
                         row_offset += output_tensor_Wt[input_idx];
                         pages_read_in_row = 0;
                     }
-                } else {
-                    ASSERT(num_pages_to_read == 1);
 
-                    if constexpr (num_targets_in_direction) {
-                        // Has valid targets to send to
-                        fabric_write_unidir(
-                            tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
+                    if (num_pages_to_read == 2) {
+                        uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+
+                        if constexpr (num_targets_in_direction) {
+                            scatter_fabric_write_unidir(
+                                tile_id,
+                                second_tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        }
+
+                        pages_read_in_row++;
+                        if (pages_read_in_row >= input_tensor_Wt[input_idx]) {
+                            row_offset += output_tensor_Wt[input_idx];
+                            pages_read_in_row = 0;
+                        }
+                    } else {
+                        ASSERT(num_pages_to_read == 1);
+
+                        if constexpr (num_targets_in_direction) {
+                            fabric_write_unidir(
+                                tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        }
                     }
-                }
 
-                tiles_read += num_pages_to_read;
-                cb_output.pop_front(packet_size_in_pages);
+                    tiles_read += num_pages_to_read;
+                    cb_output.pop_front(packet_size_in_pages);
+                }
+                tile_id_start += output_pages_per_batch_head;
+                tiles_read = input_tile_id_start[input_idx];
+                tiles_to_read = input_tile_id_end[input_idx];
+                pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+                row_offset =
+                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
             }
-            tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
-            tiles_read = input_tile_id_start[input_idx];
-            tiles_to_read = input_tile_id_end[input_idx];
-            pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-            row_offset = (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
         }
     }
 
@@ -351,54 +434,72 @@ void kernel_main() {
             ttnn::ring_attention_all_gather::tensor_rank_from_transport_rank<full_mesh_rank_mapping>(
                 slice_transport_rank, mesh_rows, mesh_cols, snake_orientation);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            uint32_t tiles_read = input_tile_id_start[input_idx];
-            uint32_t tiles_to_read = input_tile_id_end[input_idx];
-            uint32_t tile_id_start = slice_tensor_rank * input_tensor_Wt[input_idx];
-            uint32_t row_offset =
-                (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
-            uint32_t pages_read_in_row = (input_tile_id_start[input_idx] % input_tensor_Wt[input_idx]);
-            uint32_t slice_Wt = input_tensor_Wt[input_idx];
-            uint32_t stride_Wt = output_tensor_Wt[input_idx];
-
-            if (gather_dim == 3) {
-                tile_id_start = slice_tensor_rank * input_tensor_Wt[input_idx];
+            const uint32_t input_pages_per_batch_head = input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
+            const uint32_t output_pages_per_batch_head = output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
+            if constexpr (output_bank_owned_schedule) {
+                const uint32_t split_factor = is_split_forwarded_slice ? 2 : 1;
+                const uint32_t first_bank =
+                    worker_link[input_idx] + (is_split_forwarded_slice ? direction * num_links : 0);
+                const uint32_t bank_stride = num_links * split_factor;
+                for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; ++bh_idx) {
+                    const uint32_t output_page_base =
+                        bh_idx * output_pages_per_batch_head + slice_tensor_rank * input_pages_per_batch_head;
+                    write_bank_owned_slices(
+                        cb_output,
+                        output_addrgens[input_idx],
+                        pkt_hdr,
+                        *fabric_direction_connection,
+                        output_page_base,
+                        input_valid_pages[input_idx],
+                        first_bank,
+                        bank_stride);
+                }
             } else {
-                tile_id_start = slice_tensor_rank * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
-            }
-
-            // Packet-aligned midpoint of this input's per-batch-head page range
-            const uint32_t total_pages = tiles_to_read - input_tile_id_start[input_idx];
-            const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
-            const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
-            const bool split_this_input = is_split_forwarded_slice;
-
-            for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-                while (tiles_read < tiles_to_read) {
-                    uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                    uint32_t page_in_bh = tiles_read - input_tile_id_start[input_idx];
-                    bool relay_this_packet = !split_this_input || (direction == 0 ? (page_in_bh < first_half_pages)
-                                                                                  : (page_in_bh >= first_half_pages));
-
-                    uint32_t first_tile_id = tile_id_start + row_offset + pages_read_in_row;
-                    pages_read_in_row++;
-                    if (pages_read_in_row >= slice_Wt) {
-                        row_offset += stride_Wt;
-                        pages_read_in_row = 0;
+                const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
+                const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+                const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+                uint32_t relay_start = input_tile_id_start[input_idx];
+                uint32_t relay_end = input_tile_id_end[input_idx];
+                if (is_split_forwarded_slice) {
+                    if constexpr (direction == 0) {
+                        relay_end = relay_start + first_half_pages;
+                    } else {
+                        relay_start += first_half_pages;
                     }
-                    uint32_t second_tile_id = 0;
-                    if (num_pages_to_read == 2) {
-                        second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+                }
+
+                uint32_t tiles_read = relay_start;
+                uint32_t tiles_to_read = relay_end;
+                uint32_t tile_id_start = slice_tensor_rank * input_tensor_Wt[input_idx];
+                const uint32_t slice_Wt = input_tensor_Wt[input_idx];
+                const uint32_t stride_Wt = output_tensor_Wt[input_idx];
+                uint32_t row_offset = (relay_start / slice_Wt) * stride_Wt;
+                uint32_t pages_read_in_row = relay_start % slice_Wt;
+
+                if (gather_dim == 3) {
+                    tile_id_start = slice_tensor_rank * slice_Wt;
+                } else {
+                    tile_id_start = slice_tensor_rank * input_pages_per_batch_head;
+                }
+                for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
+                    while (tiles_read < tiles_to_read) {
+                        uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
+                        cb_output.wait_front(packet_size_in_pages);
+                        size_t l1_read_addr = cb_output.get_read_ptr();
+                        uint32_t first_tile_id = tile_id_start + row_offset + pages_read_in_row;
                         pages_read_in_row++;
                         if (pages_read_in_row >= slice_Wt) {
                             row_offset += stride_Wt;
                             pages_read_in_row = 0;
                         }
-                    }
-
-                    if (relay_this_packet) {
-                        cb_output.wait_front(packet_size_in_pages);
-                        size_t l1_read_addr = cb_output.get_read_ptr();
                         if (num_pages_to_read == 2) {
+                            uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+                            pages_read_in_row++;
+                            if (pages_read_in_row >= slice_Wt) {
+                                row_offset += stride_Wt;
+                                pages_read_in_row = 0;
+                            }
+
                             scatter_fabric_write_unidir(
                                 first_tile_id,
                                 second_tile_id,
@@ -417,17 +518,16 @@ void kernel_main() {
                                 l1_read_addr,
                                 output_page_size);
                         }
+
+                        tiles_read += num_pages_to_read;
                         cb_output.pop_front(packet_size_in_pages);
                     }
-
-                    tiles_read += num_pages_to_read;
+                    tile_id_start += output_pages_per_batch_head;
+                    tiles_read = relay_start;
+                    tiles_to_read = relay_end;
+                    row_offset = (relay_start / slice_Wt) * stride_Wt;
+                    pages_read_in_row = relay_start % slice_Wt;
                 }
-                tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
-                tiles_read = input_tile_id_start[input_idx];
-                tiles_to_read = input_tile_id_end[input_idx];
-                row_offset =
-                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
-                pages_read_in_row = (input_tile_id_start[input_idx] % input_tensor_Wt[input_idx]);
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_reader.cpp
@@ -15,17 +15,28 @@
 #include <cstddef>
 #include <cstdint>
 
-constexpr uint32_t my_ring_id = get_compile_time_arg_val(0);
-constexpr uint32_t ring_size = get_compile_time_arg_val(1);
-constexpr uint32_t cb_output_id = get_compile_time_arg_val(2);
-constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(3);
-constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
-constexpr uint32_t num_inputs = get_compile_time_arg_val(5);
-constexpr uint32_t page_size_base_idx = 6;
-constexpr uint32_t prefetch_packets = 4;
+enum CompileTimeArg : uint32_t {
+    kMyRingId,
+    kRingSize,
+    kCbOutputId,
+    kPacketSizeInPages,
+    kInputPageSize,
+    kNumInputs,
+    kPrefetchPackets,
+    kNumFixedCompileTimeArgs,
+};
+
+constexpr uint32_t my_ring_id = get_compile_time_arg_val(kMyRingId);
+constexpr uint32_t ring_size = get_compile_time_arg_val(kRingSize);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(kCbOutputId);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(kPacketSizeInPages);
+constexpr uint32_t input_page_size = get_compile_time_arg_val(kInputPageSize);
+constexpr uint32_t num_inputs = get_compile_time_arg_val(kNumInputs);
+constexpr uint32_t prefetch_packets = get_compile_time_arg_val(kPrefetchPackets);
 
 void kernel_main() {
-    constexpr auto input_accessor_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
+    constexpr auto input_accessor_args =
+        make_tensor_accessor_args_tuple<num_inputs, kNumFixedCompileTimeArgs + num_inputs>();
 
     uint32_t arg_idx = 0;
     const size_t incoming_ready_sem = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_prefetch_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_prefetch_utils.hpp
@@ -11,9 +11,9 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
 
-// Batch packetized DRAM reads into a CB while keeping multiple packets in flight.  The caller
-// provides the source page mapping; this supports both the dense reader's contiguous two-page
-// reads and the neighbor-halo reader's one-page reads without duplicating FIFO-wrap arithmetic.
+// Batch packetized DRAM reads into a CB while keeping multiple packets in flight. The caller
+// provides the source page mapping; this supports both the dense and neighbor-halo readers
+// without duplicating FIFO-wrap arithmetic.
 template <
     uint32_t input_page_size,
     uint32_t packet_size_in_pages,
@@ -61,4 +61,124 @@ FORCE_INLINE void prefetch_batch_read_tiles(
             cb_output.push_back(packet_size_in_pages);
         }
     }
+}
+
+// Read an arbitrary packet sequence while preserving one prefetch window across logical slice boundaries.
+// next_packet returns the first logical page id and writes the number of physically contiguous pages in that packet.
+template <
+    uint32_t input_page_size,
+    uint32_t packet_size_in_pages,
+    uint32_t prefetch_packets,
+    typename Accessor,
+    typename NextPacketFn>
+FORCE_INLINE void prefetch_batch_read_physically_contiguous_packets(
+    const Noc& noc,
+    CircularBuffer& cb_output,
+    uint32_t total_packets,
+    uint32_t cb_fifo_limit,
+    uint32_t cb_fifo_size,
+    const Accessor& accessor,
+    NextPacketFn&& next_packet) {
+    uint32_t packets_read = 0;
+    while (packets_read < total_packets) {
+        const uint32_t batch_packets = std::min(total_packets - packets_read, prefetch_packets);
+        cb_output.reserve_back(batch_packets * packet_size_in_pages);
+        uint32_t l1_write_addr = cb_output.get_write_ptr();
+        for (uint32_t packet = 0; packet < batch_packets; ++packet) {
+            if (l1_write_addr >= cb_fifo_limit) {
+                l1_write_addr -= cb_fifo_size;
+            }
+            uint32_t pages_to_read = 0;
+            const uint32_t first_page_id = next_packet(pages_to_read);
+            const uint64_t first_noc_addr = accessor.get_noc_addr(first_page_id, 0, noc.get_noc_id());
+            noc.async_read(
+                tensor_accessor::Page(first_noc_addr, 0),
+                CoreLocalMem<uint8_t>(l1_write_addr),
+                pages_to_read * input_page_size,
+                {},
+                {});
+            l1_write_addr += packet_size_in_pages * input_page_size;
+        }
+        packets_read += batch_packets;
+        noc.async_read_barrier();
+        for (uint32_t packet = 0; packet < batch_packets; ++packet) {
+            cb_output.push_back(packet_size_in_pages);
+        }
+    }
+}
+
+// Read an arbitrary packet sequence through the tensor accessor. Unlike the physically-contiguous
+// variant above, each page may have an independent logical page id, so this is valid for sharded inputs.
+template <
+    uint32_t input_page_size,
+    uint32_t packet_size_in_pages,
+    uint32_t prefetch_packets,
+    typename Accessor,
+    typename NextPacketFn,
+    typename PacketPageIdFn>
+FORCE_INLINE void prefetch_batch_read_packets(
+    const Noc& noc,
+    CircularBuffer& cb_output,
+    uint32_t total_packets,
+    uint32_t cb_fifo_limit,
+    uint32_t cb_fifo_size,
+    const Accessor& accessor,
+    NextPacketFn&& next_packet,
+    PacketPageIdFn&& packet_page_id) {
+    uint32_t packets_read = 0;
+    while (packets_read < total_packets) {
+        const uint32_t batch_packets = std::min(total_packets - packets_read, prefetch_packets);
+        cb_output.reserve_back(batch_packets * packet_size_in_pages);
+        uint32_t l1_write_addr = cb_output.get_write_ptr();
+        for (uint32_t packet = 0; packet < batch_packets; ++packet) {
+            uint32_t pages_to_read = 0;
+            const uint32_t first_page_id = next_packet(pages_to_read);
+            for (uint32_t page = 0; page < pages_to_read; ++page) {
+                if (l1_write_addr >= cb_fifo_limit) {
+                    l1_write_addr -= cb_fifo_size;
+                }
+                noc.async_read(
+                    accessor,
+                    CoreLocalMem<uint8_t>(l1_write_addr),
+                    input_page_size,
+                    {.page_id = packet_page_id(first_page_id, page)},
+                    {});
+                l1_write_addr += input_page_size;
+            }
+            l1_write_addr += (packet_size_in_pages - pages_to_read) * input_page_size;
+        }
+        packets_read += batch_packets;
+        noc.async_read_barrier();
+        for (uint32_t packet = 0; packet < batch_packets; ++packet) {
+            cb_output.push_back(packet_size_in_pages);
+        }
+    }
+}
+
+// Read a bank-owned logical page sequence as physically contiguous packet-sized NOC transactions.
+// In an interleaved DRAM buffer, logical pages separated by the DRAM-bank count are adjacent within
+// one bank. The caller is responsible for supplying exactly that mapping.
+template <
+    uint32_t input_page_size,
+    uint32_t packet_size_in_pages,
+    uint32_t prefetch_packets,
+    typename Accessor,
+    typename PageIdFn>
+FORCE_INLINE void prefetch_batch_read_physically_contiguous_tiles(
+    const Noc& noc,
+    CircularBuffer& cb_output,
+    uint32_t& tiles_read,
+    uint32_t tiles_to_read,
+    uint32_t cb_fifo_limit,
+    uint32_t cb_fifo_size,
+    const Accessor& accessor,
+    PageIdFn&& next_page_id) {
+    const uint32_t total_packets = (tiles_to_read - tiles_read + packet_size_in_pages - 1) / packet_size_in_pages;
+    prefetch_batch_read_physically_contiguous_packets<input_page_size, packet_size_in_pages, prefetch_packets>(
+        noc, cb_output, total_packets, cb_fifo_limit, cb_fifo_size, accessor, [&](uint32_t& pages_to_read) {
+            pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
+            const uint32_t first_page_id = next_page_id(tiles_read);
+            tiles_read += pages_to_read;
+            return first_page_id;
+        });
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_prefetch_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_prefetch_utils.hpp
@@ -154,31 +154,3 @@ FORCE_INLINE void prefetch_batch_read_packets(
         }
     }
 }
-
-// Read a bank-owned logical page sequence as physically contiguous packet-sized NOC transactions.
-// In an interleaved DRAM buffer, logical pages separated by the DRAM-bank count are adjacent within
-// one bank. The caller is responsible for supplying exactly that mapping.
-template <
-    uint32_t input_page_size,
-    uint32_t packet_size_in_pages,
-    uint32_t prefetch_packets,
-    typename Accessor,
-    typename PageIdFn>
-FORCE_INLINE void prefetch_batch_read_physically_contiguous_tiles(
-    const Noc& noc,
-    CircularBuffer& cb_output,
-    uint32_t& tiles_read,
-    uint32_t tiles_to_read,
-    uint32_t cb_fifo_limit,
-    uint32_t cb_fifo_size,
-    const Accessor& accessor,
-    PageIdFn&& next_page_id) {
-    const uint32_t total_packets = (tiles_to_read - tiles_read + packet_size_in_pages - 1) / packet_size_in_pages;
-    prefetch_batch_read_physically_contiguous_packets<input_page_size, packet_size_in_pages, prefetch_packets>(
-        noc, cb_output, total_packets, cb_fifo_limit, cb_fifo_size, accessor, [&](uint32_t& pages_to_read) {
-            pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-            const uint32_t first_page_id = next_page_id(tiles_read);
-            tiles_read += pages_to_read;
-            return first_page_id;
-        });
-}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_rank_mapping.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_rank_mapping.hpp
@@ -10,8 +10,8 @@
 
 namespace ttnn::ring_attention_all_gather {
 
-constexpr uint32_t kReaderFixedCompileTimeArgCount = 21;
-constexpr uint32_t kWriterFixedCompileTimeArgCount = 23;
+constexpr uint32_t kReaderFixedCompileTimeArgCount = 22;
+constexpr uint32_t kWriterFixedCompileTimeArgCount = 24;
 
 template <bool FullMesh>
 constexpr uint32_t tensor_rank_from_transport_rank(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_rank_mapping.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_rank_mapping.hpp
@@ -10,8 +10,8 @@
 
 namespace ttnn::ring_attention_all_gather {
 
-constexpr uint32_t kReaderFixedCompileTimeArgCount = 19;
-constexpr uint32_t kWriterFixedCompileTimeArgCount = 24;
+constexpr uint32_t kReaderFixedCompileTimeArgCount = 21;
+constexpr uint32_t kWriterFixedCompileTimeArgCount = 23;
 
 template <bool FullMesh>
 constexpr uint32_t tensor_rank_from_transport_rank(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -464,7 +464,6 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     using namespace CMAKE_UNIQUE_NAMESPACE;
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
-    using tt::tt_metal::DataMovementConfigDescriptor;
     using tt::tt_metal::KernelDescriptor;
     using tt::tt_metal::ReaderConfigDescriptor;
     using tt::tt_metal::SemaphoreDescriptor;
@@ -658,6 +657,11 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const CoreRangeSet sender_backward_core_ranges = placements_to_core_ranges(backward_workers);
 
     const uint32_t max_pages_per_packet = max_payload_size_bytes / l1_scratch_cb_page_size_bytes;
+    TT_FATAL(
+        max_pages_per_packet > 0,
+        "Ring attention all-gather page size {} exceeds the Fabric payload limit {}",
+        l1_scratch_cb_page_size_bytes,
+        max_payload_size_bytes);
     const uint32_t num_pages_per_packet =
         output_bank_owned_schedule ? max_pages_per_packet : std::min(max_pages_per_packet, kMaxScatterPagesPerPacket);
     // Must be >= kDoubleBufferingFactor * prefetch_packets * num_pages_per_packet for deadlock-free buffering
@@ -714,6 +718,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
 
     // The host value is a structural placeholder for the indexed gather. On the
     // trace-safe path the reader derives the actual cache slot from slot_id.
+    TT_FATAL(
+        slot_id.has_value() == kv_actual_isl.has_value(),
+        "Ring attention metadata requires slot_id and kv_actual_isl tensors together");
     const bool has_metadata = slot_id.has_value();
     const uint32_t meta_cb_index = tt::CB::c_in3;
     if (has_metadata) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -179,6 +179,12 @@ bool supports_output_bank_owned_schedule(
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
+bool ring_attention_all_gather_async_detail::uses_output_bank_owned_schedule(
+    const std::vector<Tensor>& input_tensors, const std::vector<Tensor>& output_tensors, int32_t dim) {
+    return !input_tensors.empty() && CMAKE_UNIQUE_NAMESPACE::supports_output_bank_owned_schedule(
+                                         output_tensors, dim, input_tensors.front().buffer()->page_size());
+}
+
 void ring_attention_neighbor_halo_exchange_helper(
     tt::tt_metal::ProgramDescriptor& desc,
     const std::vector<Tensor>& input_tensors,
@@ -453,6 +459,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     uint32_t kv_cache_num_layers,
     uint32_t kv_cache_layer_idx,
     bool split_forwarding_enabled,
+    bool partial_readiness_enabled,
     RingAttentionRankMapping rank_mapping) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     using tt::tt_metal::CBDescriptor;
@@ -588,7 +595,26 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
     const uint32_t num_dram_banks = mesh_device->allocator()->get_num_banks(tt::tt_metal::BufferType::DRAM);
     const bool output_bank_owned_schedule =
-        supports_output_bank_owned_schedule(output_tensor, dim, l1_scratch_cb_page_size_bytes);
+        ring_attention_all_gather_async_detail::uses_output_bank_owned_schedule(input_tensor, output_tensor, dim);
+    if (partial_readiness_enabled) {
+        TT_FATAL(fuse_op, "Partial all-gather readiness requires a fused consumer");
+        TT_FATAL(topology == ttnn::ccl::Topology::Ring, "Partial all-gather readiness requires Ring topology");
+        TT_FATAL(
+            num_targets_forward > 0 && num_targets_backward > 0,
+            "Partial all-gather readiness requires active traffic in both ring directions");
+        TT_FATAL(
+            output_bank_owned_schedule,
+            "Partial all-gather readiness currently requires the bank-owned packet schedule");
+        TT_FATAL(!split_forwarding_enabled, "Partial readiness and split forwarding cannot be enabled together");
+        TT_FATAL(input_tensor.size() == 1, "Partial all-gather readiness currently supports one input tensor");
+        const auto shape = input_tensor.front().padded_shape();
+        const uint32_t batch_heads =
+            (input_batch_slice_idx.has_value() ? 1u : shape[kBatchDimension]) * shape[kHeadDimension];
+        TT_FATAL(
+            batch_heads == 1,
+            "Partial all-gather readiness currently supports one gathered batch/head, got {}",
+            batch_heads);
+    }
     struct WorkerPlacement {
         CoreCoord core;
         uint32_t link;
@@ -743,6 +769,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             static_cast<uint32_t>(rank_mapping.orientation),    // kSnakeOrientation
             rank_mapping.mesh_rows,                             // kMeshRows
             rank_mapping.mesh_cols,                             // kMeshCols
+            static_cast<uint32_t>(partial_readiness_enabled),   // kPartialReadinessEnabled
             static_cast<uint32_t>(output_bank_owned_schedule),  // kOutputBankOwnedSchedule
             num_dram_banks,                                     // kNumDramBanks
             kPrefetchPackets,                                   // kPrefetchPackets
@@ -792,6 +819,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             static_cast<uint32_t>(rank_mapping.orientation),    // kSnakeOrientation
             rank_mapping.mesh_rows,                             // kMeshRows
             rank_mapping.mesh_cols,                             // kMeshCols
+            static_cast<uint32_t>(partial_readiness_enabled),   // kPartialReadinessEnabled
             static_cast<uint32_t>(output_bank_owned_schedule),  // kOutputBankOwnedSchedule
             num_dram_banks,                                     // kNumDramBanks
         };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -30,10 +30,11 @@
 namespace ttnn::experimental::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Per-coord ProgramDescriptor build. Pulled into an anonymous-namespace helper so
 // create_workload_descriptor() can loop coords and reuse this body verbatim. The
-// op-specific name suffix avoids Unity-build collisions across sibling factories.
+// CMake-provided namespace keeps file-local names distinct in unity builds.
 tt::tt_metal::ProgramDescriptor build_ring_attention_all_gather_program_descriptor(
     const RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::operation_attributes_t& operation_attributes,
     const RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::tensor_args_t& tensor_args,
@@ -79,6 +80,7 @@ tt::tt_metal::ProgramDescriptor build_ring_attention_all_gather_program_descript
     return desc;
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 // Returns a WorkloadDescriptor with one ProgramDescriptor per coord: device_index /
@@ -94,7 +96,7 @@ RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_workload_d
     const auto coords = tensor_coords.coords();
     wd.programs.reserve(coords.size());
     for (const auto& coord : coords) {
-        auto desc = build_ring_attention_all_gather_program_descriptor(
+        auto desc = CMAKE_UNIQUE_NAMESPACE::build_ring_attention_all_gather_program_descriptor(
             operation_attributes, tensor_args, tensor_return_value, coord);
         wd.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
@@ -135,6 +137,48 @@ void RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::override_run
 
 namespace ttnn {
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+constexpr uint32_t kBatchDimension = 0;
+constexpr uint32_t kHeadDimension = 1;
+constexpr uint32_t kSequenceDimension = 2;
+constexpr uint32_t kWidthDimension = 3;
+
+// Independent performance tunables. Keep these named rather than deriving one from another: the reader prefetch
+// window and writer header pool protect different pipelines.
+constexpr uint32_t kPrefetchPackets = 4;
+constexpr uint32_t kPacketHeaderSlots = 8;
+constexpr uint32_t kDoubleBufferingFactor = 2;
+constexpr uint32_t kMaxScatterPagesPerPacket = 2;
+
+constexpr uint32_t kSingleWorkerPerLink = 1;
+constexpr uint32_t kContiguousPagesAdvanced = 1;
+constexpr bool kForwardDirection = true;
+constexpr bool kBackwardDirection = false;
+
+bool supports_output_bank_owned_schedule(
+    const std::vector<Tensor>& output_tensors, int32_t dim, uint32_t transport_page_size) {
+    if (dim != kSequenceDimension || output_tensors.empty() || transport_page_size == 0) {
+        return false;
+    }
+    const auto* device = output_tensors.front().device();
+    const uint32_t num_dram_banks = device->allocator()->get_num_banks(tt::tt_metal::BufferType::DRAM);
+    return device->arch() == tt::ARCH::BLACKHOLE && num_dram_banks > 0 &&
+           std::all_of(
+               output_tensors.begin(),
+               output_tensors.end(),
+               [transport_page_size, device](const Tensor& tensor) {
+                   return tensor.device() == device && tensor.buffer()->is_dram() &&
+                          tensor.buffer()->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
+                          tensor.buffer()->aligned_page_size() == transport_page_size;
+               }) &&
+           tt::tt_fabric::get_tt_fabric_max_payload_size_bytes() / transport_page_size >= kMaxScatterPagesPerPacket;
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 void ring_attention_neighbor_halo_exchange_helper(
     tt::tt_metal::ProgramDescriptor& desc,
     const std::vector<Tensor>& input_tensors,
@@ -154,6 +198,7 @@ void ring_attention_neighbor_halo_exchange_helper(
     std::optional<uint32_t> input_batch_slice_idx,
     std::optional<uint32_t> gather_valid_Ht,
     const RingAttentionNeighborHaloConfig& halo) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -176,17 +221,22 @@ void ring_attention_neighbor_halo_exchange_helper(
     }
 
     const auto [worker_core_range, worker_cores] = ttnn::ccl::choose_worker_cores(
-        num_links, 1, mesh_device, sub_device_id, core_grid_offset, std::nullopt, core_allocation_strategy);
+        num_links,
+        kSingleWorkerPerLink,
+        mesh_device,
+        sub_device_id,
+        core_grid_offset,
+        std::nullopt,
+        core_allocation_strategy);
     const CoreRangeSet workers(worker_core_range);
 
     const uint32_t page_size = op_config.get_page_size();
     const uint32_t packet_buffer_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-    const uint32_t pages_per_packet = std::min(packet_buffer_bytes / page_size, 2u);
-    const uint32_t cb_pages = 8 * pages_per_packet;
+    const uint32_t pages_per_packet = std::min(packet_buffer_bytes / page_size, kMaxScatterPagesPerPacket);
+    const uint32_t cb_pages = kDoubleBufferingFactor * kPrefetchPackets * pages_per_packet;
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.front().dtype());
     constexpr uint32_t data_cb = tt::CB::c_in2;
     constexpr uint32_t packet_header_cb = tt::CB::c_in1;
-    constexpr uint32_t packet_headers = 8;
     const uint32_t packet_header_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
 
     desc.cbs.push_back(CBDescriptor{
@@ -196,7 +246,7 @@ void ring_attention_neighbor_halo_exchange_helper(
             .buffer_index = static_cast<uint8_t>(data_cb), .data_format = data_format, .page_size = page_size}}},
     });
     desc.cbs.push_back(CBDescriptor{
-        .total_size = packet_headers * packet_header_bytes * 2,
+        .total_size = kPacketHeaderSlots * packet_header_bytes * kDoubleBufferingFactor,
         .core_ranges = workers,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(packet_header_cb),
@@ -212,7 +262,8 @@ void ring_attention_neighbor_halo_exchange_helper(
     reader_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_kernel.core_ranges = workers;
     reader_kernel.config = WriterConfigDescriptor{};
-    reader_kernel.compile_time_args = {ring_index, ring_size, data_cb, pages_per_packet, page_size, num_inputs};
+    reader_kernel.compile_time_args = {
+        ring_index, ring_size, data_cb, pages_per_packet, page_size, num_inputs, kPrefetchPackets};
     for (uint32_t input = 0; input < num_inputs; ++input) {
         reader_kernel.compile_time_args.push_back(page_size);
     }
@@ -276,11 +327,11 @@ void ring_attention_neighbor_halo_exchange_helper(
         for (uint32_t input = 0; input < num_inputs; ++input) {
             const auto input_shape = input_tensors[input].padded_shape();
             const auto output_shape = output_tensors[input].padded_shape();
-            const uint32_t input_heads = input_shape[1];
-            const uint32_t input_Wt = input_shape[3] / tt::constants::TILE_WIDTH;
-            const uint32_t input_Ht = input_shape[2] / tt::constants::TILE_HEIGHT;
-            const uint32_t output_Wt = output_shape[3] / tt::constants::TILE_WIDTH;
-            const uint32_t output_Ht = output_shape[2] / tt::constants::TILE_HEIGHT;
+            const uint32_t input_heads = input_shape[kHeadDimension];
+            const uint32_t input_Wt = input_shape[kWidthDimension] / tt::constants::TILE_WIDTH;
+            const uint32_t input_Ht = input_shape[kSequenceDimension] / tt::constants::TILE_HEIGHT;
+            const uint32_t output_Wt = output_shape[kWidthDimension] / tt::constants::TILE_WIDTH;
+            const uint32_t output_Ht = output_shape[kSequenceDimension] / tt::constants::TILE_HEIGHT;
             TT_FATAL(
                 output_Wt == input_Wt,
                 "Neighbor halo requires matching input/output tile widths, got input Wt={} and output Wt={}",
@@ -319,12 +370,12 @@ void ring_attention_neighbor_halo_exchange_helper(
             const uint32_t input_tile_end =
                 range_start_page + (link + 1) * pages_per_worker + std::min(link + 1, remainder);
             TT_FATAL(
-                !input_batch_slice_idx.has_value() || *input_batch_slice_idx < input_shape[0],
+                !input_batch_slice_idx.has_value() || *input_batch_slice_idx < input_shape[kBatchDimension],
                 "input_batch_slice_idx={} out of range for input batch={}",
                 input_batch_slice_idx.value_or(0),
-                input_shape[0]);
+                input_shape[kBatchDimension]);
             const uint32_t batch_head_count =
-                input_batch_slice_idx.has_value() ? input_heads : input_shape[0] * input_heads;
+                input_batch_slice_idx.has_value() ? input_heads : input_shape[kBatchDimension] * input_heads;
             const uint32_t input_batch_base = ttnn::ring_attention_all_gather_async_detail::input_batch_base_pages(
                 input_batch_slice_idx.value_or(0), input_heads, input_Ht, input_Wt);
 
@@ -403,8 +454,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     uint32_t kv_cache_layer_idx,
     bool split_forwarding_enabled,
     RingAttentionRankMapping rank_mapping) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::DataMovementConfigDescriptor;
     using tt::tt_metal::KernelDescriptor;
     using tt::tt_metal::ReaderConfigDescriptor;
     using tt::tt_metal::SemaphoreDescriptor;
@@ -526,47 +579,64 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         target_device_coord, forward_device_coord, backward_device_coord, mesh_device);
     auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
         ttnn::ccl::get_forward_backward_configuration(ring_size, ring_index, topology);
+    (void)dynamic_alternate;
     if (topology == ttnn::ccl::Topology::Ring && ring_index % 2 == 0) {
         std::swap(num_targets_forward, num_targets_backward);
     }
-    // Get worker cores
-    // 2 sender (forward/backward, each with a reader/writer)
-    uint32_t num_senders_per_link =
-        ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kNumSendersPerLink;
-    const auto [sender_worker_core_range, sender_worker_cores] = ttnn::ccl::choose_worker_cores(
+    // L1 Scratch CB Creation
+    const uint32_t max_payload_size_bytes = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    const uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
+    const uint32_t num_dram_banks = mesh_device->allocator()->get_num_banks(tt::tt_metal::BufferType::DRAM);
+    const bool output_bank_owned_schedule =
+        supports_output_bank_owned_schedule(output_tensor, dim, l1_scratch_cb_page_size_bytes);
+    struct WorkerPlacement {
+        CoreCoord core;
+        uint32_t link;
+    };
+    const uint32_t num_reserved_ccl_cores = num_links * ring_attention_all_gather_async_detail::kRingDirectionCount;
+    auto worker_core_selection = ttnn::ccl::choose_worker_cores(
         num_links,
-        num_senders_per_link,
+        ring_attention_all_gather_async_detail::kRingDirectionCount,
         mesh_device,
         sub_device_id,
         core_grid_offset,
         std::nullopt,
         core_allocation_strategy);
+    auto& sender_reserved_cores = std::get<1>(worker_core_selection);
+    TT_FATAL(
+        sender_reserved_cores.size() == num_reserved_ccl_cores,
+        "Ring attention requested {} CCL cores but only {} are available in the selected worker region",
+        num_reserved_ccl_cores,
+        sender_reserved_cores.size());
 
-    std::set<CoreRange> sender_forward_core_ranges_set;
-    std::set<CoreRange> sender_backward_core_ranges_set;
-
-    for (int i = 0; i < static_cast<int>(sender_worker_cores.size()); i++) {
-        const auto& core = sender_worker_cores[i];
-        if (i % 2 == 1) {
-            sender_forward_core_ranges_set.insert(CoreRange(core));
-        } else {
-            sender_backward_core_ranges_set.insert(CoreRange(core));
-        }
+    std::vector<WorkerPlacement> forward_workers;
+    std::vector<WorkerPlacement> backward_workers;
+    const auto direction_core_slot = [](uint32_t link, bool is_forward) {
+        return link * ring_attention_all_gather_async_detail::kRingDirectionCount + static_cast<uint32_t>(is_forward);
+    };
+    for (uint32_t link = 0; link < num_links; ++link) {
+        backward_workers.push_back(WorkerPlacement{
+            .core = sender_reserved_cores[direction_core_slot(link, kBackwardDirection)], .link = link});
+        forward_workers.push_back(
+            WorkerPlacement{.core = sender_reserved_cores[direction_core_slot(link, kForwardDirection)], .link = link});
     }
 
-    // Convert std::set<CoreRange> -> CoreRangeSet for descriptor APIs.
-    CoreRangeSet sender_forward_core_ranges(sender_forward_core_ranges_set);
-    CoreRangeSet sender_backward_core_ranges(sender_backward_core_ranges_set);
+    const auto placements_to_core_ranges = [](const std::vector<WorkerPlacement>& placements) {
+        std::set<CoreRange> ranges;
+        for (const auto& placement : placements) {
+            ranges.insert(CoreRange(placement.core));
+        }
+        return CoreRangeSet(ranges);
+    };
+    const CoreRangeSet sender_forward_core_ranges = placements_to_core_ranges(forward_workers);
+    const CoreRangeSet sender_backward_core_ranges = placements_to_core_ranges(backward_workers);
 
-    // L1 Scratch CB Creation
-    const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-    const uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
-    const uint32_t max_scatter_write_pages = 2;
+    const uint32_t max_pages_per_packet = max_payload_size_bytes / l1_scratch_cb_page_size_bytes;
     const uint32_t num_pages_per_packet =
-        std::min(static_cast<uint32_t>(packet_size_bytes / l1_scratch_cb_page_size_bytes), max_scatter_write_pages);
-    // Must be >= 2 * PREFETCH_PACKETS(=4) * num_pages_per_packet for deadlock-free double-buffering
+        output_bank_owned_schedule ? max_pages_per_packet : std::min(max_pages_per_packet, kMaxScatterPagesPerPacket);
+    // Must be >= kDoubleBufferingFactor * prefetch_packets * num_pages_per_packet for deadlock-free buffering
     // (see PREFETCH_PACKETS in ring_attention_all_gather_reader.cpp).
-    const uint32_t cb_num_pages = 8 * num_pages_per_packet;
+    const uint32_t cb_num_pages = kDoubleBufferingFactor * kPrefetchPackets * num_pages_per_packet;
     const tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor[0].dtype());
 
     // CBs for transferring data between sender_reader and sender_writer
@@ -594,10 +664,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
 
     // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
     const auto reserved_packet_header_forward_CB_index = tt::CB::c_in1;
-    static constexpr auto num_packet_headers_storable = 8;
     const auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_packet_headers_storable * packet_header_size_bytes * 2,
+        .total_size = kPacketHeaderSlots * packet_header_size_bytes * kDoubleBufferingFactor,
         .core_ranges = sender_forward_core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(reserved_packet_header_forward_CB_index),
@@ -608,7 +677,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
 
     const auto reserved_packet_header_backward_CB_index = tt::CB::c_in1;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_packet_headers_storable * packet_header_size_bytes * 2,
+        .total_size = kPacketHeaderSlots * packet_header_size_bytes * kDoubleBufferingFactor,
         .core_ranges = sender_backward_core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(reserved_packet_header_backward_CB_index),
@@ -622,7 +691,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const bool has_metadata = slot_id.has_value();
     const uint32_t meta_cb_index = tt::CB::c_in3;
     if (has_metadata) {
-        constexpr uint32_t meta_cb_page_size_bytes = 32;
+        const uint32_t meta_cb_page_size_bytes = kv_actual_isl->buffer()->page_size();
+        TT_FATAL(
+            meta_cb_page_size_bytes >= sizeof(uint32_t),
+            "Ring attention metadata CB page has {} bytes; a uint32 scalar requires at least {}",
+            meta_cb_page_size_bytes,
+            sizeof(uint32_t));
         for (const auto& core_ranges : {sender_forward_core_ranges, sender_backward_core_ranges}) {
             desc.cbs.push_back(CBDescriptor{
                 .total_size = meta_cb_page_size_bytes,
@@ -642,62 +716,109 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // the split second-half wait); the legacy topology gate stays so standalone callers keep prior behavior.
     const bool effective_split_forwarding =
         split_forwarding_enabled && topology == ttnn::ccl::Topology::Ring && ring_size % 2 == 0 && ring_size > 2;
+    constexpr const char* exchange_reader_kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
+        "ring_attention_all_gather_reader.cpp";
     constexpr const char* exchange_writer_kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
         "ring_attention_all_gather_writer.cpp";
 
-    uint32_t tiles_to_write_per_packet = 1;
+    const auto make_reader_compile_time_args = [&](uint32_t cb_index, bool worker_direction) {
+        std::vector<uint32_t> args = {
+            ring_index,                                         // kMyTransportRank
+            cb_index,                                           // kCbOutputId
+            num_pages_per_packet,                               // kPacketSizeInPages
+            op_config.get_page_size(),                          // kInputTensorPageSize
+            num_targets_forward,                                // kNumTargetsForwardDirection
+            num_targets_backward,                               // kNumTargetsBackwardDirection
+            static_cast<uint32_t>(topology),                    // kTopology
+            kContiguousPagesAdvanced,                           // kContigPagesAdvanced
+            num_inputs,                                         // kNumInputs
+            static_cast<uint32_t>(worker_direction),            // kDirection
+            static_cast<uint32_t>(fuse_op),                     // kFuseOp
+            static_cast<uint32_t>(has_metadata),                // kHasMetadata
+            num_links,                                          // kNumLinks
+            static_cast<uint32_t>(effective_split_forwarding),  // kSplitForwardingEnabled
+            static_cast<uint32_t>(rank_mapping.full_mesh),      // kFullMeshRankMapping
+            static_cast<uint32_t>(rank_mapping.orientation),    // kSnakeOrientation
+            rank_mapping.mesh_rows,                             // kMeshRows
+            rank_mapping.mesh_cols,                             // kMeshCols
+            static_cast<uint32_t>(output_bank_owned_schedule),  // kOutputBankOwnedSchedule
+            num_dram_banks,                                     // kNumDramBanks
+            kPrefetchPackets,                                   // kPrefetchPackets
+        };
+        TT_FATAL(
+            args.size() == ttnn::ring_attention_all_gather::kReaderFixedCompileTimeArgCount,
+            "ring-attention reader fixed compile-time argument count changed unexpectedly");
+        // TensorAccessorArgs tuples expect one page-size entry per tensor before the accessor blocks.
+        args.insert(args.end(), num_inputs, op_config.get_page_size());
+        for (const auto& tensor : input_tensor) {
+            tt::tt_metal::TensorAccessorArgs(tensor.buffer()).append_to(args);
+        }
+        for (const auto& tensor : output_tensor) {
+            tt::tt_metal::TensorAccessorArgs(tensor.buffer()).append_to(args);
+        }
+        if (has_metadata) {
+            tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(args);
+            tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer()).append_to(args);
+        }
+        return args;
+    };
+
+    const auto make_writer_compile_time_args = [&](uint32_t cb_index,
+                                                   uint32_t packet_header_cb_index,
+                                                   bool worker_direction,
+                                                   uint32_t unicast_route_arg0,
+                                                   uint32_t unicast_route_arg1) {
+        std::vector<uint32_t> args = {
+            ring_index,                                         // kMyTransportRank
+            packet_header_cb_index,                             // kReservedPacketHeaderCbId
+            cb_index,                                           // kCbOutputId
+            num_pages_per_packet,                               // kPacketSizeInPages
+            op_config.get_page_size(),                          // kOutputPageSize
+            num_targets_forward,                                // kNumTargetsForwardDirection
+            num_targets_backward,                               // kNumTargetsBackwardDirection
+            static_cast<uint32_t>(fuse_op),                     // kFuseOp
+            static_cast<uint32_t>(topology),                    // kTopology
+            num_inputs,                                         // kNumInputs
+            static_cast<uint32_t>(worker_direction),            // kDirection
+            unicast_route_arg0,                                 // kUnicastRouteArg0
+            unicast_route_arg1,                                 // kUnicastRouteArg1
+            static_cast<uint32_t>(has_metadata),                // kHasMetadata
+            meta_cb_index,                                      // kCbMetaId
+            num_links,                                          // kNumLinks
+            static_cast<uint32_t>(effective_split_forwarding),  // kSplitForwardingEnabled
+            static_cast<uint32_t>(rank_mapping.full_mesh),      // kFullMeshRankMapping
+            static_cast<uint32_t>(rank_mapping.orientation),    // kSnakeOrientation
+            rank_mapping.mesh_rows,                             // kMeshRows
+            rank_mapping.mesh_cols,                             // kMeshCols
+            static_cast<uint32_t>(output_bank_owned_schedule),  // kOutputBankOwnedSchedule
+            num_dram_banks,                                     // kNumDramBanks
+        };
+        TT_FATAL(
+            args.size() == ttnn::ring_attention_all_gather::kWriterFixedCompileTimeArgCount,
+            "ring-attention writer fixed compile-time argument count changed unexpectedly");
+        // TensorAccessorArgs tuples expect one page-size entry per tensor before the accessor blocks.
+        args.insert(args.end(), num_inputs, op_config.get_page_size());
+        for (const auto& tensor : output_tensor) {
+            tt::tt_metal::TensorAccessorArgs(tensor.buffer()).append_to(args);
+        }
+        if (has_metadata) {
+            tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer()).append_to(args);
+        }
+        return args;
+    };
+
     // KERNEL CREATION
     // Forward Direction
     // Reader
     KernelDescriptor sender_reader_forward_kernel{};
-    sender_reader_forward_kernel.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
-        "ring_attention_all_gather_reader.cpp";
+    sender_reader_forward_kernel.kernel_source = exchange_reader_kernel_source;
     sender_reader_forward_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     sender_reader_forward_kernel.core_ranges = sender_forward_core_ranges;
     sender_reader_forward_kernel.config = WriterConfigDescriptor{};
-    sender_reader_forward_kernel.compile_time_args = {
-        ring_index,                       // my_transport_rank
-        sender_forward_cb_index,          // cb_forward_id
-        num_pages_per_packet,             // packet_size_in_pages
-        op_config.get_page_size(),        // tensor0_page_size
-        num_targets_forward,              // num_slices_forward_direction
-        num_targets_backward,             // num_slices_backward_direction
-        static_cast<uint32_t>(topology),  // topology
-        tiles_to_write_per_packet,        // contig_pages_advanced
-        num_inputs,                       // num_inputs
-        1,                                // direction
-        fuse_op,                          // fused op
-        static_cast<uint32_t>(has_metadata),
-        meta_cb_index,
-        num_links,
-        static_cast<uint32_t>(effective_split_forwarding),
-        static_cast<uint32_t>(rank_mapping.full_mesh),
-        static_cast<uint32_t>(rank_mapping.orientation),
-        rank_mapping.mesh_rows,
-        rank_mapping.mesh_cols,
-    };
-    TT_FATAL(
-        sender_reader_forward_kernel.compile_time_args.size() ==
-            ttnn::ring_attention_all_gather::kReaderFixedCompileTimeArgCount,
-        "ring-attention reader fixed compile-time argument count changed unexpectedly");
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        sender_reader_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
-    }
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        tt::tt_metal::TensorAccessorArgs(input_tensor[i].buffer())
-            .append_to(sender_reader_forward_kernel.compile_time_args);
-    }
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
-            .append_to(sender_reader_forward_kernel.compile_time_args);
-    }
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_forward_kernel.compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
-            .append_to(sender_reader_forward_kernel.compile_time_args);
-    }
+    sender_reader_forward_kernel.compile_time_args =
+        make_reader_compile_time_args(sender_forward_cb_index, kForwardDirection);
 
     // Writer
     KernelDescriptor sender_writer_forward_kernel{};
@@ -705,98 +826,21 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     sender_writer_forward_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     sender_writer_forward_kernel.core_ranges = sender_forward_core_ranges;
     sender_writer_forward_kernel.config = ReaderConfigDescriptor{};
-    sender_writer_forward_kernel.compile_time_args = {
-        ring_index,                               // my_transport_rank
-        reserved_packet_header_forward_CB_index,  // reserved_packet_header_cb_id
-        num_packet_headers_storable,              // num_packet_headers_storable
-        sender_forward_cb_index,                  // cb_forward_id
-        num_pages_per_packet,                     // packet_size_in_pages
-        op_config.get_page_size(),                // tensor0_page_size
-        num_targets_forward,                      // num_targets_forward_direction
-        num_targets_backward,                     // num_targets_backward_direction
-        dynamic_alternate,                        // alternate
-        fuse_op,                                  // fused op
-        static_cast<uint32_t>(topology),          // topology
-        tiles_to_write_per_packet,                // contig_pages_advanced
-        num_inputs,                               // num_inputs
-        1,                                        // direction
-        unicast_backward_args[0],                 // unicast route arg0 (dst_mesh_id or 0)
-        unicast_backward_args[1],                 // unicast route arg1 (dst_chip_id or distance_in_hops)
-        static_cast<uint32_t>(has_metadata),
-        meta_cb_index,
-        num_links,
-        static_cast<uint32_t>(effective_split_forwarding),
-        static_cast<uint32_t>(rank_mapping.full_mesh),
-        static_cast<uint32_t>(rank_mapping.orientation),
-        rank_mapping.mesh_rows,
-        rank_mapping.mesh_cols,
-    };
-    TT_FATAL(
-        sender_writer_forward_kernel.compile_time_args.size() ==
-            ttnn::ring_attention_all_gather::kWriterFixedCompileTimeArgCount,
-        "ring-attention writer fixed compile-time argument count changed unexpectedly");
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        sender_writer_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
-    }
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
-            .append_to(sender_writer_forward_kernel.compile_time_args);
-    }
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
-            .append_to(sender_writer_forward_kernel.compile_time_args);
-    }
-
+    sender_writer_forward_kernel.compile_time_args = make_writer_compile_time_args(
+        sender_forward_cb_index,
+        reserved_packet_header_forward_CB_index,
+        kForwardDirection,
+        unicast_backward_args[0],
+        unicast_backward_args[1]);
     // Backward Direction
     // Reader
     KernelDescriptor sender_reader_backward_kernel{};
-    sender_reader_backward_kernel.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
-        "ring_attention_all_gather_reader.cpp";
+    sender_reader_backward_kernel.kernel_source = exchange_reader_kernel_source;
     sender_reader_backward_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     sender_reader_backward_kernel.core_ranges = sender_backward_core_ranges;
     sender_reader_backward_kernel.config = WriterConfigDescriptor{};
-    sender_reader_backward_kernel.compile_time_args = {
-        ring_index,                       // my_transport_rank
-        sender_backward_cb_index,         // cb_backward_id
-        num_pages_per_packet,             // packet_size_in_pages
-        op_config.get_page_size(),        // tensor0_page_size
-        num_targets_forward,              // num_slices_forward_direction
-        num_targets_backward,             // num_slices_backward_direction
-        static_cast<uint32_t>(topology),  // topology
-        tiles_to_write_per_packet,        // contig_pages_advanced
-        num_inputs,                       // num_inputs
-        0,                                // direction
-        fuse_op,                          // fused op
-        static_cast<uint32_t>(has_metadata),
-        meta_cb_index,
-        num_links,
-        static_cast<uint32_t>(effective_split_forwarding),
-        static_cast<uint32_t>(rank_mapping.full_mesh),
-        static_cast<uint32_t>(rank_mapping.orientation),
-        rank_mapping.mesh_rows,
-        rank_mapping.mesh_cols,
-    };
-    TT_FATAL(
-        sender_reader_backward_kernel.compile_time_args.size() ==
-            ttnn::ring_attention_all_gather::kReaderFixedCompileTimeArgCount,
-        "ring-attention reader fixed compile-time argument count changed unexpectedly");
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        sender_reader_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
-    }
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        tt::tt_metal::TensorAccessorArgs(input_tensor[i].buffer())
-            .append_to(sender_reader_backward_kernel.compile_time_args);
-    }
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
-            .append_to(sender_reader_backward_kernel.compile_time_args);
-    }
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_backward_kernel.compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
-            .append_to(sender_reader_backward_kernel.compile_time_args);
-    }
+    sender_reader_backward_kernel.compile_time_args =
+        make_reader_compile_time_args(sender_backward_cb_index, kBackwardDirection);
 
     // Writer
     KernelDescriptor sender_writer_backward_kernel{};
@@ -804,47 +848,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     sender_writer_backward_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     sender_writer_backward_kernel.core_ranges = sender_backward_core_ranges;
     sender_writer_backward_kernel.config = ReaderConfigDescriptor{};
-    sender_writer_backward_kernel.compile_time_args = {
-        ring_index,                                // my_transport_rank
-        reserved_packet_header_backward_CB_index,  // reserved_packet_header_cb_id
-        num_packet_headers_storable,               // num_packet_headers_storable
-        sender_backward_cb_index,                  // cb_backward_id
-        num_pages_per_packet,                      // packet_size_in_pages
-        op_config.get_page_size(),                 // tensor0_page_size
-        num_targets_forward,                       // num_targets_forward_direction
-        num_targets_backward,                      // num_targets_backward_direction
-        dynamic_alternate,                         // alternate
-        fuse_op,                                   // fused op
-        static_cast<uint32_t>(topology),           // topology
-        tiles_to_write_per_packet,                 // contig_pages_advanced
-        num_inputs,                                // num_inputs
-        0,                                         // direction
-        unicast_forward_args[0],                   // unicast route arg0 (dst_mesh_id or 0)
-        unicast_forward_args[1],                   // unicast route arg1 (dst_chip_id or distance_in_hops)
-        static_cast<uint32_t>(has_metadata),
-        meta_cb_index,
-        num_links,
-        static_cast<uint32_t>(effective_split_forwarding),
-        static_cast<uint32_t>(rank_mapping.full_mesh),
-        static_cast<uint32_t>(rank_mapping.orientation),
-        rank_mapping.mesh_rows,
-        rank_mapping.mesh_cols,
-    };
-    TT_FATAL(
-        sender_writer_backward_kernel.compile_time_args.size() ==
-            ttnn::ring_attention_all_gather::kWriterFixedCompileTimeArgCount,
-        "ring-attention writer fixed compile-time argument count changed unexpectedly");
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        sender_writer_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
-    }
-    for (uint32_t i = 0; i < num_inputs; i++) {
-        tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
-            .append_to(sender_writer_backward_kernel.compile_time_args);
-    }
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
-            .append_to(sender_writer_backward_kernel.compile_time_args);
-    }
+    sender_writer_backward_kernel.compile_time_args = make_writer_compile_time_args(
+        sender_backward_cb_index,
+        reserved_packet_header_backward_CB_index,
+        kBackwardDirection,
+        unicast_forward_args[0],
+        unicast_forward_args[1]);
 
     /* All gather fusion */
     // Inline equivalent of AllGatherFusedOpSignaler::init_all_gather for the descriptor
@@ -884,217 +893,166 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             fused_op_signaler_sender_workers, sender_forward_core_ranges, sender_workers_forward);
     }
     // Kernel Runtime Args
-    for (uint32_t link = 0; link < num_links; link++) {
-        // Set Sender Reader runtime args
+    const auto build_tensor_descriptor_args = [&](const WorkerPlacement& placement) {
+        std::vector<uint32_t> tensor_descriptor_args;
+        for (uint32_t i = 0; i < num_inputs; i++) {
+            const auto input_tensor_shape = input_tensor[i].padded_shape();
+            const auto output_tensor_shape = output_tensor[i].padded_shape();
+            const uint32_t num_heads = input_tensor_shape[kHeadDimension];
+            // single_batch_head_num_pages is always pages-per-(batch,head); independent of slicing.
+            const uint32_t full_batch_head_size = input_tensor_shape[kBatchDimension] * num_heads;
 
-        const auto build_tensor_descriptor_args = [&]() {
-            std::vector<uint32_t> tensor_descriptor_args;
-            for (uint32_t i = 0; i < num_inputs; i++) {
-                const auto input_tensor_shape = input_tensor[i].padded_shape();
-                const auto output_tensor_shape = output_tensor[i].padded_shape();
-                const uint32_t num_heads = input_tensor_shape[1];
-                // single_batch_head_num_pages is always pages-per-(batch,head); independent of slicing.
-                const uint32_t full_batch_head_size = input_tensor_shape[0] * num_heads;
+            const uint32_t input_tensor_Wt = input_tensor_shape[kWidthDimension] / tt::constants::TILE_WIDTH;
+            const uint32_t input_tensor_Ht = input_tensor_shape[kSequenceDimension] / tt::constants::TILE_HEIGHT;
+            const uint32_t output_tensor_Wt = output_tensor_shape[kWidthDimension] / tt::constants::TILE_WIDTH;
+            const uint32_t output_tensor_Ht = output_tensor_shape[kSequenceDimension] / tt::constants::TILE_HEIGHT;
+            TT_ASSERT(!(input_tensor_shape[kWidthDimension] % tt::constants::TILE_WIDTH));
+            TT_ASSERT(!(output_tensor_shape[kWidthDimension] % tt::constants::TILE_WIDTH));
 
-                const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
-                const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_HEIGHT;
-                const uint32_t output_tensor_Wt = output_tensor_shape[3] / tt::constants::TILE_WIDTH;
-                const uint32_t output_tensor_Ht = output_tensor_shape[2] / tt::constants::TILE_HEIGHT;
-                TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
-                TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
+            // TensorAccessor page IDs address the logical padded tensor volume. For ND-sharded buffers,
+            // buffer()->num_pages() can additionally include physical padding in the final shard; treating
+            // those pages as tensor data would overrun a selected batch/head slice and can write past the
+            // corresponding logical output band.
+            const uint32_t single_batch_head_num_pages = input_tensor_Ht * input_tensor_Wt;
 
-                // TensorAccessor page IDs address the logical padded tensor volume. For ND-sharded buffers,
-                // buffer()->num_pages() can additionally include physical padding in the final shard; treating
-                // those pages as tensor data would overrun a selected batch/head slice and can write past the
-                // corresponding logical output band.
-                const uint32_t single_batch_head_num_pages = input_tensor_Ht * input_tensor_Wt;
-
-                // Single-slot gather: read only slot `input_batch_slice_idx`'s `num_heads` blocks (from
-                // `input_batch_base`); the writer emits them to output slot 0. A batch-1 output suffices,
-                // but a full-batch output also works (only slot 0 written). std::nullopt => full batch.
-                uint32_t batch_head_size = full_batch_head_size;
-                uint32_t input_batch_base = 0;
-                if (input_batch_slice_idx.has_value()) {
-                    TT_FATAL(
-                        *input_batch_slice_idx < input_tensor_shape[0],
-                        "input_batch_slice_idx={} out of range for input batch={}",
-                        *input_batch_slice_idx,
-                        input_tensor_shape[0]);
-                    batch_head_size = num_heads;
-                    input_batch_base = ttnn::ring_attention_all_gather_async_detail::input_batch_base_pages(
-                        *input_batch_slice_idx, num_heads, input_tensor_Ht, input_tensor_Wt);
-                }
-
-                tensor_descriptor_args.push_back(input_tensor_Wt);   // 0 == input_tensor_Wt
-                tensor_descriptor_args.push_back(input_tensor_Ht);   // 1 == input_tensor_Ht
-                tensor_descriptor_args.push_back(output_tensor_Wt);  // 2 == output_tensor_Wt
-                tensor_descriptor_args.push_back(output_tensor_Ht);  // 3 == output_tensor_Ht
-                tensor_descriptor_args.push_back(batch_head_size);   // 4 == batch_head_size (bh-loop count)
-                // The device derives the actual per-link range from valid_pages. These are retained as
-                // structural placeholders for the descriptor ABI and are overwritten before use.
-                tensor_descriptor_args.push_back(0u);                           // 5 == input_tile_id_start
-                tensor_descriptor_args.push_back(single_batch_head_num_pages);  // 6 == input_tile_id_end
-                tensor_descriptor_args.push_back(
-                    input_batch_base);  // 7 == input_batch_base (phase-1 input page offset)
-                // 8 == valid pages per (batch,head) to gather. Default: full input slab (no clamp). When
-                // gather_valid_Ht is set (fused ring_joint_sdpa with an oversized cache), bound it to the
-                // first gather_valid_Ht tile-rows so only kv_actual-sized data moves. The fused path also
-                // re-patches this per dispatch on cache hits (apply_ring_joint_scalar_runtime_args); setting
-                // it here makes the cache-miss (first) dispatch bounded too.
-                const uint32_t valid_pages_per_batch_head =
-                    gather_valid_Ht.has_value() ? std::min(*gather_valid_Ht, input_tensor_Ht) * input_tensor_Wt
-                                                : single_batch_head_num_pages;
-                tensor_descriptor_args.push_back(valid_pages_per_batch_head);  // 8 == valid_pages_per_batch_head
-                tensor_descriptor_args.push_back(link);                        // 9 == worker_link
+            // Single-slot gather: read only slot `input_batch_slice_idx`'s `num_heads` blocks (from
+            // `input_batch_base`); the writer emits them to output slot 0. A batch-1 output suffices,
+            // but a full-batch output also works (only slot 0 written). std::nullopt => full batch.
+            uint32_t batch_head_size = full_batch_head_size;
+            uint32_t input_batch_base = 0;
+            if (input_batch_slice_idx.has_value()) {
+                TT_FATAL(
+                    *input_batch_slice_idx < input_tensor_shape[kBatchDimension],
+                    "input_batch_slice_idx={} out of range for input batch={}",
+                    *input_batch_slice_idx,
+                    input_tensor_shape[kBatchDimension]);
+                batch_head_size = num_heads;
+                input_batch_base = ttnn::ring_attention_all_gather_async_detail::input_batch_base_pages(
+                    *input_batch_slice_idx, num_heads, input_tensor_Ht, input_tensor_Wt);
             }
-            return tensor_descriptor_args;
-        };
 
-        const auto tensor_descriptor_args = build_tensor_descriptor_args();
-
-        KernelDescriptor::RTArgList reader_forward_rt_args;
-        reader_forward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
-        reader_forward_rt_args.push_back(ring_size);                   // ring_size
-        reader_forward_rt_args.push_back(static_cast<uint32_t>(
-            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kForwardSemaphoreIdx)
-                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
-        reader_forward_rt_args.append(tensor_descriptor_args);
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            reader_forward_rt_args.push_back(input_tensor[input_idx].buffer());
+            tensor_descriptor_args.push_back(input_tensor_Wt);   // 0 == input_tensor_Wt
+            tensor_descriptor_args.push_back(input_tensor_Ht);   // 1 == input_tensor_Ht
+            tensor_descriptor_args.push_back(output_tensor_Wt);  // 2 == output_tensor_Wt
+            tensor_descriptor_args.push_back(output_tensor_Ht);  // 3 == output_tensor_Ht
+            tensor_descriptor_args.push_back(batch_head_size);   // 4 == batch_head_size (bh-loop count)
+            tensor_descriptor_args.push_back(input_batch_base);  // 5 == single-slot input page offset
+            // 6 == valid pages per (batch,head) to gather. Default: full input slab (no clamp). When
+            // gather_valid_Ht is set (fused ring_joint_sdpa with an oversized cache), bound it to the
+            // first gather_valid_Ht tile-rows so only kv_actual-sized data moves. The fused path also
+            // re-patches this per dispatch on cache hits (apply_ring_joint_scalar_runtime_args); setting
+            // it here makes the cache-miss (first) dispatch bounded too.
+            const uint32_t valid_pages_per_batch_head =
+                gather_valid_Ht.has_value() ? std::min(*gather_valid_Ht, input_tensor_Ht) * input_tensor_Wt
+                                            : single_batch_head_num_pages;
+            tensor_descriptor_args.push_back(valid_pages_per_batch_head);  // 6 == valid_pages_per_batch_head
+            tensor_descriptor_args.push_back(placement.link);              // 7 == worker_link
         }
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            reader_forward_rt_args.push_back(output_tensor[input_idx].buffer());
+        return tensor_descriptor_args;
+    };
+
+    const auto forward_signaler_cores = corerange_to_cores(sender_forward_core_ranges, std::nullopt, true);
+    const auto backward_signaler_cores = corerange_to_cores(sender_backward_core_ranges, std::nullopt, true);
+    const auto signaler_index = [](const std::vector<CoreCoord>& cores, const CoreCoord& core) {
+        const auto it = std::find(cores.begin(), cores.end(), core);
+        TT_FATAL(it != cores.end(), "Ring attention worker core is missing from its signaler core range");
+        return static_cast<uint32_t>(std::distance(cores.begin(), it));
+    };
+    const auto emit_worker_runtime_args = [&](const WorkerPlacement& placement, bool is_forward) {
+        const auto tensor_descriptor_args = build_tensor_descriptor_args(placement);
+        const uint32_t sem_index =
+            is_forward
+                ? ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kForwardSemaphoreIdx
+                : ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kBackwardSemaphoreIdx;
+        const auto& direction_signaler_cores = is_forward ? forward_signaler_cores : backward_signaler_cores;
+        const uint32_t worker_signaler_index = signaler_index(direction_signaler_cores, placement.core);
+
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(static_cast<uint32_t>(dim));
+        reader_args.push_back(ring_size);
+        reader_args.push_back(static_cast<uint32_t>(
+            semaphore.at(sem_index).address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
+        reader_args.append(tensor_descriptor_args);
+        for (uint32_t input_idx = 0; input_idx < num_inputs; ++input_idx) {
+            reader_args.push_back(input_tensor[input_idx].buffer());
+        }
+        for (uint32_t input_idx = 0; input_idx < num_inputs; ++input_idx) {
+            reader_args.push_back(output_tensor[input_idx].buffer());
         }
         if (has_metadata) {
-            reader_forward_rt_args.push_back(slot_id->buffer());
-            reader_forward_rt_args.push_back(kv_actual_isl->buffer());
-            reader_forward_rt_args.push_back(chunk_local_tiles);
-            reader_forward_rt_args.push_back(kv_cache_num_layers);
-            reader_forward_rt_args.push_back(kv_cache_layer_idx);
+            reader_args.push_back(slot_id->buffer());
+            reader_args.push_back(kv_actual_isl->buffer());
+            reader_args.push_back(chunk_local_tiles);
+            reader_args.push_back(kv_cache_num_layers);
+            reader_args.push_back(kv_cache_layer_idx);
         }
         if (fuse_op) {
-            std::vector<uint32_t> reader_forward_signaler_args;
-            fused_op_signaler_forward->push_all_gather_fused_op_rt_args(
-                reader_forward_signaler_args, num_links, link, 1);
-            reader_forward_rt_args.append(reader_forward_signaler_args);
+            std::vector<uint32_t> signaler_args;
+            auto& signaler = is_forward ? fused_op_signaler_forward : fused_op_signaler_backward;
+            signaler->push_all_gather_fused_op_rt_args(
+                signaler_args,
+                static_cast<uint32_t>(direction_signaler_cores.size()),
+                worker_signaler_index,
+                is_forward ? 1 : 0);
+            reader_args.append(signaler_args);
         }
-        sender_reader_forward_kernel.emplace_runtime_args(sender_worker_cores[(link * 2) + 1], reader_forward_rt_args);
+        auto& reader_kernel = is_forward ? sender_reader_forward_kernel : sender_reader_backward_kernel;
+        reader_kernel.emplace_runtime_args(placement.core, reader_args);
 
-        KernelDescriptor::RTArgList reader_backward_rt_args;
-        reader_backward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
-        reader_backward_rt_args.push_back(ring_size);                   // ring_size
-        reader_backward_rt_args.push_back(static_cast<uint32_t>(
-            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kBackwardSemaphoreIdx)
-                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
-        reader_backward_rt_args.append(tensor_descriptor_args);
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            reader_backward_rt_args.push_back(input_tensor[input_idx].buffer());
-        }
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            reader_backward_rt_args.push_back(output_tensor[input_idx].buffer());
+        const CoreCoord worker_virtual_core = mesh_device->worker_core_from_logical_core(placement.core);
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.push_back(static_cast<uint32_t>(dim));
+        writer_args.push_back(static_cast<uint32_t>(worker_virtual_core.x));
+        writer_args.push_back(static_cast<uint32_t>(worker_virtual_core.y));
+        writer_args.push_back(ring_size);
+        writer_args.push_back(static_cast<uint32_t>(
+            semaphore.at(sem_index).address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
+        writer_args.append(tensor_descriptor_args);
+        for (uint32_t input_idx = 0; input_idx < num_inputs; ++input_idx) {
+            writer_args.push_back(output_tensor[input_idx].buffer());
         }
         if (has_metadata) {
-            reader_backward_rt_args.push_back(slot_id->buffer());
-            reader_backward_rt_args.push_back(kv_actual_isl->buffer());
-            reader_backward_rt_args.push_back(chunk_local_tiles);
-            reader_backward_rt_args.push_back(kv_cache_num_layers);
-            reader_backward_rt_args.push_back(kv_cache_layer_idx);
+            writer_args.push_back(kv_actual_isl->buffer());
+            writer_args.push_back(chunk_local_tiles);
         }
-        if (fuse_op) {
-            std::vector<uint32_t> reader_backward_signaler_args;
-            fused_op_signaler_backward->push_all_gather_fused_op_rt_args(
-                reader_backward_signaler_args, num_links, link, 0);
-            reader_backward_rt_args.append(reader_backward_signaler_args);
-        }
-        const uint32_t backward_worker_index = link * 2;
-        sender_reader_backward_kernel.emplace_runtime_args(
-            sender_worker_cores[backward_worker_index], reader_backward_rt_args);
 
-        const CoreCoord sender_backward_worker_core =
-            mesh_device->worker_core_from_logical_core(sender_worker_cores[backward_worker_index]);
-
-        // Writer
-        const CoreCoord sender_forward_worker_core =
-            mesh_device->worker_core_from_logical_core(sender_worker_cores[(link * 2) + 1]);
-        KernelDescriptor::RTArgList writer_forward_rt_args;
-        writer_forward_rt_args.push_back(static_cast<uint32_t>(dim));                           // dim to gather on
-        writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.x));  // out_ready_sem_noc0_x
-        writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.y));  // out_ready_sem_noc0_y
-        writer_forward_rt_args.push_back(ring_size);                                            // ring_size
-        writer_forward_rt_args.push_back(static_cast<uint32_t>(
-            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kForwardSemaphoreIdx)
-                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
-        writer_forward_rt_args.append(tensor_descriptor_args);
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            writer_forward_rt_args.push_back(output_tensor[input_idx].buffer());
+        const auto neighbor_coord = is_forward ? backward_device_coord : forward_device_coord;
+        std::vector<uint32_t> writer_extra_args;
+        if (is_forward) {
+            writer_args.push_back(0u);
         }
-        if (has_metadata) {
-            writer_forward_rt_args.push_back(kv_actual_isl->buffer());
-            writer_forward_rt_args.push_back(chunk_local_tiles);
-        }
-        writer_forward_rt_args.push_back(0u);
-        writer_forward_rt_args.push_back(static_cast<uint32_t>(backward_device_coord.has_value()));
-        // Fabric/signaler helpers expect std::vector<uint32_t>&; collect their args separately,
-        // then merge so any BufferBinding entries above are preserved.
-        std::vector<uint32_t> writer_forward_extra_args;
-        if (backward_device_coord.has_value()) {
-            const auto target_fabric_node_id = mesh_device->get_fabric_node_id(target_device_coord);
-            const auto backward_fabric_node_id = mesh_device->get_fabric_node_id(backward_device_coord.value());
+        writer_args.push_back(static_cast<uint32_t>(neighbor_coord.has_value()));
+        if (neighbor_coord.has_value()) {
             tt::tt_fabric::append_fabric_connection_rt_args(
-                target_fabric_node_id,
-                backward_fabric_node_id,
-                link,
+                mesh_device->get_fabric_node_id(target_device_coord),
+                mesh_device->get_fabric_node_id(*neighbor_coord),
+                placement.link,
                 desc,
-                sender_worker_cores[(link * 2) + 1],
-                writer_forward_extra_args);
+                placement.core,
+                writer_extra_args);
+        }
+        if (!is_forward) {
+            writer_extra_args.push_back(0u);
         }
         if (fuse_op) {
-            fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(
-                writer_forward_extra_args, num_links, link, 1);
+            if (is_forward) {
+                fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(
+                    writer_extra_args, static_cast<uint32_t>(forward_signaler_cores.size()), worker_signaler_index, 1);
+            } else {
+                // Backward writers never issue the local-slice signal, but retain the writer ABI.
+                fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(writer_extra_args, 1, 0, 0);
+            }
         }
-        writer_forward_rt_args.append(writer_forward_extra_args);
-        sender_writer_forward_kernel.emplace_runtime_args(sender_worker_cores[(link * 2) + 1], writer_forward_rt_args);
+        writer_args.append(writer_extra_args);
+        auto& writer_kernel = is_forward ? sender_writer_forward_kernel : sender_writer_backward_kernel;
+        writer_kernel.emplace_runtime_args(placement.core, writer_args);
+    };
 
-        KernelDescriptor::RTArgList writer_backward_rt_args;
-        writer_backward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
-        writer_backward_rt_args.push_back(
-            static_cast<uint32_t>(sender_backward_worker_core.x));  // out_ready_sem_noc0_x
-        writer_backward_rt_args.push_back(
-            static_cast<uint32_t>(sender_backward_worker_core.y));  // out_ready_sem_noc0_y
-        writer_backward_rt_args.push_back(ring_size);               // ring_size
-        writer_backward_rt_args.push_back(static_cast<uint32_t>(
-            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kBackwardSemaphoreIdx)
-                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
-        writer_backward_rt_args.append(tensor_descriptor_args);
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            writer_backward_rt_args.push_back(output_tensor[input_idx].buffer());
-        }
-        if (has_metadata) {
-            writer_backward_rt_args.push_back(kv_actual_isl->buffer());
-            writer_backward_rt_args.push_back(chunk_local_tiles);
-        }
-        writer_backward_rt_args.push_back(static_cast<uint32_t>(forward_device_coord.has_value()));
-        std::vector<uint32_t> writer_backward_extra_args;
-        if (forward_device_coord.has_value()) {
-            const auto target_fabric_node_id = mesh_device->get_fabric_node_id(target_device_coord);
-            const auto forward_fabric_node_id = mesh_device->get_fabric_node_id(forward_device_coord.value());
-            tt::tt_fabric::append_fabric_connection_rt_args(
-                target_fabric_node_id,
-                forward_fabric_node_id,
-                link,
-                desc,
-                sender_worker_cores[backward_worker_index],
-                writer_backward_extra_args);
-        }
-        writer_backward_rt_args.append(writer_backward_extra_args);
-        writer_backward_rt_args.push_back(0u);
-        if (fuse_op) {
-            std::vector<uint32_t> writer_backward_signaler_args;
-            fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(writer_backward_signaler_args, 1, 0, 0);
-            writer_backward_rt_args.append(writer_backward_signaler_args);
-        }
-        sender_writer_backward_kernel.emplace_runtime_args(
-            sender_worker_cores[backward_worker_index], writer_backward_rt_args);
+    for (const auto& placement : forward_workers) {
+        emit_worker_runtime_args(placement, true);
+    }
+    for (const auto& placement : backward_workers) {
+        emit_worker_runtime_args(placement, false);
     }
 
     // Kernel descriptors are pushed last, with their runtime args fully populated.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -78,18 +78,19 @@ namespace ring_attention_all_gather_async_detail {
 // All-gather reader runtime-arg layout: [0]=dim, [1]=ring_size, [2]=out_ready_sem,
 // followed by one tensor-descriptor block per gathered input.
 constexpr uint32_t kReaderRuntimeArgHeaderCount = 3;
+constexpr uint32_t kReaderReadySemaphoreFieldOffset = 2;
 // All-gather writer runtime-arg layout: [0]=dim, [1]=sem_noc0_x, [2]=sem_noc0_y, [3]=ring_size,
 // [4]=out_ready_sem, followed by one tensor-descriptor block per gathered input.
 constexpr uint32_t kWriterRuntimeArgHeaderCount = 5;
-// Per-input fields: Wt, Ht, out_Wt, out_Ht, batch_head_size, tile_id_start, tile_id_end,
-// input_batch_base (offset 7), valid_pages_per_batch_head (offset 8), worker link (offset 9).
-constexpr uint32_t kTensorDescriptorFieldCount = 10;
-constexpr uint32_t kInputBatchBaseFieldOffset = 7;
+constexpr uint32_t kWriterReadySemaphoreFieldOffset = 4;
+// Per-input fields: Wt, Ht, out_Wt, out_Ht, batch_head_size, input_batch_base,
+// valid_pages_per_batch_head, and worker link.
+constexpr uint32_t kTensorDescriptorFieldCount = 8;
+constexpr uint32_t kInputBatchBaseFieldOffset = 5;
 // Per-(batch,head) page count each worker is allowed to gather. Defaults to the full input
 // (input_Ht * input_Wt); the fused ring_joint_sdpa path patches it down to the logical_n-valid
 // slab prefix so the gather moves only kv_actual-sized data, not the whole oversized cache.
-constexpr uint32_t kValidPagesFieldOffset = 8;
-constexpr uint32_t kWorkerLinkFieldOffset = 9;
+constexpr uint32_t kValidPagesFieldOffset = 6;
 constexpr uint32_t kNeighborReaderRuntimeArgHeaderCount = 1;
 constexpr uint32_t kNeighborReaderTensorDescriptorFieldCount = 5;
 constexpr uint32_t kNeighborReaderInputTileStartFieldOffset = 2;
@@ -102,6 +103,15 @@ constexpr uint32_t kNeighborWriterInputTileStartFieldOffset = 2;
 constexpr uint32_t kNeighborWriterInputTileEndFieldOffset = 3;
 constexpr uint32_t kNeighborWriterInputOriginPageFieldOffset = 4;
 
+constexpr uint32_t kRingDirectionCount = 2;
+
+// Kernel order appended by ring_attention_all_gather_async_multi_core_with_workers_helper.
+// Fused consumers add these offsets to the number of kernels they emit before the all-gather.
+constexpr uint32_t kReaderForwardKernelOffset = 0;
+constexpr uint32_t kWriterForwardKernelOffset = 1;
+constexpr uint32_t kReaderBackwardKernelOffset = 2;
+constexpr uint32_t kWriterBackwardKernelOffset = 3;
+
 inline uint32_t input_batch_base_pages(uint32_t batch_idx, uint32_t num_heads, uint32_t Ht, uint32_t Wt) {
     return batch_idx * num_heads * Ht * Wt;
 }
@@ -112,10 +122,10 @@ inline uint32_t input_batch_base_pages(uint32_t batch_idx, uint32_t num_heads, u
 // ring-attention all-gather worker pipeline to `desc`.
 //
 // `desc` may already contain entries from a parent op (e.g., ring_joint_sdpa).
-// Semaphore IDs assigned by this helper start at `desc.semaphores.size()` at
-// entry and are sequential. The descriptor framework auto-patches buffer
-// addresses on cache hits so callers do not need to retain kernel handles or
-// implement an override_runtime_arguments path.
+// Semaphore IDs are selected per worker core without colliding with existing
+// descriptors. The descriptor framework auto-patches buffer addresses on cache
+// hits so callers do not need to retain kernel handles or implement an
+// override_runtime_arguments path.
 void ring_attention_all_gather_async_multi_core_with_workers_helper(
     tt::tt_metal::ProgramDescriptor& desc,
     const std::vector<Tensor>& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -116,6 +116,9 @@ inline uint32_t input_batch_base_pages(uint32_t batch_idx, uint32_t num_heads, u
     return batch_idx * num_heads * Ht * Wt;
 }
 
+bool uses_output_bank_owned_schedule(
+    const std::vector<Tensor>& input_tensors, const std::vector<Tensor>& output_tensors, int32_t dim);
+
 }  // namespace ring_attention_all_gather_async_detail
 
 // Append all kernels, CBs, semaphores, and runtime args required by the
@@ -177,6 +180,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // The helper still applies the legacy even-ring topology/size gate on top, so standalone
     // callers retain their prior behavior with the default.
     bool split_forwarding_enabled = true,
+    // Opt-in two-stage fused readiness: every received shard signals once at its row midpoint and
+    // once when complete. Only consumers that interpret the doubled semaphore protocol may enable it.
+    bool partial_readiness_enabled = false,
     RingAttentionRankMapping rank_mapping = {});
 
 void ring_attention_neighbor_halo_exchange_helper(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -195,8 +195,8 @@ void validate_block_cyclic(const operation_attributes_t& attrs, const tensor_arg
     }
 }
 
-// Semaphore addresses are hashed, but different mesh devices can allocate the same L1 addresses. Re-check
-// ownership on both misses and hits so foreign fused inputs cannot cache-hit and access unrelated device memory.
+// Semaphore identity is hash-excluded and rebound on cache hits. Different mesh devices can also allocate the
+// same L1 addresses, so re-check ownership on both misses and hits before accepting fused runtime inputs.
 void validate_fused_runtime_values(const operation_attributes_t& attrs, const tensor_args_t& t) {
     if (!attrs.fused_ring.has_value()) {
         return;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -309,7 +309,7 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
 
 void IndexerScoreDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // chunk_start, cache slot, kv_len are hash-excluded runtime values -> re-checked on hits.
+    // chunk_start, cache slot, and exact kv_len are runtime values -> re-checked on hits.
     validate_runtime_values(attrs, tensor_args);
     validate_chunk_start(attrs, tensor_args);
     validate_fused_runtime_values(attrs, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -43,9 +43,10 @@ using ttnn::prim::BlockCyclicLayout;
 // is batch-1 scratch; only cache_batch_idx is gathered. The fused program factory co-schedules the all-gather
 // (the only Linear+fuse-capable AG) into the SAME program as the indexer compute, wiring a producer->consumer
 // semaphore handshake so the reader starts scoring once the gather lands. Scalar AG config only (tensors live in
-// tensor_args). All fields and semaphore addresses are hashed because the descriptor embeds them in AG worker
-// allocation/routing/runtime arguments and the cache-hit override only rebuilds consumer kernels. ring_size /
-// ring_index are DERIVED from the mesh + coordinate (cluster_axis), not stored.
+// tensor_args). Routing fields are hashed because they shape AG worker allocation and topology. Semaphore
+// addresses and other dispatch-time values are deliberately hash-excluded; the cache-hit override re-patches
+// the four AG worker kernels and the consumer kernels. ring_size / ring_index are DERIVED from the mesh +
+// coordinate (cluster_axis), not stored.
 struct FusedRingConfig {
     uint32_t num_links{1};  // fabric links for the gather
     ttnn::ccl::Topology topology{ttnn::ccl::Topology::Linear};

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -341,6 +341,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     reader_ct.insert(reader_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
     // Keep the shared reader's full-mesh rank-mapping CT tail canonical for the classic path.
     reader_ct.insert(reader_ct.end(), {0u, 0u, 0u, 0u});
+    reader_ct.push_back(0u);  // partial all-gather readiness off (non-fused path)
 
     std::vector<uint32_t> writer_ct = common_ct;
     writer_ct.push_back(0u);                             // fused_ring off
@@ -348,6 +349,9 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     // row-major page = one output row: T scores, or nblocks block-scores when pooling.
     const uint32_t out_row_elems = block_pool ? nblocks : T;
     writer_ct.push_back(out_row_elems * out_elem_bytes);
+    writer_ct.push_back(0u);  // shard-major mapping off
+    writer_ct.push_back(1u);  // unused block-cyclic run width
+    writer_ct.push_back(1u);  // unused SP size
     tt::tt_metal::TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
 
     std::vector<uint32_t> compute_ct = common_ct;
@@ -360,6 +364,9 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     compute_ct.push_back(fuse_single ? 1u : 0u);
     compute_ct.push_back(fused_stream_k ? 1u : 0u);  // fused: incremental k wait (stream) vs whole-chunk
     compute_ct.push_back(0u);                        // fused_ring off
+    compute_ct.push_back(0u);                        // shard-major block-cyclic mapping off
+    compute_ct.push_back(1u);                        // unused block-cyclic run width
+    compute_ct.push_back(1u);                        // unused SP size
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     auto reader_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -42,6 +42,9 @@ constexpr bool fuse_single = get_compile_time_arg_val(num_common_ct_args + 4) !=
 constexpr bool fused_stream_k = get_compile_time_arg_val(num_common_ct_args + 5) != 0;
 // Fused ring visits bands in the arrival-order permutation supplied in runtime args.
 constexpr bool fused_ring_enabled = get_compile_time_arg_val(num_common_ct_args + 6) != 0;
+constexpr bool shard_block_cyclic = get_compile_time_arg_val(num_common_ct_args + 7) != 0;
+constexpr uint32_t shard_chunk_local = get_compile_time_arg_val(num_common_ct_args + 8);
+constexpr uint32_t shard_sp = get_compile_time_arg_val(num_common_ct_args + 9);
 
 // k-cols sharing ONE dest acquire in the blocked-custom mul (dest-bounded). One unpack context per head
 // (w[h] + ct_dim qk cols), so unpack-context sync is paid 1/ct_dim of the per-tile bcast-mul rate.
@@ -418,6 +421,30 @@ inline void stamp_masked_suffix(
     }
 }
 
+/** Causal mask for a shard-major packed unit. Its logical tile ids are monotone but may jump between
+ *  block-cyclic runs, so find the prefix below the diagonal using the inverse physical mapping. */
+inline void stamp_masked_shard_major(
+    const ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp>& shard_span,
+    uint32_t q_row,
+    uint32_t slot_base,
+    uint32_t k_tiles_in_unit,
+    uint32_t chunk_start_tiles,
+    uint32_t straddle_q_tile,
+    uint32_t straddle_jump_tiles) {
+    const uint32_t q_row_abs = shard_span.q_tile_start() + q_row;
+    const uint32_t diag_tile =
+        iscore::causal_diag_tile(q_row_abs, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
+    uint32_t valid = 0;
+    while (valid < k_tiles_in_unit && shard_span.logical_tile(valid) < diag_tile) {
+        ++valid;
+    }
+    const uint32_t capacity = shard_span.capacity_tiles();
+    for (uint32_t k_col = valid; k_col < k_tiles_per_unit; ++k_col) {
+        const uint32_t logical_tile = k_col < capacity ? shard_span.logical_tile(k_col) : 0xFFFFFFFFu;
+        stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, logical_tile, diag_tile);
+    }
+}
+
 void kernel_main() {
     // Banded schedule: this core owns a (group-phase x band) rectangle. groups stream in num_groups phases
     // (group = row_group0 + p*group_stride); each walks num_bands k-bands (band = band0 + j). One cell ==
@@ -455,6 +482,8 @@ void kernel_main() {
 
     WorkUnitSpan span;
     span.set_valid_k_len_tiles(kv_len_tiles);
+    ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp> shard_span;
+    shard_span.set_valid_k_len_tiles(kv_len_tiles);
 
     constexpr uint32_t unit_strip = q_tiles_per_unit * k_tiles_per_unit;  // QC x KC accumulator slots
     constexpr uint32_t q_row_tiles = q_group_tiles / q_tiles_per_unit;    // heads_per_group * head_dim_tiles
@@ -468,10 +497,14 @@ void kernel_main() {
         const uint32_t group = row_group0 + phase * group_stride;
         for (uint32_t band_i = 0; band_i < band_iters; ++band_i) {
             uint32_t band = band_i;
+            uint32_t k_tiles_in_unit = 0;
             if constexpr (fused_ring_enabled) {
-                // Reordered band-visit order (local-first, then remote by ring arrival), IDENTICAL to
-                // reader/writer so the cb_k / cb_out FIFOs stay in lockstep. Permutation starts at rt slot 10.
-                band = get_arg_val<uint32_t>(10 + band_i);
+                const uint32_t physical_start = get_arg_val<uint32_t>(10 + band_i);
+                shard_span.set(group, physical_start, k_len_tiles / shard_sp);
+                k_tiles_in_unit = shard_span.k_tiles();
+            } else {
+                span.set(group, band0 + band);
+                k_tiles_in_unit = span.k_tiles();
             }
             if constexpr (stream_heads) {
                 if (band >= num_bands) {
@@ -479,11 +512,10 @@ void kernel_main() {
                     continue;
                 }
             }
-            span.set(group, band0 + band);
             // kv_len is runtime-variable while the work split is compiled for K capacity. Cells
             // wholly past that prefix have no K/output work. Head streaming still receives one
             // q-mcast block per band, so drain it to keep the row rendezvous in lockstep.
-            if (span.k_tiles() == 0) {
+            if (k_tiles_in_unit == 0) {
                 if constexpr (stream_heads) {
                     drain_phantom_band_q();
                 }
@@ -494,8 +526,6 @@ void kernel_main() {
             if constexpr (!fuse_single || !fused_stream_k) {
                 k.wait_front(k_chunk_tiles);
             }
-            const uint32_t k_tiles_in_unit = span.k_tiles();
-
             // Fused single-head: gate resident q by w IN PLACE once per group load (band 0; q is reused
             // across bands, so per-band scaling would compound w). One pass per output plane's head.
             if constexpr (fuse_single) {
@@ -537,14 +567,25 @@ void kernel_main() {
                     // Matmul left srcA in k's format; the mask copies a bf16 -inf tile -> reconfig srcA to bf16.
                     reconfig_data_format_srca(cb_k, cb_mask);
                     for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-                        stamp_masked_suffix(
-                            span,
-                            r,
-                            r * k_tiles_per_unit,
-                            k_tiles_in_unit,
-                            chunk_start_tiles,
-                            straddle_q_tile,
-                            straddle_jump_tiles);
+                        if constexpr (fused_ring_enabled) {
+                            stamp_masked_shard_major(
+                                shard_span,
+                                r,
+                                r * k_tiles_per_unit,
+                                k_tiles_in_unit,
+                                chunk_start_tiles,
+                                straddle_q_tile,
+                                straddle_jump_tiles);
+                        } else {
+                            stamp_masked_suffix(
+                                span,
+                                r,
+                                r * k_tiles_per_unit,
+                                k_tiles_in_unit,
+                                chunk_start_tiles,
+                                straddle_q_tile,
+                                straddle_jump_tiles);
+                        }
                     }
                     acc.push_back(unit_strip);
                 } else {
@@ -572,14 +613,25 @@ void kernel_main() {
                             accumulate_row_streaming(q_row, slot_base);
                         }
 
-                        stamp_masked_suffix(
-                            span,
-                            q_row,
-                            slot_base,
-                            k_tiles_in_unit,
-                            chunk_start_tiles,
-                            straddle_q_tile,
-                            straddle_jump_tiles);
+                        if constexpr (fused_ring_enabled) {
+                            stamp_masked_shard_major(
+                                shard_span,
+                                q_row,
+                                slot_base,
+                                k_tiles_in_unit,
+                                chunk_start_tiles,
+                                straddle_q_tile,
+                                straddle_jump_tiles);
+                        } else {
+                            stamp_masked_suffix(
+                                span,
+                                q_row,
+                                slot_base,
+                                k_tiles_in_unit,
+                                chunk_start_tiles,
+                                straddle_q_tile,
+                                straddle_jump_tiles);
+                        }
                     }
                     acc.push_back(unit_strip);
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -40,7 +40,7 @@ constexpr bool apply_relu = get_compile_time_arg_val(num_common_ct_args + 3) != 
 constexpr bool fuse_single = get_compile_time_arg_val(num_common_ct_args + 4) != 0;
 // Fused + no mcast: stream k (waited incrementally in the matmul). Fused + mcast: k is one block, waited whole.
 constexpr bool fused_stream_k = get_compile_time_arg_val(num_common_ct_args + 5) != 0;
-// Fused ring visits bands in the arrival-order permutation supplied in runtime args.
+// Fused ring visits physical K starts in the arrival-order permutation supplied in runtime args.
 constexpr bool fused_ring_enabled = get_compile_time_arg_val(num_common_ct_args + 6) != 0;
 constexpr bool shard_block_cyclic = get_compile_time_arg_val(num_common_ct_args + 7) != 0;
 constexpr uint32_t shard_chunk_local = get_compile_time_arg_val(num_common_ct_args + 8);
@@ -665,7 +665,8 @@ void kernel_main() {
 
             k.pop_front(k_chunk_tiles);
         }
-        // group's bands done: release its resident q/w (one block per group).
+        // Group's units are done: release its resident q/w block. The reader always pushes the group; when every
+        // unit is kv-empty, no compute path dereferences q/w, so pop_front returns that credit without a wait.
         CircularBuffer(cb_w).pop_front(w_group_tiles);  // gates waited in the mul/scale phase
         if constexpr (!stream_heads) {
             q.pop_front(q_group_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -108,3 +108,52 @@ struct WorkUnitSpan {
         return left < k_tiles_per_unit ? left : k_tiles_per_unit;
     }
 };
+
+/** One fused Ring Indexer work unit in shard-major physical order. Consecutive physical tiles stay within
+ *  one SP shard, so the local shard can run without a Fabric dependency and every remote unit has exactly
+ *  one readiness source. The block-cyclic inverse maps packed compute columns back to logical K positions. */
+template <bool BlockCyclic, uint32_t ChunkLocal, uint32_t Sp>
+struct ShardMajorWorkUnitSpan {
+    uint32_t group = 0;
+    uint32_t physical_tile_start = 0;
+    uint32_t tiles_per_shard = 0;
+    uint32_t valid_k_len_tiles = k_len_tiles;
+
+    void set(uint32_t g, uint32_t physical_start, uint32_t shard_tiles) {
+        group = g;
+        physical_tile_start = physical_start;
+        tiles_per_shard = shard_tiles;
+    }
+    void set_valid_k_len_tiles(uint32_t tiles) { valid_k_len_tiles = tiles; }
+
+    uint32_t q_tile_start() const { return group * q_tiles_per_unit; }
+    uint32_t shard() const { return physical_tile_start / tiles_per_shard; }
+    uint32_t shard_offset() const { return physical_tile_start - shard() * tiles_per_shard; }
+
+    uint32_t logical_tile(uint32_t col) const {
+        if constexpr (!BlockCyclic) {
+            return physical_tile_start + col;
+        } else {
+            const uint32_t local = shard_offset() + col;
+            const uint32_t slab = local / ChunkLocal;
+            const uint32_t slab_offset = local - slab * ChunkLocal;
+            return (slab * Sp + shard()) * ChunkLocal + slab_offset;
+        }
+    }
+
+    uint32_t capacity_tiles() const {
+        const uint32_t shard_left = tiles_per_shard - shard_offset();
+        return shard_left < k_tiles_per_unit ? shard_left : k_tiles_per_unit;
+    }
+
+    // Logical positions increase monotonically within one physical shard, though they jump between local
+    // block-cyclic runs. Therefore the runtime KV prefix is still a packed prefix of this work unit.
+    uint32_t k_tiles() const {
+        const uint32_t capacity = capacity_tiles();
+        uint32_t valid = 0;
+        while (valid < capacity && logical_tile(valid) < valid_k_len_tiles) {
+            ++valid;
+        }
+        return valid;
+    }
+};

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -549,6 +549,8 @@ void kernel_main() {
                         const uint32_t valid_slabs = (kv_len_tiles + global_slab_tiles - 1) / global_slab_tiles;
                         gathered_shard_tiles = std::min(valid_slabs * bc_chunk_local, gate->tiles_per_shard);
                     }
+                    // KEEP IN SYNC with the AG writer's row-aligned midpoint_prefix_pages() and the host's
+                    // gather_valid_height_tiles(). Units crossing this boundary wait for completion.
                     const uint32_t midpoint_tiles = (gathered_shard_tiles + 1) / 2;
                     gate->read_k(
                         noc, k_acc, physical_start, shard_span.k_tiles(), midpoint_tiles, k_dir, k_batch_page_offset);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -69,6 +69,7 @@ constexpr auto snake_orientation =
     static_cast<ttnn::ccl::snake_ring::Orientation>(get_compile_time_arg_val(bc_ct_base + 6));
 constexpr uint32_t rank_mapping_mesh_rows = get_compile_time_arg_val(bc_ct_base + 7);
 constexpr uint32_t rank_mapping_mesh_cols = get_compile_time_arg_val(bc_ct_base + 8);
+constexpr bool partial_readiness_enabled = get_compile_time_arg_val(bc_ct_base + 9) != 0;
 
 FORCE_INLINE constexpr uint32_t tensor_rank_from_transport_rank(uint32_t transport_rank) {
     return ttnn::ring_attention_all_gather::tensor_rank_from_transport_rank<full_mesh_rank_mapping>(
@@ -294,22 +295,16 @@ inline void read_k_chunk(
         });
 }
 
-/** Ring-fused k chunk: dual-source per tile. The gathered buffer (k_acc) holds every REMOTE SP-shard's slab
- *  (the all-gather wrote them); this device's OWN shard is read straight from the SP-sharded local cache
- *  (k_local_acc) -- the all-gather omits the local band from the gathered buffer. shard(logical tile L) =
- *  bc_ktile(L)/tiles_per_shard; local page = k_batch_page_offset/ring_size +
- *  (bc_ktile(L) - ring_index*tiles_per_shard)*head_dim_tiles (the slot offset is 1/ring of the gathered
- *  buffer's since k_local holds only sll=T/ring keys per slot). In indexed fused mode the gathered buffer is
- *  batch-1 (remote offset 0) while local_batch_page_offset selects the original cache slot. */
+/** Ring-fused shard-major K chunk. Every unit is a consecutive physical range inside one SP shard. Remote
+ *  shards come from the gathered buffer; this device's own shard comes directly from the AG input cache. */
 template <typename KAcc, typename KLocalAcc>
 inline void read_k_chunk_fused(
     Noc noc,
     const KAcc& k_acc,
     const KLocalAcc& k_local_acc,
     uint32_t ring_index,
-    uint32_t ring_size,
     uint32_t tiles_per_shard,
-    uint32_t k_tile_start,
+    uint32_t physical_tile_start,
     uint32_t k_tiles_in_unit,
     const McastDir& k_dir,
     uint32_t gathered_batch_page_offset,
@@ -318,15 +313,18 @@ inline void read_k_chunk_fused(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
             for (uint32_t k_col = 0; k_col < k_tiles_in_unit; ++k_col) {
-                const uint32_t seq_tile = bc_ktile(k_tile_start + k_col);
-                const uint32_t shard = seq_tile / tiles_per_shard;
+                const uint32_t physical_tile = physical_tile_start + k_col;
+                const uint32_t shard = physical_tile / tiles_per_shard;
                 if (shard == ring_index) {
                     const uint32_t local_base =
-                        local_batch_page_offset + (seq_tile - ring_index * tiles_per_shard) * head_dim_tiles;
+                        local_batch_page_offset + (physical_tile - ring_index * tiles_per_shard) * head_dim_tiles;
                     read_ktile_dims(noc, k_local_acc, ptr, local_base);  // OWN shard from the SP-local cache
                 } else {
                     read_ktile_dims(
-                        noc, k_acc, ptr, gathered_batch_page_offset + seq_tile * head_dim_tiles);  // remote slab
+                        noc,
+                        k_acc,
+                        ptr,
+                        gathered_batch_page_offset + physical_tile * head_dim_tiles);  // remote shard
                 }
             }
         });
@@ -348,13 +346,14 @@ struct FusedRingGate {
 
     uint32_t ring_index;
     uint32_t ring_size;
-    uint32_t tiles_per_shard;           // tiles per SP shard in the gathered buffer
-    uint32_t sem_id[2];                 // the two direction semaphore ids
-    KLocalAcc k_local_acc;              // local SP shard cache (the all-gather INPUT; AG omits it from gathered)
-    uint32_t local_batch_page_offset;   // selected slot in k_local; gathered k may be batch-1
-    uint32_t perm_base;                 // rt slot of the band-visit permutation (one entry per band)
-    uint32_t shard_dir[max_ring_size];  // shard -> direction semaphore index
-    uint32_t shard_val[max_ring_size];  // shard -> wait threshold
+    uint32_t tiles_per_shard;                // tiles per SP shard in the gathered buffer
+    uint32_t sem_id[2];                      // the two direction semaphore ids
+    KLocalAcc k_local_acc;                   // local SP shard cache (the all-gather INPUT; AG omits it from gathered)
+    uint32_t local_batch_page_offset;        // selected slot in k_local; gathered k may be batch-1
+    uint32_t perm_base;                      // rt slot of the band-visit permutation (one entry per band)
+    uint32_t shard_dir[max_ring_size];       // shard -> direction semaphore index
+    uint32_t shard_half_val[max_ring_size];  // shard -> midpoint-ready threshold
+    uint32_t shard_val[max_ring_size];       // shard -> wait threshold
 
     // recv has already consumed the fused block (waiting for the op signal) and advanced argidx; take the
     // k_local addr from the next slot and leave argidx at the band-perm base.
@@ -367,6 +366,7 @@ struct FusedRingGate {
         local_batch_page_offset(get_arg_val<uint32_t>(argidx++)),
         perm_base(argidx),
         shard_dir{},
+        shard_half_val{},
         shard_val{} {
         RingIdSequencer s = recv.seq;  // fresh copy (received={0,0}); replay to index (dir,val) by shard id
         for (uint32_t i = 0; i < ring_size; ++i) {
@@ -377,24 +377,33 @@ struct FusedRingGate {
             });
             const uint32_t tensor_rank = tensor_rank_from_transport_rank(rid);
             shard_dir[tensor_rank] = cap_dir;
-            shard_val[tensor_rank] = cap_val;
+            if constexpr (partial_readiness_enabled) {
+                if (tensor_rank == ring_index) {
+                    continue;
+                }
+                // Partial-readiness AG emits midpoint + completion for every remote shard. Direction 0's
+                // semaphore also contains the existing local-slice pre-signal.
+                shard_half_val[tensor_rank] = cap_dir == 0 ? 2 * (cap_val - 1) : 2 * cap_val - 1;
+                shard_val[tensor_rank] = cap_dir == 0 ? 2 * cap_val - 1 : 2 * cap_val;
+            } else {
+                shard_val[tensor_rank] = cap_val;
+            }
         }
     }
 
-    // Absolute band index this column visits at iteration band_i (striped set, band0=0).
-    uint32_t band(uint32_t band_i) const { return get_arg_val<uint32_t>(perm_base + band_i); }
+    // Physical K-tile start this column visits at iteration work_i.
+    uint32_t physical_start(uint32_t work_i) const { return get_arg_val<uint32_t>(perm_base + work_i); }
 
-    // Wait on each distinct non-local SP-shard the band [k_tile_start, +k_tiles_in_unit) lands in. Shards form
-    // contiguous runs over the tiles (change only at block boundaries), so wait once per run start.
-    void gate_band(uint32_t k_tile_start, uint32_t k_tiles_in_unit) const {
-        uint32_t prev_shard = 0xFFFFFFFFu;
-        for (uint32_t c = 0; c < k_tiles_in_unit; ++c) {
-            const uint32_t shard = bc_ktile(k_tile_start + c) / tiles_per_shard;
-            if (shard != prev_shard) {
-                prev_shard = shard;
-                if (shard != ring_index) {
-                    Semaphore<>(sem_id[shard_dir[shard]]).wait_min(shard_val[shard]);
-                }
+    void gate_shard(uint32_t physical_tile_start, uint32_t k_tiles_in_unit, uint32_t midpoint_tiles) const {
+        const uint32_t shard = physical_tile_start / tiles_per_shard;
+        if (shard != ring_index) {
+            if constexpr (partial_readiness_enabled) {
+                const uint32_t shard_offset = physical_tile_start - shard * tiles_per_shard;
+                const bool entirely_in_first_half = shard_offset + k_tiles_in_unit <= midpoint_tiles;
+                Semaphore<>(sem_id[shard_dir[shard]])
+                    .wait_min(entirely_in_first_half ? shard_half_val[shard] : shard_val[shard]);
+            } else {
+                Semaphore<>(sem_id[shard_dir[shard]]).wait_min(shard_val[shard]);
             }
         }
     }
@@ -405,21 +414,21 @@ struct FusedRingGate {
     void read_k(
         Noc noc,
         const KAcc& k_acc,
-        uint32_t k_tile_start,
+        uint32_t physical_tile_start,
         uint32_t k_tiles_in_unit,
+        uint32_t midpoint_tiles,
         const McastDir& k_dir,
         uint32_t k_batch_page_offset) const {
         if (k_mcast_on == 0 || k_dir.role == iscore::mcast_role_sender) {
-            gate_band(k_tile_start, k_tiles_in_unit);
+            gate_shard(physical_tile_start, k_tiles_in_unit, midpoint_tiles);
         }
         read_k_chunk_fused(
             noc,
             k_acc,
             k_local_acc,
             ring_index,
-            ring_size,
             tiles_per_shard,
-            k_tile_start,
+            physical_tile_start,
             k_tiles_in_unit,
             k_dir,
             k_batch_page_offset,
@@ -506,6 +515,8 @@ void kernel_main() {
 
         WorkUnitSpan span;
         span.set_valid_k_len_tiles(kv_len_tiles);
+        ShardMajorWorkUnitSpan<block_cyclic, bc_chunk_local, bc_sp> shard_span;
+        shard_span.set_valid_k_len_tiles(kv_len_tiles);
         const uint32_t band_iters = stream_heads ? max_bands : num_bands;
         for (uint32_t phase = 0; phase < num_groups; ++phase) {
             const uint32_t group = row_group0 + phase * group_stride;
@@ -524,15 +535,23 @@ void kernel_main() {
             }
             for (uint32_t band_i = 0; band_i < band_iters; ++band_i) {
                 if constexpr (fused_ring_enabled) {
-                    const uint32_t band = gate->band(band_i);
-                    span.set(group, band0 + band);
+                    const uint32_t physical_start = gate->physical_start(band_i);
+                    shard_span.set(group, physical_start, gate->tiles_per_shard);
                     // q/w were multicasted before this loop. Every row of this K-mcast column has
-                    // the same band list, so skipping an empty runtime-prefix band preserves both
+                    // the same work list, so skipping an empty runtime-prefix unit preserves both
                     // the fabric gate and the local CB protocol.
-                    if (span.k_tiles() == 0) {
+                    if (shard_span.k_tiles() == 0) {
                         continue;
                     }
-                    gate->read_k(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir, k_batch_page_offset);
+                    uint32_t gathered_shard_tiles = gate->tiles_per_shard;
+                    if constexpr (block_cyclic) {
+                        const uint32_t global_slab_tiles = bc_chunk_local * bc_sp;
+                        const uint32_t valid_slabs = (kv_len_tiles + global_slab_tiles - 1) / global_slab_tiles;
+                        gathered_shard_tiles = std::min(valid_slabs * bc_chunk_local, gate->tiles_per_shard);
+                    }
+                    const uint32_t midpoint_tiles = (gathered_shard_tiles + 1) / 2;
+                    gate->read_k(
+                        noc, k_acc, physical_start, shard_span.k_tiles(), midpoint_tiles, k_dir, k_batch_page_offset);
                 } else {
                     const uint32_t band = band_i;
                     const bool real_band = band < num_bands;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -17,6 +17,9 @@
 
 constexpr bool fused_ring_enabled = get_compile_time_arg_val(num_common_ct_args) != 0;
 constexpr uint32_t page_bytes = get_compile_time_arg_val(num_common_ct_args + 1);  // row-major page = T*2 bytes
+constexpr bool shard_block_cyclic = get_compile_time_arg_val(num_common_ct_args + 2) != 0;
+constexpr uint32_t shard_chunk_local = get_compile_time_arg_val(num_common_ct_args + 3);
+constexpr uint32_t shard_sp = get_compile_time_arg_val(num_common_ct_args + 4);
 
 constexpr uint32_t frag_bytes = tt::constants::TILE_WIDTH * sizeof(uint16_t);  // one bf16 tile row
 
@@ -38,6 +41,54 @@ inline void write_strip(
                 write_bytes,
                 {},
                 {.page_id = page_row_start + rr, .offset_bytes = k_tile_start * frag_bytes});
+            src += row_pitch;
+        }
+        noc.async_write_barrier();
+    }
+    cb.pop_front(k_tiles_per_unit);
+}
+
+/** Scatter one shard-major packed strip back to logical K columns. Consecutive physical tiles map to short
+ *  logical runs; coalesce each run so a KC-sized work unit needs only a few writes per output row rather than
+ *  one write per score tile. */
+template <typename OutAcc>
+inline void write_shard_major_strip(
+    Noc noc,
+    const OutAcc& out_acc,
+    uint32_t page_row_start,
+    const ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp>& shard_span,
+    uint32_t valid_w) {
+    CircularBuffer cb(cb_out_strip);
+    cb.wait_front(k_tiles_per_unit);
+    if (valid_w != 0) {
+        uint32_t fragment_col[k_tiles_per_unit];
+        uint32_t fragment_logical[k_tiles_per_unit];
+        uint32_t fragment_width[k_tiles_per_unit];
+        uint32_t num_fragments = 0;
+        for (uint32_t col = 0; col < valid_w;) {
+            const uint32_t logical_start = shard_span.logical_tile(col);
+            uint32_t width = 1;
+            while (col + width < valid_w && shard_span.logical_tile(col + width) == logical_start + width) {
+                ++width;
+            }
+            fragment_col[num_fragments] = col;
+            fragment_logical[num_fragments] = logical_start;
+            fragment_width[num_fragments] = width;
+            ++num_fragments;
+            col += width;
+        }
+
+        uint32_t src = cb.get_read_ptr();
+        const uint32_t row_pitch = k_tiles_per_unit * frag_bytes;
+        for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
+            for (uint32_t fragment = 0; fragment < num_fragments; ++fragment) {
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(src + fragment_col[fragment] * frag_bytes),
+                    out_acc,
+                    fragment_width[fragment] * frag_bytes,
+                    {},
+                    {.page_id = page_row_start + rr, .offset_bytes = fragment_logical[fragment] * frag_bytes});
+            }
             src += row_pitch;
         }
         noc.async_write_barrier();
@@ -135,13 +186,15 @@ void kernel_main() {
     const uint32_t straddle_q_keys = get_arg_val<uint32_t>(9) * tt::constants::TILE_WIDTH;
     const uint32_t straddle_jump_keys = get_arg_val<uint32_t>(10) * tt::constants::TILE_WIDTH;
 
-    constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 2>();
+    constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 5>();
     const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
 
     Noc noc;
 
     WorkUnitSpan span;
     span.set_valid_k_len_tiles(kv_len_tiles);
+    ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp> shard_span;
+    shard_span.set_valid_k_len_tiles(kv_len_tiles);
 
     // Output [B, num_out_groups, Sq, T]: plane g occupies rows [g*Sq, (g+1)*Sq). Compute pushes
     // num_out_groups * QC strips per cell in g-major order; drain them the same way.
@@ -151,13 +204,18 @@ void kernel_main() {
         const uint32_t group = row_group0 + phase * group_stride;
         for (uint32_t band_i = 0; band_i < num_bands; ++band_i) {
             uint32_t band = band_i;
+            uint32_t k_tile0 = 0;
+            uint32_t valid_w = 0;
             if constexpr (fused_ring_enabled) {
-                // Reordered band-visit order, IDENTICAL to reader/compute (perm starts at rt slot 11).
-                band = get_arg_val<uint32_t>(11 + band_i);
+                const uint32_t physical_start = get_arg_val<uint32_t>(11 + band_i);
+                shard_span.set(group, physical_start, k_len_tiles / shard_sp);
+                k_tile0 = physical_start;
+                valid_w = shard_span.k_tiles();
+            } else {
+                span.set(group, band0 + band);
+                k_tile0 = span.k_tile_start();
+                valid_w = span.k_tiles();
             }
-            span.set(group, band0 + band);
-            const uint32_t k_tile0 = span.k_tile_start();
-            const uint32_t valid_w = span.k_tiles();  // == KC for interior bands, < KC for a partial last band
             // The reader/compute do no K/output work for cells wholly past the runtime prefix.
             // Their q-mcast bookkeeping is completed independently before this point.
             if (valid_w == 0) {
@@ -170,7 +228,7 @@ void kernel_main() {
                 const uint32_t plane_row0 = g * sq_rows;
                 for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
                     const uint32_t q_seq_row0 =
-                        (span.q_tile_start() + q_row) * tt::constants::TILE_HEIGHT;  // within Sq
+                        (group * q_tiles_per_unit + q_row) * tt::constants::TILE_HEIGHT;  // within Sq
                     const uint32_t page_row_start = plane_row0 + q_seq_row0;
                     if constexpr (block_pool) {
                         write_pooled_strip(
@@ -184,7 +242,11 @@ void kernel_main() {
                             straddle_q_keys,
                             straddle_jump_keys);
                     } else {
-                        write_strip(noc, out_acc, page_row_start, k_tile0, valid_w);
+                        if constexpr (fused_ring_enabled && shard_block_cyclic) {
+                            write_shard_major_strip(noc, out_acc, page_row_start, shard_span, valid_w);
+                        } else {
+                            write_strip(noc, out_acc, page_row_start, k_tile0, valid_w);
+                        }
                     }
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -46,6 +46,18 @@ using tt::tt_metal::SemaphoreDescriptor;
 using tt::tt_metal::WriterConfigDescriptor;
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+constexpr uint32_t kReaderKernelIndex = 0;
+constexpr uint32_t kWriterKernelIndex = 1;
+constexpr uint32_t kComputeKernelIndex = 2;
+constexpr uint32_t kFirstAllGatherKernelIndex = 3;
+constexpr uint32_t kAllGatherReaderForwardKernelIndex = kFirstAllGatherKernelIndex + ag_rt::kReaderForwardKernelOffset;
+constexpr uint32_t kAllGatherWriterForwardKernelIndex = kFirstAllGatherKernelIndex + ag_rt::kWriterForwardKernelOffset;
+constexpr uint32_t kAllGatherReaderBackwardKernelIndex =
+    kFirstAllGatherKernelIndex + ag_rt::kReaderBackwardKernelOffset;
+constexpr uint32_t kAllGatherWriterBackwardKernelIndex =
+    kFirstAllGatherKernelIndex + ag_rt::kWriterBackwardKernelOffset;
 
 // Runtime-arg slots the kernels match POSITIONALLY. The reader shares the classic factory's layout for slots
 // 0..26 (q/k/w addrs, schedule(6), 2 mcast dirs, persistent-cache), then appends a fused-ring tail. Derived
@@ -118,15 +130,7 @@ ProgramDescriptor build_ring_program_descriptor(
     const operation_attributes_t& args,
     const tensor_args_t& tensors,
     const Tensor& out,
-    const ttnn::MeshCoordinate& coord,
-    bool consumers_only = false) {
-    // consumers_only: build ONLY the three consumer kernels (reader/writer/compute, indices 0/1/2) and SKIP the
-    // ring_attention all-gather helper. Used by override_runtime_arguments on a program-cache HIT, which reads
-    // just the consumer kernels' per-dispatch scalar slots from the returned descriptor and copies them into
-    // the live program -- it never touches the AG worker kernels (3..). Skipping the helper drops its per-hit
-    // fabric-worker setup cost and removes any dependence on it being alloc-free. The consumer kernels' runtime
-    // args are built by the SAME loop as create(), so create and override cannot compute the scalars/slots
-    // differently (the invariant the historical stale-scalar bug violated).
+    const ttnn::MeshCoordinate& coord) {
     ProgramDescriptor desc;
 
     const auto& q = tensors.q;
@@ -210,8 +214,8 @@ ProgramDescriptor build_ring_program_descriptor(
     // of the group count <= grid_y, so shaving even one row can halve the schedule (10 groups: grid_y 10->9 drops
     // group_rows 10->5 -> 55 cores instead of 110). cols_for_bands() just distributes the bands over min(bands,
     // compute_cols_x) columns (uneven remainder handled by band_list), so a reserved column costs exactly one
-    // column of compute -- no divisor cliff. The AG needs only num_links*2 workers; one column (grid_y cores) is
-    // plenty and the compute keeps grid_y*compute_cols_x cores.
+    // column of compute -- no divisor cliff. The AG uses num_links*2 workers, so compute keeps
+    // grid_y*compute_cols_x cores.
     const uint32_t grid_y = phys_grid.y;  // full compute-grid height (all rows kept for compute)
     TT_FATAL(fused.num_links >= 1, "indexer_score fused: num_links must be >= 1 (got {})", fused.num_links);
     const uint32_t ag_worker_cores = fused.num_links * 2u;                   // AG uses 2 workers (fwd/bwd) per link
@@ -573,10 +577,10 @@ ProgramDescriptor build_ring_program_descriptor(
                 q_sender,
                 cols_used - 1);
             // Reader tail (sequential push; slots named in rt_arg, matched positionally by the kernel).
-            reader_rt.push_back(k_batch_page_offset);        // rt_arg::reader_k_batch_offset (25)
-            reader_rt.push_back(kv_len_tiles);               // rt_arg::reader_kv_len_tiles (26)
-            reader_rt.append(fused_rt);             // rt_arg::reader_fused_rt_base (27..35): ring/dir/sems/split
-            reader_rt.push_back(k_local.buffer());  // rt_arg::reader_k_local_addr (36): local SP shard address
+            reader_rt.push_back(k_batch_page_offset);  // rt_arg::reader_k_batch_offset (25)
+            reader_rt.push_back(kv_len_tiles);         // rt_arg::reader_kv_len_tiles (26)
+            reader_rt.append(fused_rt);                // rt_arg::reader_fused_rt_base (27..35): ring/dir/sems/split
+            reader_rt.push_back(k_local.buffer());     // rt_arg::reader_k_local_addr (36): local SP shard address
             reader_rt.push_back(k_local_batch_page_offset);  // selected slot in the original local cache
             reader_rt.append(band_perm);                     // rt_arg::reader_band_perm_base (38..): band-visit perm
             reader_kernel.emplace_runtime_args(core, reader_rt);
@@ -607,76 +611,74 @@ ProgramDescriptor build_ring_program_descriptor(
     desc.kernels.push_back(std::move(writer_kernel));
     desc.kernels.push_back(std::move(compute_kernel));
 
-    if (!consumers_only) {  // override (cache hit) reads only the consumer kernels above -> skip the AG helper
-        // Producer-side signaler copies the consumer's receiver cores + signal semaphores.
-        std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler> ag_sig =
-            ttnn::experimental::ccl::AllGatherFusedOpSignaler();
-        ag_sig->init_fused_op(
-            sdpa_sig.fused_op_receiver_cores_noc,
-            sdpa_sig.fused_op_receiver_signal_semaphores,
-            sdpa_sig.fused_op_signaler_mode);
+    // Producer-side signaler copies the consumer's receiver cores + signal semaphores.
+    std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler> ag_sig =
+        ttnn::experimental::ccl::AllGatherFusedOpSignaler();
+    ag_sig->init_fused_op(
+        sdpa_sig.fused_op_receiver_cores_noc,
+        sdpa_sig.fused_op_receiver_signal_semaphores,
+        sdpa_sig.fused_op_signaler_mode);
 
-        std::optional<ttnn::MeshCoordinate> forward_coord;
-        std::optional<ttnn::MeshCoordinate> backward_coord;
-        if (fused.full_mesh) {
-            const ttnn::operations::ccl::common::MeshRingPlan mesh_ring_plan{
-                .cluster_axis = std::nullopt,
-                .full_mesh = true,
-                .orientation = fused.snake_orientation,
-                .mesh_rows = fused.mesh_rows,
-                .mesh_cols = fused.mesh_cols,
-                .ring_size = ring_size,
-                .num_links = fused.num_links,
-                .route_plan_hash = fused.route_plan_hash};
-            const auto position = ttnn::operations::ccl::common::get_mesh_ring_position(q, coord, mesh_ring_plan);
-            TT_FATAL(
-                position.transport_rank == transport_rank && position.tensor_rank == tensor_rank,
-                "indexer_score fused full-mesh rank plan drift at coordinate {}",
-                coord);
-            forward_coord = position.forward_coord;
-            backward_coord = position.backward_coord;
-        } else {
-            forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-                q, coord, /*offset=*/1, fused.topology, args.sp_axis());
-            backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-                q, coord, /*offset=*/-1, fused.topology, args.sp_axis());
-        }
-
-        std::vector<Tensor> ag_in = {k_local};
-        std::vector<Tensor> ag_out = {k};
-        // The gather concatenates the SP shards along the seq axis (dim 2); the reader's block-cyclic permutation
-        // assumes this, so it is a fixed constant, not a configurable knob.
-        constexpr int32_t ag_seq_concat_dim = 2;
-        ttnn::ring_attention_all_gather_async_multi_core_with_workers_helper(
-            desc,
-            ag_in,
-            coord,
-            forward_coord,
-            backward_coord,
-            ag_out,
-            ag_seq_concat_dim,
-            fused.num_links,
-            ring_size,
-            transport_rank,
-            fused.topology,
-            fused.ag_semaphore,
-            fused.ag_sub_device_id,
-            ag_sig,
-            ccl_core_grid_offset,
-            // COL_MAJOR so the reserved-column offset lays the workers DOWN the free column ((compute_cols_x,0),
-            // (compute_cols_x,1), ...) instead of running off the right grid edge as row-major would.
-            ttnn::ccl::CoreAllocationStrategy::COL_MAJOR,
-            args.cache_batch_idx,
-            gather_valid_height_tiles(args, k_local),
-            /*slot_id=*/std::nullopt,
-            /*kv_actual_isl=*/std::nullopt,
-            /*chunk_local_tiles=*/0,
-            /*kv_cache_num_layers=*/1,
-            /*kv_cache_layer_idx=*/0,
-            // This consumer's FusedRingGate has no split-shard second-half wait; keep the gather unsplit.
-            /*split_forwarding_enabled=*/false,
-            rank_mapping);
+    std::optional<ttnn::MeshCoordinate> forward_coord;
+    std::optional<ttnn::MeshCoordinate> backward_coord;
+    if (fused.full_mesh) {
+        const ttnn::operations::ccl::common::MeshRingPlan mesh_ring_plan{
+            .cluster_axis = std::nullopt,
+            .full_mesh = true,
+            .orientation = fused.snake_orientation,
+            .mesh_rows = fused.mesh_rows,
+            .mesh_cols = fused.mesh_cols,
+            .ring_size = ring_size,
+            .num_links = fused.num_links,
+            .route_plan_hash = fused.route_plan_hash};
+        const auto position = ttnn::operations::ccl::common::get_mesh_ring_position(q, coord, mesh_ring_plan);
+        TT_FATAL(
+            position.transport_rank == transport_rank && position.tensor_rank == tensor_rank,
+            "indexer_score fused full-mesh rank plan drift at coordinate {}",
+            coord);
+        forward_coord = position.forward_coord;
+        backward_coord = position.backward_coord;
+    } else {
+        forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            q, coord, /*offset=*/1, fused.topology, args.sp_axis());
+        backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            q, coord, /*offset=*/-1, fused.topology, args.sp_axis());
     }
+
+    std::vector<Tensor> ag_in = {k_local};
+    std::vector<Tensor> ag_out = {k};
+    // The gather concatenates the SP shards along the seq axis (dim 2); the reader's block-cyclic permutation
+    // assumes this, so it is a fixed constant, not a configurable knob.
+    constexpr int32_t ag_seq_concat_dim = 2;
+    ttnn::ring_attention_all_gather_async_multi_core_with_workers_helper(
+        desc,
+        ag_in,
+        coord,
+        forward_coord,
+        backward_coord,
+        ag_out,
+        ag_seq_concat_dim,
+        fused.num_links,
+        ring_size,
+        transport_rank,
+        fused.topology,
+        fused.ag_semaphore,
+        fused.ag_sub_device_id,
+        ag_sig,
+        ccl_core_grid_offset,
+        // COL_MAJOR so the reserved-column offset lays the workers DOWN the free column ((compute_cols_x,0),
+        // (compute_cols_x,1), ...) instead of running off the right grid edge as row-major would.
+        ttnn::ccl::CoreAllocationStrategy::COL_MAJOR,
+        args.cache_batch_idx,
+        gather_valid_height_tiles(args, k_local),
+        /*slot_id=*/std::nullopt,
+        /*kv_actual_isl=*/std::nullopt,
+        /*chunk_local_tiles=*/0,
+        /*kv_cache_num_layers=*/1,
+        /*kv_cache_layer_idx=*/0,
+        // This consumer's FusedRingGate has no split-shard second-half wait; keep the gather unsplit.
+        /*split_forwarding_enabled=*/false,
+        rank_mapping);
 
     log_debug(
         tt::LogOp,
@@ -699,6 +701,7 @@ ProgramDescriptor build_ring_program_descriptor(
     return desc;
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 tt::tt_metal::WorkloadDescriptor RingIndexerScoreDsaProgramFactory::create_workload_descriptor(
@@ -710,7 +713,7 @@ tt::tt_metal::WorkloadDescriptor RingIndexerScoreDsaProgramFactory::create_workl
     const auto coords = tensor_coords.coords();
     wd.programs.reserve(coords.size());
     for (const auto& coord : coords) {
-        auto desc = build_ring_program_descriptor(args, tensors, out, coord);
+        auto desc = CMAKE_UNIQUE_NAMESPACE::build_ring_program_descriptor(args, tensors, out, coord);
         wd.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
     }
     return wd;
@@ -730,6 +733,7 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
     const operation_attributes_t& args,
     const tensor_args_t& tensors,
     tensor_return_value_t& out) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;
     // Buffer addresses (q/k/w/out/k_local + the AG's gathered buffer) auto-patch via the descriptor's
     // BufferBinding fast path.
     descriptor_adapter_t::apply_descriptor(cached, args, tensors, out);
@@ -753,7 +757,6 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
     const uint32_t local_slot_pages =
         (k_local_shape[2] / tt::constants::TILE_HEIGHT) * (k_local_shape[3] / tt::constants::TILE_WIDTH);
     const uint32_t k_local_batch_page_offset = args.cache_batch_idx.value_or(0) * local_slot_pages;
-
     for (auto& [range, program] : cached.workload.get_programs()) {
         // Must match the build path's rank, or a cache hit shifts the causal offset.
         const uint32_t device_index = transport_to_tensor_rank(args, transport_rank_for(args, range.start_coord(), q));
@@ -778,28 +781,24 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
             }
         };
 
-        // kernel_idx: reader=0, writer=1, compute=2; AG workers are 3..6.
-        // The fused rt_arg namespace is file-local, but this .cpp participates in unity builds alongside
-        // the classic factory's same-named namespace. Keep these literals synchronized with its static_assert
-        // (reader_k_batch_offset=25, reader_kv_len_tiles=26, reader_k_local_batch_offset=37 — past the
-        // 9-wide fused block at 27..35 and k_local_addr at 36).
-        patch_field(0, 25u, k_batch_page_offset);
-        patch_field(0, 26u, pcache.kv_len_tiles);
-        patch_field(0, 37u, k_local_batch_page_offset);
+        patch_field(kReaderKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::reader_k_batch_offset, k_batch_page_offset);
+        patch_field(kReaderKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::reader_kv_len_tiles, pcache.kv_len_tiles);
+        patch_field(
+            kReaderKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::reader_k_local_batch_offset, k_local_batch_page_offset);
         // compute: kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles (slots [6, perm_base)).
-        patch_field(2, 6u, pcache.kv_len_tiles);
-        patch_field(2, 7u, geom.chunk_start_tiles);
-        patch_field(2, 8u, geom.straddle_q_tile);
-        patch_field(2, 9u, geom.straddle_jump_tiles);
+        patch_field(kComputeKernelIndex, 6u, pcache.kv_len_tiles);
+        patch_field(kComputeKernelIndex, 7u, geom.chunk_start_tiles);
+        patch_field(kComputeKernelIndex, 8u, geom.straddle_q_tile);
+        patch_field(kComputeKernelIndex, 9u, geom.straddle_jump_tiles);
         // writer: same four scalars after out-addr(0) + schedule(1..6) (slots [7, perm_base)).
-        patch_field(1, 7u, pcache.kv_len_tiles);
-        patch_field(1, 8u, geom.chunk_start_tiles);
-        patch_field(1, 9u, geom.straddle_q_tile);
-        patch_field(1, 10u, geom.straddle_jump_tiles);
+        patch_field(kWriterKernelIndex, 7u, pcache.kv_len_tiles);
+        patch_field(kWriterKernelIndex, 8u, geom.chunk_start_tiles);
+        patch_field(kWriterKernelIndex, 9u, geom.straddle_q_tile);
+        patch_field(kWriterKernelIndex, 10u, geom.straddle_jump_tiles);
 
         // The descriptor fast path patches buffer bindings but not scalar fields embedded in the fused AG
-        // workers. cache_batch_idx and kv_len are hash-excluded, so update the selected input slot and the
-        // slab-rounded gather extent on every cache hit (same protocol as ring_joint_sdpa).
+        // workers. cache_batch_idx and the exact kv_len are hash-excluded (only the structural schedule class is
+        // hashed), so update the selected input slot and slab-rounded gather extent on every cache hit.
         const auto& shape = k_local.padded_shape();
         const uint32_t Ht = shape[2] / tt::constants::TILE_HEIGHT;
         const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
@@ -810,13 +809,24 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
 
         const auto patch_ag_field = [&](uint32_t kernel_idx, uint32_t slot, uint32_t value) {
             auto& grid_args = GetRuntimeArgs(program, kernel_idx);
+            bool patched_any_core = false;
             for (auto& col_args : grid_args) {
                 for (auto& core_args : col_args) {
-                    if (core_args.size() > slot) {
-                        core_args[slot] = value;
+                    if (core_args.size() == 0) {
+                        continue;
                     }
+                    TT_FATAL(
+                        core_args.size() > slot,
+                        "indexer_score fused override: AG scalar slot {} out of range (size {}) for kernel {}",
+                        slot,
+                        core_args.size(),
+                        kernel_idx);
+                    core_args[slot] = value;
+                    patched_any_core = true;
                 }
             }
+            TT_FATAL(
+                patched_any_core, "indexer_score fused override: AG kernel {} has no runtime arguments", kernel_idx);
         };
 
         // Semaphore identity is hash-excluded. Rebind both ring directions on every cache hit so callers
@@ -829,21 +839,23 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
             ag_semaphores.size());
         const uint32_t backward_semaphore = static_cast<uint32_t>(ag_semaphores[0].address());
         const uint32_t forward_semaphore = static_cast<uint32_t>(ag_semaphores[1].address());
-        patch_ag_field(/*reader forward=*/3, /*out_ready_sem=*/2, forward_semaphore);
-        patch_ag_field(/*writer forward=*/4, /*out_ready_sem=*/4, forward_semaphore);
-        patch_ag_field(/*reader backward=*/5, /*out_ready_sem=*/2, backward_semaphore);
-        patch_ag_field(/*writer backward=*/6, /*out_ready_sem=*/4, backward_semaphore);
+        patch_ag_field(kAllGatherReaderForwardKernelIndex, ag_rt::kReaderReadySemaphoreFieldOffset, forward_semaphore);
+        patch_ag_field(kAllGatherWriterForwardKernelIndex, ag_rt::kWriterReadySemaphoreFieldOffset, forward_semaphore);
+        patch_ag_field(
+            kAllGatherReaderBackwardKernelIndex, ag_rt::kReaderReadySemaphoreFieldOffset, backward_semaphore);
+        patch_ag_field(
+            kAllGatherWriterBackwardKernelIndex, ag_rt::kWriterReadySemaphoreFieldOffset, backward_semaphore);
 
         constexpr uint32_t ag_reader_input_base =
             ag_rt::kReaderRuntimeArgHeaderCount + ag_rt::kInputBatchBaseFieldOffset;
         constexpr uint32_t ag_reader_valid_pages = ag_rt::kReaderRuntimeArgHeaderCount + ag_rt::kValidPagesFieldOffset;
         constexpr uint32_t ag_writer_valid_pages = ag_rt::kWriterRuntimeArgHeaderCount + ag_rt::kValidPagesFieldOffset;
-        patch_ag_field(/*reader forward=*/3, ag_reader_input_base, input_batch_base);
-        patch_ag_field(/*reader backward=*/5, ag_reader_input_base, input_batch_base);
-        patch_ag_field(/*reader forward=*/3, ag_reader_valid_pages, valid_pages);
-        patch_ag_field(/*reader backward=*/5, ag_reader_valid_pages, valid_pages);
-        patch_ag_field(/*writer forward=*/4, ag_writer_valid_pages, valid_pages);
-        patch_ag_field(/*writer backward=*/6, ag_writer_valid_pages, valid_pages);
+        patch_ag_field(kAllGatherReaderForwardKernelIndex, ag_reader_input_base, input_batch_base);
+        patch_ag_field(kAllGatherReaderBackwardKernelIndex, ag_reader_input_base, input_batch_base);
+        patch_ag_field(kAllGatherReaderForwardKernelIndex, ag_reader_valid_pages, valid_pages);
+        patch_ag_field(kAllGatherReaderBackwardKernelIndex, ag_reader_valid_pages, valid_pages);
+        patch_ag_field(kAllGatherWriterForwardKernelIndex, ag_writer_valid_pages, valid_pages);
+        patch_ag_field(kAllGatherWriterBackwardKernelIndex, ag_writer_valid_pages, valid_pages);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -167,8 +167,7 @@ ProgramDescriptor build_ring_program_descriptor(
     const uint32_t Sqt = Sq / tt::constants::TILE_HEIGHT;
     const uint32_t Tt = T / tt::constants::TILE_WIDTH;
     const uint32_t Dt = D / tt::constants::TILE_WIDTH;
-    // Per-SP-shard chunk width in tiles (block-cyclic only; 0 otherwise). Used by the overlap warning and the
-    // band-readiness shard mapping. The ternary keeps it null-safe when block-cyclic is off.
+    // Per-SP-shard block-cyclic run width in tiles (0 for a contiguous cache).
     const uint32_t cl_t = args.has_block_cyclic() ? args.block_cyclic->chunk_local / tt::constants::TILE_WIDTH : 0;
 
     const auto& cfg = args.program_config;
@@ -180,22 +179,6 @@ ProgramDescriptor build_ring_program_descriptor(
     // Step-E band reorder assumes no head streaming (all heads resident): stream_heads pads the band loop with
     // phantom q-mcast bands that the reorder would perturb. HB == Hi means head_group_size was 0 or Hi.
     TT_FATAL(HB == Hi, "indexer_score fused: head_group_size must be 0 or Hi (no head streaming) on the fused path");
-
-    // Overlap-quality guidance for block-cyclic: a k-band (KC tiles) should not straddle a per-SP-shard chunk
-    // boundary (cl_t tiles), or it inherits the LATER of two shards and piles onto the final ring-arrival wave
-    // (KC=16, cl_t=20 -> ~40% of bands wait for the farthest shard -> long exposed tail). If KC divides cl_t the
-    // readiness histogram is flat and block-cyclic overlaps as well as contiguous. Correctness is unaffected
-    // either way (the reader gates every shard a band touches); this only shapes the AG/compute overlap.
-    if (args.has_block_cyclic() && (KC == 0 || cl_t % KC != 0)) {
-        log_warning(
-            tt::LogOp,
-            "indexer_score fused: k_chunk_size ({} tiles) does not divide block_cyclic chunk_local ({} tiles); "
-            "bands straddle SP-shard boundaries and back-load the ring-arrival tail. For best AG/compute "
-            "overlap pick a k_chunk_size whose tile count divides {}.",
-            KC,
-            cl_t,
-            cl_t);
-    }
 
     const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         ttnn::get_compute_kernel_config_args(q.device()->arch(), args.compute_kernel_config);
@@ -226,74 +209,61 @@ ProgramDescriptor build_ring_program_descriptor(
     const uint32_t compute_cols_x = phys_grid.x - reserved_cols;
     const CoreCoord ccl_core_grid_offset{compute_cols_x, 0};  // AG workers start in the first reserved column
 
-    const uint32_t group_count = Sqt / QC;                                  // q-groups (banded schedule rows)
-    const uint32_t band_count = units_in_group(KC, Tt);                     // k-bands = ceil(Tt/KC)
-    const uint32_t group_rows = rows_for_groups(group_count, grid_y);       // grid rows per group (k-mcast)
-    const uint32_t cols_used = cols_for_bands(band_count, compute_cols_x);  // grid columns used by compute
-    const uint32_t num_blocks = band_row_blocks(group_count, band_count, compute_cols_x, grid_y);  // row-block reps
-    const uint32_t rows_used = group_rows * num_blocks;    // grid rows used by compute
+    const uint32_t ring_size = ring_size_for(args, q);  // shared with validate/signaler (same ring extent)
+    const uint32_t sll_t = Tt / ring_size;              // physical tiles per SP shard in gathered K
+    // The two-marker protocol requires both ring directions to carry slices. Linear topologies and a two-chip
+    // ring leave one direction with no targets, whose writer intentionally discards its local packet stream.
+    const bool partial_readiness_enabled = fused.topology == ttnn::ccl::Topology::Ring && ring_size > 2 &&
+                                           ag_rt::uses_output_bank_owned_schedule({k_local}, {k}, /*dim=*/2);
+    const uint32_t units_per_shard = units_in_group(KC, sll_t);
+    const uint32_t work_unit_count = ring_size * units_per_shard;
+    const uint32_t group_count = Sqt / QC;                             // q-groups (banded schedule rows)
+    const uint32_t group_rows = rows_for_groups(group_count, grid_y);  // grid rows per group (k-mcast)
+    const uint32_t cols_used = cols_for_bands(work_unit_count, compute_cols_x);
+    const uint32_t num_blocks =
+        band_row_blocks(group_count, work_unit_count, compute_cols_x, grid_y);  // row-block reps
+    const uint32_t rows_used = group_rows * num_blocks;                         // grid rows used by compute
     const uint32_t num_groups = group_count / group_rows;  // phase-stack count (groups per row, round-robin)
 
-    // Ring-arrival readiness, hoisted above the band->column assignment (which now balances it) AND reused by the
-    // per-column visit sort below. shard_order[c] = the ring iteration that delivers SP shard c (local shard -> 0);
-    // replay the RingIdSequencer on the HOST with the same seed as the reader. A band's readiness = max arrival-
-    // iter over the shards its tiles land in.
-    const uint32_t ring_size = ring_size_for(args, q);  // shared with validate/signaler (same ring extent)
+    // Group physical SP shards by their ring-arrival wave (the local shard is wave 0). Work units never cross a
+    // shard boundary, so each has exactly one readiness dependency. RingIdSequencer already emits each wave in
+    // the desired paired-direction order; preserve it directly rather than reconstructing and sorting it later.
     const auto rw = ring_writes_for(ring_size, transport_rank, fused.topology);
-    std::vector<uint32_t> shard_order(ring_size, 0);
+    const uint32_t max_wave = ring_size / 2;
+    std::vector<std::vector<uint32_t>> shards_by_wave(max_wave + 1);
     {
         RingIdSequencer seq(transport_rank, ring_size, rw.backward_writes_expected, rw.forward_writes_expected);
         for (uint32_t i = 0; i < ring_size; ++i) {
             const uint32_t rid = seq.get_next_ring_id([](uint32_t, uint32_t) {});
-            shard_order[transport_to_tensor_rank(args, rid)] = i;
+            shards_by_wave[(i + 1) / 2].push_back(transport_to_tensor_rank(args, rid));
         }
     }
-    const uint32_t sll_t = Tt / ring_size;  // tiles per SP shard in the gathered buffer (cl_t hoisted above)
-    const auto band_readiness = [&](uint32_t band_abs) -> uint32_t {
-        const uint32_t start = band_abs * KC;
-        const uint32_t end = std::min(start + KC, Tt);
-        uint32_t readiness = 0;
-        for (uint32_t logical_tile = start; logical_tile < end; ++logical_tile) {
-            const uint32_t shard = args.has_block_cyclic() ? (logical_tile / cl_t) % ring_size : (logical_tile / sll_t);
-            readiness = std::max(readiness, shard_order[shard]);
-        }
-        return readiness;
-    };
-
-    // READINESS-BALANCED band -> column assignment (fused overlap balance). Distribute a block's bands across
-    // columns round-robin WITHIN each ring-arrival readiness level, using a shared column cursor. This balances
-    // BOTH the total band count AND the per-readiness count across columns, so every column front-loads an equal
-    // share of already-available (local, readiness 0) work before it needs any remote shard, and every column
-    // also carries an equal share of the last-arriving shard (its tail spreads across ALL columns).
-    //   A plain `i % cols_used` stripe instead CORRELATES shard with column: since a block-cyclic band maps to
-    // shard (band's first tile / cl_t) % ring_size and the stripe maps it to column band % cols_used, a column
-    // sees only cols_used / gcd(cols_used, ring_size) distinct shards (e.g. 10 cols x ring 4 -> 2 shards/col).
-    // Half the columns then hold NO local band and stall on a remote shard at their VERY FIRST band, exposing the
-    // entire first-slab arrival (~95us here) instead of overlapping it behind local work. Bands stay ABSOLUTE
-    // indices (reader/compute/writer get band0=0 + the absolute list); the per-column readiness sort below still
-    // walks local-first-then-arrival exactly as before.
-    std::vector<std::vector<std::vector<uint32_t>>> band_list(
+    // Deal each shard's physical KC units across row-blocks and columns. This gives every compute column an even
+    // share of the local shard before it encounters a Fabric gate, while retaining KC-sized math units. The last
+    // unit of a shard is padded rather than crossing into the next shard.
+    std::vector<std::vector<std::vector<uint32_t>>> work_list(
         num_blocks, std::vector<std::vector<uint32_t>>(cols_used));
     uint32_t max_bands = 0;
     {
         for (uint32_t blk = 0; blk < num_blocks; ++blk) {
-            uint32_t col_cursor = 0;
-            for (uint32_t rlevel = 0; rlevel < ring_size; ++rlevel) {
-                // Keep every row-block useful when kv_len is a runtime prefix of the persistent K capacity.
-                // A contiguous split would give block 0 [0, capacity/blocks), block 1 the next range, etc.
-                // Consequently a short valid prefix activates only block 0 even though all row-blocks are live.
-                // Deal bands round-robin across blocks instead: every prefix is balanced to within one band, while
-                // each block still has a disjoint band set and its K-mcast remains lockstep down the block's rows.
-                for (uint32_t band_abs = blk; band_abs < band_count; band_abs += num_blocks) {
-                    if (band_readiness(band_abs) != rlevel) {
-                        continue;
+            for (uint32_t wave = 0; wave <= max_wave; ++wave) {
+                // Give each column matching offsets from both directions. Its visit order becomes
+                // A0,B0,A1,B1,..., so a core that reaches shard A's completion gate can consume the
+                // simultaneously arriving midpoint of shard B instead of idling.
+                for (uint32_t col = 0; col < cols_used; ++col) {
+                    for (uint32_t unit_slot = col;; unit_slot += cols_used) {
+                        const uint32_t unit_in_shard = blk + unit_slot * num_blocks;
+                        if (unit_in_shard >= units_per_shard) {
+                            break;
+                        }
+                        for (uint32_t shard : shards_by_wave[wave]) {
+                            work_list[blk][col].push_back(shard * sll_t + unit_in_shard * KC);
+                        }
                     }
-                    band_list[blk][col_cursor % cols_used].push_back(band_abs);
-                    ++col_cursor;
                 }
             }
             for (uint32_t col = 0; col < cols_used; ++col) {
-                max_bands = std::max<uint32_t>(max_bands, static_cast<uint32_t>(band_list[blk][col].size()));
+                max_bands = std::max<uint32_t>(max_bands, static_cast<uint32_t>(work_list[blk][col].size()));
             }
         }
     }
@@ -448,21 +418,28 @@ ProgramDescriptor build_ring_program_descriptor(
     reader_ct.push_back(static_cast<uint32_t>(rank_mapping.orientation));
     reader_ct.push_back(rank_mapping.mesh_rows);
     reader_ct.push_back(rank_mapping.mesh_cols);
+    reader_ct.push_back(static_cast<uint32_t>(partial_readiness_enabled));
 
     std::vector<uint32_t> writer_ct = common_ct;
     writer_ct.push_back(1u);  // fused_ring on
     const uint32_t out_elem_bytes = out.element_size();
     writer_ct.push_back(T * out_elem_bytes);  // row-major page = one output row (no pooling)
+    writer_ct.push_back(block_cyclic_ct[0]);  // shard-major physical -> logical output mapping
+    writer_ct.push_back(block_cyclic_ct[1]);
+    writer_ct.push_back(ring_size);  // physical shard count (also block-cyclic SP when enabled)
     tt::tt_metal::TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
 
     std::vector<uint32_t> compute_ct = common_ct;
     compute_ct.push_back(qk_subblock_h);
     compute_ct.push_back(qk_batch_heads);
     compute_ct.push_back(qk_col_batch);
-    compute_ct.push_back(1u);  // apply_relu (DSA)
-    compute_ct.push_back(0u);  // fuse_single off
-    compute_ct.push_back(0u);  // fused_stream_k off
-    compute_ct.push_back(1u);  // fused_ring on
+    compute_ct.push_back(1u);                  // apply_relu (DSA)
+    compute_ct.push_back(0u);                  // fuse_single off
+    compute_ct.push_back(0u);                  // fused_stream_k off
+    compute_ct.push_back(1u);                  // fused_ring on
+    compute_ct.push_back(block_cyclic_ct[0]);  // shard-major physical -> logical causal mapping
+    compute_ct.push_back(block_cyclic_ct[1]);
+    compute_ct.push_back(ring_size);  // physical shard count (also block-cyclic SP when enabled)
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     KernelDescriptor reader_kernel{};
@@ -507,12 +484,7 @@ ProgramDescriptor build_ring_program_descriptor(
     std::vector<uint32_t> fused_rt;
     sdpa_sig.push_ring_sdpa_fused_op_rt_args(fused_rt);  // the fused_rt_width-wide block (see rt_arg above)
 
-    // ---- Step E: band-visit reorder (local-first, then remote by ring arrival) --------------------------
-    // shard_order / band_readiness are computed above (hoisted so the band->column assignment can balance
-    // readiness across columns). The per-column stable_sort by band_readiness below makes each core score its
-    // local + already-arrived bands first and hide the farther slabs' transport behind that compute. The SAME
-    // permutation is fed to reader/compute/writer (band identity preserved) so the cb_k / cb_out FIFOs stay in
-    // lockstep.
+    // ---- Shard-major visit order: local physical shard first, then remote shards by ring arrival. --------
     for (uint32_t row = 0; row < rows_used; ++row) {
         // Q/W row mcast rect + diagonal sender (shared with the classic factory).
         const auto qb = q_mcast_bbox(phys, row, cols_used);
@@ -526,16 +498,9 @@ ProgramDescriptor build_ring_program_descriptor(
             const uint32_t k_ys = kb.ys, k_ye = kb.ye, k_px = kb.px;
             const CoreCoord k_sender = kb.sender;
             const CoreCoord core{col, row};
-            // This column's ABSOLUTE band indices (striped set), sorted by ring arrival readiness so the core
-            // scores its local + already-arrived bands first and hides the farther slabs behind that compute.
-            // band0 is passed as 0 and the kernels read these absolute indices straight from the perm slots
-            // (span.set(group, 0 + band)); identical for every row in a k-mcast column (same set + schedule), so
-            // the k-mcast stays in lockstep.
-            std::vector<uint32_t> band_perm = band_list[block][col];
-            std::stable_sort(band_perm.begin(), band_perm.end(), [&](uint32_t a, uint32_t b) {
-                return band_readiness(a) < band_readiness(b);
-            });
-            const uint32_t col_num_bands = static_cast<uint32_t>(band_perm.size());
+            // Physical K-tile starts, identical for every row in a K-mcast column.
+            const std::vector<uint32_t>& physical_starts = work_list[block][col];
+            const uint32_t col_num_bands = static_cast<uint32_t>(physical_starts.size());
             const std::array<uint32_t, 6> sched = {
                 row % group_rows, group_rows, num_groups, /*band0=*/0u, col_num_bands, max_bands};
 
@@ -582,7 +547,7 @@ ProgramDescriptor build_ring_program_descriptor(
             reader_rt.append(fused_rt);                // rt_arg::reader_fused_rt_base (27..35): ring/dir/sems/split
             reader_rt.push_back(k_local.buffer());     // rt_arg::reader_k_local_addr (36): local SP shard address
             reader_rt.push_back(k_local_batch_page_offset);  // selected slot in the original local cache
-            reader_rt.append(band_perm);                     // rt_arg::reader_band_perm_base (38..): band-visit perm
+            reader_rt.append(physical_starts);               // rt_arg::reader_band_perm_base (38..): physical K starts
             reader_kernel.emplace_runtime_args(core, reader_rt);
 
             KernelDescriptor::RTArgList compute_rt;
@@ -591,7 +556,7 @@ ProgramDescriptor build_ring_program_descriptor(
             compute_rt.push_back(chunk_t);
             compute_rt.push_back(geom.straddle_q_tile);
             compute_rt.push_back(geom.straddle_jump_tiles);
-            compute_rt.append(band_perm);  // rt_arg::compute_band_perm_base (10..): band-visit permutation
+            compute_rt.append(physical_starts);  // rt_arg::compute_band_perm_base (10..): physical K starts
             compute_kernel.emplace_runtime_args(core, compute_rt);
 
             KernelDescriptor::RTArgList writer_rt;
@@ -601,7 +566,7 @@ ProgramDescriptor build_ring_program_descriptor(
             writer_rt.push_back(chunk_t);
             writer_rt.push_back(geom.straddle_q_tile);
             writer_rt.push_back(geom.straddle_jump_tiles);
-            writer_rt.append(band_perm);  // rt_arg::writer_band_perm_base (11..): band-visit permutation
+            writer_rt.append(physical_starts);  // rt_arg::writer_band_perm_base (11..): physical K starts
             writer_kernel.emplace_runtime_args(core, writer_rt);
         }
     }
@@ -676,14 +641,15 @@ ProgramDescriptor build_ring_program_descriptor(
         /*chunk_local_tiles=*/0,
         /*kv_cache_num_layers=*/1,
         /*kv_cache_layer_idx=*/0,
-        // This consumer's FusedRingGate has no split-shard second-half wait; keep the gather unsplit.
+        // This consumer uses midpoint/completion readiness rather than diametric split forwarding.
         /*split_forwarding_enabled=*/false,
+        /*partial_readiness_enabled=*/partial_readiness_enabled,
         rank_mapping);
 
     log_debug(
         tt::LogOp,
         "indexer_score FUSED tensor_rank={} ring_size={} transport_rank={} fwd_exp={} bwd_exp={} grid={}x{}(+{} ag) "
-        "rows_used={} cols_used={} band_count={} k_mcast={} q_mcast={}",
+        "rows_used={} cols_used={} work_unit_count={} k_mcast={} q_mcast={}",
         tensor_rank,
         ring_size,
         transport_rank,
@@ -694,7 +660,7 @@ ProgramDescriptor build_ring_program_descriptor(
         reserved_cols,
         rows_used,
         cols_used,
-        band_count,
+        work_unit_count,
         k_mcast_on,
         q_mcast_on);
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <array>
-#include <numeric>
 #include <string>
 #include <vector>
 
@@ -20,15 +19,15 @@
 #include "hostdevcommon/kernel_structs.h"  // tt::CBIndex
 
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
-#include "ttnn/operations/transformer/sdpa/device/ring_fusion.hpp"                // RingSDPAFusedOpSignaler
-#include "ttnn/operations/transformer/sdpa/device/kernels/ring_id_sequencer.hpp"  // host replay for band arrival order
-#include "ttnn/operations/ccl/ccl_common.hpp"  // linearized index / neighbor / fwd-bwd config
+#include "ttnn/operations/transformer/sdpa/device/ring_fusion.hpp"  // RingSDPAFusedOpSignaler
+#include "ttnn/operations/ccl/ccl_common.hpp"                       // linearized index / neighbor / fwd-bwd config
 #include "ttnn/operations/ccl/common/host/mesh_ring_plan.hpp"
-#include "ttnn/operations/ccl/ccl_op_fusion.hpp"  // AllGatherFusedOpSignaler
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"                    // AllGatherFusedOpSignaler
 // the fused AG helper (the only Linear+fuse-capable all-gather):
 #include "ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp"
 
 #include "indexer_score_host_common.hpp"  // shared causal geometry / device index / persistent-cache args
+#include "ring_indexer_score_schedule.hpp"
 #include "kernels/indexer_score_cb.hpp"
 #include "kernels/indexer_score_work_split.hpp"
 
@@ -77,9 +76,17 @@ constexpr uint32_t reader_k_local_addr = reader_fused_rt_base + fused_rt_width; 
 constexpr uint32_t reader_k_local_batch_offset = reader_k_local_addr + 1;                                    // 37
 constexpr uint32_t reader_band_perm_base = reader_k_local_batch_offset + 1;                                  // 38
 // Compute RT: schedule(6), kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles, then perm.
-constexpr uint32_t compute_band_perm_base = 6 + 4;  // 10
+constexpr uint32_t compute_kv_len_tiles = 6;
+constexpr uint32_t compute_chunk_start_tiles = compute_kv_len_tiles + 1;
+constexpr uint32_t compute_straddle_q_tile = compute_chunk_start_tiles + 1;
+constexpr uint32_t compute_straddle_jump_tiles = compute_straddle_q_tile + 1;
+constexpr uint32_t compute_band_perm_base = compute_straddle_jump_tiles + 1;  // 10
 // Writer RT: out addr, schedule(6), kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles, perm.
-constexpr uint32_t writer_band_perm_base = 1 + 6 + 4;  // 11
+constexpr uint32_t writer_kv_len_tiles = 1 + 6;
+constexpr uint32_t writer_chunk_start_tiles = writer_kv_len_tiles + 1;
+constexpr uint32_t writer_straddle_q_tile = writer_chunk_start_tiles + 1;
+constexpr uint32_t writer_straddle_jump_tiles = writer_straddle_q_tile + 1;
+constexpr uint32_t writer_band_perm_base = writer_straddle_jump_tiles + 1;  // 11
 // Lock the derived offsets to the values the kernels hardcode (reader receiver reads the fused block at 27;
 // compute/writer read their perm at 10/11). A drift here would silently desync the kernels -> this fails to build.
 static_assert(
@@ -89,28 +96,11 @@ static_assert(
     "indexer_score fused rt_arg slot layout drifted from the kernel-side expectations");
 }  // namespace rt_arg
 
-// forward/backward all-gather writes expected for this device on the given topology (mirrors ring_joint's
-// build_ring_write_plan: Linear swaps num_targets_{fwd,bwd} into the plan).
-struct RingWrites {
-    uint32_t forward_writes_expected;
-    uint32_t backward_writes_expected;
-};
-RingWrites ring_writes_for(uint32_t ring_size, uint32_t ring_index, ttnn::ccl::Topology topology) {
-    auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
-        ttnn::ccl::get_forward_backward_configuration(ring_size, ring_index, topology);
-    (void)dynamic_alternate;
-    if (topology == ttnn::ccl::Topology::Ring && (ring_index % 2 == 0)) {
-        std::swap(num_targets_forward, num_targets_backward);
-    }
-    if (topology == ttnn::ccl::Topology::Linear) {
-        return {static_cast<uint32_t>(num_targets_backward), static_cast<uint32_t>(num_targets_forward)};
-    }
-    return {static_cast<uint32_t>(num_targets_forward), static_cast<uint32_t>(num_targets_backward)};
-}
-
 // Block-cyclic caches are slab-major on every SP rank. A global valid prefix can end partway through a
 // global slab, whose valid row count differs by rank, so gather complete touched slabs. This is the smallest
-// uniform per-rank prefix that preserves the fixed-size ring protocol and contains every valid key.
+// uniform per-rank prefix that preserves the fixed-size ring protocol and contains every valid key. KEEP IN
+// SYNC with compute_gather_valid_Ht() in the AG metadata helper and the gathered_shard_tiles calculation in
+// reader_indexer_score.cpp; all three define the producer/consumer midpoint boundary.
 std::optional<uint32_t> gather_valid_height_tiles(const operation_attributes_t& args, const Tensor& k_local) {
     if (!args.kv_len.has_value() || !args.block_cyclic.has_value()) {
         return std::nullopt;
@@ -201,7 +191,7 @@ ProgramDescriptor build_ring_program_descriptor(
     // grid_y*compute_cols_x cores.
     const uint32_t grid_y = phys_grid.y;  // full compute-grid height (all rows kept for compute)
     TT_FATAL(fused.num_links >= 1, "indexer_score fused: num_links must be >= 1 (got {})", fused.num_links);
-    const uint32_t ag_worker_cores = fused.num_links * 2u;                   // AG uses 2 workers (fwd/bwd) per link
+    const uint32_t ag_worker_cores = fused.num_links * ag_rt::kRingDirectionCount;
     const uint32_t reserved_cols = (ag_worker_cores + grid_y - 1) / grid_y;  // columns needed to hold the workers
     TT_FATAL(phys_grid.x > reserved_cols, "indexer_score fused: grid too small to reserve {} AG cols", reserved_cols);
     // Compute columns after reserving the AG worker column(s); NOTE this differs from the classic factory's
@@ -210,7 +200,8 @@ ProgramDescriptor build_ring_program_descriptor(
     const CoreCoord ccl_core_grid_offset{compute_cols_x, 0};  // AG workers start in the first reserved column
 
     const uint32_t ring_size = ring_size_for(args, q);  // shared with validate/signaler (same ring extent)
-    const uint32_t sll_t = Tt / ring_size;              // physical tiles per SP shard in gathered K
+    TT_FATAL(ring_size <= 32, "indexer_score fused: Ring size {} exceeds the consumer gate capacity 32", ring_size);
+    const uint32_t sll_t = Tt / ring_size;  // physical tiles per SP shard in gathered K
     // The two-marker protocol requires both ring directions to carry slices. Linear topologies and a two-chip
     // ring leave one direction with no targets, whose writer intentionally discards its local packet stream.
     const bool partial_readiness_enabled = fused.topology == ttnn::ccl::Topology::Ring && ring_size > 2 &&
@@ -219,52 +210,43 @@ ProgramDescriptor build_ring_program_descriptor(
     const uint32_t work_unit_count = ring_size * units_per_shard;
     const uint32_t group_count = Sqt / QC;                             // q-groups (banded schedule rows)
     const uint32_t group_rows = rows_for_groups(group_count, grid_y);  // grid rows per group (k-mcast)
-    const uint32_t cols_used = cols_for_bands(work_unit_count, compute_cols_x);
-    const uint32_t num_blocks =
-        band_row_blocks(group_count, work_unit_count, compute_cols_x, grid_y);  // row-block reps
-    const uint32_t rows_used = group_rows * num_blocks;                         // grid rows used by compute
     const uint32_t num_groups = group_count / group_rows;  // phase-stack count (groups per row, round-robin)
+    // A zero-band core is harmless for a single group phase, and retaining the ring-wide basis preserves the
+    // measured production and partial-readiness receiver grids. With multiple phases, however, its compute
+    // kernel returns while its reader can block on the next single-buffered q/w multicast. Size that geometry
+    // from one shard so every participating lane has work in every arrival schedule.
+    const uint32_t lane_sizing_units = num_groups > 1 ? units_per_shard : work_unit_count;
+    const uint32_t cols_used = cols_for_bands(lane_sizing_units, compute_cols_x);
+    const uint32_t num_blocks =
+        band_row_blocks(group_count, lane_sizing_units, compute_cols_x, grid_y);  // row-block reps
+    const uint32_t rows_used = group_rows * num_blocks;                           // grid rows used by compute
 
     // Group physical SP shards by their ring-arrival wave (the local shard is wave 0). Work units never cross a
     // shard boundary, so each has exactly one readiness dependency. RingIdSequencer already emits each wave in
     // the desired paired-direction order; preserve it directly rather than reconstructing and sorting it later.
-    const auto rw = ring_writes_for(ring_size, transport_rank, fused.topology);
-    const uint32_t max_wave = ring_size / 2;
-    std::vector<std::vector<uint32_t>> shards_by_wave(max_wave + 1);
-    {
-        RingIdSequencer seq(transport_rank, ring_size, rw.backward_writes_expected, rw.forward_writes_expected);
-        for (uint32_t i = 0; i < ring_size; ++i) {
-            const uint32_t rid = seq.get_next_ring_id([](uint32_t, uint32_t) {});
-            shards_by_wave[(i + 1) / 2].push_back(transport_to_tensor_rank(args, rid));
+    const auto rw = ring_schedule::ring_writes_for(ring_size, transport_rank, fused.topology);
+    auto shards_by_wave = ring_schedule::arrival_waves(ring_size, transport_rank, rw);
+    for (auto& wave : shards_by_wave) {
+        for (auto& shard : wave) {
+            shard = transport_to_tensor_rank(args, shard);
         }
     }
-    // Deal each shard's physical KC units across row-blocks and columns. This gives every compute column an even
-    // share of the local shard before it encounters a Fabric gate, while retaining KC-sized math units. The last
-    // unit of a shard is padded rather than crossing into the next shard.
-    std::vector<std::vector<std::vector<uint32_t>>> work_list(
-        num_blocks, std::vector<std::vector<uint32_t>>(cols_used));
+    // Deal each shard's physical KC units over the block-column lane space. A true bidirectional Ring rotates
+    // paired forward/backward waves within both row blocks. Singleton waves, Linear, and Ring-2 retain the prior
+    // mapping; paired shards keep matching offsets, adjacent row blocks retain their DRAM access pairing, and the
+    // last unit stays padded within its source shard.
+    auto work_list = ring_schedule::make_work_list(
+        shards_by_wave,
+        units_per_shard,
+        sll_t,
+        KC,
+        num_blocks,
+        cols_used,
+        ring_schedule::rotation_enabled(fused.topology, ring_size));
     uint32_t max_bands = 0;
-    {
-        for (uint32_t blk = 0; blk < num_blocks; ++blk) {
-            for (uint32_t wave = 0; wave <= max_wave; ++wave) {
-                // Give each column matching offsets from both directions. Its visit order becomes
-                // A0,B0,A1,B1,..., so a core that reaches shard A's completion gate can consume the
-                // simultaneously arriving midpoint of shard B instead of idling.
-                for (uint32_t col = 0; col < cols_used; ++col) {
-                    for (uint32_t unit_slot = col;; unit_slot += cols_used) {
-                        const uint32_t unit_in_shard = blk + unit_slot * num_blocks;
-                        if (unit_in_shard >= units_per_shard) {
-                            break;
-                        }
-                        for (uint32_t shard : shards_by_wave[wave]) {
-                            work_list[blk][col].push_back(shard * sll_t + unit_in_shard * KC);
-                        }
-                    }
-                }
-            }
-            for (uint32_t col = 0; col < cols_used; ++col) {
-                max_bands = std::max<uint32_t>(max_bands, static_cast<uint32_t>(work_list[blk][col].size()));
-            }
+    for (uint32_t blk = 0; blk < num_blocks; ++blk) {
+        for (uint32_t col = 0; col < cols_used; ++col) {
+            max_bands = std::max<uint32_t>(max_bands, static_cast<uint32_t>(work_list[blk][col].size()));
         }
     }
 
@@ -751,16 +733,18 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
         patch_field(kReaderKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::reader_kv_len_tiles, pcache.kv_len_tiles);
         patch_field(
             kReaderKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::reader_k_local_batch_offset, k_local_batch_page_offset);
-        // compute: kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles (slots [6, perm_base)).
-        patch_field(kComputeKernelIndex, 6u, pcache.kv_len_tiles);
-        patch_field(kComputeKernelIndex, 7u, geom.chunk_start_tiles);
-        patch_field(kComputeKernelIndex, 8u, geom.straddle_q_tile);
-        patch_field(kComputeKernelIndex, 9u, geom.straddle_jump_tiles);
-        // writer: same four scalars after out-addr(0) + schedule(1..6) (slots [7, perm_base)).
-        patch_field(kWriterKernelIndex, 7u, pcache.kv_len_tiles);
-        patch_field(kWriterKernelIndex, 8u, geom.chunk_start_tiles);
-        patch_field(kWriterKernelIndex, 9u, geom.straddle_q_tile);
-        patch_field(kWriterKernelIndex, 10u, geom.straddle_jump_tiles);
+        patch_field(kComputeKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::compute_kv_len_tiles, pcache.kv_len_tiles);
+        patch_field(
+            kComputeKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::compute_chunk_start_tiles, geom.chunk_start_tiles);
+        patch_field(kComputeKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::compute_straddle_q_tile, geom.straddle_q_tile);
+        patch_field(
+            kComputeKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::compute_straddle_jump_tiles, geom.straddle_jump_tiles);
+        patch_field(kWriterKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::writer_kv_len_tiles, pcache.kv_len_tiles);
+        patch_field(
+            kWriterKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::writer_chunk_start_tiles, geom.chunk_start_tiles);
+        patch_field(kWriterKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::writer_straddle_q_tile, geom.straddle_q_tile);
+        patch_field(
+            kWriterKernelIndex, CMAKE_UNIQUE_NAMESPACE::rt_arg::writer_straddle_jump_tiles, geom.straddle_jump_tiles);
 
         // The descriptor fast path patches buffer bindings but not scalar fields embedded in the fused AG
         // workers. cache_batch_idx and the exact kv_len are hash-excluded (only the structural schedule class is

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_schedule.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_schedule.hpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_id_sequencer.hpp"
+
+namespace ttnn::operations::experimental::indexer_score::program::ring_schedule {
+
+using ArrivalWaves = std::vector<std::vector<uint32_t>>;
+using WorkList = std::vector<std::vector<std::vector<uint32_t>>>;
+
+struct RingWrites {
+    uint32_t forward_writes_expected;
+    uint32_t backward_writes_expected;
+};
+
+// Forward/backward all-gather writes expected for one device (mirrors ring_joint's build_ring_write_plan).
+inline RingWrites ring_writes_for(uint32_t ring_size, uint32_t ring_index, ttnn::ccl::Topology topology) {
+    auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
+        ttnn::ccl::get_forward_backward_configuration(ring_size, ring_index, topology);
+    (void)dynamic_alternate;
+    if (topology == ttnn::ccl::Topology::Ring && (ring_index % 2 == 0)) {
+        std::swap(num_targets_forward, num_targets_backward);
+    }
+    if (topology == ttnn::ccl::Topology::Linear) {
+        return {static_cast<uint32_t>(num_targets_backward), static_cast<uint32_t>(num_targets_forward)};
+    }
+    return {static_cast<uint32_t>(num_targets_forward), static_cast<uint32_t>(num_targets_backward)};
+}
+
+// Group physical shards by the order in which this rank can consume them. Wave 0 is local; true Rings with
+// more than two ranks then have paired forward/backward waves and, for even ring sizes, one final opposite shard.
+inline ArrivalWaves arrival_waves(uint32_t ring_size, uint32_t ring_index, RingWrites writes) {
+    ArrivalWaves waves(ring_size / 2 + 1);
+    RingIdSequencer seq(ring_index, ring_size, writes.backward_writes_expected, writes.forward_writes_expected);
+    for (uint32_t iteration = 0; iteration < ring_size; ++iteration) {
+        const uint32_t shard = seq.get_next_ring_id([](uint32_t, uint32_t) {});
+        waves[(iteration + 1) / 2].push_back(shard);
+    }
+    return waves;
+}
+
+// Linear and Ring-2 do not have paired bidirectional arrival waves; retain their existing lane assignment.
+inline bool rotation_enabled(ttnn::ccl::Topology topology, uint32_t ring_size) {
+    return topology == ttnn::ccl::Topology::Ring && ring_size > 2;
+}
+
+inline uint32_t wave_column_shift(uint32_t wave, uint32_t wave_count, uint32_t column_count) {
+    // Stagger consecutive remote waves by alternating one- and two-column steps. This distributes partial
+    // KC-unit tails more broadly than a unit stride while keeping neighboring waves close on the physical grid.
+    const uint32_t column_stride = std::max(1u, column_count / (wave_count + 1));
+    return ((wave + wave / 2) * column_stride) % column_count;
+}
+
+// Build each (row-block, column) lane's shard-major list of physical K-tile starts. Rotation changes only which
+// column residue a lane owns in paired arrival waves. It is a cyclic column permutation within each row block, so
+// every KC unit remains in exactly one lane, adjacent row blocks retain their paired DRAM access pattern, and
+// paired shards retain matching, monotonically increasing offsets.
+inline WorkList make_work_list(
+    const ArrivalWaves& waves,
+    uint32_t units_per_shard,
+    uint32_t tiles_per_shard,
+    uint32_t k_tiles_per_unit,
+    uint32_t num_blocks,
+    uint32_t cols_used,
+    bool rotate_waves) {
+    WorkList work_list(num_blocks, std::vector<std::vector<uint32_t>>(cols_used));
+    const uint32_t lane_count = num_blocks * cols_used;
+    const uint32_t wave_count = static_cast<uint32_t>(waves.size());
+
+    for (uint32_t block = 0; block < num_blocks; ++block) {
+        for (uint32_t wave = 0; wave < wave_count; ++wave) {
+            // Only paired forward/backward arrivals need rotation. The local shard and an even Ring's final
+            // opposite shard are singleton waves and retain the natural mapping.
+            const uint32_t column_shift =
+                rotate_waves && waves[wave].size() > 1 ? wave_column_shift(wave, wave_count, cols_used) : 0;
+            for (uint32_t col = 0; col < cols_used; ++col) {
+                const uint32_t source_col = (col + cols_used - column_shift) % cols_used;
+                const uint32_t source_lane = block + source_col * num_blocks;
+                for (uint32_t unit = source_lane; unit < units_per_shard; unit += lane_count) {
+                    for (uint32_t shard : waves[wave]) {
+                        work_list[block][col].push_back(shard * tiles_per_shard + unit * k_tiles_per_unit);
+                    }
+                }
+            }
+        }
+    }
+    return work_list;
+}
+
+}  // namespace ttnn::operations::experimental::indexer_score::program::ring_schedule

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -2928,6 +2928,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             // Share the split-forwarding decision derived above so the all-gather only splits when this
             // consumer implements the second-half wait.
             sdpa_fused_op_signaler->split_forwarding_enabled,
+            /*partial_readiness_enabled=*/false,
             rank_mapping);
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -195,10 +195,13 @@ constexpr uint32_t kComputeKernelIndex = 2;
 
 // Dense all-gather appends reader-forward, writer-forward, reader-backward, writer-backward.
 // Compact sliding appends only its predecessor reader/writer pair at indices 3 and 4.
-constexpr uint32_t kAllGatherReaderForwardKernelIndex = 3;
-constexpr uint32_t kAllGatherWriterForwardKernelIndex = 4;
-constexpr uint32_t kAllGatherReaderBackwardKernelIndex = 5;
-constexpr uint32_t kAllGatherWriterBackwardKernelIndex = 6;
+constexpr uint32_t kFirstAllGatherKernelIndex = 3;
+constexpr uint32_t kAllGatherReaderForwardKernelIndex = kFirstAllGatherKernelIndex + ag_rt::kReaderForwardKernelOffset;
+constexpr uint32_t kAllGatherWriterForwardKernelIndex = kFirstAllGatherKernelIndex + ag_rt::kWriterForwardKernelOffset;
+constexpr uint32_t kAllGatherReaderBackwardKernelIndex =
+    kFirstAllGatherKernelIndex + ag_rt::kReaderBackwardKernelOffset;
+constexpr uint32_t kAllGatherWriterBackwardKernelIndex =
+    kFirstAllGatherKernelIndex + ag_rt::kWriterBackwardKernelOffset;
 constexpr uint32_t kNeighborHaloReaderKernelIndex = 3;
 constexpr uint32_t kNeighborHaloWriterKernelIndex = 4;
 
@@ -610,7 +613,6 @@ void apply_ring_joint_scalar_runtime_args(
     const std::array<const Tensor*, 2> ag_inputs = {
         &input_k, tensor_args.input_v.has_value() ? &tensor_args.input_v.value() : &input_k};
     const bool uses_neighbor_halo = args.has_sliding_window();
-
     // Re-patch the fused all-gather readers to gather the single cache slot `kv_cache_batch_idx`.
     // input_batch_base is uniform across all gather cores/links, so patch every core that runs the
     // reader. Mirrors the helper's create-time arithmetic so miss and hit paths agree.


### PR DESCRIPTION
### PR Category

Performance

### Summary

This PR improves the fused Ring Indexer pipeline in three trace-stable layers.

#### 1. Coalesce Ring Attention all-gather DRAM and Fabric traffic

- Give workers disjoint destination-DRAM-bank ownership instead of walking pages in logical tensor order.
- Read pages in each bank's physically contiguous order and pack each Fabric transfer up to the available payload.
- Rotate packet issue across banks so independent DRAM banks remain active.
- Prefetch batches of up to four packets and use double-buffered reader CB storage to overlap the next DRAM batch with Fabric drain.
- Split the diametric shard across both ring directions without splitting a bank stream.
- Select the bank-owned path from static capabilities: Blackhole, sequence-axis gather, interleaved DRAM layout, and compatible page/payload geometry.
- Derive pages per packet from the configured payload, so both the default limit and the production 14 KiB Fabric payload use the same implementation. With BFP8 tiles, 14 KiB carries 13 complete 1,088-byte pages instead of the old two-page scatter cap.

#### 2. Start compute from local and partially arrived shards

- Replace the old global logical-K walk with shard-major KC work units, so units fully contained in the initially local shard can run before the first all-gather round completes.
- Keep units inside physical shard boundaries while preserving their logical score destinations.
- Use a static `KC=10` unit (320 keys), aligned to the all-gather row geometry and independent of runtime `kv_len`.
- A post-firmware Ring-8 sweep of every fitting KC from 1 through 15 confirmed KC=10 as the unique 55K optimum. KC=15 improved 512K by only 0.6% while regressing 55K by 40%; KC=20 exceeded L1.
- Add a row-aligned midpoint readiness marker in addition to the existing shard-completion marker.
- Synchronize the midpoint across all links before publishing it, so a consumer never observes a partially completed ready region.
- Permit a whole KC unit contained in the first half to use the midpoint marker; units crossing the midpoint or in the second half still require completion.
- Interleave equal offsets from the two shards arriving in a paired forward/backward wave (`A0, B0, A1, B1, ...`), allowing compute to move to the other ready half instead of waiting for one complete shard.
- Update valid page counts, readiness, and work bounds on device from the runtime prefix while reusing the same cached program and trace.

#### 3. Balance Ring Indexer work across compute lanes

- Derive a cyclic source-column shift from ring-wave and compute-grid geometry instead of using Ring-4/Ring-8 lookup cases.
- Apply one shift to both shards in a paired arrival wave, preserving their interleaved readiness order.
- Spread repeated valid-prefix remainders across block-column lanes rather than repeatedly starting the extra work at lane zero.
- Preserve row blocks and adjacent-block DRAM pairing; only the source-column assignment is permuted.
- Keep offsets within every lane monotonic and assign every KC unit exactly once.
- Leave singleton local and diametric waves unshifted, and leave Linear/Ring-2 scheduling unchanged.
- Derive the schedule from static topology, capacity, phase, and grid geometry—not runtime `kv_len`—so it remains program-cache/trace stable and extends naturally to larger rings such as Ring-32.

There is no runtime `kv_len` or tensor-capacity heuristic. Runtime valid prefixes change device-side bounds and readiness only; they do not select a different program.

### Performance guide

[Open the rendered performance guide](https://htmlpreview.github.io/?https://gist.githubusercontent.com/pavlejosipovic/be696451c612f61c6c0b0f08f7d401c3/raw/97998c0c47ddf7629b6aac156955e0d338a1a652/ring-indexer-performance-guide.html)
([gist source](https://gist.github.com/pavlejosipovic/be696451c612f61c6c0b0f08f7d401c3)).

The scrolling HTML guide provides the detailed visual walkthrough behind the summary above:

- the fused DRAM → all-gather → Fabric → score-reader → compute pipeline;
- Blackhole's eight-bank page interleave, disjoint worker bank ownership, diametric-shard split, bank-local packet construction, packet-level bank rotation, four-packet prefetch, and double buffering;
- why the 14 KiB payload matters and how 13 BFP8 tile pages fit in one packet;
- why origin/main could not execute even initially local data: its logical KC units crossed source-shard boundaries;
- the new shard-major local-first KC layout, midpoint/completion readiness protocol, and paired-direction arrival order;
- the 10×10 and 11×10 measured compute grids, their 20/22 block-column scheduling lanes, the repeated-remainder imbalance, and the geometry-derived paired-wave permutation;
- the static KC=1–15 sweep and its compute-granularity/L1 trade-off;
- per-commit invariants, isolated scheduling ablations, and the end-to-end origin/main-versus-latest measurements.

### End-to-end performance

The comparable production-configuration A/B is LoudBox, Ring-8/SP=8, explicit 14 KiB Fabric payload, and warm traced fused-program duration. The latest values are the median of three independent test invocations, each using the median of three profiler replays.

| KV prefix | `origin/main` | Latest | Latency reduction | End-to-end speedup | FPU model |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 55K | 0.338 ms | 0.204 ms | 39.6% (0.134 ms) | 1.66× | 35.13% → 58.10% |
| 512K | 2.870 ms | 1.867 ms | 34.9% (1.003 ms) | 1.54× | 39.28% → 60.39% |

These absolute-duration comparisons use 14 KiB on both sides. The old `origin/main` targets were recorded with the default Fabric payload, so target-to-target movement is not a valid speedup measurement. FPU utilization here is ideal LoFi work divided by measured end-to-end duration, not a hardware-counter reading.

The paired-wave scheduler was also isolated on the same QuietBox runner with seven warm trace replays per mode. At the pathological 56,320-token remainder it reduced latency from 0.285490 ms to 0.253710 ms (11.13%); at 524,288 tokens it changed 1.976846 ms to 1.972230 ms (0.23%). The worst point across the 21-prefix sweep was a 1.34% regression, inside the symmetric 2% guard. The relevant performance job passed in [run 33313112257](https://github.com/tenstorrent/tt-metal/actions/runs/33313112257/job/99262729001); the workflow's overall red result came from a separate SDPA-nightly job.

The checked-in warm traced-median CI contract uses a symmetric ±2% band and the 14 KiB payload:

| Blackhole box | 55K target | 512K target |
| --- | ---: | ---: |
| QuietBox, Ring-4 | 52.22% | 62.99% |
| LoudBox, Ring-8 | 58.10% | 60.39% |

### Validation

- [![T3K E2E CCL](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch%3Apjosipovic/ring-indexer-dram-coalescing-multiworker+event%3Aworkflow_dispatch)

- [![Blaze Models Prefill — GLM 5.2](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/runs/33768863554)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-indexer-dram-coalescing-multiworker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-indexer-dram-coalescing-multiworker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-indexer-dram-coalescing-multiworker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-indexer-dram-coalescing-multiworker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-indexer-dram-coalescing-multiworker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-indexer-dram-coalescing-multiworker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-indexer-dram-coalescing-multiworker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-indexer-dram-coalescing-multiworker)
