### PR TITLE
update_padded_kv_cache: clamp the write to the real tokens (valid_global)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -983,6 +983,196 @@ def test_update_padded_kv_cache_metadata_matches_scalar(mesh_device, dtype, layo
     logger.info(f"program cache stable at {entries_after_first} entries across {len(cases)} metadata-path chunks")
 
 
+def _natural_from_cache(cache_slot_rows, sp, chunk_local, cache_tokens_per_dev, chunk_global):
+    """Un-rotate one cache slot read back in chip-concat order into natural token order.
+
+    ``cache_slot_rows`` is [sp * cache_tokens_per_dev, head_dim] (the composer concatenates each chip's
+    slab on the seq dim), and chip c's local row lr carries global position
+    ``(lr // chunk_local) * chunk_global + c * chunk_local + (lr % chunk_local)`` -- the block-cyclic
+    layout the writer targets."""
+    nat = torch.empty_like(cache_slot_rows)
+    for c in range(sp):
+        for lr in range(cache_tokens_per_dev):
+            pos = (lr // chunk_local) * chunk_global + c * chunk_local + (lr % chunk_local)
+            nat[pos] = cache_slot_rows[c * cache_tokens_per_dev + lr]
+    return nat
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4)], ids=["2x2", "2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "dtype, layout",
+    [(ttnn.bfloat8_b, ttnn.TILE_LAYOUT), (ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT)],
+    ids=["bfp8_tile", "bf16_rm"],
+)
+@pytest.mark.parametrize("path", ["metadata", "scalar"], ids=["metadata", "scalar"])
+@pytest.mark.parametrize(
+    "case", ["mid_chunk", "tail_overflow", "tail_chip_jump"], ids=["mid_chunk", "tail_overflow", "tail_chip_jump"]
+)
+@pytest.mark.timeout(0)
+def test_update_padded_kv_cache_valid_global_clamp(mesh_device, dtype, layout, path, case, expect_error):
+    """`valid_global` keeps a chunk's PAD tail out of the cache.
+
+    Three shapes: `mid_chunk` ends on a non-tile-aligned boundary (its 32-token block is written, the rest
+    is not); `tail_overflow` pads one tile past the cache while its real tokens fit (the case the op
+    rejects unclamped, asserted here too); `tail_chip_jump` has boundary_chip > 0, so the pre-boundary
+    chips jump a whole slab past the cache end and must write NOTHING.
+
+    Checked three ways and bit-exact against a sentinel-filled cache and poisoned pad rows: real rows
+    match what was sent, rows past the real end still hold the sentinel, and the poison appears nowhere."""
+    sp_axis, tp_axis = 0, 1
+    sp = mesh_device.shape[sp_axis]
+    tile = ttnn.TILE_SIZE
+
+    chunk_local = 4 * tile
+    chunk_global = chunk_local * sp
+    slabs = 2
+    cache_tokens_per_dev = slabs * chunk_local
+    cache_global = cache_tokens_per_dev * sp
+    num_layers = 2  # slot 0 is written, slot 1 is the neighbour that must stay untouched
+    slot_id, layer_idx = 0, 0
+    batch_idx = slot_id * num_layers + layer_idx
+
+    if case == "mid_chunk":
+        # Ends 5 tokens into a page row, so ceil-to-32 keeps the boundary row and drops the rest.
+        kv_actual, valid_global = 0, chunk_global - 2 * tile - 5
+    elif case == "tail_overflow":
+        # Starts one tile off the slab grid in the last slab: padded window ends at cache_global + tile.
+        kv_actual, valid_global = chunk_global + tile, cache_global
+    else:
+        # boundary_chip = (kv_actual / chunk_local) % sp > 0, in the LAST slab: every chip before the
+        # boundary jumps a full slab, landing exactly at the end of its cache -- nothing to write.
+        kv_actual, valid_global = cache_global - chunk_local + tile, cache_global
+        assert (kv_actual // chunk_local) % sp > 0, "case must put the boundary chip past chip 0"
+    write_end = -(-valid_global // tile) * tile
+    assert write_end < kv_actual + chunk_global, "the case must leave a pad tail to clamp away"
+    if case != "mid_chunk":
+        assert kv_actual + chunk_global > cache_global >= write_end, "the case must overflow only in its pad"
+
+    input_shard_dims = [None, None]
+    input_shard_dims[sp_axis] = 2
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 1
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape)
+    mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims)
+
+    def _to_device(rows):
+        return _make_input(rows.reshape(1, 1, chunk_global, KVPE_HEAD_DIM), dtype, layout, mesh_device, mapper)
+
+    def _read_back(tt):
+        """Rows as the device holds them, in chip-concat order, through the cache's own dtype."""
+        return ttnn.to_torch(tt, mesh_composer=composer).to(torch.float32)[0, 0]
+
+    mesh_device.enable_program_cache()
+    kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=KVPE_HEAD_DIM,
+        mesh_device=mesh_device,
+        seq_len=cache_global,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_layers,
+        dtype=dtype,
+        layout=layout,
+    )
+
+    # Sentinel: fill every slot, slab by slab, with UNCLAMPED chunk-aligned writes (natural order in,
+    # so slab s lands at positions [s*chunk_global, (s+1)*chunk_global)).
+    torch.manual_seed(7)
+    sentinel = {b: torch.randn(cache_global, KVPE_HEAD_DIM, dtype=torch.bfloat16) for b in range(num_layers)}
+    sentinel_dev = {}
+    for b in range(num_layers):
+        slab_rows = []
+        for s in range(slabs):
+            tt_slab = _to_device(sentinel[b][s * chunk_global : (s + 1) * chunk_global])
+            slab_rows.append(_read_back(tt_slab))  # what the dtype actually stored
+            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                kv_cache,
+                tt_slab,
+                slot_idx=b // num_layers,
+                layer_idx=b % num_layers,
+                num_layers=num_layers,
+                kv_actual_global=s * chunk_global,
+                cluster_axis=sp_axis,
+            )
+            ttnn.deallocate(tt_slab)
+        sentinel_dev[b] = torch.cat(slab_rows, dim=0)  # natural order, [cache_global, head_dim]
+    ttnn.synchronize_device(mesh_device)
+
+    # The chunk under test, in ROTATED order: chip c's row r carries positions[c][r]; rows past the real
+    # end are pad and carry POISON.
+    positions = _rotated_chip_positions(kv_actual, sp, chunk_local)
+    poison = torch.full((KVPE_HEAD_DIM,), 8.0, dtype=torch.bfloat16)
+    new_nat = torch.randn(chunk_global, KVPE_HEAD_DIM, dtype=torch.bfloat16)
+    rotated = torch.stack(
+        [
+            new_nat[positions[c][r] - kv_actual] if positions[c][r] < write_end else poison
+            for c in range(sp)
+            for r in range(chunk_local)
+        ]
+    )
+    tt_chunk = _to_device(rotated)
+    sent_rows = _read_back(tt_chunk)  # rotated order, through the cache dtype
+    sent_by_pos = {positions[c][r]: sent_rows[c * chunk_local + r] for c in range(sp) for r in range(chunk_local)}
+
+    if case != "mid_chunk":  # unclamped, this write does not fit -- the op must still say so
+        with expect_error(RuntimeError, "overflow global cache capacity"):
+            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                kv_cache,
+                tt_chunk,
+                slot_idx=slot_id,
+                layer_idx=layer_idx,
+                num_layers=num_layers,
+                kv_actual_global=kv_actual,
+                cluster_axis=sp_axis,
+            )
+
+    if path == "metadata":
+        slot_t, kv_t = _make_meta_tensors(mesh_device, kv_actual_global=kv_actual, slot_idx=slot_id)
+        valid_t = _make_scalar_tensor(mesh_device, valid_global)
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            kv_cache,
+            tt_chunk,
+            slot_t,
+            kv_t,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
+            cluster_axis=sp_axis,
+            valid_global=valid_t,
+        )
+        for t in (slot_t, kv_t, valid_t):
+            ttnn.deallocate(t)
+    else:
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            kv_cache,
+            tt_chunk,
+            slot_idx=slot_id,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
+            kv_actual_global=kv_actual,
+            cluster_axis=sp_axis,
+            valid_global=valid_global,
+        )
+    ttnn.synchronize_device(mesh_device)
+
+    cache_host = ttnn.to_torch(kv_cache, mesh_composer=composer).to(torch.float32)[:, :1, :, :]
+    for b in range(num_layers):
+        nat = _natural_from_cache(cache_host[b, 0], sp, chunk_local, cache_tokens_per_dev, chunk_global)
+        for pos in range(cache_global):
+            if b == batch_idx and kv_actual <= pos < write_end:
+                want, what = sent_by_pos[pos], f"the chunk's row for position {pos}"
+            else:
+                want, what = sentinel_dev[b][pos], "the sentinel (this row must not have been written)"
+            assert torch.equal(
+                nat[pos], want.to(torch.float32)
+            ), f"[{case}/{path}] slot {b} position {pos} does not hold {what}" + (
+                " -- POISON LEAKED (a pad row was written)" if torch.equal(nat[pos], poison.to(torch.float32)) else ""
+            )
+    logger.success(
+        f"[{case}/{path}] clamp held: wrote [{kv_actual}, {write_end}) of a chunk spanning "
+        f"[{kv_actual}, {kv_actual + chunk_global}) into a {cache_global}-token cache"
+    )
+
+
 def _alloc_multihead_cache(mesh_device, *, batch, heads, seq_local, head_dim, dtype, layout):
     """Cache with a per-chip HEAD dim > 1, ND-sharded exactly like the model caches (32-token bank
     chunks, round-robin over the DRAM grid). ``init_kvpe_cache`` is fixed at one head, so this is its
@@ -1025,14 +1215,15 @@ def _alloc_multihead_cache(mesh_device, *, batch, heads, seq_local, head_dim, dt
     ],
     indirect=True,
 )
+@pytest.mark.parametrize("case", ["full", "clamped"], ids=["full", "clamped"])
 @pytest.mark.timeout(0)
-def test_update_padded_kv_cache_multihead_head_stride(mesh_device):
+def test_update_padded_kv_cache_multihead_head_stride(mesh_device, case):
     """A per-chip head dim > 1 must not smear rows across heads.
 
-    The cache's head stride (cache_HtWt) is larger than the input's (input_Ht * Wt) whenever the cache is
-    deeper than one chunk, so a core holding blocks either side of a head boundary must address each
-    block from its own (head, row) -- 64 heads x 7 page-rows over ~110 cores puts several cores across a
-    boundary."""
+    The cache's head stride exceeds the input's once the cache is deeper than one chunk, so a core holding
+    blocks either side of a head boundary must address each from its own (head, row) -- 64 heads x 7
+    page-rows over ~110 cores puts several cores across one. `clamped` repeats it with valid_global, so the
+    row clamp is checked per head rather than per core."""
     sp_axis, tp_axis = 0, 1
     sp = mesh_device.shape[sp_axis]
     tile = ttnn.TILE_SIZE
@@ -1043,7 +1234,8 @@ def test_update_padded_kv_cache_multihead_head_stride(mesh_device):
     seq_local = 2 * chunk_local  # deeper than one chunk -> cache head stride != input head stride
     num_layers = 2
     layer_idx, slot_id = 0, 0
-    write_end = chunk_global
+    valid_global = chunk_global - 2 * tile - 5 if case == "clamped" else None
+    write_end = chunk_global if valid_global is None else -(-valid_global // tile) * tile
 
     input_shard_dims = [None, None]
     input_shard_dims[sp_axis] = 2
@@ -1080,6 +1272,7 @@ def test_update_padded_kv_cache_multihead_head_stride(mesh_device):
         num_layers=num_layers,
         kv_actual_global=0,
         cluster_axis=sp_axis,
+        valid_global=valid_global,
     )
     ttnn.synchronize_device(mesh_device)
 
@@ -1091,17 +1284,17 @@ def test_update_padded_kv_cache_multihead_head_stride(mesh_device):
     ).to(torch.float32)[:num_layers, :, :, :head_dim]
     written = torch.cat([host[layer_idx, :, c * seq_local : c * seq_local + chunk_local, :] for c in range(sp)], dim=1)
 
-    # Spill first, placement second: a misaddressed block shows up as a write past the real rows, and
-    # that is the more specific signal. This must read `host`, not `written` -- `written` is assembled
-    # from exactly chunk_local rows per chip, so slicing it past write_end yields nothing at all. Each
-    # chip's slab is seq_local deep with only its first chunk_local written, so the spill lands in the
-    # unwritten half.
+    # Spill first: a misaddressed block shows up as a write past the chip's real rows, and that is
+    # the more specific signal. It must read `host`, not `written` -- `written` holds exactly
+    # chunk_local rows per chip, so unclamped (write_end == chunk_global) slicing it past write_end
+    # yields nothing at all. Clamped, the per-head slice below is the dropped pad tail.
     for c in range(sp):
         tail = host[layer_idx, :, c * seq_local + chunk_local : (c + 1) * seq_local, :]
-        assert torch.count_nonzero(tail) == 0, f"chip {c}: wrote past its {chunk_local} real rows"
+        assert torch.count_nonzero(tail) == 0, f"[{case}] chip {c}: wrote past its {chunk_local} real rows"
     assert torch.count_nonzero(host[1 - layer_idx]) == 0, "wrote into the neighbouring layer slot"
     for h in range(heads):
-        assert torch.equal(
-            written[h, :write_end], src[0, h, :write_end].to(torch.float32)
-        ), f"head {h}: rows [0, {write_end}) do not match what was sent -- a block landed in another head"
-    logger.success(f"{heads} heads x {chunk_local} rows placed exactly (write_end={write_end})")
+        assert torch.equal(written[h, :write_end], src[0, h, :write_end].to(torch.float32)), (
+            f"[{case}] head {h}: rows [0, {write_end}) do not match what was sent -- a block landed in " f"another head"
+        )
+        assert torch.count_nonzero(written[h, write_end:]) == 0, f"[{case}] head {h}: wrote past {write_end}"
+    logger.success(f"[{case}] {heads} heads x {chunk_local} rows placed exactly (write_end={write_end})")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_reference.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_reference.py
@@ -94,6 +94,39 @@ def run_cpu_reference(config, weights, hidden_states, seq_len, cache_dir, cache_
     return ref_output, ref_kvpe, ref_index
 
 
+def run_cpu_reference_ragged(config, weights, hidden_states, seq_len, bounds, cache_dir, cache_tag):
+    """Chunk-loop sparse-MLA CPU truth for a RAGGED chunk schedule. Disk-cached.
+
+    ``bounds`` is a list of (actual_start, actual_end) covering the POPULATED prefix [0, bounds[-1][1]),
+    which is shorter than ``seq_len`` when the schedule is ragged. A chunk may carry
+    FEWER real tokens than the device's fixed chunk width. Each call passes only that chunk's real rows,
+    so the reference never sees the device's pad tail -- which is the point: the device output is sliced
+    to the same real rows before comparing, and anything the pad rows did must not have changed them.
+
+    Returns (ref_output [1, seq, dim], ref_kvpe [1, seq, kv_lora_rank + rope],
+    ref_index [1, seq, index_head_dim]).
+    """
+    shape_key = "-".join(f"{a}:{b}" for a, b in bounds[:2]) + f"-x{len(bounds)}"
+    cache_path = Path(cache_dir) / f"ragged_{cache_tag}_seq{seq_len}_{shape_key}.pt"
+    if cache_path.exists():
+        logger.info(f"Loading cached ragged CPU reference from {cache_path}")
+        cached = torch.load(cache_path, weights_only=True)
+        if "ref_index" in cached:
+            return cached["ref_output"], cached["ref_kvpe"], cached["ref_index"]
+        logger.info(f"Cached ragged reference at {cache_path} predates the index cache; recomputing")
+
+    ref = SparseMLAReference(config, weights, seq_len=seq_len)
+    outs = [ref.forward(hidden_states[:, a:b], actual_start=a) for a, b in bounds]
+    ref_output = torch.cat(outs, dim=1)
+    ref_kvpe = ref.kvpe_cache.squeeze(1)
+    ref_index = ref.index_cache
+
+    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+    torch.save({"ref_output": ref_output, "ref_kvpe": ref_kvpe, "ref_index": ref_index}, cache_path)
+    logger.info(f"Saved ragged CPU reference to {cache_path}")
+    return ref_output, ref_kvpe, ref_index
+
+
 def run_cpu_reference_chunked(config, weights, hidden_states, seq_len, chunk, cache_dir, cache_tag):
     """Chunk-loop sparse-MLA CPU truth (decode branch via actual_start). Disk-cached.
 

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -8,6 +8,7 @@ path separate while reusing the same TT execution helper and the production mesh
 / fabric axes from the dense MLA tests.
 """
 
+
 import pytest
 import torch
 from loguru import logger
@@ -27,6 +28,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import (
     make_hidden,
     run_cpu_reference,
     run_cpu_reference_chunked,
+    run_cpu_reference_ragged,
 )
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
@@ -501,6 +503,174 @@ def run_sparse_mla_chunked_case(
     logger.info(f"[{variant.name}] sparse MLA chunked complete")
 
 
+def pad_overflow_schedule(chunk, cache_len):
+    """[(actual_start, actual_end)] whose LAST padded window overruns ``cache_len`` while its real tokens fit.
+
+    A serving stream is ragged: chunks are a fixed width but carry fewer real tokens, so actual_start
+    drifts off the chunk grid (one tile per chunk here) until a padded window ends past the cache while
+    ceil32(actual_end) still fits. That drift is the only way to overrun -- a chunk-aligned start never can.
+    """
+    short = chunk - ttnn.TILE_SIZE
+    bounds, s = [], 0
+    for _ in range(cache_len // chunk):
+        bounds.append((s, s + short))
+        s += short
+    bounds.append((s, s + ttnn.TILE_SIZE))  # tail: one tile of real tokens, chunk - 32 of pad
+    return bounds
+
+
+def run_sparse_mla_pad_overflow_case(
+    variant, config, mesh_device, seq_len, chunk, cache_format, ds_layer, ds_checkpoint, ds_repo, ds_input
+):
+    """Chunked sparse prefill whose LAST chunk pads past the end of the cache.
+
+    This is the case the fixed chunk size forces on a server and the one update_padded_kv_cache's
+    valid_global clamp exists for: the tail chunk's padded window runs past the cache, only its real
+    tokens are written, and the indexer/top-k/gather are bounded by that written prefix instead of by
+    the window. Asserted three ways -- the output over the real rows, both caches over the real rows,
+    and the cache tail past the last real token still being untouched.
+    """
+    seed = 42
+    bounds = pad_overflow_schedule(chunk, seq_len)
+    total_real = bounds[-1][1]
+    tail_start, tail_end = bounds[-1]
+    write_end = -(-total_real // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+    assert tail_start + chunk > seq_len, "tail window must overrun the cache or this test proves nothing"
+    assert write_end <= seq_len, "the tail's REAL tokens must still fit the cache"
+    logger.info(
+        f"[{variant.name}] pad-overflow: {len(bounds)} chunks of width {chunk}, {total_real} real tokens, "
+        f"cache {seq_len}; tail [{tail_start}, {tail_end}) pads to {tail_start + chunk} "
+        f"({tail_start + chunk - seq_len} past the cache)"
+    )
+
+    weights, src_tag = build_weights(
+        variant, config, seed=seed, layer=ds_layer, checkpoint_path=ds_checkpoint, repo=ds_repo
+    )
+    config.max_seq_len = seq_len
+
+    mesh_shape = list(mesh_device.shape)
+    sp_axis, tp_axis = 0, 1
+    num_users, cache_user_id = 2, 1
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=cache_format,
+        hf_config=config,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        num_users=num_users,
+    )
+    tt_index_kv_cache = _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, slot_num=num_users)
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_chunked=True,
+        active_seq_len=chunk,
+        slot_num=num_users,
+        layer_num=1,
+        sparse_kv_cache_format=cache_format,
+    )
+    rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
+    # tail_slack: the tail chunk ropes its whole padded slab, so the table needs one chunk of headroom.
+    rope_tensors = rope.get_rope_tensors_indexed(seq_len, chunk, tail_slack=True)
+
+    hidden = make_hidden(seq_len, config.hidden_size, seed, ds_input)
+    if ds_input:
+        src_tag = f"{src_tag}_in{abs(hash(ds_input)) % 10**8}"
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+
+    # ROTATED input order. A mid-slab actual_start rotates which chip owns which block, so chunk row j is
+    # NOT global position actual_start + j -- feeding natural order only happens to work when every start
+    # is slab-aligned (what test_sparse_mla_chunked does). Every start here is drifted, so gather the
+    # chunk in rotated chip-major order and scatter the output back by the same map, exactly as
+    # test_sparse_mla_rotated does.
+    sp = mesh_device.shape[0]
+    chunk_local = chunk // sp
+    hid = hidden[0]  # [seq, hidden]
+    out_accum = None
+    for chunk_idx, (a, b) in enumerate(bounds):
+        positions = rotated_chip_positions(a, sp, chunk_local)
+        flat = [positions[c][r] for c in range(sp) for r in range(chunk_local)]
+        gather_idx = torch.tensor([min(gp, hid.shape[0] - 1) for gp in flat], dtype=torch.long)
+        chunk_in = hid[gather_idx].clone()
+        is_pad = torch.tensor([gp >= b for gp in flat])
+        chunk_in[is_pad] = 0.0  # pad rows: scored and attended on device, KV not written, output dropped
+        logger.info(
+            f"[{variant.name}] pad-overflow TT chunk {chunk_idx + 1}/{len(bounds)}: "
+            f"actual_start={a} actual_end={b} ({b - a} real, {int(is_pad.sum())} pad)"
+        )
+        tt_x = ttnn.from_torch(
+            chunk_in.reshape(1, 1, chunk, config.hidden_size),
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+        )
+        out = mla_tt.forward(
+            tt_x,
+            rope_tensors,
+            tt_kvpe_cache,
+            actual_start=a,
+            actual_end=b,
+            cache_user_id=cache_user_id,
+            index_kv_cache=tt_index_kv_cache,
+        )
+        out_flat = ttnn.to_torch(
+            out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
+        ).to(torch.bfloat16)[0, 0]
+        if out_accum is None:
+            out_accum = torch.zeros(total_real, out_flat.shape[-1], dtype=torch.bfloat16)
+        valid = [(row, gp) for row, gp in enumerate(flat) if gp < b]
+        out_accum[torch.tensor([gp for _, gp in valid])] = out_flat[torch.tensor([row for row, _ in valid])]
+    tt_output = out_accum.reshape(1, 1, total_real, out_accum.shape[-1])
+
+    cache_dir = cpu_ref_cache_dir(variant)
+    # seq_len (the CACHE length), not total_real: the reference's rope table is sized by max_seq_len and
+    # the YaRN gate keys off it, so a reference built at a different length ropes different frequencies
+    # than the device. Its caches are still returned sliced to what was actually filled (total_real).
+    ref_output, ref_kvpe, ref_index = run_cpu_reference_ragged(
+        config, weights, hidden, seq_len, bounds, cache_dir, cache_tag=f"{src_tag}_funcidx"
+    )
+
+    cache_all = _collect_kvpe_cache(tt_kvpe_cache, mesh_device)
+    assert torch.count_nonzero(cache_all[0:1]) == 0, "sparse MLA wrote KVPE into unselected user slot 0"
+    cache_sr = cache_all[cache_user_id : cache_user_id + 1, :1]
+    p = blockcyclic_positions(sp, chunk, cache_sr.shape[2])
+    nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
+    nat[p] = cache_sr[0, 0]
+    _, m = comp_pcc(ref_kvpe, nat[:total_real].unsqueeze(0), 0)
+    logger.info(f"[{variant.name}] pad-overflow kvpe prefix: {m}")
+    # The clamp's whole job: nothing was written past the last real token's 32-row block. The cache is
+    # zero-filled at allocation, so an unwritten tail is still exactly zero.
+    assert (
+        torch.count_nonzero(nat[write_end:]) == 0
+    ), f"clamped write spilled past the real tokens: KVPE rows [{write_end}, {nat.shape[0]}) are nonzero"
+
+    index_cache_layers = num_full_indexer_layers(config) or 1
+    index_cache_batch_idx = cache_user_id * index_cache_layers
+    idx_nat = _collect_index_cache_natural(
+        tt_index_kv_cache, mesh_device, config, chunk, cache_batch_idx=index_cache_batch_idx
+    )
+    _, idx_pcc = assert_with_pcc(ref_index[0, :total_real], idx_nat[:total_real], SPARSE_INDEX_PCC)
+    logger.info(f"[{variant.name}] pad-overflow indexer cache PCC: {idx_pcc}")
+    assert (
+        torch.count_nonzero(idx_nat[write_end:]) == 0
+    ), f"clamped write spilled past the real tokens: index rows [{write_end}, {idx_nat.shape[0]}) are nonzero"
+
+    _, pcc_message = assert_with_pcc(ref_output.unsqueeze(0), tt_output, SPARSE_OUTPUT_PCC)
+    logger.info(f"[{variant.name}] pad-overflow output PCC: {pcc_message}")
+    ttnn.synchronize_device(mesh_device)
+    logger.info(f"[{variant.name}] sparse MLA pad-overflow complete")
+
+
 def run_sparse_mla_kv_only_case(variant, config, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo):
     """Last-layer chunked fast path must populate packed KVPE and tiled index caches without an output."""
     seed = 42
@@ -905,6 +1075,44 @@ def test_sparse_mla_chunked(
     ds_input,
 ):
     run_sparse_mla_chunked_case(
+        variant, config_only, mesh_device, seq_len, chunk, cache_format, ds_layer, ds_checkpoint, ds_repo, ds_input
+    )
+
+
+# glm_5_2 only: the clamp is model-agnostic, so the variant axis buys nothing here and glm_5_2 is the
+# production-closest of the two (it also exercises DSA cross-layer indexer reuse). Cache format IS kept --
+# it changes the page layout the clamp addresses.
+SPARSE_PAD_OVERFLOW_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_2" in c.id]
+
+
+@pytest.mark.parametrize(
+    "variant, mesh_device, seq_len, device_params",
+    SPARSE_PAD_OVERFLOW_CASES,
+    indirect=["variant", "mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("chunk", [1024], ids=["c1k"])
+@pytest.mark.parametrize(
+    "cache_format",
+    [MlaKvCacheFormat.BF16_RM, MlaKvCacheFormat.SCALED_FP8],
+    ids=["kv_bf16", "kv_scaled_fp8"],
+)
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_mla_pad_overflow(
+    mesh_device,
+    seq_len,
+    chunk,
+    cache_format,
+    device_params,
+    variant,
+    config_only,
+    ds_layer,
+    ds_checkpoint,
+    ds_repo,
+    ds_input,
+):
+    """Ragged chunk stream whose tail chunk pads past the end of the cache (see pad_overflow_schedule)."""
+    run_sparse_mla_pad_overflow_case(
         variant, config_only, mesh_device, seq_len, chunk, cache_format, ds_layer, ds_checkpoint, ds_repo, ds_input
     )
 

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -530,6 +530,7 @@ def _run_chunked_prefill(
     use_metadata_tensor=False,
     determinism_check=False,
     profile=False,
+    tight_cache=False,
 ):
     """Unified chunked-prefill scenario, decoupled from the reference.
 
@@ -587,12 +588,35 @@ def _run_chunked_prefill(
 
     # Cache holds the max (kv_actual + chunk) window across all users/iters, slab-aligned, >= 2 slabs.
     max_window = chunk_size_global * 2
+    max_real_end = 0
     for g in groups:
         ka = prefill_len
         for v in g:
             max_window = max(max_window, ka + chunk_size_global)
             ka += v
+            max_real_end = max(max_real_end, ka)
+    if tight_cache:
+        # Cache sized to the REAL tokens, not the padded window, so a late iteration's window runs past
+        # the end of it -- the server's tail chunk. update_padded_kv_cache clamps the write and ring_mla
+        # caps logical_n at the cache.
+        write_end = -(-max_real_end // tile) * tile
+        max_window = max(chunk_size_global * 2, write_end)
     seq_len_cache = ((max_window + chunk_size_global - 1) // chunk_size_global) * chunk_size_global
+    if tight_cache:
+        overruns = [
+            ka
+            for g in groups
+            for ka in [prefill_len + sum(g[:i]) for i in range(len(g))]
+            if ka + chunk_size_global > seq_len_cache
+        ]
+        assert overruns, (
+            f"tight_cache scenario does not actually overrun: cache {seq_len_cache}, chunk "
+            f"{chunk_size_global}, real end {max_real_end} -- no iteration's padded window passes the cache"
+        )
+        logger.info(
+            f"tight_cache: cache {seq_len_cache} for {max_real_end} real tokens; "
+            f"{len(overruns)} iteration(s) pad past it, worst {max(overruns) + chunk_size_global}"
+        )
 
     if use_pretrained:
         # MLA-only fixture: this driver uses nothing but the attention weights, and the full-layer one
@@ -660,7 +684,11 @@ def _run_chunked_prefill(
     )
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
     indexed_rope = rope_setup.get_rope_tensors_indexed(
-        cache_seq_len_global=seq_len_cache, chunk_size_global=chunk_size_global
+        # tail_slack: an overrunning iteration still ropes its whole padded slab, so the table needs one
+        # chunk of headroom (as the production transformer passes).
+        cache_seq_len_global=seq_len_cache,
+        chunk_size_global=chunk_size_global,
+        tail_slack=tight_cache,
     )
     tt_kvpe_cache = init_mla_kv_cache(
         cache_format=MlaKvCacheFormat.BFP8_TILE,
@@ -776,6 +804,9 @@ def _run_chunked_prefill(
                         rope_tensors=indexed_rope,
                         kvpe_cache=tt_kvpe_cache,
                         actual_start=None if use_metadata_tensor else kv_actual,
+                        # Scalar path needs actual_end only when the window overruns; None otherwise keeps
+                        # the existing scenarios writing the whole padded slab. (Metadata always carries it.)
+                        actual_end=valid_end if (tight_cache and not use_metadata_tensor) else None,
                         cache_user_id=u,
                         metadata=kv_pad_metadata,
                     )
@@ -903,6 +934,10 @@ _CHUNKED_SCENARIOS = (
         # Multi-user WITH padding/rotation: each user runs the full maxedge pattern in its own slot
         # (partition splits [..]*2 into one maxedge per user), exercising rotation + cross-user isolation.
         ("maxedge-2u", dict(iters_isl=[2560, 2592, 5120] * 2, num_users=2)),
+        # Tail chunk padding PAST the cache end: each iter leaves a tile of pad, so kv_actual drifts and
+        # the final 32-token iter's window ends 5056 past the 10240 cache while its real tokens fit. Only
+        # a drifted start can overrun. See tight_cache in the driver.
+        ("padoverflow-1u", dict(iters_isl=[5120 - 32] * 2 + [32], tight_cache=True)),
         ("deep-50k+5k", dict(iters_isl=[5120], prefill_len=50 * 1024)),
         ("deep-2u", dict(iters_isl=[5120, 5120], prefill_len=50 * 1024, num_users=2)),
     ]
@@ -916,6 +951,7 @@ _CHUNKED_SCENARIOS = (
         pytest.param((2, 4), fabric2d_device_params(l1_small_size=1152), id="fabric2d-2x4"),
         # high_bw_all_gather parks readiness/completion semaphores in L1_SMALL. On 8x4 the
         # fallback fragments general L1 enough that a later op's static circular buffers collide.
+        #
         pytest.param((8, 4), torus_xy_device_params(l1_small_size=1152), id="torus-xy-8x4"),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -129,6 +129,48 @@ assert sum(_PADDED_FULL_55K) == SEQ_CACHE and all(v % 32 == 0 and 0 < v <= CHUNK
 _PADDED_MID_15K = [2592, 1568, 5120, 800, 3360, 1920]  # sum == 15 * 1024
 assert sum(_PADDED_MID_15K) == 15 * 1024 and all(v % 32 == 0 and 0 < v <= CHUNK for v in _PADDED_MID_15K)
 
+
+def _padded_cache_len(splits):
+    """Slab-aligned cache for the splits' REAL tokens -- deliberately NOT the padded window, so the
+    last chunk pads off the end of the cache and update_padded_kv_cache has to clamp the write. Sizing
+    to max(kv_actual + CHUNK) would house that pad tail and never exercise it.
+
+    Returns (seq_len_cache, overruns), overruns being the (chunk index, kv_actual) of every chunk
+    padding past the cache.
+    """
+    seq_len_cache = max(CHUNK * 2, ((sum(splits) + CHUNK - 1) // CHUNK) * CHUNK)
+    ka, overruns = 0, []
+    for c, v in enumerate(splits):
+        if ka + CHUNK > seq_len_cache:
+            overruns.append((c, ka))
+        ka += v
+    return seq_len_cache, overruns
+
+
+def _assert_splits_overrun():
+    """Checked at import so a splits edit that loses the overrun fails at collection, not after loading
+    61 layers of weights."""
+    for name, splits in (("_PADDED_FULL_55K", _PADDED_FULL_55K), ("_PADDED_MID_15K", _PADDED_MID_15K)):
+        cache, overruns = _padded_cache_len(splits)
+        assert overruns, (
+            f"{name} never pads past its {cache}-token cache, so it no longer covers the clamped tail "
+            f"write; keep a final chunk whose start + {CHUNK} exceeds the cache"
+        )
+
+
+_assert_splits_overrun()
+
+
+def _pad_overrun_summary(seq_len_cache, overruns):
+    """One log line naming the clamped chunks, so a CI log shows the coverage ran."""
+    worst = max(ka for _, ka in overruns) + CHUNK
+    return (
+        f"pad tail past the cache: {len(overruns)} chunk(s) {[c for c, _ in overruns]} pad past the "
+        f"{seq_len_cache}-token cache (worst window ends {worst}, +{worst - seq_len_cache}); their real "
+        f"tokens fit and update_padded_kv_cache clamps the rest"
+    )
+
+
 # Per-chunk per-layer threshold; error accumulates with depth, so this matches the single-shot
 # transformer's device-gate trace bar (TRACE_PCC_THRESHOLD_DEVICE_BF16 = 0.88). Calibrate + tighten.
 LAYER_PCC_THRESHOLD = 0.88
@@ -493,13 +535,8 @@ def run_chunked_transformer_padded(
     for v in splits:
         assert 0 < v <= CHUNK and v % tile == 0, f"split {v} must be tile-aligned and <= {CHUNK}"
 
-    # Slab-aligned cache covering the largest rotated write (kv_actual + CHUNK), >= 2 slabs.
-    max_window = CHUNK * 2
-    ka = 0
-    for v in splits:
-        max_window = max(max_window, ka + CHUNK)
-        ka += v
-    seq_len_cache = ((max_window + CHUNK - 1) // CHUNK) * CHUNK
+    # Real-token cache, pad tail off the end (see _padded_cache_len).
+    seq_len_cache, pad_overruns = _padded_cache_len(splits)
 
     emb_dim = config.hidden_size
     kvpe_dim = config.qk_rope_head_dim + config.kv_lora_rank
@@ -509,6 +546,7 @@ def run_chunked_transformer_padded(
         f"chunked-padded transformer: num_layers={num_layers} mesh={mesh_shape} splits={splits} "
         f"total_len={total_len} cache={seq_len_cache} chunk={CHUNK}"
     )
+    logger.info(_pad_overrun_summary(seq_len_cache, pad_overruns))
 
     token_ids_full = _load_metadata_token_ids(trace_dir, total_len)
 
@@ -2087,12 +2125,8 @@ def run_chunked_transformer_padded_trace(
     for v in splits:
         assert 0 < v <= CHUNK and v % tile == 0, f"split {v} must be tile-aligned and <= {CHUNK}"
 
-    # Slab-aligned cache covering the largest rotated write (mirror run_chunked_transformer_padded).
-    max_window, ka = CHUNK * 2, 0
-    for v in splits:
-        max_window = max(max_window, ka + CHUNK)
-        ka += v
-    seq_len_cache = ((max_window + CHUNK - 1) // CHUNK) * CHUNK
+    # Real-token cache, pad tail off the end (mirror run_chunked_transformer_padded).
+    seq_len_cache, pad_overruns = _padded_cache_len(splits)
 
     kvpe_dim = config.qk_rope_head_dim + config.kv_lora_rank
     config.max_seq_len = seq_len_cache
@@ -2100,6 +2134,7 @@ def run_chunked_transformer_padded_trace(
         f"chunked-padded TRACE: num_layers={num_layers} mesh={mesh_shape} splits={splits} "
         f"total_len={total_len} cache={seq_len_cache} chunk={CHUNK}"
     )
+    logger.info(_pad_overrun_summary(seq_len_cache, pad_overruns))
     token_ids_full = _load_metadata_token_ids(trace_dir, total_len)
 
     effective_cache_path = weight_cache_path / f"{sp}x{tp}"

--- a/models/demos/deepseek_v3_d_p/tt/dflash_prefill/tt_dflash_drafter.py
+++ b/models/demos/deepseek_v3_d_p/tt/dflash_prefill/tt_dflash_drafter.py
@@ -112,7 +112,9 @@ class TtDFlashDrafter:
             assert self.chunk_size is not None, "chunk_size is required to build the drafter rope table (KV-tail rank)"
             hf = build_drafter_rope_hf_config(self.config, max_seq_len=self.cache_seq)
             self._rope = RotarySetup(hf, self.mesh_device, sp_axis=self.sp_axis).get_rope_tensors_indexed(
-                cache_seq_len_global=self.cache_seq, chunk_size_global=self.chunk_size
+                cache_seq_len_global=self.cache_seq,
+                chunk_size_global=self.chunk_size,
+                tail_slack=True,
             )
         # K/V caches are owned by the CALLER (see allocate_dflash_kv_cache) and passed into
         # forward() — the drafter does not hold them, mirroring the MLA prefill model's kvpe_cache.
@@ -322,6 +324,7 @@ class TtDFlashDrafter:
         kv_actual_global: int = 0,
         *,
         slot_idx: int = 0,
+        actual_end: Optional[int] = None,
     ) -> None:
         """Finalize into the caller-owned ``k_cache``/``v_cache`` (allocate via
         ``allocate_dflash_kv_cache``): consume the accumulated TP-partial FC output, TP-reduce it,
@@ -338,6 +341,9 @@ class TtDFlashDrafter:
 
         ``slot_idx`` selects which user's cache slot to fill; the cache is user-major
         (``slot_idx * num_hidden_layers + layer_idx``), as ``allocate_dflash_kv_cache`` lays it out.
+
+        ``actual_end`` is the end of the chunk's real tokens: given it, the writes skip the padded tail,
+        so only the real tokens have to fit (the same clamp the verifier's KVPE write uses).
 
         The taps for this chunk need NOT be seq-contiguous: token ids entering the transformer are already
         block-cyclic-gathered, so each chip's tap slice is exactly the rows its cache shard will hold, and
@@ -378,9 +384,20 @@ class TtDFlashDrafter:
         assert (
             kv_actual_global % ttnn.TILE_SIZE == 0
         ), f"kv_actual_global ({kv_actual_global}) must be tile-aligned (a multiple of {ttnn.TILE_SIZE})"
-        assert kv_actual_global + chunk_global <= self.cache_seq, (
-            f"kv_actual_global ({kv_actual_global}) + chunk_global ({chunk_global}) exceeds the global cache "
-            f"depth ({self.cache_seq}); construct with a larger max_seq_len (windowing happens at migration)"
+        # With actual_end the writes are clamped to the real tokens, so that is what must fit.
+        write_end = (
+            -(-actual_end // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+            if actual_end is not None
+            else kv_actual_global + chunk_global
+        )
+        assert write_end <= self.cache_seq, (
+            f"this chunk writes up to {write_end} (kv_actual_global={kv_actual_global}, "
+            f"chunk_global={chunk_global}, actual_end={actual_end}), past the global cache depth "
+            f"({self.cache_seq}); construct with a larger max_seq_len (windowing happens at migration)"
+        )
+        assert actual_end is None or kv_actual_global <= actual_end <= kv_actual_global + chunk_global, (
+            f"actual_end ({actual_end}) must lie in this chunk's window "
+            f"[{kv_actual_global}, {kv_actual_global + chunk_global}]"
         )
         assert self.cache_seq % chunk_global == 0, (
             f"cache_seq ({self.cache_seq}) must be a whole number of chunk_global ({chunk_global}) blocks; "
@@ -459,6 +476,7 @@ class TtDFlashDrafter:
                     num_layers=cfg.num_hidden_layers,
                     kv_actual_global=kv_actual_global,
                     cluster_axis=self.sp_axis,
+                    valid_global=actual_end,
                 )
             ttnn.deallocate(k)
             ttnn.deallocate(v)

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -570,7 +570,15 @@ class TtIndexer:
         return self._index_layer_idx if self._is_index_compact else cache_layer_idx
 
     def write_k(
-        self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0, cache_layer_idx=0, index_kbuf=None
+        self,
+        hidden_states,
+        seq_len,
+        start_pos,
+        rope_tensors=None,
+        cache_user_id=0,
+        cache_layer_idx=0,
+        index_kbuf=None,
+        actual_end=None,
     ):
         """Device K stem (wk + TP all-reduce + k_norm + device rope) written into the device index-key
         cache. forward() calls this on every chunk so the key-cache stays complete — else later chunks
@@ -578,7 +586,11 @@ class TtIndexer:
         runs there.) Always block-cyclic (single-shot is folded onto it as one full-seq chunk at
         start_pos=0): rope the PER-CHIP shard at its block-cyclic positions, then write it in place via
         update_padded_kv_cache (per-(user,layer) slot, pad-aware kv_actual_global offset) — no SP
-        all-gather, no O(n^2) concat; the cache stays SP-sharded."""
+        all-gather, no O(n^2) concat; the cache stays SP-sharded.
+
+        ``actual_end`` (end of the chunk's real tokens) clamps the write to them, so a chunk padding past
+        the cache end needs only its real tokens to fit. forward() reads back the same prefix
+        (``valid_pos``)."""
         k = ttnn.linear(
             hidden_states,
             self._idx_wk,
@@ -621,6 +633,7 @@ class TtIndexer:
             num_layers=self._index_cache_layers,
             kv_actual_global=start_pos,
             cluster_axis=self.sp_axis,
+            valid_global=actual_end,
         )
         ttnn.deallocate(k)
 
@@ -634,6 +647,7 @@ class TtIndexer:
         cache_user_id: int = 0,
         cache_layer_idx: int = 0,
         index_kv_cache: ttnn.Tensor = None,
+        actual_end: int = None,
     ) -> ttnn.Tensor:
         """Indexer forward → top-k key indices [1, 1, S/sp, k] over the device index-key cache, SP-sharded
         on the query axis (each chip scores its own S/sp rows; no Q/W all-gather). Fully on-device:
@@ -657,6 +671,10 @@ class TtIndexer:
         cache_layer_idx = self._cache_slot(cache_layer_idx)
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
+        # Read bound matching write_k's clamp, on the 32-row write grid: scoring and transport follow the
+        # POPULATED prefix, not the padded window. Real query rows all sit below actual_end so their top-k
+        # is unchanged; the pad rows past it have no keys, which indexer_score allows.
+        valid_pos = end_pos if actual_end is None else min(end_pos, -(-actual_end // ttnn.TILE_SIZE) * ttnn.TILE_SIZE)
         # Block-cyclic key cache is caller-owned (like the KVPE cache) — required, never self-allocated.
         assert index_kv_cache is not None, (
             "block-cyclic indexer requires an externally-allocated index_kv_cache passed to forward() "
@@ -675,6 +693,7 @@ class TtIndexer:
             cache_user_id=cache_user_id,
             cache_layer_idx=cache_layer_idx,
             index_kbuf=index_kv_cache,
+            actual_end=actual_end,
         )
 
         # Q stem: the shared q_a latent (qr) -> indexer wq_b.
@@ -747,6 +766,8 @@ class TtIndexer:
         # key cache ONCE — but that needs L1 headroom, so k_chunk is bounded by resident head count
         # (DSA_INDEXER_CONFIG, measured per model: DeepSeek@64h=64, GLM@32h=224; larger OOMs).
         k_chunk = get_indexer_key_chunk(a.index_n_heads)
+        # Keyed on end_pos, NOT valid_pos: the program config is hashed, so keying it on a per-chunk
+        # runtime quantity would compile a second program. The valid extent travels in hash-excluded kv_len.
         cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=qc, k_chunk_size=min(k_chunk, end_pos), head_group_size=0)
         # SP-sharded queries (rotation-safe): each chip scores its S/sp rows while the fused ring indexer
         # gathers remote block-cyclic K slabs into a shared persistent full-T buffer. The reader consumes
@@ -754,13 +775,10 @@ class TtIndexer:
         # the former blocking all-gather with score compute. Per-device causality remains cluster_axis=SP
         # (chip r: chunk_start = start_pos + r*Sq). All H_idx heads are resident, so each logit is complete.
         #
-        # Bound the score to the real written prefix (kv_len=end_pos) rather than the full preallocated
-        # width T: end_pos = start_pos + chunk_global is the tightest legal value (the pad query rows
-        # push the fullest-device causal window to end_pos; the op TT_FATALs on kv_len < that). kv_len
-        # only WRITES logits[:, :, :, :end_pos] and leaves the tail [end_pos, T) STALE (not -inf); the
-        # top-k below is told the valid length (valid_length=end_pos) so it never reads or ranks that
-        # stale tail — which is the future top-k would drop anyway (causally -inf), so the selection is
-        # unchanged.
+        # Bound the score to the populated prefix (kv_len=valid_pos), not the full width T nor the padded
+        # window, which on the last chunk runs past what was written. kv_len only writes
+        # logits[..., :valid_pos] and leaves the tail STALE (not -inf); top-k is told the valid length so it
+        # never ranks that tail — which is future anyway, so the selection is unchanged.
         # Pass the persistent multi-slot ND-sharded cache directly. The fused gather selects only
         # cache_batch_idx into the batch-1 scratch and moves only the complete block-cyclic slabs touched
         # by kv_len; the score reader addresses its own shard directly in the original ND cache.
@@ -781,7 +799,7 @@ class TtIndexer:
             cache_batch_idx=cache_batch_idx,
             block_cyclic_sp_axis=self.sp_axis,
             block_cyclic_chunk_local=seq_len,
-            kv_len=end_pos,
+            kv_len=valid_pos,
         )
         if host_start is not None:
             _fused_ring_host_timing["calls"] += 1
@@ -792,10 +810,10 @@ class TtIndexer:
         # Top-k key indices [1,1,S/sp,k] (ROW_MAJOR uint32). Future/pad -inf columns surface as the
         # 0xFFFFFFFF sentinel that sparse_mla drops. The indexer score/cache contract requires a
         # 16-element-aligned key prefix; this is independent of fixed top-k capacity.
-        assert end_pos % 16 == 0, f"indexer cache prefix must be 16-element aligned; got end_pos={end_pos}"
-        # Block-cyclic logits are the full preallocated width T with a stale [end_pos, T) tail (kv_len only
-        # wrote the real prefix); valid_length bounds top-k to that prefix so the tail is never read or ranked.
-        topk_valid_length = end_pos
+        assert valid_pos % 16 == 0, f"indexer cache prefix must be 16-element aligned; got valid_pos={valid_pos}"
+        # valid_length bounds top-k to the populated prefix so the stale [valid_pos, T) tail is never
+        # ranked. topk_large_indices also requires valid_length <= T, which valid_pos satisfies.
+        topk_valid_length = valid_pos
         idx = ttnn.experimental.topk_large_indices(logits, k=self.index_topk_capacity, valid_length=topk_valid_length)
         # TP×SP: topk ran on the TP-seq-sharded rows ([1,1,S/(sp·tp),k]); regather over TP back to the
         # [1,1,S/sp,k] contract so sparse_sdpa/mla.py are unchanged. (Redundant TP-round-trip for GLM's

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -890,6 +890,7 @@ class ttMLA:
         cache_layer_idx: int,
         cache_user_id: int,
         seq_len_local: int,
+        actual_end: Optional[int] = None,
         metadata: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
         """Chunked-prefill attention via update_padded_kv_cache + ring_mla.
@@ -923,6 +924,7 @@ class ttMLA:
             cache_user_id=cache_user_id,
             cache_layer_idx=cache_layer_idx,
             kv_actual_isl=kv_actual_isl,
+            actual_end=actual_end,
             metadata=metadata,
         )
 
@@ -946,7 +948,9 @@ class ttMLA:
             ring_logical_n = kvpe_cache.storage.shape[2] * self.sp_factor  # global cache capacity
         else:
             meta_slot_kwargs = {"kv_cache_batch_idx": cache_batch_idx, "kv_actual_isl": kv_actual_isl}
-            ring_logical_n = kv_actual_isl + chunk_size_global
+            # Capped at the capacity ring_mla accepts: the last chunk's pad rows can sit past the cache
+            # end, and only pad rows read them.
+            ring_logical_n = min(kv_actual_isl + chunk_size_global, kvpe_cache.storage.shape[2] * self.sp_factor)
         attn_out, _ = ttnn.transformer.ring_mla(
             tt_q,
             kvpe_cache.storage,
@@ -1189,8 +1193,11 @@ class ttMLA:
         cache_user_id: int,
         cache_layer_idx: int,
         kv_actual_isl: int,
+        actual_end: Optional[int] = None,
         metadata: Optional[ttnn.Tensor] = None,
     ) -> None:
+        """``actual_end`` (end of this chunk's real tokens) clamps the write to them, so a chunk padding
+        past the cache end needs only its real tokens to fit. Omitted, the whole padded slab is written."""
         # Metadata (trace-safe) path: slot_idx (metadata[0]) + kv_actual_global (metadata[1]) read
         # on-device, each its own 1-element tensor. Scalar path passes host slot/kv_actual_global.
         if metadata is not None:
@@ -1202,6 +1209,7 @@ class ttMLA:
                 layer_idx=cache_layer_idx,
                 num_layers=self.layer_num,
                 cluster_axis=self.sp_axis,
+                valid_global=metadata[2],  # actual_end tensor
             )
         else:
             ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
@@ -1212,6 +1220,7 @@ class ttMLA:
                 num_layers=self.layer_num,
                 kv_actual_global=kv_actual_isl,
                 cluster_axis=self.sp_axis,
+                valid_global=actual_end,
             )
 
     def _output_gate(self, hidden_states: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
@@ -1301,6 +1310,7 @@ class ttMLA:
         kvpe_cache: MlaKvCache,
         cache_layer_idx: int = 0,
         actual_start: Optional[int] = None,
+        actual_end: Optional[int] = None,
         cache_user_id: int = 0,
         return_kv_intermediates: bool = False,
         index_kv_cache: Optional[ttnn.Tensor] = None,
@@ -1331,6 +1341,7 @@ class ttMLA:
                 kvpe_cache,
                 cache_layer_idx,
                 kv_actual_isl=actual_start or 0,
+                actual_end=actual_end,
                 cache_user_id=cache_user_id,
                 index_kv_cache=index_kv_cache,
                 metadata=metadata,
@@ -1380,6 +1391,7 @@ class ttMLA:
                 cache_user_id=cache_user_id,
                 cache_layer_idx=cache_layer_idx,
                 index_kv_cache=index_kv_cache,
+                actual_end=actual_end,
             )
         )
 
@@ -1404,6 +1416,7 @@ class ttMLA:
             cache_user_id=cache_user_id,
             seq_len_local=seq_len_local,
             kv_actual_isl=kv_actual_isl,
+            actual_end=actual_end,
             metadata=metadata,
         )
 
@@ -1471,6 +1484,7 @@ class ttMLA:
         cache_layer_idx,
         cache_user_id,
         seq_len_local,
+        actual_end=None,
         metadata=None,
         **_,
     ):
@@ -1484,6 +1498,7 @@ class ttMLA:
             cache_layer_idx=cache_layer_idx,
             cache_user_id=cache_user_id,
             seq_len_local=seq_len_local,
+            actual_end=actual_end,
             metadata=metadata,
         )
 
@@ -1498,6 +1513,7 @@ class ttMLA:
         cache_layer_idx,
         cache_user_id,
         seq_len_local,
+        actual_end=None,
         **_,
     ):
         assert indices is not None, "sparse MLA forward requires indexer top-k indices"
@@ -1515,10 +1531,17 @@ class ttMLA:
             cache_user_id=cache_user_id,
             cache_layer_idx=cache_layer_idx,
             kv_actual_isl=kv_actual_isl,
+            actual_end=actual_end,
         )
-        # After the write above, KV is populated up to [0, kv_actual_isl + chunk_size_global); the gather
-        # only needs that populated prefix (top-k indices never address the unwritten suffix).
-        populated_global = kv_actual_isl + seq_len_local * self.sp_factor
+        # The write above is clamped to the chunk's real tokens, so on the last chunk KV is populated to
+        # ceil32(actual_end), not the padded window. The gather needs only that prefix — top-k indices never
+        # address the unwritten suffix, the indexer being bounded by the same prefix.
+        chunk_end_global = kv_actual_isl + seq_len_local * self.sp_factor
+        populated_global = (
+            chunk_end_global
+            if actual_end is None
+            else min(chunk_end_global, -(-actual_end // ttnn.TILE_SIZE) * ttnn.TILE_SIZE)
+        )
         kvpe_dev = self._gather_kvpe_prefix(
             kvpe_cache,
             cache_batch_idx,
@@ -1550,6 +1573,7 @@ class ttMLA:
         kv_actual_isl: int,
         cache_user_id: int,
         index_kv_cache: Optional[ttnn.Tensor],
+        actual_end: Optional[int] = None,
         metadata: Optional[ttnn.Tensor] = None,
     ) -> None:
         """Last-layer fast path: fill the migratable KVPE cache, then stop before query/attention/output.
@@ -1574,6 +1598,7 @@ class ttMLA:
                 cache_user_id=cache_user_id,
                 cache_layer_idx=cache_layer_idx,
                 index_kbuf=index_kv_cache,
+                actual_end=actual_end,
             )
 
         # Reuse the regular KV stem so kv_only and full attention cannot drift in normalization,
@@ -1598,6 +1623,7 @@ class ttMLA:
             cache_user_id=cache_user_id,
             cache_layer_idx=cache_layer_idx,
             kv_actual_isl=kv_actual_isl,
+            actual_end=actual_end,
             metadata=metadata,
         )
         ttnn.deallocate(tt_kvpe)

--- a/models/demos/deepseek_v3_d_p/tt/mla/rope.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/rope.py
@@ -22,11 +22,14 @@ def get_rot_transformation_mat():
     return rot_emb_matrix
 
 
-def get_cos_sin_matrix(hf_config, interleave: bool = True):
+def get_cos_sin_matrix(hf_config, interleave: bool = True, num_positions: int | None = None):
     """Get cos and sin matrices for rotary positional embeddings.
 
     HuggingFace returns cos/sin in [max_seq_len, dim] with dim = [t1,..,td//2, t1,..,td//2].
-    Returns cos, sin as [1, 1, max_seq_len, dim].
+    Returns cos, sin as [1, 1, num_positions or max_seq_len, dim].
+
+    ``num_positions`` overrides how many positions the table covers (default hf_config.max_seq_len).
+    It is a table LENGTH, not a rope parameter: YaRN's frequencies do not depend on it.
 
     interleave (which physical columns form a rotated pair):
         True  -> Meta-style duplicated pairs [t1,t1,..,td//2,td//2]; pairs (0,1),(2,3),..
@@ -41,7 +44,7 @@ def get_cos_sin_matrix(hf_config, interleave: bool = True):
     """
     args = {
         "dim": hf_config.qk_rope_head_dim,
-        "max_position_embeddings": hf_config.max_seq_len,
+        "max_position_embeddings": num_positions if num_positions is not None else hf_config.max_seq_len,
         "base": hf_config.rope_theta * 1.0,
         "device": "cpu",
         "scaling_factor": hf_config.rope_scaling["factor"],
@@ -189,7 +192,9 @@ class RotarySetup:
 
         return {"cos_matrix": cos_matrix, "sin_matrix": sin_matrix, "trans_matrix": trans_matrix}
 
-    def get_rope_tensors_indexed(self, cache_seq_len_global: int, chunk_size_global: int) -> dict[str, ttnn.Tensor]:
+    def get_rope_tensors_indexed(
+        self, cache_seq_len_global: int, chunk_size_global: int, tail_slack: bool = False
+    ) -> dict[str, ttnn.Tensor]:
         """Get whole-cache cos/sin/trans matrices for the KV-pad-aware *indexed* rotated path.
 
         This builds the rope values for the *entire* cache once. The cos/sin are
@@ -205,6 +210,10 @@ class RotarySetup:
                 cover every position the cache can hold). Per-chip shard = cache_seq_len_global // sp.
             chunk_size_global: global chunk size (one chunk across all SP devices). Per-chip chunk =
                 chunk_size_global // sp_factor, which keys the block-cyclic reorder.
+            tail_slack: extend the table by ONE chunk past the cache. A chunk ropes its whole padded
+                slab, so a last chunk padding past the cache end would read past an exactly-sized
+                table. The KV cache skips that tail instead (valid_global); the rope table, being one
+                shared tensor, has to be readable.
 
         Constraints (mirroring the block-cyclic / cache layout):
             * ``cache_seq_len_global <= max_seq_len``
@@ -226,10 +235,11 @@ class RotarySetup:
             f"chunk_size_global ({chunk_size_global})"
         )
         chunk_local = chunk_size_global // sp
+        table_seq_len = cache_seq_len_global + (chunk_size_global if tail_slack else 0)
 
-        cos_matrix_torch, sin_matrix_torch = get_cos_sin_matrix(self.hf_config)
-        cos_matrix_torch = cos_matrix_torch[..., :cache_seq_len_global, :]
-        sin_matrix_torch = sin_matrix_torch[..., :cache_seq_len_global, :]
+        cos_matrix_torch, sin_matrix_torch = get_cos_sin_matrix(self.hf_config, num_positions=table_seq_len)
+        cos_matrix_torch = cos_matrix_torch[..., :table_seq_len, :]
+        sin_matrix_torch = sin_matrix_torch[..., :table_seq_len, :]
 
         # Block-cyclic reorder keyed by the per-chip chunk so a plain SP shard hands device c the
         # rope values for every global position it carries, in local-cache-row order.

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -610,6 +610,7 @@ class TtPrefillBlock(LightweightModule):
             kvpe_cache,
             cache_layer_idx=cache_layer_idx,
             actual_start=actual_start,
+            actual_end=actual_end,
             cache_user_id=cache_user_id,
             return_kv_intermediates=return_kv_intermediates,
             indexer_indices=indexer_indices,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -647,11 +647,17 @@ class TtPrefillRuntime:
             assert 0 <= slot_id < self.config.num_users, f"slot_id {slot_id} out of range [0, {self.config.num_users})"
         if actual_start is not None:
             assert (
-                actual_start + self.config.chunk_size <= self.config.max_seq_len
-            ), f"chunk at actual_start={actual_start} exceeds per-user cache {self.config.max_seq_len}"
-            assert (
                 actual_start <= actual_end <= actual_start + self.config.chunk_size
             ), f"[actual_start={actual_start}, actual_end={actual_end}) not within one chunk of {self.config.chunk_size}"
+            # The cache holds the chunk's real tokens on the 32-row write grid; the padded tail is skipped.
+            write_end = -(-actual_end // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+            assert write_end <= self.config.max_seq_len, (
+                f"chunk [{actual_start}, {actual_end}) writes up to {write_end} (32-row grid), past the "
+                f"per-user cache {self.config.max_seq_len}"
+            )
+            # Sparse/DSA has the SAME bound as dense: indexer_score now allows a causal window ending past the
+            # valid prefix, and the indexer bounds kv_len / top-k by the populated prefix instead. That uniformity
+            # matters — the inference server sizes the cache without knowing which model it is talking to.
 
         if self.config.use_trace:
             # Traced path: update the persistent input + per-element metadata IN PLACE, then replay the
@@ -738,6 +744,7 @@ class TtPrefillRuntime:
                     self._dflash_v_cache,
                     actual_start,
                     slot_idx=slot_id,
+                    actual_end=actual_end,
                 )
                 return None
             # Non-last rank: pack this rank's finalized FC partial alongside the hidden for the next rank.

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -288,6 +288,7 @@ class TtPrefillTransformer(LightweightModule):
             self.rope_setup.get_rope_tensors_indexed(
                 cache_seq_len_global=max_seq_len if max_seq_len is not None else seq_len,
                 chunk_size_global=seq_len,
+                tail_slack=is_chunked,
             )
             if (is_chunked or self._has_indexer)
             else None

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/ring_indexer_score_test_utils.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/ring_indexer_score_test_utils.py
@@ -16,9 +16,22 @@ from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_in
     QB_SQ,
 )
 
-# Ring of 4 on the LoudBox: full physical mesh, then a 1x4 submesh (SP axis = 1).
-LOUDBOX_MESH_SHAPE = (2, 4)
+# Ring of 4: open the FULL system mesh, then carve a 1x4 submesh (SP axis = 1).
+#
+# The parent shape is queried, not hardcoded: fabric only trains against the mesh the control plane
+# exposes, so a hardcoded (2, 4) on a bigger box dies in router sync ("Ethernet handshake likely failed")
+# before any op runs. Carving the ring out of the real shape works on LoudBox and galaxy alike.
 RING = 4
+
+
+def ring_parent_shape():
+    """The system mesh shape, as a (rows, cols) tuple. Raises if it cannot host the ring-of-4 carve."""
+    shape = ttnn._ttnn.multi_device.SystemMeshDescriptor().shape()
+    rows, cols = shape[0], shape[1]
+    assert cols >= RING, f"ring-of-4 needs a system mesh with axis-1 >= {RING}; got {rows}x{cols}"
+    return rows, cols
+
+
 SP_AXIS = 1  # the length-4 axis of the (1, 4) submesh
 CHUNK_GLOBAL = RING * QB_SQ  # 2560 global prefill chunk = sp * per-shard slab (chunk_local = QB_SQ)
 T = QB_HISTORY + CHUNK_GLOBAL  # 28160 all-gathered keys (880 tiles); 11 global chunks of 2560
@@ -33,8 +46,8 @@ _BUF_DIMS = (1, None)
 
 
 def _open_ring4_ccl():
-    """Open the full 2x4 with 2D fabric, carve a 1x4 submesh, load a worker sub-device, make 2 CCL semaphores
-    (the two ring directions, as ring_attention_all_gather_async needs). Returns
+    """Open the full system mesh with 2D fabric, carve a 1x4 submesh, load a worker sub-device, make 2 CCL
+    semaphores (the two ring directions, as ring_attention_all_gather_async needs). Returns
     (submesh, parent, ccl_semaphores, worker_sub_device_id, stall_group)."""
     ttnn.set_fabric_config(
         ttnn.FabricConfig.FABRIC_2D,
@@ -46,7 +59,7 @@ def _open_ring4_ccl():
     )
     parent = None
     try:
-        parent = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*LOUDBOX_MESH_SHAPE))
+        parent = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*ring_parent_shape()))
         submesh = parent.create_submesh(ttnn.MeshShape(1, RING))
 
         grid = submesh.compute_with_storage_grid_size()

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_indexer_score.py
@@ -537,17 +537,20 @@ def test_indexer_score_runtime_kv_len(device, q_chunk, k_chunk, head_group):
             )
         )
 
-    _check_kv_len(run(64), q, k, w, 64)  # only the first 2 k-tiles valid; most work units are fully past kv_len
+    # kv_len=32 with Sq=64: the causal window ends PAST the valid prefix (the chunked-prefill pad tail).
+    # Rows 32..63 saturate to the whole 32-key prefix; bands past it score nothing.
+    _check_kv_len(run(32), q, k, w, 32)
     entries_after_first = device.num_program_cache_entries()
-    for kv_len in (128, 256, 512):  # grow the valid prefix within the same T=512 buffer
+    # 64: window == kv_len exactly (the old tightest legal value). Then grow within the same T=512 buffer.
+    for kv_len in (64, 128, 256, 512):
         _check_kv_len(run(kv_len), q, k, w, kv_len)
     assert device.num_program_cache_entries() == entries_after_first, "changing kv_len recompiled"
 
 
 def test_indexer_score_rejects_bad_kv_len(device, expect_error):
-    """kv_len must be tile-aligned, within (0, T], and leave room for the causal window
-    (chunk_start + Sq <= kv_len). Each violation is rejected -- on a WARM cache too, since kv_len is excluded
-    from the hash and re-validated on a program-cache hit (validate_on_program_cache_hit)."""
+    """kv_len must be tile-aligned and within (0, T], rejected on a WARM cache too (it is hash-excluded and
+    re-validated on a hit). It need NOT leave room for the causal window, which may end past the prefix --
+    test_indexer_score_runtime_kv_len covers that positively."""
     c = KV_LEN
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
     q, w, k = _kv_len_inputs()
@@ -557,7 +560,7 @@ def test_indexer_score_rejects_bad_kv_len(device, expect_error):
     ttnn.experimental.indexer_score_dsa(
         q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=128
     )
-    for bad, why in [(c["t"] + 32, "above T"), (100, "not tile-aligned"), (32, "causal window > kv_len")]:
+    for bad, why in [(c["t"] + 32, "above T"), (100, "not tile-aligned")]:
         with expect_error(RuntimeError, "kv_len"):
             ttnn.experimental.indexer_score_dsa(
                 q_dev, k_dev, w_dev, chunk_start_idx=c["chunk_start"], program_config=cfg, kv_len=bad
@@ -1686,9 +1689,8 @@ def test_indexer_score_msa_indexed_cache_rejects(device, expect_error):
 
 
 def test_indexer_score_msa_rejects_bad_kv_len(device, expect_error):
-    """MSA mirrors the DSA base kv_len rejections (block_size=0): kv_len must be tile-aligned, within (0, T],
-    and leave room for the causal window (chunk_start + Sq <= kv_len). Each violation fails on a WARM cache
-    too (kv_len is hash-excluded and re-validated on a program-cache hit)."""
+    """MSA mirrors the DSA base kv_len rejections (block_size=0): tile-aligned, within (0, T], rejected on
+    a warm cache too. A causal window ending past kv_len is legal (the chunked-prefill pad tail)."""
     heads, dim, sq, t, chunk_start = 1, 128, 64, 512, 0
     scale = dim**-0.5
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0)
@@ -1701,7 +1703,7 @@ def test_indexer_score_msa_rejects_bad_kv_len(device, expect_error):
     ttnn.experimental.indexer_score_msa(
         q_dev, k_dev, num_groups=1, chunk_start_idx=chunk_start, scale=scale, program_config=cfg, kv_len=128
     )
-    for bad in (t + 32, 100, 32):  # above T / not tile-aligned / causal window (>= chunk_start+Sq=64) violated
+    for bad in (t + 32, 100):  # above T / not tile-aligned
         with expect_error(RuntimeError, "kv_len"):
             ttnn.experimental.indexer_score_msa(
                 q_dev, k_dev, num_groups=1, chunk_start_idx=chunk_start, scale=scale, program_config=cfg, kv_len=bad
@@ -1965,31 +1967,6 @@ def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
     default_start = t - chunk
     ref_default = indexer_score_dsa_ref(q_g, k_g, w_g, default_start)
     assert_indexer_match(out_default_t, ref_default, chunk, t, check_neg=True)
-
-
-@pytest.mark.parametrize("mesh_device", [(1, 4)], ids=["sp1xtp4"], indirect=True)
-def test_indexer_score_sp1_tp4_rejects_undersized_causal_window(mesh_device, expect_error):
-    """Validation must include every TP sub-shard when the named SP axis has size one."""
-    heads, chunk, t, chunk_start = 8, 256, 256, 32
-    q_g, k_g, w_g = _global_inputs(heads, chunk, t, seed=42)
-    mesh_shape = tuple(mesh_device.shape)
-    shard_tp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(None, 2))
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_tp_seq)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_tp_seq)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    # Rank 3 owns [chunk_start + 3*Sq, chunk_start + 4*Sq) = [224, 288), which exceeds T=256.
-    with expect_error(RuntimeError, "exceeds T"):
-        ttnn.experimental.indexer_score_dsa(
-            q_dev,
-            k_dev,
-            w_dev,
-            chunk_start_idx=chunk_start,
-            seq_shard_axes=[0, 1],
-            block_cyclic_sp_axis=0,
-            block_cyclic_chunk_local=chunk,
-            program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
-        )
 
 
 @pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["sp2xtp2"], indirect=True)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
@@ -39,6 +39,7 @@ from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_in
 )
 from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.ring_indexer_score_test_utils import (
     _open_ring4_ccl,
+    ring_parent_shape,
     _close_ring4_ccl,
     _persistent_buffer,
     _shard_k,
@@ -50,7 +51,12 @@ from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.ring_in
 
 pytestmark = [
     pytest.mark.skipif(not ttnn.device.is_blackhole(), reason="indexer_score is Blackhole-only"),
-    pytest.mark.skipif(ttnn.get_num_devices() < 8, reason="ring-of-4 needs the 8-chip LoudBox (2x4)"),
+    # The ring is carved out of whatever system mesh the box exposes (LoudBox 2x4, galaxy 8x4, ...), so the
+    # requirement is an axis-1 long enough to hold it -- not a specific box size.
+    pytest.mark.skipif(
+        ring_parent_shape()[1] < RING,
+        reason="ring-of-4 needs a system mesh with axis-1 >= 4",
+    ),
 ]
 
 
@@ -451,6 +457,73 @@ def test_indexer_score_ring4_fused_runtime_kv_len():
         assert_indexer_match(out_t[:, :, :, :kv_len], ref, CHUNK_GLOBAL, kv_len, check_neg=True)
         logger.info(
             f"ring4 fused runtime kv_len (kv_len={kv_len} of T_alloc={t_alloc}): valid prefix matched reference"
+        )
+    finally:
+        _close_ring4_ccl(parent, submesh, stall_group)
+
+
+# The chunked-prefill tail, in one geometry. A fixed chunk size means a sequence's last chunk pads its
+# query window past what the cache holds, so update_padded_kv_cache clamps the WRITE to the real tokens
+# and kv_len is the matching READ bound. One case carries every edge of that contract:
+#   * the causal window ends past the populated prefix (1632 > 384) -- pad rows with no keys to attend;
+#   * and past the cache itself (1632 > 1280), which used to be a validation error;
+#   * kv_len sits below one k_chunk (384 < 512). k_chunk_size is HASHED so it keeps its tuned value; only
+#     band 0 does partial work. Unreachable while kv_len was the padded window (never below a chunk);
+#   * the start is mid-slab, so the block-cyclic staircase straddles at boundary chip 1 -- the only
+#     boundary that exercises all three of its branches (chips below advance a slab, the boundary chip
+#     by its offset, chips above stay at the base). Chip 0 leaves "below" empty, chip 3 leaves "above".
+# T is one global chunk here rather than the module's 3: past-the-cache needs a small chunk_start, and
+# chunk_start < kv_len < k_chunk forces it small.
+_TAIL_T = ST_CHUNK  # 1280: one global chunk (T % chunk_global == 0 is required)
+_TAIL_CHUNK_START = 352  # tile-aligned, 352 % 320 != 0 -> mid-slab, boundary chip 1
+_TAIL_KV_LEN = 384  # tile-aligned, > chunk_start, < k_chunk
+
+
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_ring4_fused_window_past_short_prefix(case_id, heads):
+    """Tail chunk: the causal window ends past both the populated prefix and the cache, on a prefix
+    shorter than one k_chunk. Real query rows keep their scores; pad rows saturate."""
+    cl = ST_CHUNK // RING
+    cfg = glx_config(heads)
+    assert _TAIL_CHUNK_START + ST_CHUNK > _TAIL_KV_LEN, "the window must end past the populated prefix"
+    assert _TAIL_CHUNK_START + ST_CHUNK > _TAIL_T, "the window must end past the cache"
+    assert _TAIL_KV_LEN < cfg.k_chunk_size, "kv_len must sit below one k_chunk"
+    assert (_TAIL_CHUNK_START // cl) % RING != 0, "the start must straddle a slab boundary"
+    assert _TAIL_T % (RING * cl) == 0, "T must be a whole number of global chunks"
+
+    submesh, parent, ccl_semaphores, subdevice_id, stall_group = _open_ring4_ccl()
+    try:
+        q_g, k_nat, w_g = _global_inputs(heads, ST_CHUNK, _TAIL_T, seed=42)
+        k_bc = _to_slab(k_nat, RING, ST_CHUNK)
+        q_dev, w_dev, k_local, k_gathered = _fused_dev_inputs(submesh, q_g, w_g, k_bc)
+
+        out = ttnn.experimental.ring_indexer_score_dsa(
+            q_dev,
+            k_gathered,
+            w_dev,
+            k_local,
+            ccl_semaphores,
+            cluster_axis=SP_AXIS,
+            topology=ttnn.Topology.Linear,
+            num_links=1,
+            ag_sub_device_id=subdevice_id,
+            chunk_start_idx=_TAIL_CHUNK_START,
+            block_cyclic_sp_axis=SP_AXIS,
+            block_cyclic_chunk_local=cl,
+            kv_len=_TAIL_KV_LEN,
+            program_config=cfg,
+        )
+        ttnn.synchronize_device(submesh, sub_device_ids=stall_group)
+        out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=2))
+
+        # Reference over the populated prefix only. Rows whose block-cyclic home sits at or past kv_len
+        # mask nothing -- every key they reach is in their past, the saturation the kernel must match.
+        ref = _straddle_ref(q_g, k_nat[:, :, :_TAIL_KV_LEN, :], w_g, RING, ST_CHUNK, _TAIL_CHUNK_START, _TAIL_KV_LEN)
+        assert_indexer_match(out_t[:, :, :, :_TAIL_KV_LEN], ref, ST_CHUNK, _TAIL_KV_LEN, check_neg=True)
+        logger.info(
+            f"ring4 fused tail (heads={heads}): chunk_start={_TAIL_CHUNK_START} window ends "
+            f"{_TAIL_CHUNK_START + ST_CHUNK} past kv_len={_TAIL_KV_LEN} and cache {_TAIL_T}, "
+            f"k_chunk={cfg.k_chunk_size} -- prefix matched reference"
         )
     finally:
         _close_ring4_ccl(parent, submesh, stall_group)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
@@ -20,15 +20,19 @@
 //     override_runtime_arguments). Kept out of the program hash the same way.
 // `layer_idx`, `num_layers` and `cluster_axis` stay in the hash (structural) in both paths.
 //
-// Compile args: [0]=cb_id_out, [1]=has_metadata, [2]=cb_id_meta, [3]=tile_height, [4..]=cache
-// accessor, then (metadata path only) ONE metadata accessor (the two 1-element tensors share an
-// identical layout, so the same accessor serves both reads). tile_height divides kv tokens into the
+// Optional `valid_global` (end of the chunk's REAL tokens) arrives the same two ways in common arg 10.
+// Set, the chip writes only the page-rows holding real tokens; unset, the whole padded slab.
+//
+// Compile args: [0]=cb_id_out, [1]=has_metadata, [2]=cb_id_meta, [3]=tile_height, [4]=has_valid,
+// [5..]=cache accessor, then (metadata path only) ONE metadata accessor (the 1-element tensors share
+// an identical layout, so the same accessor serves every read). tile_height divides kv tokens into the
 // page-row unit (TILE_HEIGHT for TILE, 1 for ROW_MAJOR), so one kernel handles both layouts.
 //
 // The body lives in a template on `HasMeta` so the `if constexpr` below actually DISCARDS (does not
 // instantiate) the unused branch — `kernel_main` is not a template, so an `if constexpr` there would
 // still instantiate the metadata branch's TensorAccessor and fail to compile the scalar program.
-template <bool HasMeta>
+// `HasValid` is a template param so the no-clamp program keeps the original loop.
+template <bool HasMeta, bool HasValid>
 static void run_writer() {
     // Per-core runtime args (buffers arrive as Buffer* bindings -> addresses).
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -48,14 +52,18 @@ static void run_writer() {
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
     constexpr uint32_t tile_height = get_compile_time_arg_val(3);
-    constexpr auto cache_args = TensorAccessorArgs<4>();
+    // [4] is has_valid, consumed as the HasValid template param.
+    constexpr auto cache_args = TensorAccessorArgs<5>();
 
     Noc noc;
 
-    // Resolve the two per-request values (slot_idx, and kv_actual_global already divided into the
-    // page-row unit) from whichever source this program was compiled for.
+    // Resolve the per-request values (in page-row units) from whichever source this program was
+    // compiled for.
     uint32_t slot_idx;
     uint32_t kv_actual_global_t;
+    // Real tokens as page-rows, rounded up to 32 (zero_padded_kv_cache clears the partial block).
+    uint32_t valid_global_t = 0;
+    constexpr uint32_t kClampGranularityTokens = 32;
     if constexpr (HasMeta) {
         // Metadata path: NoC-read element [0] (page 0, 4 bytes) of each 1-element uint32 tensor into
         // the L1-scratch CB. Each read targets dst offset 0 (DRAM-read dst-alignment: a 4-byte read into
@@ -90,11 +98,27 @@ static void run_writer() {
         noc.async_read_barrier();
         invalidate_l1_cache();  // same fresh-metadata refetch as above
         kv_actual_global_t = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0] / tile_height;
+
+        if constexpr (HasValid) {
+            // Same scratch slot, same fresh-metadata refetch as above.
+            const auto s_valid = TensorAccessor(meta_args, get_common_arg_val<uint32_t>(10));
+            noc.async_read(s_valid, cb_meta, kMetadataReadBytes, {.page_id = 0}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            invalidate_l1_cache();
+            const uint32_t valid_tokens = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+            valid_global_t = kClampGranularityTokens *
+                             ((valid_tokens + kClampGranularityTokens - 1) / kClampGranularityTokens) / tile_height;
+        }
         cb_meta.push_back(1);
     } else {
         // Scalar path: per-call values arrive as common runtime args (patched on cache hits).
         slot_idx = get_common_arg_val<uint32_t>(8);
         kv_actual_global_t = get_common_arg_val<uint32_t>(9) / tile_height;
+        if constexpr (HasValid) {
+            const uint32_t valid_tokens = get_common_arg_val<uint32_t>(10);
+            valid_global_t = kClampGranularityTokens *
+                             ((valid_tokens + kClampGranularityTokens - 1) / kClampGranularityTokens) / tile_height;
+        }
     }
 
     // Cache linearization: users outer, layers inner.
@@ -117,7 +141,24 @@ static void run_writer() {
         (my_sp_coord < boundary_chip ? chunk_local_t : (my_sp_coord == boundary_chip ? boundary_offset_t : 0));
 
     const uint32_t input_Ht = chunk_local_t;
+
+    // Real rows are a prefix on every chip, so their end is the staircase above at valid_global_t.
+    uint32_t rows_to_write = input_Ht;
+    if constexpr (HasValid) {
+        const uint32_t end_slab_idx = valid_global_t / chunk_global_t;
+        const uint32_t end_chip = (valid_global_t / chunk_local_t) % sp_factor;
+        const uint32_t end_offset_t = valid_global_t % chunk_local_t;
+        const uint32_t end_idxt =
+            end_slab_idx * chunk_local_t +
+            (my_sp_coord < end_chip ? chunk_local_t : (my_sp_coord == end_chip ? end_offset_t : 0));
+        rows_to_write = (end_idxt > update_idxt) ? (end_idxt - update_idxt) : 0;
+        if (rows_to_write > input_Ht) {
+            rows_to_write = input_Ht;
+        }
+    }
+
     const uint32_t start_idx = batch_idx * cache_CHtWt + update_idxt * Wt;
+
     const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
     CircularBuffer cb(cb_id_out);
 
@@ -136,10 +177,14 @@ static void run_writer() {
         const uint32_t block = core_blocks_written + blk;
         const uint32_t row = block % input_Ht;
         const uint32_t page0 = start_idx + (block / input_Ht) * cache_HtWt + row * Wt;
+        const bool keep = !HasValid || row < rows_to_write;
         for (uint32_t w = 0; w < Wt; ++w) {
             cb.wait_front(onepage);
-            noc.async_write(cb, s, page_bytes, {}, {.page_id = page0 + w});
-            noc.async_writes_flushed();
+            // A skipped page is still POPPED: the reader streams the whole padded slab either way.
+            if (keep) {
+                noc.async_write(cb, s, page_bytes, {}, {.page_id = page0 + w});
+                noc.async_writes_flushed();
+            }
             cb.pop_front(onepage);
         }
     }
@@ -148,5 +193,10 @@ static void run_writer() {
 
 void kernel_main() {
     constexpr bool has_metadata = get_compile_time_arg_val(1);
-    run_writer<has_metadata>();
+    constexpr bool has_valid = get_compile_time_arg_val(4);
+    if constexpr (has_valid) {
+        run_writer<has_metadata, true>();
+    } else {
+        run_writer<has_metadata, false>();
+    }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/math.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
@@ -94,6 +95,14 @@ void validate_runtime_args(
             cache.logical_shape().rank());
     }
 
+    // One clamp form per path; mixing them would silently ignore one.
+    TT_FATAL(
+        !tensor_args.valid_global.has_value() || tensor_args.slot_idx.has_value(),
+        "valid_global tensor requires the metadata path (pass slot_idx/kv_actual_global as tensors too)");
+    TT_FATAL(
+        !(args.valid_global.has_value() && tensor_args.slot_idx.has_value()),
+        "scalar valid_global cannot be combined with the metadata path; pass the valid_global TENSOR instead");
+
     // Metadata-path invariant: the two per-request tensors are supplied together or not at all.
     // The path is selected on `slot_idx.has_value()`, but create_descriptor / override_runtime_arguments
     // dereference `kv_actual_global` unconditionally whenever slot_idx is set — a mismatched optional
@@ -124,6 +133,9 @@ void validate_runtime_args(
         };
         validate_meta(tensor_args.slot_idx.value(), "slot_idx");
         validate_meta(tensor_args.kv_actual_global.value(), "kv_actual_global");
+        if (tensor_args.valid_global.has_value()) {
+            validate_meta(tensor_args.valid_global.value(), "valid_global");
+        }
     }
 
     if (!tensor_args.slot_idx.has_value()) {
@@ -136,18 +148,44 @@ void validate_runtime_args(
         const uint32_t num_slots = cache.padded_shape()[0] / args.num_layers;
         TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
 
-        // This chunk is written at a per-chip offset derived from kv_actual_global; the prior valid KV
-        // plus this chunk must fit the global cache capacity (sp_factor slabs of cache_seq tokens each),
-        // else the write spills past the cache. sp_factor = mesh extent along cluster_axis.
+        // This chunk is written at a per-chip offset derived from kv_actual_global; what must fit the
+        // global cache capacity (sp_factor slabs of cache_seq tokens each) is what the write stores:
+        // the whole padded slab without a clamp, only the real tokens (rounded up to 32) with one.
+        // sp_factor = mesh extent along cluster_axis, or the whole mesh when it is nullopt.
         const uint32_t sp_factor = ttnn::ccl::get_topological_dimension(cache, args.cluster_axis);
         const uint32_t chunk_global_tokens = sp_factor * tensor_args.input.padded_shape()[-2];
         const uint32_t global_cache_capacity = sp_factor * cache.padded_shape()[-2];
-        TT_FATAL(
-            args.kv_actual_global + chunk_global_tokens <= global_cache_capacity,
-            "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({})",
-            args.kv_actual_global,
-            chunk_global_tokens,
-            global_cache_capacity);
+        if (args.valid_global.has_value()) {
+            const uint32_t valid_global = args.valid_global.value();
+            TT_FATAL(
+                valid_global >= args.kv_actual_global,
+                "valid_global ({}) must be >= kv_actual_global ({}): the real tokens end at or after the "
+                "chunk's write offset",
+                valid_global,
+                args.kv_actual_global);
+            TT_FATAL(
+                valid_global <= args.kv_actual_global + chunk_global_tokens,
+                "valid_global ({}) exceeds this chunk's window [{}, {}); one call writes at most one chunk",
+                valid_global,
+                args.kv_actual_global,
+                args.kv_actual_global + chunk_global_tokens);
+            const uint32_t write_end = tt::round_up(valid_global, TILE_HEIGHT);
+            TT_FATAL(
+                write_end <= global_cache_capacity,
+                "valid_global ({} tok, {} written after page-row rounding) would overflow global cache "
+                "capacity ({})",
+                valid_global,
+                write_end,
+                global_cache_capacity);
+        } else {
+            TT_FATAL(
+                args.kv_actual_global + chunk_global_tokens <= global_cache_capacity,
+                "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({}). Pass "
+                "valid_global to clamp the write to the real tokens and keep the padded tail out of the cache.",
+                args.kv_actual_global,
+                chunk_global_tokens,
+                global_cache_capacity);
+        }
     }
 }
 
@@ -255,8 +293,10 @@ ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
     // Hash the full padded shapes, not just their volumes: the descriptor derives Wt, input_Ht,
     // cache_HtWt/CHtWt and the work split from specific dimensions, so two differently-shaped
     // tensors that happen to share a volume must NOT collide onto the same cached program.
+    // has_valid is a writer compile arg, so it is hashed; the VALUE stays out (patched runtime arg).
     return tt::tt_metal::operation::hash_operation<UpdatePaddedKvCacheDeviceOperation>(
         tensor_args.slot_idx.has_value(),
+        tensor_args.valid_global.has_value() || args.valid_global.has_value(),
         args.layer_idx,
         args.num_layers,
         args.cluster_axis,
@@ -282,6 +322,7 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     const auto& input = tensor_args.input;
     auto* device = input.device();
     const bool has_metadata = tensor_args.slot_idx.has_value();
+    const bool has_valid = tensor_args.valid_global.has_value() || args.valid_global.has_value();
 
     const auto& cache_shape = cache.padded_shape();
     const auto& input_shape = input.padded_shape();
@@ -381,14 +422,18 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     // Writer kernel descriptor. Compile args (uniform leading layout so the kernel offsets are fixed):
     // [0]=kSrcCbIndex, [1]=has_metadata, [2]=kMetaCbIndex (placeholder 0 on scalar path),
-    // [3]=writer_tile_height, [4..]=cache accessor, then (metadata path only) ONE metadata accessor
+    // [3]=writer_tile_height, [4]=has_valid, [5..]=cache accessor, then (metadata path only) ONE metadata accessor
     // (the slot_idx and kv_actual_global tensors share an identical 1-element uint32 replicated-DRAM
     // layout, so the same TensorAccessorArgs serves both reads). writer_tile_height divides kv tokens
     // into the page-row unit (TILE_HEIGHT for TILE, 1 for ROW_MAJOR). On the metadata path the writer
     // reads slot_idx then kv_actual_global (each element [0]) via this accessor against the two raw
     // addresses in common args 8/9; on the scalar path it reads them directly from common args 8/9.
     KernelDescriptor::CompileTimeArgs writer_compile_args = {
-        kSrcCbIndex, static_cast<uint32_t>(has_metadata), has_metadata ? kMetaCbIndex : 0u, writer_tile_height};
+        kSrcCbIndex,
+        static_cast<uint32_t>(has_metadata),
+        has_metadata ? kMetaCbIndex : 0u,
+        writer_tile_height,
+        static_cast<uint32_t>(has_valid)};
     TensorAccessorArgs(cache.buffer()).append_to(writer_compile_args);
     if (has_metadata) {
         // One accessor reused for both 1-element tensors (identical layout).
@@ -424,6 +469,9 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
             slot_idx_addr,          // smuggled-rta-ok: 1-element metadata tensor DRAM addr; the writer reads
                                     // slot_idx on-device from it (trace-safe; value kept out of the program hash)
             kv_actual_global_addr,  // smuggled-rta-ok: 1-element metadata tensor DRAM addr; read on-device
+            // Arg 10: valid_global's DRAM addr when clamping, else an inert 0 (always present so the
+            // indices never shift).
+            has_valid ? tensor_args.valid_global->buffer()->address() : 0u,  // smuggled-rta-ok: as above
         });
     } else {
         writer_kernel.emplace_common_runtime_args({
@@ -437,6 +485,7 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
             cache_CHtWt,
             args.slot_idx,
             args.kv_actual_global,
+            args.valid_global.value_or(0),  // arg 10; read only by the has_valid program
         });
     }
 
@@ -496,15 +545,20 @@ void UpdatePaddedKvCacheDeviceOperation::MeshWorkloadFactory::override_runtime_a
     constexpr uint32_t kWriterKernelHandle = 1;  // writer is pushed second in create_descriptor
     constexpr uint32_t kArg8 = 8;
     constexpr uint32_t kArg9 = 9;
+    constexpr uint32_t kArg10 = 10;
     const bool has_metadata = tensor_args.slot_idx.has_value();
     const uint32_t arg8 = has_metadata ? tensor_args.slot_idx->buffer()->address() : args.slot_idx;
     const uint32_t arg9 = has_metadata ? tensor_args.kv_actual_global->buffer()->address() : args.kv_actual_global;
+    // Arg 10: valid_global's address (metadata) or token count (scalar); 0 when not clamping.
+    const uint32_t arg10 = tensor_args.valid_global.has_value() ? tensor_args.valid_global->buffer()->address()
+                                                                : args.valid_global.value_or(0);
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& writer_common = GetCommonRuntimeArgs(program, kWriterKernelHandle);
         TT_FATAL(
-            kArg9 < writer_common.size(), "update_padded_kv_cache writer is missing its per-call common runtime args");
+            kArg10 < writer_common.size(), "update_padded_kv_cache writer is missing its per-call common runtime args");
         writer_common[kArg8] = arg8;
         writer_common[kArg9] = arg9;
+        writer_common[kArg10] = arg10;
     }
 }
 
@@ -521,7 +575,9 @@ ttnn::Tensor update_padded_kv_cache(
     uint32_t kv_actual_global,
     uint32_t layer_idx,
     uint32_t num_layers,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<ttnn::Tensor>& valid_global_tensor,
+    std::optional<uint32_t> valid_global) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::UpdatePaddedKvCacheDeviceOperation;
     auto attrs = OperationType::operation_attributes_t{
@@ -530,12 +586,14 @@ ttnn::Tensor update_padded_kv_cache(
         .layer_idx = layer_idx,
         .num_layers = num_layers,
         .cluster_axis = cluster_axis,
+        .valid_global = valid_global,
     };
     auto tensor_args = OperationType::tensor_args_t{
         .cache = cache,
         .input = input,
         .slot_idx = slot_idx_tensor,
         .kv_actual_global = kv_actual_global_tensor,
+        .valid_global = valid_global_tensor,
     };
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
@@ -39,6 +39,10 @@ struct UpdatePaddedKvCacheDeviceOperation {
         // Named mesh axis for the legacy SP cache, or nullopt when sequence shards span the
         // complete 2D mesh in canonical row-major coordinate order.
         std::optional<uint32_t> cluster_axis;
+        // Optional write clamp, SCALAR path only (the metadata path uses the tensor below): the end of
+        // this chunk's real tokens. Set, only the page-rows holding them are written, so a chunk whose
+        // pad window runs past the cache end is legal. Presence is hashed; the value is a runtime arg.
+        std::optional<uint32_t> valid_global;
     };
 
     struct tensor_args_t {
@@ -51,6 +55,8 @@ struct UpdatePaddedKvCacheDeviceOperation {
         // op uses the scalar `slot_idx`/`kv_actual_global` attributes instead.
         std::optional<Tensor> slot_idx;
         std::optional<Tensor> kv_actual_global;
+        // Optional, METADATA path only: 1-element uint32 valid_global (= actual_end). Same clamp.
+        std::optional<Tensor> valid_global;
     };
 
     using spec_return_value_t = tt::tt_metal::TensorSpec;
@@ -122,6 +128,8 @@ ttnn::Tensor update_padded_kv_cache(
     uint32_t kv_actual_global,
     uint32_t layer_idx,
     uint32_t num_layers,
-    std::optional<uint32_t> cluster_axis);
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<ttnn::Tensor>& valid_global_tensor = std::nullopt,
+    std::optional<uint32_t> valid_global = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
@@ -18,7 +18,8 @@ ttnn::Tensor update_padded_kv_cache(
     uint32_t layer_idx,
     uint32_t num_layers,
     uint32_t kv_actual_global,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> valid_global) {
     return ttnn::prim::update_padded_kv_cache(
         cache,
         input,
@@ -28,7 +29,9 @@ ttnn::Tensor update_padded_kv_cache(
         kv_actual_global,
         layer_idx,
         num_layers,
-        cluster_axis);
+        cluster_axis,
+        /*valid_global_tensor=*/std::nullopt,
+        valid_global);
 }
 
 // Per-element-tensor form: slot_idx/kv_actual_global read on-device from the two 1-element tensors
@@ -40,7 +43,8 @@ ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& kv_actual_global,
     uint32_t layer_idx,
     uint32_t num_layers,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<ttnn::Tensor>& valid_global) {
     return ttnn::prim::update_padded_kv_cache(
         cache,
         input,
@@ -50,7 +54,9 @@ ttnn::Tensor update_padded_kv_cache(
         /*kv_actual_global=*/0,
         layer_idx,
         num_layers,
-        cluster_axis);
+        cluster_axis,
+        valid_global,
+        /*valid_global=*/std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
@@ -29,6 +29,11 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 //
 // In-place: returns a handle to `cache`. Two call forms (identical results):
 
+// `valid_global` (optional, both forms): the end of this chunk's REAL tokens. Given it, only the rows
+// holding them are written, so what must fit the cache is ceil32(valid_global) rather than
+// kv_actual_global + chunk_global, and a chunk padding past the cache end is legal. The 32-token block
+// holding the last real token IS written (zero_padded_kv_cache clears its pad cells).
+//
 // (1) Scalar form (original): per-call `slot_idx`/`kv_actual_global` are host values, passed as
 //     common runtime args and patched on cache hits.
 ttnn::Tensor update_padded_kv_cache(
@@ -38,7 +43,8 @@ ttnn::Tensor update_padded_kv_cache(
     uint32_t layer_idx,
     uint32_t num_layers,
     uint32_t kv_actual_global,
-    std::optional<uint32_t> cluster_axis);
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> valid_global = std::nullopt);
 
 // (2) Per-element-tensor form (traceable): `slot_idx`/`kv_actual_global` are read on-device by the
 //     writer kernel from two 1-element uint32 DRAM tensors ([1,1,1,1], ROW_MAJOR, replicated across
@@ -53,7 +59,8 @@ ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& kv_actual_global,
     uint32_t layer_idx,
     uint32_t num_layers,
-    std::optional<uint32_t> cluster_axis);
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<ttnn::Tensor>& valid_global = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -5,6 +5,7 @@
 #include "update_padded_kv_cache_nanobind.hpp"
 
 #include <cstdint>
+#include <optional>
 
 #include <nanobind/nanobind.h>
 
@@ -66,6 +67,12 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                 cluster_axis (Optional[int]): Cluster axis along which the cache is sharded (0 or 1).
                     Explicit None means that sequence shards span the complete 2D mesh in canonical
                     row-major coordinate order.
+                valid_global (int | ttnn.Tensor, optional): end of this chunk's REAL tokens — an int
+                    (scalar form) or a 1-element uint32 tensor read on-device (tensor form). Given it,
+                    only the rows holding real tokens are written, so the cache must fit
+                    ``ceil32(valid_global)`` rather than ``kv_actual_global + chunk_global``. The
+                    32-token block holding the last real token is still written; clear it with
+                    ``zero_padded_kv_cache``. Omitted: the whole padded slab is written.
 
             Returns:
                 ttnn.Tensor: handle to `cache` with the new slab written in place.
@@ -79,6 +86,7 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                 uint32_t,
                 uint32_t,
                 uint32_t,
+                std::optional<uint32_t>,
                 std::optional<uint32_t>>(&update_padded_kv_cache),
             nb::arg("cache").noconvert(),
             nb::arg("input").noconvert(),
@@ -86,7 +94,8 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
             nb::arg("layer_idx"),
             nb::arg("num_layers"),
             nb::arg("kv_actual_global"),
-            nb::arg("cluster_axis")),
+            nb::arg("cluster_axis"),
+            nb::arg("valid_global") = nb::none()),
         // Per-element-tensor form (traceable).
         ttnn::overload_t(
             nb::overload_cast<
@@ -96,14 +105,16 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                 const Tensor&,
                 uint32_t,
                 uint32_t,
-                std::optional<uint32_t>>(&update_padded_kv_cache),
+                std::optional<uint32_t>,
+                const std::optional<Tensor>&>(&update_padded_kv_cache),
             nb::arg("cache").noconvert(),
             nb::arg("input").noconvert(),
             nb::arg("slot_idx").noconvert(),
             nb::arg("kv_actual_global").noconvert(),
             nb::arg("layer_idx"),
             nb::arg("num_layers"),
-            nb::arg("cluster_axis")));
+            nb::arg("cluster_axis"),
+            nb::arg("valid_global").noconvert() = nb::none()));
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::detail

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -34,9 +34,8 @@ bool is_replicated_across_complete_mesh(const Tensor& tensor) {
            });
 }
 
-// Largest linearized index of q's devices along the given mesh axis (0 on a single device). Single source
-// for the worst-case window check (max_chunk_start) and the host-side chunk_start deduction, so a future
-// change to the coord/linearization semantics can't desync the deduced base from the validated window.
+// Largest linearized index of q's devices along the given mesh axis (0 on a single device). Used by the
+// host-side chunk_start deduction.
 uint32_t max_linearized_rank(const Tensor& q, std::optional<uint32_t> axis) {
     uint32_t max_rank = 0;
     if (q.device_storage().get_coords().size() > 1) {
@@ -45,22 +44,6 @@ uint32_t max_linearized_rank(const Tensor& q, std::optional<uint32_t> axis) {
         }
     }
     return max_rank;
-}
-
-// Fullest device's chunk_start (= its causal-window end - Sq). Used by the worst-case window check.
-//   * block-cyclic: the devices collectively cover the whole global chunk [chunk_start, +sp*chunk_local),
-//     so the fullest window reaches chunk_start + sp*chunk_local no matter how SP×TP slices it. (For the
-//     SP-only case Sq == chunk_local, so this equals the old chunk_start + (sp-1)*chunk_local.)
-//   * contiguous (incl. a size-1 SP axis, stored as no block-cyclic): each device's row 0 sits at
-//     chunk_start + rank*Sq, where rank is the SP rank PLUS the TP sub-shard rank. The two are
-//     mutually-exclusive-nonzero here (a TP sub-shard needs block_cyclic_sp_axis with sp==1, which forces
-//     SP rank 0; no sub-shard -> TP rank 0), mirroring device_causal_geometry's no-block-cyclic branch.
-uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, uint32_t Sq) {
-    if (attrs.block_cyclic.has_value()) {
-        return attrs.chunk_start_idx + attrs.block_cyclic->sp * attrs.block_cyclic->chunk_local - Sq;
-    }
-    const uint32_t tp_rank = attrs.tp_axis().has_value() ? max_linearized_rank(q, attrs.tp_axis()) : 0u;
-    return attrs.chunk_start_idx + (max_linearized_rank(q, attrs.sp_axis()) + tp_rank) * Sq;
 }
 
 // Miss-only checks: hash-pinned (placement, non-indexed k batch shape) so they can't differ on a hit. The
@@ -134,37 +117,33 @@ void validate_runtime_values(const operation_attributes_t& attrs, const tensor_a
 }
 
 // Runs on miss AND hit (chunk_start is hash-excluded). All chunk_start checks in one place: base alignment
-// and the fullest device's window against T and (when set) kv_len.
+// and the chunk's start against T and (when set) kv_len.
+//
+// The causal window MAY end past the valid prefix, and past T: a chunked prefill runs a fixed chunk
+// size, so a sequence's last chunk pads its query window past what the cache holds, and those pad rows
+// have no keys to attend. Requiring it to fit forced callers to pass the padded window as kv_len rather
+// than the prefix they populated. Nothing downstream needs it -- the banded schedule spans T either way,
+// WorkUnitSpan::k_tiles() yields 0 past kv_len, and valid_prefix_tiles() saturates. What must still hold
+// is that the chunk STARTS inside the prefix, else nothing is scored at all.
 void validate_chunk_start(const operation_attributes_t& attrs, const tensor_args_t& t) {
-    const uint32_t Sq = t.q.logical_shape()[2];
     const uint32_t T = t.k.logical_shape()[2];
     TT_FATAL(
         attrs.chunk_start_idx % tt::constants::TILE_WIDTH == 0,
         "chunk_start_idx {} must be tile-aligned",
         attrs.chunk_start_idx);
-    const uint32_t max_cs = max_chunk_start(attrs, t.q, Sq);
     TT_FATAL(
-        max_cs + Sq <= T,
-        "fullest-device chunk window [{}, {}+{}) exceeds T={} (base={}, per-rank stride Sq={})",
-        max_cs,
-        max_cs,
-        Sq,
-        T,
+        attrs.chunk_start_idx < T,
+        "chunk_start_idx {} starts at or past T={} (the allocated k length): nothing would be scored",
         attrs.chunk_start_idx,
-        Sq);
-    // Causal window must also stay inside the valid prefix.
+        T);
     if (attrs.kv_len.has_value()) {
         const uint32_t kv_len = attrs.kv_len.value();
         TT_FATAL(
-            max_cs + Sq <= kv_len,
-            "fullest-device causal window [{}, {}+{}) exceeds kv_len={} (cannot attend past the valid keys; "
-            "base={}, per-rank stride Sq={})",
-            max_cs,
-            max_cs,
-            Sq,
-            kv_len,
+            attrs.chunk_start_idx < kv_len,
+            "chunk_start_idx {} starts at or past kv_len={} (the valid key prefix): nothing would be scored. "
+            "The causal window may END past kv_len (pad query rows), but the chunk must BEGIN inside it",
             attrs.chunk_start_idx,
-            Sq);
+            kv_len);
     }
 }
 // Block-cyclic layout (sp derived from block_cyclic_sp_axis, global chunk = sp*block_cyclic_chunk_local):

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -58,7 +58,10 @@ void bind_indexer_score(nb::module_& mod) {
                 recompile.
             kv_len: optional int. Valid prefix of a k allocated at its full T;
                 the rest is masked out. Tile-aligned, in (0, T], with
-                chunk_start_idx + Sq <= kv_len. Re-applied each dispatch, so a
+                chunk_start_idx < kv_len -- the chunk must BEGIN inside the valid
+                prefix, but its causal window MAY end past kv_len (and past T):
+                those trailing rows are pad queries with no keys to attend.
+                Re-applied each dispatch, so a
                 serving loop growing kv_len (<= T) reuses one program -- no
                 recompile. Only output columns [0, kv_len) are written.
             seq_shard_axes: the mesh axes the query seq is sharded over, outermost
@@ -150,7 +153,9 @@ void bind_indexer_score(nb::module_& mod) {
                 recompile. Same semantics as indexer_score_dsa.
             kv_len: optional int. Valid prefix of a k allocated at its full T;
                 the rest is masked out. Tile-aligned, in (0, T], with
-                chunk_start_idx + Sq <= kv_len. When block-max-pooling
+                chunk_start_idx < kv_len -- the chunk must BEGIN inside the valid
+                prefix, but its causal window MAY end past kv_len (and past T).
+                When block-max-pooling
                 (block_size > 0) it must also be a multiple of block_size (whole
                 blocks are written). Re-applied each dispatch (a serving loop
                 growing kv_len reuses one program). Only columns/blocks within


### PR DESCRIPTION
Closes #53999.

> Stacked on #54743 — base is `ipotkonjak/kv_cache_head_stride`, not `main`. GitHub retargets
> this to `main` automatically once #54743 merges. The clamp's row-level skip uses the `row`
> variable that PR introduces, so it cannot land first.

A chunked prefill runs a FIXED chunk width, so a sequence's last chunk pads well past its real
tokens — and that padded window can run off the end of the KV cache even when every real token
fits. #53999 hits this when a reuse remount lands within one `chunk_size` of `max_seq_len`
(their example: `max_seq_len=55K`, `chunk_size=5K`, remount at 55K-64 needs room for 60K-64 in
a 55K cache). It was rejected outright, forcing the caller to size the cache to the padded
window.

This implements the **permissive contract** the issue preferred — the caller guarantees
`actual_end` fits and the kernels handle the overflow — so the conservative fallback
(`actual_start < max_seq_len - chunk_size`, with its extra recomputation) is not needed.

### What it does
`valid_global` (optional, both call forms: an int on the scalar path, a 1-element uint32 tensor
on the metadata path) is the absolute end of the chunk's real tokens. Given it, each device
writes only the page-rows holding real tokens and skips the padded tail, so what must fit the
cache is `ceil32(valid_global)` rather than `kv_actual_global + chunk_global`. Presence is
hashed (it selects a different compiled writer); the value travels as a patched common runtime
arg, so the op stays trace-safe. Omitted, the whole padded slab is written as before.

Reads are bounded to match the write:
* `indexer_score` no longer requires the causal window to end inside the valid prefix. It may
  end past `kv_len` and past `T` — those trailing rows are pad queries with no keys to attend.
  Nothing downstream needs it to fit: the banded schedule spans `T` either way,
  `WorkUnitSpan::k_tiles()` yields 0 past `kv_len`, and `valid_prefix_tiles()` saturates. The
  chunk must still BEGIN inside the prefix.
* the indexer bounds `kv_len` and top-k `valid_length` by the populated prefix, and sparse MLA
  bounds its KVPE gather the same way, so what is read and what was written agree.
* `ring_mla`'s `logical_n` is capped at the cache capacity.
* the indexed rope table gets one chunk of tail slack: a chunk ropes its whole padded slab, so
  the table must stay readable past the cache end even though the KV write does not go there.

### Tests
Op-level clamp coverage (mid-chunk, tail overflow, and a `boundary_chip > 0` tail where a chip
writes nothing) across both paths and both layouts; a ring `indexer_score` tail case carrying
window-past-prefix, window-past-cache and `kv_len` below one `k_chunk`; sparse MLA over a
ragged chunk stream; and the chunked MLA/transformer harnesses now size their caches to the
real tokens so the last chunk pads past the end and exercises the clamp.

Two existing `indexer_score` tests drop their `causal window > kv_len` rejection case and one
is removed outright — they asserted an error the relaxation no longer raises.

### Verification (8x4 Blackhole galaxy)
| | |
|---|---|
| `valid_global_clamp` op unit | 24/24 |
| `sparse_mla_pad_overflow` | 2/2, PCC >= 0.995 |
| ring `indexer_score` tail | passed, all four properties |
| chunked MLA `padoverflow-1u` | PCC 0.992–0.997 |
| **L61 padded transformer, notrace + traced** | **KV PCC 0.992160, decoder 0.950134** |

Perf, branch vs main, same box: Kimi traced identical (10/11 chunks to the millisecond, stddev
<= 0.003s), Kimi untraced never slower, GLM-5.2 +0.23% with mixed signs. No regression.

### CI impact
The two `kimi_chunked_padded` jobs now exercise the clamp for free (their padded harness sizes
its cache to the real tokens, so chunk 5 pads +3200 past it) and cover both plumbings —
notrace passes `valid_global` as a scalar, traced as `metadata[2]`. Verified at L61 above. No
new jobs; wall time is unchanged or lower.

Unrelated pre-existing flake worth knowing: the untraced Kimi perf gate is stale on this
hardware — **main itself** breached its ±5% baseline on chunk 1 (1.105s vs a 1.088s ceiling)
when I measured it. The baseline is deliberately left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/kv_pad_clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/kv_pad_clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/kv_pad_clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/kv_pad_clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/kv_pad_clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/kv_pad_clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/kv_pad_clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/kv_pad_clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/kv_pad_clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/kv_pad_clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/kv_pad_clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/kv_pad_clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/kv_pad_clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/kv_pad_clamp)