### PR TITLE
Fix benchmark data makedirs race

### DIFF
--- a/models/perf/benchmarking_utils.py
+++ b/models/perf/benchmarking_utils.py
@@ -205,8 +205,9 @@ class BenchmarkData:
 
             filename = os.path.join(self.output_folder, f"partial_run_{run_start_ts}.pkl")
             parent_dir = os.path.dirname(filename)
-            if parent_dir != "" and not os.path.exists(parent_dir):
-                os.makedirs(parent_dir)
+            if parent_dir != "":
+                # exist_ok=True avoids a race when parallel MPI ranks create the directory concurrently
+                os.makedirs(parent_dir, exist_ok=True)
             with open(filename, "wb") as f:
                 f.write(pkl_data)
             logger.info(f"Run and measurement data saved to {filename}")

--- a/models/tt_dit/tests/models/flux2/test_performance_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_performance_flux2.py
@@ -14,6 +14,7 @@ from models.common.utility_functions import is_blackhole
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 
 from ....pipelines.flux2.pipeline_flux2 import Flux2Pipeline
+from ....utils.test import is_global_rank_zero
 from .test_pipeline_flux2 import line_params_8k_flux2, line_params_flux2, ring_params_8k_flux2
 
 NUM_INFERENCE_STEPS = 50
@@ -207,7 +208,9 @@ def test_flux2_performance(
 
     print("=" * 80)
 
-    if is_ci_env:
+    if is_ci_env and is_global_rank_zero():
+        # Report from rank 0 only: all ranks time the same collective run, and
+        # concurrent saves race on the shared output file.
         device_name_map = {
             (2, 2): "BH_QB",
             (2, 4): "BH_LB" if is_blackhole() else "WH_T3K",

--- a/models/tt_dit/tests/models/flux2/test_performance_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_performance_flux2.py
@@ -14,7 +14,6 @@ from models.common.utility_functions import is_blackhole
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 
 from ....pipelines.flux2.pipeline_flux2 import Flux2Pipeline
-from ....utils.test import is_global_rank_zero
 from .test_pipeline_flux2 import line_params_8k_flux2, line_params_flux2, ring_params_8k_flux2
 
 NUM_INFERENCE_STEPS = 50
@@ -208,9 +207,7 @@ def test_flux2_performance(
 
     print("=" * 80)
 
-    if is_ci_env and is_global_rank_zero():
-        # Report from rank 0 only: all ranks time the same collective run, and
-        # concurrent saves race on the shared output file.
+    if is_ci_env:
         device_name_map = {
             (2, 2): "BH_QB",
             (2, 4): "BH_LB" if is_blackhole() else "WH_T3K",

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -21,6 +21,7 @@ from models.tt_dit.pipelines.wan.quant_config import QuantConfig, set_quant_conf
 from models.tt_dit.utils.video import export_to_video
 
 from ....utils.test import (
+    is_global_rank_zero,
     line_params_req_exact_devices,
     ring_params_8k_req_exact_devices,
     ring_params_req_exact_devices,
@@ -215,7 +216,7 @@ def test_pipeline_performance(
     # Skip 4U.
     if galaxy_type == "4U":
         # NOTE: Pipelines fail if a performance test is skipped without providing a benchmark output.
-        if is_ci_env:
+        if is_ci_env and is_global_rank_zero():
             with benchmark_profiler("run", iteration=0):
                 pass
 
@@ -409,8 +410,9 @@ def test_pipeline_performance(
         "total": statistics.mean(total_times),
     }
 
-    if is_ci_env:
-        # In CI, dump a performance report
+    if is_ci_env and is_global_rank_zero():
+        # In CI, dump a performance report from rank 0 only: all ranks time the same
+        # collective run, and concurrent saves race on the shared output file.
         benchmark_data = BenchmarkData()
         for iteration in range(num_perf_runs):
             for step_name in ["encoder", "denoising", "vae", "run"]:

--- a/models/tt_dit/utils/test.py
+++ b/models/tt_dit/utils/test.py
@@ -37,6 +37,17 @@ ring_params_req_exact_devices = {**ring_params, "require_exact_physical_num_devi
 ring_params_8k_req_exact_devices = {**ring_params_8k, "require_exact_physical_num_devices": True}
 
 
+def is_global_rank_zero():
+    """True when this process should do once-per-run host work (e.g. benchmark reporting).
+
+    In a multi-process (multihost) run only rank 0 qualifies; in a single-process
+    run there is no distributed context and every caller qualifies. Multihost ranks
+    time the same collective pipeline, so per-rank benchmark records are duplicates,
+    and concurrent writes to the shared benchmark output path race with each other.
+    """
+    return not ttnn.distributed_context_is_initialized() or int(ttnn.distributed_context_get_rank()) == 0
+
+
 def skip_if_unsupported_num_links(mesh_device, num_links):
     """Skip the test if the mesh device does not support the requested number of links."""
     from models.common.modules.tt_ccl import get_num_links


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Solves regression https://tenstorrent.atlassian.net/browse/RELEASE-7
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Solves issue described in https://tenstorrent.atlassian.net/browse/RELEASE-7
This is a race condition where it's possible for multiple MPI ranks to see that the target directory does not exist, and then create it, failing since directory is created with `exist_ok=False`.
This PR sets `exist_ok=True` in the benchmark profiler and also gates benchmark profiler behind `is_rank_0` in known multi-host tests.

### Manual CI runs
- https://github.com/tenstorrent/tt-metal/actions/runs/33178338664

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/fix_benchmark_data_makedirs_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/fix_benchmark_data_makedirs_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cglagovich/fix_benchmark_data_makedirs_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cglagovich/fix_benchmark_data_makedirs_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/fix_benchmark_data_makedirs_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/fix_benchmark_data_makedirs_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cglagovich/fix_benchmark_data_makedirs_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cglagovich/fix_benchmark_data_makedirs_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/fix_benchmark_data_makedirs_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/fix_benchmark_data_makedirs_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/fix_benchmark_data_makedirs_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/fix_benchmark_data_makedirs_race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/fix_benchmark_data_makedirs_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/fix_benchmark_data_makedirs_race)