### PR TITLE
[Performance] Auto-select Blackhole DRAM-sharded matmul readers

### DIFF
--- a/models/common/tests/modules/test_tensor_utils.py
+++ b/models/common/tests/modules/test_tensor_utils.py
@@ -247,7 +247,7 @@ def test_zeros_like_paged_cache():
     assert torch.all(result == 0)
 
 
-@pytest.mark.parametrize("num_workers_per_dram_bank", [1, 2])
+@pytest.mark.parametrize("num_workers_per_dram_bank", [None, 1, 2], ids=["auto", "one", "two"])
 def test_program_config_to_dict_with_to_json(num_workers_per_dram_bank):
     """Test program_config_to_dict for a config that has to_json (matmul configs)."""
     cfg = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
@@ -265,7 +265,8 @@ def test_program_config_to_dict_with_to_json(num_workers_per_dram_bank):
     assert d["per_core_N"] == 2
     assert d["num_workers_per_dram_bank"] == num_workers_per_dram_bank
     assert "fused_activation" in d
-    assert f"num_workers_per_dram_bank={num_workers_per_dram_bank}" in repr(cfg)
+    repr_value = "std::nullopt" if num_workers_per_dram_bank is None else num_workers_per_dram_bank
+    assert f"num_workers_per_dram_bank={repr_value}" in repr(cfg)
 
     json_str = json.dumps(d, sort_keys=True)
     roundtrip = json.loads(json_str)

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -606,9 +606,9 @@ targets:
             seq_len: 712
             status: active
             perf:
-              # Same fast-path as wh_n150 above. Measured 33.04-33.13 t/s/u over 4 CI runs,
-              # was 20.3; TTFT 53.31-53.35 ms, was 75.
-              decode_t/s/u: 33.0
+              # Blackhole DRAM-sharded matmul auto-selection measured 39.91 t/s/u in
+              # matched P150 E2E CI; the one-reader main baseline measured 32.71.
+              decode_t/s/u: 40.0
               prefill_time_to_first_token: 53
             accuracy: {}
       bh_p300:

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
@@ -284,16 +284,16 @@ def test_matmul_in1_dram_sharded_worker_count_default_is_auto():
         # 33 logical tiles naturally pad to an odd shard width on p100, p150,
         # and Wormhole. Automatic mode must retain one reader.
         (2048, 1056, (1, 1)),
-        # Fifteen logical tiles occupy sixteen storage tiles on an eight-bank
-        # Blackhole. The shard is even, but a two-reader split would leave a
-        # partial final reader, so automatic mode must retain one reader.
+        # Fifteen logical tiles occupy sixteen existing padded storage tiles on
+        # an eight-bank Blackhole. The weight is small, so automatic mode keeps
+        # the established one-reader path without changing its storage.
         (512, 480, (1, 1)),
     ],
     ids=[
         "small_even_shard_falls_back",
         "large_64_core_weight_uses_two_readers",
         "natural_odd_shard_falls_back",
-        "partial_final_reader_falls_back",
+        "small_padded_weight_falls_back",
     ],
 )
 def test_matmul_in1_dram_sharded_auto_worker_count(device, K, N, grid_size, function_level_defaults):

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
@@ -79,10 +79,12 @@ def run_test_matmul_in1_dram_sharded(
     else:
         num_banks = 12
 
-    # Multi-reader kernels split each bank's width shard evenly. Pad the storage
-    # layout to banks * readers while keeping the tensor's logical N unchanged.
+    # Explicit multi-reader tests prepare storage for the requested count. Automatic
+    # tests retain the established bank-only padding so they exercise selection
+    # against the caller's existing layout.
+    storage_worker_count = num_workers_per_dram_bank if num_workers_per_dram_bank is not None else 1
     N_padded = (
-        pad_to_dram_banks(N, num_banks * num_workers_per_dram_bank) if N_padded_override is None else N_padded_override
+        pad_to_dram_banks(N, num_banks * storage_worker_count) if N_padded_override is None else N_padded_override
     )
 
     in0_shape = [1, 1, M, K]
@@ -258,6 +260,65 @@ def run_test_matmul_in1_dram_sharded(
     )
 
 
+def test_matmul_in1_dram_sharded_worker_count_default_is_auto():
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fused_activation=None,
+    )
+
+    assert program_config.num_workers_per_dram_bank is None
+    assert "num_workers_per_dram_bank=std::nullopt" in repr(program_config)
+
+
+@pytest.mark.parametrize(
+    "K,N,grid_size",
+    [
+        # The natural per-bank shard is even, but this small weight stays on the
+        # conservative one-reader path.
+        (2048, 2048, (8, 2)),
+        # A large compressed weight on 64 input cores exercises the two-reader
+        # automatic regime without caller-side padding or repacking.
+        (8192, 2048, (8, 8)),
+        # 33 logical tiles naturally pad to an odd shard width on p100, p150,
+        # and Wormhole. Automatic mode must retain one reader.
+        (2048, 1056, (1, 1)),
+        # Fifteen logical tiles occupy sixteen storage tiles on an eight-bank
+        # Blackhole. The shard is even, but a two-reader split would leave a
+        # partial final reader, so automatic mode must retain one reader.
+        (512, 480, (1, 1)),
+    ],
+    ids=[
+        "small_even_shard_falls_back",
+        "large_64_core_weight_uses_two_readers",
+        "natural_odd_shard_falls_back",
+        "partial_final_reader_falls_back",
+    ],
+)
+def test_matmul_in1_dram_sharded_auto_worker_count(device, K, N, grid_size, function_level_defaults):
+    torch.manual_seed(0)
+    run_test_matmul_in1_dram_sharded(
+        device=device,
+        in0_sharded=True,
+        out_sharded=True,
+        in1_in_dram=True,
+        M=32,
+        K=K,
+        N=N,
+        fidelity=ttnn.MathFidelity.HiFi2,
+        packer_l1_acc=True,
+        has_bias=False,
+        activation=None,
+        grid_size=grid_size,
+        in0_dtype=ttnn.bfloat16,
+        in1_dtype=ttnn.bfloat8_b,
+        out_dtype=ttnn.bfloat16,
+        function_level_defaults=function_level_defaults,
+        num_workers_per_dram_bank=None,
+    )
+
+
 @pytest.mark.parametrize("num_workers_per_dram_bank", [1, 2, 3], ids=["one_worker", "two_workers", "three_workers"])
 @pytest.mark.parametrize(
     "N,fidelity,has_bias,activation,grid_size,in1_dtype",
@@ -345,6 +406,35 @@ def test_matmul_in1_dram_sharded_multi_workers_rejects_oversized_storage(
             # Keep the intentionally oversized shard tile-aligned for each
             # Blackhole variant. p150 has eight banks, while p100 has seven.
             N_padded_override=device.dram_grid_size().x * 32 * shard_width_tiles,
+        )
+
+
+def test_matmul_in1_dram_sharded_explicit_multi_worker_rejects_nondivisible_shard(
+    device, function_level_defaults, expect_error
+):
+    if not is_blackhole():
+        pytest.skip("Multiple DRAM-sharded matmul workers per bank are currently Blackhole-only")
+
+    with expect_error(RuntimeError, "must be divisible by workers_per_bank"):
+        run_test_matmul_in1_dram_sharded(
+            device=device,
+            in0_sharded=True,
+            out_sharded=True,
+            in1_in_dram=True,
+            M=32,
+            K=2048,
+            N=1056,
+            fidelity=ttnn.MathFidelity.HiFi2,
+            packer_l1_acc=True,
+            has_bias=False,
+            activation=None,
+            grid_size=(1, 1),
+            in0_dtype=ttnn.bfloat16,
+            in1_dtype=ttnn.bfloat8_b,
+            out_dtype=ttnn.bfloat16,
+            function_level_defaults=function_level_defaults,
+            num_workers_per_dram_bank=2,
+            N_padded_override=device.dram_grid_size().x * 32 * 5,
         )
 
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -77,7 +77,7 @@ struct MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig {
     std::size_t per_core_M{};
     std::size_t per_core_N{};
     std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
-    std::size_t num_workers_per_dram_bank = 1;
+    std::optional<std::size_t> num_workers_per_dram_bank = std::nullopt;
 };
 
 struct MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -944,7 +944,8 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
     const auto& output_tensors = tensor_return_value;
 
     const auto& a = input_tensors.at(0);
-    const auto& b = input_tensors.at(1).mesh_tensor();
+    const auto& input_tensor_b = input_tensors.at(1);
+    const auto& b = input_tensor_b.mesh_tensor();
     const auto& bias = optional_input_tensors.at(0);
     const auto& output = output_tensors.at(0);
     const auto& ashape = a.padded_shape();
@@ -1029,7 +1030,8 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
     const auto& in0_block_w = program_config.in0_block_w;
     const auto& per_core_M = program_config.per_core_M;
     const auto& per_core_N = program_config.per_core_N;
-    const auto& workers_per_bank = program_config.num_workers_per_dram_bank;
+    const auto workers_per_bank = dram_sharded_helpers::resolve_num_workers_per_dram_bank(
+        program_config.num_workers_per_dram_bank, a, input_tensor_b);
     const auto& fused_activation = program_config.fused_activation;
 
     const auto& untilize_out = operation_attributes.untilize_out;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -583,7 +583,9 @@ void validate_matmul_nonzero_block_dims(
 // Mcast2D/Mcast1D also check the program grid is non-zero and fits the device (Mcast1D
 // gather_in0 skips that grid check — its grid comes from the input A shard grid).
 void validate_matmul_compute_grid_and_per_core_dims(
-    const Tensor& input_tensor_a, const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     const CoreCoord device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
     const auto config_name = ttsl::get_active_type_name_in_variant(chosen_program_config);
     std::visit(
@@ -629,10 +631,10 @@ void validate_matmul_compute_grid_and_per_core_dims(
                 if constexpr (std::is_same_v<
                                   ProgramConfigType,
                                   operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
-                    dram_sharded_helpers::validate_num_workers_per_dram_bank(program_config.num_workers_per_dram_bank);
+                    const auto workers_per_bank = dram_sharded_helpers::resolve_num_workers_per_dram_bank(
+                        program_config.num_workers_per_dram_bank, input_tensor_a, input_tensor_b);
                     TT_FATAL(
-                        program_config.num_workers_per_dram_bank == 1 ||
-                            input_tensor_a.device()->arch() == tt::ARCH::BLACKHOLE,
+                        workers_per_bank == 1 || input_tensor_a.device()->arch() == tt::ARCH::BLACKHOLE,
                         "{}: num_workers_per_dram_bank > 1 is currently supported only on Blackhole",
                         config_name);
                 }
@@ -2271,7 +2273,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     // ---- universal checks, part 2: need the chosen program config ----
     // Config-based shared validators (each self-filters by config via std::visit).
     validate_matmul_tiny_tile_constraints(input_tensor_b, in0_tile, in1_tile, chosen_program_config);
-    validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
+    validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
     validate_matmul_sharded_operand_grids_within_program_compute_grid(
         input_tensor_a, input_tensor_b, chosen_program_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -382,20 +382,18 @@ std::size_t resolve_num_workers_per_dram_bank(
     // so automatic mode falls back instead of failing during program creation.
     const auto primary_workers = device->get_optimal_dram_bank_to_logical_worker_assignment(tt::tt_metal::NOC::NOC_0);
     const uint32_t physical_bank_count = static_cast<uint32_t>(primary_workers.size());
-    const auto& input_b_shape = input_tensor_b.padded_shape();
+    const auto& input_b_padded_shape = input_tensor_b.padded_shape();
     // The automatic policy is measured on eight-bank Blackhole devices. Keep
     // other bank topologies on the established path until they have equivalent
     // model-level evidence; explicit reader counts remain available there.
-    if (physical_bank_count != 8 || input_b_shape[-1] % tile_width != 0) {
+    if (physical_bank_count != 8 || input_b_padded_shape[-1] % tile_width != 0) {
         return 1;
     }
-    const uint32_t logical_width_tiles = input_b_shape[-1] / tile_width;
+    const uint32_t padded_width_tiles = input_b_padded_shape[-1] / tile_width;
     const uint32_t storage_width_tiles = shard_width_tiles * physical_bank_count;
-    // Do not put a partially filled final reader into automatic mode. The existing
-    // multi-reader writeback path assigns every reader a complete storage interval;
-    // exact logical coverage makes that contract unambiguous and avoids introducing
-    // caller-visible padding or a special partial-reader path.
-    if (logical_width_tiles != storage_width_tiles) {
+    // Use only the tensor's existing padded storage. Automatic mode does not add
+    // padding or repack the weight to make a multi-reader split legal.
+    if (padded_width_tiles != storage_width_tiles) {
         return 1;
     }
 
@@ -407,12 +405,12 @@ std::size_t resolve_num_workers_per_dram_bank(
     constexpr uint64_t min_weight_bytes = 8ULL * 1024 * 1024;
     constexpr uint32_t min_reader_row_bytes = 4 * 1024;
     constexpr uint32_t min_input_a_cores = 64;
-    if (input_b_shape[-2] % tile_height != 0) {
+    if (input_b_padded_shape[-2] % tile_height != 0) {
         return 1;
     }
     const uint64_t tile_bytes = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype()));
     const uint64_t weight_bytes =
-        static_cast<uint64_t>(input_b_shape[-2] / tile_height) * logical_width_tiles * tile_bytes;
+        static_cast<uint64_t>(input_b_padded_shape[-2] / tile_height) * padded_width_tiles * tile_bytes;
     const uint64_t reader_row_bytes = static_cast<uint64_t>(shard_width_tiles / 2) * tile_bytes;
     if (weight_bytes < min_weight_bytes || reader_row_bytes < min_reader_row_bytes) {
         return 1;

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -334,7 +334,6 @@ void validate_matmul_reuse_work_split(
 
 }  // namespace ttnn::operations::matmul::utilities
 
-
 namespace ttnn::prim::dram_sharded_helpers {
 
 void validate_num_workers_per_dram_bank(std::size_t workers_per_bank) {
@@ -342,6 +341,100 @@ void validate_num_workers_per_dram_bank(std::size_t workers_per_bank) {
         workers_per_bank >= 1 && workers_per_bank <= 3,
         "num_workers_per_dram_bank must be in [1, 3], got {}",
         workers_per_bank);
+}
+
+std::size_t resolve_num_workers_per_dram_bank(
+    const std::optional<std::size_t>& requested_workers_per_bank,
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b) {
+    if (requested_workers_per_bank.has_value()) {
+        validate_num_workers_per_dram_bank(requested_workers_per_bank.value());
+        return requested_workers_per_bank.value();
+    }
+
+    auto* device = input_tensor_a.device();
+    if (device == nullptr || device->arch() != tt::ARCH::BLACKHOLE ||
+        tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch()) != tt::tt_metal::NOC::NOC_0) {
+        return 1;
+    }
+
+    const auto& input_b_shard_spec = input_tensor_b.shard_spec();
+    if (!input_b_shard_spec.has_value()) {
+        return 1;
+    }
+    if (input_tensor_b.dtype() != tt::tt_metal::DataType::BFLOAT4_B &&
+        input_tensor_b.dtype() != tt::tt_metal::DataType::BFLOAT8_B) {
+        return 1;
+    }
+    const auto& input_b_tile = input_tensor_b.tensor_spec().tile();
+    const uint32_t tile_height = input_b_tile.get_height();
+    const uint32_t tile_width = input_b_tile.get_width();
+    if (tile_height == 0 || tile_width == 0 || input_b_shard_spec->shape[1] % tile_width != 0) {
+        return 1;
+    }
+    const uint32_t shard_width_tiles = input_b_shard_spec->shape[1] / tile_width;
+    if (shard_width_tiles % 2 != 0) {
+        return 1;
+    }
+
+    // The assignment algorithm needs one additional core per bank outside the
+    // primary-reader set and the input-A storage grid. Count that capacity here
+    // so automatic mode falls back instead of failing during program creation.
+    const auto primary_workers = device->get_optimal_dram_bank_to_logical_worker_assignment(tt::tt_metal::NOC::NOC_0);
+    const uint32_t physical_bank_count = static_cast<uint32_t>(primary_workers.size());
+    const auto& input_b_shape = input_tensor_b.padded_shape();
+    // The automatic policy is measured on eight-bank Blackhole devices. Keep
+    // other bank topologies on the established path until they have equivalent
+    // model-level evidence; explicit reader counts remain available there.
+    if (physical_bank_count != 8 || input_b_shape[-1] % tile_width != 0) {
+        return 1;
+    }
+    const uint32_t logical_width_tiles = input_b_shape[-1] / tile_width;
+    const uint32_t storage_width_tiles = shard_width_tiles * physical_bank_count;
+    // Do not put a partially filled final reader into automatic mode. The existing
+    // multi-reader writeback path assigns every reader a complete storage interval;
+    // exact logical coverage makes that contract unambiguous and avoids introducing
+    // caller-visible padding or a special partial-reader path.
+    if (logical_width_tiles != storage_width_tiles) {
+        return 1;
+    }
+
+    // Two readers are a default only in the broad regime that was consistently
+    // faster across the Blackhole policy sweep: a large compressed weight,
+    // useful NoC transaction size per reader, and enough in0 multicast cores.
+    // Smaller or narrower programs retain one reader; callers can still request
+    // two or three explicitly after tuning their workload.
+    constexpr uint64_t min_weight_bytes = 8ULL * 1024 * 1024;
+    constexpr uint32_t min_reader_row_bytes = 4 * 1024;
+    constexpr uint32_t min_input_a_cores = 64;
+    if (input_b_shape[-2] % tile_height != 0) {
+        return 1;
+    }
+    const uint64_t tile_bytes = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype()));
+    const uint64_t weight_bytes =
+        static_cast<uint64_t>(input_b_shape[-2] / tile_height) * logical_width_tiles * tile_bytes;
+    const uint64_t reader_row_bytes = static_cast<uint64_t>(shard_width_tiles / 2) * tile_bytes;
+    if (weight_bytes < min_weight_bytes || reader_row_bytes < min_reader_row_bytes) {
+        return 1;
+    }
+
+    const auto worker_grid = device->compute_with_storage_grid_size();
+    const auto& input_a_shard_spec = input_tensor_a.shard_spec();
+    if (!input_a_shard_spec.has_value() || input_a_shard_spec->grid.num_cores() < min_input_a_cores) {
+        return 1;
+    }
+    const auto& excluded_cores = input_a_shard_spec->grid;
+    const std::set<tt::tt_metal::CoreCoord> primary_worker_set(primary_workers.begin(), primary_workers.end());
+    std::size_t available_secondary_cores = 0;
+    for (uint32_t x = 0; x < worker_grid.x; ++x) {
+        for (uint32_t y = 0; y < worker_grid.y; ++y) {
+            const tt::tt_metal::CoreCoord candidate{x, y};
+            if (!primary_worker_set.contains(candidate) && !excluded_cores.contains(candidate)) {
+                ++available_secondary_cores;
+            }
+        }
+    }
+    return available_secondary_cores >= primary_workers.size() ? 2 : 1;
 }
 
 tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -361,8 +361,8 @@ void validate_num_workers_per_dram_bank(std::size_t workers_per_bank);
 // An explicit value is returned unchanged and validated strictly. Automatic mode
 // uses two readers only for a large compressed weight on an eight-bank Blackhole,
 // with useful per-reader transaction size, at least 64 input multicast cores,
-// exact existing storage coverage, and enough legal reader cores. All other
-// cases retain one.
+// exact coverage of the tensor's existing padded storage, and enough legal
+// reader cores. All other cases retain one.
 std::size_t resolve_num_workers_per_dram_bank(
     const std::optional<std::size_t>& requested_workers_per_bank,
     const ttnn::Tensor& input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -357,6 +357,17 @@ struct DramBankReaderAssignment {
 
 void validate_num_workers_per_dram_bank(std::size_t workers_per_bank);
 
+// Resolve the optional program-config setting without changing tensor storage.
+// An explicit value is returned unchanged and validated strictly. Automatic mode
+// uses two readers only for a large compressed weight on an eight-bank Blackhole,
+// with useful per-reader transaction size, at least 64 input multicast cores,
+// exact existing storage coverage, and enough legal reader cores. All other
+// cases retain one.
+std::size_t resolve_num_workers_per_dram_bank(
+    const std::optional<std::size_t>& requested_workers_per_bank,
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b);
+
 // This type of access pattern cannot be copied.
 // Treat it as a one off patch to restore functionality that
 // was adjusted to fix one P0 causing another P0.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -561,13 +561,18 @@ void py_module(nb::module_& mod) {
 
     matmul_multi_core_reuse_multicast_dram_sharded_program_config
         .def(
-            nb::init<std::size_t, std::size_t, std::size_t, std::optional<UnaryWithParam>, std::size_t>(),
+            nb::init<
+                std::size_t,
+                std::size_t,
+                std::size_t,
+                std::optional<UnaryWithParam>,
+                std::optional<std::size_t>>(),
             nb::kw_only(),
             nb::arg("in0_block_w").noconvert(),
             nb::arg("per_core_M").noconvert(),
             nb::arg("per_core_N").noconvert(),
             nb::arg("fused_activation") = nb::none(),
-            nb::arg("num_workers_per_dram_bank") = 1)
+            nb::arg("num_workers_per_dram_bank") = nb::none())
         .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::in0_block_w, R"doc(
             Block width for both input tensors along the K dimension (shared inner dimension).
 
@@ -603,24 +608,14 @@ void py_module(nb::module_& mod) {
             R"doc(
             Number of Tensix reader/compute workers assigned to each DRAM bank.
 
-            The default of 1 preserves the established cross-architecture path. Values of 2 or 3
-            split each bank's width shard evenly across multiple workers on Blackhole. All readers
-            for one bank use NOC0 and the same allocator-selected DRAM endpoint. The per-bank shard
-            width in tiles must equal this value times the reader width.
-        )doc")
-        .def("__repr__", [](const MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig& config) {
-            // Include fused_activation in the repr for full visibility during tracing/debugging.
-            std::string fused_activation_repr =
-                config.fused_activation.has_value() ? fmt::format("{}", config.fused_activation.value()) : "None";
-            return fmt::format(
-                "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(in0_block_w={}, per_core_M={}, per_core_N={}, "
-                "fused_activation={}, num_workers_per_dram_bank={})",
-                config.in0_block_w,
-                config.per_core_M,
-                config.per_core_N,
-                fused_activation_repr,
-                config.num_workers_per_dram_bank);
-        });
+            ``None`` selects two workers for large compressed weights on eight-bank Blackhole devices
+            when the existing per-bank shard splits evenly, each reader gets at least 4 KiB per weight
+            row, input A uses at least 64 multicast cores, the shard covers the logical width exactly,
+            and the device has enough legal reader cores. Otherwise it selects one. Automatic selection
+            does not pad or repack the tensor. Explicit values of 1, 2, or 3 are strict.
+            Multiple workers split each bank's width shard evenly. All readers for one bank use NOC0
+            and the same allocator-selected DRAM endpoint.
+        )doc");
 
     auto matmul_multi_core_reuse_multicast_batched_dram_sharded_program_config =
         tt_serializable_class<MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -610,7 +610,7 @@ void py_module(nb::module_& mod) {
 
             ``None`` selects two workers for large compressed weights on eight-bank Blackhole devices
             when the existing per-bank shard splits evenly, each reader gets at least 4 KiB per weight
-            row, input A uses at least 64 multicast cores, the shard covers the logical width exactly,
+            row, input A uses at least 64 multicast cores, the shard covers the existing padded width exactly,
             and the device has enough legal reader cores. Otherwise it selects one. Automatic selection
             does not pad or repack the tensor. Explicit values of 1, 2, or 3 are strict.
             Multiple workers split each bank's width shard evenly. All readers for one bank use NOC0


### PR DESCRIPTION
Codex: This change makes the safe Blackhole DRAM-sharded matmul reader selection the default.

## What changed

- `num_workers_per_dram_bank=None` now selects the worker count automatically.
- The selector uses two workers only for large BFP4/BFP8 weights on an eight-bank Blackhole when the existing shard geometry divides evenly, each reader has a useful transaction size, input A has a broad multicast grid, and enough legal reader cores are available.
- All other cases use one worker.
- Explicit values of 1, 2, or 3 keep their current strict behavior.

The selector has no model or exact-shape allowlist. It does not pad or repack a tensor, and it does not run a timing-based autotuner.

## Performance

On a p150b with firmware 19.5, the policy replay covered 39 successful shape/dtype pairs. It selected two readers for 15 pairs and one reader for 24 pairs. All results had PCC 1.0. Every selected pair improved over one reader by 10.7% to 40.7%.

Matched model CI results:

| Workload | Main | This change | Delta |
| --- | ---: | ---: | ---: |
| Llama 3.1 8B, P150, decode | 32.71 t/s/u | 39.91 t/s/u | +22.02% |
| Llama 3.1 8B, P300, average decode | 32.39 t/s/u | 39.59 t/s/u | +22.23% |
| Llama 3.1 8B, P300, 1st token | 36.96 t/s/u | 46.95 t/s/u | +27.03% |
| Llama 3.1 8B, P300, 128th token | 35.86 t/s/u | 44.91 t/s/u | +25.24% |
| Llama 3.1 8B, P300, 1024th token | 29.40 t/s/u | 35.18 t/s/u | +19.66% |

P150 prefill and TTFT were unchanged. P300 TTFT changed from 26.07 ms to 26.29 ms.

The Llama production config uses 32 input cores for QKV and attention output,
which retain one reader, and 64 cores for the MLP projections, which select two.
Five alternating-order repetitions on one p150b measured:

| Projection | Precision | One reader | Auto | Gain |
| --- | --- | ---: | ---: | ---: |
| Gate/up, layers 0–30 | BFP4/LoFi | 196.89 µs | 116.00 µs | +68.36% |
| Gate/up, layer 31 | BFP8/HiFi2 | 236.79 µs | 147.60 µs | +59.81% |
| Down | BFP8/HiFi2 | 225.04 µs | 147.03 µs | +53.50% |

All 25 projection pairs had PCC 1.0 and zero maximum absolute error. A
same-card, same-binary warmed traced one-layer control with deterministic dummy
weights improved logical batch 1 by 6.07% and logical batch 32 by 6.95%, also
with exact auto-versus-one output agreement.

## Validation

- 17 focused Blackhole DRAM-sharded matmul cases passed.
- Three program-configuration serialization cases passed.
- The policy replay passed all 39 measured pairs with PCC 1.0.
- The P150 Tier 1/2/3 E2E matrix passed all eight model jobs after the Llama decode target was updated from 33 to 40 t/s/u.
- The fixed-card production-grid Llama comparison passed all 25 pairs; only the
  intended 64-core MLP projections changed reader count.
- The fixed-card one-layer Llama trace improved at logical batches 1 and 32.
- Matched full Blackhole Tier 1/2/3 E2E runs cover 37 identical model/SKU jobs across P150, P150b CIV2, P300, QuietBox 2, Galaxy, and LoudBox. Final outcome summary: **pending**.

Evidence:

- P150 branch run: https://github.com/tenstorrent/tt-metal/actions/runs/33172291269
- Full Blackhole branch run: https://github.com/tenstorrent/tt-metal/actions/runs/33177313242
- Matched current-main run: https://github.com/tenstorrent/tt-metal/actions/runs/33177319593
