### PR TITLE
MINFRA-1673: Expose auto triage parameters in setup-multihost-job

### DIFF
--- a/.github/actions/setup-multihost-job/action.yml
+++ b/.github/actions/setup-multihost-job/action.yml
@@ -55,6 +55,14 @@ inputs:
     description: Prepend the wheel's build/lib onto LD_LIBRARY_PATH (manylinux). Leave false for inplace.
     required: false
     default: "false"
+  auto-triage:
+    description: 'Enable detection of timeout on fast dispatch and automatically call tt-triage'
+    default: false
+    type: boolean
+  hang-detection-timeout:
+    description: 'Timeout in seconds when dispatcher is not making progress before tt-triage is called automatically'
+    default: 5.0
+    type: float
 
 runs:
   using: "composite"
@@ -190,3 +198,22 @@ runs:
         mpirun --pernode --tag-output bash -lc '
           test -r /mnt/models
         '
+
+    - name: Set up env vars for auto-triage
+      if: ${{ inputs.auto-triage == 'true' }}
+      working-directory: /home/user/tt-metal
+      run: |
+        echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"
+        TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH=/home/user/tt-metal/generated/debug_bus_signal_groups.json
+        TT_TRIAGE_OUTPUT_PATH=/home/user/tt-metal/generated/triage_output.txt
+        TT_TRIAGE_LLM_OUTPUT_PATH=/home/user/tt-metal/generated/triage_llm_output.txt
+        HANG_REPORT="/opt/venv/bin/python3 $(pwd)/.github/scripts/utils/hang_report.py"
+        TRIAGE="/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress --path=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH --triage-summary-path=generated/triage_summary.txt --llm-output-path=$TT_TRIAGE_LLM_OUTPUT_PATH"
+        TRIAGE_SENTINEL=generated/.tt_triage_already_ran
+        echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=mkdir -p generated; if [ -e $TRIAGE_SENTINEL ]; then echo 'Triage already ran in this job; skipping — device is not reset between tests, so subsequent triage is unreliable' >&2; else touch $TRIAGE_SENTINEL; $HANG_REPORT; $TRIAGE 2>&1 | tee $TT_TRIAGE_OUTPUT_PATH 1>&2; $HANG_REPORT --update; fi" >> $GITHUB_ENV
+        echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
+        echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1" >> $GITHUB_ENV
+        echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
+        echo "TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH" >> $GITHUB_ENV
+        echo "TT_TRIAGE_LLM_OUTPUT_PATH=$TT_TRIAGE_LLM_OUTPUT_PATH" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/setup-multihost-job/action.yml
+++ b/.github/actions/setup-multihost-job/action.yml
@@ -56,13 +56,27 @@ inputs:
     required: false
     default: "false"
   auto-triage:
-    description: 'Enable detection of timeout on fast dispatch and automatically call tt-triage'
-    default: false
-    type: boolean
+    description: >
+      Enable hang detection and tt-triage on workers. Off by default so
+      ttop-recovery is never armed unless a caller opts in after this action
+      (or via this input, which runs after recovery).
+    required: false
+    default: "false"
   hang-detection-timeout:
-    description: 'Timeout in seconds when dispatcher is not making progress before tt-triage is called automatically'
-    default: 5.0
-    type: float
+    description: Seconds without dispatch progress before tt-triage fires on the hung rank(s)
+    required: false
+    default: "5.0"
+  triage-output-dir:
+    description: >
+      NFS directory for per-host triage dumps (must be writable on workers).
+      Empty uses TRIAGE_OUTPUT_DIR from the job env, or
+      /ci/triage_output/<run>-<attempt>/<job>.
+    required: false
+    default: ""
+  triage-job-info:
+    description: Identity string written into each host's triage report dir when triage fires
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -201,19 +215,47 @@ runs:
 
     - name: Set up env vars for auto-triage
       if: ${{ inputs.auto-triage == 'true' }}
-      working-directory: /home/user/tt-metal
+      shell: bash
+      env:
+        TRIAGE_JOB_INFO_INPUT: ${{ inputs.triage-job-info }}
+        TRIAGE_OUTPUT_DIR_INPUT: ${{ inputs.triage-output-dir }}
+        HANG_DETECTION_TIMEOUT: ${{ inputs.hang-detection-timeout }}
       run: |
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"
-        TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH=/home/user/tt-metal/generated/debug_bus_signal_groups.json
-        TT_TRIAGE_OUTPUT_PATH=/home/user/tt-metal/generated/triage_output.txt
-        TT_TRIAGE_LLM_OUTPUT_PATH=/home/user/tt-metal/generated/triage_llm_output.txt
-        HANG_REPORT="/opt/venv/bin/python3 $(pwd)/.github/scripts/utils/hang_report.py"
-        TRIAGE="/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress --path=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH --triage-summary-path=generated/triage_summary.txt --llm-output-path=$TT_TRIAGE_LLM_OUTPUT_PATH"
-        TRIAGE_SENTINEL=generated/.tt_triage_already_ran
-        echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=mkdir -p generated; if [ -e $TRIAGE_SENTINEL ]; then echo 'Triage already ran in this job; skipping — device is not reset between tests, so subsequent triage is unreliable' >&2; else touch $TRIAGE_SENTINEL; $HANG_REPORT; $TRIAGE 2>&1 | tee $TT_TRIAGE_OUTPUT_PATH 1>&2; $HANG_REPORT --update; fi" >> $GITHUB_ENV
-        echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
-        echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1" >> $GITHUB_ENV
-        echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
-        echo "TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH" >> $GITHUB_ENV
-        echo "TT_TRIAGE_LLM_OUTPUT_PATH=$TT_TRIAGE_LLM_OUTPUT_PATH" >> $GITHUB_ENV
-      shell: bash
+        if [ -z "${TRIAGE_OUTPUT_DIR:-}" ]; then
+          if [ -n "$TRIAGE_OUTPUT_DIR_INPUT" ]; then
+            TRIAGE_OUTPUT_DIR="$TRIAGE_OUTPUT_DIR_INPUT"
+          else
+            TRIAGE_OUTPUT_DIR="/ci/triage_output/${{ github.run_id }}-${{ github.run_attempt }}/${{ github.job }}"
+          fi
+        fi
+        mkdir -p "$TRIAGE_OUTPUT_DIR"
+        echo "TRIAGE_OUTPUT_DIR=$TRIAGE_OUTPUT_DIR" >> "$GITHUB_ENV"
+
+        if [ -n "$TRIAGE_JOB_INFO_INPUT" ]; then
+          TRIAGE_JOB_INFO="$TRIAGE_JOB_INFO_INPUT"
+        else
+          TRIAGE_JOB_INFO="job: ${{ github.job }}"
+        fi
+        echo "TT_TRIAGE_JOB_INFO=$TRIAGE_JOB_INFO | runner: ${RUNNER_NAME:-unknown} | run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" >> "$GITHUB_ENV"
+
+        TRIAGE_CMD='D="${TRIAGE_OUTPUT_DIR:-/tmp/tt_triage}/$(hostname)"; mkdir -p "$D" || D=/tmp; if [ -e "$D/.tt_triage_already_ran" ]; then echo "[auto-triage] triage already ran on $(hostname); skipping (cards are not reset between tests, so a second triage is unreliable)" >&2; else touch "$D/.tt_triage_already_ran"; printf "%s\n" "${TT_TRIAGE_JOB_INFO:-unknown leg}" > "$D/job_info.txt"; /opt/venv/bin/python3 "${TT_METAL_HOME:-/home/user/tt-metal}/tools/tt-triage.py" --disable-progress --path="$D/debug_bus_signal_groups.json" --triage-summary-path="$D/triage_summary.txt" --llm-output-path="$D/triage_llm_output.txt" 2>&1 | tee "$D/triage_output.txt" 1>&2; fi'
+
+        {
+          echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=$TRIAGE_CMD"
+          echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=$HANG_DETECTION_TIMEOUT"
+          echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1"
+          echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1"
+        } >> "$GITHUB_ENV"
+
+        export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="$TRIAGE_CMD"
+        export TRIAGE_OUTPUT_DIR
+        mpirun --bind-to none --pernode --tag-output bash -lc '
+          ok=1
+          [ -n "$TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE" ] || { echo "triage hook not forwarded to this rank"; ok=0; }
+          [ -w "${TRIAGE_OUTPUT_DIR:-/nonexistent}" ] || { echo "TRIAGE_OUTPUT_DIR not writable here: ${TRIAGE_OUTPUT_DIR:-<unset>}"; ok=0; }
+          /opt/venv/bin/python3 -c "import ttexalens" 2>/dev/null || { echo "ttexalens missing from /opt/venv"; ok=0; }
+          [ "$ok" = 1 ] && echo "triage armed"
+        ' || echo "::warning::Could not verify triage arming on all hosts; a hang here may not produce triage output"
+
+        echo "Triage fires after ${HANG_DETECTION_TIMEOUT}s without dispatch progress"

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -177,6 +177,9 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           create-pipeline-dir: "false"
+          auto-triage: ${{ inputs.hang-detection-timeout > 0 }}
+          hang-detection-timeout: ${{ inputs.hang-detection-timeout }}
+          triage-job-info: "leg: ${{ matrix.test-group.name }} | sku: ${{ matrix.test-group.sku }}"
 
       - name: Configure TorusXY fabric profile
         if: ${{ matrix.test-group.fabric_profile == 'torus_xy' }}
@@ -184,49 +187,6 @@ jobs:
         run: |
           echo "TT_MESH_GRAPH_DESC_PATH=/home/user/tt-metal/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto" >> "$GITHUB_ENV"
           echo "PREFILL_TORUS_XY_CERTIFIED=1" >> "$GITHUB_ENV"
-
-      # Same mechanism as .github/actions/setup-job, which this job can't use (not a container
-      # job, tests run under mpirun): on dispatch stall the runtime runs
-      # TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE inside the hung rank, then throws. Armed here
-      # rather than job-wide so setup-multihost-job's ttop-recovery step is unaffected.
-      - name: 🧯 Enable tt-triage on hang
-        if: ${{ inputs.hang-detection-timeout > 0 }}
-        timeout-minutes: 5
-        env:
-          TEST_NAME: ${{ matrix.test-group.name }}
-        run: |
-          mkdir -p "$TRIAGE_OUTPUT_DIR"
-
-          # Identity of the leg, written into the report dir when triage fires. A downloaded
-          # artifact otherwise says nothing about which job produced it, and the triage output does
-          # not always reach the step log — a hang inside a process the test spawned itself (e.g.
-          # the prefill producer) writes the files but its stderr never gets to the log.
-          echo "TT_TRIAGE_JOB_INFO=leg: $TEST_NAME | sku: ${{ matrix.test-group.sku }} | runner: ${RUNNER_NAME:-unknown} | run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" >> $GITHUB_ENV
-
-          # Single-quoted: expanded by /bin/sh on the rank's node, not here. Sentinel keeps it to
-          # the first hang — cards aren't reset between tests, so later triage is misleading.
-          TRIAGE_CMD='D="${TRIAGE_OUTPUT_DIR:-/tmp/tt_triage}/$(hostname)"; mkdir -p "$D" || D=/tmp; if [ -e "$D/.tt_triage_already_ran" ]; then echo "[auto-triage] triage already ran on $(hostname); skipping (cards are not reset between tests, so a second triage is unreliable)" >&2; else touch "$D/.tt_triage_already_ran"; printf "%s\n" "${TT_TRIAGE_JOB_INFO:-unknown leg}" > "$D/job_info.txt"; /opt/venv/bin/python3 "${TT_METAL_HOME:-/home/user/tt-metal}/tools/tt-triage.py" --disable-progress --path="$D/debug_bus_signal_groups.json" --triage-summary-path="$D/triage_summary.txt" --llm-output-path="$D/triage_llm_output.txt" 2>&1 | tee "$D/triage_output.txt" 1>&2; fi'
-
-          {
-            echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=$TRIAGE_CMD"
-            echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}"
-            echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1"
-            echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1"
-          } >> $GITHUB_ENV
-
-          # Confirm per host that the hook actually reaches the ranks (env forwarding is done by
-          # ttop via PRTE_MCA_prte_fwd_environment, not by this workflow) and that triage can run
-          # there. Diagnostics only — never fails the leg.
-          export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="$TRIAGE_CMD"
-          mpirun --bind-to none --pernode --tag-output bash -lc '
-            ok=1
-            [ -n "$TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE" ] || { echo "triage hook not forwarded to this rank"; ok=0; }
-            [ -w "${TRIAGE_OUTPUT_DIR:-/nonexistent}" ] || { echo "TRIAGE_OUTPUT_DIR not writable here: ${TRIAGE_OUTPUT_DIR:-<unset>}"; ok=0; }
-            /opt/venv/bin/python3 -c "import ttexalens" 2>/dev/null || { echo "ttexalens missing from /opt/venv"; ok=0; }
-            [ "$ok" = 1 ] && echo "triage armed"
-          ' || echo "::warning::Could not verify triage arming on all hosts; a hang here may not produce triage output"
-
-          echo "Triage fires after ${{ inputs.hang-detection-timeout }}s without dispatch progress"
 
       - name: ${{ matrix.test-group.name }}
         id: run-test


### PR DESCRIPTION
### PR Category
Feature

### Summary
Currently we only expose tt-triage env vars to single host workflows and we want to extend it to multihost environments 

### Notes for reviewers
Copied the same things from `setup-job` action

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dpopov-add-tt-triage-to-multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dpopov-add-tt-triage-to-multihost)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dpopov-add-tt-triage-to-multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dpopov-add-tt-triage-to-multihost)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dpopov-add-tt-triage-to-multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dpopov-add-tt-triage-to-multihost)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dpopov-add-tt-triage-to-multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dpopov-add-tt-triage-to-multihost)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dpopov-add-tt-triage-to-multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dpopov-add-tt-triage-to-multihost)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dpopov-add-tt-triage-to-multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dpopov-add-tt-triage-to-multihost)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dpopov-add-tt-triage-to-multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dpopov-add-tt-triage-to-multihost)