### PR TITLE
common/prefill: unshadow remove_stale_device_map_sidecars in _serve_request

### DIFF
--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -830,7 +830,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             migration_device_map_file_path,
             publish_serialized_table_and_wait_ready,
             rank_scoped_device_map_path,
-            remove_stale_device_map_sidecars,
         )
 
         # This rank's pipeline stage owns layers [first_layer_idx, first_layer_idx + num_my_layers).


### PR DESCRIPTION
Fixes the nightly `(Kimi-K2.6-1T) prefill runner accuracy code_debug 55k@5k [bh_sc1]` leg, red on main since #54313 (a6c0acfae42, 2026-08-26).

`_serve_request` imports `remove_stale_device_map_sidecars` at module level, but the `if _migration_enabled:` block also imports it locally. That makes the name function-local for the whole body, so the mock-migration branch above it (`_mock_migration and not _migration_enabled`, which never executes the local import) raises:

```
File "models/demos/common/prefill/runners/prefill_runner.py", line 808, in _serve_request
    remove_stale_device_map_sidecars(_mock_map_path)
UnboundLocalError: local variable 'remove_stale_device_map_sidecars' referenced before assignment
```

The runner exits rc=1 during startup and the e2e test fails with `runner [single_user_full_depth] exited early (rc=1) during startup`. The SC4 disaggregated legs stay green because they take the real-migration path, which does execute the local import.

Dropping the redundant name from the local import list; the module-level import already covers both call sites.

Validation: https://github.com/tenstorrent/tt-metal/actions/runs/33181936471 (`test-type=prefill_runner`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/fix-mock-migration-unbound-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/fix-mock-migration-unbound-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/fix-mock-migration-unbound-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/fix-mock-migration-unbound-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/fix-mock-migration-unbound-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/fix-mock-migration-unbound-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/fix-mock-migration-unbound-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/fix-mock-migration-unbound-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/fix-mock-migration-unbound-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/fix-mock-migration-unbound-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/fix-mock-migration-unbound-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/fix-mock-migration-unbound-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/fix-mock-migration-unbound-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/fix-mock-migration-unbound-import)