### PR TITLE
Hoist redundant `row_stick_ids` build out of the tile loop in untilize

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
@@ -54,10 +54,10 @@ void kernel_main() {
 
     uint32_t curr_offset = offset_within_stick;
     for (uint32_t i = 0; i < num_sticks / tile_height; i++) {
+        for (uint32_t j = 0; j < tile_height; j++) {
+            row_stick_ids[j] = stick_id + j;
+        }
         for (uint32_t tile_id = 0; tile_id < num_tiles_per_core; tile_id++) {
-            for (uint32_t j = 0; j < tile_height; j++) {
-                row_stick_ids[j] = stick_id + j;
-            }
             curr_stick_offset = curr_offset;
             write_tiles(1, tile_width_size);
             curr_offset += tile_width_size;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/54691

### Summary
The untilize parallel-columns writer rebuilt `row_stick_ids` once per tile, but the table depends only on `stick_id`, which advances once per row of tiles. Hoisting it out of the tile loop removes `tile_height * (num_tiles_per_core - 1)` redundant stores per row.

### Measured Performance
Tested across 5 runs, best-case (min) BRISC times:
| **shape** | **tiles/core** | **before (ns)** | **after (ns)** | **Δ (ns)** | **Δ (%)** |
|---|---|---|---|---|---|
| [1,1,32,512] | 4 | 8573 | 8087 | −486 | −5.7% |
| [1,1,32,1024] | 8 | 16579 | 15423 | −1156 | −7.0% |
| [1,1,32,2048] | 16 | 32707 | 30114 | −2593 | −7.9% |
| [1,1,32,4096] | 32 | 64989 | 59632 | −5357 | −8.2% |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/untilize_stick_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/untilize_stick_id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/untilize_stick_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/untilize_stick_id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/untilize_stick_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/untilize_stick_id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/untilize_stick_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/untilize_stick_id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/untilize_stick_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/untilize_stick_id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/untilize_stick_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/untilize_stick_id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/untilize_stick_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/untilize_stick_id)