### PR TITLE
#54745: add ops tests for quasar testing based on a gpt oss graph trace

### DIFF
--- a/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
+++ b/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
@@ -74,6 +74,8 @@ _SHARD_SHAPE_RE = re.compile(r"shape=\[(\d+), *(\d+)\]")
 _SHARD_ORIENT_RE = re.compile(r"orientation=ShardOrientation::(\w+)")
 _CONFIG_RE = re.compile(r"^(?P<kind>[A-Z]\w*(?:ProgramConfig|Config))\((?P<body>.*)\)$")
 _TENSOR_ID_RE = re.compile(r"tensor_id=(\d+)")
+# ttnn.Tile's repr, e.g. gpt-oss's sparse_matmul(output_tile=ttnn.Tile([32, 32])).
+_TILE_RE = re.compile(r"^Tile with shape: \[(?P<h>\d+), (?P<w>\d+)\]$")
 _GRID_RE = re.compile(r"^(\d+)-(\d+)$")
 
 _DTYPE_TAG = {
@@ -262,6 +264,9 @@ def parse_argument(text: str):
         return {"k": "layout", "v": text.split(".", 1)[1]}
     if text.startswith("MeshDevice("):
         return {"k": "device"}
+    tile = _TILE_RE.match(text)
+    if tile:
+        return {"k": "tile", "shape": [int(tile.group("h")), int(tile.group("w"))]}
     if text.startswith("[UnaryOpType."):
         return {"k": "acts", "v": re.findall(r"UnaryOpType\.(\w+)", text)}
     if text.startswith("slice(") or text.startswith("(slice("):

--- a/models/experimental/ops/quasar/gpt_oss/demo/text_demo.py
+++ b/models/experimental/ops/quasar/gpt_oss/demo/text_demo.py
@@ -497,10 +497,12 @@ def test_gpt_oss_demo(
         # step repeats the same ops, so a handful covers the decode surface while 200 steps only
         # multiply the record count -- a 200-token capture of a comparable model produced ~750k
         # records and 5 GB. Fewer steps make `count` in a generated suite smaller, not the set of
-        # captured calls narrower.
-        if max_generated_tokens > _CAPTURE_MAX_GENERATED_TOKENS:
+        # captured calls narrower. Gated on enable_graph_report, not enable_logging: only a run
+        # writing a report has a capture to keep small, and enable_logging alone is a diagnostics
+        # flag that must not quietly shorten a long-generation debug run.
+        if ttnn.CONFIG.enable_graph_report and max_generated_tokens > _CAPTURE_MAX_GENERATED_TOKENS:
             logger.info(
-                f"ttnn logging is enabled: generating {_CAPTURE_MAX_GENERATED_TOKENS} tokens instead of "
+                f"ttnn graph reporting is enabled: generating {_CAPTURE_MAX_GENERATED_TOKENS} tokens instead of "
                 f"{max_generated_tokens} to keep the capture readable"
             )
             max_generated_tokens = _CAPTURE_MAX_GENERATED_TOKENS

--- a/models/experimental/ops/quasar/gpt_oss/demo/text_demo.py
+++ b/models/experimental/ops/quasar/gpt_oss/demo/text_demo.py
@@ -42,6 +42,9 @@ from models.tt_transformers.tt.common import PagedAttentionConfig, get_padded_pr
 from models.tt_transformers.tt.generator import Generator, create_submeshes
 from models.tt_transformers.tt.model_config import determine_device_name
 
+# Decode steps recorded when ttnn logging (graph capture) is on -- see the cap in the demo body.
+_CAPTURE_MAX_GENERATED_TOKENS = 8
+
 
 def create_long_context_page_table(
     global_batch_size: int,
@@ -480,6 +483,28 @@ def test_gpt_oss_demo(
     state_dict,
 ):
     """GPT-OSS demo using full tt_transformers generation pipeline"""
+    # ttnn logging and device trace capture are mutually exclusive: with enable_logging on, every op
+    # calls ttnn.synchronize_device and the python I/O recorder reads tensors back to host, both
+    # hard-fatal inside a trace region ("Event Synchronization / Reads are not supported during
+    # trace capture"). A graph-capture run therefore gives up device tracing; the ops it records are
+    # the eager calls a traced run would replay.
+    if ttnn.CONFIG.enable_logging:
+        if enable_decode_trace or enable_prefill_trace:
+            logger.info("ttnn logging is enabled: running without device trace capture so graph capture can complete")
+            enable_decode_trace = False
+            enable_prefill_trace = False
+        # Without device trace, decode runs eagerly and every op of every step is recorded. Each
+        # step repeats the same ops, so a handful covers the decode surface while 200 steps only
+        # multiply the record count -- a 200-token capture of a comparable model produced ~750k
+        # records and 5 GB. Fewer steps make `count` in a generated suite smaller, not the set of
+        # captured calls narrower.
+        if max_generated_tokens > _CAPTURE_MAX_GENERATED_TOKENS:
+            logger.info(
+                f"ttnn logging is enabled: generating {_CAPTURE_MAX_GENERATED_TOKENS} tokens instead of "
+                f"{max_generated_tokens} to keep the capture readable"
+            )
+            max_generated_tokens = _CAPTURE_MAX_GENERATED_TOKENS
+
     mesh_shape = tuple(mesh_device.shape)
     test_id = request.node.callspec.id if hasattr(request.node, "callspec") else request.node.name
     is_seqlen_sweep = "seqlen-sweep" in test_id

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/README.md
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/README.md
@@ -1,0 +1,141 @@
+# Per-op tests generated from a GPT-OSS graph capture (`tests/gpt_oss_ops/`)
+
+Isolated per-op tests **generated mechanically from a ttnn graph capture** of a gpt-oss-20b demo
+run, so each op is exercised with the exact shapes, dtypes, layouts, memory configs and program
+configs the model really used.
+
+Sibling of [`tests/qwen3_vl_ops/`](../qwen3_vl_ops/README.md) and of the original
+[`models/experimental/llama32_1b_quasar/tests/graph_ops/`](../../../../llama32_1b_quasar/tests/graph_ops/README.md),
+sharing their generator and runtime — read the llama README for the full discussion of how a case
+is reconstructed and what a capture cannot tell you. This file covers what is specific to GPT-OSS.
+
+## Quick start
+
+```bash
+# whole suite
+pytest models/experimental/ops/quasar/tests/gpt_oss_ops/ -v
+
+# one op, one case
+pytest models/experimental/ops/quasar/tests/gpt_oss_ops/test_sparse_matmul.py -k 00_1x2880 -v
+
+# the subset that fits the 2-node Quasar emulator
+pytest models/experimental/ops/quasar/tests/gpt_oss_ops/ -m emulator
+
+# shapes/dtypes/finiteness only — no PCC against a torch golden
+TTNN_GRAPH_OPS_NO_GOLDEN=1 pytest models/experimental/ops/quasar/tests/gpt_oss_ops/
+```
+
+## Coverage of the current capture
+
+Source: a `-k "prefill_128"` run of gpt-oss-20b on a single Blackhole device (1x1 mesh), with
+device trace off and the decode length capped — see [Regenerating](#regenerating). 15,141 recorded
+python-level calls over 42 ops.
+
+- **38 op files, 119 distinct cases, covering 14,198 captured calls.**
+- **Value coverage: 101 of 119 cases (11,798 of 14,198 calls) are checked against a torch
+  golden**, 2 more (480 calls) against the paged-cache postcondition, and 16 (1,920 calls) on
+  shape/dtype/placement/finiteness only: both SDPAs, rope, `topk`, `scatter` and `sparse_matmul`
+  (`graph_case.GOLDEN`'s header comment says why each).
+- **88 of 119 cases are marked `emulator`**, over 32 of the 38 ops — a much larger fraction than
+  the qwen3_vl suite, because this capture is batch-1 decode-dominated rather than
+  prefill-dominated.
+- 4 ops are deliberately not generated (`SKIP_OPS`): `ttnn.deallocate`, `ttnn.from_torch` /
+  `ttnn.as_tensor` (exercised by every case's input upload) and `ttnn.to_torch` (used by every
+  assertion).
+
+The MoE machinery is what distinguishes this suite from its siblings. `ttnn.sparse_matmul` (720
+calls, 4 cases) is the expert matmul; `topk` + `softmax` + `sigmoid` are the router; `clamp` (480
+calls) is the SwiGLU limit; `ttnn.experimental.fast_reduce_nc` combines the weighted expert
+outputs (`gpt_oss/tt/experts/operations.py:66`); and `scatter` / `permute` / `repeat` move tokens
+between the token-major and expert-major layouts.
+
+## Regenerating
+
+**Prerequisite:** the capture step needs the `enable_torch_tracer` split from
+`martemov/llama-graph-tracing-bbradel-fork`, which is not on main yet. Without it,
+`enable_logging` + `enable_graph_report` turns on the legacy python torch tracer
+(`ttnn/ttnn/decorators.py:997-999`), which wraps every incoming `torch.Tensor` in a
+`TracedTorchTensor` that nanobind cannot dtype-convert — `ttnn.from_torch` aborts before the model
+is built. The committed cases came from a capture taken with that branch merged locally; nothing
+in this directory depends on it, only the act of re-capturing does.
+
+```bash
+# 1. capture a run. The demo turns device trace off and caps generated tokens by itself when
+#    ttnn logging is on (text_demo.py) -- logging syncs the device and reads tensors per op, both
+#    hard-fatal inside a trace region, and 200 eager decode steps only inflate the record count.
+MESH_DEVICE=<sku> HF_MODEL=<path to gpt-oss-20b> \
+TTNN_CONFIG_OVERRIDES='{"enable_logging":true,"enable_fast_runtime_mode":false,"enable_graph_report":true,"enable_detailed_buffer_report":false,"report_name":"gpt_oss_demo"}' \
+    pytest models/experimental/ops/quasar/gpt_oss/demo/text_demo.py -k "prefill_128 and not 128k"
+
+# 2. drop the per-record captured_graph the generator does not read (124 MB -> 19 MB)
+python models/experimental/ops/quasar/tests/gpt_oss_ops/slim_python_io.py \
+    generated/ttnn/reports/<report>/graph_capture.python_io.json \
+    generated/ttnn/reports/<report>/graph_capture.python_io.slim.json
+
+# 3. generate the suite (the generator is shared with the llama and qwen3_vl suites)
+python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+    --capture generated/ttnn/reports/<report>/graph_capture.python_io.slim.json \
+    --out    models/experimental/ops/quasar/tests/gpt_oss_ops
+
+# 4. validate without a device: the generated data (no ttnn), then the goldens (imports ttnn,
+#    opens nothing)
+python models/experimental/ops/quasar/tests/gpt_oss_ops/validate_cases.py
+python models/experimental/ops/quasar/tests/gpt_oss_ops/validate_goldens.py
+```
+
+**Keep the capture if you want to regenerate.** `ttnn.CONFIG.delete_reports_on_start` wipes
+`generated/ttnn/reports/` when the next run starts.
+
+Do not hand-edit `test_<op>.py` — fix `graph_case.py` (or the generator) instead. The generated
+files are data only, so a fidelity improvement applies to every op at once and survives
+regeneration.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `test_<op>.py` | **generated.** A `CASES` list (pure data) + a two-line test body. One file per op. |
+| `graph_case.py` | Runtime. Turns a case back into ttnn objects, runs it, checks the result. **All interpretation lives here.** |
+| `op_utils.py` | The four model-specific hooks `graph_case` needs, re-exported from the llama op suite. |
+| `conftest.py` | Tags emulator-appropriate cases with the `emulator` marker. |
+| `validate_cases.py` | Offline consistency check of generated data vs `graph_case.py`'s tables. |
+| `validate_goldens.py` | Checks that every `GOLDEN` reference runs against its cases — no device, though it imports ttnn. |
+| `slim_python_io.py` | Step 2 above: strips `captured_graph` from a capture, streaming. |
+
+## What this capture needed that the siblings did not
+
+**`ttnn.Tile` arguments.** `sparse_matmul` passes an explicit `output_tile`, which reaches the
+capture as `Tile with shape: [32, 32]`. The generator had no branch for it, so all 720 calls of
+the model's central op were dropped as unreconstructible. Added to `parse_argument` (a `tile`
+spec) and to `graph_case._build_value` (`ttnn.Tile(shape)`).
+
+**Four more `MatmulMultiCoreReuseMultiCast1DProgramConfig` fields.** This is the first capture to
+use that config, and `graph_case._PROGRAM_CONFIG_FIELDS` predated `gather_in0`,
+`num_global_cb_receivers`, `untilize_out` and `stream_in1` — all real ctor kwargs
+(`matmul_nanobind.cpp:401-406`). `validate_cases.py` flagged every one, which is what it is for.
+`hop_cores` is handled like `allowed_worker_cores` but compares against *empty* rather than null:
+its ctor default is an empty CoreRangeSet, so the repr prints `{}` rather than `std::nullopt`.
+
+**Goldens for the MoE ops** (`graph_case.GOLDEN`): `matmul`, `sigmoid`, `softmax`, `clamp`,
+`permute`, `repeat`, `sum`, and `fast_reduce_nc` (a keepdim sum over the expert dim — each
+expert's output is already scaled by its routing weight, so combining them is addition).
+
+Deliberately without a golden: `topk` (random bfloat16 values tie often enough that torch's
+indices and the op's are both correct and different — the same reason `argmax` has none) and
+`sparse_matmul` (the result depends on the sparsity tensor's routing semantics, which the capture
+records as data rather than meaning).
+
+## Fidelity
+
+The llama README's fidelity table applies verbatim — random tensor values,
+`compute_kernel_config` dropped, index tensors filled semantically, replicated onto the `(1, 1)`
+mesh the capture ran on. Each generated file's docstring lists the gaps that apply to that op.
+
+Two caveats specific to this capture:
+
+- **device trace was off**, so the decode ops are recorded as the eager calls a traced run would
+  replay. A bug that only appears when the op runs from a captured trace is out of reach here.
+- **the decode length was capped**, so `count` reflects a handful of steps rather than a full
+  generation. The *set* of captured calls is unaffected (every decode step issues the same ops),
+  but `count` ranks cases, so it should be read as relative weight within a step, not as the
+  model's real call volume.

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/conftest.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/conftest.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Local conftest for the graph-capture-derived suite: tags emulator-appropriate cases.
+
+Same contract as ``tests/ops/conftest.py`` — ``-m emulator`` selects the subset the
+2-node Quasar emulator can run — but the classification reads the *generated case
+data* instead of parameter names, because every test here takes a single ``case``
+dict:
+
+  * non-(1, 1) mesh                                     -> not emulator
+  * primary input (arg 0) taller than ``_EMU_MAX_ROWS``
+    rows, i.e. a prefill-sized activation                -> not emulator
+  * total footprint of all inputs over
+    ``_EMU_MAX_INPUT_BYTES``                             -> not emulator
+  * any L1-sharded input whose captured grid needs more
+    than ``_EMU_MAX_CORES`` cores                        -> not emulator
+
+Note the row cap deliberately applies to the *activation* only: a matmul weight or a
+paged KV cache is legitimately tall, and judging it by row count would drop every
+``linear`` and cache case. That is arg 0 for most ops, but arg 1 for the paged-cache
+ops, whose arg 0 is the cache (see ``_PRIMARY_ARG``). Bulk is handled by the
+footprint rule instead.
+
+These are collection-time estimates, and every case remains runnable without
+``-m emulator``. The authoritative check happens at run time in
+``graph_case.build_memory_config``, which skips a case whose captured shard grid
+does not fit the device actually under test.
+
+    pytest models/experimental/ops/quasar/tests/gpt_oss_ops/ -m emulator
+"""
+
+import pytest
+
+_EMU_MAX_ROWS = 128
+# 2 nodes x (1x2 worth of usable compute cores) — deliberately conservative; the
+# run-time gate in graph_case is the real one.
+_EMU_MAX_CORES = 8
+_EMU_MAX_INPUT_BYTES = 16 << 20
+
+# Bytes per element, block-float dtypes including their per-face exponents.
+_ELEM_BYTES = {
+    "FLOAT32": 4,
+    "INT32": 4,
+    "UINT32": 4,
+    "BFLOAT16": 2,
+    "UINT16": 2,
+    "BFLOAT8_B": 1.0625,
+    "BFLOAT4_B": 0.5625,
+    "UINT8": 1,
+}
+
+
+def _rows_of(shape) -> int:
+    rows = 1
+    for d in shape[:-1]:
+        rows *= d
+    return rows
+
+
+def _bytes_of(spec) -> float:
+    numel = 1
+    for d in spec["shape"]:
+        numel *= d
+    return numel * _ELEM_BYTES.get(spec["dtype"], 2)
+
+
+def _cores_of(shard) -> int:
+    return sum((x1 - x0 + 1) * (y1 - y0 + 1) for x0, y0, x1, y1 in shard["grid"])
+
+
+# Ops whose first argument is a persistent cache rather than an activation. The row
+# cap exists to drop prefill-sized *activations*; a paged KV cache is legitimately
+# tall (128 pages x 8 heads x 32 rows), so judging these by arg 0 would exclude them
+# from the emulator subset for the one tensor the exemption is about. Their
+# activation — the tensor being written into the cache — is arg 1.
+_PRIMARY_ARG = {
+    "ttnn.experimental.paged_update_cache": 1,
+    "ttnn.experimental.paged_fill_cache": 1,
+}
+
+
+def _primary_input(case):
+    """The activation whose height decides whether this is a prefill-sized case."""
+    start = _PRIMARY_ARG.get(case.get("op"), 0)
+    return next((a for a in case["args"][start:] if a.get("k") == "t"), None)
+
+
+def _tensor_specs(case):
+    for spec in list(case["args"]) + list(case["kwargs"].values()):
+        if spec.get("k") == "t":
+            yield spec
+        elif spec.get("k") == "tlist":
+            yield from spec["tensors"]
+
+
+def _fits_emulator(item) -> bool:
+    callspec = getattr(item, "callspec", None)
+    if callspec is None:
+        return True
+    params = callspec.params
+
+    mesh = params.get("ttnn_mesh_device")
+    if mesh is not None and tuple(mesh) != (1, 1):
+        return False
+
+    case = params.get("case")
+    if not isinstance(case, dict):
+        return True
+
+    primary = _primary_input(case)
+    if primary is not None and _rows_of(primary["shape"]) > _EMU_MAX_ROWS:
+        return False
+
+    total_bytes = 0.0
+    for spec in _tensor_specs(case):
+        total_bytes += _bytes_of(spec)
+        mem = spec.get("mem") or {}
+        shard = mem.get("shard")
+        if shard and mem.get("buffer") == "L1" and _cores_of(shard) > _EMU_MAX_CORES:
+            return False
+    return total_bytes <= _EMU_MAX_INPUT_BYTES
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "emulator: graph-capture case that fits the 2-node Quasar emulator (small / single-device)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if _fits_emulator(item):
+            item.add_marker(pytest.mark.emulator)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/graph_case.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/graph_case.py
@@ -547,7 +547,23 @@ def _ref_identity(inputs, kwargs, case):
 
 
 def _ref_matmul(inputs, kwargs, case):
-    return inputs["0"].float() @ inputs["1"].float()
+    """a @ b, plus the captured bias where ttnn.linear supplied one.
+
+    Three of gpt-oss's four linear cases pass a bias (the router's [1, 32] and the MLP's [5120]);
+    leaving it out of the reference means an op that dropped the bias would agree with it. The
+    flatten-and-trim mirrors how rms_norm's gamma is handled, so a tile-padded bias lines up with
+    the output row too; a bias too short to cover the row is not something this can align, so the
+    case falls back to the structural checks rather than a reference that is quietly wrong.
+    """
+    out = inputs["0"].float() @ inputs["1"].float()
+    bias = inputs.get("bias")
+    if bias is None:
+        return out
+    flat = bias.float().reshape(-1)
+    width = out.shape[-1]
+    if flat.numel() < width:
+        return None
+    return out + flat[:width]
 
 
 def _second_operand(inputs, case):

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/graph_case.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/graph_case.py
@@ -1,0 +1,1303 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Runtime for the graph-capture-derived per-op suite (``tests/graph_ops/``).
+
+Every test file in this directory is **generated** by
+``generate_from_graph_capture.py`` from a ttnn graph capture
+(``generated/ttnn/reports/<run>/graph_capture.python_io.json``). The generated
+files hold nothing but data: a ``CASES`` list of the *distinct* calls the model
+actually made to one op, each carrying the exact shapes / dtypes / layouts /
+memory configs / program configs that were recorded.
+
+This module turns that data back into ttnn objects and runs it. All the
+interpretation lives here, so a fix (a renamed program-config field, a better
+index heuristic, a new golden reference) is made **once** and every generated
+test picks it up without regeneration.
+
+What a case run does
+--------------------
+1. materialize each input tensor: random torch data of the captured shape/dtype,
+   uploaded with the captured layout + memory config (so sharded inputs are
+   really sharded, DRAM-sharded weights are really DRAM-sharded, …);
+2. rebuild the captured keyword arguments (memory_config, program_config, dtype,
+   scalars, activations);
+3. call the op;
+4. check every returned tensor against its captured output spec — shape, dtype,
+   layout and memory config (so a relayout op that hands back its input untouched
+   fails), plus finiteness. A multi-output op such as ``nlp_create_qkv_heads`` has
+   all of Q, K and V checked. Where the capture never observed an output, what the
+   call itself pins down is used instead (``_derived_spec``), and ops whose result
+   metadata cannot show they did anything get an explicit ``POSTCONDITION``;
+5. on top of that, a torch golden (PCC) for the ops where a reference is
+   unambiguous — see ``GOLDEN``.
+
+Fidelity caveats (deliberate, documented, all visible in the generated data)
+---------------------------------------------------------------------------
+* ``compute_kernel_config`` is captured only as a python object repr
+  (``<WormholeComputeKernelConfig object at 0x…>``) — its fields are NOT in the
+  capture, so the kwarg is dropped and the op's default is used. This can move
+  PCC (math fidelity / fp32 accumulation) but not shapes or program structure.
+* Tensor *values* are not captured; inputs are random. Index-like tensors
+  (page tables, cur_pos, update_idxs, embedding ids) would fault the device with
+  random values, so they get semantic values from ``INDEX_VALUES`` below.
+* Program configs are rebuilt field-for-field from the repr (including
+  LayerNorm's ``legacy_reduction`` / ``legacy_rsqrt`` / ``use_welford`` and SDPA's
+  ``max_cores_per_head_batch``). The only exceptions are the optional
+  CoreRangeSet restrictions (``sub_core_grids``, ``allowed_worker_cores``): those
+  print as ``std::nullopt`` in every capture so far, and a non-null value skips
+  the case instead of running a different core set — see
+  ``_PROGRAM_CONFIG_FIELDS`` / ``_MUST_BE_NULL``.
+* Mesh placement is replicated onto the (1, 1) mesh the capture ran on.
+
+Set ``TTNN_GRAPH_OPS_NO_GOLDEN=1`` to reduce every case to
+"runs + right shape/dtype + finite" (useful while a golden reference is under
+suspicion, or on an emulator where PCC of a bfloat8_b path is not the point).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import op_utils as U
+
+# Re-exported so generated files need one import only.
+with_default_mesh = U.with_default_mesh
+from_tt = U.from_tt
+
+# =============================================================================
+# Enum tables (capture string -> ttnn object)
+# =============================================================================
+
+DTYPE = {
+    "BFLOAT16": ttnn.bfloat16,
+    "BFLOAT8_B": ttnn.bfloat8_b,
+    "BFLOAT4_B": ttnn.bfloat4_b,
+    "FLOAT32": ttnn.float32,
+    "UINT32": ttnn.uint32,
+    "INT32": ttnn.int32,
+    "UINT16": ttnn.uint16,
+    "UINT8": ttnn.uint8,
+}
+
+LAYOUT = {"TILE": ttnn.TILE_LAYOUT, "ROW_MAJOR": ttnn.ROW_MAJOR_LAYOUT}
+
+MEM_LAYOUT = {
+    "INTERLEAVED": ttnn.TensorMemoryLayout.INTERLEAVED,
+    "HEIGHT_SHARDED": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    "WIDTH_SHARDED": ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    "BLOCK_SHARDED": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+}
+
+BUFFER_TYPE = {
+    "L1": ttnn.BufferType.L1,
+    "DRAM": ttnn.BufferType.DRAM,
+    "L1_SMALL": ttnn.BufferType.L1_SMALL,
+    "TRACE": ttnn.BufferType.TRACE,
+}
+
+ORIENTATION = {"ROW_MAJOR": ttnn.ShardOrientation.ROW_MAJOR, "COL_MAJOR": ttnn.ShardOrientation.COL_MAJOR}
+
+# Integer dtypes get integer torch data (and semantic values where the op needs
+# them); everything else gets bfloat16 noise.
+_INT_DTYPES = {"UINT32", "INT32", "UINT16", "UINT8"}
+
+# The bar is PCC > 0.999 against the torch reference. Every floor below it is a
+# property of the call, not a blanket allowance, and each mirrors the number the
+# hand-written tests/ops suite settled on for the same op on real hardware:
+#
+#   * block-float dtypes quantize to a per-face exponent, so the reference (built in
+#     fp32) cannot be reproduced to 0.999 no matter how correct the op is;
+#   * a K-deep matmul accumulates rounding over the reduction — tests/ops/test_linear.py:30
+#     uses 0.99, and 0.98 for the K=8192 down-projection;
+#   * rms_norm (reduction + rsqrt), embedding (gather of a quantized table) and
+#     typecast (the captured casts are bf16 -> bfloat8_b) are 0.99 in tests/ops for
+#     the same reasons — test_rms_norm.py:56, test_embedding.py:58, test_typecast.py:26.
+#
+# On top of that, ``compute_kernel_config`` is not reconstructible from a capture
+# (see the module docstring), so these run at each op's default math fidelity rather
+# than the fidelity the model asked for — which costs precision on exactly the
+# reduction-heavy ops listed here.
+_DEFAULT_PCC = 0.999
+_PCC_BY_DTYPE = {"BFLOAT8_B": 0.97, "BFLOAT4_B": 0.90}
+_PCC_BY_OP = {
+    "ttnn.linear": 0.99,
+    "ttnn.experimental.minimal_matmul": 0.99,
+    "ttnn.rms_norm": 0.99,
+    "ttnn.embedding": 0.99,
+    "ttnn.typecast": 0.99,
+}
+# Ops that reduce along the input's last dimension, and the depth past which they get
+# the looser floor tests/ops uses for the K=8192 down-projection.
+_REDUCTION_OPS = frozenset({"ttnn.linear", "ttnn.experimental.minimal_matmul", "ttnn.rms_norm"})
+_DEEP_K = 4096
+_DEEP_K_PCC = 0.98
+
+NO_GOLDEN = os.environ.get("TTNN_GRAPH_OPS_NO_GOLDEN", "") not in ("", "0", "false", "False")
+
+
+# =============================================================================
+# Memory configs
+# =============================================================================
+
+
+def _core_range_set(ranges):
+    return ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(x0, y0), ttnn.CoreCoord(x1, y1)) for (x0, y0, x1, y1) in ranges}
+    )
+
+
+def _shard_grid_fits(spec, mesh_device):
+    """Does the captured shard grid exist on this device? Returns (fits, why not).
+
+    A captured shard grid is absolute (the capture ran on an N150-class 8x8 grid),
+    so on a smaller device — e.g. the 2-node Quasar emulator — it may name cores or
+    DRAM banks that are not there. DRAM shard grids index banks instead of compute
+    cores and are gated separately.
+    """
+    shard = spec.get("shard")
+    if shard is None:
+        return True, ""
+
+    max_x = max(r[2] for r in shard["grid"])
+    max_y = max(r[3] for r in shard["grid"])
+    if spec["buffer"] == "L1":
+        grid = mesh_device.compute_with_storage_grid_size()
+        if max_x >= grid.x or max_y >= grid.y:
+            return False, (
+                f"captured L1 shard grid needs cores up to ({max_x},{max_y}); "
+                f"device compute grid is {grid.x}x{grid.y}"
+            )
+    else:
+        dram_grid = getattr(mesh_device, "dram_grid_size", None)
+        if callable(dram_grid):
+            g = dram_grid()
+            if max_x >= g.x or max_y >= g.y:
+                return False, (
+                    f"captured DRAM shard grid needs banks up to ({max_x},{max_y}); " f"device DRAM grid is {g.x}x{g.y}"
+                )
+    return True, ""
+
+
+def build_memory_config(spec, mesh_device):
+    """Rebuild a captured MemoryConfig; skip the case if its grid exceeds the device.
+
+    A config whose shard grid is not on this device cannot be allocated at all, so
+    the case is SKIPPED rather than failed (see ``_shard_grid_fits``).
+    """
+    if spec is None:
+        return None
+    shard = spec.get("shard")
+    if shard is None:
+        return ttnn.MemoryConfig(MEM_LAYOUT[spec["layout"]], BUFFER_TYPE[spec["buffer"]])
+
+    fits, why = _shard_grid_fits(spec, mesh_device)
+    if not fits:
+        pytest.skip(f"{why} — shape too large for this device")
+
+    shard_spec = ttnn.ShardSpec(_core_range_set(shard["grid"]), list(shard["shape"]), ORIENTATION[shard["orientation"]])
+    return ttnn.MemoryConfig(MEM_LAYOUT[spec["layout"]], BUFFER_TYPE[spec["buffer"]], shard_spec)
+
+
+# =============================================================================
+# Program configs
+# =============================================================================
+
+# Fields the (keyword-only) python constructors accept. Verified against the
+# nanobind definitions:
+#   matmul_nanobind.cpp:145,330,556 | layernorm_nanobind.cpp:52
+#   transformer_nanobind.cpp:27     | minimal_matmul_nanobind.cpp:164
+# Anything the C++ repr prints but the ctor does not accept is listed in
+# _DROPPED_FIELDS, so the omission is explicit rather than silent.
+_PROGRAM_CONFIG_FIELDS = {
+    "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig": ("in0_block_w", "per_core_M", "per_core_N"),
+    "MatmulMultiCoreReuseMultiCastProgramConfig": (
+        "compute_with_storage_grid_size",
+        "in0_block_w",
+        "out_subblock_h",
+        "out_subblock_w",
+        "out_block_h",
+        "out_block_w",
+        "per_core_M",
+        "per_core_N",
+        "transpose_mcast",
+        "fuse_batch",
+    ),
+    "MatmulMultiCoreReuseMultiCast1DProgramConfig": (
+        "compute_with_storage_grid_size",
+        "in0_block_w",
+        "out_subblock_h",
+        "out_subblock_w",
+        "out_block_h",
+        "out_block_w",
+        "per_core_M",
+        "per_core_N",
+        "fuse_batch",
+        "mcast_in0",
+        # gpt-oss's sparse_matmul is the first capture to use this config; these are ctor kwargs
+        # (matmul_nanobind.cpp:401-406) that the table predates.
+        "gather_in0",
+        "num_global_cb_receivers",
+        "untilize_out",
+        "stream_in1",
+    ),
+    "LayerNormShardedMultiCoreProgramConfig": (
+        "compute_with_storage_grid_size",
+        "subblock_w",
+        "block_h",
+        "block_w",
+        "inplace",
+        "legacy_reduction",
+        "legacy_rsqrt",
+        "use_welford",
+    ),
+    "SDPAProgramConfig": (
+        "compute_with_storage_grid_size",
+        "q_chunk_size",
+        "k_chunk_size",
+        "exp_approx_mode",
+        "max_cores_per_head_batch",
+    ),
+    "MinimalMatmulConfig": (
+        "M_block_size",
+        "K_block_size",
+        "N_block_size",
+        "subblock_h",
+        "subblock_w",
+        "compute_with_storage_grid_size",
+    ),
+}
+
+# Fields the repr prints that this runtime does not reconstruct. Both are
+# std::nullopt in every capture generated so far; a non-null value makes the case
+# skip (see build_program_config) rather than run a subtly different config.
+_DROPPED_FIELDS = {
+    "SDPAProgramConfig": ("sub_core_grids",),
+    "MatmulMultiCoreReuseMultiCastProgramConfig": ("allowed_worker_cores",),
+    "MatmulMultiCoreReuseMultiCast1DProgramConfig": ("allowed_worker_cores", "hop_cores"),
+}
+
+# Optional CoreRangeSet fields that must be std::nullopt for a faithful rebuild.
+_MUST_BE_NULL = ("sub_core_grids", "allowed_worker_cores")
+# hop_cores is a CoreRangeSet too, but its ctor default is an *empty* set rather than nullopt, so
+# the repr prints {} rather than std::nullopt. Empty means "no hop cores", which is what leaving it
+# out reproduces; a non-empty one would change which cores the op runs on.
+_MUST_BE_EMPTY = ("hop_cores",)
+
+# The C++ repr prints bools as 0/1, but these ctor args are bound `.noconvert()`,
+# which rejects a python int. Coerce them back to bool.
+_BOOL_FIELDS = frozenset(
+    {
+        "inplace",
+        "legacy_reduction",
+        "legacy_rsqrt",
+        "use_welford",
+        "transpose_mcast",
+        "fuse_batch",
+        "mcast_in0",
+        "gather_in0",
+        "untilize_out",
+        "stream_in1",
+        "exp_approx_mode",
+    }
+)
+
+
+def build_program_config(spec):
+    """Rebuild a captured program config (e.g. SDPAProgramConfig(...))."""
+    if spec is None:
+        return None
+    kind = spec["kind"]
+    cls = getattr(ttnn, kind, None)
+    if cls is None:
+        pytest.skip(f"{kind} is not exposed on this ttnn build")
+
+    fields = spec["fields"]
+    allowed = _PROGRAM_CONFIG_FIELDS.get(kind)
+    if allowed is None:
+        pytest.skip(f"no python field mapping for {kind} — add it to graph_case._PROGRAM_CONFIG_FIELDS")
+
+    kwargs: dict[str, Any] = {}
+    for name in allowed:
+        if name not in fields:
+            continue
+        value = fields[name]
+        if name == "compute_with_storage_grid_size":
+            value = ttnn.CoreCoord(*value)
+        elif name in _BOOL_FIELDS:
+            value = bool(value)
+        kwargs[name] = value
+
+    # A fused activation is reconstructible only through its UnaryOpType name.
+    activation = fields.get("fused_activation")
+    if activation is not None:
+        op_type = getattr(ttnn.UnaryOpType, str(activation).upper(), None)
+        if op_type is None:
+            pytest.skip(f"{kind} fused_activation={activation!r} is not reconstructible from the capture")
+        kwargs["fused_activation"] = ttnn.UnaryWithParam(op_type)
+
+    # Optional core-grid restrictions are not reconstructed; a captured non-null
+    # value would change which cores the op runs on, so skip instead of lying.
+    for name in _MUST_BE_NULL:
+        if fields.get(name) is not None:
+            pytest.skip(f"{kind}.{name}={fields[name]!r} is not reconstructible from the capture")
+    for name in _MUST_BE_EMPTY:
+        if fields.get(name):
+            pytest.skip(f"{kind}.{name}={fields[name]!r} is not reconstructible from the capture")
+
+    try:
+        return cls(**kwargs)
+    except TypeError as exc:  # ttnn version drift in the ctor signature
+        pytest.skip(f"{kind}(**{sorted(kwargs)}) rejected by this ttnn build: {exc}")
+
+
+# =============================================================================
+# Input tensors
+# =============================================================================
+
+
+def _numel(shape):
+    return math.prod(shape) if shape else 1
+
+
+def _zeros(spec, case):
+    return torch.zeros(spec["shape"], dtype=torch.int32)
+
+
+def _arange_pages(spec, case):
+    """Page table: distinct page ids, one per entry (values must index the cache)."""
+    n = _numel(spec["shape"])
+    return torch.arange(n, dtype=torch.int32).reshape(spec["shape"])
+
+
+def _small_position(spec, case):
+    """cur_pos / update_idxs: a valid, small KV position for every user."""
+    return torch.full(spec["shape"], 8, dtype=torch.int32)
+
+
+def _embedding_ids(spec, case):
+    """Token ids must be < the embedding table's row count (args[1] is the table)."""
+    table = case["args"][1]
+    rows = table["shape"][-2]
+    return torch.randint(0, rows, spec["shape"], dtype=torch.int32)
+
+
+# A cache write is checked by looking for this value in the cache afterwards, so the
+# tensor written into the cache is filled with it instead of random noise. It has to
+# be a value the surrounding random data (standard normal, so |x| < 6) cannot produce
+# even once across a multi-million-element cache, or the count below is meaningless.
+# A power of two is exact in bfloat16/bfloat8_b, and the tolerance is one bfloat8_b
+# mantissa step at this exponent (1024/128), which covers a block-float round-trip.
+CACHE_SENTINEL = 1024.0
+_CACHE_SENTINEL_TOL = 8.0
+
+
+def _cache_sentinel(spec, case):
+    """The tensor a paged-cache op writes: a value we can look for afterwards."""
+    return torch.full(spec["shape"], CACHE_SENTINEL, dtype=torch.bfloat16)
+
+
+# (op name, argument key) -> value generator. Random data in an index tensor
+# faults the device, so these are the ops where values carry meaning.
+INDEX_VALUES = {
+    ("ttnn.embedding", "0"): _embedding_ids,
+    ("ttnn.experimental.paged_update_cache", "1"): _cache_sentinel,
+    ("ttnn.experimental.paged_update_cache", "page_table"): _arange_pages,
+    ("ttnn.experimental.paged_update_cache", "update_idxs_tensor"): _small_position,
+    ("ttnn.experimental.paged_fill_cache", "1"): _cache_sentinel,
+    ("ttnn.experimental.paged_fill_cache", "2"): _arange_pages,
+    ("ttnn.transformer.paged_scaled_dot_product_attention_decode", "page_table_tensor"): _arange_pages,
+    ("ttnn.transformer.paged_scaled_dot_product_attention_decode", "cur_pos_tensor"): _small_position,
+}
+
+
+def _torch_data(spec, case, op_name, key):
+    hook = INDEX_VALUES.get((op_name, key))
+    if hook is not None:
+        return hook(spec, case)
+    if spec["dtype"] in _INT_DTYPES:
+        return _zeros(spec, case)
+    return U.torch_rand(spec["shape"])
+
+
+# Ops that take a HOST tensor: the capture records the argument's spec after the
+# upload, so uploading it here first would hand the op a tensor already on device.
+HOST_INPUT = {("ttnn.to_device", "0")}
+
+
+def _rows_of(shape):
+    return math.prod(shape[:-1]) if len(shape) > 1 else 1
+
+
+def _shard_row_capacity(mem):
+    """How many rows the captured shard region holds (vs the tensor's logical rows)."""
+    shard = mem["shard"]
+    cores = sum((x1 - x0 + 1) * (y1 - y0 + 1) for x0, y0, x1, y1 in shard["grid"])
+    shard_h = shard["shape"][0]
+    return shard_h * cores if mem["layout"] == "HEIGHT_SHARDED" else shard_h
+
+
+def _is_partial_shard(spec):
+    """True when the logical shape does not fill its shard region.
+
+    The model reaches this state by sharding a small tensor into a tile-sized shard
+    — e.g. rope's cos/sin at logical [1, 1, 1, 64] inside a 32x64 shard, or decode's
+    8 KV heads inside a 32-row shard. Handing such a memory config straight to
+    ``from_torch`` pads the *logical* shape up to the shard, which changes what the
+    op computes (rope then returns 32 rows instead of the captured 8). Building
+    interleaved first and relaying out keeps the logical shape intact.
+    """
+    mem = spec.get("mem")
+    if not mem or not mem.get("shard"):
+        return False
+    return _rows_of(spec["shape"]) < _shard_row_capacity(mem)
+
+
+def build_tensor(spec, mesh_device, case, op_name, key):
+    """Materialize one captured input tensor. Returns (ttnn tensor, torch source)."""
+    data = _torch_data(spec, case, op_name, key)
+    if (op_name, key) in HOST_INPUT:
+        return ttnn.from_torch(data, dtype=DTYPE[spec["dtype"]], layout=LAYOUT[spec["layout"]]), data
+
+    memory_config = build_memory_config(spec.get("mem"), mesh_device) or ttnn.DRAM_MEMORY_CONFIG
+    partial = _is_partial_shard(spec)
+    tt = ttnn.from_torch(
+        data,
+        dtype=DTYPE[spec["dtype"]],
+        layout=LAYOUT[spec["layout"]],
+        device=mesh_device,
+        # a partially filled shard is reached in two steps, see _is_partial_shard
+        memory_config=ttnn.DRAM_MEMORY_CONFIG if partial else memory_config,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh_device),
+    )
+    if partial:
+        tt = ttnn.to_memory_config(tt, memory_config)
+    return tt, data
+
+
+def _build_value(spec, mesh_device, case, op_name, key, torch_sink):
+    """Turn one captured argument spec into the object to pass to the op."""
+    kind = spec["k"]
+    if kind == "t":
+        tt, data = build_tensor(spec, mesh_device, case, op_name, key)
+        torch_sink[key] = data
+        return tt
+    if kind == "tlist":
+        out = []
+        for i, sub in enumerate(spec["tensors"]):
+            tt, data = build_tensor(sub, mesh_device, case, op_name, f"{key}[{i}]")
+            torch_sink[f"{key}[{i}]"] = data
+            out.append(tt)
+        return out
+    if kind == "mem":
+        return build_memory_config(spec, mesh_device)
+    if kind == "cfg":
+        return build_program_config(spec)
+    if kind == "tile":
+        # gpt-oss's sparse_matmul passes an explicit output_tile; the capture records its repr.
+        return ttnn.Tile(spec["shape"])
+    if kind == "dtype":
+        return DTYPE[spec["v"]]
+    if kind == "layout":
+        return LAYOUT[spec["v"]]
+    if kind == "acts":
+        return [getattr(ttnn.UnaryOpType, name) for name in spec["v"]]
+    if kind == "device":
+        return mesh_device
+    if kind == "lit":
+        return spec["v"]
+    if kind == "slices":
+        return tuple(slice(*s) if isinstance(s, (list, tuple)) else s for s in spec["v"])
+    if kind == "skip":
+        pytest.skip(f"argument {key} is not reconstructible from the capture: {spec.get('repr', '')[:120]}")
+    raise AssertionError(f"unknown argument kind {kind!r}")
+
+
+# =============================================================================
+# Golden references
+# =============================================================================
+
+
+def _silu(x):
+    return torch.nn.functional.silu(x)
+
+
+_ACTIVATIONS = {"SILU": _silu, "RELU": torch.relu, "GELU": torch.nn.functional.gelu}
+
+
+def _apply_activations(x, acts):
+    for name in acts or ():
+        fn = _ACTIVATIONS.get(name)
+        if fn is None:
+            return None  # unknown activation -> no golden
+        x = fn(x)
+    return x
+
+
+def _ref_identity(inputs, kwargs, case):
+    """Ops that move/relayout data without changing it."""
+    return inputs["0"]
+
+
+def _ref_matmul(inputs, kwargs, case):
+    return inputs["0"].float() @ inputs["1"].float()
+
+
+def _second_operand(inputs, case):
+    """The right-hand operand of a binary op: a tensor, or a captured scalar literal.
+
+    ``ttnn.multiply(cache, 0, output_tensor=cache)`` — the demo's KV-cache reset — passes
+    a python scalar, which never becomes a torch input, so ``inputs`` holds only arg 0.
+    Returns None when arg 1 is neither, so the case falls back to the structural checks.
+    """
+    if "1" in inputs:
+        return inputs["1"].float()
+    spec = case["args"][1] if len(case["args"]) > 1 else None
+    if spec is None or spec.get("k") != "lit" or not isinstance(spec.get("v"), (int, float)):
+        return None
+    return float(spec["v"])
+
+
+def _ref_binary(fn):
+    def ref(inputs, kwargs, case):
+        a = inputs["0"].float()
+        b = _second_operand(inputs, case)
+        if b is None:
+            return None
+        acts = case["kwargs"].get("input_tensor_a_activations")
+        if acts is not None:
+            a = _apply_activations(a, acts.get("v"))
+            if a is None:
+                return None
+        return fn(a, b)
+
+    return ref
+
+
+def _ref_transpose(inputs, kwargs, case):
+    dims = [a["v"] for a in case["args"][1:] if a["k"] == "lit"]
+    if len(dims) != 2:
+        return None
+    return inputs["0"].float().transpose(dims[0], dims[1])
+
+
+def _ref_concat(inputs, kwargs, case):
+    dim = case["kwargs"].get("dim", {}).get("v")
+    if dim is None:
+        return None
+    # keys are "0[0]", "0[1]", … — filter before sorting on the list index
+    keys = [k for k in inputs if k.startswith("0[")]
+    keys.sort(key=lambda s: int(s.split("[")[1].rstrip("]")))
+    return torch.cat([inputs[k].float() for k in keys], dim=dim)
+
+
+def _ref_slice(inputs, kwargs, case):
+    lits = [a["v"] for a in case["args"][1:] if a["k"] == "lit"]
+    if len(lits) != 2:
+        return None
+    start, end = lits
+    x = inputs["0"].float()
+    if len(start) != x.dim():
+        return None
+    return x[tuple(slice(s, e) for s, e in zip(start, end))]
+
+
+def _ref_getitem(inputs, kwargs, case):
+    key = next((a for a in case["args"][1:] if a["k"] == "slices"), None)
+    if key is None:
+        return None
+    return inputs["0"].float()[tuple(slice(*s) for s in key["v"])]
+
+
+def _ref_rms_norm(inputs, kwargs, case):
+    x = inputs["0"].float()
+    weight = inputs.get("weight")
+    eps = case["kwargs"].get("epsilon", {}).get("v", 1e-5)
+    gamma = weight.float().reshape(-1)[: x.shape[-1]] if weight is not None else None
+    normed = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    return normed * gamma if gamma is not None else normed
+
+
+def _ref_embedding(inputs, kwargs, case):
+    ids = inputs["0"].long()
+    table = inputs["1"].float()
+    return torch.nn.functional.embedding(ids.reshape(-1), table.reshape(-1, table.shape[-1]))
+
+
+def _out_shapes(case):
+    """Captured output shapes, or None when any of them was never observed."""
+    outs = case.get("outs") or []
+    if not outs or any(o is None for o in outs):
+        return None
+    return [tuple(o["shape"]) for o in outs]
+
+
+def _ref_view(inputs, kwargs, case):
+    """Ops that reinterpret the same row-major data: reshape, unsqueeze_to_4D.
+
+    The captured output shape is the reference: same elements, same order. It can be
+    *smaller* than the input — ``ttnn.reshape(x, (1,1,1,3072), (1,1,32,3072))`` keeps
+    one logical row of a batch-padded decode tensor — in which case the reference is
+    the leading elements, which is where row-major puts that row.
+    """
+    shapes = _out_shapes(case)
+    if not shapes:
+        return None
+    flat = inputs["0"].float().reshape(-1)
+    n = math.prod(shapes[0])
+    if n > flat.numel():
+        return None  # output larger than the input: the extra is padding we cannot define
+    return flat[:n].reshape(shapes[0])
+
+
+# The head ops below mirror the references the hand-written tests/ops suite verified
+# on hardware — test_nlp_create_qkv_heads.py:57-60, test_nlp_create_qkv_heads_decode.py:110-113,
+# test_nlp_concat_heads.py:51 — so a permutation or a mis-split of the fused QKV is
+# caught here too, instead of only shape/dtype. Each returns None if the captured
+# shapes do not match the layout it models, so an unfamiliar capture falls back to the
+# structural checks rather than failing against a reference that does not apply.
+def _qkv_dims(x, shapes):
+    """(batch/seq-carrying view, q_dim, kv_dim) for a fused-QKV split, or None."""
+    if len(shapes) != 3:
+        return None
+    q_shape, k_shape, v_shape = shapes
+    if k_shape != v_shape or len(q_shape) != 4 or len(k_shape) != 4:
+        return None
+    head_dim = q_shape[3]
+    q_dim, kv_dim = q_shape[1] * head_dim, k_shape[1] * head_dim
+    return (q_dim, kv_dim) if x.shape[-1] == q_dim + 2 * kv_dim else None
+
+
+def _ref_create_qkv_heads(inputs, kwargs, case):
+    """Prefill: [1,1,seq,QKV] -> Q [1,heads,seq,hd], K/V [1,kv_heads,seq,hd]."""
+    shapes = _out_shapes(case)
+    if not shapes:
+        return None
+    x = inputs["0"].float()
+    dims = _qkv_dims(x, [(s[0], s[1], s[2], s[3]) for s in shapes])
+    if dims is None or case["kwargs"].get("transpose_k_heads", {}).get("v") is not False:
+        return None
+    q_dim, kv_dim = dims
+    seq = shapes[0][2]
+
+    def heads(chunk, count):
+        return chunk.reshape(1, seq, count, shapes[0][3]).permute(0, 2, 1, 3)
+
+    return [
+        heads(x[..., :q_dim], shapes[0][1]),
+        heads(x[..., q_dim : q_dim + kv_dim], shapes[1][1]),
+        heads(x[..., q_dim + kv_dim :], shapes[2][1]),
+    ]
+
+
+def _ref_create_qkv_heads_decode(inputs, kwargs, case):
+    """Decode: [1,1,batch,QKV] -> Q [1,batch,heads,hd], K/V [1,batch,kv_heads,hd]."""
+    shapes = _out_shapes(case)
+    if not shapes or len(shapes[0]) != 4:
+        return None
+    x = inputs["0"].float()
+    batch, n_heads, head_dim = shapes[0][1], shapes[0][2], shapes[0][3]
+    n_kv = shapes[1][2]
+    q_dim, kv_dim = n_heads * head_dim, n_kv * head_dim
+    if x.shape[-1] != q_dim + 2 * kv_dim or x.shape[2] < batch:
+        return None
+    rows = x[:, :, :batch, :]
+    return [
+        rows[..., :q_dim].reshape(1, batch, n_heads, head_dim),
+        rows[..., q_dim : q_dim + kv_dim].reshape(1, batch, n_kv, head_dim),
+        rows[..., q_dim + kv_dim :].reshape(1, batch, n_kv, head_dim),
+    ]
+
+
+def _ref_concat_heads(inputs, kwargs, case):
+    """Prefill: [1,heads,seq,hd] -> [1,1,seq,heads*hd]."""
+    x = inputs["0"].float()
+    if x.dim() != 4:
+        return None
+    _, n_heads, seq, head_dim = x.shape
+    return x.permute(0, 2, 1, 3).reshape(1, 1, seq, n_heads * head_dim)
+
+
+def _ref_concat_heads_decode(inputs, kwargs, case):
+    """Decode: [1,batch,heads,hd] -> [1,1,batch,heads*hd] (batch padded in the output).
+
+    The captured output is padded up to a tile row, so the reference covers only the
+    real batch; ``assert_pcc`` compares it against the leading elements, which is
+    where row-major puts those users.
+    """
+    x = inputs["0"].float()
+    n_heads = case["kwargs"].get("num_heads", {}).get("v")
+    if x.dim() != 4 or n_heads is None or x.shape[2] != n_heads:
+        return None
+    batch, head_dim = x.shape[1], x.shape[3]
+    return x.reshape(1, 1, batch, n_heads * head_dim)
+
+
+def _ref_layer_norm(inputs, kwargs, case):
+    """LayerNorm over the last dim (the vision tower's norm).
+
+    weight/bias arrive tile-padded exactly as rms_norm's gamma does, so they are
+    flattened and trimmed to the normalized width the same way.
+    """
+    x = inputs["0"].float()
+    eps = case["kwargs"].get("epsilon", {}).get("v", 1e-5)
+    width = x.shape[-1]
+    out = (x - x.mean(-1, keepdim=True)) * torch.rsqrt(x.var(-1, unbiased=False, keepdim=True) + eps)
+    weight, bias = inputs.get("weight"), inputs.get("bias")
+    if weight is not None:
+        out = out * weight.float().reshape(-1)[:width]
+    if bias is not None:
+        out = out + bias.float().reshape(-1)[:width]
+    return out
+
+
+def _ref_split(inputs, kwargs, case):
+    """``ttnn.split(x, split_size, dim=d)`` -> the same chunks torch.split returns."""
+    x = inputs["0"].float()
+    lits = [a["v"] for a in case["args"][1:] if a["k"] == "lit"]
+    dim = case["kwargs"].get("dim", {}).get("v")
+    if not lits or dim is None or x.shape[dim] % lits[0]:
+        return None
+    return list(torch.split(x, lits[0], dim=dim))
+
+
+def _ref_plus_one(inputs, kwargs, case):
+    """Increment, in place. ``skip_negative_entries`` leaves entries below zero alone."""
+    x = inputs["0"].float()
+    if case["kwargs"].get("skip_negative_entries", {}).get("v"):
+        return torch.where(x < 0, x, x + 1.0)
+    return x + 1.0
+
+
+def _ref_expand(inputs, kwargs, case):
+    """Broadcast to the requested shape (-1 keeps the input's extent on that dim)."""
+    x = inputs["0"].float()
+    target = next((a["v"] for a in case["args"][1:] if a["k"] == "lit"), None)
+    if target is None:
+        return None
+    target = list(target) if isinstance(target, (list, tuple)) else [target]
+    if len(target) != x.dim():
+        return None
+    return x.expand(*target).contiguous()
+
+
+def _ref_zeros_like(inputs, kwargs, case):
+    return torch.zeros_like(inputs["0"].float())
+
+
+def _ref_mesh_partition(inputs, kwargs, case):
+    """Identity on the single-device mesh the capture ran on.
+
+    ``ttnn::mesh_partition`` returns its input unchanged when the cluster axis holds
+    one device (mesh_partition.cpp:17). On a larger mesh it really partitions, so the
+    reference applies only while the captured output keeps the input's shape.
+    """
+    shapes = _out_shapes(case)
+    x = inputs["0"]
+    if not shapes or tuple(x.shape) != shapes[0]:
+        return None
+    return x
+
+
+def _ref_sigmoid(inputs, kwargs, case):
+    return torch.sigmoid(inputs["0"].float())
+
+
+def _ref_softmax(inputs, kwargs, case):
+    """Router softmax over the captured dim (numeric_stable does not change the value)."""
+    dim = case["kwargs"].get("dim", {}).get("v")
+    if dim is None:
+        return None
+    return torch.softmax(inputs["0"].float(), dim=dim)
+
+
+def _ref_clamp(inputs, kwargs, case):
+    """The SwiGLU limit clamp; either bound may be absent (captured as None)."""
+    low = case["kwargs"].get("min", {}).get("v")
+    high = case["kwargs"].get("max", {}).get("v")
+    if low is None and high is None:
+        return None
+    return torch.clamp(inputs["0"].float(), min=low, max=high)
+
+
+def _ref_permute(inputs, kwargs, case):
+    dims = next((a["v"] for a in case["args"][1:] if a["k"] == "lit"), None)
+    if dims is None or len(dims) != inputs["0"].dim():
+        return None
+    return inputs["0"].float().permute(*dims).contiguous()
+
+
+def _ref_repeat(inputs, kwargs, case):
+    reps = next((a["v"] for a in case["args"][1:] if a["k"] == "lit"), None)
+    if reps is None or len(reps) != inputs["0"].dim():
+        return None
+    return inputs["0"].float().repeat(*reps)
+
+
+def _ref_sum(inputs, kwargs, case):
+    dim = case["kwargs"].get("dim", {}).get("v")
+    if dim is None:
+        return None
+    keepdim = bool(case["kwargs"].get("keepdim", {}).get("v", False))
+    return torch.sum(inputs["0"].float(), dim=dim, keepdim=keepdim)
+
+
+def _ref_fast_reduce_nc(inputs, kwargs, case):
+    """Sum over the named dims, keeping them.
+
+    gpt-oss uses it as ``reduce_experts`` (experts/operations.py:66): each expert's output is
+    already scaled by its routing weight, so combining them is a sum over the expert dim.
+    """
+    dims = case["kwargs"].get("dims", {}).get("v")
+    if dims is None:
+        return None
+    return torch.sum(inputs["0"].float(), dim=tuple(dims), keepdim=True)
+
+
+# Ops whose output is a deterministic function of the inputs we generated. A
+# reference here is worth more than the structural checks: it catches a permutation,
+# a mis-split or a wrong reduction that every shape/dtype/placement assertion passes.
+#
+# Everything absent from this table is checked for shape / dtype / placement /
+# finiteness only. What is left out, and why:
+#   * rope — the Meta-format cos/sin plus the tile-wise transformation matrix make a
+#     torch reference fiddly and easy to get subtly wrong; the hand-written
+#     tests/ops/test_rotary_embedding_llama.py:33 came to the same conclusion;
+#   * SDPA — the captured page tables/positions describe the KV geometry, but a
+#     reference would have to reimplement chunked flash attention;
+#   * the paged caches — value semantics are checked by POSTCONDITION instead, which
+#     verifies the write landed where the page table says it should;
+#   * argmax — random bfloat16 logits tie at the maximum often enough that the index
+#     torch picks and the index the op picks are both correct and different;
+#   * scatter and pad — the index/pad-value semantics would have to be re-derived, and
+#     a reference that is subtly wrong is worse than the structural checks;
+#   * topk — random bfloat16 values tie often enough that the indices torch returns and the ones
+#     the op returns are both correct and different (the same reason argmax has no reference);
+#   * sparse_matmul — the result depends on the sparsity tensor's routing semantics, which the
+#     capture records as data rather than meaning.
+GOLDEN = {
+    "ttnn.to_memory_config": _ref_identity,
+    "ttnn.to_device": _ref_identity,
+    "ttnn.sharded_to_interleaved": _ref_identity,
+    "ttnn.interleaved_to_sharded": _ref_identity,
+    "ttnn.untilize": _ref_identity,
+    "ttnn.typecast": _ref_identity,
+    "ttnn.linear": _ref_matmul,
+    "ttnn.experimental.minimal_matmul": _ref_matmul,
+    "ttnn.add": _ref_binary(torch.add),
+    "ttnn.multiply": _ref_binary(torch.mul),
+    "ttnn.transpose": _ref_transpose,
+    "ttnn.concat": _ref_concat,
+    "ttnn.slice": _ref_slice,
+    "ttnn.Tensor.__getitem__": _ref_getitem,
+    "ttnn.rms_norm": _ref_rms_norm,
+    "ttnn.embedding": _ref_embedding,
+    "ttnn.reshape": _ref_view,
+    "ttnn.unsqueeze_to_4D": _ref_view,
+    "ttnn.experimental.nlp_create_qkv_heads": _ref_create_qkv_heads,
+    "ttnn.experimental.nlp_create_qkv_heads_decode": _ref_create_qkv_heads_decode,
+    "ttnn.experimental.nlp_concat_heads": _ref_concat_heads,
+    "ttnn.experimental.nlp_concat_heads_decode": _ref_concat_heads_decode,
+    "ttnn.matmul": _ref_matmul,
+    "ttnn.sigmoid": _ref_sigmoid,
+    "ttnn.softmax": _ref_softmax,
+    "ttnn.clamp": _ref_clamp,
+    "ttnn.permute": _ref_permute,
+    "ttnn.repeat": _ref_repeat,
+    "ttnn.sum": _ref_sum,
+    "ttnn.experimental.fast_reduce_nc": _ref_fast_reduce_nc,
+    "ttnn.to_layout": _ref_identity,
+    "ttnn.unsqueeze": _ref_view,
+    "ttnn.layer_norm": _ref_layer_norm,
+    "ttnn.split": _ref_split,
+    "ttnn.plus_one": _ref_plus_one,
+    "ttnn.expand": _ref_expand,
+    "ttnn.zeros_like": _ref_zeros_like,
+    "ttnn.mesh_partition": _ref_mesh_partition,
+}
+
+
+# =============================================================================
+# Derived expectations (for outputs the capture never observed)
+# =============================================================================
+
+# An op's output spec is recovered only if that tensor is used again later in the
+# capture. When it is not (``outs`` entry is None), shape/dtype/layout/placement
+# would go unchecked and an op that returned its input untouched would pass on
+# finiteness alone — which is precisely what an identity PCC cannot catch either.
+# So what the *call itself* pins down is reconstructed instead:
+#
+#   * a ``memory_config`` argument is where the output must land, by definition;
+#   * a layout-changing op fixes the output layout whatever else is unknown;
+#   * a relayout/move op preserves the input's shape.
+#
+# Nothing here is a guess about the op's semantics: each rule is a property of the
+# call as written. Anything not derivable stays unchecked (see POSTCONDITION for
+# the ops whose real content check needs more than metadata).
+
+_OUTPUT_LAYOUT = {
+    "ttnn.untilize": "ROW_MAJOR",
+    "ttnn.untilize_with_unpadding": "ROW_MAJOR",
+    "ttnn.tilize": "TILE",
+    "ttnn.tilize_with_val_padding": "TILE",
+}
+
+# Ops that move or relayout data without reshaping it (the identity goldens).
+_SHAPE_PRESERVING = frozenset(op for op, ref in GOLDEN.items() if ref is _ref_identity)
+
+
+def _derived_spec(case, op_name, index):
+    """What the call itself says the output must be; {} when it says nothing."""
+    spec = {}
+
+    first = case["args"][0] if case["args"] else None
+    if index == 0 and op_name in _SHAPE_PRESERVING and first is not None and first["k"] == "t":
+        spec["shape"] = first["shape"]
+
+    layout = _OUTPUT_LAYOUT.get(op_name)
+    if layout is None:
+        layout = next((v["v"] for v in case["kwargs"].values() if v["k"] == "layout"), None)
+    if layout is not None:
+        spec["layout"] = layout
+
+    dtype = next((v["v"] for v in case["kwargs"].values() if v["k"] == "dtype"), None)
+    if dtype is not None:
+        spec["dtype"] = dtype
+
+    mem = case["kwargs"].get("memory_config")
+    if mem is not None and mem["k"] == "mem":
+        spec["mem"] = {"layout": mem["layout"], "buffer": mem["buffer"], "shard": mem.get("shard")}
+
+    return spec
+
+
+# =============================================================================
+# Postconditions (ops whose result metadata alone cannot show they did anything)
+# =============================================================================
+
+
+# Paged KV cache layout, from the op's own tests
+# (tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py:449-530
+# for the decode update, :641-700 for the prefill fill):
+#
+#   cache      [max_num_blocks, n_heads, block_size, head_dim]   (physical pages)
+#   page_table [num_users, max_num_blocks_per_seq]               virtual -> physical
+#   token at position p of user b lives in page_table[b, p // block_size], slot p % block_size
+#
+# The suite generates both the page table (``_arange_pages``) and the positions
+# (``_small_position``), so the destination is known and can be asserted, not just
+# the amount written. If a capture ever has a geometry this does not describe, the
+# region comes back None and only the count is checked.
+def _paged_write_region(torch_inputs, case, op_name, cache_shape):
+    """Mask of the cache cells this call must write, or None if not modelled."""
+    if len(cache_shape) != 4:
+        return None
+    n_pages, cache_heads, block_size, head_dim = cache_shape
+    update = case["args"][1]["shape"]
+    if len(update) != 4 or update[3] != head_dim:
+        return None
+    mask = torch.zeros(cache_shape, dtype=torch.bool)
+
+    if op_name.endswith("paged_update_cache"):
+        page_table = torch_inputs.get("page_table")
+        positions = torch_inputs.get("update_idxs_tensor")
+        if page_table is None or positions is None:
+            return None
+        batch, heads = update[1], update[2]
+        if heads > cache_heads:
+            return None
+        page_table = page_table.reshape(batch, -1)
+        positions = positions.reshape(-1)
+        for user in range(batch):
+            pos = int(positions[user])
+            block = pos // block_size
+            if block >= page_table.shape[1]:
+                return None
+            page = int(page_table[user, block])
+            if not 0 <= page < n_pages:
+                return None
+            mask[page, :heads, pos % block_size, :] = True
+        return mask
+
+    # paged_fill_cache(cache, x, page_table, batch_idx=user): the whole sequence.
+    page_table = torch_inputs.get("2")
+    if page_table is None:
+        return None
+    user = case["kwargs"].get("batch_idx", {}).get("v", 0)
+    heads, seq = update[1], update[2]
+    if heads > cache_heads or page_table.dim() != 2 or user >= page_table.shape[0]:
+        return None
+    for start in range(0, seq, block_size):
+        block = start // block_size
+        if block >= page_table.shape[1]:
+            return None
+        page = int(page_table[user, block])
+        if not 0 <= page < n_pages:
+            return None
+        mask[page, :heads, : min(block_size, seq - start), :] = True
+    return mask
+
+
+def _check_cache_written(args, torch_inputs, case, op_name, mesh_device):
+    """A paged-cache op must write what it was given, where the page table says.
+
+    The capture never sees these outputs again, so without this the case passes as
+    long as the (unchanged, finite) cache comes back. The tensor being written is
+    filled with ``CACHE_SENTINEL`` instead of noise, so the write is visible in the
+    cache afterwards — and since the page table and positions are generated here, so
+    is the destination: a write to the wrong page or slot shows up as sentinel values
+    outside the region, which is what the second assertion is for.
+    """
+    cache_shape = case["args"][0]["shape"]
+    host = from_tt(args[0], mesh_device)
+    hits = (host - CACHE_SENTINEL).abs() <= _CACHE_SENTINEL_TOL
+
+    region = _paged_write_region(torch_inputs, case, op_name, cache_shape)
+    if region is None or host.numel() != region.numel():
+        want = _numel(case["args"][1]["shape"])
+        written = int(hits.sum())
+        assert written >= want, (
+            f"{op_name}: {written} of the {want} written value(s) are in the cache afterwards "
+            f"— the op did not write what it was given (cache holds {host.numel()} elements)"
+        )
+        return
+
+    hits = hits.reshape(cache_shape)
+    want = int(region.sum())
+    inside = int((hits & region).sum())
+    outside = int((hits & ~region).sum())
+    assert inside == want, (
+        f"{op_name}: {inside} of the {want} cell(s) the page table maps hold the written value "
+        f"— the op did not write the region "
+        f"[pages/heads/slots the generated page table and positions select] (see _paged_write_region)"
+    )
+    assert outside == 0, (
+        f"{op_name}: {outside} written value(s) landed outside the region the page table maps "
+        f"— wrong page or slot (see _paged_write_region for the layout this assumes)"
+    )
+
+
+POSTCONDITION = {
+    "ttnn.experimental.paged_update_cache": _check_cache_written,
+    "ttnn.experimental.paged_fill_cache": _check_cache_written,
+}
+
+
+# =============================================================================
+# Case runner
+# =============================================================================
+
+
+def _input_elements(case):
+    """Total elements across all captured input tensors."""
+    total = 0
+    for spec in list(case["args"]) + list(case["kwargs"].values()):
+        if spec.get("k") == "t":
+            total += _numel(spec["shape"])
+        elif spec.get("k") == "tlist":
+            total += sum(_numel(s["shape"]) for s in spec["tensors"])
+    return total
+
+
+def _check_finite(host, case, op_name, index):
+    """Assert the region the op can actually define is finite.
+
+    An output with more elements than *all* of its inputs combined cannot be fully
+    written by any implementation — decode ops are the common case, where a batch-1
+    result lives in a tensor padded to 32 tile rows and the remaining rows keep
+    whatever the L1 shard held before. Requiring every element to be finite would
+    fail on that untouched padding forever.
+
+    So for those outputs the check narrows to the *leading* elements the inputs can
+    account for. Row-major puts the logical data first (user 0's row, the first
+    head, …), which is exactly the region the op writes; a NaN/Inf there still
+    fails, and checking the leading slice rather than merely counting finite values
+    means finite garbage in the padding cannot mask it.
+    """
+    finite = torch.isfinite(host)
+    n_finite, n_total = int(finite.sum()), host.numel()
+    if n_finite == n_total:
+        return
+
+    budget = _input_elements(case)
+    if n_total > budget:
+        head = finite.reshape(-1)[:budget]
+        bad = int(head.numel() - head.sum())
+        if bad == 0:
+            return  # only the padding the op cannot define is non-finite
+        assert False, (
+            f"{op_name}: output[{index}] has {bad} non-finite value(s) in the leading {budget} "
+            f"element(s) the op must define ({n_total - n_finite} of {n_total} non-finite overall; "
+            f"the tail beyond {budget} is batch/tile padding the op does not write)"
+        )
+
+    assert False, (
+        f"{op_name}: output[{index}] has {n_total - n_finite} non-finite of {n_total} element(s) "
+        f"(inputs account for {budget}, so the whole output should be written)"
+    )
+
+
+def _check_placement(got, spec, mesh_device, op_name, index, source="captured"):
+    """Assert the output landed in the expected layout / buffer type / shard.
+
+    Without this a no-op ``to_memory_config`` or ``interleaved_to_sharded`` — one
+    that hands back its input untouched — passes on shape and dtype alone, which is
+    exactly the regression those cases exist to catch.
+
+    The shard *detail* (grid, per-core shape, orientation) is compared only when the
+    expected grid exists on this device: on a smaller device the op derives its own
+    grid, and the capture's absolute core coordinates are then not the answer to
+    compare against (the memory layout and buffer type still are).
+    """
+    if "layout" in spec:
+        want_layout = LAYOUT[spec["layout"]]
+        assert got.layout == want_layout, f"{op_name}: output[{index}] layout {got.layout} != {source} {want_layout}"
+
+    mem = spec.get("mem")
+    if mem is None or not ttnn.is_tensor_storage_on_device(got):
+        return
+
+    got_mem = got.memory_config()
+    want_mem_layout = MEM_LAYOUT[mem["layout"]]
+    assert got_mem.memory_layout == want_mem_layout, (
+        f"{op_name}: output[{index}] memory layout {got_mem.memory_layout} != {source} {want_mem_layout} "
+        f"— the op did not place its output where the model expects it"
+    )
+    want_buffer = BUFFER_TYPE[mem["buffer"]]
+    assert (
+        got_mem.buffer_type == want_buffer
+    ), f"{op_name}: output[{index}] buffer type {got_mem.buffer_type} != {source} {want_buffer}"
+
+    if mem.get("shard") is None or not _shard_grid_fits(mem, mesh_device)[0]:
+        return
+    want_mem = build_memory_config(mem, mesh_device)
+    assert got_mem == want_mem, f"{op_name}: output[{index}] memory config {got_mem} != {source} {want_mem}"
+
+
+def _check_output(out, case, mesh_device, op_name):
+    """Check every returned tensor against its captured spec, then its values.
+
+    ``case["outs"]`` holds one spec per tensor the op returned in the capture, in
+    order — multi-output ops (``nlp_create_qkv_heads``: Q, K, V) get all of theirs
+    checked, not just the first. An entry is None when that output was never
+    consumed again in the capture, so its spec was never observed; the entry is
+    still present, which is what makes the output *count* checkable, and the checks
+    fall back to ``_derived_spec`` rather than to nothing.
+    """
+    expected = case.get("outs") or []
+    tensors = list(out) if isinstance(out, (list, tuple)) else [out]
+
+    if expected:
+        assert len(tensors) == len(
+            expected
+        ), f"{op_name}: op returned {len(tensors)} tensor(s), capture recorded {len(expected)}"
+
+    for i, got in enumerate(tensors):
+        spec = expected[i] if i < len(expected) else None
+        source = "captured"
+        if spec is None:
+            # Fall back to what the call itself pins down, so an unobserved output
+            # is still held to its memory config / layout / shape (see _derived_spec).
+            spec, source = _derived_spec(case, op_name, i), "implied by the call"
+        if not spec:
+            continue
+
+        if "shape" in spec:
+            want_shape = tuple(spec["shape"])
+            assert (
+                tuple(got.shape) == want_shape
+            ), f"{op_name}: output[{i}] shape {tuple(got.shape)} != {source} {want_shape}"
+        if "dtype" in spec:
+            want_dtype = DTYPE[spec["dtype"]]
+            assert got.dtype == want_dtype, f"{op_name}: output[{i}] dtype {got.dtype} != {source} {want_dtype}"
+        _check_placement(got, spec, mesh_device, op_name, i, source)
+
+    for i, t in enumerate(tensors):
+        _check_finite(from_tt(t, mesh_device), case, op_name, i)
+
+
+def _golden_pcc(case, op_name):
+    """Floor for this case: 0.999 unless the call itself costs precision.
+
+    Every reason to go below the bar is spelled out where the tables are defined
+    (``_PCC_BY_DTYPE`` / ``_PCC_BY_OP`` / ``_DEEP_K``); the lowest applicable floor
+    wins, so a bfloat8_b matmul is judged on its dtype rather than its op.
+    """
+    floors = [_DEFAULT_PCC, _PCC_BY_OP.get(op_name, _DEFAULT_PCC)]
+
+    dtypes = [out["dtype"] for out in case.get("outs") or [] if out is not None]
+    dtypes += [a["dtype"] for a in case["args"] if a["k"] == "t"]
+    floors += [_PCC_BY_DTYPE.get(d, _DEFAULT_PCC) for d in dtypes]
+
+    if op_name in _REDUCTION_OPS and case["args"] and case["args"][0]["k"] == "t":
+        shape = case["args"][0]["shape"]
+        if shape and shape[-1] >= _DEEP_K:
+            floors.append(_DEEP_K_PCC)
+
+    return min(floors)
+
+
+# Kwargs naming a destination the op writes into. When the captured call passed the same
+# tensor as argument 0 — ``ttnn.mul(k_cache, 0, output_tensor=k_cache)``, the demo's
+# KV-cache reset — the op runs in place, which is a different path through the op than
+# writing into a fresh buffer. A case keeps no tensor identity (``tensor_id`` is dropped
+# so repeated calls dedupe into one case), so an identical spec is the only signal left
+# that the two were one tensor; reuse argument 0 on that basis rather than allocating a
+# second destination and never exercising the alias. The cost of guessing wrong is
+# running an in-place call where the capture had two distinct same-shaped tensors.
+_DESTINATION_KWARGS = {"output_tensor"}
+
+
+def _aliased_arg(name, spec, case, args):
+    """Argument 0 when this destination kwarg is indistinguishable from it, else None."""
+    if name not in _DESTINATION_KWARGS or spec.get("k") != "t" or not case["args"]:
+        return None
+    return args[0] if case["args"][0] == spec else None
+
+
+def run_case(op, case, mesh_device, *, op_name=None, pcc=None):
+    """Materialize one captured call, run it, and check the result.
+
+    ``op`` is the callable (``ttnn.linear``, or a small lambda for operators like
+    ``Tensor.__getitem__``); ``case`` is one entry of a generated ``CASES`` list.
+    """
+    op_name = op_name or case["op"]
+    torch_inputs: dict[str, torch.Tensor] = {}
+
+    args = [_build_value(spec, mesh_device, case, op_name, str(i), torch_inputs) for i, spec in enumerate(case["args"])]
+    kwargs = {}
+    for name, spec in case["kwargs"].items():
+        alias = _aliased_arg(name, spec, case, args)
+        kwargs[name] = (
+            alias if alias is not None else _build_value(spec, mesh_device, case, op_name, name, torch_inputs)
+        )
+
+    out = op(*args, **kwargs)
+
+    _check_output(out, case, mesh_device, op_name)
+
+    post_fn = POSTCONDITION.get(op_name)
+    if post_fn is not None:
+        post_fn(args, torch_inputs, case, op_name, mesh_device)
+
+    ref_fn = None if NO_GOLDEN else GOLDEN.get(op_name)
+    if ref_fn is not None:
+        ref = ref_fn(torch_inputs, kwargs, case)
+        if ref is not None:
+            # A reference may cover every output (the qkv splits return Q, K and V),
+            # so compare position by position rather than only the first tensor.
+            refs = list(ref) if isinstance(ref, (list, tuple)) else [ref]
+            tensors = list(out) if isinstance(out, (list, tuple)) else [out]
+            floor = pcc or _golden_pcc(case, op_name)
+            for i, one in enumerate(refs):
+                if one is not None and i < len(tensors):
+                    U.assert_pcc(one, tensors[i], pcc=floor, mesh_device=mesh_device)
+
+    return out

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/op_utils.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/op_utils.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Runtime helpers for the GPT-OSS graph-capture-derived per-op suite (``tests/gpt_oss_ops/``).
+
+``graph_case.py`` is model-agnostic except for this module, which supplies the four things it
+needs: the ``ttnn_mesh_device`` parametrization helper, torch<->ttnn conversion, random tensor
+data, and the PCC assertion.
+
+As in the sibling ``tests/qwen3_vl_ops`` and ``tests/yolo_ops`` suites, these are re-exported from
+the llama op suite rather than duplicated -- they are arch- and model-agnostic (mesh composition,
+PCC), so one copy means a fidelity fix reaches every suite.
+
+The ``ttnn_mesh_device`` fixture itself comes from ``tests/conftest.py`` one level up, and
+``reset_seeds`` from the repo-root ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import pytest  # noqa: F401  (re-exported convenience for generated op files)
+import torch  # noqa: F401
+
+import ttnn  # noqa: F401
+
+from models.experimental.llama32_1b_quasar.tests.ops.op_utils import (  # noqa: F401
+    DEFAULT_MESH,
+    assert_pcc,
+    assert_shape_dtype,
+    comp_pcc,
+    from_tt,
+    to_tt,
+    torch_rand,
+    with_default_mesh,
+)
+
+# gpt-oss-20b, the model this suite's capture was taken from (configs/gpt-oss-20b/config.json).
+# Present so a generated case's shapes can be read against the config that produced them; nothing
+# here is used to build a case -- every number in a case comes from the capture.
+HF_MODEL = "gpt-oss-20b"
+
+DIM = 2880  # hidden_size
+N_LAYERS = 24
+N_HEADS = 64
+N_KV_HEADS = 8
+HEAD_DIM = 64
+INTERMEDIATE = 2880  # per-expert MLP width
+VOCAB = 201088
+
+NUM_EXPERTS = 32  # num_local_experts
+EXPERTS_PER_TOK = 4  # top-k routing

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/slim_python_io.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/slim_python_io.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shrink a ``graph_capture.python_io.json`` to the fields the generator reads.
+
+    python models/experimental/ops/quasar/tests/gpt_oss_ops/slim_python_io.py \
+        generated/ttnn/reports/<report>/graph_capture.python_io.json \
+        generated/ttnn/reports/<report>/graph_capture.python_io.slim.json
+
+Why this exists: a full Qwen3-VL demo run (200 generated tokens x 2 repeat batches x
+36 decoder layers) records ~750k python-level calls, and every record carries its own
+``captured_graph`` — the C++ node list for that one op. That field is ~97% of the
+bytes and ``generate_from_graph_capture.py`` never reads it (it uses ``name``,
+``arguments``, ``input_tensor_ids``, ``output_tensor_ids``). Dropping it took the
+Qwen3-VL capture from 5.0 GB to 1.1 GB, which is what makes the generator's
+read-it-all approach viable here.
+
+Every record is kept, so call counts in the generated cases stay exact.
+
+Streaming: the input is decoded one record at a time over a sliding buffer, so peak
+memory is the chunk size, not the file size. The llama suite's captures are ~100 MB
+and skip this step entirely -- the generator reads those directly.
+"""
+
+import json
+import sys
+
+# Fields generate_from_graph_capture.py reads (build_cases / iter_records).
+KEEP = ("name", "arguments", "input_tensor_ids", "output_tensor_ids")
+CHUNK = 64 << 20
+
+
+def stream_records(path):
+    """Yield each record of the top-level JSON array without holding the whole file.
+
+    Every way of running out of input is an error, never a quiet stop: a capture that
+    was truncated mid-write would otherwise slim down to a syntactically valid array of
+    fewer records, and the suite generated from it would silently be missing model calls
+    with no sign that anything went wrong.
+    """
+    decoder = json.JSONDecoder()
+    buf = ""
+    with open(path) as f:
+        while "[" not in buf:
+            chunk = f.read(1 << 16)
+            if not chunk:
+                raise ValueError(f"{path}: no JSON array found; not a python_io capture?")
+            buf += chunk
+        i = buf.index("[") + 1
+        while True:
+            while True:
+                while i < len(buf) and buf[i] in " \n\r\t,":
+                    i += 1
+                if i < len(buf) and buf[i] == "]":
+                    return
+                try:
+                    record, i = decoder.raw_decode(buf, i)
+                    break
+                except ValueError as exc:  # incomplete record: more input, or a bad file
+                    more = f.read(CHUNK)
+                    if not more:
+                        raise ValueError(f"{path}: input ended inside a record (truncated capture): {exc}") from exc
+                    buf += more
+            yield record
+            if i > CHUNK:  # drop the consumed prefix so the buffer stays bounded
+                buf = buf[i:]
+                i = 0
+
+
+def main(src, dst):
+    written = 0
+    with open(dst, "w") as out:
+        out.write("[")
+        for record in stream_records(src):
+            if written:
+                out.write(",\n")
+            out.write(json.dumps({k: record.get(k) for k in KEEP}))
+            written += 1
+            if written % 100000 == 0:
+                print(f"  {written} records", flush=True)
+        out.write("]")
+    if not written:
+        raise ValueError(f"{src}: no records; an empty capture would generate an empty suite")
+    print(f"wrote {written} records -> {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_add.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_add.py
@@ -1,0 +1,441 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.add`` — every distinct call the model made, as captured.
+
+Captured 1872 call(s) to this op; 11 distinct signature(s) covering 1872 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.add
+
+CASES = [
+    {
+        "id": "00_32x2880_bf8_int-l1",
+        "op": "ttnn.add",
+        "count": 576,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_1x2880_bf8_int-l1",
+        "op": "ttnn.add",
+        "count": 376,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_1x5120_bf16_int-dram",
+        "op": "ttnn.add",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 5120],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [5120],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 1, 1, 5120],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            None,
+        ],
+    },
+    {
+        "id": "03_32x2880_bf16_ws-l1",
+        "op": "ttnn.add",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "WIDTH_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 10, 3], [0, 4, 0, 4]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "04_32x2880_bf8_int-l1",
+        "op": "ttnn.add",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": 1},
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "05_32x128x2880_bf8_int-dram",
+        "op": "ttnn.add",
+        "count": 144,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [32, 1, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "06_128x2880_bf16_int-dram",
+        "op": "ttnn.add",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            None,
+        ],
+    },
+    {
+        "id": "07_128x2880_bf16_int-dram",
+        "op": "ttnn.add",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "08_128x2880_bf8_int-dram",
+        "op": "ttnn.add",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "09_32x128x2880_bf8_int-dram",
+        "op": "ttnn.add",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": 1},
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "10_1x2880_bf8_int-dram",
+        "op": "ttnn.add",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_add(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_clamp.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_clamp.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.clamp`` — every distinct call the model made, as captured.
+
+Captured 480 call(s) to this op; 4 distinct signature(s) covering 480 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.clamp
+
+CASES = [
+    {
+        "id": "00_32x2880_bf8_int-l1",
+        "op": "ttnn.clamp",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "min": {"k": "lit", "v": None},
+            "max": {"k": "lit", "v": 7.0},
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_32x2880_bf8_int-l1",
+        "op": "ttnn.clamp",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "min": {"k": "lit", "v": -7.0},
+            "max": {"k": "lit", "v": 7.0},
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_32x128x2880_bf8_int-dram",
+        "op": "ttnn.clamp",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "min": {"k": "lit", "v": None},
+            "max": {"k": "lit", "v": 7.0},
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "03_32x128x2880_bf8_int-dram",
+        "op": "ttnn.clamp",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "min": {"k": "lit", "v": -7.0},
+            "max": {"k": "lit", "v": 7.0},
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_clamp(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_embedding.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_embedding.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.embedding`` — every distinct call the model made, as captured.
+
+Captured 26 call(s) to this op; 3 distinct signature(s) covering 26 of them.
+
+Fidelity notes for this op:
+  * an integer index tensor is involved; the capture holds no values, so it is filled by graph_case.INDEX_VALUES (page ids, positions, token ids) instead of random data
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.embedding
+
+CASES = [
+    {
+        "id": "00_1x32_u32_int-dram",
+        "op": "ttnn.embedding",
+        "count": 16,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 131072, 64],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "layout": {"k": "layout", "v": "TILE"},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 64],
+            },
+        ],
+    },
+    {
+        "id": "01_1x1_u32_int-dram",
+        "op": "ttnn.embedding",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 1],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 201088, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "layout": {"k": "layout", "v": "TILE"},
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_1x128_u32_int-dram",
+        "op": "ttnn.embedding",
+        "count": 2,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 128],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 201088, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "layout": {"k": "layout", "v": "TILE"},
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_embedding(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_fast_reduce_nc.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_fast_reduce_nc.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.fast_reduce_nc`` — every distinct call the model made, as captured.
+
+Captured 48 call(s) to this op; 1 distinct signature(s) covering 48 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.fast_reduce_nc
+
+CASES = [
+    {
+        "id": "00_32x128x2880_bf8_int-dram",
+        "op": "ttnn.experimental.fast_reduce_nc",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dims": {"k": "lit", "v": [1]},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_fast_reduce_nc(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_interleaved_to_sharded.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_interleaved_to_sharded.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.interleaved_to_sharded`` — every distinct call the model made, as captured.
+
+Captured 16 call(s) to this op; 1 distinct signature(s) covering 16 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.interleaved_to_sharded
+
+CASES = [
+    {
+        "id": "00_1x64_bf16_int-dram",
+        "op": "ttnn.interleaved_to_sharded",
+        "count": 16,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "layout": "HEIGHT_SHARDED",
+                "buffer": "L1",
+                "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                "k": "mem",
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [32, 64]},
+                },
+                "shape": [1, 1, 1, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_linear.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_linear.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.linear`` — every distinct call the model made, as captured.
+
+Captured 480 call(s) to this op; 4 distinct signature(s) covering 480 of them.
+
+Fidelity notes for this op:
+  * compute_kernel_config is recorded only as an object address in the capture, so it is dropped and the op's default is used (can shift PCC, not shapes)
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.linear
+
+CASES = [
+    {
+        "id": "00_32x4096_bf16_ws-l1",
+        "op": "ttnn.linear",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 4096],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "WIDTH_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 10, 4], [0, 5, 8, 5]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [4096, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dtype": {"k": "dtype", "v": "BFLOAT16"},
+            "memory_config": {"layout": "WIDTH_SHARDED", "buffer": "L1", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "WIDTH_SHARDED",
+                    "shard": {"grid": [[0, 0, 10, 3], [0, 4, 0, 4]], "orientation": "ROW_MAJOR", "shape": [32, 64]},
+                },
+                "shape": [1, 1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_1x2880_bf8_int-l1",
+        "op": "ttnn.linear",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [2880, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "bias": {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32],
+            },
+        ],
+    },
+    {
+        "id": "02_128x2880_bf16_int-dram",
+        "op": "ttnn.linear",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [2880, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "bias": {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 32],
+            },
+        ],
+    },
+    {
+        "id": "03_128x2880_bf8_int-dram",
+        "op": "ttnn.linear",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 2880, 5120],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "bias": {
+                "k": "t",
+                "shape": [5120],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "dtype": {"k": "dtype", "v": "BFLOAT16"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 5120],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_linear(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_matmul.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_matmul.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.matmul`` — every distinct call the model made, as captured.
+
+Captured 250 call(s) to this op; 5 distinct signature(s) covering 250 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.matmul
+
+CASES = [
+    {
+        "id": "00_1x2880_bf8_int-l1",
+        "op": "ttnn.matmul",
+        "count": 184,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 2880, 5120],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dtype": {"k": "dtype", "v": "BFLOAT16"},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 5120],
+            },
+        ],
+    },
+    {
+        "id": "01_128x4096_bf8_int-dram",
+        "op": "ttnn.matmul",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 4096],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [4096, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dtype": {"k": "dtype", "v": "BFLOAT16"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_1x2880_bf8_int-dram",
+        "op": "ttnn.matmul",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 2880, 5120],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dtype": {"k": "dtype", "v": "BFLOAT16"},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 5120],
+            },
+        ],
+    },
+    {
+        "id": "03_1x2880_bf8_int-l1",
+        "op": "ttnn.matmul",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [2880, 262144],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            None,
+        ],
+    },
+    {
+        "id": "04_32x2880_bf8_int-dram",
+        "op": "ttnn.matmul",
+        "count": 2,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [2880, 262144],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 262144],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_matmul(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_multiply.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_multiply.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.multiply`` — every distinct call the model made, as captured.
+
+Captured 1008 call(s) to this op; 7 distinct signature(s) covering 1008 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.multiply
+
+CASES = [
+    {
+        "id": "00_32x2880_bf8_int-l1",
+        "op": "ttnn.multiply",
+        "count": 384,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_32x2880_bf8_int-l1",
+        "op": "ttnn.multiply",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 1],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_32x2880_bf8_int-l1",
+        "op": "ttnn.multiply",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": 1.702},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "03_32x128x2880_bf8_int-dram",
+        "op": "ttnn.multiply",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "04_128x32_bf16_int-l1",
+        "op": "ttnn.multiply",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [128, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [128, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 32],
+            },
+        ],
+    },
+    {
+        "id": "05_32x128x2880_bf8_int-dram",
+        "op": "ttnn.multiply",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 1],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "output_tensor": {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "06_32x128x2880_bf8_int-dram",
+        "op": "ttnn.multiply",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": 1.702},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_multiply(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_concat_heads.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_concat_heads.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.nlp_concat_heads`` — every distinct call the model made, as captured.
+
+Captured 48 call(s) to this op; 1 distinct signature(s) covering 48 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.nlp_concat_heads
+
+CASES = [
+    {
+        "id": "00_64x128x64_bf16_int-dram",
+        "op": "ttnn.experimental.nlp_concat_heads",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 64, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 4096],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_nlp_concat_heads(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_concat_heads_decode.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_concat_heads_decode.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.nlp_concat_heads_decode`` — every distinct call the model made, as captured.
+
+Captured 192 call(s) to this op; 1 distinct signature(s) covering 192 of them.
+
+Fidelity notes for this op:
+  * the output has more elements than all inputs combined (a batch-padded decode tensor), so the op cannot write all of it; finiteness is asserted over the portion the inputs can account for
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.nlp_concat_heads_decode
+
+CASES = [
+    {
+        "id": "00_64x64_bf16_hs-l1",
+        "op": "ttnn.experimental.nlp_concat_heads_decode",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 64, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [64, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+        ],
+        "kwargs": {
+            "num_heads": {"k": "lit", "v": 64},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "WIDTH_SHARDED",
+                    "shard": {"grid": [[0, 0, 10, 4], [0, 5, 8, 5]], "orientation": "ROW_MAJOR", "shape": [32, 64]},
+                },
+                "shape": [1, 1, 32, 4096],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_nlp_concat_heads_decode(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_create_qkv_heads.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_create_qkv_heads.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.nlp_create_qkv_heads`` — every distinct call the model made, as captured.
+
+Captured 48 call(s) to this op; 1 distinct signature(s) covering 48 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.nlp_create_qkv_heads
+
+CASES = [
+    {
+        "id": "00_128x5120_bf16_int-dram",
+        "op": "ttnn.experimental.nlp_create_qkv_heads",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 5120],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "num_heads": {"k": "lit", "v": 64},
+            "num_kv_heads": {"k": "lit", "v": 8},
+            "transpose_k_heads": {"k": "lit", "v": False},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 64, 128, 64],
+            },
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 8, 128, 64],
+            },
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 8, 128, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_nlp_create_qkv_heads(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_create_qkv_heads_decode.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_nlp_create_qkv_heads_decode.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.nlp_create_qkv_heads_decode`` — every distinct call the model made, as captured.
+
+Captured 192 call(s) to this op; 1 distinct signature(s) covering 192 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.nlp_create_qkv_heads_decode
+
+CASES = [
+    {
+        "id": "00_1x5120_bf16_int-dram",
+        "op": "ttnn.experimental.nlp_create_qkv_heads_decode",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 5120],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "num_heads": {"k": "lit", "v": 64},
+            "num_kv_heads": {"k": "lit", "v": 8},
+            "memory_config": {"layout": "HEIGHT_SHARDED", "buffer": "L1", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [64, 64]},
+                },
+                "shape": [1, 1, 64, 64],
+            },
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [32, 64]},
+                },
+                "shape": [1, 1, 8, 64],
+            },
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [32, 64]},
+                },
+                "shape": [1, 1, 8, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_nlp_create_qkv_heads_decode(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_paged_fill_cache.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_paged_fill_cache.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.paged_fill_cache`` — every distinct call the model made, as captured.
+
+Captured 96 call(s) to this op; 1 distinct signature(s) covering 96 of them.
+
+Fidelity notes for this op:
+  * an integer index tensor is involved; the capture holds no values, so it is filled by graph_case.INDEX_VALUES (page ids, positions, token ids) instead of random data
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.paged_fill_cache
+
+CASES = [
+    {
+        "id": "00_64x8x64x64_bf8_int-dram",
+        "op": "ttnn.experimental.paged_fill_cache",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [64, 8, 64, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 8, 128, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 2],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "batch_idx": {"k": "lit", "v": 0},
+        },
+        "outs": [
+            None,
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_paged_fill_cache(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_paged_scaled_dot_product_attention_decode.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_paged_scaled_dot_product_attention_decode.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.transformer.paged_scaled_dot_product_attention_decode`` — every distinct call the model made, as captured.
+
+Captured 192 call(s) to this op; 2 distinct signature(s) covering 192 of them.
+
+Fidelity notes for this op:
+  * compute_kernel_config is recorded only as an object address in the capture, so it is dropped and the op's default is used (can shift PCC, not shapes)
+  * an integer index tensor is involved; the capture holds no values, so it is filled by graph_case.INDEX_VALUES (page ids, positions, token ids) instead of random data
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.transformer.paged_scaled_dot_product_attention_decode
+
+CASES = [
+    {
+        "id": "00_64x64_bf16_hs-l1",
+        "op": "ttnn.transformer.paged_scaled_dot_product_attention_decode",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 64, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [64, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [64, 8, 64, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [64, 8, 64, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "cur_pos_tensor": {
+                "k": "t",
+                "shape": [1],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "sliding_window_size": {"k": "lit", "v": 128},
+            "attention_sink": {
+                "k": "t",
+                "shape": [64, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "page_table_tensor": {
+                "k": "t",
+                "shape": [1, 64],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "scale": {"k": "lit", "v": 0.125},
+            "program_config": {
+                "kind": "SDPAProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [8, 8],
+                    "sub_core_grids": None,
+                    "q_chunk_size": 0,
+                    "k_chunk_size": 128,
+                    "exp_approx_mode": False,
+                    "max_cores_per_head_batch": 16,
+                },
+                "k": "cfg",
+            },
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 64, 64],
+            },
+        ],
+    },
+    {
+        "id": "01_64x64_bf16_hs-l1",
+        "op": "ttnn.transformer.paged_scaled_dot_product_attention_decode",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 64, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [64, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [64, 8, 64, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [64, 8, 64, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "cur_pos_tensor": {
+                "k": "t",
+                "shape": [1],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "sliding_window_size": {"k": "lit", "v": None},
+            "attention_sink": {
+                "k": "t",
+                "shape": [64, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "page_table_tensor": {
+                "k": "t",
+                "shape": [1, 64],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "scale": {"k": "lit", "v": 0.125},
+            "program_config": {
+                "kind": "SDPAProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [8, 8],
+                    "sub_core_grids": None,
+                    "q_chunk_size": 0,
+                    "k_chunk_size": 128,
+                    "exp_approx_mode": False,
+                    "max_cores_per_head_batch": 16,
+                },
+                "k": "cfg",
+            },
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 64, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_paged_scaled_dot_product_attention_decode(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_paged_update_cache.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_paged_update_cache.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.paged_update_cache`` — every distinct call the model made, as captured.
+
+Captured 384 call(s) to this op; 1 distinct signature(s) covering 384 of them.
+
+Fidelity notes for this op:
+  * an integer index tensor is involved; the capture holds no values, so it is filled by graph_case.INDEX_VALUES (page ids, positions, token ids) instead of random data
+  * an input's logical shape does not fill its shard (e.g. 8 rows in a 32-row shard), so it is built interleaved and relaid out — handing that memory config straight to from_torch would pad the logical shape up to the shard and change what the op computes
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.paged_update_cache
+
+CASES = [
+    {
+        "id": "00_64x8x64x64_bf8_int-dram",
+        "op": "ttnn.experimental.paged_update_cache",
+        "count": 384,
+        "args": [
+            {
+                "k": "t",
+                "shape": [64, 8, 64, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 8, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+        ],
+        "kwargs": {
+            "update_idxs_tensor": {
+                "k": "t",
+                "shape": [1],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "page_table": {
+                "k": "t",
+                "shape": [1, 64],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            None,
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_paged_update_cache(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_permute.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_permute.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.permute`` — every distinct call the model made, as captured.
+
+Captured 432 call(s) to this op; 3 distinct signature(s) covering 432 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.permute
+
+CASES = [
+    {
+        "id": "00_1x32_bf16_int-l1",
+        "op": "ttnn.permute",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 0)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [32, 1],
+            },
+        ],
+    },
+    {
+        "id": "01_32x1x2880_bf8_int-l1",
+        "op": "ttnn.permute",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (0, 2, 1, 3)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_128x32_bf16_int-l1",
+        "op": "ttnn.permute",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [128, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 0)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [32, 128],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_permute(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_repeat.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_repeat.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.repeat`` — every distinct call the model made, as captured.
+
+Captured 48 call(s) to this op; 1 distinct signature(s) covering 48 of them.
+
+Fidelity notes for this op:
+  * the output has more elements than all inputs combined (a batch-padded decode tensor), so the op cannot write all of it; finiteness is asserted over the portion the inputs can account for
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.repeat
+
+CASES = [
+    {
+        "id": "00_1x32_bf16_int-dram",
+        "op": "ttnn.repeat",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (1, 1, 4, 1)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 4, 32],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_repeat(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_reshape.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_reshape.py
@@ -1,0 +1,391 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.reshape`` — every distinct call the model made, as captured.
+
+Captured 2352 call(s) to this op; 14 distinct signature(s) covering 2352 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.reshape
+
+CASES = [
+    {
+        "id": "00_32x2880_bf8_int-l1",
+        "op": "ttnn.reshape",
+        "count": 576,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_32x1x2880_bf8_int-l1",
+        "op": "ttnn.reshape",
+        "count": 384,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 32, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32, 1, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_32x1_bf16_int-l1",
+        "op": "ttnn.reshape",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [32, 1],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32, 1)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 1],
+            },
+        ],
+    },
+    {
+        "id": "03_1x2880_bf8_int-l1",
+        "op": "ttnn.reshape",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (-1, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "04_1x2880_bf8_int-l1",
+        "op": "ttnn.reshape",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 1, 1, 2880)},
+            {"k": "lit", "v": (1, 1, 32, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "05_32x2880_bf8_int-l1",
+        "op": "ttnn.reshape",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 1, 1, 2880)},
+            {"k": "lit", "v": (1, 1, 32, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "06_32x1x2880_bf8_int-l1",
+        "op": "ttnn.reshape",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [32, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32, 1, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "07_32x1x4x32x2880_bf8_int-dram",
+        "op": "ttnn.reshape",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 1, 4, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32, 128, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "08_32x128x2880_bf8_int-dram",
+        "op": "ttnn.reshape",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32, 128, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "09_1x32_bf16_int-dram",
+        "op": "ttnn.reshape",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32],
+            },
+        ],
+    },
+    {
+        "id": "10_128x2880_bf16_int-dram",
+        "op": "ttnn.reshape",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (-1, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "11_128x2880_bf16_int-dram",
+        "op": "ttnn.reshape",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (1, 4, 32, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 4, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "12_32x128_bf16_int-l1",
+        "op": "ttnn.reshape",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [32, 128],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": (1, 32, 128, 1)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 1],
+            },
+        ],
+    },
+    {
+        "id": "13_128x2880_bf8_int-dram",
+        "op": "ttnn.reshape",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (1, 1, 128, 2880)},
+            {"k": "lit", "v": (1, 1, 128, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_reshape(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_rms_norm.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_rms_norm.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.rms_norm`` — every distinct call the model made, as captured.
+
+Captured 490 call(s) to this op; 5 distinct signature(s) covering 490 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.rms_norm
+
+CASES = [
+    {
+        "id": "00_1x2880_bf8_int-l1",
+        "op": "ttnn.rms_norm",
+        "count": 384,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "weight": {
+                "k": "t",
+                "shape": [1, 1, 90, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "epsilon": {"k": "lit", "v": 1e-05},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_128x2880_bf16_int-dram",
+        "op": "ttnn.rms_norm",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "weight": {
+                "k": "t",
+                "shape": [1, 1, 90, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "epsilon": {"k": "lit", "v": 1e-05},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_128x2880_bf8_int-dram",
+        "op": "ttnn.rms_norm",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "weight": {
+                "k": "t",
+                "shape": [1, 1, 90, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "epsilon": {"k": "lit", "v": 1e-05},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "03_1x2880_bf8_int-dram",
+        "op": "ttnn.rms_norm",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "weight": {
+                "k": "t",
+                "shape": [1, 1, 90, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "epsilon": {"k": "lit", "v": 1e-05},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "04_32x2880_bf8_int-dram",
+        "op": "ttnn.rms_norm",
+        "count": 2,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "weight": {
+                "k": "t",
+                "shape": [1, 1, 90, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "epsilon": {"k": "lit", "v": 1e-05},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_rms_norm(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_rotary_embedding_llama.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_rotary_embedding_llama.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.experimental.rotary_embedding_llama`` — every distinct call the model made, as captured.
+
+Captured 480 call(s) to this op; 4 distinct signature(s) covering 480 of them.
+
+Fidelity notes for this op:
+  * an input's logical shape does not fill its shard (e.g. 8 rows in a 32-row shard), so it is built interleaved and relaid out — handing that memory config straight to from_torch would pad the logical shape up to the shard and change what the op computes
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.experimental.rotary_embedding_llama
+
+CASES = [
+    {
+        "id": "00_8x64_bf16_hs-l1",
+        "op": "ttnn.experimental.rotary_embedding_llama",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 8, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 32], "orientation": "ROW_MAJOR"},
+                },
+            },
+        ],
+        "kwargs": {
+            "is_decode_mode": {"k": "lit", "v": True},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [32, 64]},
+                },
+                "shape": [1, 1, 8, 64],
+            },
+        ],
+    },
+    {
+        "id": "01_64x64_bf16_hs-l1",
+        "op": "ttnn.experimental.rotary_embedding_llama",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 64, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [64, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 32], "orientation": "ROW_MAJOR"},
+                },
+            },
+        ],
+        "kwargs": {
+            "is_decode_mode": {"k": "lit", "v": True},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [64, 64]},
+                },
+                "shape": [1, 1, 64, 64],
+            },
+        ],
+    },
+    {
+        "id": "02_64x128x64_bf16_int-dram",
+        "op": "ttnn.experimental.rotary_embedding_llama",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 64, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "is_decode_mode": {"k": "lit", "v": False},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 64, 128, 64],
+            },
+        ],
+    },
+    {
+        "id": "03_8x128x64_bf16_int-dram",
+        "op": "ttnn.experimental.rotary_embedding_llama",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 8, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "is_decode_mode": {"k": "lit", "v": False},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 8, 128, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_rotary_embedding_llama(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_scaled_dot_product_attention.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_scaled_dot_product_attention.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.transformer.scaled_dot_product_attention`` — every distinct call the model made, as captured.
+
+Captured 48 call(s) to this op; 2 distinct signature(s) covering 48 of them.
+
+Fidelity notes for this op:
+  * compute_kernel_config is recorded only as an object address in the capture, so it is dropped and the op's default is used (can shift PCC, not shapes)
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.transformer.scaled_dot_product_attention
+
+CASES = [
+    {
+        "id": "00_64x128x64_bf16_int-dram",
+        "op": "ttnn.transformer.scaled_dot_product_attention",
+        "count": 24,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 64, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 8, 128, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 8, 128, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "is_causal": {"k": "lit", "v": True},
+            "sliding_window_size": {"k": "lit", "v": 128},
+            "program_config": {
+                "kind": "SDPAProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [8, 8],
+                    "sub_core_grids": None,
+                    "q_chunk_size": 32,
+                    "k_chunk_size": 32,
+                    "exp_approx_mode": False,
+                    "max_cores_per_head_batch": 16,
+                },
+                "k": "cfg",
+            },
+            "attention_sink": {
+                "k": "t",
+                "shape": [1, 64, 1, 1],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 64, 128, 64],
+            },
+        ],
+    },
+    {
+        "id": "01_64x128x64_bf16_int-dram",
+        "op": "ttnn.transformer.scaled_dot_product_attention",
+        "count": 24,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 64, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 8, 128, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 8, 128, 64],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "is_causal": {"k": "lit", "v": True},
+            "sliding_window_size": {"k": "lit", "v": None},
+            "program_config": {
+                "kind": "SDPAProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [8, 8],
+                    "sub_core_grids": None,
+                    "q_chunk_size": 32,
+                    "k_chunk_size": 32,
+                    "exp_approx_mode": False,
+                    "max_cores_per_head_batch": 16,
+                },
+                "k": "cfg",
+            },
+            "attention_sink": {
+                "k": "t",
+                "shape": [1, 64, 1, 1],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 64, 128, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_scaled_dot_product_attention(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_scatter.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_scatter.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.scatter`` — every distinct call the model made, as captured.
+
+Captured 240 call(s) to this op; 2 distinct signature(s) covering 240 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.scatter
+
+CASES = [
+    {
+        "id": "00_1x32_bf8_int-l1",
+        "op": "ttnn.scatter",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dim": {"k": "lit", "v": 1},
+            "index": {
+                "k": "t",
+                "shape": [1, 4],
+                "dtype": "UINT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            "src": {
+                "k": "t",
+                "shape": [1, 4],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32],
+            },
+        ],
+    },
+    {
+        "id": "01_128x32_bf16_int-l1",
+        "op": "ttnn.scatter",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [128, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dim": {"k": "lit", "v": 1},
+            "index": {
+                "k": "t",
+                "shape": [128, 4],
+                "dtype": "UINT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            "src": {
+                "k": "t",
+                "shape": [128, 4],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 32],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_scatter(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_sigmoid.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_sigmoid.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.sigmoid`` — every distinct call the model made, as captured.
+
+Captured 240 call(s) to this op; 2 distinct signature(s) covering 240 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.sigmoid
+
+CASES = [
+    {
+        "id": "00_32x2880_bf8_int-l1",
+        "op": "ttnn.sigmoid",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_32x128x2880_bf8_int-dram",
+        "op": "ttnn.sigmoid",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_sigmoid(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_slice.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_slice.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.slice`` — every distinct call the model made, as captured.
+
+Captured 2 call(s) to this op; 1 distinct signature(s) covering 2 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.slice
+
+CASES = [
+    {
+        "id": "00_128x2880_bf8_int-dram",
+        "op": "ttnn.slice",
+        "count": 2,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": (0, 0, 64, 0)},
+            {"k": "lit", "v": (1, 1, 96, 2880)},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_slice(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_softmax.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_softmax.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.softmax`` — every distinct call the model made, as captured.
+
+Captured 240 call(s) to this op; 2 distinct signature(s) covering 240 of them.
+
+Fidelity notes for this op:
+  * compute_kernel_config is recorded only as an object address in the capture, so it is dropped and the op's default is used (can shift PCC, not shapes)
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.softmax
+
+CASES = [
+    {
+        "id": "00_1x4_bf16_int-l1",
+        "op": "ttnn.softmax",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 4],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dim": {"k": "lit", "v": 1},
+            "numeric_stable": {"k": "lit", "v": True},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 4],
+            },
+        ],
+    },
+    {
+        "id": "01_128x4_bf16_int-l1",
+        "op": "ttnn.softmax",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [128, 4],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dim": {"k": "lit", "v": 1},
+            "numeric_stable": {"k": "lit", "v": True},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 4],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_softmax(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_sparse_matmul.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_sparse_matmul.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.sparse_matmul`` — every distinct call the model made, as captured.
+
+Captured 720 call(s) to this op; 4 distinct signature(s) covering 720 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.sparse_matmul
+
+CASES = [
+    {
+        "id": "00_1x2880_bf8_int-l1",
+        "op": "ttnn.sparse_matmul",
+        "count": 384,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 2880, 2880],
+                "dtype": "BFLOAT4_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "sparsity": {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            "nnz": {"k": "lit", "v": None},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None, "k": "mem"},
+            "output_tile": {"k": "tile", "shape": [32, 32]},
+            "program_config": {
+                "kind": "MatmulMultiCoreReuseMultiCast1DProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [3, 4],
+                    "in0_block_w": 30,
+                    "out_subblock_h": 1,
+                    "out_subblock_w": 1,
+                    "out_block_h": 1,
+                    "out_block_w": 1,
+                    "per_core_M": 1,
+                    "per_core_N": 8,
+                    "fuse_batch": 0,
+                    "fused_activation": None,
+                    "mcast_in0": 1,
+                    "gather_in0": 0,
+                    "hop_cores": {},
+                    "num_global_cb_receivers": 1,
+                    "untilize_out": 0,
+                    "allowed_worker_cores": None,
+                    "stream_in1": 0,
+                },
+                "k": "cfg",
+            },
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 32, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_32x1x2880_bf8_int-l1",
+        "op": "ttnn.sparse_matmul",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 2880, 2880],
+                "dtype": "BFLOAT4_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "sparsity": {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            "nnz": {"k": "lit", "v": None},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None, "k": "mem"},
+            "output_tile": {"k": "tile", "shape": [32, 32]},
+            "is_input_a_sparse": {"k": "lit", "v": True},
+            "program_config": {
+                "kind": "MatmulMultiCoreReuseMultiCast1DProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [5, 6],
+                    "in0_block_w": 10,
+                    "out_subblock_h": 1,
+                    "out_subblock_w": 1,
+                    "out_block_h": 1,
+                    "out_block_w": 1,
+                    "per_core_M": 1,
+                    "per_core_N": 3,
+                    "fuse_batch": 0,
+                    "fused_activation": None,
+                    "mcast_in0": 1,
+                    "gather_in0": 0,
+                    "hop_cores": {},
+                    "num_global_cb_receivers": 1,
+                    "untilize_out": 0,
+                    "allowed_worker_cores": None,
+                    "stream_in1": 0,
+                },
+                "k": "cfg",
+            },
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_4x32x2880_bf16_int-dram",
+        "op": "ttnn.sparse_matmul",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 4, 32, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 2880, 2880],
+                "dtype": "BFLOAT4_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "sparsity": {
+                "k": "t",
+                "shape": [1, 1, 4, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "nnz": {"k": "lit", "v": 128},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+            "output_tile": {"k": "tile", "shape": [32, 32]},
+            "program_config": {
+                "kind": "MatmulMultiCoreReuseMultiCast1DProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [3, 4],
+                    "in0_block_w": 30,
+                    "out_subblock_h": 1,
+                    "out_subblock_w": 1,
+                    "out_block_h": 1,
+                    "out_block_w": 1,
+                    "per_core_M": 1,
+                    "per_core_N": 8,
+                    "fuse_batch": 0,
+                    "fused_activation": None,
+                    "mcast_in0": 1,
+                    "gather_in0": 0,
+                    "hop_cores": {},
+                    "num_global_cb_receivers": 1,
+                    "untilize_out": 0,
+                    "allowed_worker_cores": None,
+                    "stream_in1": 0,
+                },
+                "k": "cfg",
+            },
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 4, 1, 32, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "03_32x128x2880_bf8_int-dram",
+        "op": "ttnn.sparse_matmul",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "k": "t",
+                "shape": [1, 32, 2880, 2880],
+                "dtype": "BFLOAT4_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "sparsity": {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            "nnz": {"k": "lit", "v": 32},
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+            "output_tile": {"k": "tile", "shape": [32, 32]},
+            "is_input_a_sparse": {"k": "lit", "v": True},
+            "program_config": {
+                "kind": "MatmulMultiCoreReuseMultiCast1DProgramConfig",
+                "fields": {
+                    "compute_with_storage_grid_size": [5, 6],
+                    "in0_block_w": 10,
+                    "out_subblock_h": 1,
+                    "out_subblock_w": 1,
+                    "out_block_h": 1,
+                    "out_block_w": 1,
+                    "per_core_M": 4,
+                    "per_core_N": 3,
+                    "fuse_batch": 0,
+                    "fused_activation": None,
+                    "mcast_in0": 1,
+                    "gather_in0": 0,
+                    "hop_cores": {},
+                    "num_global_cb_receivers": 1,
+                    "untilize_out": 0,
+                    "allowed_worker_cores": None,
+                    "stream_in1": 0,
+                },
+                "k": "cfg",
+            },
+            "dtype": {"k": "dtype", "v": "BFLOAT8_B"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_sparse_matmul(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_sum.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_sum.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.sum`` — every distinct call the model made, as captured.
+
+Captured 192 call(s) to this op; 1 distinct signature(s) covering 192 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.sum
+
+CASES = [
+    {
+        "id": "00_32x2880_bf8_int-l1",
+        "op": "ttnn.sum",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dim": {"k": "lit", "v": 1},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_sum(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_tensor_getitem.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_tensor_getitem.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.Tensor.__getitem__`` — every distinct call the model made, as captured.
+
+Captured 26 call(s) to this op; 3 distinct signature(s) covering 26 of them.
+
+Fidelity notes for this op:
+  * an integer index tensor is involved; the capture holds no values, so it is filled by graph_case.INDEX_VALUES (page ids, positions, token ids) instead of random data
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.Tensor.__getitem__
+
+CASES = [
+    {
+        "id": "00_32x1x64_bf16_int-dram",
+        "op": "ttnn.Tensor.__getitem__",
+        "count": 16,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 1, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "slices", "v": [[None, None, None], [None, 1, None], [None, None, None], [None, None, None]]},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 64],
+            },
+        ],
+    },
+    {
+        "id": "01_1x32_u32_int-dram",
+        "op": "ttnn.Tensor.__getitem__",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "slices", "v": [[None, None, None], [None, None, None], [None, None, None], [None, 1, None]]},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "UINT32",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 1],
+            },
+        ],
+    },
+    {
+        "id": "02_131072x64_bf16_int-dram",
+        "op": "ttnn.Tensor.__getitem__",
+        "count": 2,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 131072, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "slices", "v": [[None, None, None], [None, None, None], [None, 128, None], [None, None, None]]},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_tensor_getitem(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_to_device.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_to_device.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.to_device`` — every distinct call the model made, as captured.
+
+Captured 40 call(s) to this op; 5 distinct signature(s) covering 40 of them.
+
+Fidelity notes for this op:
+  * an integer index tensor is involved; the capture holds no values, so it is filled by graph_case.INDEX_VALUES (page ids, positions, token ids) instead of random data
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.to_device
+
+CASES = [
+    {
+        "id": "00_1x64_i32_int-dram",
+        "op": "ttnn.to_device",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 64],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "device": {"k": "device"},
+        },
+        "outs": [
+            {
+                "dtype": "INT32",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 64],
+            },
+        ],
+    },
+    {
+        "id": "01_1_i32_int-dram",
+        "op": "ttnn.to_device",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1],
+                "dtype": "INT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "device": {"k": "device"},
+        },
+        "outs": [
+            {
+                "dtype": "INT32",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1],
+            },
+        ],
+    },
+    {
+        "id": "02_1x32_u32_int-dram",
+        "op": "ttnn.to_device",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "device": {"k": "device"},
+        },
+        "outs": [
+            {
+                "dtype": "UINT32",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 32],
+            },
+        ],
+    },
+    {
+        "id": "03_1x32_u32_int-dram",
+        "op": "ttnn.to_device",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "device"},
+        ],
+        "kwargs": {
+            "memory_config": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None, "k": "mem"},
+        },
+        "outs": [
+            {
+                "dtype": "UINT32",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32],
+            },
+        ],
+    },
+    {
+        "id": "04_1x32_u32_int-dram",
+        "op": "ttnn.to_device",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "device": {"k": "device"},
+        },
+        "outs": [
+            {
+                "dtype": "UINT32",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_to_device(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_to_layout.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_to_layout.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.to_layout`` — every distinct call the model made, as captured.
+
+Captured 192 call(s) to this op; 1 distinct signature(s) covering 192 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.to_layout
+
+CASES = [
+    {
+        "id": "00_1x32_bf16_int-l1",
+        "op": "ttnn.to_layout",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "layout", "v": "ROW_MAJOR"},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 32],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_to_layout(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_to_memory_config.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_to_memory_config.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.to_memory_config`` — every distinct call the model made, as captured.
+
+Captured 576 call(s) to this op; 2 distinct signature(s) covering 576 of them.
+
+Fidelity notes for this op:
+  * an input's logical shape does not fill its shard (e.g. 8 rows in a 32-row shard), so it is built interleaved and relaid out — handing that memory config straight to from_torch would pad the logical shape up to the shard and change what the op computes
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.to_memory_config
+
+CASES = [
+    {
+        "id": "00_8x64_bf16_hs-l1",
+        "op": "ttnn.to_memory_config",
+        "count": 384,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 8, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {
+                    "layout": "HEIGHT_SHARDED",
+                    "buffer": "L1",
+                    "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                },
+            },
+            {
+                "layout": "HEIGHT_SHARDED",
+                "buffer": "L1",
+                "shard": {"grid": [[0, 0, 0, 0]], "shape": [32, 64], "orientation": "ROW_MAJOR"},
+                "k": "mem",
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [32, 64]},
+                },
+                "shape": [1, 1, 8, 64],
+            },
+        ],
+    },
+    {
+        "id": "01_64x64_bf16_int-dram",
+        "op": "ttnn.to_memory_config",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 64, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {
+                "layout": "HEIGHT_SHARDED",
+                "buffer": "L1",
+                "shard": {"grid": [[0, 0, 0, 0]], "shape": [64, 64], "orientation": "ROW_MAJOR"},
+                "k": "mem",
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {
+                    "buffer": "L1",
+                    "layout": "HEIGHT_SHARDED",
+                    "shard": {"grid": [[0, 0, 0, 0]], "orientation": "ROW_MAJOR", "shape": [64, 64]},
+                },
+                "shape": [1, 1, 64, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_to_memory_config(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_topk.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_topk.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.topk`` — every distinct call the model made, as captured.
+
+Captured 240 call(s) to this op; 2 distinct signature(s) covering 240 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.topk
+
+CASES = [
+    {
+        "id": "00_1x32_bf16_int-l1",
+        "op": "ttnn.topk",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "k": {"k": "lit", "v": 4},
+            "dim": {"k": "lit", "v": -1},
+            "sorted": {"k": "lit", "v": True},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 4],
+            },
+            {
+                "dtype": "UINT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 4],
+            },
+        ],
+    },
+    {
+        "id": "01_128x32_bf16_int-l1",
+        "op": "ttnn.topk",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [128, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "k": {"k": "lit", "v": 4},
+            "dim": {"k": "lit", "v": -1},
+            "sorted": {"k": "lit", "v": True},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 4],
+            },
+            {
+                "dtype": "UINT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 4],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_topk(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_transpose.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_transpose.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.transpose`` — every distinct call the model made, as captured.
+
+Captured 832 call(s) to this op; 5 distinct signature(s) covering 832 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.transpose
+
+CASES = [
+    {
+        "id": "00_32x1x2880_bf8_int-l1",
+        "op": "ttnn.transpose",
+        "count": 384,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": 1},
+            {"k": "lit", "v": 2},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_32x2880_bf8_int-l1",
+        "op": "ttnn.transpose",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "lit", "v": 1},
+            {"k": "lit", "v": 0},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [32, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_32x2880_bf16_int-dram",
+        "op": "ttnn.transpose",
+        "count": 144,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": 1},
+            {"k": "lit", "v": 0},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [32, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "03_4x1x32x32x2880_bf8_int-dram",
+        "op": "ttnn.transpose",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 4, 1, 32, 32, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": 1},
+            {"k": "lit", "v": 3},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 1, 4, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "04_32x64_bf16_int-dram",
+        "op": "ttnn.transpose",
+        "count": 16,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": 1},
+            {"k": "lit", "v": 2},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32, 1, 64],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_transpose(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_typecast.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_typecast.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.typecast`` — every distinct call the model made, as captured.
+
+Captured 528 call(s) to this op; 4 distinct signature(s) covering 528 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.typecast
+
+CASES = [
+    {
+        "id": "00_32x2880_bf16_int-l1",
+        "op": "ttnn.typecast",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+            {"k": "dtype", "v": "BFLOAT8_B"},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 2880],
+            },
+        ],
+    },
+    {
+        "id": "01_1x32_bf8_int-l1",
+        "op": "ttnn.typecast",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "dtype": {"k": "dtype", "v": "BFLOAT16"},
+        },
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32],
+            },
+        ],
+    },
+    {
+        "id": "02_8x128x64_bf16_int-dram",
+        "op": "ttnn.typecast",
+        "count": 96,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 8, 128, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "dtype", "v": "BFLOAT8_B"},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 8, 128, 64],
+            },
+        ],
+    },
+    {
+        "id": "03_128x4096_bf16_int-dram",
+        "op": "ttnn.typecast",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 4096],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "dtype", "v": "BFLOAT8_B"},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 4096],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_typecast(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_unsqueeze.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_unsqueeze.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.unsqueeze`` — every distinct call the model made, as captured.
+
+Captured 8 call(s) to this op; 1 distinct signature(s) covering 8 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.unsqueeze
+
+CASES = [
+    {
+        "id": "00_1x2880_bf8_int-dram",
+        "op": "ttnn.unsqueeze",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+            {"k": "lit", "v": 0},
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_unsqueeze(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_unsqueeze_to_4D.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_unsqueeze_to_4D.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.unsqueeze_to_4D`` — every distinct call the model made, as captured.
+
+Captured 698 call(s) to this op; 8 distinct signature(s) covering 698 of them.
+
+Fidelity notes for this op:
+  * an integer index tensor is involved; the capture holds no values, so it is filled by graph_case.INDEX_VALUES (page ids, positions, token ids) instead of random data
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.unsqueeze_to_4D
+
+CASES = [
+    {
+        "id": "00_1x32_bf16_int-l1",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 32],
+            },
+        ],
+    },
+    {
+        "id": "01_1x2880_bf8_int-l1",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "02_1x2880_bf8_int-l1",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 2880],
+            },
+        ],
+    },
+    {
+        "id": "03_128x2880_bf16_int-dram",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "04_128x2880_bf8_int-dram",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+    {
+        "id": "05_32x64_bf16_int-dram",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 16,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32, 64],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 32, 64],
+            },
+        ],
+    },
+    {
+        "id": "06_32_u32_int-dram",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 8,
+        "args": [
+            {
+                "k": "t",
+                "shape": [32],
+                "dtype": "UINT32",
+                "layout": "ROW_MAJOR",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "UINT32",
+                "k": "t",
+                "layout": "ROW_MAJOR",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 1, 32],
+            },
+        ],
+    },
+    {
+        "id": "07_128x2880_bf8_int-dram",
+        "op": "ttnn.unsqueeze_to_4D",
+        "count": 2,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 128, 2880],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "DRAM", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 1, 128, 2880],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_unsqueeze_to_4D(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_untilize.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_untilize.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.untilize`` — every distinct call the model made, as captured.
+
+Captured 2 call(s) to this op; 1 distinct signature(s) covering 2 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.untilize
+
+CASES = [
+    {
+        "id": "00_32x262144_bf8_int-dram",
+        "op": "ttnn.untilize",
+        "count": 2,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 1, 32, 262144],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None},
+            },
+        ],
+        "kwargs": {
+            "use_multicore": {"k": "lit", "v": True},
+        },
+        "outs": [
+            None,
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_untilize(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/test_zeros_like.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/test_zeros_like.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# GENERATED FILE - do not edit by hand.
+# Regenerate with:
+#   python models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py \
+#       --capture generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json --out models/experimental/ops/quasar/tests/gpt_oss_ops
+# Source capture: generated/ttnn/reports/gpt_oss_demo_aug28_1452/graph_capture.python_io.slim.json
+# ---------------------------------------------------------------------------
+"""
+Per-op test: ``ttnn.zeros_like`` — every distinct call the model made, as captured.
+
+Captured 240 call(s) to this op; 2 distinct signature(s) covering 240 of them.
+
+Each CASES entry is one distinct call: the exact input shapes / dtypes / layouts /
+memory configs, the keyword arguments (memory_config, program_config, scalars) and
+one captured output spec per tensor the op returned. ``count`` is how many times
+that exact call occurred in the captured run. See ``graph_case.py`` for how a case
+is materialized and checked, and README.md for the fidelity caveats (random inputs,
+no compute_kernel_config).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.gpt_oss_ops import graph_case as G
+
+_OP = ttnn.zeros_like
+
+CASES = [
+    {
+        "id": "00_1x32_bf8_int-l1",
+        "op": "ttnn.zeros_like",
+        "count": 192,
+        "args": [
+            {
+                "k": "t",
+                "shape": [1, 32],
+                "dtype": "BFLOAT8_B",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT8_B",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [1, 32],
+            },
+        ],
+    },
+    {
+        "id": "01_128x32_bf16_int-l1",
+        "op": "ttnn.zeros_like",
+        "count": 48,
+        "args": [
+            {
+                "k": "t",
+                "shape": [128, 32],
+                "dtype": "BFLOAT16",
+                "layout": "TILE",
+                "mem": {"layout": "INTERLEAVED", "buffer": "L1", "shard": None},
+            },
+        ],
+        "kwargs": {},
+        "outs": [
+            {
+                "dtype": "BFLOAT16",
+                "k": "t",
+                "layout": "TILE",
+                "mem": {"buffer": "L1", "layout": "INTERLEAVED", "shard": None},
+                "shape": [128, 32],
+            },
+        ],
+    },
+]
+
+
+@G.with_default_mesh()
+@pytest.mark.parametrize("case", CASES, ids=[c["id"] for c in CASES])
+def test_zeros_like(ttnn_mesh_device, reset_seeds, case):
+    G.run_case(_OP, case, ttnn_mesh_device)

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/validate_cases.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/validate_cases.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Offline validation of a generated graph_ops suite — no ttnn, no device needed.
+
+    python models/experimental/ops/quasar/tests/gpt_oss_ops/validate_cases.py
+
+Run this after regenerating (and after editing ``graph_case.py``) to catch capture
+parsing regressions before spending emulator time on them. It cross-checks the
+generated ``CASES`` data against ``graph_case.py``'s own tables, so the two cannot
+drift apart silently:
+
+  * ``CASES`` is a pure literal, ids are unique, no unreconstructible spec leaked in;
+  * every dtype / layout / memory layout / buffer type / shard orientation name is
+    in the corresponding ``graph_case`` table;
+  * every program-config kind and every one of its fields is handled by
+    ``graph_case._PROGRAM_CONFIG_FIELDS`` (a field the runtime would silently drop
+    is an error — that is how a stale field mapping shows up);
+  * shard arithmetic: the shard shape times the core count actually covers the
+    tensor (allowing DRAM bank padding and tile padding, rejecting a shard grid
+    that cannot hold the tensor at all — the signature of a bad parse);
+  * bfloat8_b/bfloat4_b tensors are TILE layout;
+  * ``GOLDEN`` / ``INDEX_VALUES`` entries refer to ops the capture actually called.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+TILE = 32
+
+_graph_case_src = (HERE / "graph_case.py").read_text()
+_tree = ast.parse(_graph_case_src)
+
+
+def _assignment(name):
+    for node in _tree.body:
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) == name:
+            value = node.value
+            if isinstance(value, ast.Call):  # frozenset({...})
+                value = value.args[0]
+            return value
+    raise AssertionError(f"{name} not found in graph_case.py")
+
+
+def _keys(name):
+    """Key set of a dict whose *values* are ttnn objects (not literals)."""
+    return {ast.literal_eval(k) for k in _assignment(name).keys}
+
+
+def _field_map(name):
+    node = _assignment(name)
+    return {ast.literal_eval(k): set(ast.literal_eval(v)) for k, v in zip(node.keys, node.values)}
+
+
+DTYPE = _keys("DTYPE")
+LAYOUT = _keys("LAYOUT")
+MEM_LAYOUT = _keys("MEM_LAYOUT")
+BUFFER_TYPE = _keys("BUFFER_TYPE")
+ORIENTATION = _keys("ORIENTATION")
+PROGRAM_CONFIG_FIELDS = _field_map("_PROGRAM_CONFIG_FIELDS")
+DROPPED_FIELDS = _field_map("_DROPPED_FIELDS")
+GOLDEN_OPS = set(re.findall(r'^\s+"(ttnn\.[^"]+)": _ref', _graph_case_src, re.M))
+POSTCONDITION_OPS = set(re.findall(r'^\s+"(ttnn\.[^"]+)": _check_', _graph_case_src, re.M))
+INDEX_OPS = {op for op, _ in re.findall(r'\("(ttnn\.[^"]+)", "([^"]+)"\)', _graph_case_src)}
+
+KINDS = {"t", "tlist", "mem", "cfg", "dtype", "layout", "acts", "device", "lit", "slices", "tile"}
+
+errors: list[str] = []
+notes: list[str] = []
+
+
+def _rows_and_width(shape):
+    return math.prod(shape[:-1]) if len(shape) > 1 else 1, shape[-1]
+
+
+def check_memory_config(mem, where, shape=None):
+    if mem is None:
+        return
+    if mem["layout"] not in MEM_LAYOUT:
+        errors.append(f"{where}: memory layout {mem['layout']!r} missing from graph_case.MEM_LAYOUT")
+    if mem["buffer"] not in BUFFER_TYPE:
+        errors.append(f"{where}: buffer type {mem['buffer']!r} missing from graph_case.BUFFER_TYPE")
+
+    shard = mem.get("shard")
+    if shard is None:
+        if mem["layout"] != "INTERLEAVED":
+            # Real and reproducible: the model passes a sharded memory config with no
+            # shard spec and lets the op derive it from the program config.
+            notes.append(f"{where}: {mem['layout']} with no shard spec (op derives it)")
+        return
+
+    if shard["orientation"] not in ORIENTATION:
+        errors.append(f"{where}: shard orientation {shard['orientation']!r} missing from graph_case.ORIENTATION")
+    cores = sum((x1 - x0 + 1) * (y1 - y0 + 1) for x0, y0, x1, y1 in shard["grid"])
+    if cores <= 0:
+        errors.append(f"{where}: empty shard grid {shard['grid']}")
+        return
+    if shape is None:
+        return
+
+    rows, width = _rows_and_width(shape)
+    sh, sw = shard["shape"]
+    padded_rows = math.ceil(rows / TILE) * TILE
+
+    if mem["layout"] == "WIDTH_SHARDED":
+        # width split over cores (padded up per bank/core), full height per shard
+        if sw * cores < width:
+            errors.append(
+                f"{where}: WIDTH_SHARDED shard {sh}x{sw} over {cores} cores cannot cover "
+                f"width {width} of shape {shape} — likely a bad capture parse"
+            )
+        elif sw * (cores - 1) >= width:
+            # DRAM/L1 shard widths are rounded up to a tile multiple, so the last
+            # bank(s) can end up entirely padding. Normal, but worth seeing.
+            notes.append(
+                f"{where}: WIDTH_SHARDED shard {sh}x{sw} over {cores} cores leaves "
+                f"{cores - math.ceil(width / sw)} core(s) unused for width {width}"
+            )
+        if sh < min(rows, padded_rows):
+            errors.append(f"{where}: WIDTH_SHARDED shard height {sh} < tensor rows {rows} of shape {shape}")
+    elif mem["layout"] == "HEIGHT_SHARDED":
+        if sh * cores < min(rows, padded_rows):
+            errors.append(
+                f"{where}: HEIGHT_SHARDED shard {sh}x{sw} over {cores} cores cannot cover "
+                f"{rows} rows of shape {shape}"
+            )
+        if sw < width:
+            errors.append(f"{where}: HEIGHT_SHARDED shard width {sw} < tensor width {width} of shape {shape}")
+    elif mem["layout"] == "BLOCK_SHARDED":
+        if sh * sw * cores < padded_rows * width:
+            errors.append(f"{where}: BLOCK_SHARDED shard {sh}x{sw} over {cores} cores cannot cover shape {shape}")
+
+
+def check_tensor(spec, where):
+    if spec["dtype"] not in DTYPE:
+        errors.append(f"{where}: dtype {spec['dtype']!r} missing from graph_case.DTYPE")
+    if spec["layout"] not in LAYOUT:
+        errors.append(f"{where}: layout {spec['layout']!r} missing from graph_case.LAYOUT")
+    if not spec["shape"]:
+        # Everything below indexes the shape (check_memory_config -> shape[-1]).
+        errors.append(f"{where}: empty shape")
+        return
+    if spec["dtype"] in ("BFLOAT8_B", "BFLOAT4_B") and spec["layout"] != "TILE":
+        errors.append(f"{where}: {spec['dtype']} requires TILE layout, capture says {spec['layout']}")
+    check_memory_config(spec.get("mem"), where, spec["shape"])
+
+
+def check_spec(spec, where):
+    kind = spec.get("k")
+    if kind == "skip":
+        errors.append(f"{where}: unreconstructible spec leaked into a generated case: {spec.get('repr')}")
+        return
+    if kind not in KINDS:
+        errors.append(f"{where}: unknown spec kind {kind!r} (graph_case._build_value would raise)")
+        return
+
+    if kind == "t":
+        check_tensor(spec, where)
+    elif kind == "tlist":
+        for i, sub in enumerate(spec["tensors"]):
+            check_tensor(sub, f"{where}[{i}]")
+    elif kind == "mem":
+        check_memory_config(spec, where)
+    elif kind == "cfg":
+        config_kind, fields = spec["kind"], spec["fields"]
+        allowed = PROGRAM_CONFIG_FIELDS.get(config_kind)
+        if allowed is None:
+            errors.append(f"{where}: program config {config_kind!r} has no mapping in graph_case")
+            return
+        known = allowed | DROPPED_FIELDS.get(config_kind, set()) | {"fused_activation"}
+        for field in fields:
+            if field not in known:
+                errors.append(
+                    f"{where}: {config_kind} field {field!r} is not in graph_case._PROGRAM_CONFIG_FIELDS "
+                    f"— the runtime would drop it"
+                )
+        for field in allowed:
+            if field not in fields:
+                notes.append(f"{where}: {config_kind} has no {field!r} in the capture (ctor default used)")
+    elif kind == "dtype" and spec["v"] not in DTYPE:
+        errors.append(f"{where}: dtype {spec['v']!r} missing from graph_case.DTYPE")
+    elif kind == "layout" and spec["v"] not in LAYOUT:
+        errors.append(f"{where}: layout {spec['v']!r} missing from graph_case.LAYOUT")
+
+
+def main():
+    files = sorted(HERE.glob("test_*.py"))
+    if not files:
+        print(f"no test_*.py in {HERE} — run generate_from_graph_capture.py first")
+        return 1
+
+    ops_seen, n_cases, n_calls, n_shards = set(), 0, 0, 0
+    for path in files:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        cases = None
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) == "CASES":
+                try:
+                    cases = ast.literal_eval(node.value)
+                except ValueError as exc:
+                    errors.append(f"{path.name}: CASES is not a pure literal ({exc})")
+        if cases is None:
+            errors.append(f"{path.name}: no CASES list found")
+            continue
+
+        ids = [c["id"] for c in cases]
+        if len(set(ids)) != len(ids):
+            errors.append(f"{path.name}: duplicate case ids: {sorted(ids)}")
+
+        for case in cases:
+            n_cases += 1
+            n_calls += case["count"]
+            ops_seen.add(case["op"])
+            for i, spec in enumerate(case["args"]):
+                check_spec(spec, f"{path.name}:{case['id']}:arg{i}")
+                n_shards += 1 if spec.get("k") == "t" and (spec.get("mem") or {}).get("shard") else 0
+            for name, spec in case["kwargs"].items():
+                check_spec(spec, f"{path.name}:{case['id']}:{name}")
+            for i, out in enumerate(case["outs"]):
+                if out is not None:
+                    check_tensor(out, f"{path.name}:{case['id']}:out{i}")
+
+    for op in sorted(GOLDEN_OPS - ops_seen):
+        notes.append(f"graph_case.GOLDEN has a reference for {op}, which this capture never called")
+    for op in sorted(INDEX_OPS - ops_seen):
+        notes.append(f"graph_case.INDEX_VALUES targets {op}, which this capture never called")
+    for op in sorted(POSTCONDITION_OPS - ops_seen):
+        notes.append(f"graph_case.POSTCONDITION has a check for {op}, which this capture never called")
+
+    print(
+        f"{len(files)} op file(s), {n_cases} case(s) covering {n_calls} captured call(s), "
+        f"{len(ops_seen)} op(s), {n_shards} sharded input(s)"
+    )
+    print(f"\n{len(errors)} error(s)")
+    for e in errors:
+        print(f"  ERROR {e}")
+    print(f"\n{len(notes)} note(s)")
+    for n in notes:
+        print(f"  note  {n}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/experimental/ops/quasar/tests/gpt_oss_ops/validate_goldens.py
+++ b/models/experimental/ops/quasar/tests/gpt_oss_ops/validate_goldens.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Check that every GOLDEN reference runs against its cases — no device needed.
+
+    python models/experimental/ops/quasar/tests/gpt_oss_ops/validate_goldens.py
+
+``validate_cases.py`` checks the generated *data* (ids unique, enums known, program-config
+fields mapped). This checks the *reference code* on the other side: for each case whose op
+has an entry in ``graph_case.GOLDEN``, build torch inputs shaped like that case and call
+the reference.
+
+It exists because a reference that crashes on one case's argument shape is invisible until
+a device run reaches it — which is how ``ttnn.multiply(cache, 0, output_tensor=cache)``
+(a scalar right-hand operand, so ``inputs["1"]`` does not exist) and ``_ref_split`` reading
+a literal spec dict where it wanted the literal's value both got through review.
+
+What it does NOT check: that a reference computes the *right* answer. Only a device run
+comparing against it can say that. A reference returning None is reported too — that is
+the "no reference applies, fall back to structural checks" path, which is legitimate but
+worth seeing, since a reference that silently returns None for every case looks like it
+passes while checking nothing.
+
+This imports ``graph_case`` and the generated test modules the ordinary way, so it needs
+``ttnn`` importable (no device is opened, nothing is dispatched). Modules are imported by
+dotted path rather than read as text on purpose: reading a module and exec'ing it would
+be the same work with none of the import system's guarantees.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import torch
+
+HERE = pathlib.Path(__file__).resolve().parent
+_INT_DTYPES = {"UINT32", "INT32", "UINT16", "UINT8"}
+
+
+def _package() -> str:
+    """Dotted path of this directory, so the generated modules import as themselves."""
+    root = next((p for p in HERE.parents if (p / ".git").exists()), None)
+    if root is None:
+        raise SystemExit(f"cannot locate the repo root above {HERE}")
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    return ".".join(HERE.relative_to(root).parts)
+
+
+def _data(spec):
+    """Mirror graph_case._torch_data's dtype split (int tensors are indices -> zeros)."""
+    if spec["dtype"] in _INT_DTYPES:
+        return torch.zeros(spec["shape"], dtype=torch.int32)
+    return torch.randn(*spec["shape"]).to(torch.bfloat16)
+
+
+def _inputs(case):
+    """Mirror the keys graph_case's torch_sink ends up with, list elements included."""
+    built = {}
+
+    def add(key, spec):
+        if spec.get("k") == "t":
+            built[key] = _data(spec)
+        elif spec.get("k") == "tlist":
+            for i, sub in enumerate(spec["tensors"]):
+                built[f"{key}[{i}]"] = _data(sub)
+
+    for index, spec in enumerate(case["args"]):
+        add(str(index), spec)
+    for name, spec in case["kwargs"].items():
+        add(name, spec)
+    return built
+
+
+def main():
+    torch.manual_seed(0)
+    package = _package()
+    golden = importlib.import_module(f"{package}.graph_case").GOLDEN
+
+    errors, notes = [], []
+    ran = 0
+    for path in sorted(HERE.glob("test_*.py")):
+        cases = getattr(importlib.import_module(f"{package}.{path.stem}"), "CASES", [])
+        for case in cases:
+            ref_fn = golden.get(case["op"])
+            if ref_fn is None:
+                continue
+            try:
+                result = ref_fn(_inputs(case), {}, case)
+            except Exception as exc:  # a reference must never raise: that is a crash on device
+                errors.append(f"{path.name}:{case['id']}: {type(exc).__name__}: {exc}")
+                continue
+            ran += 1
+            if result is None:
+                notes.append(f"{path.name}:{case['id']}: reference returned None (structural checks only)")
+
+    print(f"{len(golden)} reference(s) wired, {ran} case(s) exercised\n")
+    for note in notes:
+        print(f"  note  {note}")
+    for err in errors:
+        print(f"  ERROR {err}")
+    print(f"\n{len(errors)} error(s), {len(notes)} note(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature, Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #54745
- adds ops tests based on gpt oss graph trace
- adjusts setttings in gpt oss quasar model to make graph tracing work and generate a modestly sized file
- fixes up generate_from_graph_capture.py for a case run into by gpt-oss

Verified locally tests pass:
```
pytest models/experimental/ops/quasar/tests/gpt_oss_ops/
...
PASSED models/experimental/ops/quasar/tests/gpt_oss_ops/test_zeros_like.py::test_zeros_like[01_128x32_bf16_int-l1-ttnn_mesh_device0]
========================================================== 119 passed in 85.59s (0:01:25)
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-54646_gpt_oss_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-54646_gpt_oss_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-54646_gpt_oss_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-54646_gpt_oss_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-54646_gpt_oss_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-54646_gpt_oss_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-54646_gpt_oss_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-54646_gpt_oss_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-54646_gpt_oss_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-54646_gpt_oss_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-54646_gpt_oss_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-54646_gpt_oss_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-54646_gpt_oss_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-54646_gpt_oss_graph_trace)