### PR TITLE
[tt-triage] Return tt-run rank

### DIFF
--- a/tools/tests/triage/test_ttrun_rank.py
+++ b/tools/tests/triage/test_ttrun_rank.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# tt-run must export TT_RUN_RANK per rank, and triage must derive its per-rank identity from
+# it (falling back to OMPI_COMM_WORLD_RANK under raw mpirun). These need no hardware - if rank
+# resolution breaks, every rank silently collapses onto rank 0's inspector data and output path.
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+metal_home = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+triage_home = os.path.join(metal_home, "tools", "triage")
+
+sys.path.insert(0, triage_home)
+
+from utils import resolve_mpi_rank
+
+
+def _load_ttrun():
+    # Load by file path: importing ttnn.distributed.ttrun would drag in the ttnn C extension.
+    path = os.path.join(metal_home, "ttnn", "ttnn", "distributed", "ttrun.py")
+    spec = importlib.util.spec_from_file_location("ttrun_for_triage_rank_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ttrun = _load_ttrun()
+
+
+@pytest.fixture(autouse=True)
+def clean_rank_env(monkeypatch):
+    """A rank var inherited from the caller must not decide the outcome of any test here."""
+    for var in ("TT_RUN_RANK", "OMPI_COMM_WORLD_RANK", "OMPI_COMM_WORLD_SIZE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _config(tmp_path, num_ranks):
+    mesh_graph = tmp_path / "mesh_graph.yaml"
+    mesh_graph.touch()
+    return ttrun.TTRunConfig(
+        rank_bindings=[ttrun.RankBinding(rank=rank, mesh_id=0) for rank in range(num_ranks)],
+        mesh_graph_desc_path=mesh_graph,
+    )
+
+
+def test_ttrun_exports_rank_per_rank(tmp_path):
+    """Every rank gets TT_RUN_RANK equal to its own global MPI rank, not the launcher's."""
+    config = _config(tmp_path, 4)
+
+    for binding in config.rank_bindings:
+        env = ttrun.get_rank_environment(binding, config)
+        assert env["TT_RUN_RANK"] == str(binding.rank)
+
+
+def test_ttrun_rank_reaches_mpirun_args(tmp_path):
+    """TT_RUN_RANK survives into the -x list mpirun actually receives."""
+    config = _config(tmp_path, 4)
+
+    for binding in config.rank_bindings:
+        args = ttrun.build_rank_environment_args(binding, config)
+        assert f"TT_RUN_RANK={binding.rank}" in args
+
+
+def test_stale_parent_rank_does_not_leak(tmp_path, monkeypatch):
+    """A TT_RUN_RANK left over in the launching shell must not override the per-rank value."""
+    monkeypatch.setenv("TT_RUN_RANK", "99")
+    config = _config(tmp_path, 2)
+
+    for binding in config.rank_bindings:
+        env = ttrun.get_rank_environment(binding, config)
+        assert env["TT_RUN_RANK"] == str(binding.rank)
+
+
+def test_tt_run_rank_wins_over_launcher_rank(monkeypatch):
+    """TT_RUN_RANK is the override: when both are set, it decides."""
+    monkeypatch.setenv("TT_RUN_RANK", "2")
+    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "7")
+    monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "8")
+    assert resolve_mpi_rank() == 2
+
+
+def test_falls_back_to_launcher_rank(monkeypatch):
+    """Raw mpirun sets only the OMPI vars - triage must still find its rank."""
+    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "7")
+    monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "8")
+    assert resolve_mpi_rank() == 7
+
+
+def test_single_rank_world_has_no_rank(monkeypatch):
+    """Metal only rank-suffixes Inspector output when the world holds more than one rank."""
+    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
+    monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "1")
+    assert resolve_mpi_rank() is None
+
+
+def test_no_rank_env_at_all():
+    """A plain non-MPI run stays rank-less."""
+    assert resolve_mpi_rank() is None
+
+
+def test_unparseable_rank_is_ignored(monkeypatch):
+    """A malformed rank must degrade to rank-less, not raise."""
+    monkeypatch.setenv("TT_RUN_RANK", "not-a-number")
+    assert resolve_mpi_rank() is None

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -23,8 +23,9 @@ Owner:
     tt-vjovanovic
 """
 
-from triage import triage_singleton, ScriptConfig, TTTriageError, log_warning, run_script
+from triage import triage_singleton, ScriptConfig, TTTriageError, run_script
 from parse_inspector_logs import get_log_directory
+from utils import resolve_mpi_rank
 import asyncio
 import atexit
 import capnp
@@ -180,13 +181,7 @@ def run(args, context) -> InspectorData:
 
     if not args["--inspector-disable-rank"]:
         # If MPI rank is available, add rank to the RPC host and port
-        try:
-            rank_env = os.environ.get("TT_RUN_RANK")
-            if rank_env is not None:
-                rank = int(rank_env)
-        except Exception as e:
-            log_warning(f"Warning: MPI rank is not available or failed to parse, running in rank-less mode. Error: {e}")
-            pass
+        rank = resolve_mpi_rank()
 
     # First try to connect to Inspector RPC
     try:

--- a/tools/triage/utils.py
+++ b/tools/triage/utils.py
@@ -11,16 +11,33 @@ if TYPE_CHECKING:
     from rich.theme import Theme
 
 
+def resolve_mpi_rank() -> int | None:
+    """This process's rank in the MPI world, or None when the run is single-rank."""
+
+    rank_env = os.environ.get("TT_RUN_RANK")
+    if rank_env is None:
+        try:
+            size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "1"))
+            if size <= 1:
+                return None
+            rank_env = os.environ.get("OMPI_COMM_WORLD_RANK")
+            if rank_env is None:
+                return None
+        except ValueError:
+            return None
+
+    try:
+        return int(rank_env)
+    except ValueError:
+        return None
+
+
 def safe_path(path: str | None) -> str | None:
     """Disambiguate an output path per process so parallel tt-run instances don't clobber it."""
     if not path:
         return path
-    rank_env = os.environ.get("TT_RUN_RANK")
-    if rank_env is None:
-        return path
-    try:
-        rank = int(rank_env)
-    except ValueError:
+    rank = resolve_mpi_rank()
+    if rank is None:
         return path
     root, ext = os.path.splitext(path)
     return f"{root}_rank_{rank}{ext}"

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -1611,6 +1611,7 @@ ENV_BLOCKLIST = frozenset(
         "TT_MESH_HOST_RANK",  # Host rank within mesh from rank binding
         "TT_MESH_GRAPH_DESC_PATH",  # Path to mesh graph descriptor from config
         "TT_RUN_ORIGINAL_CWD",  # Always set to ORIGINAL_CWD by tt-run
+        "TT_RUN_RANK",  # Global MPI world rank from rank binding
         "TT_RUN_SUBCONTEXT_ID",  # Set when using merged rank-bindings mapping
         "TT_RUN_SUBCONTEXT_SIZES",
         "TT_METAL_MOCK_CLUSTER_DESC_PATH",  # Mock cluster path for testing
@@ -1696,6 +1697,8 @@ def get_rank_environment(
             ),
             # Pass the original CWD to subprocesses so they can resolve relative paths correctly
             "TT_RUN_ORIGINAL_CWD": str(ORIGINAL_CWD),
+            # Global MPI world rank; read by tt-triage (tools/triage/utils.py, inspector_data.py)
+            "TT_RUN_RANK": str(binding.rank),
         }
     )
 
@@ -2280,6 +2283,7 @@ def legacy_flow(
         - LD_LIBRARY_PATH: Library search path
         - TT_MESH_GRAPH_DESC_PATH: Path to mesh graph descriptor
         - TT_RUN_ORIGINAL_CWD: Directory where tt-run was launched (for subprocess path resolution)
+        - TT_RUN_RANK: Global MPI world rank (used by tt-triage to identify the rank)
         - HOME: Passed through (required by OpenMPI for process management)
         - USER: Passed through (required by OpenMPI for process identity)
         - PATH: Passed through from caller (enables venv tools like pytest on remote hosts)
@@ -2307,7 +2311,7 @@ def legacy_flow(
         - TT_VISIBLE_DEVICES: Must be set per-rank via env_overrides in rank bindings to ensure
           correct device visibility. Cluster descriptors and rank bindings configure this per-rank.
         - TT_MESH_ID, TT_MESH_HOST_RANK, TT_MESH_GRAPH_DESC_PATH: Derived from rank bindings/config
-        - TT_RUN_ORIGINAL_CWD, TT_METAL_MOCK_CLUSTER_DESC_PATH: Set by tt-run internally
+        - TT_RUN_ORIGINAL_CWD, TT_RUN_RANK, TT_METAL_MOCK_CLUSTER_DESC_PATH: Set by tt-run internally
 
         Note: TT_METAL_HOME, TT_METAL_RUNTIME_ROOT, and TT_METAL_CACHE ARE passed through from
         the parent environment to support NFS-based distributed workloads where all MPI ranks


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/pull/43175 removed `TT_RUN_RANK` from `ttrun.py` accidentally so it broke `tt-triage`'s rank resolving.

- Returning it
- Adding triage tests around it
- Adding a fallback on `OMPI_WORLD_` for jobs that run `mpirun` directly

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-tt-run-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-tt-run-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-tt-run-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-tt-run-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-tt-run-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-tt-run-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-tt-run-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-tt-run-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-tt-run-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-tt-run-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-tt-run-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-tt-run-rank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-tt-run-rank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-tt-run-rank)