### PR TITLE
[Cleanup] Remove implicit `MetalContext::instance()` in host API implementations.

### DIFF
--- a/tt_metal/impl/emulation/host_sanitizers.cpp
+++ b/tt_metal/impl/emulation/host_sanitizers.cpp
@@ -33,8 +33,7 @@ namespace {
 // WriteToBuffer issues by design). Resolved here, behind the enabled-check, so
 // it never runs on the production host path.
 uint32_t host_alignment_requirement(const IDevice* device, uint32_t size) {
-    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
-    return metal_ctx.get_cluster().get_alignment_requirements(device->id(), size);
+    return MetalContext::instance().get_cluster().get_alignment_requirements(device->id(), size);
 }
 }  // namespace
 
@@ -82,7 +81,7 @@ void check_program_metadata_size(Program& program) {
     // The CB/L1 validators only fire when an L1 tensor pins
     // lowest_occupied_compute_l1_address; on a freshly-initialized device a
     // program can still statically exceed the reserved KERNEL_CONFIG window.
-    const auto& hal = MetalContext::instance(program.impl().get_context_id()).hal();
+    const auto& hal = MetalContext::instance().hal();
     const auto& metadata_sizes = program.impl().get_program_config_sizes();
     for (uint32_t pct_index = 0; pct_index < hal.get_programmable_core_type_count(); pct_index++) {
         HalProgrammableCoreType pct = hal.get_programmable_core_type(pct_index);

--- a/tt_metal/impl/emulation/host_sanitizers.cpp
+++ b/tt_metal/impl/emulation/host_sanitizers.cpp
@@ -33,7 +33,8 @@ namespace {
 // WriteToBuffer issues by design). Resolved here, behind the enabled-check, so
 // it never runs on the production host path.
 uint32_t host_alignment_requirement(const IDevice* device, uint32_t size) {
-    return MetalContext::instance().get_cluster().get_alignment_requirements(device->id(), size);
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    return metal_ctx.get_cluster().get_alignment_requirements(device->id(), size);
 }
 }  // namespace
 
@@ -81,7 +82,7 @@ void check_program_metadata_size(Program& program) {
     // The CB/L1 validators only fire when an L1 tensor pins
     // lowest_occupied_compute_l1_address; on a freshly-initialized device a
     // program can still statically exceed the reserved KERNEL_CONFIG window.
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(program.impl().get_context_id()).hal();
     const auto& metadata_sizes = program.impl().get_program_config_sizes();
     for (uint32_t pct_index = 0; pct_index < hal.get_programmable_core_type_count(); pct_index++) {
         HalProgrammableCoreType pct = hal.get_programmable_core_type(pct_index);

--- a/tt_metal/impl/host_api/temp_quasar_api.cpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.cpp
@@ -80,8 +80,9 @@ std::set<ProcessorClassType> GetProcessorsPerClusterQuasar(
         }
     }
 
-    const uint32_t programmable_core_type_index =
-        MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
+    const uint32_t programmable_core_type_index = MetalContext::instance(program.impl().get_context_id())
+                                                      .hal()
+                                                      .get_programmable_core_type_index(programmable_core_type);
     std::unordered_set<const KernelGroup*> kernel_groups;
     for (const CoreRange& core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -541,7 +541,8 @@ void WriteToDeviceSharded(
     auto* device = buffer.device();
     const auto& allocator = device->allocator();
 
-    const auto& cluster = MetalContext::instance().get_cluster();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    const auto& cluster = metal_ctx.get_cluster();
     const size_t alignment_req = cluster.get_alignment_requirements(device->id(), page_size);
     const size_t aligned_bytes = alignment_req ? (page_size / alignment_req) * alignment_req : page_size;
     const size_t remainder_bytes = page_size - aligned_bytes;
@@ -570,8 +571,7 @@ void WriteToDeviceSharded(
                                         (write_device_page * buffer.aligned_page_size()) + offset;
                 auto core_coordinates =
                     device->worker_core_from_logical_core(buffer.allocator()->get_logical_core_from_bank_id(bank_id));
-                MetalContext::instance().get_cluster().write_core(
-                    device->id(), core_coordinates, page, absolute_address);
+                cluster.write_core(device->id(), core_coordinates, page, absolute_address);
             } else {
                 auto bank_local_address = buffer.address() + (write_device_page * buffer.aligned_page_size()) + offset;
                 WriteToDeviceDRAMChannel(device, bank_id, bank_local_address, page);
@@ -637,7 +637,8 @@ void WriteToDeviceInterleavedContiguous(const Buffer& buffer, ttsl::Span<const u
     size_t bank_index = 0;
     size_t data_index = 0;
 
-    const auto& cluster = MetalContext::instance().get_cluster();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    const auto& cluster = metal_ctx.get_cluster();
     const size_t alignment_req = cluster.get_alignment_requirements(device->id(), page_size);
     const size_t aligned_bytes = alignment_req ? (page_size / alignment_req) * alignment_req : page_size;
     const size_t remainder_bytes = page_size - aligned_bytes;
@@ -713,7 +714,8 @@ void ReadFromDeviceInterleavedContiguous(const Buffer& buffer, uint8_t* host_buf
     size_t host_idx = 0;
     size_t bank_index = 0;
 
-    const auto& cluster = MetalContext::instance().get_cluster();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    const auto& cluster = metal_ctx.get_cluster();
     size_t aligned_page_size = tt::align(page_size, cluster.get_alignment_requirements(device->id(), page_size));
 
     std::vector<uint8_t> page(aligned_page_size);
@@ -728,8 +730,7 @@ void ReadFromDeviceInterleavedContiguous(const Buffer& buffer, uint8_t* host_buf
             case BufferType::L1_SMALL: {
                 auto core_coordinates = device->worker_core_from_logical_core(
                     buffer.allocator()->get_logical_core_from_bank_id(bank_index));
-                tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-                    page.data(), aligned_page_size, tt_cxy_pair(device->id(), core_coordinates), address);
+                cluster.read_core(page.data(), aligned_page_size, tt_cxy_pair(device->id(), core_coordinates), address);
             } break;
             default: TT_THROW("Unsupported buffer type to read from device!");
         }
@@ -751,7 +752,8 @@ void read_pages_to_host_helper(
     const uint32_t& core_page_id,
     const uint32_t& bank_id) {
     uint64_t host_buffer_start = uint64_t(host_page_id) * page_size;
-    const auto& cluster = MetalContext::instance().get_cluster();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    const auto& cluster = metal_ctx.get_cluster();
     size_t aligned_page_size = tt::align(page_size, cluster.get_alignment_requirements(device->id(), page_size));
 
     if (dev_buffer.is_l1()) {
@@ -762,11 +764,11 @@ void read_pages_to_host_helper(
                                 (core_page_id * dev_buffer.aligned_page_size());
         if (aligned_page_size > page_size) {
             std::vector<uint8_t> page(aligned_page_size);
-            MetalContext::instance().get_cluster().read_core(
+            cluster.read_core(
                 page.data(), aligned_page_size, tt_cxy_pair(device->id(), core_coordinates), absolute_address);
             std::memcpy(host_buffer + host_buffer_start, page.data(), page_size);
         } else {
-            MetalContext::instance().get_cluster().read_core(
+            cluster.read_core(
                 host_buffer + host_buffer_start,
                 page_size,
                 tt_cxy_pair(device->id(), core_coordinates),
@@ -819,10 +821,11 @@ void ReadFromBuffer(Buffer& buffer, uint8_t* host_buffer) {
         case BufferType::TRACE:
         case BufferType::L1:  // fallthrough
         case BufferType::L1_SMALL: {
+            const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
             if (buffer.is_dram()) {
-                MetalContext::instance().get_cluster().dram_barrier(device->id());
+                metal_ctx.get_cluster().dram_barrier(device->id());
             } else {
-                MetalContext::instance().get_cluster().l1_barrier(device->id());
+                metal_ctx.get_cluster().l1_barrier(device->id());
             }
             ReadFromDevice(buffer, host_buffer);
         } break;

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -241,8 +241,8 @@ bool WriteToDeviceDRAMChannel(
         address >= device->allocator()->get_base_allocator_addr(HalMemType::DRAM),
         "Cannot write to reserved DRAM region, addresses [0, {}) are reserved!",
         device->allocator()->get_base_allocator_addr(HalMemType::DRAM));
-    MetalContext::instance().get_cluster().write_dram_vec(
-        host_buffer.data(), host_buffer.size(), device->id(), dram_channel, address);
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    metal_ctx.get_cluster().write_dram_vec(host_buffer.data(), host_buffer.size(), device->id(), dram_channel, address);
     return true;
 }
 
@@ -260,9 +260,9 @@ bool ReadFromDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t addre
             device, address, static_cast<uint32_t>(host_buffer.size()), "ReadFromDeviceDRAMChannel");
     }
     bool pass = true;
-    MetalContext::instance().get_cluster().dram_barrier(device->id());
-    MetalContext::instance().get_cluster().read_dram_vec(
-        host_buffer.data(), host_buffer.size(), device->id(), dram_channel, address);
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    metal_ctx.get_cluster().dram_barrier(device->id());
+    metal_ctx.get_cluster().read_dram_vec(host_buffer.data(), host_buffer.size(), device->id(), dram_channel, address);
     return pass;
 }
 
@@ -288,7 +288,8 @@ bool WriteToDeviceL1(
         }
     }
     auto worker_core = device->virtual_core_from_logical_core(logical_core, core_type);
-    MetalContext::instance().get_cluster().write_core(device->id(), worker_core, host_buffer, address);
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    metal_ctx.get_cluster().write_core(device->id(), worker_core, host_buffer, address);
     return true;
 }
 
@@ -308,7 +309,8 @@ bool WriteToDeviceL1(
 
 bool WriteRegToDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, const uint32_t& regval) {
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    MetalContext::instance().get_cluster().write_reg(&regval, tt_cxy_pair(device->id(), worker_core), address);
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    metal_ctx.get_cluster().write_reg(&regval, tt_cxy_pair(device->id(), worker_core), address);
     return true;
 }
 
@@ -325,9 +327,10 @@ bool ReadFromDeviceL1(
                 device->id(), address, address + static_cast<uint32_t>(host_buffer.size()));
         }
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    metal_ctx.get_cluster().l1_barrier(device->id());
     auto virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
-    MetalContext::instance().get_cluster().read_core(
+    metal_ctx.get_cluster().read_core(
         host_buffer.data(), host_buffer.size(), tt_cxy_pair(device->id(), virtual_core), address);
     return true;
 }
@@ -345,16 +348,18 @@ bool ReadFromDeviceL1(
             emule::LiveL1HostPokeRanges::add(device->id(), address, address + size);
         }
     }
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    metal_ctx.get_cluster().l1_barrier(device->id());
     auto virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
-    host_buffer = MetalContext::instance().get_cluster().read_core(device->id(), virtual_core, address, size);
+    host_buffer = metal_ctx.get_cluster().read_core(device->id(), virtual_core, address, size);
     return true;
 }
 
 bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval) {
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    metal_ctx.get_cluster().l1_barrier(device->id());
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    MetalContext::instance().get_cluster().read_reg(&regval, tt_cxy_pair(device->id(), worker_core), address);
+    metal_ctx.get_cluster().read_reg(&regval, tt_cxy_pair(device->id(), worker_core), address);
     return true;
 }
 

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -119,7 +119,7 @@ DataMovementConfigStatus CheckDataMovementConfig(
             data_movement_config_status.noc1_in_use = local_noc1_usage;
         };
 
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(program.impl().get_context_id()).hal();
     for (const auto& core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
@@ -168,8 +168,8 @@ void ConfigureKernelGroup(
     uint32_t programmable_core_type_index,
     const KernelGroup* kernel_group,
     IDevice* device,
-    const CoreCoord& logical_core) {
-    const auto& hal = MetalContext::instance().hal();
+    const CoreCoord& logical_core,
+    const Hal& hal) {
     uint32_t kernel_config_base =
         hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index), HalL1MemAddrType::KERNEL_CONFIG);
     for (auto kernel_id : kernel_group->kernel_ids) {
@@ -421,9 +421,10 @@ void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
     ZoneScoped;
 
     auto device_id = device->id();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
 
 #ifdef TT_METAL_USE_EMULE
-    if (MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Emule) {
+    if (metal_ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Emule) {
         // Emule lazily JIT-compiles inside execute_program_emulated, so is_finalized()/is_compiled()
         // are never set — skip both asserts (HW-only) and run synchronously, mirroring LaunchProgram.
         // Configure before writing runtime args: ConfigureDeviceWithProgram allocates the ephemeral
@@ -461,9 +462,9 @@ void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
     detail::ConfigureDeviceWithProgram(device, program, /*force_slow_dispatch=*/false);
     detail::WriteRuntimeArgsToDevice(device, program, /*force_slow_dispatch=*/false);
 
-    MetalContext::instance().get_cluster().dram_barrier(device_id);
-    MetalContext::instance().get_cluster().l1_barrier(device_id);
-    const auto& hal = MetalContext::instance().hal();
+    metal_ctx.get_cluster().dram_barrier(device_id);
+    metal_ctx.get_cluster().l1_barrier(device_id);
+    const auto& hal = metal_ctx.hal();
     for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
         CoreType core_type = hal.get_core_type(programmable_core_type_index);
@@ -496,7 +497,13 @@ void CloseDevices(const std::map<ChipId, IDevice*>& devices) {
     for (const auto& [id, device] : devices) {
         devices_to_close.push_back(device);
     }
-    MetalContext::instance().device_manager()->close_devices(devices_to_close);
+    if (devices.empty()) {
+        MetalContext::instance().device_manager()->close_devices(devices_to_close);
+    } else {
+        MetalContext::instance(extract_context_id(devices.begin()->second))
+            .device_manager()
+            ->close_devices(devices_to_close);
+    }
 }
 
 void ReleaseOwnership() {
@@ -875,9 +882,8 @@ void LaunchProgram(
 // Such programs (e.g. the persistent tensor-prefetcher DRISC senders) are disjoint from the FD
 // worker grid and dispatch column, so launching them via slow dispatch does not perturb an active
 // FD session. Used to scope the force-slow-dispatch guard in LaunchProgram.
-bool program_targets_only_dram_cores(const Program& program) {
+bool program_targets_only_dram_cores(const Program& program, const Hal& hal) {
     const auto& logical_cores_used_in_program = program.impl().logical_cores();
-    const auto& hal = MetalContext::instance().hal();
     bool has_any_core = false;
     for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
@@ -895,6 +901,7 @@ bool program_targets_only_dram_cores(const Program& program) {
 void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done, bool force_slow_dispatch) {
     {  // Profiler scope start
         ZoneScoped;
+        MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
         /// This function is shared between FD and SD.
         // We call this function when initializing HW Command Queues or when reading Profiler Device to Device
         // sync information from the accelerators.
@@ -902,17 +909,16 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         if (!force_slow_dispatch) {
             detail::DispatchStateCheck(false);
         } else {
-            auto& dm = MetalContext::instance().device_manager();
+            auto& dm = metal_ctx.device_manager();
             const bool fd_active = dm->is_dispatch_firmware_active();
             const bool rt_done = dm->is_rt_profiler_device_init_complete(device->id());
             // Scope the service bypass to this device
-            const bool service_active =
-                !tt::tt_metal::MetalContext::instance().get_service_core_manager().claimed_cores(device->id()).empty();
+            const bool service_active = !metal_ctx.get_service_core_manager().claimed_cores(device->id()).empty();
             // DRAM-only programs (e.g. the persistent tensor-prefetcher DRISC senders) run on the DRAM
             // programmable cores, which are disjoint from the FD worker grid and dispatch column. Launching
             // them via slow dispatch does not touch FD-owned cores or the FD pipeline, so it is safe to mix
             // with an active FD session regardless of profiler init state.
-            const bool dram_only = detail::program_targets_only_dram_cores(program);
+            const bool dram_only = detail::program_targets_only_dram_cores(program, metal_ctx.hal());
             TT_ASSERT(
                 !(fd_active && rt_done) || service_active || dram_only,
                 "Cannot force slow dispatch while fast dispatch firmware is active and real-time profiler init has "
@@ -920,7 +926,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         }
 
 #ifdef TT_METAL_USE_EMULE
-        if (MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Emule)
+        if (metal_ctx.get_cluster().get_target_device_type() != tt::TargetDevice::Emule)
 #endif
         {
             program.impl().compile(device);
@@ -938,7 +944,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         auto device_id = device->id();
 
 #ifdef TT_METAL_USE_EMULE
-        if (MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Emule) {
+        if (metal_ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Emule) {
             // Emulated mode always executes synchronously (slow dispatch only).
             // The wait_until_cores_done flag is not honored; all kernels complete
             // before this function returns.
@@ -947,15 +953,15 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         }
 #endif
         {
-            MetalContext::instance().get_cluster().dram_barrier(device_id);
+            metal_ctx.get_cluster().dram_barrier(device_id);
 
             // Note: the l1_barrier below is needed to be sure writes to cores that
             // don't get the GO mailbox (eg, storage cores) have all landed
-            MetalContext::instance().get_cluster().l1_barrier(device->id());
+            metal_ctx.get_cluster().l1_barrier(device->id());
 
             std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
             std::unordered_set<CoreCoord> not_done_cores;
-            const auto& hal = MetalContext::instance().hal();
+            const auto& hal = metal_ctx.hal();
             for (uint32_t programmable_core_type_index = 0;
                  programmable_core_type_index < logical_cores_used_in_program.size();
                  programmable_core_type_index++) {
@@ -1004,6 +1010,7 @@ void WaitProgramDone(IDevice* device, Program& program, bool read_device_profile
 bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_slow_dispatch) {
     ZoneScoped;
     bool pass = true;
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
     // This function is shared between FD and SD.
     // We call this function when initializing HW Command Queues or when reading Profiler Device to Device
     // sync information from the accelerators.
@@ -1021,7 +1028,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
 
     bool is_emulated = false;
 #ifdef TT_METAL_USE_EMULE
-    is_emulated = MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Emule;
+    is_emulated = metal_ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Emule;
 #endif
 
     try {
@@ -1053,7 +1060,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
     }
 
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         const auto& logical_cores = logical_cores_used_in_program[index];
@@ -1063,7 +1070,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
             CoreCoord physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
             // Skip binary writing for emulated mode (JIT compilation happens in execute_program_emulated)
             if (!is_emulated) {
-                ConfigureKernelGroup(program, index, kernel_group, device, logical_core);
+                ConfigureKernelGroup(program, index, kernel_group, device, logical_core, hal);
             }
             // TODO: add support for CB for ethernet cores
             if (core_type == CoreType::WORKER) {
@@ -1102,8 +1109,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                         }
                     }  // PROF_END("CBS")
                     uint64_t addr = kernel_config_base + program.impl().get_program_config(index).cb_offset;
-                    MetalContext::instance().get_cluster().write_core(
-                        device_id, physical_core, circular_buffer_config_vec, addr);
+                    metal_ctx.get_cluster().write_core(device_id, physical_core, circular_buffer_config_vec, addr);
                 }
 
                 if (!dfbs_on_core.empty()) {
@@ -1124,7 +1130,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                         kernel_config_base,
                         program.impl().get_program_config(index).dfb_offset,
                         bytes_written);
-                    MetalContext::instance().get_cluster().write_core(
+                    metal_ctx.get_cluster().write_core(
                         device_id, physical_core, std::span<const uint8_t>(dfb_config_vec.data(), bytes_written), addr);
                 }
 
@@ -1159,12 +1165,11 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                         // core's shard of the dedicated config Buffer.
                         const auto& page =
                             program.impl().get_cross_node_dfb(participant.remote_dfb_id).config_page(logical_core);
-                        MetalContext::instance().get_cluster().write_core(
+                        metal_ctx.get_cluster().write_core(
                             device_id, physical_core, page, participant.config_page_addr);
                     }
                     uint64_t addr = kernel_config_base + cross_node_dfb_offset;
-                    MetalContext::instance().get_cluster().write_core(
-                        device_id, physical_core, cross_node_dfb_vec, addr);
+                    metal_ctx.get_cluster().write_core(device_id, physical_core, cross_node_dfb_vec, addr);
                 }
             }
             program.impl().init_semaphores(*device, logical_core, index);
@@ -1185,7 +1190,8 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
         detail::DispatchStateCheck(false);
     }
 
-    const auto& hal = MetalContext::instance().hal();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    const auto& hal = metal_ctx.hal();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);
         HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(index);
@@ -1221,8 +1227,7 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
                                     physical_core.str(),
                                     rt_args_addr,
                                     rt_args);
-                                MetalContext::instance().get_cluster().write_core(
-                                    device_id, physical_core, rt_args, rt_args_addr);
+                                metal_ctx.get_cluster().write_core(device_id, physical_core, rt_args, rt_args_addr);
                             }
 
                             const auto& common_rt_args = kernel->common_runtime_args();
@@ -1238,7 +1243,7 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
                                     physical_core.str(),
                                     common_rt_args_addr,
                                     common_rt_args);
-                                MetalContext::instance().get_cluster().write_core(
+                                metal_ctx.get_cluster().write_core(
                                     device_id, physical_core, common_rt_args, common_rt_args_addr);
                             }
                         }
@@ -1351,16 +1356,17 @@ IDevice* CreateDeviceMinimal(
 bool CloseDevice(IDevice* device) {
     ZoneScoped;
     auto device_id = device->id();
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
 
     // This API may not be used to close a single remote device or multi-chip cluster.
     // MeshDevice RAII should be used instead to ensure proper teardown.
     TT_FATAL(
-        MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id,
+        metal_ctx.get_cluster().get_associated_mmio_device(device_id) == device_id,
         "CloseDevice(device_id={}) may only be used for closing single MMIO capable devices. For multi chip clusters, "
         "use MeshDevice RAII or MeshDevice::close().",
         device_id);
 
-    return MetalContext::instance().device_manager()->close_device(device_id);
+    return metal_ctx.device_manager()->close_device(device_id);
 }
 
 Program CreateProgram() { return Program(); }
@@ -1792,7 +1798,8 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDevic
 void DeallocateBuffer(Buffer& buffer) { buffer.deallocate(); }
 
 void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program& program) {
-    detail::DispatchStateCheck(MetalContext::instance().rtoptions().get_fast_dispatch());
+    const MetalContext& metal_ctx = MetalContext::instance(program.impl().get_context_id());
+    detail::DispatchStateCheck(metal_ctx.rtoptions().get_fast_dispatch());
     program.impl().add_buffer(buffer);
 }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -161,12 +161,10 @@ using SemaphoreNameToIdMap = std::unordered_map<SemaphoreSpecName, uint32_t>;
 // Basic Utility Helpers
 // ============================================================================
 
-inline tt::ARCH get_arch() { return tt::tt_metal::hal::get_arch(); }
+inline bool is_gen2_arch(const Hal& hal) { return hal.get_arch() == tt::ARCH::QUASAR; }
 
-inline bool is_gen2_arch() { return get_arch() == tt::ARCH::QUASAR; }
-
-inline bool is_gen1_arch() {
-    tt::ARCH arch = get_arch();
+inline bool is_gen1_arch(const Hal& hal) {
+    tt::ARCH arch = hal.get_arch();
     return arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE;
 }
 
@@ -748,8 +746,9 @@ bool DmKernelDisablesImplicitSync(const DataMovementGen2Config& gen2_config, con
 // Assumes CollectedSpecData is already built.
 
 void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& collected, MetalContext& metal_ctx) {
+    const Hal& hal = metal_ctx.hal();
     // Sanity check for supported architecture.
-    TT_FATAL(is_gen1_arch() || is_gen2_arch(), "Unsupported architecture.");
+    TT_FATAL(is_gen1_arch(hal) || is_gen2_arch(hal), "Unsupported architecture.");
 
     //////////////////////////////
     // Node bounds checks
@@ -800,7 +799,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(kernel.num_threads > 0, "KernelSpec '{}' has no threads!", kernel.unique_id);
         if (kernel.is_compute_kernel()) {
-            if (is_gen2_arch()) {
+            if (is_gen2_arch(hal)) {
                 TT_FATAL(
                     kernel.num_threads <= QUASAR_TENSIX_ENGINES_PER_NODE,
                     "KernelSpec '{}' has too many threads. The architecture supports up to {} for compute kernels.",
@@ -822,7 +821,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             }
         }
         if (kernel.is_data_movement_kernel()) {
-            if (is_gen2_arch()) {
+            if (is_gen2_arch(hal)) {
                 TT_FATAL(
                     kernel.num_threads <= QUASAR_USER_DM_CORES_PER_NODE,
                     "KernelSpec '{}' has too many data movement threads. The maximum is {}.",
@@ -846,7 +845,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (kernel.is_data_movement_kernel()) {
             const auto& data_movement_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
 
-            if (is_gen1_arch()) {
+            if (is_gen1_arch(hal)) {
                 TT_FATAL(
                     std::holds_alternative<DataMovementGen1Config>(data_movement_config),
                     "KernelSpec '{}' targets Gen1 (WH/BH) but its DataMovementHardwareConfig holds a "
@@ -866,7 +865,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     "RISCV_0 and RISCV_1; RISCV_2..RISCV_7 exist only on Gen2/Quasar.",
                     kernel.unique_id,
                     static_cast<int>(processor));
-            } else if (is_gen2_arch()) {
+            } else if (is_gen2_arch(hal)) {
                 TT_FATAL(
                     std::holds_alternative<DataMovementGen2Config>(data_movement_config),
                     "KernelSpec '{}' targets Gen2 (Quasar) but its DataMovementHardwareConfig holds a "
@@ -878,13 +877,13 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (kernel.is_compute_kernel()) {
             const auto& compute_config = std::get<ComputeHardwareConfig>(kernel.hw_config);
 
-            if (is_gen1_arch()) {
+            if (is_gen1_arch(hal)) {
                 TT_FATAL(
                     std::holds_alternative<ComputeGen1Config>(compute_config),
                     "KernelSpec '{}' targets Gen1 (WH/BH) but its ComputeHardwareConfig holds a "
                     "ComputeGen2Config. Supply a Gen1 config (ComputeGen1Config).",
                     kernel.unique_id);
-            } else if (is_gen2_arch()) {
+            } else if (is_gen2_arch(hal)) {
                 TT_FATAL(
                     std::holds_alternative<ComputeGen2Config>(compute_config),
                     "KernelSpec '{}' targets Gen2 (Quasar) but its ComputeHardwareConfig holds a "
@@ -911,7 +910,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     //      the second DM kernel is registered). DM_DYNAMIC_NOC kernels are exempt: they may
     //      intentionally share a NOC, freeing the other NOC for fabric.
     // (Each kernel's effective node set is derived from WorkUnitSpec membership.)
-    if (is_gen1_arch()) {
+    if (is_gen1_arch(hal)) {
         // (node, processor) -> the kernel that already claimed it.
         std::map<std::pair<NodeCoord, DataMovementProcessor>, KernelSpecName> claimed_processor;
         // node -> (noc mode, the kernel that first set it) — all DM kernels on a node must agree.
@@ -1223,10 +1222,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // indexes the packed config by device slot up to dfb::NUM_DFBS. Tile-counter exhaustion on
     // Gen2 is still checked later at enqueue.
     {
-        const auto& hal = metal_ctx.hal();
-        const uint32_t max_slots_per_core = hal.has_tile_counter_registers()
-                                                ? static_cast<uint32_t>(::dfb::NUM_DFBS)
-                                                : tt::tt_metal::hal::get_arch_num_circular_buffers();
+        const uint32_t max_slots_per_core = hal.has_tile_counter_registers() ? static_cast<uint32_t>(::dfb::NUM_DFBS)
+                                                                             : hal.get_arch_num_circular_buffers();
 
         std::unordered_map<NodeCoord, uint32_t> dfbs_per_node;
         for (const auto& dfb : spec.dataflow_buffers) {
@@ -1239,7 +1236,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (count <= max_slots_per_core) {
                 continue;
             }
-            if (is_gen1_arch()) {
+            if (is_gen1_arch(hal)) {
                 TT_THROW(
                     "ProgramSpec '{}' places {} DataflowBufferSpecs on node ({}, {}), but Gen1 "
                     "supports at most {} device slots per core (disjoint cores may reuse slots).",
@@ -1248,7 +1245,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     node.x,
                     node.y,
                     max_slots_per_core);
-            } else if (is_gen2_arch()) {
+            } else if (is_gen2_arch(hal)) {
                 TT_THROW(
                     "ProgramSpec '{}' places {} DataflowBufferSpecs on node ({}, {}), but the "
                     "target architecture supports at most {} device slots per core. The true "
@@ -1282,7 +1279,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // tile-counter / remapper machinery is driven by the producer/consumer masks, so a multi-bound
     // instance cannot be lowered. Reject the flag itself on Gen2, independent of whether any instance
     // is actually multi-bound — a Gen2 spec carrying it is never valid.
-    if (is_gen2_arch()) {
+    if (is_gen2_arch(hal)) {
         for (const auto& dfb : spec.dataflow_buffers) {
             TT_FATAL(
                 !dfb.advanced_options.allow_instance_multi_binding,
@@ -1479,7 +1476,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             // consumer_risc_mask must not overlap" error in the DFB backend. (Compute self-loops are
             // always legal: they lower to the intra-Tensix packer->unpacker flow.)
             TT_FATAL(
-                !(is_gen2_arch() && self_loop_kernel->is_data_movement_kernel()),
+                !(is_gen2_arch(hal) && self_loop_kernel->is_data_movement_kernel()),
                 "DataflowBuffer '{}' is self-looped by data-movement kernel '{}' (bound as both PRODUCER "
                 "and CONSUMER). Self-loop DFBs are not supported for data-movement kernels on Gen2 "
                 "architectures. Consider using a scratchpad or LocalTensorAccessor instead.",
@@ -1719,7 +1716,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     }
 
     // Data format must be valid for the architecture
-    const tt::ARCH arch = get_arch();
+    const tt::ARCH arch = hal.get_arch();
     for (const auto& dfb : spec.dataflow_buffers) {
         if (dfb.data_format_metadata.has_value()) {
             TT_FATAL(
@@ -1737,7 +1734,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
     for (const auto& sem : spec.semaphores) {
         const uint32_t init_value = sem.advanced_options.initial_value;
-        if (is_gen2_arch()) {
+        if (is_gen2_arch(hal)) {
             TT_FATAL(
                 init_value == 0,
                 "SemaphoreSpec '{}' has initial_value={} but only zero is supported on Quasar",
@@ -1788,7 +1785,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 dm_cores_needed += kernel_spec->num_threads;
             }
         }
-        if (is_gen2_arch()) {
+        if (is_gen2_arch(hal)) {
             TT_FATAL(
                 compute_engines_needed <= QUASAR_TENSIX_ENGINES_PER_NODE,
                 "WorkUnitSpec '{}' needs {} Tensix engines, but only {} are available",
@@ -1802,7 +1799,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 dm_cores_needed,
                 QUASAR_USER_DM_CORES_PER_NODE);
         }
-        if (is_gen1_arch()) {
+        if (is_gen1_arch(hal)) {
             TT_FATAL(
                 compute_engines_needed <= 1,
                 "WorkUnitSpec '{}' has {} compute kernels. The target architecture supports at most one.",
@@ -2741,8 +2738,8 @@ DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
 // ----------------------------------------------------------------------------
 
 std::vector<UnpackToDestMode> BuildUnpackToDestModeVector(
-    const ComputeUnpackModes& user_modes, const DFBNameToSlotMap& dfb_name_to_slot) {
-    const uint32_t max_cbs = tt::tt_metal::hal::get_arch_num_circular_buffers();
+    const ComputeUnpackModes& user_modes, const DFBNameToSlotMap& dfb_name_to_slot, const Hal& hal) {
+    const uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     std::vector<UnpackToDestMode> unpack_modes(max_cbs, UnpackToDestMode::Default);
     for (const auto& [dfb_name, mode] : user_modes) {
         // Indexed by device slot: this vector is consumed by the HLK alongside the CB-indexed data
@@ -2768,7 +2765,8 @@ std::vector<UnpackToDestMode> BuildUnpackToDestModeVector(
 // MakeGen1ComputeConfig: Create a ComputeConfig (WH/BH) from a KernelSpec
 // ----------------------------------------------------------------------------
 
-ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot) {
+ComputeConfig MakeGen1ComputeConfig(
+    const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot, const Hal& hal) {
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeHardwareConfig>(kernel_spec.hw_config);
 
@@ -2778,7 +2776,8 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         "ComputeGen1Config, generation mismatch, please provide the correctly typed hardware config.");
     const auto& gen1 = std::get<ComputeGen1Config>(compute_config);
 
-    std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen1.unpack_modes, dfb_name_to_slot);
+    std::vector<UnpackToDestMode> unpack_dst_modes =
+        BuildUnpackToDestModeVector(gen1.unpack_modes, dfb_name_to_slot, hal);
 
     return ComputeConfig{
         .math_fidelity = gen1.fpu_math_fidelity,
@@ -2818,7 +2817,7 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(cons
 // ----------------------------------------------------------------------------
 
 experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
-    const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot) {
+    const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot, const Hal& hal) {
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeHardwareConfig>(kernel_spec.hw_config);
     TT_FATAL(
@@ -2827,7 +2826,8 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
         "ComputeGen2Config, generation mismatch, please provide the correctly typed hardware config.");
     const auto& gen2 = std::get<ComputeGen2Config>(compute_config);
 
-    std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen2.unpack_modes, dfb_name_to_slot);
+    std::vector<UnpackToDestMode> unpack_dst_modes =
+        BuildUnpackToDestModeVector(gen2.unpack_modes, dfb_name_to_slot, hal);
 
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
@@ -2892,6 +2892,7 @@ namespace {
 Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
     log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.name);
     MetalContext& metal_ctx = MetalContext::instance(extract_context_id(&mesh_device));
+    const Hal& hal = metal_ctx.hal();
 
     // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)
     CollectedSpecData collected = CollectSpecData(spec);
@@ -2905,7 +2906,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
     //  - Gen2: backtracking solver assigns DM cores automatically
     //  - Gen1: processor is user-specified in Gen1Config
     KernelRiscMaskMap kernel_to_risc_mask =
-        is_gen2_arch() ? SolveGen2KernelRiscMasks(spec, collected) : BuildGen1KernelRiscMasks(spec);
+        is_gen2_arch(hal) ? SolveGen2KernelRiscMasks(spec, collected) : BuildGen1KernelRiscMasks(spec);
 
     // Step 2b: For multi-binding DFBs, all KernelSpecs on the same role must end up with
     // identical risc_masks. The DFB has a single producer_risc_mask / consumer_risc_mask in
@@ -2941,7 +2942,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                 if (mask == first_mask) {
                     continue;
                 }
-                if (is_gen2_arch()) {
+                if (is_gen2_arch(hal)) {
                     TT_THROW(
                         "Internal error: Gen2 solver produced disagreeing risc_masks for DFB '{}' "
                         "{} bindings ('{}' = 0x{:x} vs '{}' = 0x{:x}). The coupling-group solver "
@@ -3121,7 +3122,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // Kernel creation APIs accept a "is_metal2_kernel" bool, which fences Metal 2.0 JIT machinery
         constexpr bool is_metal2_kernel = true;
 
-        if (is_gen2_arch()) {
+        if (is_gen2_arch(hal)) {
             uint16_t risc_mask = kernel_to_risc_mask.at(&kernel_spec);
             if (kernel_spec.is_data_movement_kernel()) {
                 auto config = MakeQuasarDataMovementConfig(kernel_spec);
@@ -3141,7 +3142,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                     tensor_binding_handles,
                     ta_bindings.crta_layout);
             } else {
-                auto config = MakeGen2ComputeConfig(kernel_spec, dfb_name_to_slot);
+                auto config = MakeGen2ComputeConfig(kernel_spec, dfb_name_to_slot, hal);
                 config.compile_args = std::move(compile_args);
                 auto processors = GetComputeProcessorSet(ComputeEngineMask{(uint8_t)(risc_mask >> 8)});
                 kernel = std::make_shared<experimental::quasar::QuasarComputeKernel>(
@@ -3175,7 +3176,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                     tensor_binding_handles,
                     ta_bindings.crta_layout);
             } else {
-                auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_slot);
+                auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_slot, hal);
                 config.compile_args = std::move(compile_args);
                 kernel = std::make_shared<ComputeKernel>(
                     program_impl->get_context_id(),

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -671,12 +671,11 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 // ASSUMPTION: All chips in a MeshDevice are identical, so chip 0 is
 // representative of every device in the mesh.
 
-void ValidateNodeBounds(const ProgramSpec& spec) {
-
-    MetalEnvImpl& env_impl = MetalEnvAccessor(MetalContext::instance().get_env()).impl();
+void ValidateNodeBounds(const ProgramSpec& spec, MetalContext& metal_ctx) {
+    MetalEnvImpl& env_impl = MetalEnvAccessor(metal_ctx.get_env()).impl();
 
     // Handle the mock device case (for cheap unit testing)
-    const bool is_mock = MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
+    const bool is_mock = metal_ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
 
     // A default DispatchCoreConfig and 1 CQ is sufficient to look up the compute grid size
     // from the YAML descriptor, and both are available in mock mode.
@@ -687,7 +686,7 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
     // But, best get the real dispatch_core_config and num_hw_cqs
     // (Makes no difference now, but hardbaking that assumption could be brittle)
     if (!is_mock) {
-        auto& dispatch_mgr = MetalContext::instance().get_dispatch_core_manager();
+        auto& dispatch_mgr = metal_ctx.get_dispatch_core_manager();
         dispatch_core_config = dispatch_mgr.get_dispatch_core_config();
         num_hw_cqs = dispatch_mgr.get_num_hw_cqs();
     }
@@ -748,7 +747,7 @@ bool DmKernelDisablesImplicitSync(const DataMovementGen2Config& gen2_config, con
 //
 // Assumes CollectedSpecData is already built.
 
-void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& collected) {
+void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& collected, MetalContext& metal_ctx) {
     // Sanity check for supported architecture.
     TT_FATAL(is_gen1_arch() || is_gen2_arch(), "Unsupported architecture.");
 
@@ -756,7 +755,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Node bounds checks
     //////////////////////////////
 
-    ValidateNodeBounds(spec);
+    ValidateNodeBounds(spec, metal_ctx);
 
     //////////////////////////////
     // Validate KernelSpecs
@@ -1224,7 +1223,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // indexes the packed config by device slot up to dfb::NUM_DFBS. Tile-counter exhaustion on
     // Gen2 is still checked later at enqueue.
     {
-        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+        const auto& hal = metal_ctx.hal();
         const uint32_t max_slots_per_core = hal.has_tile_counter_registers()
                                                 ? static_cast<uint32_t>(::dfb::NUM_DFBS)
                                                 : tt::tt_metal::hal::get_arch_num_circular_buffers();
@@ -2892,13 +2891,14 @@ namespace {
 
 Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
     log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.name);
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(&mesh_device));
 
     // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)
     CollectedSpecData collected = CollectSpecData(spec);
 
     // Step 1b: Validate semantic rules (can be skipped for trusted inputs)
     if (!skip_validation) {
-        ValidateProgramSpec(spec, collected);
+        ValidateProgramSpec(spec, collected, metal_ctx);
     }
 
     // Step 2a: Build kernel risc masks (arch-specific)


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Route host-side MetalContext access through handles already in scope (IDevice*, Buffer::device(), Program&, MeshDevice&) instead of the default singleton. Public tt-metalium signatures are unchanged.

- Direct DRAM/L1/register I/O and buffer transfers hoist context from the device.
- Program launch, configure, close, and related host helpers use the device or stored program context.
- The Quasar helper uses the program owner context.
- ProgramSpec validation and lowering take MetalContext from MeshDevice and query arch / circular-buffer limits through that HAL.

#### No device/context yet in tt_metal.cpp:

- CreateDevices / CreateDevice / CreateDeviceMinimal
- GetActiveDevice
- GetNumAvailableDevices, IsGalaxyCluster, GetNumPCIeDevices, GetPCIeDeviceID, GetClusterType, SerializeClusterDescriptor
- command-queue id stack (Push / Pop / GetCurrentCommandQueueIdForThread)
- empty-map CloseDevices fallback (the non-empty path hoists from the first device)

### Notes for reviewers

MetalContext::instance() after this PR:

- program_spec.cpp: none. The only call is instance(extract_context_id(&mesh_device)).
- temp_quasar_api.cpp: none. The only call is instance(program.impl().get_context_id()).
- tt_metal.cpp: Some remain due to the unchanged public APIs that lack a handle to MetalContext.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/metal-context-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/metal-context-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/metal-context-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/metal-context-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/metal-context-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/metal-context-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/metal-context-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/metal-context-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/metal-context-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/metal-context-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/metal-context-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/metal-context-4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/metal-context-4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/metal-context-4)