### PR TITLE
Fix automapper sweep 0 Solution hang

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,6 +92,7 @@ tools/bringup/ @ctr-martemovTT
 # Scaleout Tools
 tools/**/scaleout/ @tt-aho @tt-asaigal @aliuTT @Riddy21 @agupta-tt @cfjchu @jpanasiukTT
 tools/**/scaleout/**/CMakeLists.txt @tt-aho @tt-asaigal @aliuTT @Riddy21 @agupta-tt @cfjchu @jpanasiukTT @tenstorrent/metalium-developers-infra
+tools/scaleout/sweep_rank_binding_solutions.py @Riddy21 @p1-0tr
 tools/scaleout/exabox/ @jpanasiukTT @aczajkowskiTT @ctr-fmamedov-crypto @gsarabandoTT @tt-mnijjar @mgajewskiTT @pbaraTT @vdu-TT @tt-rkim @jlakisTT @dpopovTT
 tools/scaleout/exabox/run_fabric_tests.sh @jpanasiukTT @aczajkowskiTT @ctr-fmamedov-crypto @gsarabandoTT @tt-mnijjar @mgajewskiTT @pbaraTT @vdu-TT @tt-rkim @jlakisTT @dpopovTT @nnyamagoudar-TT
 
@@ -276,6 +277,7 @@ tests/tt_metal/tt_metal/deployment/ @rdjogoTT @ctr-nradojevicTT @ctr-adjokicTT
 # TTNN
 ttnn/ @tenstorrent/metalium-developers-ttnn-core
 # nanobind
+ttnn/ttnn/distributed/ttrun.py @Riddy21 @p1-0tr
 ttnn/**/*nanobind* @tenstorrent/metalium-developers-ttnn-core @nsextonTT
 ttnn/ttnn/_experimental/moe_compute_utils.py @tenstorrent/metalium-developers-ops-data-movement
 ttnn/ttnn/operations/ @tenstorrent/metalium-developers-ops-leads

--- a/tools/scaleout/sweep_rank_binding_solutions.py
+++ b/tools/scaleout/sweep_rank_binding_solutions.py
@@ -357,6 +357,28 @@ def _read_index_safe(solutions_dir: Path) -> Optional[dict]:
         return None
 
 
+def _index_enumeration_complete(solutions_dir: Path) -> bool:
+    """True once the on-disk index is the producer's FINAL write, i.e. enumeration is over.
+
+    Mid-stream index rewrites always carry ``truncated: true``; the final rewrite carries the
+    definitive flag: ``false`` when the enumeration genuinely exhausted, or ``true`` with
+    ``found == max_solutions`` when a positive cap bounded it. This lets the consumer conclude
+    "no more solutions are coming" from the index CONTENT, independent of producer process
+    liveness -- an MPI rank wedged in device teardown can keep the producer's mpirun alive
+    forever after the enumeration (and even the final index write) completed."""
+    idx = _read_index_safe(solutions_dir)
+    if idx is None:
+        return False
+    enum = idx.get("enumeration")
+    if not isinstance(enum, dict):
+        return False
+    if enum.get("truncated") is False:
+        return True
+    max_solutions = enum.get("max_solutions") or 0
+    found = enum.get("found", len(idx.get("solutions", []) or []))
+    return max_solutions > 0 and found >= max_solutions
+
+
 def _select_solutions(index: dict, select: Optional[str], limit: Optional[int]) -> List[dict]:
     solutions = list(index.get("solutions", []))
     if select:
@@ -908,6 +930,9 @@ class SolutionConsumer:
         self.results: List[dict] = []
         self.stopped_early = False
         self.recover_exhausted = False
+        # Set when we killed a producer that lingered after its FINAL index write (enumeration was
+        # already complete) -- distinguishes that deliberate stop from a producer crash.
+        self.producer_finalized = False
 
     def _available(self) -> List[dict]:
         """Solutions on offer right now: the fixed list, or the producer's streaming index (may be empty)."""
@@ -1043,6 +1068,24 @@ class SolutionConsumer:
                 continue
 
             # Nothing new to consume yet.
+            # Final-index short-circuit: once the index content says enumeration is over and every
+            # listed solution has been swept, the stream is done -- regardless of whether the
+            # producer PROCESS has exited. This is what ends the sweep when a rank wedges in device
+            # teardown and keeps mpirun alive forever (otherwise the heartbeat below spins for good,
+            # e.g. "generating: 0 swept, 0 found" on a 0-solution enumeration).
+            if (
+                self.producer is not None
+                and len(avail) == len(consumed)
+                and _index_enumeration_complete(self.cfg.sol_dir)
+            ):
+                if self.producer.alive():
+                    self.log.line(
+                        f"■ enumeration complete per final index ({len(avail)} solution(s), all swept) "
+                        f"but the producer process is still running (likely wedged in teardown); stopping it."
+                    )
+                    self.producer.stop()
+                    self.producer_finalized = True
+                break
             if self.producer is not None and self.producer.alive():
                 if time.time() - last_heartbeat >= HEARTBEAT_INTERVAL_S:
                     self.log.line(f"… generating: {len(consumed)} swept, {len(avail)} found so far")
@@ -1367,6 +1410,11 @@ def main(
         if producer.alive():
             log.line("■ stopping producer (sweep ending)")
             producer.stop()
+        elif consumer.producer_finalized:
+            # The consumer killed a producer that lingered after its final index write -- the
+            # enumeration itself completed, so the (kill-induced) exit code is not a crash. A
+            # 0-solution enumeration still fails below via the "No solutions were swept" guard.
+            pass
         elif producer_rc not in (None, 0):
             # Producer exited non-zero on its OWN (a crash -- us stopping it leaves it alive, handled above).
             # Generation is therefore incomplete, so this is an error even if some solutions were already

--- a/tools/scaleout/sweep_rank_binding_solutions.py
+++ b/tools/scaleout/sweep_rank_binding_solutions.py
@@ -60,8 +60,6 @@ PRODUCER_SETTLE_BEFORE_RECOVER_S = 300.0
 # the visible index is final. NFS close-to-open attribute-cache lag can hide the producer's last
 # write from another client for up to ~60s (acregmax default); add 30s margin.
 PRODUCER_EXIT_INDEX_SETTLE_S = 90.0
-# Poll cadence inside the post-exit settle window.
-PRODUCER_EXIT_INDEX_POLL_INTERVAL_S = 3.0
 
 
 def _short_id(sid: str) -> str:
@@ -1067,55 +1065,38 @@ class SolutionConsumer:
                     break
                 continue
 
-            # Nothing new to consume yet.
-            # Final-index short-circuit: once the index content says enumeration is over and every
-            # listed solution has been swept, the stream is done -- regardless of whether the
-            # producer PROCESS has exited. This is what ends the sweep when a rank wedges in device
-            # teardown and keeps mpirun alive forever (otherwise the heartbeat below spins for good,
-            # e.g. "generating: 0 swept, 0 found" on a 0-solution enumeration).
-            if (
-                self.producer is not None
-                and len(avail) == len(consumed)
-                and _index_enumeration_complete(self.cfg.sol_dir)
-            ):
+            # Nothing new to consume yet -- decide whether the stream can still grow.
+            if self.producer is None:
+                break  # fixed --solutions-dir list, fully consumed
+            # The index's FINAL write is the authoritative end-of-stream signal (mid-stream rewrites
+            # always say truncated=true). Once it is visible and fully swept, we are done even if the
+            # producer PROCESS lingers (e.g. a rank wedged in device teardown keeps mpirun alive).
+            if _index_enumeration_complete(self.cfg.sol_dir) and len(avail) == len(consumed):
                 if self.producer.alive():
-                    self.log.line(
-                        f"■ enumeration complete per final index ({len(avail)} solution(s), all swept) "
-                        f"but the producer process is still running (likely wedged in teardown); stopping it."
-                    )
+                    self.log.line("■ enumeration complete (final index visible); stopping lingering producer.")
                     self.producer.stop()
                     self.producer_finalized = True
                 break
-            if self.producer is not None and self.producer.alive():
-                if time.time() - last_heartbeat >= HEARTBEAT_INTERVAL_S:
-                    self.log.line(f"… generating: {len(consumed)} swept, {len(avail)} found so far")
-                    last_heartbeat = time.time()
-                time.sleep(POLL_INTERVAL_S)
-                continue
-            # Producer-exit settle: the producer may run on a different NFS client than this consumer,
-            # and an index read right after its exit can be served from a stale attribute cache
-            # (close-to-open consistency lag, up to ~60s) -- hiding trailing solutions, or wrongly
-            # concluding 0. Keep polling (through the normal loop) until the settle window from
-            # producer exit expires, clipped to --sweep-timeout. Fast path: if the freshest read
-            # shows every enumerated solution consumed, the stream is complete -- no wait.
-            if self.producer is not None:
-                if consumed and len(avail) == len(consumed):
-                    break  # index fully consumed as of the freshest read
-                if producer_exited_at is None:
-                    producer_exited_at = time.time()
-                settle_deadline = producer_exited_at + PRODUCER_EXIT_INDEX_SETTLE_S
+            # Producer exited but the index does not read as final yet: NFS close-to-open lag can
+            # serve a stale index for up to ~60s after the producer's last write. Keep polling until
+            # the settle window (clipped to --sweep-timeout) expires, then take the freshest read.
+            if not self.producer.alive():
+                producer_exited_at = producer_exited_at or time.time()
+                deadline = producer_exited_at + PRODUCER_EXIT_INDEX_SETTLE_S
                 if cfg.sweep_timeout is not None:
-                    settle_deadline = min(settle_deadline, self.sweep_start + cfg.sweep_timeout)
-                if time.time() < settle_deadline:
-                    time.sleep(PRODUCER_EXIT_INDEX_POLL_INTERVAL_S)
-                    continue
-                if not consumed:
-                    self.log.line(
-                        f"⚠ producer exited and the solutions index stayed empty through the "
-                        f"{PRODUCER_EXIT_INDEX_SETTLE_S:.0f}s settle window; reporting 0 solutions. "
-                        f"If the producer log shows solutions were found, this is NFS index-visibility lag."
-                    )
-            break  # producer finished (or none) and nothing new left to consume
+                    deadline = min(deadline, self.sweep_start + cfg.sweep_timeout)
+                if time.time() >= deadline:
+                    if not consumed:
+                        self.log.line(
+                            f"⚠ producer exited and the index never became final within the "
+                            f"{PRODUCER_EXIT_INDEX_SETTLE_S:.0f}s settle window; reporting "
+                            f"{len(avail)} solution(s) from the freshest read."
+                        )
+                    break
+            if time.time() - last_heartbeat >= HEARTBEAT_INTERVAL_S:
+                self.log.line(f"… generating: {len(consumed)} swept, {len(avail)} found so far")
+                last_heartbeat = time.time()
+            time.sleep(POLL_INTERVAL_S)
         return self.results
 
 

--- a/tools/scaleout/sweep_rank_binding_solutions.py
+++ b/tools/scaleout/sweep_rank_binding_solutions.py
@@ -237,9 +237,6 @@ def _build_producer_cmd(
             "--mca",
             "btl_tcp_if_include",
             tcp_interface,
-            "--prtemca",
-            "oob_tcp_if_include",
-            tcp_interface,
         ] + list(mpi_args or [])
 
     cmd = build_generate_rank_bindings_mpi_cmd(


### PR DESCRIPTION
## Bug

The consumer decided "no more solutions are coming" by checking if the producer process was alive. A producer rank can wedge in device teardown after all work is done, keeping mpirun alive — so the consumer spun on `… generating: 0 swept, 0 found so far` forever.

## Fix

The index file already says when enumeration is over (mid-stream writes are `truncated: true`; only the final write has the real flag). The consumer now decides in this order:

1. Final index visible and every listed solution swept → done. Kill the producer process if it's still lingering. 0 solutions → fail fast and move on.
2. Producer process exited but index not final yet → poll up to 90s (NFS can hide the last write ~60s), then take the freshest read.
3. Otherwise → heartbeat and poll every 2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/sweep-driver-final-index-stop)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/sweep-driver-final-index-stop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/sweep-driver-final-index-stop)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/sweep-driver-final-index-stop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/sweep-driver-final-index-stop)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/sweep-driver-final-index-stop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/sweep-driver-final-index-stop)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/sweep-driver-final-index-stop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/sweep-driver-final-index-stop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/sweep-driver-final-index-stop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/sweep-driver-final-index-stop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/sweep-driver-final-index-stop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/sweep-driver-final-index-stop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/sweep-driver-final-index-stop)
