### PR TITLE
[Test Only] Update Quasar regression test list

### DIFF
--- a/tests/scripts/quasar/quasar_regression_tests.yaml
+++ b/tests/scripts/quasar/quasar_regression_tests.yaml
@@ -105,11 +105,6 @@ unit_tests_legacy:
     config: 2x3_DISPATCH
     back2back: true
 
-    # - filter: "QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline"
-  #   config: 1x3
-  #   back2back: true
-  #   env:
-
   - filter: "*MultiDmAddTwoInts*"
     config: 2x3_DISPATCH
     back2back: true
@@ -146,7 +141,75 @@ unit_tests_legacy:
     config: 2x3_DISPATCH
     back2back: true
 
-  - filter: "*QuasarFdsFixture*"
+  # - filter: "*QuasarMultiSemaphorePipeline"
+  #   config: 2x3_DISPATCH
+  #   back2back: true
+
+  # - filter: "*QuasarMultipleClustersMultiSemaphorePipeline"
+  #   config: 2x3_DISPATCH
+  #   back2back: true
+
+  - filter: "*QuasarTraceSingleReplay"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarTraceMultipleReplays"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*EventSynchronize"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*EventQuery"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*EventBetweenWorkloads"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*MeshBufferWriteReadDRAM"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*MeshBufferMultipleWriteReadRoundsDRAM"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*MeshBufferWriteReadL1"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*MeshBufferMultipleWriteReadRoundsL1"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*TestSingleWorkloadNonBlockingEnqueueFinish"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*TestMultipleWorkloadsNonBlockingEnqueueFinish"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*BmmMultinode"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*PackReluZero"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*PackReluMinThreshold"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*PackReluMaxThreshold"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarFdsFixture*:-*DispatchEngineConcurrentEngines*"
     config: 2x3_DISPATCH
     back2back: true
     env:
@@ -323,12 +386,6 @@ unit_tests_api:
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-  - filter: "ImplicitSync/DFBImplicitSyncParamFixture.DMTest1xDFB1Sx1S/ImplicitSyncTrue"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
   - filter: "ImplicitSync/DFBImplicitSyncParamFixture.DMTest1xDFB_NumEntriesOverride_ReEntry_3Sx3S/ImplicitSyncTrue"
     config: 1x3
     back2back: true
@@ -341,19 +398,19 @@ unit_tests_api:
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-  - filter: "MeshDeviceFixture.DMTest1xDFB2Sx4SConfig"
+  - filter: "UnitMeshFixture.DMTest1xDFB2Sx4SConfig"
     config: 1x3
     back2back: true
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-  - filter: "MeshDeviceFixture.DFBReentryOverridePreservesTcAndRecomputesTxn"
+  - filter: "UnitMeshFixture.DFBReentryOverridePreservesTcAndRecomputesTxn"
     config: 1x3
     back2back: true
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-  - filter: "MeshDeviceFixture.DFBOverrideCapacityExceedsUint16Fails"
+  - filter: "UnitMeshFixture.DFBOverrideCapacityExceedsUint16Fails"
     config: 1x3
     back2back: true
     env:
@@ -390,6 +447,52 @@ unit_tests_api:
   - filter: "*TensixSingleCoreDirectDramReaderDatacopyWriter"
     config: 2x3_DISPATCH
     back2back: true
+
+  - filter: "*ScopedLockCache*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  # - filter: "*QuasarDatacopyToDestWriter"
+  #   config: 2x3_DISPATCH
+  #   back2back: true
+
+  - filter: "*QuasarMergeProgramRunArgs"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarUpdateProgramRunArgs"
+    config: 2x3_DISPATCH
+    back2back: true
+
+unit_tests_data_movement:
+  - filter: "*QuasarL1DCacheOps*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarL2CacheOps*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarCacheWrite*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarIdmaOps*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+# Fixtures require slow dispatch
+  - filter: "*QuasarAddrgenOps*"
+    config: 1x3
+    back2back: true
+    env:
+      TT_METAL_SLOW_DISPATCH_MODE: 1
+
+  - filter: "*QuasarIm2ColOps*"
+    config: 1x3
+    back2back: true
+    env:
+      TT_METAL_SLOW_DISPATCH_MODE: 1
 
 unit_tests_device:
   - filter: "*SimulatorFixture*QuasarStaticTlbReadWrite*"

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -19,7 +19,6 @@ void kernel_main() {
     uint32_t value = get_arg(args::value);
     uint32_t num_words = get_arg(args::num_words);
 
-    DPRINT << "START mode=" << test_mode << " words=" << num_words << ENDL();
     DEVICE_PRINT("START mode={} words={}\n", test_mode, num_words);
 
     // Write values to cacheable addresses
@@ -28,7 +27,6 @@ void kernel_main() {
         ptr[i] = value + i;
     }
 
-    DPRINT << "WRITES DONE" << ENDL();
     DEVICE_PRINT("WRITES DONE\n");
 
     // Flush/invalidate based on test mode
@@ -85,6 +83,5 @@ void kernel_main() {
             while (1);
     }
 
-    DPRINT << "DONE" << ENDL();
     DEVICE_PRINT("DONE\n");
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -6,7 +6,7 @@
 // Writes values to cacheable memory and flushes/invalidates using various L2 functions.
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "dev_mem_map.h"
 #include "experimental/kernel_args.h"
 #include "risc_common.h"

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_1d_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_1d_example.cpp
@@ -8,7 +8,7 @@
 //   num_of_addresses - total number of addresses to generate in the main loop
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
@@ -46,7 +46,6 @@ void kernel_main() {
         uint64_t dest_addr = peek_dest_addrgen_0();
         pop_src_addrgen_0();
         pop_dest_addrgen_0();
-        DPRINT << "  Source address: " << HEX() << (uint32_t)src_addr << " Destination address: " << HEX()
-               << (uint32_t)dest_addr << ENDL();
+        DEVICE_PRINT("  Source address: 0x{:x} Destination address: 0x{:x}\n", src_addr, dest_addr);
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_2d_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_2d_example.cpp
@@ -9,7 +9,7 @@
 //                      must equal inner_count * outer_count (4 * 4 = 16 for the default config)
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
@@ -52,8 +52,7 @@ void kernel_main() {
         uint64_t dest_addr = peek_dest_addrgen_0();
         pop_src_addrgen_0();
         pop_dest_addrgen_0();
-        DPRINT << "  Source address: " << HEX() << (uint32_t)src_addr << " Destination address: " << HEX()
-               << (uint32_t)dest_addr << ENDL();
+        DEVICE_PRINT("  Source address: 0x{:x} Destination address: 0x{:x}\n", src_addr, dest_addr);
     }
 }
 // /* Real loop with noc */

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_example.cpp
@@ -8,7 +8,7 @@
 //   2: num_of_addresses - total number of addresses to generate in the main loop
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
 
@@ -76,8 +76,7 @@ void kernel_main() {
         uint64_t dest_addr = peek_dest_addrgen_0();
         pop_src_addrgen_0();
         pop_dest_addrgen_0();
-        DPRINT << "  Source address: " << HEX() << (uint32_t)src_addr << " Destination address: " << HEX()
-               << (uint32_t)dest_addr << ENDL();
+        DEVICE_PRINT("  Source address: 0x{:x} Destination address: 0x{:x}\n", src_addr, dest_addr);
     }
 }
 // /* Real loop with noc */

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_face_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_face_example.cpp
@@ -22,7 +22,7 @@
 //   num_of_addresses - total addresses to generate; should be num_faces * outer_count * inner_count
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
@@ -71,8 +71,7 @@ void kernel_main() {
         uint64_t dest_addr = peek_dest_addrgen_0();
         pop_src_addrgen_0();
         pop_dest_addrgen_0();
-        DPRINT << "  Source address: " << HEX() << (uint32_t)src_addr << " Destination address: " << HEX()
-               << (uint32_t)dest_addr << ENDL();
+        DEVICE_PRINT("  Source address: 0x{:x} Destination address: 0x{:x}\n", src_addr, dest_addr);
     }
 }
 // /* Real loop with noc */

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_interleaved_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/kernels/addrgen_interleaved_example.cpp
@@ -22,7 +22,7 @@
 //  adjusting the loop structure in the comment above accordingly.
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>
@@ -72,7 +72,6 @@ void kernel_main() {
         uint64_t dest_addr = peek_dest_addrgen_0();
         pop_src_addrgen_0();
         pop_dest_addrgen_0();
-        DPRINT << "  Source address: " << HEX() << (uint64_t)src_addr << " Destination address: " << HEX()
-               << (uint64_t)dest_addr << ENDL();
+        DEVICE_PRINT("  Source address: 0x{:x} Destination address: 0x{:x}\n", src_addr, dest_addr);
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_dilation1_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_dilation1_example.cpp
@@ -82,8 +82,7 @@ void kernel_main() {
             uint64_t dest_addr = peek_dest_addrgen_0();
             pop_src_addrgen_0();
             pop_dest_addrgen_0();
-            DPRINT << "  Source address: " << HEX() << (uint64_t)src_addr << " Destination address: " << HEX()
-                   << (uint64_t)dest_addr << ENDL();
+            DEVICE_PRINT("  Source address: 0x{:x} Destination address: 0x{:x}\n", src_addr, dest_addr);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_dilation1_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_dilation1_example.cpp
@@ -28,7 +28,7 @@
 //   num_of_addresses — must equal matrix_size * kH * kW
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/kernels/addrgen_im2col_example.cpp
@@ -87,8 +87,7 @@ void kernel_main() {
                 uint64_t dest_addr = peek_dest_addrgen_0();
                 pop_src_addrgen_0();
                 pop_dest_addrgen_0();
-                DPRINT << "  Source address: " << HEX() << (uint64_t)src_addr << " Destination address: " << HEX()
-                       << (uint64_t)dest_addr << ENDL();
+                DEVICE_PRINT("  Source address: 0x{:x} Destination address: 0x{:x}\n", src_addr, dest_addr);
             }
         }
     }


### PR DESCRIPTION
### PR Category
Test Only

### Summary
This PR updates the Quasar test list and moves some Quasar test kernels to a newer print macro. In `tests/scripts/quasar/quasar_regression_tests.yaml`, new entries cover trace replay, event synchronize/query, event-between-workloads, mesh buffer read and write on DRAM and L1, non-blocking enqueue-finish, BmmMultinode, and PackRelu variants. A new `unit_tests_data_movement` section adds L1 cache ops, L2 cache ops, cache write, IDMA, addrgen, and im2col tests. Two `MeshDeviceFixture` filters are renamed to `UnitMeshFixture`, because the tests already use that class and the old names matched nothing. Stale commented-out entries are removed, and a few new ones are added commented out for later use. 

The kernels under `tests/tt_metal/tt_metal/data_movement/quasar_cache` and `quasar_examples` change from `DPRINT` to `DEVICE_PRINT`, with the include changed from `dprint.h` to `device_print.h`. In `l2_flush_test.cpp`, duplicate `DPRINT` calls are removed, so each message prints once.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/update_qsr_test_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/update_qsr_test_script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/update_qsr_test_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/update_qsr_test_script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/update_qsr_test_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/update_qsr_test_script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/update_qsr_test_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/update_qsr_test_script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/update_qsr_test_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/update_qsr_test_script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/update_qsr_test_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/update_qsr_test_script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/update_qsr_test_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/update_qsr_test_script)