### PR TITLE
[skip ci] Reassign runtime_sim_cpp_unit_tests owner to runtime team lead

### DIFF
--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -96,7 +96,7 @@
       timeout: 30
     sim_bh_p150:
       timeout: 30
-  owner_id: U08PR765YJ1 # Matt Craighead
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
 - name: runtime_sim_galaxy_cpp_unit_tests (wormhole_b0)
@@ -108,7 +108,7 @@
   skus:
     sim_wh_galaxy:
       timeout: 10
-  owner_id: U08PR765YJ1 # Matt Craighead
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
 - name: runtime_sim_galaxy_cpp_unit_tests (blackhole)
@@ -120,5 +120,5 @@
   skus:
     sim_bh_galaxy:
       timeout: 10
-  owner_id: U08PR765YJ1 # Matt Craighead
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime


### PR DESCRIPTION
## Summary
- `runtime_sim_cpp_unit_tests` and `runtime_sim_galaxy_cpp_unit_tests` (wormhole_b0, blackhole) in `tests/pipeline_reorg/runtime_sanity_tests.yaml` are tagged `team: runtime` but were assigned `owner_id: U08PR765YJ1` (Matt Craighead, the ttsim team lead) instead of the runtime team lead.
- These jobs run core tt-metal unit test suites (`unit_tests_api`, `unit_tests_data_movement`, `unit_tests_debug_tools`, `unit_tests_dispatch`, `unit_tests_eth`, `unit_tests_legacy`) on simulator SKUs — they exercise tt-metal runtime code under TTSim, not TTSim itself, so failures are almost always caused by tt-metal code issues rather than ttsim issues.
- Reassigns `owner_id` to `U099A7FMKL2` (Manish Sudumbrekar), matching every other `team: runtime` entry in this file, per the team → lead mapping in `.github/TESTOWNERS`.

## Test plan
- [ ] N/A — metadata-only change to test ownership fields, no test logic changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=evan/reassign-runtime-sim-test-owner)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:evan/reassign-runtime-sim-test-owner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=evan/reassign-runtime-sim-test-owner)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:evan/reassign-runtime-sim-test-owner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=evan/reassign-runtime-sim-test-owner)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:evan/reassign-runtime-sim-test-owner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=evan/reassign-runtime-sim-test-owner)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:evan/reassign-runtime-sim-test-owner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=evan/reassign-runtime-sim-test-owner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:evan/reassign-runtime-sim-test-owner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=evan/reassign-runtime-sim-test-owner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:evan/reassign-runtime-sim-test-owner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=evan/reassign-runtime-sim-test-owner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:evan/reassign-runtime-sim-test-owner)