### PR TITLE
[Bug Fix] Remove Double DFB Consumer in Eltwise Mul

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
@@ -89,6 +89,10 @@ void kernel_main() {
 
             tile_regs_commit();
             tile_regs_release();
+            // Handed off to the reader, this buffer's only consumer: it slices the tile into single
+            // rows and pops it. Compute never pops in1_transposed — unlike in0_transposed and
+            // out_transposed below, it is not read back here, and a buffer's read pointer may only
+            // be advanced by one thread.
             dfb_in1_transposed.push_back(onetile);
             dfb_in1.pop_front(onetile);
 
@@ -154,8 +158,6 @@ void kernel_main() {
                 dfb_out.push_back(onetile);
                 dfb_out_transposed.pop_front(onetile);
             }
-
-            dfb_in1_transposed.pop_front(onetile);
 #endif
         }
 #ifdef REPEAT_IN0

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -114,12 +114,9 @@ ttnn::device_operation::ProgramArtifacts RepeatAndInterleaveEltwiseMulProgramFac
     // invokes.
     //
     // in1_transposed carries the transposed in1 tile from compute to the reader, which slices it
-    // into single rows. Under REPEAT_INTERLEAVE_IN1 compute both pushes the tile and pops it
-    // (ssm_eltwise_mul.cpp) while the reader also pops it, so the buffer has two consumer
-    // endpoints on one node. Gen1 tolerates that — a DFB lowers to a plain circular buffer whose
-    // FIFO pointers any endpoint can drive — but it forfeits the FIFO's own protection, so it
-    // must be declared with the multi-binding option. Outside that configuration nothing touches
-    // the buffer and the two kernels that name it split the endpoints one apiece.
+    // into single rows. Compute produces and the reader consumes, one endpoint apiece, in every
+    // configuration — the same shape as out. Outside REPEAT_INTERLEAVE_IN1 neither kernel touches
+    // the buffer, but the endpoints stay as they are because every DFB needs both.
     Group<DataflowBufferSpec> dataflow_buffers = {
         DataflowBufferSpec{
             .unique_id = IN0,
@@ -150,7 +147,6 @@ ttnn::device_operation::ProgramArtifacts RepeatAndInterleaveEltwiseMulProgramFac
             .entry_size = interm_single_tile_size,
             .num_entries = interm_num_entries,
             .data_format_metadata = interm_data_format,
-            .advanced_options = {.allow_instance_multi_binding = repeat_interleave_in1},
         },
         DataflowBufferSpec{
             .unique_id = IN1_BCAST_ROW,
@@ -281,16 +277,6 @@ ttnn::device_operation::ProgramArtifacts RepeatAndInterleaveEltwiseMulProgramFac
             .endpoint_type = DFBEndpointType::CONSUMER,
         },
     };
-    if (repeat_interleave_in1) {
-        // Compute pops the transposed in1 tile it produced, so it is a consumer endpoint too.
-        // Shares the accessor name with the producer binding above, so the kernel still sees a
-        // single dfb::in1_transposed handle in every configuration.
-        compute_dfb_bindings.push_back(DFBBinding{
-            .dfb_spec_name = IN1_TRANSPOSED,
-            .accessor_name = "in1_transposed",
-            .endpoint_type = DFBEndpointType::CONSUMER,
-        });
-    }
 
     // Compute hw_config — Style B (the legacy factory set a Metal ComputeConfigDescriptor directly,
     // with no TTNN ComputeKernelConfig behind it). Build ComputeGen1Config field by field: the three


### PR DESCRIPTION
### Summary
For the `ssm_repeat_and_interleave_eltwise_mul` op, under certain inputs (with `REPEAT_INTERLEAVE_IN1`) the compute kernel could pack a tile into `in1_transposed` and then pop it again. It never unpacks that buffer since the reader is the real consumer, but this meant that it has two consumers (the reader and the compute). i.e. there were two pops for every push. This technically worked on WH/BH since the DFB is actually just a CB using `allow_instance_multi_binding`. It won't work on Quasar and throws errors. 

This PR deletes the compute-side `pop_front`, the extra compute CONSUMER binding, and the `allow_instance_multi_binding` flag. This leaves `in1_transposed` as an ordinary one-producer/one-consumer buffer (i.e. the compute reserves, packs, and pushes, then the reader pops). 

Nothing depended on the removed pop, since the 32-row loop is synchronized through `in1_bcast_row` and slot reuse comes from the reader's ack.

Test is [passing](https://github.com/tenstorrent/tt-metal/actions/runs/33203552584/job/98963126736) in nightly L2 run

Closes https://github.com/tenstorrent/tt-metal/issues/54471
Closes https://github.com/tenstorrent/tt-metal/issues/54470
Closes https://github.com/tenstorrent/tt-metal/issues/54469
Closes https://github.com/tenstorrent/tt-metal/issues/54402

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/54402/eltwise_mul_DFB_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/54402/eltwise_mul_DFB_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/54402/eltwise_mul_DFB_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/54402/eltwise_mul_DFB_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/54402/eltwise_mul_DFB_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/54402/eltwise_mul_DFB_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/54402/eltwise_mul_DFB_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/54402/eltwise_mul_DFB_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/54402/eltwise_mul_DFB_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/54402/eltwise_mul_DFB_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/54402/eltwise_mul_DFB_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/54402/eltwise_mul_DFB_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/54402/eltwise_mul_DFB_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/54402/eltwise_mul_DFB_access)