### PR TITLE
Allocate host-socket config buffers and global semaphores bottom-up

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -207,7 +207,9 @@ class AnyBuffer {
 public:
     AnyBuffer() = default;
     static AnyBuffer create(
-        const tt::tt_metal::ShardedBufferConfig& config, std::optional<uint64_t> address = std::nullopt);
+        const tt::tt_metal::ShardedBufferConfig& config,
+        std::optional<uint64_t> address = std::nullopt,
+        std::optional<bool> bottom_up = std::nullopt);
     static AnyBuffer create(
         const tt::tt_metal::InterleavedBufferConfig& config, std::optional<uint64_t> address = std::nullopt);
 

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -177,7 +177,7 @@ void D2HSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
         .page_size = config_buffer_size,
         .buffer_type = BufferType::L1,
         .sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
-        .bottom_up = true,  // LOCAL: keep 64 B configs out of the top region (see DSpark wave OOM)
+        .bottom_up = true,  // tiny + address-agnostic: keep it out of the top region (see PR)
         .sub_device_id = std::nullopt,
     };
 

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -177,7 +177,7 @@ void D2HSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
         .page_size = config_buffer_size,
         .buffer_type = BufferType::L1,
         .sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
-        .bottom_up = std::nullopt,
+        .bottom_up = true,  // LOCAL: keep 64 B configs out of the top region (see DSpark wave OOM)
         .sub_device_id = std::nullopt,
     };
 

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -158,7 +158,7 @@ void H2DSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
         .page_size = config_buffer_size,
         .buffer_type = BufferType::L1,
         .sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
-        .bottom_up = std::nullopt,
+        .bottom_up = true,  // LOCAL: keep 64 B configs out of the top region (see DSpark wave OOM)
         .sub_device_id = std::nullopt,
     };
 

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -158,7 +158,7 @@ void H2DSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
         .page_size = config_buffer_size,
         .buffer_type = BufferType::L1,
         .sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
-        .bottom_up = true,  // LOCAL: keep 64 B configs out of the top region (see DSpark wave OOM)
+        .bottom_up = true,  // tiny + address-agnostic: keep it out of the top region (see PR)
         .sub_device_id = std::nullopt,
     };
 

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -392,7 +392,8 @@ AnyBuffer::AnyBuffer(std::shared_ptr<Buffer> buffer) : buffer_(buffer.get()), ho
 AnyBuffer::AnyBuffer(std::shared_ptr<MeshBuffer> buffer) :
     buffer_(buffer->get_reference_buffer()), holder_(std::move(buffer)) {}
 
-AnyBuffer AnyBuffer::create(const tt::tt_metal::ShardedBufferConfig& config, std::optional<uint64_t> address) {
+AnyBuffer AnyBuffer::create(
+    const tt::tt_metal::ShardedBufferConfig& config, std::optional<uint64_t> address, std::optional<bool> bottom_up) {
     // TODO #20966: Remove single device support and branches + dynamic_cast
     auto* mesh_device = dynamic_cast<MeshDevice*>(config.device);
     if (!mesh_device) {
@@ -408,6 +409,7 @@ AnyBuffer AnyBuffer::create(const tt::tt_metal::ShardedBufferConfig& config, std
         .page_size = config.page_size,
         .buffer_type = config.buffer_type,
         .sharding_args = BufferShardingArgs(config.shard_parameters, config.buffer_layout),
+        .bottom_up = bottom_up,
     };
     return MeshBuffer::create(mesh_config, local_config, mesh_device, address);
 }

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -245,7 +245,10 @@ std::shared_ptr<MeshBuffer> create_socket_config_buffer(
         .page_size = config_buffer_size,
         .buffer_type = BufferType::L1,
         .sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
-        .bottom_up = std::nullopt,
+        // Tiny and address-agnostic: keep it out of the top region, where a top-down
+        // lockstep placement below other banks' per-core ranges strands 64 B markers
+        // that fragment every bank's top into sub-CB slivers (see PR #54788).
+        .bottom_up = true,
         .sub_device_id = is_sender ? socket_mem_config.sender_sub_device : socket_mem_config.receiver_sub_device,
     };
 

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -97,7 +97,7 @@ void GlobalSemaphoreImpl::setup_buffer(
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = std::move(shard_parameters),
     };
-    // LOCAL: bottom-up so 64 B semaphores do not fragment the top region (DSpark wave OOM).
+    // Bottom-up: tiny and address-agnostic, so it must not fragment the top region (see PR).
     buffer_ = distributed::AnyBuffer::create(sem_shard_config, address, /*bottom_up=*/true);
 
     if (initial_value.has_value()) {

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -97,7 +97,8 @@ void GlobalSemaphoreImpl::setup_buffer(
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = std::move(shard_parameters),
     };
-    buffer_ = distributed::AnyBuffer::create(sem_shard_config, address);
+    // LOCAL: bottom-up so 64 B semaphores do not fragment the top region (DSpark wave OOM).
+    buffer_ = distributed::AnyBuffer::create(sem_shard_config, address, /*bottom_up=*/true);
 
     if (initial_value.has_value()) {
         this->reset_semaphore_value(initial_value.value());


### PR DESCRIPTION
## Problem

The 64 B H2D/D2H socket config buffers and global semaphores allocate top-down in lockstep L1. A lockstep placement must avoid every bank's per-core allocations, so each of these tiny buffers lands just below whatever per-core range (e.g. a per-core socket data buffer, #52551) happens to cap some *other* bank — stranding a 64 B lockstep marker high in the address space of **every** bank.

Measured on a Blackhole galaxy running a DSpark temporal pipeline wave (HYBRID allocator, per-core sockets): three such markers at 1,572,800 / 1,457,600 / 1,342,272 fragmented the top ~230 KB of every L1 bank into <=115 KB slivers. A 487 KB CB that would otherwise pack flush at the top was forced ~500 KB down the bank, and a 230 KB staging buffer then failed to allocate even though the bank had ~400 KB free — OOM purely from fragmentation.

## Change

These allocations are tiny and address-agnostic, so place them bottom-up with the other small lockstep tenants:

- `AnyBuffer::create` (sharded overload) grows an optional `bottom_up` parameter (default `std::nullopt`, existing callers unchanged),
- global semaphores pass `bottom_up = true`,
- the H2D and D2H socket config buffers set `.bottom_up = true`.

10 insertions. With this (plus per-core socket buffers from #52551), the workload above allocates with ~177 KB to spare and runs; kernels read these addresses from runtime args / config blobs, so placement direction is transparent to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dyurshevich/socket-config-gsem-bottom-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dyurshevich/socket-config-gsem-bottom-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dyurshevich/socket-config-gsem-bottom-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dyurshevich/socket-config-gsem-bottom-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dyurshevich/socket-config-gsem-bottom-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dyurshevich/socket-config-gsem-bottom-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dyurshevich/socket-config-gsem-bottom-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dyurshevich/socket-config-gsem-bottom-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dyurshevich/socket-config-gsem-bottom-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dyurshevich/socket-config-gsem-bottom-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dyurshevich/socket-config-gsem-bottom-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dyurshevich/socket-config-gsem-bottom-up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dyurshevich/socket-config-gsem-bottom-up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dyurshevich/socket-config-gsem-bottom-up)