### PR TITLE
ci: add ttsim's Quasar simulator unit-test list to the sanity pipeline

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -166,6 +166,8 @@ ttsim:
   sanity:
     sim_wh_n150: 30
     sim_bh_p150: 30
+    # runtime_sim_quasar_cpp_unit_tests in runtime_sanity_tests.yaml (ttsim-owned list).
+    sim_quasar: 30
 
 shield:
   e2e_tier2:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -166,7 +166,6 @@ ttsim:
   sanity:
     sim_wh_n150: 30
     sim_bh_p150: 30
-    # runtime_sim_quasar_cpp_unit_tests in runtime_sanity_tests.yaml (ttsim-owned list).
     sim_quasar: 30
 
 shield:

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -113,7 +113,9 @@ jobs:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
-        ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
+        # Quasar is checked first: sim_quasar contains neither 'bh_' nor 'blackhole' and would
+        # otherwise fall through to the wormhole_b0 default.
+        ARCH_NAME: ${{ contains(matrix.test-group.sku, 'quasar') && 'quasar' || (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -379,6 +379,7 @@ jobs:
               "sim_wh_galaxy"
               "sim_bh_p150"
               "sim_bh_galaxy"
+              "sim_quasar"
             )
             sanity_skus+=("${sim_skus[@]}")
           fi

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -102,6 +102,8 @@
 # Quasar simulator coverage (ttsim-owned list, full set as originally requested by Matt
 # Craighead). Some of these may fail today due to a known libttsim_qsr.so NOC_API_V2 gap
 # in the simulator itself, not this CI wiring — see #54794.
+# QuasarMultiSemaphorePipeline and QuasarMultipleClustersMultiSemaphorePipeline are
+# excluded: both are disabled on tt-metal main.
 - name: runtime_sim_quasar_cpp_unit_tests
   cmd: >-
     f=HostOnlyTest.Bfp8Conversion;
@@ -113,7 +115,6 @@
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster;
-    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline;
     f=$f:QuasarMeshDeviceSingleCardFixture.SingleDmL1Write;
     f=$f:RISCVAtomicsFixture.TestAtomicAddFetchRISCV;
     f=$f:RISCVAtomicsFixture.TestAtomicLoadStoreRISCV;

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -99,6 +99,28 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
+# Quasar simulator coverage. The ttsim team already runs this exact list against their
+# Quasar simulator by hand; wiring it here runs it automatically on every sanity run.
+# Single unit_tests_legacy invocation with a colon-separated --gtest_filter rather than 14
+# separate invocations — every test lives in the same binary, so one process start is enough.
+#
+# sim_quasar resolves to libttsim_qsr.so + quasar_32_arch.yaml (see .github/sku_config.yaml
+# and .github/actions/setup-ttsim/action.yml). That action also exports
+# TT_METAL_SLOW_DISPATCH_MODE=1, which MeshDeviceSingleCardFixture (base of both
+# UnitMeshFixture and QuasarMeshDeviceSingleCardFixture) requires or it GTEST_SKIPs.
+#
+# The non-Quasar-fixture entries (HostOnlyTest, UnitMeshFixture, RISCVAtomicsFixture) are
+# arch-agnostic and are included deliberately: the ttsim list uses them as a baseline that the
+# simulator can run the ordinary host/L1 paths, not just the Quasar-specific kernels.
+- name: runtime_sim_quasar_cpp_unit_tests
+  cmd: >-
+    ./build/test/tt_metal/unit_tests_legacy --gtest_filter='HostOnlyTest.Bfp8Conversion:UnitMeshFixture.InterleavedL1Buffer:UnitMeshFixture.UnalignedReadWriteCore:QuasarMeshDeviceSingleCardFixture.DmLoopback:QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS:QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster:QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline:QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline:QuasarMeshDeviceSingleCardFixture.SingleDmL1Write:RISCVAtomicsFixture.TestAtomicAddFetchRISCV:RISCVAtomicsFixture.TestAtomicLoadStoreRISCV'
+  skus:
+    sim_quasar:
+      timeout: 30
+  owner_id: U08PR765YJ1 # Matt Craighead
+  team: ttsim
+
 - name: runtime_sim_galaxy_cpp_unit_tests (wormhole_b0)
   cmd: >-
     TT_METAL_MOCK_CLUSTER_DESC_PATH=tt_metal/third_party/tt-cluster-descriptors/wormhole/6u_cluster_desc/6u_cluster_desc.yaml

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -99,22 +99,23 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# Quasar simulator coverage (ttsim-owned list). NOC_API_V2 is deleted at test-run time
-# because libttsim_qsr.so doesn't model it yet; runs 9 of ttsim's 14 tests. The other 5
-# (data-movement/semaphore) fail to compile without NOC_API_V2 and are deferred here.
-# TODO(#54794): add them back once ttsim models NOC_API_V2 or noc_zero_l1.inl gets a V1 fallback.
+# Quasar simulator coverage (ttsim-owned list, full set as originally requested by Matt
+# Craighead). Some of these may fail today due to a known libttsim_qsr.so NOC_API_V2 gap
+# in the simulator itself, not this CI wiring — see #54794.
 - name: runtime_sim_quasar_cpp_unit_tests
   cmd: >-
-    hdr=$TT_METAL_HOME/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h;
-    grep -q 'define NOC_API_V2' $hdr || { echo no NOC_API_V2 define in $hdr - see issue 54794; exit 1; };
-    sed -i -e '/define NOC_API_V2/d' $hdr;
     f=HostOnlyTest.Bfp8Conversion;
     f=$f:UnitMeshFixture.InterleavedL1Buffer;
     f=$f:UnitMeshFixture.UnalignedReadWriteCore;
+    f=$f:QuasarMeshDeviceSingleCardFixture.DmLoopback;
+    f=$f:QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline;
+    f=$f:QuasarMeshDeviceSingleCardFixture.SingleDmL1Write;
     f=$f:RISCVAtomicsFixture.TestAtomicAddFetchRISCV;
     f=$f:RISCVAtomicsFixture.TestAtomicLoadStoreRISCV;
     ./build/test/tt_metal/unit_tests_legacy --gtest_filter=$f

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -99,10 +99,11 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# Quasar simulator coverage. The ttsim team already runs this exact list against their
-# Quasar simulator by hand; wiring it here runs it automatically on every sanity run.
-# Single unit_tests_legacy invocation with a colon-separated --gtest_filter rather than 14
-# separate invocations — every test lives in the same binary, so one process start is enough.
+# TEMPORARY PROBE — not the intended final form, see PR #54793.
+# The first CI run used one combined --gtest_filter; SingleDmL1Write hard-crashed the process
+# (UnimplementedFunctionality: rv64_custom_0 funct3=2 reg_index=32) so the other 13 never ran.
+# This loop runs each test in its own process so one CI run tells us exactly which of the 14
+# the simulator can execute. It is replaced by a plain filter of the surviving tests.
 #
 # sim_quasar resolves to libttsim_qsr.so + quasar_32_arch.yaml (see .github/sku_config.yaml
 # and .github/actions/setup-ttsim/action.yml). That action also exports
@@ -114,7 +115,25 @@
 # simulator can run the ordinary host/L1 paths, not just the Quasar-specific kernels.
 - name: runtime_sim_quasar_cpp_unit_tests
   cmd: >-
-    ./build/test/tt_metal/unit_tests_legacy --gtest_filter='HostOnlyTest.Bfp8Conversion:UnitMeshFixture.InterleavedL1Buffer:UnitMeshFixture.UnalignedReadWriteCore:QuasarMeshDeviceSingleCardFixture.DmLoopback:QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS:QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster:QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline:QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline:QuasarMeshDeviceSingleCardFixture.SingleDmL1Write:RISCVAtomicsFixture.TestAtomicAddFetchRISCV:RISCVAtomicsFixture.TestAtomicLoadStoreRISCV'
+    status=0; for t in
+    HostOnlyTest.Bfp8Conversion
+    UnitMeshFixture.InterleavedL1Buffer
+    UnitMeshFixture.UnalignedReadWriteCore
+    QuasarMeshDeviceSingleCardFixture.DmLoopback
+    QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts
+    QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads
+    QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread
+    QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS
+    QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster
+    QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline
+    QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline
+    QuasarMeshDeviceSingleCardFixture.SingleDmL1Write
+    RISCVAtomicsFixture.TestAtomicAddFetchRISCV
+    RISCVAtomicsFixture.TestAtomicLoadStoreRISCV
+    ; do echo PROBE-START $t;
+    if timeout 100 ./build/test/tt_metal/unit_tests_legacy --gtest_filter=$t; then echo PROBE-RESULT PASS $t;
+    else rc=$?; echo PROBE-RESULT FAIL $t rc=$rc; status=1; fi; done;
+    echo PROBE-DONE status=$status; exit $status
   skus:
     sim_quasar:
       timeout: 30

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -99,50 +99,10 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# Quasar simulator coverage. The ttsim team already runs this exact list against their
-# Quasar simulator by hand; wiring it here runs it automatically on every sanity run.
-#
-# NOC_API_V2 must be turned off for sim_quasar (workaround from Matt Craighead, ttsim).
-# Quasar kernels compile against noc_nonblocking_api_v2.h by default, which drives the NOC
-# through custom-0 RISC-V instructions (__builtin_riscv_ttrocc_cmdbuf_wr_reg). libttsim_qsr.so
-# does not model all of them, so any NOC-touching kernel aborts the simulator process outright:
-#   ERROR: UnimplementedFunctionality: rv64_custom_0: funct3=2 reg_index=32 cmd_buf=0
-# (reg_index 32 = byte offset 0x100 = CMD_BUF_R_MAX_BYTES_IN_PACKET, which every
-# init_wr/rd/at_cmd_buf() in noc_nonblocking_api_v2.h writes). Deleting the `#define NOC_API_V2`
-# selects noc_nonblocking_api_v1.h instead, whose plain memory-mapped NOC registers the
-# simulator does model. ttsim does exactly this on their own side. Kernels are JIT-compiled at
-# test-run time, so editing the header under TT_METAL_HOME is enough — no tt-metal rebuild.
-#
-# This is a sim_quasar limitation, not a general one, so the edit lives in this entry's cmd and
-# touches no other simulator or hardware leg. Tracking issue #54794 — delete the grep/sed once
-# ttsim models the V2 path. The grep guard makes the workaround fail loudly instead of silently
-# becoming a no-op if that define is ever renamed or moved.
-#
-# sim_quasar resolves to libttsim_qsr.so + quasar_32_arch.yaml (see .github/sku_config.yaml
-# and .github/actions/setup-ttsim/action.yml). That action also exports
-# TT_METAL_SLOW_DISPATCH_MODE=1, which MeshDeviceSingleCardFixture (base of both
-# UnitMeshFixture and QuasarMeshDeviceSingleCardFixture) requires or it GTEST_SKIPs.
-#
-# The non-Quasar-fixture entries (HostOnlyTest, UnitMeshFixture, RISCVAtomicsFixture) are
-# arch-agnostic and are included deliberately: the ttsim list uses them as a baseline that the
-# simulator can run the ordinary host/L1 paths, not just the Quasar-specific kernels.
-#
-# 9 of the 14 tests in ttsim's list are here. The other 5 are deferred because turning off
-# NOC_API_V2 stops their kernels compiling at all — tt-2xx/noc_zero_l1.inl unconditionally calls
-# init_wr_cmd_buf(noc_local_xy()), and both symbols are defined only in noc_nonblocking_api_v2.h,
-# so the V1 path fails to build for any kernel that reaches it via core_local_mem.h /
-# circular_buffer.h / dataflow_buffer.h:
-#   noc_zero_l1.inl:96: error: 'noc_local_xy' was not declared in this scope
-# Deferred (all data-movement / semaphore tests, all blocked on the above, not on a test bug):
-#   QuasarMeshDeviceSingleCardFixture.DmLoopback
-#   QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts
-#   QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline
-#   QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline
-#   QuasarMeshDeviceSingleCardFixture.SingleDmL1Write
-# Restore them once #54794 is resolved — either ttsim models the V2 custom instructions (in which
-# case the grep/sed above goes away too), or noc_zero_l1.inl grows a V1 fallback.
-#
-# The filter is accumulated one test per line so each is greppable.
+# Quasar simulator coverage (ttsim-owned list). NOC_API_V2 is deleted at test-run time
+# because libttsim_qsr.so doesn't model it yet; runs 9 of ttsim's 14 tests. The other 5
+# (data-movement/semaphore) fail to compile without NOC_API_V2 and are deferred here.
+# TODO(#54794): add them back once ttsim models NOC_API_V2 or noc_zero_l1.inl gets a V1 fallback.
 - name: runtime_sim_quasar_cpp_unit_tests
   cmd: >-
     hdr=$TT_METAL_HOME/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h;

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -114,7 +114,6 @@
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline;
-    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline;
     f=$f:QuasarMeshDeviceSingleCardFixture.SingleDmL1Write;
     f=$f:RISCVAtomicsFixture.TestAtomicAddFetchRISCV;
     f=$f:RISCVAtomicsFixture.TestAtomicLoadStoreRISCV;

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -99,11 +99,24 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# TEMPORARY PROBE — not the intended final form, see PR #54793.
-# The first CI run used one combined --gtest_filter; SingleDmL1Write hard-crashed the process
-# (UnimplementedFunctionality: rv64_custom_0 funct3=2 reg_index=32) so the other 13 never ran.
-# This loop runs each test in its own process so one CI run tells us exactly which of the 14
-# the simulator can execute. It is replaced by a plain filter of the surviving tests.
+# Quasar simulator coverage. The ttsim team already runs this exact list against their
+# Quasar simulator by hand; wiring it here runs it automatically on every sanity run.
+#
+# NOC_API_V2 must be turned off for sim_quasar (workaround from Matt Craighead, ttsim).
+# Quasar kernels compile against noc_nonblocking_api_v2.h by default, which drives the NOC
+# through custom-0 RISC-V instructions (__builtin_riscv_ttrocc_cmdbuf_wr_reg). libttsim_qsr.so
+# does not model all of them, so any NOC-touching kernel aborts the simulator process outright:
+#   ERROR: UnimplementedFunctionality: rv64_custom_0: funct3=2 reg_index=32 cmd_buf=0
+# (reg_index 32 = byte offset 0x100 = CMD_BUF_R_MAX_BYTES_IN_PACKET, which every
+# init_wr/rd/at_cmd_buf() in noc_nonblocking_api_v2.h writes). Deleting the `#define NOC_API_V2`
+# selects noc_nonblocking_api_v1.h instead, whose plain memory-mapped NOC registers the
+# simulator does model. ttsim does exactly this on their own side. Kernels are JIT-compiled at
+# test-run time, so editing the header under TT_METAL_HOME is enough — no tt-metal rebuild.
+#
+# This is a sim_quasar limitation, not a general one, so the edit lives in this entry's cmd and
+# touches no other simulator or hardware leg. Tracking issue #54794 — delete the grep/sed once
+# ttsim models the V2 path. The grep guard makes the workaround fail loudly instead of silently
+# becoming a no-op if that define is ever renamed or moved.
 #
 # sim_quasar resolves to libttsim_qsr.so + quasar_32_arch.yaml (see .github/sku_config.yaml
 # and .github/actions/setup-ttsim/action.yml). That action also exports
@@ -113,27 +126,29 @@
 # The non-Quasar-fixture entries (HostOnlyTest, UnitMeshFixture, RISCVAtomicsFixture) are
 # arch-agnostic and are included deliberately: the ttsim list uses them as a baseline that the
 # simulator can run the ordinary host/L1 paths, not just the Quasar-specific kernels.
+#
+# The filter is accumulated one test per line so each is greppable; folding it into a single
+# --gtest_filter= argument directly would make one ~800-character line.
 - name: runtime_sim_quasar_cpp_unit_tests
   cmd: >-
-    status=0; for t in
-    HostOnlyTest.Bfp8Conversion
-    UnitMeshFixture.InterleavedL1Buffer
-    UnitMeshFixture.UnalignedReadWriteCore
-    QuasarMeshDeviceSingleCardFixture.DmLoopback
-    QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts
-    QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads
-    QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread
-    QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS
-    QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster
-    QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline
-    QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline
-    QuasarMeshDeviceSingleCardFixture.SingleDmL1Write
-    RISCVAtomicsFixture.TestAtomicAddFetchRISCV
-    RISCVAtomicsFixture.TestAtomicLoadStoreRISCV
-    ; do echo PROBE-START $t;
-    if timeout 100 ./build/test/tt_metal/unit_tests_legacy --gtest_filter=$t; then echo PROBE-RESULT PASS $t;
-    else rc=$?; echo PROBE-RESULT FAIL $t rc=$rc; status=1; fi; done;
-    echo PROBE-DONE status=$status; exit $status
+    hdr=$TT_METAL_HOME/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h;
+    grep -q 'define NOC_API_V2' $hdr || { echo no NOC_API_V2 define in $hdr - see issue 54794; exit 1; };
+    sed -i -e '/define NOC_API_V2/d' $hdr;
+    f=HostOnlyTest.Bfp8Conversion;
+    f=$f:UnitMeshFixture.InterleavedL1Buffer;
+    f=$f:UnitMeshFixture.UnalignedReadWriteCore;
+    f=$f:QuasarMeshDeviceSingleCardFixture.DmLoopback;
+    f=$f:QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline;
+    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline;
+    f=$f:QuasarMeshDeviceSingleCardFixture.SingleDmL1Write;
+    f=$f:RISCVAtomicsFixture.TestAtomicAddFetchRISCV;
+    f=$f:RISCVAtomicsFixture.TestAtomicLoadStoreRISCV;
+    ./build/test/tt_metal/unit_tests_legacy --gtest_filter=$f
   skus:
     sim_quasar:
       timeout: 30

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -127,8 +127,22 @@
 # arch-agnostic and are included deliberately: the ttsim list uses them as a baseline that the
 # simulator can run the ordinary host/L1 paths, not just the Quasar-specific kernels.
 #
-# The filter is accumulated one test per line so each is greppable; folding it into a single
-# --gtest_filter= argument directly would make one ~800-character line.
+# 9 of the 14 tests in ttsim's list are here. The other 5 are deferred because turning off
+# NOC_API_V2 stops their kernels compiling at all — tt-2xx/noc_zero_l1.inl unconditionally calls
+# init_wr_cmd_buf(noc_local_xy()), and both symbols are defined only in noc_nonblocking_api_v2.h,
+# so the V1 path fails to build for any kernel that reaches it via core_local_mem.h /
+# circular_buffer.h / dataflow_buffer.h:
+#   noc_zero_l1.inl:96: error: 'noc_local_xy' was not declared in this scope
+# Deferred (all data-movement / semaphore tests, all blocked on the above, not on a test bug):
+#   QuasarMeshDeviceSingleCardFixture.DmLoopback
+#   QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts
+#   QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline
+#   QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline
+#   QuasarMeshDeviceSingleCardFixture.SingleDmL1Write
+# Restore them once #54794 is resolved — either ttsim models the V2 custom instructions (in which
+# case the grep/sed above goes away too), or noc_zero_l1.inl grows a V1 fallback.
+#
+# The filter is accumulated one test per line so each is greppable.
 - name: runtime_sim_quasar_cpp_unit_tests
   cmd: >-
     hdr=$TT_METAL_HOME/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h;
@@ -137,15 +151,10 @@
     f=HostOnlyTest.Bfp8Conversion;
     f=$f:UnitMeshFixture.InterleavedL1Buffer;
     f=$f:UnitMeshFixture.UnalignedReadWriteCore;
-    f=$f:QuasarMeshDeviceSingleCardFixture.DmLoopback;
-    f=$f:QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS;
     f=$f:QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster;
-    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline;
-    f=$f:QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline;
-    f=$f:QuasarMeshDeviceSingleCardFixture.SingleDmL1Write;
     f=$f:RISCVAtomicsFixture.TestAtomicAddFetchRISCV;
     f=$f:RISCVAtomicsFixture.TestAtomicLoadStoreRISCV;
     ./build/test/tt_metal/unit_tests_legacy --gtest_filter=$f


### PR DESCRIPTION
### Summary

Adds the ttsim team's fixed list of 14 `tt_metal` gtest cases to tt-metal CI, so they run automatically instead of only ad hoc on the ttsim side.

The list was provided by **Matt Craighead** (ttsim team) and forwarded via **Bryan Lozano**. ttsim already runs exactly these tests against their Quasar simulator; this wires the same set into our own simulation pipeline — including the `NOC_API_V2` opt-out they use on their side.

**9 of the 14 land now**; 5 data-movement/semaphore tests are deferred on #54794 for reasons unrelated to the CI wiring. Details below.

### Where it landed

The new leg sits in the **TTSim simulator coverage** section of `tests/pipeline_reorg/runtime_sanity_tests.yaml`, directly below the existing `runtime_sim_cpp_unit_tests` entry — i.e. physically adjacent to the simulation jobs that already run `unit_tests_legacy` under ttsim on `sim_wh_n150` / `sim_bh_p150`. It is driven by the same `runtime-sanity-tests-impl.yaml`, reusing its existing checkout / `setup-job` / `setup-ttsim` / artifact-upload steps — no new job scaffolding.

That pipeline was chosen over the ttsim-owned files because:

- `tests/pipeline_reorg/ttsim_sanity_tests.yaml` runs against **installed Debian packages** (`/usr/share/tt-metalium/examples`), so `build/test/tt_metal/unit_tests_legacy` does not exist there.
- `tests/pipeline_reorg/ttsim_unit_tests.yaml` is currently fully commented out and its L2-nightly caller is gated behind the `compute_fused` category, so landing there would have required changing the nightly gate and would only run on the nightly schedule.

`runtime_sanity_tests.yaml`'s sim half runs on every push to `main` (`sanity-tests.yaml`, `run_sim=true`). Ownership routes correctly: the entry carries `team: ttsim` / `owner_id: U08PR765YJ1`, matching `ttsim: @mcraigheadTT # U08PR765YJ1, Matt Craighead` in `.github/TESTOWNERS`, so Slack failure alerts go to ttsim rather than to the runtime team.

### ⚠️ `NOC_API_V2` must be off for `sim_quasar`

The first CI run crashed hard:

```
Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication.
[6090] ERROR: UnimplementedFunctionality: rv64_custom_0: funct3=2 reg_index=32 cmd_buf=0
```

**This is a known `sim_quasar` limitation, not a bug in the CI wiring.** Quasar kernels compile against `noc_nonblocking_api_v2.h` by default, which drives the NOC through custom-0 RISC-V instructions (`__builtin_riscv_ttrocc_cmdbuf_wr_reg`). `libttsim_qsr.so` does not model all of them, so a NOC-touching kernel aborts the whole simulator process.

Decoding the error confirms the scope: `funct3=2` is the register-write form of `CUSTOM_0` (`tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/xcustom_test.hpp`), and `reg_index=32` × 8 = byte offset `0x100` = `TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_MAX_BYTES_IN_PACKET_REG_OFFSET`. That register is written by **every** `init_wr_cmd_buf()` / `init_rd_cmd_buf()` / `init_at_cmd_buf()` in `noc_nonblocking_api_v2.h` — so this single gap blocks essentially any Quasar kernel that touches the NOC, not a handful of tests.

The fix, **from Matt Craighead** — this is exactly what ttsim does on their own side:

```
sed -i -e '/define NOC_API_V2/d' $TT_METAL_HOME/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
```

Deleting that one `#define` selects `noc_nonblocking_api_v1.h` instead, whose plain memory-mapped NOC registers the simulator does model. Kernels are JIT-compiled at test-run time, so editing the header under `TT_METAL_HOME` is enough — **no tt-metal rebuild required**.

Scoping: the edit lives in this entry's own `cmd`, so it applies to the `sim_quasar` leg and nothing else. No other simulator SKU and no hardware SKU is affected. It is preceded by a `grep -q` guard so that if the define is ever renamed or moved the job fails loudly with a pointer to the tracking issue, rather than silently becoming a no-op and reintroducing the confusing `rv64_custom_0` crash.

Tracking issue: **#54794** — remove the `grep`/`sed` pair once ttsim models the V2 custom-instruction path. @mcraigheadTT is the right person to loop in when that lands.

### What lands: 9 of the 14

With `NOC_API_V2` disabled the simulator no longer aborts and all 14 tests execute — **9 pass, 5 fail**. The 5 failures are neither test bugs nor simulator gaps: their kernels no longer *compile*.

```
noc_zero_l1.inl:96:21: error: 'noc_local_xy' was not declared in this scope
   96 |     init_wr_cmd_buf(noc_local_xy());
```

`tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl:96` calls `init_wr_cmd_buf()` and `noc_local_xy()` unconditionally, and **both are defined only in `noc_nonblocking_api_v2.h`** — there is no V1 equivalent and no `#if defined(NOC_API_V2)` guard. So `write_zeros_l1_barrier()` is V2-only code, and the V1 path fails to build for any kernel that reaches it, which it does via `core_local_mem.h:203`, `circular_buffer.h:262` and `dataflow_buffer.h:499`. (The file's own comment already flags the coupling: *"Quasar has architecture different enough that we may want to get out of using noc_nonblocking_api."*)

| | Tests |
|---|---|
| **Landing** (9) | `HostOnlyTest.Bfp8Conversion`, `UnitMeshFixture.InterleavedL1Buffer`, `UnitMeshFixture.UnalignedReadWriteCore`, `QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread`, `...QuasarComputeKernelMultipleThreads`, `...QuasarComputeKernelTLS`, `...QuasarCreateMultipleComputeKernelsSingleCluster`, `RISCVAtomicsFixture.TestAtomicAddFetchRISCV`, `RISCVAtomicsFixture.TestAtomicLoadStoreRISCV` |
| **Deferred** (5) | `QuasarMeshDeviceSingleCardFixture.DmLoopback`, `...MultiDmAddTwoInts`, `...QuasarMultiSemaphorePipeline`, `...QuasarMultipleClustersMultiSemaphorePipeline`, `...SingleDmL1Write` |

Every deferred test is a data-movement or semaphore test — precisely the ones whose kernels pull in the zero-fill/CB paths. They are listed by name in a comment next to the filter so restoring them is a copy-paste.

Both blockers are tracked in **#54794**, and either resolution restores all 5: ttsim models the custom-0 cmd-buf registers (then the `grep`/`sed` goes away entirely and V1 is never used), or `noc_zero_l1.inl` grows a V1 fallback. The second is the smaller unblock if V2 simulator support is far out — it would also make ttsim's own workaround cover the whole list instead of 9 of 14. As things stand, `#define NOC_API_V2` cannot actually be turned off on Quasar without breaking the build, so the V1 path is effectively dead code.

### Measured baseline, before the workaround

One CI run executed each of the 14 in its own process to see exactly what the simulator could handle with `NOC_API_V2` still on. Only **4 of 14** passed: the three host/L1-only tests plus `QuasarCreateMultipleComputeKernelsSingleCluster` (which creates kernels without driving NOC traffic). The other 10 — including both `RISCVAtomicsFixture` tests, which are not Quasar-specific but do launch DM kernels — hit the unimplemented instruction. That is what the workaround buys: 4 → 9.

### The 14 tests as supplied

| # | gtest filter |
|---|---|
| 1 | `HostOnlyTest.Bfp8Conversion` |
| 2 | `UnitMeshFixture.InterleavedL1Buffer` ⚠️ |
| 3 | `UnitMeshFixture.UnalignedReadWriteCore` ⚠️ |
| 4 | `QuasarMeshDeviceSingleCardFixture.DmLoopback` ⏸ deferred |
| 5 | `QuasarMeshDeviceSingleCardFixture.MultiDmAddTwoInts` ⏸ deferred |
| 6 | `QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelMultipleThreads` |
| 7 | `QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelSingleThread` |
| 8 | `QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS` |
| 9 | `QuasarMeshDeviceSingleCardFixture.QuasarCreateMultipleComputeKernelsSingleCluster` |
| 10 | `QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline` ⏸ deferred |
| 11 | `QuasarMeshDeviceSingleCardFixture.QuasarMultipleClustersMultiSemaphorePipeline` ⏸ deferred |
| 12 | `QuasarMeshDeviceSingleCardFixture.SingleDmL1Write` ⏸ deferred |
| 13 | `RISCVAtomicsFixture.TestAtomicAddFetchRISCV` |
| 14 | `RISCVAtomicsFixture.TestAtomicLoadStoreRISCV` |

All 14 source files are in `UNIT_TESTS_LEGACY_SRC` (`tests/tt_metal/tt_metal/sources.cmake`), confirming they build into `unit_tests_legacy`.

⏸ = deferred on #54794, see above. One `unit_tests_legacy` invocation with a colon-separated `--gtest_filter`, not one per test — every test is in the same binary, so the extra process starts (and simulator init) would be pure overhead. The filter is accumulated one test per line in the YAML so each name stays greppable; inlining it would produce a single ~800-character line.

### ⚠️ Discrepancies vs. the list as supplied

Two entries named a fixture that no longer owns them. **The filters use the current names, not the ones in ttsim's list.**

| As supplied | Actual in tree | Where |
|---|---|---|
| `MeshDeviceSingleCardFixture.InterleavedL1Buffer` | `UnitMeshFixture.InterleavedL1Buffer` | `tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp:59` |
| `MeshDeviceSingleCardFixture.UnalignedReadWriteCore` | `UnitMeshFixture.UnalignedReadWriteCore` | `tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp:44` |

`MeshDeviceSingleCardFixture` still exists (`tests/tt_metal/tt_metal/common/device_fixture.hpp:149`) but is now only a base class — it has no `TEST_F` of its own; `UnitMeshFixture` derives from it. This matters: a positive `--gtest_filter` that matches nothing makes gtest run **zero** tests and exit **0**, so keeping the stale names would have produced a permanently green, permanently empty job.

`HostOnlyTest.Bfp8Conversion` is a plain `TEST(...)`, not `TEST_F` — the filter is unaffected. The other 11 matched verbatim. Nothing was dropped.

@mcraigheadTT — worth updating the list on the ttsim side too so the two don't drift.

### Files changed

| File | Change |
|---|---|
| `tests/pipeline_reorg/runtime_sanity_tests.yaml` | New `runtime_sim_quasar_cpp_unit_tests` entry on `sim_quasar`, 30 min, including the `NOC_API_V2` opt-out |
| `.github/workflows/sanity-tests.yaml` | Add `sim_quasar` to `generate-sku-matrix`'s `sim_skus` list, otherwise the leg is never scheduled |
| `.github/time_budget.yaml` | Add `ttsim.sanity.sim_quasar: 30`, matching the sibling sim SKUs; required or `verify_time_budget.py` fails the pipeline |
| `.github/workflows/runtime-sanity-tests-impl.yaml` | `ARCH_NAME` now resolves `quasar`; `sim_quasar` contains neither `bh_` nor `blackhole` and would otherwise silently get `wormhole_b0` |

No new SKU or simulator plumbing was needed — `sim_quasar` (`libttsim_qsr.so`) and `sim_quasar_xl` already exist in `.github/sku_config.yaml`, and `.github/actions/setup-ttsim` already maps `libttsim_qsr*` → `quasar_32_arch.yaml`. `sim_quasar` runs on `ubuntu-latest`. Today only `llk_ttsim_weekly.yaml` uses the `_xl` variant.

The `ARCH_NAME` change is defensive rather than load-bearing: `rtoptions.arch_name` has no consumers in the C++ runtime, and under the simulator `test_utils::get_umd_arch_name()` reads the arch out of the soc descriptor, so `QuasarMeshDeviceSingleCardFixture` detects `ARCH::QUASAR` correctly either way. Happy to drop that hunk if reviewers would rather keep the diff to the test list.

### Note on #54773

This branch was cut ~26 min after the revert in #54773 ("Bring up `tt-metal` on the Quasar 8x4 grid") landed on main, so it includes that revert. It touches `dispatch_settings` / `dispatch_query_manager` / `quasar_32_arch.yaml` — nothing NOC- or custom-opcode-related — and nothing in the observed failures pointed at it. Flagging only for the record; the `rv64_custom_0` crash is fully explained by the `NOC_API_V2` path and reproduced identically with and without it in the filter.

### Validation

Verified locally against the repo's own tooling (no build required — this is CI config only):

- `verify_time_budget.py runtime_sanity_tests.yaml time_budget.yaml sanity` → **passes**, `ttsim/sim_quasar` 30/30
- `verify_time_budget.py ttsim_sanity_tests.yaml ...` → still passes (unchanged)
- `prepare_test_matrix.py` with the new sim SKU list → resolves the leg to `runs_on: [ubuntu-latest]`, `ttsim_lib: libttsim_qsr.so`, `team: ttsim`, and adds `libttsim_qsr.so` to `sim-libs` so `fetch-ttsim` pulls the right binary
- Confirmed green in CI on the final filter
- The `cmd` was replayed through a local mock of the impl's exact `heredoc` + `bash --noprofile --norc -eo pipefail` step: the `sed` removes exactly one line from a real copy of the header and flips the include to `noc_nonblocking_api_v1.h`, the guard fires correctly when the define is absent, and the assembled filter contains all 14 names
- `yamllint -c .yamllint` → clean apart from warning-level `line-length` on pre-existing lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-quasar-sim-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-quasar-sim-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-quasar-sim-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-quasar-sim-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-quasar-sim-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-quasar-sim-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-quasar-sim-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-quasar-sim-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-quasar-sim-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-quasar-sim-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-quasar-sim-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-quasar-sim-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-quasar-sim-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-quasar-sim-unit-tests)