### PR TITLE
[Test Only] Gate MiniMax-H3 tiled VAE encode at non-square canvases

### DIFF
--- a/models/tt_dit/tests/models/minimax_h3/test_vae_minimax_h3.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_vae_minimax_h3.py
@@ -120,19 +120,31 @@ def test_tiling_geometry_matches_reference(width, height, num_frames):
 
 
 @pytest.mark.parametrize(
-    ("num_frames", "temporal_taps", "expected_latent_frames"),
-    [pytest.param(1, 1, 1, id="keyframe"), pytest.param(17, 3, 5, id="clip")],
+    ("num_frames", "temporal_taps", "expected_latent_frames", "height", "width"),
+    [
+        pytest.param(1, 1, 1, 512, 512, id="keyframe"),
+        pytest.param(17, 3, 5, 512, 512, id="clip"),
+        # An fl2va keyframe arrives on the `resolve_canvas_size` canvas, which is never square:
+        # a 16:9 keyframe lands on (768, 1344) and a 9:16 one on (1344, 768). A square-only
+        # gate cannot catch an H/W transposition in the device path, so both orientations run.
+        pytest.param(1, 1, 1, 768, 1344, id="keyframe_768P"),
+        pytest.param(1, 1, 1, 1344, 768, id="keyframe_768P_portrait"),
+        # 1440P is not a keyframe canvas -- `resolve_canvas_size` caps the area at 768 * 1344 --
+        # but it is a VAE working point (8x13 tiles in the perf tests), so a single frame is the
+        # cheapest way to gate the tiled encode geometry at that scale, in both orientations.
+        pytest.param(1, 1, 1, 1440, 2560, id="single_frame_1440P"),
+        pytest.param(1, 1, 1, 2560, 1440, id="single_frame_1440P_portrait"),
+    ],
 )
 @pytest.mark.parametrize(("mesh_device", "device_params"), SINGLE_DEVICE, indirect=["mesh_device", "device_params"])
-def test_encode_clip_tiled(mesh_device, num_frames, temporal_taps, expected_latent_frames):
+def test_encode_clip_tiled(mesh_device, num_frames, temporal_taps, expected_latent_frames, height, width):
     """Tiled ``encode_clip`` vs the reference's tiled ``_encode_clip``; also the whole-encoder gate."""
     # Whole-encoder coverage skips without MINIMAX_H3_MODEL_PATH.
     weights_dir = _weights_dir()
     reference, config = _build_reference(weights_dir)
     torch.manual_seed(4)
 
-    extent = 512
-    x = torch.randn(1, 3, num_frames, extent, extent)
+    x = torch.randn(1, 3, num_frames, height, width)
     with torch.no_grad():
         expected = reference._encode_clip(x)
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`test_encode_clip_tiled` only exercised the MiniMax-H3 keyframe VAE encode path at square 512x512, while fl2va keyframes always arrive on a non-square `resolve_canvas_size` canvas — (768, 1344) landscape or (1344, 768) portrait. An H/W transposition anywhere in the device encode path would have passed the square-only gate.

### What's changed
Parametrize the keyframe case of `test_encode_clip_tiled` over five canvases:
- 512x512 (existing square gate)
- 768x1344 and 1344x768 — the real fl2va landscape/portrait canvases
- 1440x2560 and 2560x1440 — not reachable as a keyframe canvas (`resolve_canvas_size` caps the area at 768*1344), but a VAE working point at an 8x13 tile grid, so a single frame is the cheapest gate of the tiled encode geometry at that scale

### Checklist
- [x] All six cases pass on Blackhole (single device) against the diffusers reference with the real checkpoint at ~99.999% PCC, RMSE/σ 0.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jonathansu/vae-encode-nonsquare-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jonathansu/vae-encode-nonsquare-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jonathansu/vae-encode-nonsquare-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jonathansu/vae-encode-nonsquare-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jonathansu/vae-encode-nonsquare-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jonathansu/vae-encode-nonsquare-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jonathansu/vae-encode-nonsquare-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jonathansu/vae-encode-nonsquare-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jonathansu/vae-encode-nonsquare-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jonathansu/vae-encode-nonsquare-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jonathansu/vae-encode-nonsquare-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jonathansu/vae-encode-nonsquare-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jonathansu/vae-encode-nonsquare-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jonathansu/vae-encode-nonsquare-tests)