### PR TITLE
[Test Only] test_ttnn_moe: split GLM-5.2 rows out of test_ds_moe into test_glm_moe

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -118,7 +118,7 @@ def run_model(
     shared_activation=ACTIVATION_SILU,
     measure=None,
 ):
-    """TtMoe PCC body — shared between `test_ds_moe` / `test_kimi_moe`.
+    """TtMoe PCC body — shared by every per-model test in this file.
 
     The gate's grouping (n_group, topk_group) and route_scale are read from
     the variant's HF config. DSv3 values are a no-op; Kimi values switch the
@@ -721,11 +721,6 @@ def _ci_unsupported_param_combos_ds_moe(**params):
         pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 8, GateComputeMode.DEVICE_FP32,   True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-256"),
         # Perf: LB 8x1 dispatch/combine proxy. 64 experts + 2 picks/tok match one glx column's per-chip traffic (balanced_load=160).
         pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE,  64, 2, 8, GateComputeMode.HOST_ALL, False, False, marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-host-64"),
-        # GLM-5.2 MoE (256 experts / top-8, emb 6144, moe_int 2048). Exercises the >64-expert unfused
-        # extract->FFN->insert routed-expert path on GLM dims. Gate is generic here (op-level test);
-        # GLM's noaux_tc knife-edge gate is validated at the transformer level.
-        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-glm-256"),
-        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, False, True,  marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-device-glm-256"),
         # fmt: on
     ],
 )
@@ -769,6 +764,105 @@ def _ci_unsupported_param_combos_ds_moe(**params):
 )
 @pytest.mark.parametrize("variant", ["deepseek_v3_d_p"], indirect=True, ids=["deepseek_v3"])
 def test_ds_moe(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    seq_len_per_chip,
+    emb_dim,
+    hidden_dim,
+    num_routed_experts,
+    num_experts_per_tok,
+    dispatch_buffer_capacity_factor,
+    run_pcc_check,
+    is_balanced,
+    num_links,
+    gate_fallback_mode,
+    request,
+    padded_percent,
+):
+    topology = per_axis_topology(device_params["fabric_config"])
+    run_model(
+        variant,
+        config_only,
+        mesh_device,
+        device_params,
+        seq_len_per_chip,
+        emb_dim,
+        hidden_dim,
+        num_routed_experts,
+        num_experts_per_tok,
+        dispatch_buffer_capacity_factor,
+        run_pcc_check,
+        num_links,
+        topology,
+        gate_fallback_mode,
+        request,
+        is_balanced=is_balanced,
+        padded_percent=padded_percent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GLM-5.2 MoE
+# ---------------------------------------------------------------------------
+#
+# 256 experts / top-8, emb 6144, moe_int 2048. Exercises the >64-expert unfused
+# extract->FFN->insert routed-expert path on GLM dims. Gate is generic here (op-level test);
+# GLM's noaux_tc knife-edge gate is validated at the transformer level.
+@pytest.mark.parametrize(
+    (
+        "seq_len_per_chip, emb_dim, hidden_dim, num_routed_experts, num_experts_per_tok, "
+        "dispatch_buffer_capacity_factor, gate_fallback_mode, run_pcc_check, is_balanced"
+    ),
+    [
+        # fmt: off
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-glm-256"),
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, False, True,  marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-device-glm-256"),
+        # fmt: on
+    ],
+)
+@pytest.mark.parametrize("padded_percent", [0, 50], ids=lambda p: f"pad{p}")
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links",
+    [
+        pytest.param(
+            (8, 1),
+            torus_y_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            2 if is_blackhole() else 1,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="torus-y-8x1",
+        ),
+        pytest.param(
+            (4, 2),
+            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            2 if is_blackhole() else 1,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
+            id="fabric2d-mesh-4x2",
+        ),
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            2 if is_blackhole() else 1,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-mesh-2x4",
+        ),
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            2 if is_blackhole() else 1,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+# Deliberately the DSv3 variant, not glm_5_2: the GLM adapter bundles no upstream MoE reference,
+# so running under it would silently drop the CPU cross-check this test still gets. The MoE dims
+# all come from GLM52Config above; the variant only supplies the generic gate config and the
+# reference class.
+@pytest.mark.parametrize("variant", ["deepseek_v3_d_p"], indirect=True, ids=["ds-ref"])
+def test_glm_moe(
     variant,
     config_only,
     mesh_device,

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -512,7 +512,7 @@
     # GLM-5.2 256-expert MoE (device gate, DEVICE_FP32) vs the CPU MoE reference; random weights.
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "torus-xy-8x4 and (pcc-device-glm-256 or perf-device-glm-256)" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_glm_moe -k "torus-xy-8x4" -vvv --tb=short
     '
   test_type: glm_moe
   test_tags: [glm_5_2, moe]


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Closes #54763.

`tests/pcc/test_ttnn_moe.py` gave each Kimi generation its own test function but folded GLM-5.2 into
`test_ds_moe`, so the Blaze job "(GLM-5.2-744B) MoE accuracy + perf 5k" selected a DeepSeek node id
and a GLM regression was reported against a DeepSeek test. The two GLM rows move into their own
`test_glm_moe`, matching the Kimi pattern, and the pipeline selector is repointed in the same commit.

Pure split: parameters, marks, mesh options and the padding parametrize all carry over, and the
collected node set maps 1:1 (47 ids before, 47 after).

### Notes for reviewers
- `test_glm_moe` deliberately keeps the `deepseek_v3_d_p` variant (id `ds-ref`), not `glm_5_2`. The
  GLM adapter defines no `reference_moe_cls`, so switching variants would silently drop the upstream
  CPU MoE cross-check these rows run today. All MoE dims still come from `GLM52Config`.
- Row ids keep the `glm` infix, so `-k pcc-device-glm-256` stays unambiguous against `test_ds_moe`'s
  `pcc-device-256`.
- Blaze selector is now `::test_glm_moe -k "torus-xy-8x4"`, which resolves to the same four cases as
  the old `-k "torus-xy-8x4 and (pcc-device-glm-256 or perf-device-glm-256)"`.
- `test_moe_perf.py` only selects DeepSeek rows, so it needs no change.

### Validation
Run on a Blackhole LoudBox at `fabric2d-mesh-2x4` (the 8x4 anchor needs a galaxy), both cases pass:

| case | device vs torch | vs CPU reference | threshold |
| --- | --- | --- | --- |
| `pcc-device-glm-256` | 0.988176 | 0.988160 | 0.982 |
| `perf-device-glm-256` | passed | n/a | n/a |

### CI runs
Triggered for this branch:

- Blaze Models Prefill, `test-type: glm_moe` -- the exact job whose selector this PR repoints: https://github.com/tenstorrent/tt-metal/actions/runs/33238396265

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/54763-split-glm-moe-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/54763-split-glm-moe-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/54763-split-glm-moe-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/54763-split-glm-moe-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/54763-split-glm-moe-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/54763-split-glm-moe-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/54763-split-glm-moe-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/54763-split-glm-moe-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/54763-split-glm-moe-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/54763-split-glm-moe-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/54763-split-glm-moe-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/54763-split-glm-moe-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/54763-split-glm-moe-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/54763-split-glm-moe-test)