### PR TITLE
[Performance] sdpa: reintroduce even-ring split forwarding with the second-half wait fixed

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -36,6 +36,10 @@ constexpr bool fuse_op = get_compile_time_arg_val(10);
 constexpr bool has_metadata = get_compile_time_arg_val(11);
 constexpr uint32_t cb_meta_id = get_compile_time_arg_val(12);
 constexpr uint32_t num_links = get_compile_time_arg_val(13);
+// Host-derived even-ring split-forwarding gate: the parent fused op owns this protocol decision and
+// passes the same flag to both all-gather directions and its own receiver, so producer and consumer
+// cannot disagree. Standalone (non-fused) callers get the legacy even-ring topology gate from the host.
+constexpr bool split_forwarding_enabled = get_compile_time_arg_val(14);
 
 // Prefetch: batch multiple packets of DRAM reads before a single barrier.
 // This keeps more reads in flight across interleaved DRAM banks, hiding latency.
@@ -43,7 +47,7 @@ constexpr uint32_t num_links = get_compile_time_arg_val(13);
 constexpr uint32_t PREFETCH_PACKETS = 4;
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 14;
+    constexpr uint32_t page_size_base_idx = 15;
     constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<
         num_inputs,
@@ -198,7 +202,7 @@ void kernel_main() {
     }
 
     // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring the diametric
-    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    // slice is relayed half per direction. The gate is a host-derived compile-time flag (see top of file).
     if (split_forwarding_enabled && direction == 1) {
         slices_expected++;
         writes_expected++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -197,6 +197,13 @@ void kernel_main() {
         }
     }
 
+    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring the diametric
+    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        slices_expected++;
+        writes_expected++;
+    }
+
     while (slices_received < slices_expected) {
         // Do i expect more from the backward direction?
         // In the linear case, I expect num_targets_backward_direction slices from the left
@@ -236,16 +243,32 @@ void kernel_main() {
         // In the ring case, if I have received on the right less than my targets on the left, forward
         if ((topology == Topology::Linear && writes_expected > 0) ||
             (topology == Topology::Ring && (slices_received < (writes_expected + 1)))) {
+            // The last slice we relay is the diametric shard of our downstream neighbor
+            const bool is_split_forwarded_slice = split_forwarding_enabled && (slices_received == writes_expected);
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-                uint32_t tiles_read = input_tile_id_start[input_idx];
-                uint32_t tiles_to_read = input_tile_id_end[input_idx];
-
-                uint32_t output_tile_id_start = 0;
-                uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-                uint32_t row_offset =
-                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
                 uint32_t slice_Wt = input_tensor_Wt[input_idx];
                 uint32_t stride_Wt = output_tensor_Wt[input_idx];
+
+                // Packet-aligned midpoint of this input's per-batch-head page range (matches the writer)
+                const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
+                const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+                const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+                const bool split_this_input = is_split_forwarded_slice;
+                uint32_t relay_start = input_tile_id_start[input_idx];
+                uint32_t relay_end = input_tile_id_end[input_idx];
+                if (split_this_input) {
+                    if (direction == 0) {
+                        relay_end = input_tile_id_start[input_idx] + first_half_pages;
+                    } else {
+                        relay_start = input_tile_id_start[input_idx] + first_half_pages;
+                    }
+                }
+
+                uint32_t tiles_read = relay_start;
+                uint32_t tiles_to_read = relay_end;
+                uint32_t output_tile_id_start = 0;
+                uint32_t pages_read_in_row = relay_start % slice_Wt;
+                uint32_t row_offset = (relay_start / slice_Wt) * stride_Wt;
                 if (gather_dim == 3) {
                     output_tile_id_start = actual_sender_chip_id * input_tensor_Wt[input_idx];
                 } else {
@@ -274,11 +297,10 @@ void kernel_main() {
                             }
                             return pid;
                         });
-                    pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
-                    row_offset =
-                        (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
-                    tiles_read = input_tile_id_start[input_idx];
-                    tiles_to_read = input_tile_id_end[input_idx];
+                    pages_read_in_row = relay_start % slice_Wt;
+                    row_offset = (relay_start / slice_Wt) * stride_Wt;
+                    tiles_read = relay_start;
+                    tiles_to_read = relay_end;
                     output_tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -49,9 +49,11 @@ constexpr uint32_t unicast_route_arg1 = get_compile_time_arg_val(15);
 constexpr bool has_metadata = get_compile_time_arg_val(16);
 constexpr uint32_t cb_meta_id = get_compile_time_arg_val(17);
 constexpr uint32_t num_links = get_compile_time_arg_val(18);
+// Host-derived even-ring split-forwarding gate; see ring_attention_all_gather_reader.cpp for semantics.
+constexpr bool split_forwarding_enabled = get_compile_time_arg_val(19);
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 19;
+    constexpr uint32_t page_size_base_idx = 20;
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
     // Metadata accessor follows the output accessors (metadata path only); fall back to a valid (unused)
     // accessor offset when absent so TensorAccessorArgs<> never names a non-accessor compile arg.
@@ -306,8 +308,8 @@ void kernel_main() {
         }
     }
 
-    // On an even ring the terminal relayed slice
-    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    // On an even ring the terminal relayed slice (the downstream neighbor's diametric shard) is relayed
+    // half per direction. The gate is a host-derived compile-time flag (see top of file).
     if (split_forwarding_enabled && direction == 1) {
         writes_expected++;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -306,6 +306,12 @@ void kernel_main() {
         }
     }
 
+    // On an even ring the terminal relayed slice
+    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    if (split_forwarding_enabled && direction == 1) {
+        writes_expected++;
+    }
+
     while (slice_writes < writes_expected) {
         // Direction == backward
         // Did I get something from my left to send to my right?
@@ -327,6 +333,7 @@ void kernel_main() {
             slice_chip_id = my_chip_id - slice_writes - 1;
             actual_slice_chip_id = (slice_chip_id < 0) ? ring_size + slice_chip_id : slice_chip_id;
         }
+        const bool is_split_forwarded_slice = split_forwarding_enabled && (slice_writes == writes_expected - 1);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             uint32_t tiles_read = input_tile_id_start[input_idx];
             uint32_t tiles_to_read = input_tile_id_end[input_idx];
@@ -342,47 +349,62 @@ void kernel_main() {
             } else {
                 tile_id_start = actual_slice_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
             }
+
+            // Packet-aligned midpoint of this input's per-batch-head page range
+            const uint32_t total_pages = tiles_to_read - input_tile_id_start[input_idx];
+            const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
+            const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
+            const bool split_this_input = is_split_forwarded_slice;
+
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                 while (tiles_read < tiles_to_read) {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                    cb_output.wait_front(packet_size_in_pages);
-                    size_t l1_read_addr = cb_output.get_read_ptr();
+                    uint32_t page_in_bh = tiles_read - input_tile_id_start[input_idx];
+                    bool relay_this_packet = !split_this_input || (direction == 0 ? (page_in_bh < first_half_pages)
+                                                                                  : (page_in_bh >= first_half_pages));
+
                     uint32_t first_tile_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
                     if (pages_read_in_row >= slice_Wt) {
                         row_offset += stride_Wt;
                         pages_read_in_row = 0;
                     }
-
+                    uint32_t second_tile_id = 0;
                     if (num_pages_to_read == 2) {
-                        uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+                        second_tile_id = tile_id_start + row_offset + pages_read_in_row;
                         pages_read_in_row++;
                         if (pages_read_in_row >= slice_Wt) {
                             row_offset += stride_Wt;
                             pages_read_in_row = 0;
                         }
+                    }
 
-                        scatter_fabric_write_unidir(
-                            first_tile_id,
-                            second_tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
-                    } else {
-                        ASSERT(num_pages_to_read == 1);
-                        fabric_write_unidir(
-                            first_tile_id,
-                            output_addrgens[input_idx],
-                            pkt_hdr,
-                            *fabric_direction_connection,
-                            l1_read_addr,
-                            output_page_size);
+                    if (relay_this_packet) {
+                        cb_output.wait_front(packet_size_in_pages);
+                        size_t l1_read_addr = cb_output.get_read_ptr();
+                        if (num_pages_to_read == 2) {
+                            scatter_fabric_write_unidir(
+                                first_tile_id,
+                                second_tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        } else {
+                            ASSERT(num_pages_to_read == 1);
+                            fabric_write_unidir(
+                                first_tile_id,
+                                output_addrgens[input_idx],
+                                pkt_hdr,
+                                *fabric_direction_connection,
+                                l1_read_addr,
+                                output_page_size);
+                        }
+                        cb_output.pop_front(packet_size_in_pages);
                     }
 
                     tiles_read += num_pages_to_read;
-                    cb_output.pop_front(packet_size_in_pages);
                 }
                 tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 tiles_read = input_tile_id_start[input_idx];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -370,7 +370,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     std::optional<Tensor> kv_actual_isl,
     uint32_t chunk_local_tiles,
     uint32_t kv_cache_num_layers,
-    uint32_t kv_cache_layer_idx) {
+    uint32_t kv_cache_layer_idx,
+    bool split_forwarding_enabled) {
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -519,6 +520,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
 
     // Tensor Info
     const uint32_t num_inputs = input_tensor.size();
+    // Even-ring split-forwarding: the caller owns the protocol decision (a fused consumer must implement
+    // the split second-half wait); the legacy topology gate stays so standalone callers keep prior behavior.
+    const bool effective_split_forwarding =
+        split_forwarding_enabled && topology == ttnn::ccl::Topology::Ring && ring_size % 2 == 0 && ring_size > 2;
     constexpr const char* exchange_writer_kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
         "ring_attention_all_gather_writer.cpp";
@@ -549,6 +554,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
         num_links,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -593,6 +599,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
         num_links,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -630,6 +637,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
         num_links,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -674,6 +682,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
         num_links,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_backward_kernel.compile_time_args.push_back(op_config.get_page_size());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -130,7 +130,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // cache slot as slot * kv_cache_num_layers + kv_cache_layer_idx (slot = slot_id[0]), matching
     // update_padded_kv_cache. Defaults (1, 0) reduce to slot, so single-layer callers are unaffected.
     uint32_t kv_cache_num_layers = 1,
-    uint32_t kv_cache_layer_idx = 0);
+    uint32_t kv_cache_layer_idx = 0,
+    // Even-ring split-forwarding gate. The parent fused op owns this protocol decision: a fused
+    // consumer must implement the split-shard second-half wait (RingSDPAOpReceiver) to enable it.
+    // The helper still applies the legacy even-ring topology/size gate on top, so standalone
+    // callers retain their prior behavior with the default.
+    bool split_forwarding_enabled = true);
 
 void ring_attention_neighbor_halo_exchange_helper(
     tt::tt_metal::ProgramDescriptor& desc,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -345,7 +345,7 @@ struct FusedRingGate {
     uint32_t shard_dir[max_ring_size];  // shard -> direction semaphore index
     uint32_t shard_val[max_ring_size];  // shard -> wait threshold
 
-    // recv has already consumed the 6-arg fused block (waiting for the op signal) and advanced argidx; take the
+    // recv has already consumed the fused block (waiting for the op signal) and advanced argidx; take the
     // k_local addr from the next slot and leave argidx at the band-perm base.
     FusedRingGate(const RingSDPAOpReceiver& recv, uint32_t& argidx) :
         ring_index(recv.seq.ring_index),
@@ -558,8 +558,9 @@ void kernel_main() {
     };
 
     if constexpr (fused_ring_enabled) {
-        // The receiver consumes the six fused args at slot 27 and waits for the producer signal. The gate then
-        // consumes k_local and records the following band-permutation base.
+        // The receiver consumes the fused-arg block at slot 27 (ring/dir/sems plus the split-forwarding
+        // triple — this op runs with split forwarding disabled) and waits for the producer signal. The
+        // gate then consumes k_local and records the following band-permutation base.
         uint32_t fused_argidx = 27;
         RingSDPAOpReceiver fused_recv(/*wait_for_op_signal=*/true, fused_argidx);
         const FusedRingGate gate(fused_recv, fused_argidx);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -739,10 +739,12 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
 
         // kernel_idx: reader=0, writer=1, compute=2; AG workers are 3..6.
         // The fused rt_arg namespace is file-local, but this .cpp participates in unity builds alongside
-        // the classic factory's same-named namespace. Keep these literals synchronized with its static_assert.
+        // the classic factory's same-named namespace. Keep these literals synchronized with its static_assert
+        // (reader_k_batch_offset=25, reader_kv_len_tiles=26, reader_k_local_batch_offset=37 — past the
+        // 9-wide fused block at 27..35 and k_local_addr at 36).
         patch_field(0, 25u, k_batch_page_offset);
         patch_field(0, 26u, pcache.kv_len_tiles);
-        patch_field(0, 34u, k_local_batch_page_offset);
+        patch_field(0, 37u, k_local_batch_page_offset);
         // compute: kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles (slots [6, perm_base)).
         patch_field(2, 6u, pcache.kv_len_tiles);
         patch_field(2, 7u, geom.chunk_start_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -54,13 +54,15 @@ namespace rt_arg {
 constexpr uint32_t reader_num_scalars = 3 + 6;  // q/k/w addrs + schedule {row_group0..max_bands}
 constexpr uint32_t mcast_args_per_dir = 8;      // role, rect(xs,ys,xe,ye), sender(sx,sy), ndst
 constexpr uint32_t reader_num_mcast_dirs = 2;   // K column, then Q/W row
-constexpr uint32_t fused_rt_width = 6;          // {ring_size, ring_index, fwd, bwd, sem0, sem1}
+// {ring_size, ring_index, fwd, bwd, sem0, sem1, split_enabled, split_shard_id, split_second_half_wait}
+// (the kernel-side RingSDPAOpReceiver consumes all nine; this consumer runs with split forwarding off)
+constexpr uint32_t fused_rt_width = 9;
 constexpr uint32_t reader_k_batch_offset = reader_num_scalars + reader_num_mcast_dirs * mcast_args_per_dir;  // 25
 constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;                                          // 26
 constexpr uint32_t reader_fused_rt_base = reader_kv_len_tiles + 1;                                           // 27
-constexpr uint32_t reader_k_local_addr = reader_fused_rt_base + fused_rt_width;                              // 33
-constexpr uint32_t reader_k_local_batch_offset = reader_k_local_addr + 1;                                    // 34
-constexpr uint32_t reader_band_perm_base = reader_k_local_batch_offset + 1;                                  // 35
+constexpr uint32_t reader_k_local_addr = reader_fused_rt_base + fused_rt_width;                              // 36
+constexpr uint32_t reader_k_local_batch_offset = reader_k_local_addr + 1;                                    // 37
+constexpr uint32_t reader_band_perm_base = reader_k_local_batch_offset + 1;                                  // 38
 // Compute RT: schedule(6), kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles, then perm.
 constexpr uint32_t compute_band_perm_base = 6 + 4;  // 10
 // Writer RT: out addr, schedule(6), kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles, perm.
@@ -69,7 +71,7 @@ constexpr uint32_t writer_band_perm_base = 1 + 6 + 4;  // 11
 // compute/writer read their perm at 10/11). A drift here would silently desync the kernels -> this fails to build.
 static_assert(
     reader_k_batch_offset == 25 && reader_kv_len_tiles == 26 && reader_fused_rt_base == 27 &&
-        reader_k_local_addr == 33 && reader_k_local_batch_offset == 34 && reader_band_perm_base == 35 &&
+        reader_k_local_addr == 36 && reader_k_local_batch_offset == 37 && reader_band_perm_base == 38 &&
         compute_band_perm_base == 10 && writer_band_perm_base == 11,
     "indexer_score fused rt_arg slot layout drifted from the kernel-side expectations");
 }  // namespace rt_arg
@@ -481,7 +483,7 @@ ProgramDescriptor build_ring_program_descriptor(
     const uint32_t kv_len_tiles = pcache.kv_len_tiles;
 
     std::vector<uint32_t> fused_rt;
-    sdpa_sig.push_ring_sdpa_fused_op_rt_args(fused_rt);  // {ring_size, ring_index, fwd, bwd, sem0, sem1}
+    sdpa_sig.push_ring_sdpa_fused_op_rt_args(fused_rt);  // the fused_rt_width-wide block (see rt_arg above)
 
     // ---- Step E: band-visit reorder (local-first, then remote by ring arrival) --------------------------
     // shard_order / band_readiness are computed above (hoisted so the band->column assignment can balance
@@ -555,10 +557,10 @@ ProgramDescriptor build_ring_program_descriptor(
             // Reader tail (sequential push; slots named in rt_arg, matched positionally by the kernel).
             reader_rt.push_back(k_batch_page_offset);        // rt_arg::reader_k_batch_offset (25)
             reader_rt.push_back(kv_len_tiles);               // rt_arg::reader_kv_len_tiles (26)
-            reader_rt.append(fused_rt);                      // rt_arg::reader_fused_rt_base (27..32): ring/dir/sems
-            reader_rt.push_back(k_local.buffer());           // rt_arg::reader_k_local_addr (33): local SP shard address
+            reader_rt.append(fused_rt);             // rt_arg::reader_fused_rt_base (27..35): ring/dir/sems/split
+            reader_rt.push_back(k_local.buffer());  // rt_arg::reader_k_local_addr (36): local SP shard address
             reader_rt.push_back(k_local_batch_page_offset);  // selected slot in the original local cache
-            reader_rt.append(band_perm);                     // rt_arg::reader_band_perm_base (35..): band-visit perm
+            reader_rt.append(band_perm);                     // rt_arg::reader_band_perm_base (38..): band-visit perm
             reader_kernel.emplace_runtime_args(core, reader_rt);
 
             KernelDescriptor::RTArgList compute_rt;
@@ -626,7 +628,14 @@ ProgramDescriptor build_ring_program_descriptor(
             // (compute_cols_x,1), ...) instead of running off the right grid edge as row-major would.
             ttnn::ccl::CoreAllocationStrategy::COL_MAJOR,
             args.cache_batch_idx,
-            gather_valid_height_tiles(args, k_local));
+            gather_valid_height_tiles(args, k_local),
+            /*slot_id=*/std::nullopt,
+            /*kv_actual_isl=*/std::nullopt,
+            /*chunk_local_tiles=*/0,
+            /*kv_cache_num_layers=*/1,
+            /*kv_cache_layer_idx=*/0,
+            // This consumer's FusedRingGate has no split-shard second-half wait; keep the gather unsplit.
+            /*split_forwarding_enabled=*/false);
     }
 
     log_debug(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -16,6 +16,11 @@ struct RingSDPAOpReceiver {
     std::array<uint32_t, 2> signal_op_semaphore_ids = {0, 0};
     bool initialized = false;
 
+    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled on both
+    bool split_forwarding_enabled = false;
+    uint32_t split_shard_id = 0;
+    uint32_t split_second_half_wait = 0;
+
     RingSDPAOpReceiver() {}
 
     RingSDPAOpReceiver(bool wait_for_op_signal, uint32_t& rt_args_idx) : wait_for_op_signal(wait_for_op_signal) {
@@ -29,6 +34,9 @@ struct RingSDPAOpReceiver {
             signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
             // Second is AllGather's FWD semaphore. It belongs to direction 0.
             signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
+            split_forwarding_enabled = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+            split_shard_id = get_arg_val<uint32_t>(rt_args_idx++);
+            split_second_half_wait = get_arg_val<uint32_t>(rt_args_idx++);
         }
 
         seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);
@@ -37,11 +45,16 @@ struct RingSDPAOpReceiver {
 
     uint32_t get_next_ring_id_and_sync() {
         ASSERT(initialized);
-        return seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
+        uint32_t ring_id = seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
             if (this->wait_for_op_signal) {
                 Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
+        // The split shard's second half lands via direction 1 (all-gather semaphore index 0)
+        if (this->wait_for_op_signal && this->split_forwarding_enabled && ring_id == this->split_shard_id) {
+            Semaphore<>(this->signal_op_semaphore_ids[0]).wait_min(this->split_second_half_wait);
+        }
+        return ring_id;
     }
 
     uint32_t get_next_ring_id_and_consume_one_signal() {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -50,7 +50,9 @@ struct RingSDPAOpReceiver {
                 Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
-        // The split shard's second half lands via direction 1 (all-gather semaphore index 0)
+        // The split shard's second half is the forward chain's final arrival, on semaphore_ids[0] —
+        // the semaphore that also carries the local-slice pre-signal (hence the +2 in the threshold;
+        // see push_ring_sdpa_fused_op_rt_args).
         if (this->wait_for_op_signal && this->split_forwarding_enabled && ring_id == this->split_shard_id) {
             Semaphore<>(this->signal_op_semaphore_ids[0]).wait_min(this->split_second_half_wait);
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -69,5 +69,13 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     out_rt_args.push_back(static_cast<uint32_t>(this->backward_writes_expected));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[0]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
+
+    // Even-ring split-forwarding: the diametric shard S arrives split across both links
+    const uint32_t split_shard_id =
+        this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
+    const uint32_t split_second_half_wait = this->backward_writes_expected + 1;
+    out_rt_args.push_back(static_cast<uint32_t>(this->split_forwarding_enabled ? 1 : 0));
+    out_rt_args.push_back(static_cast<uint32_t>(split_shard_id));
+    out_rt_args.push_back(static_cast<uint32_t>(split_second_half_wait));
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -73,7 +73,14 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     // Even-ring split-forwarding: the diametric shard S arrives split across both links
     const uint32_t split_shard_id =
         this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
-    const uint32_t split_second_half_wait = this->backward_writes_expected + 1;
+    // The forward chain's semaphore counts the local-slice pre-signal (the direction-1 all-gather
+    // writer signals its own slice; see synchronize_workers_and_signal_op in
+    // ring_attention_all_gather_writer.cpp) plus one signal per received slice — which is why
+    // RingIdSequencer's dir-0 waits use received + 1. The diametric shard's second half is that
+    // chain's final arrival, so its count is 1 (local) + backward_writes_expected (full slices)
+    // + 1 (second half). Waiting for backward_writes_expected + 1 would be subsumed by the
+    // sequencer's earlier wait for shard ring_index + backward_writes_expected, i.e. a no-op.
+    const uint32_t split_second_half_wait = this->backward_writes_expected + 2;
     out_rt_args.push_back(static_cast<uint32_t>(this->split_forwarding_enabled ? 1 : 0));
     out_rt_args.push_back(static_cast<uint32_t>(split_shard_id));
     out_rt_args.push_back(static_cast<uint32_t>(split_second_half_wait));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
@@ -24,6 +24,9 @@ struct RingSDPAFusedOpSignaler {
     uint32_t forward_writes_expected = 0;
     uint32_t backward_writes_expected = 0;
 
+    // Set by the program factory when the all-gather relays the diametric slice split across both links
+    bool split_forwarding_enabled = false;
+
     bool initialized_all_gather = false;
     bool initialized_fused_op = false;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1182,11 +1182,16 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->initialized_fused_op = true;
     }
 
-    // Must match the all-gather kernels' split-forwarding gate exactly
+    // Single host-derived split-forwarding decision, shared with the all-gather (passed to the
+    // helper below), so producer and consumer cannot disagree. Latent-V stays on the established
+    // unsplit protocol (its cache-replay consumption would deadlock waiting for a second half);
+    // sliding-window consumes shards via get_next_ring_id_and_consume_one_signal, which has no
+    // split second-half wait.
     sdpa_fused_op_signaler->split_forwarding_enabled =
         (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
         (args.all_gather_operation_attributes.ring_size % 2 == 0) &&
-        (args.all_gather_operation_attributes.ring_size > 2);
+        (args.all_gather_operation_attributes.ring_size > 2) && !tensor_args.has_latent_v() &&
+        !args.has_sliding_window();
 
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
     log_debug(
@@ -2864,7 +2869,10 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             // (user, layer)-major KV-cache batch factor: the all-gather reader computes the gathered slot as
             // slot_id[0] * kv_cache_num_layers + kv_cache_layer_idx. Defaults (1, 0) keep callers unaffected.
             args.kv_cache_num_layers,
-            args.kv_cache_layer_idx);
+            args.kv_cache_layer_idx,
+            // Share the split-forwarding decision derived above so the all-gather only splits when this
+            // consumer implements the second-half wait.
+            sdpa_fused_op_signaler->split_forwarding_enabled);
     }
 
     return desc;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1182,6 +1182,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->initialized_fused_op = true;
     }
 
+    // Must match the all-gather kernels' split-forwarding gate exactly
+    sdpa_fused_op_signaler->split_forwarding_enabled =
+        (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
+        (args.all_gather_operation_attributes.ring_size % 2 == 0) &&
+        (args.all_gather_operation_attributes.ring_size > 2);
+
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
     log_debug(
         tt::LogOp, "mesh_device->compute_with_storage_grid_size(): {}", mesh_device->compute_with_storage_grid_size());


### PR DESCRIPTION
Reintroduces the even-ring split forwarding of the last slice in ring-joint SDPA's fused all-gather (#52730, reverted in #53076) together with the synchronization fix for the bug that got it reverted. Builds upon @pavlejosipovic's #53053.

### Root cause of the original failures

`split_second_half_wait = backward_writes_expected + 1` was a **provable no-op**. The forward chain's fused semaphore counts one local-slice pre-signal (the direction-1 all-gather writer signals its own slice; `ring_attention_all_gather_writer.cpp`, "the fused op signaler will account for it in future waits") plus one per received slice — which is exactly why `RingIdSequencer`'s dir-0 waits use `received + 1`. So the sequencer's ordinary wait for shard `ring_index + backward_writes_expected` already waited for value `backward_writes_expected + 1`, and the "extra" second-half wait at the same threshold never blocked. The diametric shard's second half (which lands at `backward_writes_expected + 2`) was consumed with **no synchronization at all**, on every ring size.

The race only loses when per-ring-iteration compute is tiny — exactly the indexed / short-valid-prefix chunk-0 cases (`logical_n=256`, QB2 ring-4) — producing the observed PCC ~0.98 confined to the diametric shard's second half, and iteration-to-iteration nondeterminism.

#53053 diagnosed the same off-by-one but its final form kept the `+1`, on the premise that the semaphore counts only remote slices; the semaphore wiring (`ccl_op_fusion.cpp` pushes `fused_op_receiver_signal_semaphores[all_gather_direction]`; the factory hands the forward writer index 1, the same index the forward reader signals) contradicts that premise. Its `+2` experiment failed for a different reason: latent-V was still split-enabled at the time, and that path never delivers a split second half — a deadlock, not evidence against `+2`.

### The fix

- `split_second_half_wait = backward_writes_expected + 2` (`ring_fusion.cpp`).
- The parent fused op derives the split decision **once** and passes it to the all-gather helper; the AG reader/writer take it as a compile-time arg instead of re-deriving the gate in three places (the cross-op-mirror fragility #53076 flagged).
- Latent-V and sliding-window stay on the unsplit protocol (latent-V cache replay would deadlock waiting for a second half; sliding's `get_next_ring_id_and_consume_one_signal` has no split wait).
- `ring_indexer_score_dsa` passes `split_forwarding_enabled=false` (its `FusedRingGate` has no second-half wait — previously its all-gather split while its consumer never waited), and its `fused_rt` slot-layout constants are corrected to the 9-wide block the host pushes and `RingSDPAOpReceiver` consumes.
- The standalone (non-fused) ring-attention all-gather keeps its existing behavior via the helper's default.

### Validation

[Run 33237371801](https://github.com/tenstorrent/tt-metal/actions/runs/33237371801) (`sanity-tests.yaml` workflow_dispatch on this branch) — **completed success, all jobs green**, including the gate that killed #52730:

- `sdpa nightly tests (QB2 only)`: **125 passed / 0 failed** (was 6 failed / 119 passed one commit earlier on this branch, same 12:03 wall clock). The exact failing cases now pass with margin, split forwarding **enabled** on the dense path: chunk-0 `logical_n=256` PCC 0.99988 / 0.99984 (thresholds 0.994 / 0.997, previously 0.9796 / 0.9818); `kv_actual_isl` reuse determinism 0.99991 and deterministic; chunked indexed 0.99987 (previously 0.946).
- `TTNN multi-device CCL, SDPA PERF, and indexer tests (QB2 only)`: success — ring_joint / ring_mla / exp perf gates and the indexer suite all pass (attempt 1 died on `test_high_bw_all_gather_quietbox_ci_perf`, an op this PR does not touch, which passed unchanged on attempt 2 — box-state flake).

cc @cglagovichTT @pavlejosipovic @nwoodallTT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jonathansu/reapply-ring-joint-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jonathansu/reapply-ring-joint-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jonathansu/reapply-ring-joint-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jonathansu/reapply-ring-joint-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jonathansu/reapply-ring-joint-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jonathansu/reapply-ring-joint-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jonathansu/reapply-ring-joint-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jonathansu/reapply-ring-joint-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jonathansu/reapply-ring-joint-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jonathansu/reapply-ring-joint-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jonathansu/reapply-ring-joint-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jonathansu/reapply-ring-joint-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jonathansu/reapply-ring-joint-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jonathansu/reapply-ring-joint-split-forwarding)
### Device-time evidence (split enabled vs main's unsplit)

QB2 realtime-profiler perf checks, this branch ([attempt 2 of run 33237371801](https://github.com/tenstorrent/tt-metal/actions/runs/33237371801)) vs main ([run 33233399285](https://github.com/tenstorrent/tt-metal/actions/runs/33233399285), same box, same day):

| shape | main (unsplit) | this PR (split) |
|---|---|---|
| `wan2_2_1xGLX-q288-k512` | 7.910 ms / 68.36% util | 7.912 ms / 68.35% util |
| `mla_100k-q160-k320` | 4.825 ms / 62.69% util | 4.813 ms / 62.84% util |
| `kimi50k-q32-k640-chunk2560` | 2.878 ms / 65.86% util | 2.878 ms / 65.86% util |
| `kimi_k3-q32-k640-chunk2560` | 4.849 ms / 67.01% util | 4.849 ms / 67.01% util |

These gate shapes are compute-bound — the all-gather is fully hidden behind SDPA compute with or without the split — so the expected and observed effect there is **zero** (the corrected wait costs nothing; it only closes a race). The split's benefit case is communication-bound joint-attention shapes, where the diametric slice is the tail of the critical path and splitting it across both links halves that tail: that is the LTX pipeline context #52730 shipped it in (as part of the 6.1 s e2e bring-up, without an isolated per-op A/B). This PR's primary claim is therefore *restoring #52730's intended protocol with correct synchronization at no measured cost*; an isolated split-vs-unsplit A/B on a comm-bound LTX shape needs a galaxy and can be run as a follow-up if reviewers want it before merge.
