### PR TITLE
Kimi-K3 modules: vendor ttKDA and AttnRes onto main, and fix the KDA UT-transform inversion (#54813)

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_layer.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_layer.py
@@ -55,15 +55,10 @@ def test_reference_layer_is_bit_identical() -> None:
             )
 
 
-def test_reference_rejects_missing_or_mismatched_weights(expect_error) -> None:
+def test_reference_layer_validates_weights(expect_error) -> None:
     config = make_config()
-    hidden_states = torch.zeros(1, 1, config.hidden_size)
     weights = random_weights(config)
     del weights["q_proj.weight"]
-    with expect_error(ValueError, "missing KDA weight: q_proj.weight"):
-        kda_forward_reference(hidden_states, weights, config)
 
-    weights = random_weights(config)
-    weights["q_proj.weight"] = weights["q_proj.weight"][:-1]
-    with expect_error(ValueError, "q_proj.weight shape"):
-        kda_forward_reference(hidden_states, weights, config)
+    with expect_error(ValueError, "missing KDA weight: q_proj.weight"):
+        kda_forward_reference(torch.zeros(1, 1, config.hidden_size), weights, config)

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_weights.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_weights.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for the KDA reference weight contract."""
+
+from dataclasses import replace
+
+import torch
+
+from models.demos.deepseek_v3_d_p.reference.kda.tests.helpers import make_config, random_weights
+from models.demos.deepseek_v3_d_p.reference.kda.weights import normalize_kda_state_dict, validate_kda_weights
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_equal
+
+
+def test_weight_validation_reports_exact_name_and_shape(expect_error) -> None:
+    config = make_config(use_full_rank_gate=True)
+    weights = random_weights(config)
+    weights["q_proj.weight"] = torch.empty(config.q_dim, config.hidden_size + 1)
+
+    with expect_error(ValueError, r"q_proj\.weight shape .* !="):
+        validate_kda_weights(weights, config)
+
+
+def test_weight_validation_reports_exact_missing_name(expect_error) -> None:
+    config = make_config(use_full_rank_gate=True)
+    weights = random_weights(config)
+    del weights["q_proj.weight"]
+
+    with expect_error(ValueError, "missing KDA weight: q_proj.weight"):
+        validate_kda_weights(weights, config)
+
+
+def test_normalize_state_dict_trims_kimi_k3_padded_a_log() -> None:
+    config = replace(make_config(use_full_rank_gate=True), num_heads=96)
+    state_dict = random_weights(config)
+    padded = torch.arange(128, dtype=torch.float32)
+    state_dict["A_log"] = padded
+
+    normalized = normalize_kda_state_dict(state_dict, config)
+
+    assert normalized["A_log"].shape == (1, 1, config.num_heads, 1)
+    assert_equal(padded[: config.num_heads], normalized["A_log"].reshape(-1), name="trimmed A_log")
+    assert state_dict["A_log"] is padded
+
+
+def test_normalize_state_dict_rejects_unsupported_a_log_padding(expect_error) -> None:
+    config = replace(make_config(use_full_rank_gate=True), num_heads=96)
+    state_dict = random_weights(config)
+    state_dict["A_log"] = torch.arange(127, dtype=torch.float32)
+
+    with expect_error(ValueError, "A_log has 127 entries"):
+        normalize_kda_state_dict(state_dict, config)
+
+
+def test_normalize_state_dict_requires_a_log(expect_error) -> None:
+    config = make_config()
+    state_dict = random_weights(config)
+    del state_dict["A_log"]
+
+    with expect_error(ValueError, "missing KDA weight: A_log"):
+        normalize_kda_state_dict(state_dict, config)

--- a/models/demos/deepseek_v3_d_p/reference/kda/weights.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/weights.py
@@ -29,6 +29,15 @@ KDA_LOW_RANK_GATE_WEIGHT_NAMES = ("g_a_proj.weight", "g_b_proj.weight")
 KDA_FULL_RANK_GATE_WEIGHT_NAMES = ("g_proj.weight",)
 
 
+def normalize_kda_a_log(a_log: torch.Tensor, config: KDAConfig) -> torch.Tensor:
+    """Normalize checkpoint head padding into canonical ``[1,1,H,1]`` form."""
+    if a_log.numel() == config.num_heads:
+        return a_log.reshape(1, 1, config.num_heads, 1)
+    if config.num_heads == 96 and a_log.numel() == 128:
+        return a_log.reshape(-1)[: config.num_heads].reshape(1, 1, config.num_heads, 1)
+    raise ValueError(f"A_log has {a_log.numel()} entries; expected {config.num_heads} logical heads")
+
+
 def required_kda_weight_names(config: KDAConfig) -> tuple[str, ...]:
     """Return the canonical layer-local checkpoint keys for ``config``."""
     gate_names = KDA_FULL_RANK_GATE_WEIGHT_NAMES if config.use_full_rank_gate else KDA_LOW_RANK_GATE_WEIGHT_NAMES
@@ -73,3 +82,14 @@ def validate_kda_weights(weights: Mapping[str, torch.Tensor], config: KDAConfig)
             raise ValueError(f"missing KDA weight: {name}") from error
         if tuple(weight.shape) != expected_shape:
             raise ValueError(f"{name} shape {tuple(weight.shape)} != {expected_shape}")
+
+
+def normalize_kda_state_dict(state_dict: Mapping[str, torch.Tensor], config: KDAConfig) -> dict[str, torch.Tensor]:
+    """Copy, canonicalize, and validate a layer-local host-weight mapping."""
+    normalized = dict(state_dict)
+    try:
+        normalized["A_log"] = normalize_kda_a_log(normalized["A_log"], config)
+    except KeyError as error:
+        raise ValueError("missing KDA weight: A_log") from error
+    validate_kda_weights(normalized, config)
+    return normalized

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -12,7 +12,7 @@ Values from HuggingFace config.json for Kimi-K3 (``text_config``), whose ``model
 the TT stack reads lives under ``text_config``.
 
 K3 is a **hybrid**: of its 93 layers only 24 are full-attention (MLA) layers, the rest are KDA
-linear-attention layers. Only the MLA side is modelled here.
+linear-attention layers. This module owns the text-tower constants shared by MLA, KDA, MoE, and FFN consumers.
 
 MLA deltas vs Kimi-K2.6:
   * 96 attention heads (K2.6: 64)
@@ -93,11 +93,12 @@ class KimiK3Config:
                                52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 93]
     # fmt: on
 
-    # KDA (linear attention) sizing, recorded for completeness; no TT implementation exists yet.
+    # KDA (linear attention) sizing.
     KDA_NUM_HEADS = 96
     KDA_HEAD_DIM = 128
     KDA_SHORT_CONV_KERNEL_SIZE = 4
     KDA_GATE_LOWER_BOUND = -5.0
+    KDA_USE_FULL_RANK_GATE = True
 
     # AttnRes (attention-side, out of scope here; recorded so the delta is not lost)
     ATTN_RES_BLOCK_SIZE = 12

--- a/models/demos/deepseek_v3_d_p/tests/kda/checkpoint/test_layer_checkpoint.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/checkpoint/test_layer_checkpoint.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for loading one KDA layer from an indexed safetensor checkpoint."""
+
+import json
+from pathlib import Path
+
+from safetensors.torch import save_file
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kda.weights import required_kda_weight_names
+from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import (
+    kda_layer_prefix,
+    load_kda_layer_state_dict,
+    resolve_kda_layer_shards,
+)
+from models.demos.deepseek_v3_d_p.tests.kda.utils import make_config, random_weights
+
+
+def _write_indexed_layer(checkpoint_dir: Path, layer_idx: int, config: KDAConfig) -> Path:
+    shard_name = "model-00001-of-00001.safetensors"
+    prefix = kda_layer_prefix(layer_idx)
+    weights = {f"{prefix}{name}": tensor.contiguous() for name, tensor in random_weights(config).items()}
+    save_file(weights, checkpoint_dir / shard_name)
+    index = {"weight_map": {name: shard_name for name in weights}}
+    (checkpoint_dir / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+    return checkpoint_dir / shard_name
+
+
+def test_loads_one_indexed_full_rank_kda_layer(tmp_path: Path) -> None:
+    config = make_config(use_full_rank_gate=True)
+    shard = _write_indexed_layer(tmp_path, layer_idx=1, config=config)
+
+    assert resolve_kda_layer_shards(tmp_path, 1, config) == (shard,)
+    actual = load_kda_layer_state_dict(tmp_path, 1, config)
+
+    assert set(actual) == set(required_kda_weight_names(config))
+    assert "g_proj.weight" in actual
+    assert "g_a_proj.weight" not in actual
+    assert actual["A_log"].shape == (1, 1, config.num_heads, 1)
+
+
+def test_rejects_incomplete_checkpoint_shard_set(tmp_path: Path, expect_error) -> None:
+    config = make_config(use_full_rank_gate=True)
+    _write_indexed_layer(tmp_path, layer_idx=1, config=config).unlink()
+
+    with expect_error(FileNotFoundError, "missing complete KDA checkpoint shard"):
+        resolve_kda_layer_shards(tmp_path, 1, config)
+
+
+def test_rejects_index_missing_required_kda_weight(tmp_path: Path, expect_error) -> None:
+    config = make_config(use_full_rank_gate=True)
+    _write_indexed_layer(tmp_path, layer_idx=1, config=config)
+    index_path = tmp_path / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    del index["weight_map"][f"{kda_layer_prefix(1)}g_proj.weight"]
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    with expect_error(ValueError, "g_proj.weight"):
+        resolve_kda_layer_shards(tmp_path, 1, config)

--- a/models/demos/deepseek_v3_d_p/tests/kda/checkpoint_utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/checkpoint_utils.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Indexed safetensor loading for one Kimi Delta Attention layer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kda.weights import normalize_kda_state_dict, required_kda_weight_names
+
+KIMI_K3_FIRST_KDA_LAYER = 1
+KIMI_K3_HF_REVISION = "9f62e4e9fffbd0a83ddd60e1c209d828994b3569"
+KIMI_K3_LAYER_1_SHA256 = "10b99878599e02d002f2566b04c9cc7433da6d267351991978f6e348478f3097"
+
+
+def kda_state_dict_sha256(state_dict: Mapping[str, torch.Tensor]) -> str:
+    """Return a canonical content identity for the normalized KDA layer weights."""
+    fingerprint = hashlib.sha256()
+    for name in sorted(state_dict):
+        tensor = state_dict[name].detach().cpu().contiguous()
+        metadata = json.dumps([name, str(tensor.dtype), list(tensor.shape)], separators=(",", ":"))
+        fingerprint.update(metadata.encode())
+        fingerprint.update(memoryview(tensor.view(torch.uint8).numpy()))
+    return fingerprint.hexdigest()
+
+
+def kda_layer_prefix(layer_idx: int) -> str:
+    """Return Kimi-K3's Hugging Face prefix for one KDA layer."""
+    if layer_idx < 0:
+        raise ValueError(f"layer_idx must be nonnegative, got {layer_idx}")
+    return f"language_model.model.layers.{layer_idx}.self_attn."
+
+
+def resolve_kda_layer_shards(checkpoint_dir: Path, layer_idx: int, config: KDAConfig) -> tuple[Path, ...]:
+    """Resolve and validate the complete local shards containing one KDA layer."""
+    checkpoint_dir = Path(checkpoint_dir)
+    index_path = checkpoint_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise FileNotFoundError(f"missing safetensor index: {index_path}")
+    with index_path.open(encoding="utf-8") as index_file:
+        weight_map = json.load(index_file).get("weight_map", {})
+
+    prefix = kda_layer_prefix(layer_idx)
+    full_names = {name: f"{prefix}{name}" for name in required_kda_weight_names(config)}
+    missing = [name for name, full_name in full_names.items() if full_name not in weight_map]
+    if missing:
+        raise ValueError(f"layer {layer_idx} checkpoint index is missing KDA weights: {missing}")
+
+    shards = tuple(sorted({checkpoint_dir / weight_map[full_name] for full_name in full_names.values()}))
+    missing_shards = [path for path in shards if not path.is_file()]
+    if missing_shards:
+        raise FileNotFoundError(f"missing complete KDA checkpoint shard(s): {missing_shards}")
+    return shards
+
+
+def load_kda_layer_state_dict(checkpoint_dir: Path, layer_idx: int, config: KDAConfig) -> dict[str, torch.Tensor]:
+    """Load and canonicalize one KDA layer from complete indexed safetensor shards."""
+    checkpoint_dir = Path(checkpoint_dir)
+    shards = resolve_kda_layer_shards(checkpoint_dir, layer_idx, config)
+    prefix = kda_layer_prefix(layer_idx)
+    required = required_kda_weight_names(config)
+    state_dict: dict[str, torch.Tensor] = {}
+    for shard in shards:
+        with safe_open(shard, framework="pt", device="cpu") as shard_file:
+            shard_keys = set(shard_file.keys())
+            for name in required:
+                full_name = f"{prefix}{name}"
+                if full_name in shard_keys:
+                    state_dict[name] = shard_file.get_tensor(full_name)
+
+    missing = [name for name in required if name not in state_dict]
+    if missing:
+        raise ValueError(f"layer {layer_idx} checkpoint shard(s) are missing KDA weights: {missing}")
+    return normalize_kda_state_dict(state_dict, config)

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Blackhole correctness tests for the 2D-mesh KDA convolution halo."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.tests.kda.utils import collect_mesh_accuracy_and_determinism_results
+from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_equal
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+]
+
+
+def _coordinate(sp_rank: int, tp_rank: int, sp_axis: int) -> tuple[int, int]:
+    return (sp_rank, tp_rank) if sp_axis == 0 else (tp_rank, sp_rank)
+
+
+def _to_device(tensor: torch.Tensor, device: ttnn.MeshDevice, dims: tuple[int | None, int | None]) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=dims, mesh_shape=tuple(device.shape)),
+    )
+
+
+def _sp_carries(tensor: ttnn.Tensor, device: ttnn.MeshDevice, sp_axis: int, tp_axis: int) -> torch.Tensor:
+    shards = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+    rows, columns = tuple(device.shape)
+    sp_size, tp_size = (rows, columns)[sp_axis], (rows, columns)[tp_axis]
+    partitions = []
+    for sp_rank in range(sp_size):
+        channel_shards = []
+        for tp_rank in range(tp_size):
+            row, column = _coordinate(sp_rank, tp_rank, sp_axis)
+            channel_shards.append(shards[row * columns + column])
+        partitions.append(torch.cat(channel_shards, dim=2))
+    return torch.stack(partitions)
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_exchange_convolution_carry_preserves_causal_carries(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    sp_axis = 1 - tensor_parallel_axis
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+    tp_size = tuple(mesh_device.shape)[tensor_parallel_axis]
+    batch, local_sequence, history = 1, 8, 3
+    channels = tp_size * 32
+    sequence = sp_size * local_sequence
+
+    qkv = torch.arange(batch * sequence * channels, dtype=torch.float32).reshape(batch, sequence, channels)
+    qkv = ((qkv.remainder(97) - 48) / 8).to(torch.bfloat16)
+    external = torch.arange(batch * history * channels, dtype=torch.float32).reshape(batch, history, channels)
+    external = (-(external.remainder(31) + 1) / 8).to(torch.bfloat16)
+
+    qkv_dims = [None, None]
+    qkv_dims[sp_axis], qkv_dims[tensor_parallel_axis] = 1, 2
+    state_dims = [None, None]
+    state_dims[tensor_parallel_axis] = 2
+    qkv_tt = _to_device(qkv, mesh_device, tuple(qkv_dims))
+    state_tt = _to_device(external, mesh_device, tuple(state_dims))
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        return exchange_convolution_carry(qkv_tt, state_tt, sequence_parallel_axis=sp_axis)
+
+    (entry_tt, final_tt), mismatch_markers = collect_mesh_accuracy_and_determinism_results(run)
+    actual_entries = _sp_carries(entry_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    actual_finals = _sp_carries(final_tt, mesh_device, sp_axis, tensor_parallel_axis)
+
+    expected_entries = [external]
+    for sp_rank in range(1, sp_size):
+        predecessor_end = sp_rank * local_sequence
+        expected_entries.append(qkv[:, predecessor_end - history : predecessor_end])
+    expected_entries_tensor = torch.stack(expected_entries)
+    expected_final = qkv[:, -history:]
+
+    assert_equal(expected_entries_tensor, actual_entries, name="halo entries")
+    for sp_rank in range(sp_size):
+        assert_equal(expected_final, actual_finals[sp_rank], name=f"halo final rank {sp_rank}")
+    assert all(marker.item() == 0 for marker in mismatch_markers), "halo output is not bit-identical across runs"
+    print(
+        f"tp_axis={tensor_parallel_axis}: rank0 external carry, {sp_size - 1} neighbor carries, "
+        "and all replicated final carries are exact"
+    )

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
@@ -1,0 +1,361 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Blackhole contract tests for the KDA recurrence component."""
+
+import time
+from typing import Literal
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda.ops import kda_recurrent_reference
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    collect_mesh_accuracy_and_determinism_results,
+    compare_cpu_device,
+    reconstruct_state_at_sp_rank,
+)
+from models.demos.deepseek_v3_d_p.tt.kda import recurrence
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDARecurrenceProgramConfig
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
+    assert_accurate,
+    assert_bit_identical,
+    collect_accuracy_and_determinism_results,
+)
+
+pytestmark = run_for_blackhole()
+
+
+def _to_device(tensor: torch.Tensor, device: ttnn.Device, dtype: ttnn.DataType) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        tensor,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _run_recurrence(
+    device: ttnn.Device,
+    q: ttnn.Tensor,
+    k: ttnn.Tensor,
+    v: ttnn.Tensor,
+    gate: ttnn.Tensor,
+    beta: ttnn.Tensor,
+    state: ttnn.Tensor,
+    *,
+    summary_group_chunks: int = 8,
+    local_scan_strategy: Literal["direct", "grouped"] = "direct",
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    executor = recurrence.KDARecurrence(
+        device,
+        KDARecurrenceProgramConfig(
+            summary_group_chunks=summary_group_chunks,
+            local_scan_strategy=local_scan_strategy,
+        ),
+        sequence_parallel_axis=None,
+    )
+    return executor(q=q, k=k, v=v, gate=gate, beta=beta, initial_state=state)
+
+
+@pytest.mark.parametrize(
+    "sequence,heads,key_dim,value_dim,summary_group_chunks,local_scan_strategy",
+    [
+        pytest.param(32, 2, 32, 32, 8, "direct", id="direct-minimal"),
+        pytest.param(64, 2, 32, 128, 8, "direct", id="direct-nonsquare-state"),
+        pytest.param(256, 2, 32, 32, 2, "grouped", id="grouped-minimal"),
+        pytest.param(2816, 12, 128, 128, 21, "grouped", id="grouped-divisor-fallback"),
+        pytest.param(5120, 1, 128, 128, 8, "grouped", id="grouped-production-length"),
+        pytest.param(5152, 2, 32, 32, 8, "grouped", id="grouped-tail-chunk"),
+        pytest.param(5152, 12, 128, 128, 20, "direct", id="direct-long-sequence"),
+    ],
+)
+@pytest.mark.use_module_device
+def test_recurrence_matches_reference_and_is_deterministic(
+    device: ttnn.Device,
+    sequence: int,
+    heads: int,
+    key_dim: int,
+    value_dim: int,
+    summary_group_chunks: int,
+    local_scan_strategy: Literal["direct", "grouped"],
+) -> None:
+    generator = torch.Generator().manual_seed(401 + sequence + heads)
+    shape = (1, sequence, heads)
+    q = torch.randn(*shape, key_dim, generator=generator)
+    k = torch.randn(*shape, key_dim, generator=generator)
+    v = torch.randn(*shape, value_dim, generator=generator)
+    gate = -0.02 * torch.rand(*shape, key_dim, generator=generator)
+    beta = torch.sigmoid(torch.randn(*shape, generator=generator))
+    state = 0.02 * torch.randn(1, heads, key_dim, value_dim, generator=generator)
+    print("KDA_CPU_REFERENCE_CACHE=disabled; computing deterministic operation oracle", flush=True)
+    reference_start = time.perf_counter()
+    golden_output, golden_state = kda_recurrent_reference(q, k, v, gate, beta, state)
+    golden_output = golden_output.to(torch.bfloat16)
+    print(f"KDA_CPU_REFERENCE_SECONDS={time.perf_counter() - reference_start:.3f}", flush=True)
+
+    q_tt = _to_device(q.reshape(1, sequence, heads * key_dim), device, ttnn.bfloat16)
+    k_tt = _to_device(k.reshape(1, sequence, heads * key_dim), device, ttnn.bfloat16)
+    v_tt = _to_device(v.reshape(1, sequence, heads * value_dim), device, ttnn.bfloat16)
+    gate_tt = _to_device(gate.reshape(1, sequence, heads * key_dim), device, ttnn.bfloat16)
+    beta_tt = _to_device(beta, device, ttnn.float32)
+    state_tt = _to_device(state, device, ttnn.float32)
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            final_state, output = _run_recurrence(
+                device,
+                q_tt,
+                k_tt,
+                v_tt,
+                gate_tt,
+                beta_tt,
+                state_tt,
+                summary_group_chunks=summary_group_chunks,
+                local_scan_strategy=local_scan_strategy,
+            )
+        return output, final_state
+
+    (
+        (output_tt, final_state_tt),
+        (actual_output, actual_state),
+        mismatch_marker,
+    ) = collect_accuracy_and_determinism_results(device, run)
+    assert mismatch_marker.item() == 0, "recurrence results are not bit-identical across runs"
+
+    assert final_state_tt.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    actual_output = actual_output.reshape(1, heads, sequence, value_dim).permute(0, 2, 1, 3)
+    label = f"H={heads},K={key_dim},V={value_dim},T={sequence},group={summary_group_chunks}"
+    _, output_failures = compare_cpu_device(
+        f"{label} output",
+        golden_output,
+        actual_output,
+        pcc_threshold=0.999,
+    )
+    _, state_failures = compare_cpu_device(
+        f"{label} state",
+        golden_state,
+        actual_state,
+        pcc_threshold=0.999,
+    )
+    failures = output_failures + state_failures
+    assert not failures, "\n".join(failures)
+
+
+@pytest.mark.use_module_device
+def test_grouped_scan_preserves_weak_decay_across_group_sizes(device: ttnn.Device) -> None:
+    sequence, heads, dim = 5120, 1, 32
+    generator = torch.Generator().manual_seed(9401)
+    shape = (1, sequence, heads, dim)
+    q = torch.randn(*shape, generator=generator)
+    k = torch.randn(*shape, generator=generator)
+    v = torch.randn(*shape, generator=generator)
+    gate = torch.full(shape, -1e-5)
+    beta = torch.sigmoid(torch.randn(1, sequence, heads, generator=generator))
+    state = 0.02 * torch.randn(1, heads, dim, dim, generator=generator)
+    golden_output, golden_state = kda_recurrent_reference(q, k, v, gate, beta, state)
+    golden_output = golden_output.to(torch.bfloat16)
+
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        state_eight, output_eight_tt = _run_recurrence(
+            device,
+            _to_device(q.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(k.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(v.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(gate.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(beta, device, ttnn.float32),
+            _to_device(state, device, ttnn.float32),
+            summary_group_chunks=8,
+            local_scan_strategy="grouped",
+        )
+
+    ttnn.synchronize_device(device)
+
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        state_two, output_two_tt = _run_recurrence(
+            device,
+            _to_device(q.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(k.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(v.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(gate.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(beta, device, ttnn.float32),
+            _to_device(state, device, ttnn.float32),
+            summary_group_chunks=2,
+            local_scan_strategy="grouped",
+        )
+
+    output_eight = ttnn.to_torch(output_eight_tt).reshape(1, sequence, heads, dim)
+    output_two = ttnn.to_torch(output_two_tt).reshape(1, sequence, heads, dim)
+    label = "weak-decay production contract"
+    assert_accurate(golden_output, output_eight, name=f"{label} grouped output")
+    assert_accurate(
+        output_two,
+        output_eight,
+        name=f"{label} group-size output invariance",
+        pcc_threshold=0.9999,
+    )
+    assert_accurate(
+        ttnn.to_torch(state_two),
+        ttnn.to_torch(state_eight),
+        name=f"{label} group-size state invariance",
+        pcc_threshold=0.9999,
+    )
+    assert_accurate(golden_state, ttnn.to_torch(state_eight), name=f"{label} grouped state")
+
+
+def _to_mesh(
+    tensor: torch.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    mesh_dims: tuple[int | None, int | None],
+    dtype: ttnn.DataType,
+) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        tensor,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=mesh_dims, mesh_shape=tuple(mesh_device.shape)),
+    )
+
+
+def _reconstruct_recurrence_output(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+) -> torch.Tensor:
+    shards = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+    rows, columns = tuple(mesh_device.shape)
+    sp_size = (rows, columns)[sp_axis]
+    tp_size = (rows, columns)[tp_axis]
+    sequence_partitions = []
+    for sp_rank in range(sp_size):
+        head_partitions = []
+        for tp_rank in range(tp_size):
+            row, column = (sp_rank, tp_rank) if sp_axis == 0 else (tp_rank, sp_rank)
+            head_partitions.append(shards[row * columns + column])
+        sequence_partitions.append(torch.cat(head_partitions, dim=0).transpose(0, 1))
+    return torch.cat(sequence_partitions, dim=0).unsqueeze(0)
+
+
+def _distributed_recurrence_case(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> tuple[
+    recurrence.KDARecurrence,
+    tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor],
+    torch.Tensor,
+    torch.Tensor,
+    int,
+]:
+    sp_axis = 1 - tensor_parallel_axis
+    sequence, heads, dim = 128, 8, 32
+    generator = torch.Generator().manual_seed(1621 + tensor_parallel_axis)
+    shape = (1, sequence, heads)
+    q = torch.randn(*shape, dim, generator=generator)
+    k = torch.randn(*shape, dim, generator=generator)
+    v = torch.randn(*shape, dim, generator=generator)
+    gate = -0.02 * torch.rand(*shape, dim, generator=generator)
+    beta = torch.sigmoid(torch.randn(*shape, generator=generator))
+    initial_state = 0.02 * torch.randn(1, heads, dim, dim, generator=generator)
+    expected_output, expected_state = kda_recurrent_reference(q, k, v, gate, beta, initial_state)
+
+    activation_dims = [None, None]
+    activation_dims[sp_axis] = 1
+    activation_dims[tensor_parallel_axis] = 2
+    state_dims = [None, None]
+    state_dims[tensor_parallel_axis] = 1
+    inputs = (
+        _to_mesh(q.reshape(1, sequence, heads * dim), mesh_device, tuple(activation_dims), ttnn.bfloat16),
+        _to_mesh(k.reshape(1, sequence, heads * dim), mesh_device, tuple(activation_dims), ttnn.bfloat16),
+        _to_mesh(v.reshape(1, sequence, heads * dim), mesh_device, tuple(activation_dims), ttnn.bfloat16),
+        _to_mesh(gate.reshape(1, sequence, heads * dim), mesh_device, tuple(activation_dims), ttnn.bfloat16),
+        _to_mesh(beta, mesh_device, tuple(activation_dims), ttnn.float32),
+        _to_mesh(initial_state, mesh_device, tuple(state_dims), ttnn.float32),
+    )
+    executor = recurrence.KDARecurrence(
+        mesh_device,
+        KDARecurrenceProgramConfig(summary_group_chunks=8),
+        sequence_parallel_axis=sp_axis,
+    )
+    return executor, inputs, expected_output.to(torch.bfloat16), expected_state, sp_axis
+
+
+def _run_distributed_recurrence(
+    executor: recurrence.KDARecurrence,
+    inputs: tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor],
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    q, k, v, gate, beta, initial_state = inputs
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        new_state, output = executor(q=q, k=k, v=v, gate=gate, beta=beta, initial_state=initial_state)
+    return output, new_state
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_distributed_recurrence_matches_serial_and_is_deterministic(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    executor, inputs, expected_output, expected_state, sp_axis = _distributed_recurrence_case(
+        mesh_device, tensor_parallel_axis
+    )
+
+    (output_tt, state_tt), mismatch_markers = collect_mesh_accuracy_and_determinism_results(
+        lambda: _run_distributed_recurrence(executor, inputs)
+    )
+    ttnn.synchronize_device(mesh_device)
+    cache_entries = mesh_device.num_program_cache_entries()
+    repeated_output, repeated_state = _run_distributed_recurrence(executor, inputs)
+    ttnn.synchronize_device(mesh_device)
+    assert mesh_device.num_program_cache_entries() == cache_entries
+    ttnn.deallocate(repeated_output)
+    ttnn.deallocate(repeated_state)
+    assert output_tt.dtype == ttnn.bfloat16
+    assert state_tt.dtype == ttnn.float32
+    assert all(marker.item() == 0 for marker in mismatch_markers), "distributed recurrence is not bit-identical"
+
+    actual_output = _reconstruct_recurrence_output(output_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    actual_state = reconstruct_state_at_sp_rank(state_tt, mesh_device, sp_axis, tensor_parallel_axis, sp_rank=0)
+    label = f"tp_axis={tensor_parallel_axis}"
+    assert_accurate(expected_output, actual_output, name=f"{label} output")
+    assert_accurate(expected_state, actual_state, name=f"{label} state")
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_distributed_recurrence_trace_replay_matches_eager(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    executor, inputs, _, _, sp_axis = _distributed_recurrence_case(mesh_device, tensor_parallel_axis)
+    eager_output_tt, eager_state_tt = _run_distributed_recurrence(executor, inputs)
+
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    traced_output_tt, traced_state_tt = _run_distributed_recurrence(executor, inputs)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    for _ in range(3):
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+
+    eager_output = _reconstruct_recurrence_output(eager_output_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    traced_output = _reconstruct_recurrence_output(traced_output_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    eager_state = reconstruct_state_at_sp_rank(eager_state_tt, mesh_device, sp_axis, tensor_parallel_axis, sp_rank=0)
+    traced_state = reconstruct_state_at_sp_rank(traced_state_tt, mesh_device, sp_axis, tensor_parallel_axis, sp_rank=0)
+    ttnn.release_trace(mesh_device, trace_id)
+
+    assert_bit_identical(eager_output, traced_output, name=f"tp_axis={tensor_parallel_axis} traced output")
+    assert_bit_identical(eager_state, traced_state, name=f"tp_axis={tensor_parallel_axis} traced state")

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Device weight-placement contracts for the KDA layer."""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tests.kda.utils import random_weights
+from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
+from models.demos.deepseek_v3_d_p.tt.kda.weights import load_kda_weights
+from models.tt_transformers.tt.ccl import TT_CCL
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_equal
+
+pytestmark = run_for_blackhole()
+
+
+def _host_shards(tensor: ttnn.Tensor) -> list[torch.Tensor]:
+    return [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+
+
+def _tp_rank(physical_index: int, mesh_columns: int, tensor_parallel_axis: int) -> int:
+    row, column = divmod(physical_index, mesh_columns)
+    return (row, column)[tensor_parallel_axis]
+
+
+@pytest.mark.parametrize(
+    "mesh_device,tensor_parallel_axis",
+    [
+        pytest.param((1, 8), 1, id="tp8-1d"),
+        pytest.param((2, 4), 0, id="tp2-axis0"),
+        pytest.param((2, 4), 1, id="tp4-axis1"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+def test_device_weight_placement(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    config = KDAConfig(
+        hidden_size=64,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    state_dict = random_weights(config)
+    weights = load_kda_weights(
+        mesh_device,
+        config,
+        state_dict,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )
+    tensor_parallel_size = tuple(mesh_device.shape)[tensor_parallel_axis]
+    local_heads = config.num_heads // tensor_parallel_size
+    gate_projection = state_dict["g_b_proj.weight"].reshape(config.num_heads, config.head_v_dim, config.head_v_dim)
+    direct_gate = torch.matmul(gate_projection, state_dict["g_a_proj.weight"]).reshape(config.v_dim, config.hidden_size)
+    decay_scale = -state_dict["A_log"].float().exp()
+    decay_scale = decay_scale.expand(-1, -1, -1, config.head_k_dim).reshape(1, 1, config.q_dim)
+    decay_bias = state_dict["dt_bias"].reshape(1, 1, config.q_dim)
+
+    assert weights.tensor_parallel_size == tensor_parallel_size
+    assert weights.tensor_parallel_axis == tensor_parallel_axis
+    fields = {
+        "input": _host_shards(weights.input_projection),
+        "decay_output": _host_shards(weights.decay_output_projection),
+        "output": _host_shards(weights.output_projection),
+        "decay_scale": _host_shards(weights.decay_scale_flat),
+        "decay_bias": _host_shards(weights.decay_bias_flat),
+        "norm": _host_shards(weights.norm),
+        "tap": _host_shards(weights.convolution_taps[0]),
+    }
+
+    for physical_index in range(len(fields["input"])):
+        tp_rank = (
+            _tp_rank(physical_index, tuple(mesh_device.shape)[1], tensor_parallel_axis)
+            if tuple(mesh_device.shape)[0] > 1
+            else physical_index
+        )
+        head_start = tp_rank * local_heads
+        head_stop = head_start + local_heads
+        key_start, key_stop = head_start * config.head_k_dim, head_stop * config.head_k_dim
+        value_start, value_stop = head_start * config.head_v_dim, head_stop * config.head_v_dim
+        expected_qkv = torch.cat(
+            (
+                state_dict["q_proj.weight"][key_start:key_stop],
+                state_dict["k_proj.weight"][key_start:key_stop],
+                state_dict["v_proj.weight"][value_start:value_stop],
+            ),
+            dim=0,
+        ).T
+        expected_auxiliary = torch.cat(
+            (
+                state_dict["f_a_proj.weight"],
+                direct_gate[value_start:value_stop],
+                state_dict["b_proj.weight"][head_start:head_stop],
+            ),
+            dim=0,
+        ).T
+        expected_tap = torch.cat(
+            (
+                state_dict["q_conv1d.weight"][key_start:key_stop, 0, 0],
+                state_dict["k_conv1d.weight"][key_start:key_stop, 0, 0],
+                state_dict["v_conv1d.weight"][value_start:value_stop, 0, 0],
+            )
+        ).reshape(1, 1, -1)
+        expected = {
+            "input": torch.cat((expected_qkv, expected_auxiliary), dim=-1),
+            "decay_output": state_dict["f_b_proj.weight"].T[:, key_start:key_stop],
+            "output": state_dict["o_proj.weight"][:, value_start:value_stop].T,
+            "decay_scale": decay_scale[..., key_start:key_stop],
+            "decay_bias": decay_bias[..., key_start:key_stop],
+            "norm": state_dict["o_norm.weight"],
+            "tap": expected_tap,
+        }
+        for name, expected_tensor in expected.items():
+            assert_equal(
+                expected_tensor.to(torch.bfloat16),
+                fields[name][physical_index],
+                name=f"{name} weight device {physical_index}",
+            )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+def test_tp_layer_with_nonsquare_state_matches_reference(mesh_device: ttnn.MeshDevice) -> None:
+    config = KDAConfig(
+        hidden_size=256,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=256,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    state_dict = random_weights(config)
+    sequence = 32
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(911)).to(
+        torch.bfloat16
+    )
+    golden_output, golden_state = kda_forward_reference(hidden, state_dict, config)
+
+    layer = ttKDA(mesh_device, config, state_dict, tt_ccl=TT_CCL(mesh_device))
+    initial_state = layer.allocate_state(batch_size=1)
+    hidden_tt = ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, state = layer.forward(hidden_tt, initial_state)
+
+    actual_output = ttnn.to_torch(output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1))
+    recurrent_shards = _host_shards(state.recurrent)
+    convolution_shards = _host_shards(state.convolution)
+    actual_recurrent = torch.cat(recurrent_shards, dim=1)
+    local_key_width = config.head_k_dim
+    local_value_width = config.head_v_dim
+    actual_convolution = torch.cat(
+        (
+            torch.cat([shard[..., :local_key_width] for shard in convolution_shards], dim=-1),
+            torch.cat([shard[..., local_key_width : 2 * local_key_width] for shard in convolution_shards], dim=-1),
+            torch.cat(
+                [
+                    shard[..., 2 * local_key_width : 2 * local_key_width + local_value_width]
+                    for shard in convolution_shards
+                ],
+                dim=-1,
+            ),
+        ),
+        dim=-1,
+    )
+    golden_convolution = torch.cat(
+        (golden_state.q_convolution, golden_state.k_convolution, golden_state.v_convolution), dim=-1
+    ).to(torch.bfloat16)
+
+    for name, golden, actual in (
+        ("output", golden_output, actual_output),
+        ("recurrent state", golden_state.recurrent, actual_recurrent),
+        ("convolution state", golden_convolution, actual_convolution),
+    ):
+        assert_accurate(golden, actual, name=f"TP=8 {name}", pcc_threshold=0.999)

--- a/models/demos/deepseek_v3_d_p/tests/kda/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/conftest.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared KDA test fixtures."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "perf: mark explicit KDA performance tests")
+
+
+@pytest.fixture
+def isolated_program_cache(device):
+    """Give one cache-sensitive test an enabled, empty program cache."""
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+
+
+@pytest.fixture(scope="session")
+def kimi_k3_checkpoint_dir() -> Path:
+    """Return the explicitly selected pinned Kimi-K3 checkpoint subset."""
+    value = os.getenv("KIMI_K3_CKPT")
+    if value is None:
+        pytest.skip("set KIMI_K3_CKPT to the pinned Kimi-K3 checkpoint subset")
+    return Path(value)

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic CI and local real-weight acceptance for the Kimi-K3 KDA layer."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    check_kimi_k3_accuracy,
+    collect_mesh_accuracy_and_determinism_results,
+    make_kimi_k3_device_case,
+    make_kimi_k3_test_case,
+    make_synthetic_kimi_k3_test_case,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState
+
+pytestmark = [run_for_blackhole(), pytest.mark.timeout(900)]
+
+_SEQUENCE = 5120
+_PCC_THRESHOLD = 0.9995
+
+
+@pytest.mark.parametrize(
+    "mesh_device,tensor_parallel_axis,device_params",
+    [
+        pytest.param(
+            (2, 4),
+            1,
+            fabric_1d_device_params(),
+            id="SP2xTP4-fabric-1d",
+        ),
+        pytest.param(
+            (8, 4),
+            1,
+            torus_xy_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="SP8xTP4-torus-xy",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_synthetic_kimi_k3_accuracy_and_determinism(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    device_params: dict,
+) -> None:
+    """Gate K3 dimensions against Torch and compare three device runs bit-for-bit."""
+    mesh_shape = tuple(mesh_device.shape)
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    layout = f"SP{mesh_shape[sequence_parallel_axis]}xTP{mesh_shape[tensor_parallel_axis]}"
+    case = make_synthetic_kimi_k3_test_case(sequence=_SEQUENCE)
+    reference_start = time.perf_counter()
+    golden_output, golden_state = kda_forward_reference(case.hidden, case.state_dict, case.config)
+    reference_seconds = time.perf_counter() - reference_start
+    layer, hidden_tt = make_kimi_k3_device_case(
+        mesh_device,
+        case,
+        tensor_parallel_axis=tensor_parallel_axis,
+        cache_weights=False,
+    )
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        initial_state = layer.allocate_state(batch_size=1)
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            output, state = layer.forward(hidden_tt, initial_state)
+        return output, state.recurrent, state.convolution
+
+    (output, recurrent, convolution), mismatch_markers = collect_mesh_accuracy_and_determinism_results(run)
+    state = KdaState(recurrent=recurrent, convolution=convolution)
+    try:
+        pcc = check_kimi_k3_accuracy(
+            f"Synthetic Kimi-K3 T=5120 {layout}",
+            case,
+            golden_output,
+            golden_state,
+            state,
+            output,
+            mesh_device,
+            tensor_parallel_axis,
+            pcc_threshold=_PCC_THRESHOLD,
+        )
+        assert all(
+            marker.item() == 0 for marker in mismatch_markers
+        ), "synthetic Kimi-K3 outputs and states are not bit-identical across three runs"
+        print(
+            "KDA_SYNTHETIC_ACCURACY_DETERMINISM="
+            + json.dumps(
+                {
+                    "layout": layout,
+                    "sequence": _SEQUENCE,
+                    "weights": "deterministic synthetic",
+                    "reference": "independent pure-Torch FP32 CPU reference",
+                    "cpu_reference_seconds": reference_seconds,
+                    "pcc": pcc,
+                    "determinism_repetitions": 3,
+                    "bit_identical": True,
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        ttnn.deallocate(output)
+        ttnn.deallocate(recurrent)
+        ttnn.deallocate(convolution)
+
+
+@pytest.mark.parametrize(
+    "mesh_device,tensor_parallel_axis,device_params,sequence",
+    [
+        pytest.param((1, 8), 1, fabric_1d_device_params(), 128, id="SP1xTP8"),
+        pytest.param((2, 4), 1, fabric_1d_device_params(), 128, id="SP2xTP4"),
+        pytest.param((2, 4), 0, fabric_1d_device_params(), 128, id="SP4xTP2"),
+        pytest.param(
+            (8, 4),
+            1,
+            torus_xy_device_params(),
+            512,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="SP8xTP4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_kimi_k3_layer_1_real_weights_accuracy(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    kimi_k3_checkpoint_dir: Path,
+    sequence: int,
+) -> None:
+    case = make_kimi_k3_test_case(kimi_k3_checkpoint_dir, sequence=sequence)
+    golden_output, golden_state = kda_forward_reference(case.hidden, case.state_dict, case.config)
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    local_chunks = case.hidden.shape[1] // tuple(mesh_device.shape)[sequence_parallel_axis] // ttnn.TILE_SIZE
+    # Existing eight-device layouts retain their shortest common tile-aligned T=128; the
+    # Galaxy case uses T=512 so SP8 has two local chunks. Keep production K3 tuning
+    # except for this local grouping constraint.
+    layer, hidden_tt = make_kimi_k3_device_case(
+        mesh_device,
+        case,
+        tensor_parallel_axis=tensor_parallel_axis,
+        summary_group_chunks=local_chunks,
+    )
+    state = layer.allocate_state(batch_size=1)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, state = layer.forward(hidden_tt, state)
+    ttnn.synchronize_device(mesh_device)
+
+    mesh_shape = tuple(mesh_device.shape)
+    layout = f"SP{mesh_shape[sequence_parallel_axis]}xTP{mesh_shape[tensor_parallel_axis]}"
+    check_kimi_k3_accuracy(
+        f"Kimi-K3 layer 1 {layout}",
+        case,
+        golden_output,
+        golden_state,
+        state,
+        output,
+        mesh_device,
+        tensor_parallel_axis,
+        pcc_threshold=0.9995,
+    )

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_contract.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_contract.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Public contract tests for the composed TTNN KDA layer."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    collect_mesh_accuracy_and_determinism_results,
+    make_config,
+    random_weights,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_bit_identical
+
+pytestmark = [run_for_blackhole(), pytest.mark.use_module_device]
+
+
+def _hidden_to_device(hidden: torch.Tensor, device: ttnn.Device) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _forward(layer: ttKDA, hidden: torch.Tensor, state: KdaState) -> tuple[ttnn.Tensor, KdaState]:
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        return layer.forward(_hidden_to_device(hidden, layer.device), state)
+
+
+def _assert_state_metadata(state: KdaState, config) -> None:
+    assert tuple(state.recurrent.shape) == (1, config.num_heads, config.head_k_dim, config.head_v_dim)
+    assert state.recurrent.dtype == ttnn.float32
+    assert state.recurrent.layout == ttnn.TILE_LAYOUT
+    assert state.recurrent.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    assert tuple(state.convolution.shape) == (
+        1,
+        config.conv_kernel_size - 1,
+        config.q_dim + config.k_dim + config.v_dim,
+    )
+    assert state.convolution.dtype == ttnn.bfloat16
+    assert state.convolution.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert state.convolution.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+
+
+def test_layer_matches_reference_and_is_deterministic(device: ttnn.Device) -> None:
+    config = make_config()
+    weights = random_weights(config)
+    sequence = 32
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(41 + sequence)).to(
+        torch.bfloat16
+    )
+    golden_output, golden_state = kda_forward_reference(hidden, weights, config)
+    layer = ttKDA(device, config, weights)
+    hidden_tt = _hidden_to_device(hidden, device)
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            output, state = layer.forward(hidden_tt, layer.allocate_state())
+        return output, state.recurrent, state.convolution
+
+    (output_tt, recurrent_tt, convolution_tt), mismatch_markers = collect_mesh_accuracy_and_determinism_results(run)
+    golden_convolution = torch.cat(
+        (golden_state.q_convolution, golden_state.k_convolution, golden_state.v_convolution), dim=-1
+    ).to(torch.bfloat16)
+    assert_accurate(golden_output, ttnn.to_torch(output_tt), name="layer output", pcc_threshold=0.999)
+    assert_accurate(
+        golden_state.recurrent, ttnn.to_torch(recurrent_tt), name="layer recurrent state", pcc_threshold=0.999
+    )
+    assert_accurate(
+        golden_convolution,
+        ttnn.to_torch(convolution_tt),
+        name="layer convolution state",
+        pcc_threshold=0.999,
+    )
+    assert all(marker.item() == 0 for marker in mismatch_markers), "KDA layer is not bit-identical across runs"
+
+
+def test_allocate_state_contract(device: ttnn.Device) -> None:
+    config = make_config()
+    layer = ttKDA(device, config, random_weights(config))
+    first = layer.allocate_state()
+    second = layer.allocate_state()
+
+    _assert_state_metadata(first, config)
+    _assert_state_metadata(second, config)
+    assert first.recurrent.buffer_address() != second.recurrent.buffer_address()
+    assert first.convolution.buffer_address() != second.convolution.buffer_address()
+
+
+def test_forward_contract(device: ttnn.Device) -> None:
+    config = make_config()
+    weights = random_weights(config)
+    hidden = torch.randn(1, 64, config.hidden_size, generator=torch.Generator().manual_seed(109)).to(torch.bfloat16)
+    golden_output, golden_state = kda_forward_reference(hidden, weights, config)
+    layer = ttKDA(device, config, weights)
+    input_state = layer.allocate_state()
+    input_recurrent_before = ttnn.to_torch(input_state.recurrent)
+    input_convolution_before = ttnn.to_torch(input_state.convolution)
+    recurrent_address = input_state.recurrent.buffer_address()
+    convolution_address = input_state.convolution.buffer_address()
+
+    first_output, next_state = _forward(layer, hidden[:, :32], input_state)
+    second_output, final_state = _forward(layer, hidden[:, 32:], next_state)
+    actual_output = torch.cat((ttnn.to_torch(first_output), ttnn.to_torch(second_output)), dim=1)
+    golden_convolution = torch.cat(
+        (golden_state.q_convolution, golden_state.k_convolution, golden_state.v_convolution), dim=-1
+    ).to(torch.bfloat16)
+
+    assert tuple(first_output.shape) == (1, 32, config.hidden_size)
+    assert first_output.dtype == ttnn.float32
+    assert first_output.layout == ttnn.TILE_LAYOUT
+    assert first_output.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    _assert_state_metadata(final_state, config)
+    assert next_state.recurrent is not input_state.recurrent
+    assert next_state.convolution is not input_state.convolution
+    assert input_state.recurrent.buffer_address() == recurrent_address
+    assert input_state.convolution.buffer_address() == convolution_address
+    assert_bit_identical(input_recurrent_before, ttnn.to_torch(input_state.recurrent), name="input recurrent state")
+    assert_bit_identical(
+        input_convolution_before, ttnn.to_torch(input_state.convolution), name="input convolution state"
+    )
+    assert_accurate(golden_output, actual_output, name="segmented layer output", pcc_threshold=0.999)
+    assert_accurate(
+        golden_state.recurrent,
+        ttnn.to_torch(final_state.recurrent),
+        name="segmented recurrent state",
+        pcc_threshold=0.999,
+    )
+    assert_accurate(
+        golden_convolution,
+        ttnn.to_torch(final_state.convolution),
+        name="segmented convolution state",
+        pcc_threshold=0.999,
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param("axes", id="sp-and-tp-axes-must-be-distinct"),
+        pytest.param("weight_sources", id="weight-sources-are-mutually-exclusive"),
+        pytest.param("grouped_nonsquare", id="grouped-scan-requires-square-state"),
+        pytest.param("batch_state", id="state-allocation-requires-batch-one"),
+    ],
+)
+def test_layer_rejects_invalid_construction(case: str, device: ttnn.Device, expect_error) -> None:
+    config = make_config()
+    state_dict = random_weights(config)
+
+    if case == "axes":
+        with expect_error(ValueError, "requires distinct 2D SP/TP axes"):
+            ttKDA(device, config, state_dict, sp_axis=0, tp_axis=0)
+    elif case == "weight_sources":
+        weights = ttKDA(device, config, state_dict).weights
+        with expect_error(ValueError, "either constructed KDAWeights or host state_dict"):
+            ttKDA(device, config, state_dict, weights=weights)
+    elif case == "grouped_nonsquare":
+        nonsquare_config = replace(config, head_v_dim=64)
+        base_program_config = KDAProgramConfig()
+        program_config = replace(
+            base_program_config,
+            recurrence=replace(base_program_config.recurrence, local_scan_strategy="grouped"),
+        )
+        with expect_error(ValueError, "grouped KDA affine prefix currently requires K == V"):
+            ttKDA(device, nonsquare_config, random_weights(nonsquare_config), program_config=program_config)
+    else:
+        layer = ttKDA(device, config, state_dict)
+        with expect_error(ValueError, "batch_size=1"):
+            layer.allocate_state(batch_size=2)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param("sequence", id="sequence-must-be-positive-tile-multiple"),
+        pytest.param("batch", id="forward-requires-batch-one"),
+        pytest.param("hidden_width", id="hidden-width-must-match-config"),
+        pytest.param("recurrent_shape", id="recurrent-state-shape"),
+        pytest.param("recurrent_dtype", id="recurrent-state-dtype"),
+        pytest.param("convolution_shape", id="convolution-state-shape"),
+        pytest.param("convolution_dtype", id="convolution-state-dtype-and-layout"),
+    ],
+)
+def test_layer_rejects_invalid_forward(case: str, device: ttnn.Device, expect_error) -> None:
+    config = make_config()
+    layer = ttKDA(device, config, random_weights(config))
+    hidden_shape = (1, 32, config.hidden_size)
+    state = layer.allocate_state()
+
+    if case == "sequence":
+        hidden_shape, error = (1, 4, config.hidden_size), r"requires local T .* divisible by 32"
+    elif case == "batch":
+        hidden_shape, error = (2, 32, config.hidden_size), "requires batch size 1"
+    elif case == "hidden_width":
+        hidden_shape, error = (1, 32, config.hidden_size + 32), "hidden_states shape"
+    elif case == "recurrent_shape":
+        state = replace(
+            state,
+            recurrent=ttnn.zeros(
+                (1, config.num_heads, config.head_k_dim, config.head_v_dim + 32),
+                dtype=ttnn.float32,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        )
+        error = "recurrent state shape"
+    elif case == "recurrent_dtype":
+        state = replace(
+            state,
+            recurrent=ttnn.zeros(
+                tuple(state.recurrent.shape),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        )
+        error = "recurrent state dtype"
+    elif case == "convolution_shape":
+        state = replace(
+            state,
+            convolution=ttnn.zeros(
+                (1, config.conv_kernel_size, config.q_dim + config.k_dim + config.v_dim),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        )
+        error = "convolution state shape"
+    else:
+        state = replace(
+            state,
+            convolution=ttnn.zeros(
+                tuple(state.convolution.shape),
+                dtype=ttnn.float32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        )
+        error = "convolution state must be BF16 row-major"
+
+    hidden = torch.randn(*hidden_shape, generator=torch.Generator().manual_seed(45), dtype=torch.bfloat16)
+    with expect_error(ValueError, error):
+        _forward(layer, hidden, state)

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end KDA sequence-parallel correctness tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    collect_mesh_accuracy_and_determinism_results,
+    random_weights,
+    reconstruct_convolution_at_sp_rank,
+    reconstruct_sp_tp_tensor,
+    reconstruct_state_at_sp_rank,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, KDARecurrenceProgramConfig
+from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
+from models.tt_transformers.tt.ccl import TT_CCL
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+]
+
+
+def _to_sp_input(
+    hidden: torch.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+) -> ttnn.Tensor:
+    mesh_dims = [None, None]
+    mesh_dims[sp_axis] = 1
+    return ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=tuple(mesh_dims), mesh_shape=tuple(mesh_device.shape)),
+    )
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_sp_group_divisor_fallback_matches_reference(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    config = KDAConfig(
+        hidden_size=128,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    weights = random_weights(config)
+    # SP2 produces 20 local chunks; configured group size 8 falls back to divisor 5.
+    sequence = 1280
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(937)).to(
+        torch.bfloat16
+    )
+    expected_output, expected_state = kda_forward_reference(hidden, weights, config)
+
+    sp_axis = 1 - tensor_parallel_axis
+    program_config = KDAProgramConfig(
+        recurrence=KDARecurrenceProgramConfig(summary_group_chunks=8),
+        gated_rms_output_dtype=ttnn.bfloat16,
+        output_projection_math_fidelity=ttnn.MathFidelity.HiFi2,
+    )
+    layer = ttKDA(
+        mesh_device,
+        config,
+        weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sp_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=program_config,
+    )
+    initial_state = layer.allocate_state(batch_size=1)
+    hidden_tt = _to_sp_input(hidden, mesh_device, sp_axis)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output_tt, state = layer.forward(hidden_tt, initial_state)
+    assert len(output_tt.shape) == 3
+
+    actual_output = reconstruct_sp_tp_tensor(
+        output_tt,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        tp_dim=2,
+        sp_dim=1,
+    )
+    expected_output = expected_output.to(torch.bfloat16)
+    expected_convolution = torch.cat(
+        (expected_state.q_convolution, expected_state.k_convolution, expected_state.v_convolution), dim=-1
+    ).to(torch.bfloat16)
+    local_heads = config.num_heads // tuple(mesh_device.shape)[tensor_parallel_axis]
+    local_width = local_heads * config.head_k_dim
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+
+    assert_accurate(
+        expected_output,
+        actual_output,
+        name=f"tp_axis={tensor_parallel_axis} output",
+        pcc_threshold=0.999,
+    )
+    for sp_rank in range(sp_size):
+        actual_recurrent = reconstruct_state_at_sp_rank(
+            state.recurrent, mesh_device, sp_axis, tensor_parallel_axis, sp_rank
+        )
+        actual_convolution = reconstruct_convolution_at_sp_rank(
+            state.convolution,
+            mesh_device,
+            sp_axis,
+            tensor_parallel_axis,
+            sp_rank,
+            local_width,
+        )
+        assert_accurate(
+            expected_state.recurrent,
+            actual_recurrent,
+            name=f"tp_axis={tensor_parallel_axis} sp_rank={sp_rank} recurrent",
+            pcc_threshold=0.999,
+        )
+        assert_accurate(
+            expected_convolution,
+            actual_convolution,
+            name=f"tp_axis={tensor_parallel_axis} sp_rank={sp_rank} convolution",
+            pcc_threshold=0.999,
+        )
+
+
+@pytest.mark.parametrize(
+    "tensor_parallel_axis,summary_group_chunks,splits",
+    [
+        pytest.param(1, 8, (2048, 3072), id="tp-axis-1-uneven-split"),
+        pytest.param(0, 10, (2560, 2560), id="tp-axis-0-even-split"),
+    ],
+)
+def test_sp_segmented_prefill_matches_one_shot(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    summary_group_chunks: int,
+    splits: tuple[int, int],
+) -> None:
+    config = KDAConfig(
+        hidden_size=128,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    weights = random_weights(config)
+    sequence = sum(splits)
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(421)).to(
+        torch.bfloat16
+    )
+    sp_axis = 1 - tensor_parallel_axis
+    layer = ttKDA(
+        mesh_device,
+        config,
+        weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sp_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=KDAProgramConfig(
+            recurrence=KDARecurrenceProgramConfig(summary_group_chunks=summary_group_chunks)
+        ),
+    )
+
+    one_shot_input_state = layer.allocate_state(batch_size=1)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        one_shot_tt, one_shot_state = layer.forward(_to_sp_input(hidden, mesh_device, sp_axis), one_shot_input_state)
+    one_shot = reconstruct_sp_tp_tensor(
+        one_shot_tt,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        tp_dim=2,
+        sp_dim=1,
+    )
+    one_shot_recurrent = reconstruct_state_at_sp_rank(
+        one_shot_state.recurrent, mesh_device, sp_axis, tensor_parallel_axis, sp_rank=0
+    )
+    local_heads = config.num_heads // tuple(mesh_device.shape)[tensor_parallel_axis]
+    one_shot_convolution = reconstruct_convolution_at_sp_rank(
+        one_shot_state.convolution,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        sp_rank=0,
+        local_width=local_heads * config.head_k_dim,
+    )
+
+    chunked_state = layer.allocate_state(batch_size=1)
+    outputs = []
+    start = 0
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        for split in splits:
+            stop = start + split
+            output_tt, chunked_state = layer.forward(
+                _to_sp_input(hidden[:, start:stop], mesh_device, sp_axis), chunked_state
+            )
+            outputs.append(
+                reconstruct_sp_tp_tensor(
+                    output_tt,
+                    mesh_device,
+                    sp_axis,
+                    tensor_parallel_axis,
+                    tp_dim=2,
+                    sp_dim=1,
+                )
+            )
+            start = stop
+
+    chunked = torch.cat(outputs, dim=1)
+    chunked_recurrent = reconstruct_state_at_sp_rank(
+        chunked_state.recurrent, mesh_device, sp_axis, tensor_parallel_axis, sp_rank=0
+    )
+    chunked_convolution = reconstruct_convolution_at_sp_rank(
+        chunked_state.convolution,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        sp_rank=0,
+        local_width=local_heads * config.head_k_dim,
+    )
+    label = f"tp_axis={tensor_parallel_axis} group={summary_group_chunks}"
+    assert_accurate(one_shot, chunked, name=f"{label} chunked output", pcc_threshold=0.9999)
+    assert_accurate(
+        one_shot_recurrent,
+        chunked_recurrent,
+        name=f"{label} chunked recurrent",
+        pcc_threshold=0.9999,
+    )
+    assert_accurate(
+        one_shot_convolution,
+        chunked_convolution,
+        name=f"{label} chunked convolution",
+        pcc_threshold=0.9999,
+    )
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_sp_minimal_group_matches_reference_and_is_deterministic(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    config = KDAConfig(
+        hidden_size=128,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    weights = random_weights(config)
+    sp_axis = 1 - tensor_parallel_axis
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+    sequence = sp_size * ttnn.TILE_SIZE
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(2421)).to(
+        torch.bfloat16
+    )
+    expected_output, expected_state = kda_forward_reference(hidden, weights, config)
+    expected_convolution = torch.cat(
+        (expected_state.q_convolution, expected_state.k_convolution, expected_state.v_convolution), dim=-1
+    ).to(torch.bfloat16)
+    layer = ttKDA(
+        mesh_device,
+        config,
+        weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sp_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=KDAProgramConfig(recurrence=KDARecurrenceProgramConfig(summary_group_chunks=1)),
+    )
+    hidden_tt = _to_sp_input(hidden, mesh_device, sp_axis)
+    tp_size = tuple(mesh_device.shape)[tensor_parallel_axis]
+    local_width = config.num_heads // tp_size * config.head_k_dim
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        state = layer.allocate_state(batch_size=1)
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            output_tt, state = layer.forward(hidden_tt, state)
+        return output_tt, state.recurrent, state.convolution
+
+    (output_tt, recurrent_tt, convolution_tt), mismatch_markers = collect_mesh_accuracy_and_determinism_results(run)
+    actual_output = reconstruct_sp_tp_tensor(output_tt, mesh_device, sp_axis, tensor_parallel_axis, tp_dim=2, sp_dim=1)
+    assert_accurate(expected_output.to(actual_output.dtype), actual_output, name="SP layer output", pcc_threshold=0.999)
+    for sp_rank in range(sp_size):
+        actual_recurrent = reconstruct_state_at_sp_rank(
+            recurrent_tt, mesh_device, sp_axis, tensor_parallel_axis, sp_rank
+        )
+        actual_convolution = reconstruct_convolution_at_sp_rank(
+            convolution_tt,
+            mesh_device,
+            sp_axis,
+            tensor_parallel_axis,
+            sp_rank,
+            local_width,
+        )
+        assert_accurate(
+            expected_state.recurrent.to(actual_recurrent.dtype),
+            actual_recurrent,
+            name=f"SP layer recurrent sp_rank={sp_rank}",
+            pcc_threshold=0.999,
+        )
+        assert_accurate(
+            expected_convolution.to(actual_convolution.dtype),
+            actual_convolution,
+            name=f"SP layer convolution sp_rank={sp_rank}",
+            pcc_threshold=0.999,
+        )
+    assert all(marker.item() == 0 for marker in mismatch_markers), "SP layer is not bit-identical across runs"

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_stateful.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_stateful.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""State continuity and trace-replay tests for the TTNN KDA layer."""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.tests.kda.utils import make_config, random_weights
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_bit_identical
+
+pytestmark = run_for_blackhole()
+
+
+def _forward(layer: ttKDA, hidden: torch.Tensor, state: KdaState) -> tuple[torch.Tensor, KdaState]:
+    hidden_tt = ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=layer.device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, next_state = layer.forward(hidden_tt, state)
+    return ttnn.to_torch(output), next_state
+
+
+def test_segmented_prefill_matches_reference_and_reuses_program(
+    device: ttnn.Device,
+    isolated_program_cache: None,
+) -> None:
+    config = make_config()
+    weights = random_weights(config)
+    hidden = torch.randn(1, 64, config.hidden_size, generator=torch.Generator().manual_seed(73)).to(torch.bfloat16)
+    golden_first, golden_state = kda_forward_reference(hidden[:, :32], weights, config)
+    golden_second, golden_state = kda_forward_reference(hidden[:, 32:], weights, config, golden_state)
+
+    layer = ttKDA(device, config, weights)
+    state = layer.allocate_state()
+    actual_first, state = _forward(layer, hidden[:, :32], state)
+    cache_entries_after_first = device.num_program_cache_entries()
+    assert cache_entries_after_first > 0, "first KDA forward must populate the program cache"
+    actual_second, state = _forward(layer, hidden[:, 32:], state)
+    assert device.num_program_cache_entries() == cache_entries_after_first
+
+    golden_convolution = torch.cat(
+        (golden_state.q_convolution, golden_state.k_convolution, golden_state.v_convolution), dim=-1
+    ).to(torch.bfloat16)
+    assert_accurate(golden_first, actual_first, name="first prefill segment output", pcc_threshold=0.999)
+    assert_accurate(golden_second, actual_second, name="second prefill segment output", pcc_threshold=0.999)
+    assert_accurate(
+        golden_state.recurrent,
+        ttnn.to_torch(state.recurrent),
+        name="segmented recurrent state",
+        pcc_threshold=0.999,
+    )
+    assert_accurate(
+        golden_convolution,
+        ttnn.to_torch(state.convolution),
+        name="segmented convolution state",
+        pcc_threshold=0.999,
+    )
+
+
+@pytest.mark.use_module_device
+def test_trace_replay_matches_eager_without_mutating_input_state(device: ttnn.Device) -> None:
+    config = make_config()
+    hidden = torch.randn(1, 32, config.hidden_size, generator=torch.Generator().manual_seed(1917)).to(torch.bfloat16)
+    hidden_tt = ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    layer = ttKDA(device, config, random_weights(config))
+
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        eager_output, _ = layer.forward(hidden_tt, layer.allocate_state())
+    ttnn.synchronize_device(device)
+    eager_result = ttnn.to_torch(eager_output)
+
+    input_state = layer.allocate_state()
+    input_state_before = (ttnn.to_torch(input_state.recurrent), ttnn.to_torch(input_state.convolution))
+    trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, next_state = layer.forward(hidden_tt, input_state)
+    ttnn.end_trace_capture(device, trace_id, cq_id=0)
+    assert next_state.recurrent is not input_state.recurrent
+    assert next_state.convolution is not input_state.convolution
+
+    ttnn.execute_trace(device, trace_id, cq_id=0, blocking=True)
+    replayed_output = ttnn.to_torch(output)
+    input_state_after = (ttnn.to_torch(input_state.recurrent), ttnn.to_torch(input_state.convolution))
+    ttnn.release_trace(device, trace_id)
+
+    assert_bit_identical(eager_result, replayed_output, name="traced layer output")
+    for name, expected, actual in zip(("recurrent", "convolution"), input_state_before, input_state_after):
+        assert_bit_identical(expected, actual, name=f"traced input {name} state")

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
@@ -1,0 +1,544 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Local real-weight and CI-synthetic performance acceptance for Kimi-K3 KDA."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import asdict
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import KDAReferenceState, kda_forward_reference
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import KIMI_K3_FIRST_KDA_LAYER
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    KimiK3TestCase,
+    check_kimi_k3_accuracy,
+    make_kimi_k3_device_case,
+    make_kimi_k3_test_case,
+    make_synthetic_kimi_k3_test_case,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.perf,
+    pytest.mark.timeout(900),
+]
+
+_SEQUENCE = 5120
+_REPETITIONS = 10
+_TIMING_SAMPLES = 5
+_PCC_THRESHOLD = 0.9995
+_CPU_REFERENCE_CACHE_VERSION = 4
+_PERF_SKU = "bh_loudbox"
+_PERF_MARGIN = 0.03
+# LoudBox calibration at 350413d7a98e (2026-08-31): median across five independent
+# sessions, each using the median of five warm synchronized 10-replay samples.
+_PERF_REFERENCE_MS = {
+    "SP1xTP8": 9.597,
+    "SP2xTP4": 9.539,
+    "SP4xTP2": 9.991,
+}
+# Temporary impossible reference: the first hosted Galaxy run must emit samples and fail.
+_GALAXY_PERF_REFERENCE_MS = 0.0
+
+
+def _tensor_sha256(tensor: torch.Tensor) -> str:
+    storage = tensor.detach().cpu().contiguous().view(torch.uint8).numpy()
+    return hashlib.sha256(memoryview(storage)).hexdigest()
+
+
+def _cpu_reference_cache_path(case: KimiK3TestCase) -> Path:
+    reference_dir = Path(inspect.getfile(kda_forward_reference)).parent
+    fingerprint = hashlib.sha256()
+    fingerprint.update(f"v{_CPU_REFERENCE_CACHE_VERSION}".encode())
+    fingerprint.update(str(KIMI_K3_FIRST_KDA_LAYER).encode())
+    fingerprint.update(str(case.hidden.shape[1]).encode())
+    fingerprint.update(case.weights_identity.encode())
+    fingerprint.update(json.dumps(asdict(case.config), sort_keys=True).encode())
+    fingerprint.update(_tensor_sha256(case.hidden).encode())
+    for source_path in sorted(reference_dir.glob("*.py")):
+        fingerprint.update(source_path.name.encode())
+        fingerprint.update(source_path.read_bytes())
+    return (
+        Path(ttnn.CONFIG.model_cache_path)
+        / "kimi_k3"
+        / case.weights_identity
+        / "cpu_reference"
+        / f"layer_{KIMI_K3_FIRST_KDA_LAYER}_t{case.hidden.shape[1]}_{fingerprint.hexdigest()[:20]}.pt"
+    )
+
+
+def _reference_tensors(output: torch.Tensor, state: KDAReferenceState) -> dict[str, torch.Tensor]:
+    return {
+        "output": output.detach().clone(),
+        "recurrent": state.recurrent.detach().clone(),
+        "q_convolution": state.q_convolution.detach().clone(),
+        "k_convolution": state.k_convolution.detach().clone(),
+        "v_convolution": state.v_convolution.detach().clone(),
+    }
+
+
+def _validate_cached_reference(case: KimiK3TestCase, payload: dict[str, Any]) -> tuple[torch.Tensor, KDAReferenceState]:
+    tensors = {name: payload[name] for name in payload["digests"]}
+    expected_shapes = {
+        "output": (1, case.hidden.shape[1], case.config.hidden_size),
+        "recurrent": (1, case.config.num_heads, case.config.head_k_dim, case.config.head_v_dim),
+        "q_convolution": (1, case.config.conv_kernel_size - 1, case.config.q_dim),
+        "k_convolution": (1, case.config.conv_kernel_size - 1, case.config.k_dim),
+        "v_convolution": (1, case.config.conv_kernel_size - 1, case.config.v_dim),
+    }
+    assert set(tensors) == set(expected_shapes), f"unexpected CPU-reference cache tensors: {set(tensors)}"
+    for name, tensor in tensors.items():
+        assert isinstance(tensor, torch.Tensor), f"cached {name} is not a tensor"
+        assert (
+            tuple(tensor.shape) == expected_shapes[name]
+        ), f"cached {name} shape {tuple(tensor.shape)} != {expected_shapes[name]}"
+        assert _tensor_sha256(tensor) == payload["digests"][name], f"cached {name} checksum mismatch"
+    return tensors["output"], KDAReferenceState(
+        recurrent=tensors["recurrent"],
+        q_convolution=tensors["q_convolution"],
+        k_convolution=tensors["k_convolution"],
+        v_convolution=tensors["v_convolution"],
+    )
+
+
+def _load_or_compute_cpu_reference(case: KimiK3TestCase) -> tuple[torch.Tensor, KDAReferenceState, float]:
+    cache_path = _cpu_reference_cache_path(case)
+    start = time.perf_counter()
+    if cache_path.exists():
+        payload = torch.load(cache_path, map_location="cpu", weights_only=True)
+        output, state = _validate_cached_reference(case, payload)
+        elapsed = time.perf_counter() - start
+        logger.info(f"KDA T=5120 CPU reference cache hit: {cache_path}")
+        logger.info(f"KDA T=5120 CPU reference load completed in {elapsed:.3f} seconds")
+        return output, state, elapsed
+
+    output, state = kda_forward_reference(case.hidden, case.state_dict, case.config)
+    tensors = _reference_tensors(output, state)
+    payload = {**tensors, "digests": {name: _tensor_sha256(tensor) for name, tensor in tensors.items()}}
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = cache_path.with_suffix(f".{os.getpid()}.tmp")
+    try:
+        torch.save(payload, temporary_path)
+        temporary_path.replace(cache_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    elapsed = time.perf_counter() - start
+    logger.info(f"KDA T=5120 CPU reference cache miss: {cache_path}")
+    logger.info(f"KDA T=5120 CPU reference computation completed in {elapsed:.3f} seconds")
+    return output, state, elapsed
+
+
+@pytest.fixture(scope="session")
+def kimi_k3_production_reference(
+    kimi_k3_checkpoint_dir: Path,
+) -> Callable[[], tuple[KimiK3TestCase, torch.Tensor, KDAReferenceState, float]]:
+    """Return a lazy loader for the session-cached production-length CPU oracle."""
+    cached_reference: tuple[KimiK3TestCase, torch.Tensor, KDAReferenceState, float] | None = None
+
+    def load() -> tuple[KimiK3TestCase, torch.Tensor, KDAReferenceState, float]:
+        nonlocal cached_reference
+        if cached_reference is None:
+            case = make_kimi_k3_test_case(kimi_k3_checkpoint_dir, sequence=_SEQUENCE)
+            golden_output, golden_state, elapsed = _load_or_compute_cpu_reference(case)
+            cached_reference = case, golden_output, golden_state, elapsed
+        return cached_reference
+
+    return load
+
+
+def _perf_reference_ms(layout: str) -> float:
+    if os.environ.get("KDA_PERF_SKU") != _PERF_SKU:
+        raise ValueError(f"set KDA_PERF_SKU={_PERF_SKU} to opt in to this hardware-specific performance gate")
+    return _PERF_REFERENCE_MS[layout]
+
+
+def _allocate_state(layer: ttKDA) -> KdaState:
+    return layer.allocate_state(batch_size=1)
+
+
+def _deallocate_state(state: KdaState) -> None:
+    ttnn.deallocate(state.recurrent)
+    ttnn.deallocate(state.convolution)
+
+
+def _device_program_label(kernel_sources: tuple[str, ...]) -> str:
+    names = set()
+    for source in kernel_sources:
+        parts = source.replace("\\", "/").split("/")
+        if "operations" not in parts:
+            continue
+        index = parts.index("operations") + 1
+        experimental = index < len(parts) and parts[index] == "experimental"
+        if experimental:
+            index += 1
+        if index < len(parts):
+            name = f"{'experimental.' if experimental else ''}{parts[index]}"
+            if name.endswith(("kda", "ccl")) and index + 1 < len(parts):
+                name = f"{name}.{parts[index + 1]}"
+            names.add(name)
+    if names:
+        return "+".join(sorted(names))
+    basenames = {Path(source).stem for source in kernel_sources}
+    return "+".join(sorted(basenames)) if basenames else "unknown"
+
+
+def test_device_program_label_preserves_material_operation_identity() -> None:
+    assert (
+        _device_program_label(("src/operations/experimental/kda/recurrent_chunk_scan/kernel.cpp",))
+        == "experimental.kda.recurrent_chunk_scan"
+    )
+    assert _device_program_label(("src/operations/ccl/all_gather_async/kernel.cpp",)) == "ccl.all_gather_async"
+    assert _device_program_label(("src/operations/matmul/kernel.cpp",)) == "matmul"
+    assert _device_program_label(("src/operations/experimental/matmul/kernel.cpp",)) == "experimental.matmul"
+    assert (
+        _device_program_label(("src/operations/experimental/ccl/reduce_scatter/kernel.cpp",))
+        == "experimental.ccl.reduce_scatter"
+    )
+    assert _device_program_label(("src/reader.cpp", "src/writer.cpp")) == "reader+writer"
+    assert _device_program_label(()) == "unknown"
+
+
+def _assert_galaxy_performance(median_wall_ms: float) -> None:
+    lower = _GALAXY_PERF_REFERENCE_MS * (1.0 - _PERF_MARGIN)
+    upper = _GALAXY_PERF_REFERENCE_MS * (1.0 + _PERF_MARGIN)
+    assert lower <= median_wall_ms <= upper, (
+        f"SP8xTP4 median trace wall {median_wall_ms:.3f} ms is outside Galaxy range "
+        f"[{lower:.3f}, {upper:.3f}] ms "
+        f"(reference {_GALAXY_PERF_REFERENCE_MS:.3f} ms ± {_PERF_MARGIN:.0%})"
+    )
+
+
+def test_temporary_galaxy_reference_rejects_positive_latency(expect_error) -> None:
+    with expect_error(AssertionError, "outside Galaxy range"):
+        _assert_galaxy_performance(1.0)
+
+
+def _log_device_program_times(mesh_device: ttnn.MeshDevice, layer: ttKDA, hidden: ttnn.Tensor, layout: str) -> None:
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        raise RuntimeError(f"real-time profiler is inactive for the {layout} KDA e2e device-time breakdown")
+    state = _allocate_state(layer)
+    output = None
+    next_state = None
+    profiled_results: list[tuple[ttnn.Tensor, KdaState]] = []
+
+    def run_profiled_forward() -> tuple[ttnn.Tensor, KdaState]:
+        result = layer.forward(hidden, state)
+        profiled_results.append(result)
+        return result
+
+    try:
+        (output, next_state), records = profile_realtime_program(
+            mesh_device,
+            run_profiled_forward,
+            collect_all=True,
+            record_timeout_seconds=30.0,
+        )
+        per_program: dict[int, dict[str, Any]] = {}
+        for record in records:
+            runtime_id = record["runtime_id"]
+            if not runtime_id:
+                continue
+            entry = per_program.setdefault(
+                runtime_id,
+                {
+                    "duration_ns": 0.0,
+                    "kernel_sources": record["kernel_sources"],
+                    "chip_ids": set(),
+                    "record_count": 0,
+                },
+            )
+            entry["duration_ns"] = max(entry["duration_ns"], record["duration_ns"])
+            entry["chip_ids"].add(record["chip_id"])
+            entry["record_count"] += 1
+        if not per_program:
+            raise RuntimeError("real-time profiler returned no KDA program records")
+        expected_chip_count = mesh_device.get_num_devices()
+        programs: list[dict[str, Any]] = [
+            {
+                "sequence": sequence,
+                "name": _device_program_label(info["kernel_sources"]),
+                "device_time_ns": round(float(info["duration_ns"]), 3),
+                "chip_count": len(info["chip_ids"]),
+                "record_count": int(info["record_count"]),
+                "complete": len(info["chip_ids"]) == expected_chip_count,
+            }
+            for sequence, info in enumerate(per_program.values())
+        ]
+        incomplete_program_sequences = [program["sequence"] for program in programs if not program["complete"]]
+        durations_by_name: dict[str, list[float]] = {}
+        for program in programs:
+            durations_by_name.setdefault(program["name"], []).append(program["device_time_ns"])
+        operation_summary = [
+            {
+                "name": name,
+                "program_count": len(durations),
+                "median_device_time_ns": round(statistics.median(durations), 3),
+                "max_device_time_ns": round(max(durations), 3),
+            }
+            for name, durations in durations_by_name.items()
+        ]
+        print(
+            "KDA_LAYER_DEVICE_TIMES="
+            + json.dumps(
+                {
+                    "layout": layout,
+                    "measurement": "one warm eager forward outside gated trace samples",
+                    "duration_semantics": (
+                        "per-program max across reported chip records; programs may overlap and durations must not be summed"
+                    ),
+                    "chip_completeness": {
+                        "expected_chip_count": expected_chip_count,
+                        "incomplete_program_sequences": incomplete_program_sequences,
+                    },
+                    "operation_summary": operation_summary,
+                    "programs": programs,
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        if profiled_results and output is None:
+            output, next_state = profiled_results[-1]
+        if output is not None:
+            ttnn.deallocate(output)
+        if next_state is not None:
+            _deallocate_state(next_state)
+        _deallocate_state(state)
+
+
+def _trace_wall_samples_ms(
+    mesh_device: ttnn.MeshDevice,
+    layer: ttKDA,
+    hidden: ttnn.Tensor,
+    repetitions: int,
+    validate_first_replay: Callable[[KdaState, ttnn.Tensor], dict[str, float]] | None = None,
+) -> tuple[list[float], dict[str, float] | None]:
+    state = None
+    warm_output = None
+    warm_state = None
+    trace_id = None
+    output = None
+    next_state = None
+    try:
+        state = _allocate_state(layer)
+        warm_output, warm_state = layer.forward(hidden, state)
+        ttnn.synchronize_device(mesh_device)
+        ttnn.deallocate(warm_output)
+        warm_output = None
+        _deallocate_state(warm_state)
+        warm_state = None
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        output, next_state = layer.forward(hidden, state)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+        ttnn.synchronize_device(mesh_device)
+        validation = validate_first_replay(next_state, output) if validate_first_replay is not None else None
+
+        samples_ms = []
+        for _ in range(_TIMING_SAMPLES):
+            start = time.perf_counter()
+            for _ in range(repetitions):
+                ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(mesh_device)
+            samples_ms.append((time.perf_counter() - start) * 1e3 / repetitions)
+        return samples_ms, validation
+    finally:
+        try:
+            if trace_id is not None:
+                ttnn.release_trace(mesh_device, trace_id)
+        finally:
+            if warm_output is not None:
+                ttnn.deallocate(warm_output)
+            if warm_state is not None:
+                _deallocate_state(warm_state)
+            if output is not None:
+                ttnn.deallocate(output)
+            if state is not None:
+                _deallocate_state(state)
+            if next_state is not None:
+                _deallocate_state(next_state)
+
+
+@pytest.mark.parametrize(
+    "mesh_device,tensor_parallel_axis",
+    [((1, 8), 1), ((2, 4), 1), ((2, 4), 0)],
+    indirect=["mesh_device"],
+    ids=["SP1xTP8", "SP2xTP4", "SP4xTP2"],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        # FABRIC_2D follow-up: SP1xTP8 hangs with a device timeout and failed
+        # Ethernet-core recovery. SP2xTP4/SP4xTP2 were correct but 0.05%/0.10%
+        # slower than FABRIC_1D; do not enable 2D until the SP1 failure is fixed.
+        pytest.param(
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            },
+            id="fabric_1d",
+        ),
+    ],
+    indirect=True,
+)
+def test_kimi_k3_layer_1_perf(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    kimi_k3_production_reference: Callable[[], tuple[KimiK3TestCase, torch.Tensor, KDAReferenceState, float]],
+) -> None:
+    """Compare production geometry with an independent CPU oracle before timing it."""
+    sequence = _SEQUENCE
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    mesh_shape = tuple(mesh_device.shape)
+    layout = f"SP{mesh_shape[sequence_parallel_axis]}xTP{mesh_shape[tensor_parallel_axis]}"
+    repetitions = _REPETITIONS
+    reference_ms = _perf_reference_ms(layout)
+    case, golden_output, golden_state, cpu_reference_seconds = kimi_k3_production_reference()
+    layer, hidden_tt = make_kimi_k3_device_case(
+        mesh_device,
+        case,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )
+
+    initial_state = _allocate_state(layer)
+    start = time.perf_counter()
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, state = layer.forward(hidden_tt, initial_state)
+    ttnn.synchronize_device(mesh_device)
+    device_forward_ms = (time.perf_counter() - start) * 1e3
+    try:
+        pcc = check_kimi_k3_accuracy(
+            f"Kimi-K3 layer 1 T={sequence} {layout}",
+            case,
+            golden_output,
+            golden_state,
+            state,
+            output,
+            mesh_device,
+            tensor_parallel_axis,
+            pcc_threshold=_PCC_THRESHOLD,
+        )
+    finally:
+        ttnn.deallocate(output)
+    _deallocate_state(initial_state)
+    _deallocate_state(state)
+
+    validate_trace_replay = partial(
+        check_kimi_k3_accuracy,
+        f"Kimi-K3 layer 1 T={case.hidden.shape[1]} {layout} trace replay",
+        case,
+        golden_output,
+        golden_state,
+        mesh_device=mesh_device,
+        tensor_parallel_axis=tensor_parallel_axis,
+        pcc_threshold=_PCC_THRESHOLD,
+    )
+    samples_ms, trace_pcc = _trace_wall_samples_ms(
+        mesh_device,
+        layer,
+        hidden_tt,
+        repetitions,
+        validate_first_replay=validate_trace_replay,
+    )
+    assert trace_pcc is not None
+    first_wall_ms = samples_ms[0]
+    median_wall_ms = statistics.median(samples_ms)
+    tail_wall_ms = max(samples_ms)
+    min_wall_ms = reference_ms * (1.0 - _PERF_MARGIN)
+    max_wall_ms = reference_ms * (1.0 + _PERF_MARGIN)
+    result = {
+        "fabric_config": ttnn.get_fabric_config().name,
+        "layout": layout,
+        "sequence": sequence,
+        "repetitions": repetitions,
+        "pcc": pcc,
+        "trace_pcc": trace_pcc,
+        "pcc_reference": "independent pure-Torch FP32 CPU reference",
+        "trace_wall_ms": median_wall_ms,
+        "first_trace_wall_ms": first_wall_ms,
+        "trace_wall_samples_ms": samples_ms,
+        "median_trace_wall_ms": median_wall_ms,
+        "tail_trace_wall_ms": tail_wall_ms,
+        "timing_sample_count": _TIMING_SAMPLES,
+        "reference_trace_wall_ms": reference_ms,
+        "perf_margin_pct": _PERF_MARGIN * 100.0,
+        "min_trace_wall_ms": min_wall_ms,
+        "max_trace_wall_ms": max_wall_ms,
+        "cpu_reference_seconds": cpu_reference_seconds,
+        "device_forward_ms": device_forward_ms,
+    }
+    print("KDA_LAYER_PERF=" + json.dumps(result, sort_keys=True))
+    if layout == "SP2xTP4":
+        try:
+            _log_device_program_times(mesh_device, layer, hidden_tt, layout)
+        except Exception as error:
+            print("KDA_LAYER_DEVICE_TIMES_ERROR=" + json.dumps({"layout": layout, "error": str(error)}, sort_keys=True))
+    assert min_wall_ms <= median_wall_ms <= max_wall_ms, (
+        f"{layout} median trace wall {median_wall_ms:.3f} ms is outside LoudBox range "
+        f"[{min_wall_ms:.3f}, {max_wall_ms:.3f}] ms (reference {reference_ms:.3f} ms ± {_PERF_MARGIN:.0%})"
+    )
+
+
+@pytest.mark.parametrize(
+    "mesh_device,device_params",
+    [
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="SP8xTP4-torus-xy",
+        )
+    ],
+    indirect=True,
+)
+def test_synthetic_kimi_k3_perf(
+    mesh_device: ttnn.MeshDevice,
+    device_params: dict,
+) -> None:
+    """Measure checkpoint-free production K3 latency and fail until its reference is calibrated."""
+    tensor_parallel_axis = 1
+    case = make_synthetic_kimi_k3_test_case(sequence=_SEQUENCE)
+    layer, hidden_tt = make_kimi_k3_device_case(
+        mesh_device,
+        case,
+        tensor_parallel_axis=tensor_parallel_axis,
+        cache_weights=False,
+    )
+    samples_ms, _ = _trace_wall_samples_ms(mesh_device, layer, hidden_tt, _REPETITIONS)
+    median_wall_ms = statistics.median(samples_ms)
+    result = {
+        "fabric_config": ttnn.get_fabric_config().name,
+        "layout": "SP8xTP4",
+        "sequence": _SEQUENCE,
+        "weights": "deterministic synthetic",
+        "repetitions": _REPETITIONS,
+        "trace_wall_samples_ms": samples_ms,
+        "median_trace_wall_ms": median_wall_ms,
+        "timing_sample_count": _TIMING_SAMPLES,
+        "reference_trace_wall_ms": _GALAXY_PERF_REFERENCE_MS,
+        "perf_margin_pct": _PERF_MARGIN * 100.0,
+    }
+    print("KDA_SYNTHETIC_PERF=" + json.dumps(result, sort_keys=True))
+    try:
+        _log_device_program_times(mesh_device, layer, hidden_tt, "SP8xTP4")
+    except Exception as error:
+        print("KDA_LAYER_DEVICE_TIMES_ERROR=" + json.dumps({"layout": "SP8xTP4", "error": str(error)}, sort_keys=True))
+    _assert_galaxy_performance(median_wall_ms)

--- a/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Persistent-cache and constructor-policy contracts for the KDA layer."""
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import kda_state_dict_sha256
+from models.demos.deepseek_v3_d_p.tests.kda.utils import make_config, random_weights
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, KDARecurrenceProgramConfig
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights, load_kda_weights
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate
+
+pytestmark = run_for_blackhole()
+
+
+def _forward(layer: ttKDA, hidden: torch.Tensor, state: KdaState) -> torch.Tensor:
+    hidden_tt = ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=layer.device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, _ = layer.forward(hidden_tt, state)
+    return ttnn.to_torch(output)
+
+
+def _cache_artifact_names(path: Path) -> set[str]:
+    return {artifact.name for artifact in path.glob("*.tensorbin")}
+
+
+def test_cache_identity_changes_with_weight_content() -> None:
+    baseline = {"weight": torch.tensor([1.0, 2.0], dtype=torch.bfloat16)}
+    changed = {"weight": torch.tensor([1.0, 3.0], dtype=torch.bfloat16)}
+
+    assert kda_state_dict_sha256(baseline) == kda_state_dict_sha256(baseline)
+    assert kda_state_dict_sha256(baseline) != kda_state_dict_sha256(changed)
+
+
+def test_cache_key_covers_semantic_config_and_placement(tmp_path: Path) -> None:
+    baseline = make_config()
+    bounded = replace(baseline, gate_lower_bound=-5.0)
+    cases = {
+        "baseline": (baseline, 1),
+        "bounded-gate": (bounded, 1),
+        "tp-axis-0": (baseline, 0),
+    }
+    names = {}
+    for case, (config, tensor_parallel_axis) in cases.items():
+        case_path = tmp_path / case
+        KDAWeights.build_ttnn_cache(
+            random_weights(config),
+            case_path,
+            "layer_0.kda",
+            config,
+            object(),
+            tensor_parallel_axis=tensor_parallel_axis,
+        )
+        names[case] = _cache_artifact_names(case_path)
+
+    assert names["baseline"]
+    assert names["baseline"] != names["bounded-gate"]
+    assert names["baseline"] != names["tp-axis-0"]
+
+
+def test_missing_cache_is_incomplete(tmp_path: Path) -> None:
+    assert not KDAWeights.check_cache_complete(tmp_path / "missing", "layer_0.kda", make_config(), object())
+
+
+def test_weight_loader_rejects_empty_source_weights(expect_error) -> None:
+    with expect_error(ValueError, "state_dict must be non-empty"):
+        load_kda_weights(object(), make_config(), {})
+
+
+def test_cache_build_requires_source_weights(tmp_path: Path, expect_error) -> None:
+    with expect_error(ValueError, "requires a state_dict"):
+        KDAWeights.build_ttnn_cache(None, tmp_path, "layer_0.kda", make_config(), object())
+
+
+@pytest.mark.use_module_device
+def test_cache_only_load_rejects_corrupt_tensor(device: ttnn.Device, tmp_path: Path, expect_error) -> None:
+    config = make_config()
+    cache_prefix = "layer_0.kda"
+    KDAWeights.build_ttnn_cache(random_weights(config), tmp_path, cache_prefix, config, device)
+    next(tmp_path.glob("*.tensorbin")).write_bytes(b"corrupt")
+
+    with expect_error(RuntimeError, "too small"):
+        KDAWeights.from_cache(tmp_path, cache_prefix, config, device)
+
+
+@pytest.mark.use_module_device
+def test_cached_and_in_memory_layers_match(device: ttnn.Device, tmp_path: Path) -> None:
+    config = make_config()
+    state_dict = random_weights(config)
+    hidden = torch.randn(1, 32, config.hidden_size, generator=torch.Generator().manual_seed(151), dtype=torch.bfloat16)
+    cache_prefix = "layer_0.kda"
+    KDAWeights.build_ttnn_cache(state_dict, tmp_path, cache_prefix, config, device)
+
+    in_memory_layer = ttKDA(device, config, state_dict)
+    cached_layer = ttKDA(
+        device,
+        config,
+        weights=KDAWeights.from_cache(tmp_path, cache_prefix, config, device),
+    )
+    cache_only_layer = ttKDA(device, config, None, weight_cache_path=tmp_path, layer_idx=0)
+    outputs = {
+        "in-memory": _forward(in_memory_layer, hidden, in_memory_layer.allocate_state()),
+        "preloaded-cache": _forward(cached_layer, hidden, cached_layer.allocate_state()),
+        "cache-only": _forward(cache_only_layer, hidden, cache_only_layer.allocate_state()),
+    }
+
+    assert_accurate(outputs["in-memory"], outputs["preloaded-cache"], name="preloaded cache", pcc_threshold=0.9999)
+    assert_accurate(outputs["in-memory"], outputs["cache-only"], name="cache-only", pcc_threshold=0.9999)
+
+
+@pytest.mark.use_module_device
+def test_program_config_resolution(device: ttnn.Device) -> None:
+    config = make_config()
+    program_config = replace(KDAProgramConfig(), qkv_channel_chunk_size=128, tp_ccl_topology=ttnn.Topology.Ring)
+    layer = ttKDA(device, config, random_weights(config), program_config=program_config)
+
+    assert layer.qkv_convolution_program_config.channel_chunk_size == 96
+    assert layer.tp_ccl_topology == ttnn.Topology.Ring
+
+
+@pytest.mark.parametrize(
+    "config_type,kwargs,message",
+    [
+        pytest.param(KDAProgramConfig, {"qkv_channel_chunk_size": 0}, "positive multiple", id="zero-qkv-chunk"),
+        pytest.param(KDAProgramConfig, {"qkv_channel_chunk_size": -32}, "positive multiple", id="negative-qkv-chunk"),
+        pytest.param(KDAProgramConfig, {"qkv_channel_chunk_size": 31}, "positive multiple", id="unaligned-qkv-chunk"),
+        pytest.param(
+            KDARecurrenceProgramConfig,
+            {"local_scan_strategy": "invalid"},
+            "local_scan_strategy",
+            id="unknown-scan-strategy",
+        ),
+        pytest.param(
+            KDARecurrenceProgramConfig,
+            {"summary_group_chunks": 0},
+            "summary_group_chunks must be positive",
+            id="nonpositive-summary-group",
+        ),
+    ],
+)
+def test_program_config_rejects_invalid_values(
+    config_type: type[KDAProgramConfig] | type[KDARecurrenceProgramConfig],
+    kwargs: dict[str, object],
+    message: str,
+    expect_error,
+) -> None:
+    with expect_error(ValueError, message):
+        config_type(**kwargs)

--- a/models/demos/deepseek_v3_d_p/tests/kda/utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/utils.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared deterministic KDA test cases and runners."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.kda import KDAReferenceState
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import (
+    KIMI_K3_FIRST_KDA_LAYER,
+    KIMI_K3_HF_REVISION,
+    KIMI_K3_LAYER_1_SHA256,
+    kda_state_dict_sha256,
+    load_kda_layer_state_dict,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, kimi_k3_program_config
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights
+from models.tt_transformers.tt.ccl import TT_CCL
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate
+
+
+@dataclass(frozen=True)
+class KimiK3TestCase:
+    config: KDAConfig
+    state_dict: dict[str, torch.Tensor]
+    hidden: torch.Tensor
+    weights_identity: str
+
+
+def _mesh_coordinate(sp_rank: int, tp_rank: int, sp_axis: int) -> tuple[int, int]:
+    return (sp_rank, tp_rank) if sp_axis == 0 else (tp_rank, sp_rank)
+
+
+def _device_shards(tensor: ttnn.Tensor) -> list[torch.Tensor]:
+    return [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+
+
+def collect_mesh_accuracy_and_determinism_results(
+    run: Callable[[], Sequence[ttnn.Tensor]],
+    *,
+    count: int = 3,
+) -> tuple[tuple[ttnn.Tensor, ...], tuple[torch.Tensor, ...]]:
+    """Retain first mesh outputs and reduce exact repeat mismatches on device."""
+    if count <= 1:
+        raise ValueError("count must be greater than one")
+
+    reference_outputs = tuple(run())
+    if not reference_outputs:
+        raise ValueError("run must return at least one output")
+
+    mismatch_marker = None
+    for _ in range(1, count):
+        outputs = tuple(run())
+        if len(outputs) != len(reference_outputs):
+            for output in outputs:
+                ttnn.deallocate(output)
+            raise ValueError("run returned a different number of outputs")
+        for reference, output in zip(reference_outputs, outputs, strict=True):
+            if (
+                output.shape != reference.shape
+                or output.dtype != reference.dtype
+                or output.layout != reference.layout
+                or output.memory_config() != reference.memory_config()
+            ):
+                for repeat_output in outputs:
+                    ttnn.deallocate(repeat_output)
+                raise ValueError("run returned output with different metadata")
+            mismatch = ttnn.ne(reference, output, dtype=ttnn.bfloat16)
+            current_marker = ttnn.max(mismatch)
+            ttnn.deallocate(mismatch)
+            if mismatch_marker is None:
+                mismatch_marker = current_marker
+            else:
+                updated_marker = ttnn.maximum(mismatch_marker, current_marker)
+                ttnn.deallocate(mismatch_marker)
+                ttnn.deallocate(current_marker)
+                mismatch_marker = updated_marker
+        for output in outputs:
+            ttnn.deallocate(output)
+
+    assert mismatch_marker is not None
+    mismatch_marker_host = ttnn.from_device(mismatch_marker)
+    mismatch_markers = tuple(ttnn.to_torch(shard).clone() for shard in ttnn.get_device_tensors(mismatch_marker_host))
+    ttnn.deallocate(mismatch_marker)
+    return reference_outputs, mismatch_markers
+
+
+def reconstruct_sp_tp_tensor(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    tp_dim: int,
+    sp_dim: int,
+) -> torch.Tensor:
+    """Reconstruct a logical tensor from sequence- and tensor-parallel device shards."""
+    shards = _device_shards(tensor)
+    rows, columns = tuple(mesh_device.shape)
+    sp_size, tp_size = (rows, columns)[sp_axis], (rows, columns)[tp_axis]
+    partitions = []
+    for sp_rank in range(sp_size):
+        tp_shards = []
+        for tp_rank in range(tp_size):
+            row, column = _mesh_coordinate(sp_rank, tp_rank, sp_axis)
+            shard = shards[row * columns + column]
+            if shard.ndim == 4:
+                shard = shard.reshape(shard.shape[0], shard.shape[-2], shard.shape[-1])
+            tp_shards.append(shard)
+        partitions.append(torch.cat(tp_shards, dim=tp_dim))
+    return torch.cat(partitions, dim=sp_dim)
+
+
+def reconstruct_state_at_sp_rank(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    sp_rank: int,
+) -> torch.Tensor:
+    """Reconstruct a tensor-parallel recurrent state at one sequence rank."""
+    shards = _device_shards(tensor)
+    columns = tuple(mesh_device.shape)[1]
+    tp_size = tuple(mesh_device.shape)[tp_axis]
+    tp_shards = []
+    for tp_rank in range(tp_size):
+        row, column = _mesh_coordinate(sp_rank, tp_rank, sp_axis)
+        tp_shards.append(shards[row * columns + column])
+    return torch.cat(tp_shards, dim=1)
+
+
+def reconstruct_convolution_at_sp_rank(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    sp_rank: int,
+    local_width: int,
+) -> torch.Tensor:
+    """Reconstruct grouped Q/K/V convolution state at one sequence rank."""
+    shards = _device_shards(tensor)
+    columns = tuple(mesh_device.shape)[1]
+    tp_size = tuple(mesh_device.shape)[tp_axis]
+    physical = []
+    for tp_rank in range(tp_size):
+        row, column = _mesh_coordinate(sp_rank, tp_rank, sp_axis)
+        physical.append(shards[row * columns + column])
+    return torch.cat(
+        tuple(
+            torch.cat([shard[..., index * local_width : (index + 1) * local_width] for shard in physical], dim=-1)
+            for index in range(3)
+        ),
+        dim=-1,
+    )
+
+
+def compare_cpu_device(
+    name: str,
+    expected: torch.Tensor,
+    actual: torch.Tensor,
+    *,
+    pcc_threshold: float,
+) -> tuple[float, list[str]]:
+    """Run the shared accuracy contract without hiding later tensor results."""
+    try:
+        pcc = assert_accurate(expected, actual, name=name, pcc_threshold=pcc_threshold)
+    except AssertionError as error:
+        return float("nan"), [str(error)]
+    return pcc, []
+
+
+def check_kimi_k3_accuracy(
+    name: str,
+    case: KimiK3TestCase,
+    golden_output: torch.Tensor,
+    golden_state: KDAReferenceState,
+    state: KdaState,
+    output: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    *,
+    pcc_threshold: float,
+) -> dict[str, float]:
+    """Reconstruct an SP/TP K3 result and run the shared accuracy contract on every endpoint."""
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    mesh_shape = tuple(mesh_device.shape)
+    sp_size = mesh_shape[sequence_parallel_axis]
+    tp_size = mesh_shape[tensor_parallel_axis]
+    actual_output = reconstruct_sp_tp_tensor(
+        output,
+        mesh_device,
+        sequence_parallel_axis,
+        tensor_parallel_axis,
+        tp_dim=2,
+        sp_dim=1,
+    )
+    golden_output = golden_output.to(torch.bfloat16)
+    golden_convolution = torch.cat(
+        (golden_state.q_convolution, golden_state.k_convolution, golden_state.v_convolution), dim=-1
+    ).to(torch.bfloat16)
+    local_width = case.config.num_heads // tp_size * case.config.head_k_dim
+    output_pcc, failures = compare_cpu_device(
+        f"{name} output", golden_output, actual_output, pcc_threshold=pcc_threshold
+    )
+    pcc = {"output": output_pcc}
+    for sp_rank in range(sp_size):
+        actual_recurrent = reconstruct_state_at_sp_rank(
+            state.recurrent, mesh_device, sequence_parallel_axis, tensor_parallel_axis, sp_rank
+        )
+        actual_convolution = reconstruct_convolution_at_sp_rank(
+            state.convolution,
+            mesh_device,
+            sequence_parallel_axis,
+            tensor_parallel_axis,
+            sp_rank,
+            local_width,
+        )
+        recurrent_pcc, recurrent_failures = compare_cpu_device(
+            f"{name} sp_rank={sp_rank} recurrent state",
+            golden_state.recurrent,
+            actual_recurrent,
+            pcc_threshold=pcc_threshold,
+        )
+        pcc[f"sp_rank_{sp_rank}_recurrent"] = recurrent_pcc
+        failures.extend(recurrent_failures)
+        convolution_pcc, convolution_failures = compare_cpu_device(
+            f"{name} sp_rank={sp_rank} convolution state",
+            golden_convolution,
+            actual_convolution,
+            pcc_threshold=pcc_threshold,
+        )
+        pcc[f"sp_rank_{sp_rank}_convolution"] = convolution_pcc
+        failures.extend(convolution_failures)
+    assert not failures, "\n".join(failures)
+    return pcc
+
+
+def _kda_config_from_kimi_k3_constants() -> KDAConfig:
+    return KDAConfig(
+        hidden_size=KimiK3Config.EMB_SIZE,
+        num_heads=KimiK3Config.KDA_NUM_HEADS,
+        head_k_dim=KimiK3Config.KDA_HEAD_DIM,
+        head_v_dim=KimiK3Config.KDA_HEAD_DIM,
+        conv_kernel_size=KimiK3Config.KDA_SHORT_CONV_KERNEL_SIZE,
+        norm_eps=KimiK3Config.RMS_NORM_EPS,
+        use_full_rank_gate=KimiK3Config.KDA_USE_FULL_RANK_GATE,
+        gate_lower_bound=KimiK3Config.KDA_GATE_LOWER_BOUND,
+    )
+
+
+def make_kimi_k3_test_case(checkpoint_dir: Path, *, sequence: int) -> KimiK3TestCase:
+    """Load the pinned Kimi-K3 layer and deterministic input used by correctness and perf."""
+    config = _kda_config_from_kimi_k3_constants()
+    downloaded_config = json.loads((checkpoint_dir / "config.json").read_text(encoding="utf-8"))
+    assert KDAConfig.from_model_config(downloaded_config) == config
+    state_dict = load_kda_layer_state_dict(checkpoint_dir, KIMI_K3_FIRST_KDA_LAYER, config)
+    checkpoint_identity = kda_state_dict_sha256(state_dict)
+    assert checkpoint_identity == KIMI_K3_LAYER_1_SHA256, (
+        f"Kimi-K3 layer {KIMI_K3_FIRST_KDA_LAYER} weights do not match pinned revision "
+        f"{KIMI_K3_HF_REVISION}: {checkpoint_identity}"
+    )
+    hidden = torch.randn(
+        1,
+        sequence,
+        config.hidden_size,
+        generator=torch.Generator().manual_seed(1607),
+        dtype=torch.bfloat16,
+    )
+    return KimiK3TestCase(
+        config=config,
+        state_dict=state_dict,
+        hidden=hidden,
+        weights_identity=checkpoint_identity,
+    )
+
+
+def make_synthetic_kimi_k3_test_case(*, sequence: int) -> KimiK3TestCase:
+    """Build deterministic production-dimension Kimi-K3 inputs without a checkpoint."""
+    config = _kda_config_from_kimi_k3_constants()
+    state_dict = random_weights(config)
+    hidden = torch.randn(
+        1,
+        sequence,
+        config.hidden_size,
+        generator=torch.Generator().manual_seed(1607),
+        dtype=torch.bfloat16,
+    )
+    return KimiK3TestCase(
+        config=config,
+        state_dict=state_dict,
+        hidden=hidden,
+        weights_identity=kda_state_dict_sha256(state_dict),
+    )
+
+
+def make_kimi_k3_device_case(
+    mesh_device: ttnn.MeshDevice,
+    case: KimiK3TestCase,
+    *,
+    tensor_parallel_axis: int = 1,
+    summary_group_chunks: int | None = None,
+    program_config: KDAProgramConfig | None = None,
+    weights: KDAWeights | None = None,
+    cache_weights: bool = True,
+) -> tuple[ttKDA, ttnn.Tensor]:
+    """Construct a production-dimension Kimi-K3 layer and sequence-parallel input."""
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    tensor_cache_path = (
+        kimi_k3_tensor_cache_path(case.weights_identity, mesh_device, tensor_parallel_axis) if cache_weights else None
+    )
+    mesh_dims: list[int | None] = [None, None]
+    mesh_dims[sequence_parallel_axis] = 1
+    hidden = ttnn.from_torch(
+        case.hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=tuple(mesh_dims),
+            mesh_shape=tuple(mesh_device.shape),
+        ),
+    )
+    default_program_config = kimi_k3_program_config(
+        tp_ccl_topology=(
+            ttnn.Topology.Ring if tuple(mesh_device.shape)[sequence_parallel_axis] == 1 else ttnn.Topology.Linear
+        )
+    )
+    selected_program_config = program_config or default_program_config
+    if summary_group_chunks is not None:
+        selected_program_config = replace(
+            selected_program_config,
+            recurrence=replace(selected_program_config.recurrence, summary_group_chunks=summary_group_chunks),
+        )
+    layer = ttKDA(
+        mesh_device,
+        case.config,
+        case.state_dict if weights is None else None,
+        weight_cache_path=tensor_cache_path,
+        layer_idx=KIMI_K3_FIRST_KDA_LAYER,
+        weights=weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sequence_parallel_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=selected_program_config,
+    )
+    return layer, hidden
+
+
+def kimi_k3_tensor_cache_path(
+    weights_identity: str,
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> Path:
+    """Select TTNN model-cache storage for one weight content identity and mesh placement."""
+    mesh_shape = tuple(mesh_device.shape)
+    if len(weights_identity) != 64 or any(character not in "0123456789abcdef" for character in weights_identity):
+        raise ValueError("weights_identity must be a lowercase SHA-256 hex digest")
+    layout = f"mesh{mesh_shape[0]}x{mesh_shape[1]}_tpaxis{tensor_parallel_axis}"
+    return Path(ttnn.CONFIG.model_cache_path) / "kimi_k3" / weights_identity / layout
+
+
+def make_config(
+    *,
+    use_full_rank_gate: bool = False,
+) -> KDAConfig:
+    return KDAConfig(
+        hidden_size=64,
+        num_heads=2,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+        use_full_rank_gate=use_full_rank_gate,
+    )
+
+
+def random_weights(config: KDAConfig) -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(20260723)
+
+    def normal(*shape: int, scale: float = 0.05) -> torch.Tensor:
+        return scale * torch.randn(*shape, generator=generator)
+
+    hidden = config.hidden_size
+    key_rank, value_rank = config.head_k_dim, config.head_v_dim
+    weights = {
+        "q_proj.weight": normal(config.q_dim, hidden),
+        "k_proj.weight": normal(config.k_dim, hidden),
+        "v_proj.weight": normal(config.v_dim, hidden),
+        "q_conv1d.weight": normal(config.q_dim, 1, config.conv_kernel_size, scale=0.2),
+        "k_conv1d.weight": normal(config.k_dim, 1, config.conv_kernel_size, scale=0.2),
+        "v_conv1d.weight": normal(config.v_dim, 1, config.conv_kernel_size, scale=0.2),
+        "A_log": torch.log(torch.linspace(1.0, 4.0, config.num_heads)).reshape(1, 1, config.num_heads, 1),
+        "f_a_proj.weight": normal(key_rank, hidden),
+        "f_b_proj.weight": normal(config.num_heads * key_rank, key_rank),
+        "dt_bias": normal(config.num_heads * key_rank),
+        "b_proj.weight": normal(config.num_heads, hidden),
+        "o_norm.weight": 1.0 + normal(value_rank),
+        "o_proj.weight": normal(hidden, config.num_heads * value_rank),
+    }
+    if config.use_full_rank_gate:
+        weights["g_proj.weight"] = normal(config.v_dim, hidden)
+    else:
+        weights["g_a_proj.weight"] = normal(value_rank, hidden)
+        weights["g_b_proj.weight"] = normal(config.num_heads * value_rank, value_rank)
+    return weights

--- a/models/demos/deepseek_v3_d_p/tt/kda/__init__.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Public Kimi Delta Attention layer API."""
+
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+
+__all__ = ["ttKDA", "KdaState"]

--- a/models/demos/deepseek_v3_d_p/tt/kda/config.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/config.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Device-program configuration for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+import ttnn
+
+KDA_CHUNK_SIZE = ttnn.TILE_SIZE
+KDA_QKV_DTYPE = ttnn.bfloat16
+KDA_GATE_DTYPE = ttnn.bfloat16
+KDA_BETA_DTYPE = ttnn.float32
+KDA_RECURRENT_STATE_DTYPE = ttnn.float32
+KDA_AFFINE_SUMMARY_DTYPE = ttnn.bfloat16
+KDA_SCAN_OUTPUT_DTYPE = ttnn.bfloat16
+KDA_PREP_OUTPUT_BF16_MASK = (1 << 1) | (1 << 2) | (1 << 5)
+KDA_PREPARATION_MEMORY_CONFIG = ttnn.DRAM_MEMORY_CONFIG
+KDA_LOCAL_PREFIX_MEMORY_CONFIG = ttnn.L1_MEMORY_CONFIG
+KDA_DISTRIBUTED_PREFIX_MEMORY_CONFIG = ttnn.DRAM_MEMORY_CONFIG
+KDA_DISTRIBUTED_WORKING_MEMORY_CONFIG = ttnn.L1_MEMORY_CONFIG
+KDA_OUTPUT_MEMORY_CONFIG = ttnn.DRAM_MEMORY_CONFIG
+
+
+@dataclass(frozen=True)
+class KDARecurrenceProgramConfig:
+    """Tunable recurrence strategy and compute fidelity."""
+
+    local_scan_strategy: Literal["direct", "grouped"] = "direct"
+    # Used by grouped scan, which runs when local_scan_strategy="grouped" or sequence
+    # parallelism is enabled. This is a ceiling: the effective size is the largest
+    # local-chunk divisor no greater than this value.
+    summary_group_chunks: int = 20
+    affine_prefix_math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.HiFi2
+    scan_math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.HiFi2
+
+    def __post_init__(self) -> None:
+        if self.local_scan_strategy not in ("direct", "grouped"):
+            raise ValueError("local_scan_strategy must be 'direct' or 'grouped'")
+        if self.summary_group_chunks <= 0:
+            raise ValueError("summary_group_chunks must be positive")
+
+
+@dataclass(frozen=True)
+class KDAProgramConfig:
+    """Device-program tuning kept separate from checkpoint model dimensions."""
+
+    recurrence: KDARecurrenceProgramConfig = field(default_factory=KDARecurrenceProgramConfig)
+    # Ceiling: the effective chunk is the largest TP-local channel divisor no greater than this value.
+    qkv_channel_chunk_size: int = 768
+    tp_ccl_topology: ttnn.Topology = ttnn.Topology.Linear
+    gated_rms_output_dtype: ttnn.DataType = ttnn.float32
+    output_projection_math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.HiFi4
+
+    def __post_init__(self) -> None:
+        if self.qkv_channel_chunk_size <= 0 or self.qkv_channel_chunk_size % ttnn.TILE_SIZE:
+            raise ValueError(
+                "qkv_channel_chunk_size must be a positive multiple of "
+                f"{ttnn.TILE_SIZE}, got {self.qkv_channel_chunk_size}"
+            )
+        if self.gated_rms_output_dtype not in (ttnn.float32, ttnn.bfloat16):
+            raise ValueError("gated_rms_output_dtype must be ttnn.float32 or ttnn.bfloat16")
+
+
+def kimi_k3_program_config(*, tp_ccl_topology: ttnn.Topology) -> KDAProgramConfig:
+    """Return the production K3 program configuration with caller-owned per-axis CCL topology."""
+    return KDAProgramConfig(
+        # Scan policy is fixed at construction. Direct scan avoids summary overhead for shorter fixed
+        # sequences; grouped scan trades P local scans of N/P chunks plus a log2(P) prefix for summary
+        # overhead and requires batch_heads * P worker owners. K3 at T=5120 uses grouped scan.
+        recurrence=KDARecurrenceProgramConfig(local_scan_strategy="grouped", summary_group_chunks=20),
+        qkv_channel_chunk_size=512,
+        tp_ccl_topology=tp_ccl_topology,
+        gated_rms_output_dtype=ttnn.bfloat16,
+        output_projection_math_fidelity=ttnn.MathFidelity.HiFi2,
+    )

--- a/models/demos/deepseek_v3_d_p/tt/kda/convolution.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/convolution.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Sequence-parallel carry exchange for KDA causal convolution."""
+
+from __future__ import annotations
+
+import ttnn
+
+
+def exchange_convolution_carry(
+    projected_qkv: ttnn.Tensor,
+    initial_carry: ttnn.Tensor,
+    *,
+    sequence_parallel_axis: int,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """Return partition entry carries and the replicated final stream carry.
+
+    Both outputs have shape ``[B, history, Q_local + K_local + V_local]`` in
+    row-major DRAM. ``partition_carry`` differs by SP rank: rank zero receives
+    ``initial_carry`` and every later rank receives its predecessor tail.
+    ``final_carry`` is the global stream tail replicated across SP. Channels
+    remain sharded across TP.
+    """
+    batch, local_sequence, channels = projected_qkv.shape
+    history = initial_carry.shape[1]
+    mesh_device = projected_qkv.device()
+    mesh_shape = tuple(mesh_device.shape)
+    sp_size = mesh_shape[sequence_parallel_axis]
+
+    local_tail = ttnn.slice(
+        projected_qkv,
+        (0, local_sequence - history, 0),
+        (batch, local_sequence, channels),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    padded_tail = ttnn.pad(
+        local_tail,
+        ((0, 0), (0, ttnn.TILE_SIZE - history), (0, 0)),
+        value=0.0,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tiled_tail = ttnn.to_layout(padded_tail, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    gathered_tails = ttnn.all_gather(
+        tiled_tail,
+        dim=1,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    entry_carries = [initial_carry]
+    for rank in range(sp_size - 1):
+        tiled_rank_tail = ttnn.slice(
+            gathered_tails,
+            (0, rank * ttnn.TILE_SIZE, 0),
+            (batch, (rank + 1) * ttnn.TILE_SIZE, channels),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        rank_tail = ttnn.to_layout(tiled_rank_tail, ttnn.ROW_MAJOR_LAYOUT)
+        entry_carries.append(
+            ttnn.slice(
+                rank_tail,
+                (0, 0, 0),
+                (batch, history, channels),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        )
+    replicated_entries = ttnn.concat(entry_carries, dim=1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    partition_carry = ttnn.mesh_partition(
+        replicated_entries,
+        dim=1,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tiled_final_carry = ttnn.slice(
+        gathered_tails,
+        (0, (sp_size - 1) * ttnn.TILE_SIZE, 0),
+        (batch, sp_size * ttnn.TILE_SIZE, channels),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    final_row_major = ttnn.to_layout(tiled_final_carry, ttnn.ROW_MAJOR_LAYOUT)
+    final_carry = ttnn.slice(
+        final_row_major,
+        (0, 0, 0),
+        (batch, history, channels),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return partition_carry, final_carry

--- a/models/demos/deepseek_v3_d_p/tt/kda/kda.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/kda.py
@@ -1,0 +1,408 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Composed TTNN Kimi Delta Attention layer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tt.kda.config import (
+    KDA_BETA_DTYPE,
+    KDA_CHUNK_SIZE,
+    KDA_OUTPUT_MEMORY_CONFIG,
+    KDA_RECURRENT_STATE_DTYPE,
+    KDAProgramConfig,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
+from models.demos.deepseek_v3_d_p.tt.kda.recurrence import KDARecurrence
+from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights, load_kda_weights
+from models.tt_transformers.tt.ccl import TT_CCL
+
+
+def _slice_width(tensor: ttnn.Tensor, start: int, end: int) -> ttnn.Tensor:
+    stop = list(tensor.shape)
+    begin = [0] * len(stop)
+    begin[-1] = start
+    stop[-1] = end
+    return ttnn.slice(tensor, tuple(begin), tuple(stop), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+
+def _largest_divisor_at_most(value: int, limit: int) -> int:
+    for divisor in range(limit, 0, -1):
+        if value % divisor == 0:
+            return divisor
+    return 1
+
+
+def _effective_qkv_channel_chunk_size(channels: int, configured_chunk_size: int) -> int:
+    """Resolve a configured ceiling to an exact TP-local channel divisor."""
+    return ttnn.TILE_SIZE * _largest_divisor_at_most(
+        channels // ttnn.TILE_SIZE, configured_chunk_size // ttnn.TILE_SIZE
+    )
+
+
+@dataclass(frozen=True)
+class _ProjectedInputs:
+    qkv: ttnn.Tensor
+    decay_rank: ttnn.Tensor
+    output_gate: ttnn.Tensor
+    beta: ttnn.Tensor
+
+
+@dataclass(frozen=True)
+class KdaState:
+    """Caller-owned KDA carries.
+
+    ``recurrent`` is TP-local and must be replicated across the SP axis.
+    ``convolution`` is the BF16 row-major DRAM stream tail with shape
+    ``[B, kernel_size - 1, Q_local + K_local + V_local]``. Its channels are
+    sharded across TP and the complete tail is replicated across SP. The halo
+    exchange derives each partition entry carry from it. Construct state with
+    :meth:`ttKDA.allocate_state` or reuse a state returned by :meth:`ttKDA.forward`.
+    """
+
+    recurrent: ttnn.Tensor
+    convolution: ttnn.Tensor
+
+
+class ttKDA:
+    """Prefill-only KDA layer with immutable, caller-owned logical state."""
+
+    def __init__(
+        self,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        config: KDAConfig,
+        state_dict: Mapping[str, torch.Tensor] | None = None,
+        layer_idx: int = 0,
+        weight_cache_path: Path | None = None,
+        tt_ccl: TT_CCL | None = None,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
+        program_config: KDAProgramConfig | None = None,
+        weights: KDAWeights | None = None,
+    ) -> None:
+        if tp_axis not in (0, 1) or sp_axis not in (0, 1) or sp_axis == tp_axis:
+            raise ValueError(f"KDA requires distinct 2D SP/TP axes, got SP={sp_axis}, TP={tp_axis}")
+        program_config = program_config or KDAProgramConfig()
+        self.device = mesh_device
+        self.tensor_parallel_axis = tp_axis
+        self.sequence_parallel_axis = sp_axis
+        self.sequence_parallel_size = (
+            tuple(mesh_device.shape)[self.sequence_parallel_axis] if isinstance(mesh_device, ttnn.MeshDevice) else 1
+        )
+        uses_grouped_scan = (
+            self.sequence_parallel_size > 1 or program_config.recurrence.local_scan_strategy == "grouped"
+        )
+        if uses_grouped_scan and config.head_k_dim != config.head_v_dim:
+            raise ValueError("grouped KDA affine prefix currently requires K == V")
+        self.tp_ccl_topology = program_config.tp_ccl_topology
+        self.gated_rms_output_dtype = program_config.gated_rms_output_dtype
+        if weights is not None and state_dict is not None:
+            raise ValueError("pass either constructed KDAWeights or host state_dict, not both")
+        if weights is None:
+            weights = load_kda_weights(
+                mesh_device,
+                config,
+                state_dict,
+                weight_cache_path,
+                cache_name_prefix=f"layer_{layer_idx}.kda",
+                tensor_parallel_axis=tp_axis,
+            )
+        expected_tp_size = tuple(mesh_device.shape)[tp_axis] if isinstance(mesh_device, ttnn.MeshDevice) else 1
+        if weights.tensor_parallel_size != expected_tp_size or weights.tensor_parallel_axis != tp_axis:
+            raise ValueError(
+                "KDAWeights placement does not match the layer mesh: "
+                f"weights TP={weights.tensor_parallel_size} axis={weights.tensor_parallel_axis}, "
+                f"layer TP={expected_tp_size} axis={tp_axis}"
+            )
+        self.weights = weights
+        self.tensor_parallel_size = self.weights.tensor_parallel_size
+        self.config = replace(config, num_heads=config.num_heads // self.tensor_parallel_size)
+        qkv_channel_chunk_size = _effective_qkv_channel_chunk_size(
+            self._convolution_width, program_config.qkv_channel_chunk_size
+        )
+        self.qkv_convolution_program_config = ttnn.QkvCausalConv1dSiluProgramConfig(
+            channel_chunk_size=qkv_channel_chunk_size
+        )
+        if self.tensor_parallel_size > 1 and tt_ccl is None:
+            raise ValueError("tt_ccl is required for tensor-parallel KDA")
+        self.tt_ccl = tt_ccl
+        # Ordinary matmuls (input and decay projections) keep packer L1 accumulation.
+        self.compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        # Experimental KDA operations reject packer_l1_acc=True because their kernels do not
+        # accumulate through L1. Keep this separate from projection matmuls, which accept the flag.
+        self.kda_compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        self.recurrence = KDARecurrence(
+            mesh_device,
+            program_config.recurrence,
+            sequence_parallel_axis=(self.sequence_parallel_axis if self.sequence_parallel_size > 1 else None),
+        )
+        self.output_projection_compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=program_config.output_projection_math_fidelity,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+    @property
+    def _convolution_width(self) -> int:
+        return self.config.q_dim + self.config.k_dim + self.config.v_dim
+
+    def allocate_state(self, batch_size: int = 1) -> KdaState:
+        """Allocate the canonical device-resident KDA carries for one prefill stream."""
+        if batch_size != 1:
+            raise ValueError(f"KDA prefill currently requires batch_size=1, got {batch_size}")
+        return KdaState(
+            recurrent=ttnn.zeros(
+                (batch_size, self.config.num_heads, self.config.head_k_dim, self.config.head_v_dim),
+                dtype=KDA_RECURRENT_STATE_DTYPE,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.device,
+                memory_config=KDA_OUTPUT_MEMORY_CONFIG,
+            ),
+            convolution=ttnn.zeros(
+                (batch_size, self.config.conv_kernel_size - 1, self._convolution_width),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self.device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        )
+
+    def _validate_forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        state: KdaState,
+    ) -> None:
+        """Validate shape/type plus the documented SP state-distribution contract."""
+        if len(hidden_states.shape) != 3 or hidden_states.shape[-1] != self.config.hidden_size:
+            raise ValueError(
+                f"hidden_states shape {tuple(hidden_states.shape)} must be [B,T,{self.config.hidden_size}]"
+            )
+        batch = hidden_states.shape[0]
+        sequence = hidden_states.shape[1]
+        if batch != 1:
+            raise ValueError(f"KDA prefill currently requires batch size 1, got B={batch}")
+        if sequence <= 0 or sequence % KDA_CHUNK_SIZE != 0:
+            raise ValueError(
+                f"KDA prefill requires local T to be positive and divisible by {KDA_CHUNK_SIZE}, got T={sequence}"
+            )
+        expected_recurrent = (batch, self.config.num_heads, self.config.head_k_dim, self.config.head_v_dim)
+        expected_convolution = (batch, self.config.conv_kernel_size - 1, self._convolution_width)
+        if tuple(state.recurrent.shape) != expected_recurrent:
+            raise ValueError(f"recurrent state shape {tuple(state.recurrent.shape)} != {expected_recurrent}")
+        if tuple(state.convolution.shape) != expected_convolution:
+            raise ValueError(f"convolution state shape {tuple(state.convolution.shape)} != {expected_convolution}")
+        if state.recurrent.dtype != KDA_RECURRENT_STATE_DTYPE:
+            raise ValueError(f"recurrent state dtype {state.recurrent.dtype} != {KDA_RECURRENT_STATE_DTYPE}")
+        if state.convolution.dtype != ttnn.bfloat16 or state.convolution.layout != ttnn.ROW_MAJOR_LAYOUT:
+            raise ValueError("convolution state must be BF16 row-major")
+
+    def _convolve_qkv(
+        self,
+        qkv: ttnn.Tensor,
+        convolution_state: ttnn.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        """Run depthwise convolution and emit Q/K/V without post-convolution slices."""
+        config = self.config
+        channels = self._convolution_width
+        sequence = qkv.shape[1]
+        qkv_row_major = ttnn.to_layout(
+            qkv,
+            ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        state_row_major = ttnn.to_layout(
+            convolution_state,
+            ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        if self.sequence_parallel_size > 1:
+            state_row_major, new_state = exchange_convolution_carry(
+                qkv_row_major,
+                state_row_major,
+                sequence_parallel_axis=self.sequence_parallel_axis,
+            )
+        else:
+            new_state = ttnn.slice(
+                qkv_row_major,
+                (0, sequence - (config.conv_kernel_size - 1), 0),
+                (qkv_row_major.shape[0], sequence, channels),
+            )
+        # The replacement state is BF16 row-major DRAM [B, K - 1, Q_local + K_local + V_local],
+        # channel-sharded across TP and replicated across SP.
+        q, k, v = ttnn.experimental.kda.qkv_causal_conv1d_silu(
+            qkv_row_major,
+            state_row_major,
+            *self.weights.convolution_taps,
+            config.q_dim,
+            config.k_dim,
+            config.v_dim,
+            program_config=self.qkv_convolution_program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return q, k, v, new_state
+
+    def _project_inputs(
+        self,
+        hidden_states: ttnn.Tensor,
+    ) -> _ProjectedInputs:
+        """Run the fused input projection and split its semantic outputs."""
+        config = self.config
+        weights = self.weights
+        projected = ttnn.linear(
+            hidden_states,
+            weights.input_projection,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_config,
+        )
+        auxiliary_start = self._convolution_width
+        return _ProjectedInputs(
+            qkv=_slice_width(projected, 0, auxiliary_start),
+            decay_rank=_slice_width(projected, auxiliary_start, auxiliary_start + config.head_k_dim),
+            output_gate=_slice_width(
+                projected,
+                auxiliary_start + config.head_k_dim,
+                auxiliary_start + config.head_k_dim + config.v_dim,
+            ),
+            beta=_slice_width(
+                projected,
+                auxiliary_start + config.head_k_dim + config.v_dim,
+                auxiliary_start + config.head_k_dim + config.v_dim + config.num_heads,
+            ),
+        )
+
+    def _compute_gates(
+        self,
+        *,
+        beta: ttnn.Tensor,
+        decay_rank: ttnn.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Evaluate the decay and write gates consumed by the recurrence."""
+        config, weights = self.config, self.weights
+        # Preserve the sigmoid result at the FP32 precision required by chunk preparation.
+        beta_for_recurrence = ttnn.sigmoid(
+            ttnn.typecast(
+                beta,
+                KDA_BETA_DTYPE,
+                memory_config=KDA_OUTPUT_MEMORY_CONFIG,
+            ),
+            memory_config=KDA_OUTPUT_MEMORY_CONFIG,
+        )
+        gate = ttnn.linear(
+            decay_rank,
+            weights.decay_output_projection,
+            bias=weights.decay_bias_flat,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_config,
+        )
+        if config.gate_lower_bound is None:
+            gate = ttnn.multiply(
+                weights.decay_scale_flat,
+                gate,
+                input_tensor_b_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0)],
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        else:
+            gate = ttnn.multiply(
+                weights.decay_scale_flat,
+                gate,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            gate = ttnn.sigmoid(gate, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            gate = ttnn.multiply(gate, config.gate_lower_bound, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return gate, beta_for_recurrence
+
+    def _kda_rms_norm(
+        self,
+        output: ttnn.Tensor,
+        output_gate: ttnn.Tensor,
+    ) -> ttnn.Tensor:
+        """Apply the KDA gated RMSNorm epilogue."""
+        config, weights = self.config, self.weights
+        return ttnn.experimental.kda.sigmoid_gated_rms_norm(
+            output,
+            output_gate,
+            weights.norm,
+            config.num_heads,
+            epsilon=config.norm_eps,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.kda_compute_config,
+            output_dtype=self.gated_rms_output_dtype,
+        )
+
+    def _project_output(
+        self,
+        output: ttnn.Tensor,
+    ) -> ttnn.Tensor:
+        """Project normalized heads and perform the required TP reduction."""
+        weights = self.weights
+        output = ttnn.linear(
+            output,
+            weights.output_projection,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.output_projection_compute_config,
+        )
+        if self.tensor_parallel_size > 1:
+            cluster_axis = None if self.sequence_parallel_size == 1 else self.tensor_parallel_axis
+            output = ttnn.experimental.reduce_scatter_minimal_async(
+                output,
+                dim=-1,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                num_links=self.tt_ccl.get_num_links(cluster_axis),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.tp_ccl_topology,
+                cluster_axis=cluster_axis,
+            )
+        return output
+
+    def forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        state: KdaState,
+    ) -> tuple[ttnn.Tensor, KdaState]:
+        """Run prefill KDA and return replacement logical carries.
+
+        The input state is only read. No tensor reachable from it is used as a
+        ``ttnn.copy`` destination or retained on this layer. The returned output
+        is sequence-partitioned along SP and, when TP > 1, reduce-scattered on
+        the hidden dimension; TP == 1 returns the full hidden dimension.
+        """
+        self._validate_forward(hidden_states, state)
+        projected = self._project_inputs(hidden_states)
+        q, k, v, new_convolution = self._convolve_qkv(projected.qkv, state.convolution)
+        gate, beta = self._compute_gates(
+            beta=projected.beta,
+            decay_rank=projected.decay_rank,
+        )
+        new_recurrent, output = self.recurrence(
+            q=q,
+            k=k,
+            v=v,
+            gate=gate,
+            beta=beta,
+            initial_state=state.recurrent,
+        )
+        output = self._kda_rms_norm(output, projected.output_gate)
+        output = self._project_output(output)
+        return output, KdaState(recurrent=new_recurrent, convolution=new_convolution)

--- a/models/demos/deepseek_v3_d_p/tt/kda/recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/recurrence.py
@@ -1,0 +1,462 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Python-owned KDA graph orchestration.
+
+The KDA layer keeps collective and state-flow decisions here; device leaves only
+perform the bespoke kernels exposed by ``ttnn.experimental.kda``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.kda.config import (
+    KDA_AFFINE_SUMMARY_DTYPE,
+    KDA_CHUNK_SIZE,
+    KDA_DISTRIBUTED_PREFIX_MEMORY_CONFIG,
+    KDA_DISTRIBUTED_WORKING_MEMORY_CONFIG,
+    KDA_LOCAL_PREFIX_MEMORY_CONFIG,
+    KDA_OUTPUT_MEMORY_CONFIG,
+    KDA_PREP_OUTPUT_BF16_MASK,
+    KDA_PREPARATION_MEMORY_CONFIG,
+    KDA_RECURRENT_STATE_DTYPE,
+    KDARecurrenceProgramConfig,
+)
+
+
+def _group_summary_memory_config(device: ttnn.Device, group_heads: int, key_dim: int) -> ttnn.MemoryConfig:
+    grid = device.compute_with_storage_grid_size()
+    capacity = grid.x * grid.y
+    if group_heads > capacity:
+        raise ValueError(f"grouped KDA needs {group_heads} summary owners, but only {capacity} are supported")
+    worker_cores = ttnn.num_cores_to_corerangeset(group_heads, grid, row_wise=True)
+    return ttnn.create_sharded_memory_config(
+        (group_heads, key_dim, key_dim),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+@dataclass(frozen=True)
+class _RecurrenceGeometry:
+    batch: int
+    sequence: int
+    heads: int
+    key_dim: int
+    value_dim: int
+    chunk_size: int
+    num_chunks: int
+
+    @property
+    def batch_heads(self) -> int:
+        return self.batch * self.heads
+
+
+@dataclass(frozen=True)
+class _PreparedChunks:
+    v_beta: ttnn.Tensor
+    kd: ttnn.Tensor
+    q_decay: ttnn.Tensor
+    intra: ttnn.Tensor
+    k_dec_t: ttnn.Tensor
+    final_decay: ttnn.Tensor
+    t_inv: ttnn.Tensor
+
+    def as_kernel_args(self) -> tuple[ttnn.Tensor, ...]:
+        return (
+            self.v_beta,
+            self.kd,
+            self.q_decay,
+            self.intra,
+            self.k_dec_t,
+            self.final_decay,
+            self.t_inv,
+        )
+
+
+@dataclass(frozen=True)
+class _ScanResult:
+    output: ttnn.Tensor
+    final_state: ttnn.Tensor
+
+
+@dataclass(frozen=True)
+class _RecurrenceComputeConfig:
+    preparation: ttnn.DeviceComputeKernelConfig
+    affine_prefix: ttnn.DeviceComputeKernelConfig
+    scan: ttnn.DeviceComputeKernelConfig
+
+
+def _recurrence_geometry(
+    q: ttnn.Tensor,
+    v: ttnn.Tensor,
+    beta: ttnn.Tensor,
+) -> _RecurrenceGeometry:
+    """Derive host-only execution metadata from layer-produced tensors."""
+    q_shape = tuple(q.shape)
+    v_shape = tuple(v.shape)
+    batch, sequence, heads = tuple(beta.shape)
+    key_dim = q_shape[2] // heads
+    value_dim = v_shape[2] // heads
+    return _RecurrenceGeometry(
+        batch=batch,
+        sequence=sequence,
+        heads=heads,
+        key_dim=key_dim,
+        value_dim=value_dim,
+        chunk_size=KDA_CHUNK_SIZE,
+        num_chunks=sequence // KDA_CHUNK_SIZE,
+    )
+
+
+def _prepare_chunk_terms(
+    q: ttnn.Tensor,
+    k: ttnn.Tensor,
+    v: ttnn.Tensor,
+    gate: ttnn.Tensor,
+    beta: ttnn.Tensor,
+    geometry: _RecurrenceGeometry,
+    *,
+    compute_config: _RecurrenceComputeConfig,
+) -> _PreparedChunks:
+    beta_by_head = ttnn.permute(beta, (0, 2, 1))
+    beta_by_chunk = ttnn.reshape(
+        beta_by_head,
+        (geometry.batch_heads, geometry.num_chunks, geometry.chunk_size, 1),
+    )
+    outputs = ttnn.experimental.kda.prepare_chunk_recurrence(
+        q,
+        k,
+        v,
+        gate,
+        beta_by_chunk,
+        geometry.heads,
+        memory_config=KDA_PREPARATION_MEMORY_CONFIG,
+        compute_kernel_config=compute_config.preparation,
+        output_bf16_mask=KDA_PREP_OUTPUT_BF16_MASK,
+    )
+    return _PreparedChunks(*outputs)
+
+
+def _reshape_chunks_for_groups(
+    prepared: _PreparedChunks,
+    geometry: _RecurrenceGeometry,
+    *,
+    group_heads: int,
+    summary_group_chunks: int,
+) -> _PreparedChunks:
+    return _PreparedChunks(
+        v_beta=ttnn.reshape(
+            prepared.v_beta, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.value_dim)
+        ),
+        kd=ttnn.reshape(prepared.kd, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.key_dim)),
+        q_decay=ttnn.reshape(
+            prepared.q_decay, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.key_dim)
+        ),
+        intra=ttnn.reshape(
+            prepared.intra, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.chunk_size)
+        ),
+        k_dec_t=ttnn.reshape(
+            prepared.k_dec_t, (group_heads, summary_group_chunks, geometry.key_dim, geometry.chunk_size)
+        ),
+        final_decay=ttnn.reshape(prepared.final_decay, (group_heads, summary_group_chunks, geometry.key_dim, 1)),
+        t_inv=ttnn.reshape(
+            prepared.t_inv, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.chunk_size)
+        ),
+    )
+
+
+def _summarize_chunk_groups(
+    grouped: _PreparedChunks,
+    geometry: _RecurrenceGeometry,
+    *,
+    compute_config: _RecurrenceComputeConfig,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    summary_memory_config = _group_summary_memory_config(
+        grouped.v_beta.device(), grouped.v_beta.shape[0], geometry.key_dim
+    )
+    affine_a, affine_b = ttnn.experimental.kda.summarize_chunk_recurrence(
+        *grouped.as_kernel_args(),
+        memory_config=summary_memory_config,
+        # Summary generation is part of chunk preparation; the affine-prefix
+        # fidelity knob applies only to composition of the emitted summaries.
+        compute_kernel_config=compute_config.preparation,
+    )
+    # Precision boundary: summary-pair math is FP32; summaries are stored and transported as BF16.
+    summary_a = ttnn.typecast(affine_a, KDA_AFFINE_SUMMARY_DTYPE, memory_config=summary_memory_config)
+    summary_b = ttnn.typecast(affine_b, KDA_AFFINE_SUMMARY_DTYPE, memory_config=summary_memory_config)
+    return summary_a, summary_b
+
+
+def _effective_summary_group_chunks(num_chunks: int, configured_group_chunks: int) -> int:
+    """Return the largest configured-or-smaller group size that divides the local chunk count."""
+    for group_chunks in range(min(num_chunks, configured_group_chunks), 0, -1):
+        if num_chunks % group_chunks == 0:
+            return group_chunks
+    return 1
+
+
+def _scan_chunks(
+    prepared: _PreparedChunks,
+    initial_states: ttnn.Tensor,
+    *,
+    compute_config: ttnn.DeviceComputeKernelConfig,
+) -> _ScanResult:
+    output, final_states = ttnn.experimental.kda.recurrent_chunk_scan(
+        *prepared.as_kernel_args(),
+        initial_states,
+        memory_config=KDA_OUTPUT_MEMORY_CONFIG,
+        compute_kernel_config=compute_config,
+    )
+    return _ScanResult(output=output, final_state=final_states)
+
+
+def _distributed_affine_prefix(
+    transform_a: ttnn.Tensor,
+    transform_b: ttnn.Tensor,
+    initial_state: ttnn.Tensor,
+    *,
+    sequence_parallel_axis: int,
+    compute_config: ttnn.DeviceComputeKernelConfig,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """Compose SP partition affine summaries and return entry/final carries."""
+    shape = tuple(transform_a.shape)
+
+    mesh_device = transform_a.device()
+    mesh_shape = tuple(mesh_device.shape)
+    sp_size = mesh_shape[sequence_parallel_axis]
+    batch_heads, key_dim = shape[0], shape[1]
+    value_dim = transform_b.shape[-1]
+    output_memory = KDA_OUTPUT_MEMORY_CONFIG
+    working_memory = KDA_DISTRIBUTED_WORKING_MEMORY_CONFIG
+
+    # Precision boundary: FP32 composition is transported as BF16.
+    transport_a = ttnn.typecast(transform_a, KDA_AFFINE_SUMMARY_DTYPE, memory_config=output_memory)
+    transport_b = ttnn.typecast(transform_b, KDA_AFFINE_SUMMARY_DTYPE, memory_config=output_memory)
+    transport_a = ttnn.reshape(transport_a, (1, batch_heads, key_dim, key_dim))
+    transport_b = ttnn.reshape(transport_b, (1, batch_heads, key_dim, value_dim))
+    packed = ttnn.concat([transport_a, transport_b], dim=3, memory_config=output_memory)
+    gathered = ttnn.all_gather(
+        packed,
+        dim=0,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=output_memory,
+    )
+
+    carry = ttnn.to_memory_config(initial_state, working_memory)
+    carry = ttnn.reshape(carry, (1, batch_heads, key_dim, value_dim))
+    entry_states = []
+    for rank in range(sp_size):
+        entry_states.append(carry)
+        transported_rank_a = ttnn.slice(
+            gathered,
+            (rank, 0, 0, 0),
+            (rank + 1, batch_heads, key_dim, key_dim),
+            memory_config=working_memory,
+        )
+        transported_rank_b = ttnn.slice(
+            gathered,
+            (rank, 0, 0, key_dim),
+            (rank + 1, batch_heads, key_dim, key_dim + value_dim),
+            memory_config=working_memory,
+        )
+        # Precision boundary: BF16 collective payload is restored for FP32 carry math.
+        rank_a_for_carry = ttnn.typecast(
+            transported_rank_a,
+            KDA_RECURRENT_STATE_DTYPE,
+            memory_config=working_memory,
+        )
+        rank_b_for_carry = ttnn.typecast(
+            transported_rank_b,
+            KDA_RECURRENT_STATE_DTYPE,
+            memory_config=working_memory,
+        )
+        carry = ttnn.matmul(
+            rank_a_for_carry,
+            carry,
+            memory_config=working_memory,
+            dtype=KDA_RECURRENT_STATE_DTYPE,
+            compute_kernel_config=compute_config,
+        )
+        carry = ttnn.add(carry, rank_b_for_carry, memory_config=working_memory)
+
+    replicated_entries = ttnn.concat(entry_states, dim=0, memory_config=output_memory)
+    entry_state = ttnn.mesh_partition(
+        replicated_entries,
+        dim=0,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=output_memory,
+    )
+    final_state = ttnn.to_memory_config(carry, output_memory)
+    entry_state = ttnn.reshape(entry_state, (batch_heads, key_dim, value_dim))
+    final_state = ttnn.reshape(final_state, (batch_heads, key_dim, value_dim))
+    return entry_state, final_state
+
+
+def _last_group_state(
+    grouped_final_states: ttnn.Tensor,
+    geometry: _RecurrenceGeometry,
+    groups_per_head: int,
+) -> ttnn.Tensor:
+    all_final_states = ttnn.reshape(
+        grouped_final_states,
+        (geometry.batch_heads, groups_per_head, geometry.key_dim, geometry.value_dim),
+    )
+    last_final_state = ttnn.slice(
+        all_final_states,
+        (0, groups_per_head - 1, 0, 0),
+        (geometry.batch_heads, groups_per_head, geometry.key_dim, geometry.value_dim),
+        memory_config=KDA_OUTPUT_MEMORY_CONFIG,
+    )
+    return ttnn.reshape(last_final_state, (geometry.batch_heads, geometry.key_dim, geometry.value_dim))
+
+
+def _scan_grouped_chunks(
+    prepared: _PreparedChunks,
+    initial_state: ttnn.Tensor,
+    geometry: _RecurrenceGeometry,
+    *,
+    summary_group_chunks: int,
+    sequence_parallel_axis: int | None,
+    compute_config: _RecurrenceComputeConfig,
+) -> _ScanResult:
+    group_chunks = _effective_summary_group_chunks(geometry.num_chunks, summary_group_chunks)
+    groups_per_head = geometry.num_chunks // group_chunks
+    group_heads = geometry.batch_heads * groups_per_head
+
+    grouped = _reshape_chunks_for_groups(
+        prepared,
+        geometry,
+        group_heads=group_heads,
+        summary_group_chunks=group_chunks,
+    )
+    summary_a, summary_b = _summarize_chunk_groups(grouped, geometry, compute_config=compute_config)
+
+    prefix_initial_state = initial_state
+    prefix_memory_config = KDA_LOCAL_PREFIX_MEMORY_CONFIG
+    if sequence_parallel_axis is not None:
+        partition_a, partition_b = ttnn.experimental.kda.reduce_affine_transforms(
+            summary_a,
+            summary_b,
+            groups_per_head,
+            memory_config=KDA_OUTPUT_MEMORY_CONFIG,
+            compute_kernel_config=compute_config.affine_prefix,
+        )
+        prefix_initial_state, distributed_final_state = _distributed_affine_prefix(
+            partition_a,
+            partition_b,
+            initial_state,
+            sequence_parallel_axis=sequence_parallel_axis,
+            compute_config=compute_config.affine_prefix,
+        )
+        prefix_memory_config = KDA_DISTRIBUTED_PREFIX_MEMORY_CONFIG
+
+    group_initial_states = ttnn.experimental.kda.affine_exclusive_scan(
+        summary_a,
+        summary_b,
+        prefix_initial_state,
+        groups_per_head,
+        memory_config=prefix_memory_config,
+        compute_kernel_config=compute_config.affine_prefix,
+    )
+    grouped_scan = _scan_chunks(grouped, group_initial_states, compute_config=compute_config.scan)
+    output = ttnn.reshape(
+        grouped_scan.output,
+        (geometry.batch_heads, geometry.num_chunks, geometry.chunk_size, geometry.value_dim),
+    )
+
+    if sequence_parallel_axis is not None:
+        return _ScanResult(output=output, final_state=distributed_final_state)
+    return _ScanResult(
+        output=output,
+        final_state=_last_group_state(grouped_scan.final_state, geometry, groups_per_head),
+    )
+
+
+class KDARecurrence:
+    """Constructor-fixed KDA recurrence executor."""
+
+    def __init__(
+        self,
+        device: ttnn.Device | ttnn.MeshDevice,
+        program_config: KDARecurrenceProgramConfig,
+        *,
+        sequence_parallel_axis: int | None,
+    ) -> None:
+        preparation = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        affine_prefix = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=program_config.affine_prefix_math_fidelity,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        scan = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=program_config.scan_math_fidelity,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        self._compute_config = _RecurrenceComputeConfig(
+            preparation=preparation,
+            affine_prefix=affine_prefix,
+            scan=scan,
+        )
+        self._summary_group_chunks = program_config.summary_group_chunks
+        self._sequence_parallel_axis = sequence_parallel_axis
+        self._use_grouped_scan = sequence_parallel_axis is not None or program_config.local_scan_strategy == "grouped"
+
+    def __call__(
+        self,
+        *,
+        q: ttnn.Tensor,
+        k: ttnn.Tensor,
+        v: ttnn.Tensor,
+        gate: ttnn.Tensor,
+        beta: ttnn.Tensor,
+        initial_state: ttnn.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Return ``(new_state, output)`` for directly named recurrence tensors."""
+        geometry = _recurrence_geometry(q, v, beta)
+
+        state = ttnn.reshape(
+            initial_state,
+            (geometry.batch_heads, geometry.key_dim, geometry.value_dim),
+        )
+        prepared = _prepare_chunk_terms(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            geometry,
+            compute_config=self._compute_config,
+        )
+        if self._use_grouped_scan:
+            scan = _scan_grouped_chunks(
+                prepared,
+                state,
+                geometry,
+                summary_group_chunks=self._summary_group_chunks,
+                sequence_parallel_axis=self._sequence_parallel_axis,
+                compute_config=self._compute_config,
+            )
+        else:
+            scan = _scan_chunks(prepared, state, compute_config=self._compute_config.scan)
+        output = ttnn.reshape(
+            scan.output,
+            (geometry.batch_heads, geometry.sequence, geometry.value_dim),
+        )
+        final_state = ttnn.reshape(
+            scan.final_state,
+            (geometry.batch, geometry.heads, geometry.key_dim, geometry.value_dim),
+        )
+        return final_state, output

--- a/models/demos/deepseek_v3_d_p/tt/kda/weights.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/weights.py
@@ -1,0 +1,470 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Device weight loading for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kda.weights import normalize_kda_state_dict
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import FastCacheChecker
+
+_CACHE_SCHEMA_VERSION = 2
+
+
+def _parallel_geometry(device: ttnn.Device | ttnn.MeshDevice, tensor_parallel_axis: int) -> tuple[tuple[int, int], int]:
+    if tensor_parallel_axis not in (0, 1):
+        raise ValueError(f"tensor_parallel_axis must be 0 or 1, got {tensor_parallel_axis}")
+    if isinstance(device, ttnn.MeshDevice):
+        mesh_shape = tuple(device.shape)
+        return mesh_shape, mesh_shape[tensor_parallel_axis]
+    return (1, 1), 1
+
+
+def _cache_artifact_names(config: KDAConfig) -> tuple[str, ...]:
+    fixed = (
+        "input_projection_head_major",
+        "decay_output_projection",
+        "output_projection",
+        "decay_scale_flat",
+        "decay_bias_flat",
+        "norm",
+    )
+    return fixed + tuple(f"conv_tap_{tap}" for tap in range(config.conv_kernel_size))
+
+
+def _cache_stem(
+    cache_name_prefix: str,
+    name: str,
+    config: KDAConfig,
+    mesh_shape: tuple[int, int],
+    tensor_parallel_axis: int,
+) -> str:
+    config_payload = json.dumps(asdict(config), sort_keys=True, separators=(",", ":"))
+    config_digest = hashlib.sha256(config_payload.encode("utf-8")).hexdigest()[:16]
+    return (
+        f"{cache_name_prefix}.{name}.v{_CACHE_SCHEMA_VERSION}.{config_digest}."
+        f"mesh{mesh_shape[0]}x{mesh_shape[1]}.tpaxis{tensor_parallel_axis}"
+    )
+
+
+@dataclass(frozen=True)
+class _KDAHostWeights:
+    input_projection: torch.Tensor
+    decay_output_projection: torch.Tensor
+    output_projection: torch.Tensor
+    decay_scale_flat: torch.Tensor
+    decay_bias_flat: torch.Tensor
+    norm: torch.Tensor
+    convolution_taps: tuple[torch.Tensor, ...]
+
+
+@dataclass(frozen=True)
+class KDAWeights:
+    input_projection: ttnn.Tensor
+    decay_output_projection: ttnn.Tensor
+    output_projection: ttnn.Tensor
+    decay_scale_flat: ttnn.Tensor
+    decay_bias_flat: ttnn.Tensor
+    norm: ttnn.Tensor
+    convolution_taps: tuple[ttnn.Tensor, ...]
+    tensor_parallel_size: int
+    tensor_parallel_axis: int
+
+    @classmethod
+    def check_cache_complete(
+        cls,
+        cache_path: Path | None,
+        cache_name_prefix: str,
+        config: KDAConfig,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        *,
+        tensor_parallel_axis: int = 1,
+    ) -> bool:
+        """Return whether every dtype/layout/placement-specific KDA tensorbin exists."""
+        if cache_path is None:
+            return False
+        cache_path = Path(cache_path)
+        if not cache_path.is_dir():
+            return False
+        checker = FastCacheChecker(cache_path)
+        mesh_shape, _ = _parallel_geometry(mesh_device, tensor_parallel_axis)
+        for name in _cache_artifact_names(config):
+            stem = _cache_stem(cache_name_prefix, name, config, mesh_shape, tensor_parallel_axis)
+            pattern = f"{stem}_dtype_{ttnn.bfloat16.name}_layout_{ttnn.TILE_LAYOUT.name}.tensorbin"
+            if not checker.pattern_exists(pattern, "KDA"):
+                return False
+        return True
+
+    @classmethod
+    def build_ttnn_cache(
+        cls,
+        state_dict: Mapping[str, torch.Tensor],
+        cache_path: Path,
+        cache_name_prefix: str,
+        config: KDAConfig,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        *,
+        tensor_parallel_axis: int = 1,
+    ) -> None:
+        """Build all KDA tensorbins without copying weights to device memory."""
+        if not state_dict:
+            raise ValueError("building the KDA TTNN cache requires a state_dict")
+        mesh_shape, tensor_parallel_size = _validated_parallel_geometry(
+            mesh_device,
+            config,
+            tensor_parallel_axis,
+        )
+        host_weights = _prepare_kda_host_weights(state_dict, config, tensor_parallel_size)
+        _materialize_kda_weights(
+            host_weights,
+            device=mesh_device,
+            config=config,
+            tensor_cache_path=Path(cache_path),
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            place_on_device=False,
+        )
+
+    @classmethod
+    def from_cache(
+        cls,
+        cache_path: Path,
+        cache_name_prefix: str,
+        config: KDAConfig,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        *,
+        tensor_parallel_axis: int = 1,
+    ) -> "KDAWeights":
+        """Construct device weights exclusively from a complete TTNN cache."""
+        return load_kda_weights(
+            mesh_device,
+            config,
+            None,
+            cache_path,
+            cache_name_prefix=cache_name_prefix,
+            tensor_parallel_axis=tensor_parallel_axis,
+        )
+
+
+def _validated_parallel_geometry(
+    device: ttnn.Device | ttnn.MeshDevice,
+    config: KDAConfig,
+    tensor_parallel_axis: int,
+) -> tuple[tuple[int, int], int]:
+    mesh_shape, tensor_parallel_size = _parallel_geometry(device, tensor_parallel_axis)
+    if config.num_heads % tensor_parallel_size != 0:
+        raise ValueError(
+            f"num_heads {config.num_heads} must be divisible by tensor parallel size {tensor_parallel_size}"
+        )
+    return mesh_shape, tensor_parallel_size
+
+
+def _group_projection_rows_by_tp_rank(
+    weights: tuple[torch.Tensor, ...],
+    tensor_parallel_size: int,
+) -> torch.Tensor:
+    """Place every projection's corresponding head slice next to the same TP rank."""
+    grouped = []
+    for device_index in range(tensor_parallel_size):
+        rank_weights = []
+        for weight in weights:
+            shard_width = weight.shape[0] // tensor_parallel_size
+            start = device_index * shard_width
+            rank_weights.append(weight[start : start + shard_width])
+        grouped.append(torch.cat(rank_weights, dim=0))
+    return torch.cat(grouped, dim=0)
+
+
+def _prepare_kda_host_weights(
+    state_dict: Mapping[str, torch.Tensor],
+    config: KDAConfig,
+    tensor_parallel_size: int,
+) -> _KDAHostWeights:
+    state_dict = normalize_kda_state_dict(state_dict, config)
+    common_input_weights = (
+        state_dict["q_proj.weight"],
+        state_dict["k_proj.weight"],
+        state_dict["v_proj.weight"],
+        state_dict["f_a_proj.weight"].repeat(tensor_parallel_size, 1),
+    )
+    if config.use_full_rank_gate:
+        input_projection = _group_projection_rows_by_tp_rank(
+            common_input_weights
+            + (
+                state_dict["g_proj.weight"],
+                state_dict["b_proj.weight"],
+            ),
+            tensor_parallel_size,
+        ).T
+    else:
+        output_gate_projection = state_dict["g_b_proj.weight"].reshape(
+            config.num_heads,
+            config.head_v_dim,
+            config.head_v_dim,
+        )
+        output_gate_direct = torch.matmul(
+            output_gate_projection,
+            state_dict["g_a_proj.weight"],
+        ).reshape(config.v_dim, config.hidden_size)
+        input_projection = _group_projection_rows_by_tp_rank(
+            common_input_weights
+            + (
+                output_gate_direct,
+                state_dict["b_proj.weight"],
+            ),
+            tensor_parallel_size,
+        ).T
+
+    decay_scale = state_dict["A_log"].float().exp()
+    if config.gate_lower_bound is None:
+        decay_scale = -decay_scale
+    decay_bias = state_dict["dt_bias"].reshape(1, 1, config.num_heads, config.head_k_dim)
+    decay_scale_flat = decay_scale.expand(-1, -1, -1, config.head_k_dim).reshape(1, 1, config.q_dim)
+    decay_bias_flat = decay_bias.reshape(1, 1, config.q_dim)
+
+    convolution_taps = []
+    for tap in range(config.conv_kernel_size):
+        tap_weights = (
+            state_dict["q_conv1d.weight"][:, 0, tap],
+            state_dict["k_conv1d.weight"][:, 0, tap],
+            state_dict["v_conv1d.weight"][:, 0, tap],
+        )
+        fused_tap = _group_projection_rows_by_tp_rank(tap_weights, tensor_parallel_size).reshape(1, 1, -1)
+        convolution_taps.append(fused_tap)
+
+    return _KDAHostWeights(
+        input_projection=input_projection,
+        decay_output_projection=state_dict["f_b_proj.weight"].T,
+        output_projection=state_dict["o_proj.weight"].T,
+        decay_scale_flat=decay_scale_flat,
+        decay_bias_flat=decay_bias_flat,
+        norm=state_dict["o_norm.weight"],
+        convolution_taps=tuple(convolution_taps),
+    )
+
+
+def _mesh_mapper(
+    device: ttnn.Device | ttnn.MeshDevice,
+    *,
+    mesh_shape: tuple[int, int],
+    tensor_parallel_size: int,
+    tensor_parallel_axis: int,
+    shard_dim: int | None,
+) -> ttnn.CppTensorToMesh | None:
+    if tensor_parallel_size == 1:
+        return None
+    mesh_dims = [None, None]
+    mesh_dims[tensor_parallel_axis] = shard_dim
+    return ttnn.ShardTensor2dMesh(device, dims=tuple(mesh_dims), mesh_shape=mesh_shape)
+
+
+def _materialize_kda_tensor(
+    host_tensor: torch.Tensor | None,
+    name: str,
+    *,
+    device: ttnn.Device | ttnn.MeshDevice,
+    config: KDAConfig,
+    tensor_cache_path: Path | None,
+    cache_name_prefix: str,
+    mesh_shape: tuple[int, int],
+    tensor_parallel_size: int,
+    tensor_parallel_axis: int,
+    shard_dim: int | None = None,
+    place_on_device: bool,
+) -> ttnn.Tensor:
+    cache_name = _cache_stem(cache_name_prefix, name, config, mesh_shape, tensor_parallel_axis)
+    cache_file = tensor_cache_path / cache_name if tensor_cache_path is not None else None
+    if host_tensor is None:
+        if cache_file is None:
+            raise ValueError("cache-only KDA weight loading requires tensor_cache_path")
+        serialized_cache_file = Path(
+            f"{cache_file}_dtype_{ttnn.bfloat16.name}_layout_{ttnn.TILE_LAYOUT.name}.tensorbin"
+        )
+        return ttnn.load_tensor(serialized_cache_file, device=device)
+
+    return ttnn.as_tensor(
+        host_tensor.contiguous(),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device if place_on_device else None,
+        mesh_mapper=_mesh_mapper(
+            device,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            shard_dim=shard_dim,
+        ),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG if place_on_device else None,
+        cache_file_name=cache_file,
+    )
+
+
+def _materialize_kda_weights(
+    host_weights: _KDAHostWeights | None,
+    *,
+    device: ttnn.Device | ttnn.MeshDevice,
+    config: KDAConfig,
+    tensor_cache_path: Path | None,
+    cache_name_prefix: str,
+    mesh_shape: tuple[int, int],
+    tensor_parallel_size: int,
+    tensor_parallel_axis: int,
+    place_on_device: bool,
+) -> tuple[dict[str, ttnn.Tensor], tuple[ttnn.Tensor, ...]]:
+    if tensor_cache_path is not None:
+        tensor_cache_path.mkdir(parents=True, exist_ok=True)
+
+    materialized = {
+        "input_projection": _materialize_kda_tensor(
+            None if host_weights is None else host_weights.input_projection,
+            "input_projection_head_major",
+            device=device,
+            config=config,
+            tensor_cache_path=tensor_cache_path,
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            shard_dim=-1,
+            place_on_device=place_on_device,
+        ),
+        "decay_output_projection": _materialize_kda_tensor(
+            None if host_weights is None else host_weights.decay_output_projection,
+            "decay_output_projection",
+            device=device,
+            config=config,
+            tensor_cache_path=tensor_cache_path,
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            shard_dim=-1,
+            place_on_device=place_on_device,
+        ),
+        "output_projection": _materialize_kda_tensor(
+            None if host_weights is None else host_weights.output_projection,
+            "output_projection",
+            device=device,
+            config=config,
+            tensor_cache_path=tensor_cache_path,
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            shard_dim=-2,
+            place_on_device=place_on_device,
+        ),
+        "decay_scale_flat": _materialize_kda_tensor(
+            None if host_weights is None else host_weights.decay_scale_flat,
+            "decay_scale_flat",
+            device=device,
+            config=config,
+            tensor_cache_path=tensor_cache_path,
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            shard_dim=-1,
+            place_on_device=place_on_device,
+        ),
+        "decay_bias_flat": _materialize_kda_tensor(
+            None if host_weights is None else host_weights.decay_bias_flat,
+            "decay_bias_flat",
+            device=device,
+            config=config,
+            tensor_cache_path=tensor_cache_path,
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            shard_dim=-1,
+            place_on_device=place_on_device,
+        ),
+        "norm": _materialize_kda_tensor(
+            None if host_weights is None else host_weights.norm,
+            "norm",
+            device=device,
+            config=config,
+            tensor_cache_path=tensor_cache_path,
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            place_on_device=place_on_device,
+        ),
+    }
+    host_taps = [None] * config.conv_kernel_size if host_weights is None else host_weights.convolution_taps
+    convolution_taps = tuple(
+        _materialize_kda_tensor(
+            tensor,
+            f"conv_tap_{tap}",
+            device=device,
+            config=config,
+            tensor_cache_path=tensor_cache_path,
+            cache_name_prefix=cache_name_prefix,
+            mesh_shape=mesh_shape,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_axis=tensor_parallel_axis,
+            shard_dim=-1,
+            place_on_device=place_on_device,
+        )
+        for tap, tensor in enumerate(host_taps)
+    )
+    return materialized, convolution_taps
+
+
+def load_kda_weights(
+    device: ttnn.Device | ttnn.MeshDevice,
+    config: KDAConfig,
+    state_dict: Mapping[str, torch.Tensor] | None,
+    tensor_cache_path: Path | None = None,
+    *,
+    cache_name_prefix: str = "kda",
+    tensor_parallel_axis: int = 1,
+) -> KDAWeights:
+    """Prepare KDA weights and materialize them on the target device."""
+    if state_dict is not None and not state_dict:
+        raise ValueError("state_dict must be non-empty when provided; use None for cache-only loading")
+    mesh_shape, tensor_parallel_size = _validated_parallel_geometry(device, config, tensor_parallel_axis)
+    cache_path = Path(tensor_cache_path) if tensor_cache_path is not None else None
+    if state_dict is None:
+        if not KDAWeights.check_cache_complete(
+            cache_path,
+            cache_name_prefix,
+            config,
+            device,
+            tensor_parallel_axis=tensor_parallel_axis,
+        ):
+            raise FileNotFoundError(f"incomplete KDA TTNN cache for {cache_name_prefix!r} at {cache_path!r}")
+        host_weights = None
+    else:
+        host_weights = _prepare_kda_host_weights(state_dict, config, tensor_parallel_size)
+
+    materialized, convolution_taps = _materialize_kda_weights(
+        host_weights,
+        device=device,
+        config=config,
+        tensor_cache_path=cache_path,
+        cache_name_prefix=cache_name_prefix,
+        mesh_shape=mesh_shape,
+        tensor_parallel_size=tensor_parallel_size,
+        tensor_parallel_axis=tensor_parallel_axis,
+        place_on_device=True,
+    )
+    return KDAWeights(
+        **materialized,
+        convolution_taps=convolution_taps,
+        tensor_parallel_size=tensor_parallel_size,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )


### PR DESCRIPTION
Base for the Kimi-K3 prefill bring-up (#53508). Carries the two module families Kimi-K3 needs that are not yet on `main`, rebased onto `8683264f415`, plus one fix to a merged op.

**This duplicates work from open PRs and should be coordinated with them, not merged around them.** The first two commits are other people's PRs vendored so the model work could proceed:

| commit | source | contents |
|---|---|---|
| `9b05ab8fc01` | #52799 (KDA 7/8, open) | ttKDA prefill layer — 23 files, +4821 |
| `62d1ae7b5dc` | #53116 → #53126 → #53318 (open) | AttnRes ops + device model — 52 files, +6494 |
| `557e81a0d62` | new | `t_inv` fix for #54813 |

Vendored via squash-merge with a 3-way merge against the real merge base, so the already-merged halves of each PR collapsed rather than re-applying. Conflicts resolved to `main`: six add/add in `recurrent_chunk_scan` (merged as #52798 after the KDA branch was cut, and carrying the later O3 fix #54734), plus `.github/CODEOWNERS` and the `deepseek_prefill` → `disaggregated_prefill` rename. `tt/kda/` was deliberately not taken from `jjovicic/kimi-k3-model` — that copy targets a dead op ABI and raises `TypeError` against `main`.

## The one original change: `t_inv` (#54813)

`prepare_chunk_recurrence` inverted the delta rule's UT transform with the doubling product `(I-N)^-1 = (I+N)(I+N^2)(I+N^4)(I+N^8)(I+N^16)`. Exact in real arithmetic and cheaper than the Horner path it replaced — 8 tile matmuls against 30 — but its intermediates are the explicit powers `N^2..N^16`, and the kernel comment stated the stability claim "must be validated empirically". It was not.

At Kimi-K3's real decay magnitudes `‖N‖∞` reaches 17, so `N^16` reaches O(1e2) while the inverse is bounded by 1; the cancellation costs more digits than the hardware carries. No compute config recovers it — LoFi/HiFi2/HiFi4 with and without fp32 dest accumulation all land between 6.1 and 64.5 max absolute error. `invert_horner` sums the same nilpotent series as `S <- I + N*S`, so intermediates are partial sums bounded by the answer.

| | before | after |
|---|---|---|
| `t_inv` strictly-lower PCC | 0.93549 | **1.00000** |
| KDA layer 1, one chip, vs torch reference | 0.69629 | **0.99988** |
| KDA layer 1, 8x4, vs the model's own output | −0.00469 | **0.99990** |

This broke **68 of Kimi-K3's 69 KDA layers**. Layer 0 was the only one that worked — its decay drives `N → 0`, so `t_inv ≈ I` trivially.

**Cost:** 30 tile matmuls per chunk instead of 8. `test_prepare_chunk_recurrence_production_performance` regresses on its smallest shape (h2-n4-k32-v64), 36.1 µs against a 26.7 µs budget, and is **left failing rather than rebaselined**. At layer level it does not show. `invert_doubling` is kept in the file for anyone restoring it behind a bound on `‖N‖`.

Two op-level suites are added covering the magnitudes the existing generators never produce: `host_protocol` pins `final_decay` to [0.86, 0.94] and the strict-lower block to 0.015, and `_host_inputs` builds the gate as `-0.001 - 0.05 * rand` while Kimi-K3's spans `(-5, 0)`.

## Testing

241 of 244 KDA op tests pass; the two `sigmoid_gated_rms_norm` perf failures reproduce with the stock kernel on this box and the third is the documented `prepare_chunk_recurrence` perf regression above. KDA model layer suite 11/11.

Stacked: the model work is in the PR based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=feature/kimi-k3-modules)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:feature/kimi-k3-modules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=feature/kimi-k3-modules)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:feature/kimi-k3-modules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=feature/kimi-k3-modules)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:feature/kimi-k3-modules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=feature/kimi-k3-modules)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:feature/kimi-k3-modules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=feature/kimi-k3-modules)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:feature/kimi-k3-modules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=feature/kimi-k3-modules)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:feature/kimi-k3-modules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=feature/kimi-k3-modules)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:feature/kimi-k3-modules)