### PR TITLE
[Bug fix] Update device print buffer handling to reset positions during startup

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -126,8 +126,7 @@ void deassert_trisc() {
         trisc_print->aux.lock = 0;
         uint32_t wpos = trisc_print->aux.wpos;
         if (wpos != DEBUG_PRINT_SERVER_DISABLED_MAGIC && wpos != DEBUG_PRINT_SERVER_STARTING_MAGIC) {
-            trisc_print->aux.wpos = 0;
-            trisc_print->aux.rpos = 0;
+            trisc_print->aux.wpos = DEBUG_PRINT_SERVER_STARTING_MAGIC;
         }
     }
 #endif

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -1598,6 +1598,13 @@ uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintBufferType* device_print_b
         return 0;
     }
 
+    // Check if we should reset buffer (happening usually during startup).
+    if (read_position == DEVICE_PRINT_RESET_BUFFER_MAGIC) {
+        device_print_buffer->aux.wpos = 0;
+        device_print_buffer->aux.rpos = 0;
+        return 0;
+    }
+
     // Check if there is enough space for the message until end of the buffer.
     if (write_position + message_size > sizeof(device_print_buffer->data)) {
         // It is important not to perform wrap around while reader position is at the beginning of the buffer,
@@ -1698,7 +1705,7 @@ uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintBufferType* device_print_b
     }
 
     // Check if there is enough space between wpos and rpos
-    if (write_position < read_position) {
+    if (write_position < read_position && write_position + message_size >= read_position) {
         // Wrapped around, check if there is enough space between wpos and rpos
         WAYPOINT("DPW");
         // Mark that we are in stall waiting for reader


### PR DESCRIPTION
Race condition was happening between dm core startup and host side. This PR addresses that issue.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/dprint_quasar_race_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/dprint_quasar_race_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/dprint_quasar_race_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/dprint_quasar_race_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/dprint_quasar_race_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/dprint_quasar_race_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/dprint_quasar_race_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/dprint_quasar_race_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/dprint_quasar_race_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/dprint_quasar_race_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/dprint_quasar_race_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/dprint_quasar_race_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/dprint_quasar_race_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/dprint_quasar_race_fix)