### PR TITLE
[Bug fix] Fix datacopy tilize hangs and pack perf ELF hash mismatch

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -104,4 +104,12 @@ inline void _llk_unpack_tilize_uninit_wrapper_(const std::uint32_t unpack_dst_fo
 #error "Unsupported architecture for LLK unpack tilize wrappers"
 #endif
 
+// Isolate handshake count shared by unpack and math. The two TRISC threads deadlock
+// if they disagree. Tilize posts architecture-specific dvalids (BH: 1/tile, WH: 1/face);
+// unpack_A posts one per face.
+inline std::uint32_t _perf_src_handshake_iters_(const bool tilize_en, const std::uint32_t num_tiles, const std::uint32_t num_faces)
+{
+    return tilize_en ? _llk_unpack_tilize_num_dvalids_wrapper_(num_tiles, num_faces) : num_tiles * num_faces;
+}
+
 #endif // ENV_LLK_INFRA

--- a/tt_metal/tt-llk/tests/python_tests/test_pack.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_pack.py
@@ -152,10 +152,13 @@ def test_pack(
             + str(relu_type)
         )
 
+    # Perf folds RELU_CONFIG into the ELF under --speed-of-light. Compile-producer
+    # replaces PackGolden with zeros, so a threshold from torch.mean(golden) hashes a
+    # different variant than compile-consumer (missing unpack.elf / riscv-tt-elf-size).
     tensor_average = (
-        torch.mean(golden_tensor).item()
-        if not formats.output_format.is_integer()
-        else 0.0
+        0.0
+        if is_perf or formats.output_format.is_integer()
+        else torch.mean(golden_tensor).item()
     )
 
     relu_config = PackGolden.generate_relu_config(

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -37,10 +37,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t NUM_TILES_IN_BLOCK = params.NUM_TILES_IN_BLOCK;
     const Operand& buffer_A                = params.buffer_A;
 #endif
-    const std::uint32_t num_tiles = NUM_BLOCKS * NUM_TILES_IN_BLOCK;
-    // unpack_A posts one DVALID per face. Tilize posts one per tile on Blackhole
-    // (per face on Wormhole); see _llk_unpack_tilize_num_dvalids_wrapper_.
-    const std::uint32_t src_handshake_iters = LOOP_FACTOR * (tilize_en ? _llk_unpack_tilize_num_dvalids_wrapper_(num_tiles, num_faces) : num_tiles * num_faces);
+    const std::uint32_t num_tiles           = NUM_BLOCKS * NUM_TILES_IN_BLOCK;
+    const std::uint32_t src_handshake_iters = LOOP_FACTOR * _perf_src_handshake_iters_(tilize_en, num_tiles, num_faces);
 
     {
         START_PERF_MEASURE("INIT")
@@ -70,8 +68,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            // Tilize A2D still waits on SrcA (and SrcB when dest is FP32). Leaving
-            // unpack idle here deadlocks MATH_ISOLATE.
+            // MATH_ISOLATE must fake the dvalids unpack would post. Blackhole tilize
+            // always posts SrcB (UNP_ZEROSRC) per tile regardless of dest acc;
+            // non-tilize unpack_A posts SrcB only for FP32 dest acc. Leaving unpack
+            // idle here deadlocks math.
             if constexpr (!unpack_to_dest)
             {
                 _perf_unpack_loop_set_valid</* src A */ true, /* src B */ tilize_en || is_fp32_dest_acc_en>(src_handshake_iters);
@@ -143,7 +143,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int DST_INDEX                    = params.DST_INDEX;
 #endif
     const std::uint32_t num_tiles           = NUM_BLOCKS * NUM_TILES_IN_BLOCK;
-    const std::uint32_t src_handshake_iters = LOOP_FACTOR * (tilize_en ? _llk_unpack_tilize_num_dvalids_wrapper_(num_tiles, num_faces) : num_tiles * num_faces);
+    const std::uint32_t src_handshake_iters = LOOP_FACTOR * _perf_src_handshake_iters_(tilize_en, num_tiles, num_faces);
 
     {
         START_PERF_MEASURE("INIT")

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -37,8 +37,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t NUM_TILES_IN_BLOCK = params.NUM_TILES_IN_BLOCK;
     const Operand& buffer_A                = params.buffer_A;
 #endif
-    const std::uint32_t num_tiles           = NUM_BLOCKS * NUM_TILES_IN_BLOCK;
-    const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_tiles * num_faces;
+    const std::uint32_t num_tiles = NUM_BLOCKS * NUM_TILES_IN_BLOCK;
+    // unpack_A posts one DVALID per face. Tilize posts one per tile on Blackhole
+    // (per face on Wormhole); see _llk_unpack_tilize_num_dvalids_wrapper_.
+    const std::uint32_t src_handshake_iters = LOOP_FACTOR * (tilize_en ? _llk_unpack_tilize_num_dvalids_wrapper_(num_tiles, num_faces) : num_tiles * num_faces);
 
     {
         START_PERF_MEASURE("INIT")
@@ -68,9 +70,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            if constexpr (!tilize_en && !unpack_to_dest)
+            // Tilize A2D still waits on SrcA (and SrcB when dest is FP32). Leaving
+            // unpack idle here deadlocks MATH_ISOLATE.
+            if constexpr (!unpack_to_dest)
             {
-                _perf_unpack_loop_set_valid</* src A */ true, /* src B */ is_fp32_dest_acc_en>(src_handshake_iters);
+                _perf_unpack_loop_set_valid</* src A */ true, /* src B */ tilize_en || is_fp32_dest_acc_en>(src_handshake_iters);
             }
         }
         else
@@ -121,6 +125,7 @@ const bool is_int_fpu_en = false;
 #endif
 
 #include "llk_lib_math_wrappers.h"
+#include "llk_lib_unpack_wrappers.h"
 #include "params.h"
 
 using namespace ckernel;
@@ -137,7 +142,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t NUM_TILES_IN_BLOCK = params.NUM_TILES_IN_BLOCK;
     const int DST_INDEX                    = params.DST_INDEX;
 #endif
-    const std::uint32_t src_handshake_iters = LOOP_FACTOR * NUM_BLOCKS * NUM_TILES_IN_BLOCK * num_faces;
+    const std::uint32_t num_tiles           = NUM_BLOCKS * NUM_TILES_IN_BLOCK;
+    const std::uint32_t src_handshake_iters = LOOP_FACTOR * (tilize_en ? _llk_unpack_tilize_num_dvalids_wrapper_(num_tiles, num_faces) : num_tiles * num_faces);
 
     {
         START_PERF_MEASURE("INIT")


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Two LLK perf failures, both reproduced locally on Blackhole.

**1. Datacopy `tilize=Yes` hangs (isolate handshake)**

`tilize=Yes` cases of `perf_eltwise_unary_datacopy` hung (`TENSIX TIMED OUT` waiting for Math). CI run [33289584719](https://github.com/tenstorrent/tt-metal/actions/runs/33289584719) (`llk_perf_blackhole group 1/5`) failed on the first four parametrizations because the suite uses `-x`; every `tilize=Yes` perf variant was affected.

Blackhole `unpack_tilize` posts **one SrcA/SrcB dvalid per tile**, not per face. Isolate loops still waited `num_tiles * num_faces` times, and MATH_ISOLATE left unpack idle even though tilize math still waits on those dvalids.

The datacopy kernel now counts isolate handshakes with `_llk_unpack_tilize_num_dvalids_wrapper_` and MATH_ISOLATE unpack posts SrcA (and SrcB when tilize or FP32 dest acc). L1_TO_L1 was already correct; `tilize=No` is unchanged.

**2. Pack perf missing `unpack.elf` (compile-producer / consumer hash mismatch)**

[33305573962](https://github.com/tenstorrent/tt-metal/actions/runs/33305573962) (`llk_perf_blackhole` and `llk_perf_wormhole` group 5/5, `--speed-of-light`) failed in `perf_pack` with `riscv-tt-elf-size .../unpack.elf: No such file`. Groups 1–4 on that run were green.

Under `--speed-of-light`, `RELU_CONFIG` is baked into the ELF variant hash. Compile-producer replaces `PackGolden` with a dummy zeros tensor, so `torch.mean(golden)` is 0. Compile-consumer uses the real golden mean, hashes a **different** variant, and looks for an ELF that was never built. Min/Max threshold ReLU cases hit this; `-x` stopped after the first few.

Perf tests now use a fixed ReLU threshold (`0.0`) instead of the golden mean so producer and consumer share the same hash. Functional pack tests still derive the threshold from the golden.

### Notes for reviewers
- Handshake counting matches `unpack_tilize_perf.cpp`. MATH_ISOLATE is kept for tilize (unlike unpack_tilize, which skips it) by faking the dvalids the tilize A2D MOP still consumes.
- The pack threshold change is perf-only; it does not affect functional correctness checks.

## Test plan
- [x] Reproduced the datacopy hang locally with `--speed-of-light`
- [x] All 4 CI-failing datacopy node IDs pass locally after the handshake fix
- [x] All 87 `tilize=Yes` datacopy perf cases pass locally (`--speed-of-light`)
- [x] `tilize=No` Float32 `[64, 64]` dest_acc=No regression passes
- [x] Reproduced missing `unpack.elf` with `--speed-of-light --compile-producer` then `--compile-consumer` (consumer hashed `2342fa76…`, same as CI, which producer never built)
- [x] After the pack fix, the same producer/consumer `--speed-of-light` path passes for CI MinThresholdRelu cases plus MaxThresholdRelu and NoRelu
- [x] LLK perf with **speed-of-light disabled**: [33303692662](https://github.com/tenstorrent/tt-metal/actions/runs/33303692662) — **success**
- [ ] LLK perf with **speed-of-light enabled** (includes pack group 5): [33322023304](https://github.com/tenstorrent/tt-metal/actions/runs/33322023304) — in progress

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_perf_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_perf_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_perf_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_perf_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_perf_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_perf_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_perf_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_perf_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_perf_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_perf_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_perf_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_perf_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_perf_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_perf_failures)