### PR TITLE
Bug fix: use a BF16-independent saturation for GELU' in FP32

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_gelu_bw_ulp.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_gelu_bw_ulp.cpp
@@ -1752,4 +1752,87 @@ TEST_F(GeluBwPolyTest, SpecialValues) {
     EXPECT_EQ(result_nan, 1.0f) << "NaN treated as large positive by SFPU, saturates to 1.0";
 }
 
+// =============================================================================
+// FP32 accuracy of the positive tail.
+//
+// Everything above runs in BFLOAT16, where saturating GELU' to 1 from x=3.1719
+// is within 1 ULP and therefore correct. gelu_bw also accepts FLOAT32
+// (gelu_bw_device_operation.cpp) and sets fp32_dest_acc_en accordingly
+// (gelu_bw_program_factory.cpp), and in FP32 that same threshold is 7.5e-3 low
+// -- GELU'(3.1719) = 1.00751 and GELU' does not reach 1.0f until x ~= 5.911.
+//
+// These tests pin the FP32 path so the BF16-derived threshold cannot be
+// reintroduced. Tolerances are in absolute error against the exact GELU'
+// evaluated in double, because ULP counting near 1.0 in FP32 is dominated by
+// the polynomial's own error rather than by the branch under test.
+// =============================================================================
+float run_gelu_bw_single_fp32(tt::tt_metal::distributed::MeshDevice& device, float input_val, float grad_val = 1.0f) {
+    ttnn::Shape shape({1, 1, 32, 32});
+
+    auto input_tensor = ttnn::full(shape, input_val, DataType::FLOAT32, ttnn::TILE_LAYOUT, device);
+    auto grad_tensor = ttnn::full(shape, grad_val, DataType::FLOAT32, ttnn::TILE_LAYOUT, device);
+
+    auto result = ttnn::experimental::gelu_bw(grad_tensor, input_tensor, "none");
+
+    auto output_cpu = ttnn::from_device(result);
+    auto output_vec = output_cpu.to_vector<float>();
+    return output_vec[0];
+}
+
+TEST_F(GeluBwPolyTest, DerivativePositiveTailFp32) {
+    // Absolute-error budgets. Before the fix the kernel returns exactly 1.0f
+    // here, so the error equals 1 - GELU'(x): 7.5e-3 at 3.1719 and 5.0e-4 at
+    // x=4, both far outside these budgets. Nothing is asserted about ULP
+    // because the point is the missing hump, not last-bit rounding.
+    std::vector<std::pair<float, double>> cases = {
+        {3.1719f, 1.0e-4},  // the boundary itself: worst case for the old code
+        {3.25f, 1.0e-4},
+        {3.5f, 5.0e-5},
+        {4.0f, 5.0e-6},
+        {4.5f, 1.0e-6},
+        {5.0f, 1.0e-6},
+    };
+
+    std::cout << "\n[FP32] Positive tail, absolute error vs exact GELU':\n";
+    for (const auto& [x, budget] : cases) {
+        float actual = run_gelu_bw_single_fp32(*device_, x);
+        double expected = bf16_ulp_bw::gelu_derivative_exact(static_cast<double>(x));
+        double err = std::abs(static_cast<double>(actual) - expected);
+
+        std::cout << "[FP32] x=" << x << ": expected=" << expected << ", actual=" << actual << ", abs err=" << err
+                  << " (budget " << budget << ")\n";
+
+        EXPECT_LT(err, budget) << "FP32 GELU'(" << x << ") is outside its budget; a BF16-derived "
+                               << "saturation threshold truncates the hump (GELU' > 1 up to x~3.16)";
+        // GELU' genuinely exceeds 1 on this interval, so a result of exactly
+        // 1.0f is the specific failure mode being guarded against.
+        EXPECT_GT(actual, 1.0f) << "FP32 GELU'(" << x << ") must not be clamped to 1.0f";
+    }
+}
+
+TEST_F(GeluBwPolyTest, DerivativeFp32SaturatesEventually) {
+    // The complement: past the point where GELU' is within one FP32 ulp of 1,
+    // returning exactly 1.0f is right, and must stay right -- including for
+    // inputs large enough that x*x would overflow to inf.
+    for (float x : {6.0f, 8.0f, 13.375f, 20.0f, 1.0e6f, 3.0e38f}) {
+        float actual = run_gelu_bw_single_fp32(*device_, x);
+        std::cout << "[FP32] x=" << x << ": actual=" << actual << "\n";
+        EXPECT_TRUE(std::isfinite(actual)) << "FP32 GELU'(" << x << ") must stay finite";
+        EXPECT_FLOAT_EQ(actual, 1.0f) << "FP32 GELU'(" << x << ") should be 1.0f";
+    }
+}
+
+TEST_F(GeluBwPolyTest, DerivativeFp32CoreRegionUnchanged) {
+    // Control: the fix must not touch x < 3.1719. These values are inside the
+    // degree-8 polynomial's fit range and must keep their previous accuracy.
+    for (float x : {-3.0f, -1.0f, 0.0f, 1.0f, 2.0f, 3.0f, 3.17f}) {
+        float actual = run_gelu_bw_single_fp32(*device_, x);
+        double expected = bf16_ulp_bw::gelu_derivative_exact(static_cast<double>(x));
+        double err = std::abs(static_cast<double>(actual) - expected);
+        std::cout << "[FP32] core x=" << x << ": expected=" << expected << ", actual=" << actual << ", abs err=" << err
+                  << "\n";
+        EXPECT_LT(err, 1.0e-4) << "FP32 core region GELU'(" << x << ") regressed";
+    }
+}
+
 }  // namespace ttnn::test

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -430,8 +430,51 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
     sfpi::vFloat result = 0.0f;  // Default: 0 for x <= -13.375
 
-    // For x >= 3.1719, output saturates to 1 (verified saturation threshold)
-    v_if(x >= 3.1719f) { result = 1.0f; }
+    // For x >= 3.1719, GELU'(x) rounds to exactly 1 in BF16, so BF16 can saturate
+    // here. FP32 cannot: GELU'(3.1719) = 1.00751, and GELU' does not reach 1.0f
+    // until x ~= 5.911, so saturating at 3.1719 truncates the hump by 7.5e-3
+    // (~63,000 fp32 eps) and puts a step discontinuity in a smooth function --
+    // which lands directly in the gradient, since gelu_bw computes
+    // grad_out * GELU'(input).
+    //
+    // The reflection GELU'(x) + GELU'(-x) = 1 lets the existing negative-tail
+    // machinery serve the positive tail: GELU'(x) = 1 - [(-x)*phi(x) * mills(x)].
+    // Measured against the exact GELU' in fp32, that form is 142 eps at 3.1719 and
+    // under 3 eps from x=4 on, versus the polynomial's 5,350 eps already at 3.3 --
+    // so 3.1719 is also where the two cross, and stays the right boundary.
+    v_if(x >= 3.1719f) {
+        if constexpr (is_fp32_dest_acc_en) {
+            // Mirror of the negative branch's 13.375 cutoff. Past it the
+            // correction is below one fp32 ulp of 1.0 anyway, and computing it
+            // would be actively unsafe: x*x overflows to inf for x >= 1.85e19,
+            // making t = -inf and feeding inf to the helper's round-to-int step.
+            result = 1.0f;
+            v_if(x < 13.375f) {
+                constexpr float INV_SQRT_2PI = 0.3989422804014327f;  // 1/sqrt(2*pi)
+
+                sfpi::vFloat x2 = x * x;
+                sfpi::vFloat t = x2 * (-0.5f);  // t = -x^2/2
+
+                // Reuse the fused (-x) * exp(t) helper: same underflow
+                // protection, and -x < 0 here, which is the sign it is
+                // written for.
+                sfpi::vFloat neg_x_exp = x_times_exp_negative_tail(-x, t);
+
+                if constexpr (APPROXIMATION_MODE) {
+                    result = 1.0f - neg_x_exp * INV_SQRT_2PI;
+                } else {
+                    // Mills ratio correction, matching the negative branch below.
+                    sfpi::vFloat inv_x2 = sfpu_reciprocal_iter<2>(x2);  // 1/x^2
+                    sfpi::vFloat inv_x4 = inv_x2 * inv_x2;              // 1/x^4
+                    sfpi::vFloat correction = 1.0f - inv_x2 + inv_x4;
+                    result = 1.0f - neg_x_exp * INV_SQRT_2PI * correction;
+                }
+            }
+            v_endif;
+        } else {
+            result = 1.0f;
+        }
+    }
     // Core region [-3, 3.1719]: GELU'(x) = 0.5 + x * h(x²)
     // Odd-function decomposition: GELU'(x) + GELU'(-x) = 1, so GELU'(x) - 0.5
     // is odd and can be written as x * h(x²). Degree-8 in u=x² (~12 ops vs ~32).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -427,8 +427,51 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
     sfpi::vFloat result = 0.0f;  // Default: 0 for x <= -13.375
 
-    // For x >= 3.1719, output saturates to 1 (verified saturation threshold)
-    v_if(x >= 3.1719f) { result = 1.0f; }
+    // For x >= 3.1719, GELU'(x) rounds to exactly 1 in BF16, so BF16 can saturate
+    // here. FP32 cannot: GELU'(3.1719) = 1.00751, and GELU' does not reach 1.0f
+    // until x ~= 5.911, so saturating at 3.1719 truncates the hump by 7.5e-3
+    // (~63,000 fp32 eps) and puts a step discontinuity in a smooth function --
+    // which lands directly in the gradient, since gelu_bw computes
+    // grad_out * GELU'(input).
+    //
+    // The reflection GELU'(x) + GELU'(-x) = 1 lets the existing negative-tail
+    // machinery serve the positive tail: GELU'(x) = 1 - [(-x)*phi(x) * mills(x)].
+    // Measured against the exact GELU' in fp32, that form is 142 eps at 3.1719 and
+    // under 3 eps from x=4 on, versus the polynomial's 5,350 eps already at 3.3 --
+    // so 3.1719 is also where the two cross, and stays the right boundary.
+    v_if(x >= 3.1719f) {
+        if constexpr (is_fp32_dest_acc_en) {
+            // Mirror of the negative branch's 13.375 cutoff. Past it the
+            // correction is below one fp32 ulp of 1.0 anyway, and computing it
+            // would be actively unsafe: x*x overflows to inf for x >= 1.85e19,
+            // making t = -inf and feeding inf to the helper's round-to-int step.
+            result = 1.0f;
+            v_if(x < 13.375f) {
+                constexpr float INV_SQRT_2PI = 0.3989422804014327f;  // 1/sqrt(2*pi)
+
+                sfpi::vFloat x2 = x * x;
+                sfpi::vFloat t = x2 * (-0.5f);  // t = -x^2/2
+
+                // Reuse the fused (-x) * exp(t) helper: same underflow
+                // protection, and -x < 0 here, which is the sign it is
+                // written for.
+                sfpi::vFloat neg_x_exp = x_times_exp_negative_tail(-x, t);
+
+                if constexpr (APPROXIMATION_MODE) {
+                    result = 1.0f - neg_x_exp * INV_SQRT_2PI;
+                } else {
+                    // Mills ratio correction, matching the negative branch below.
+                    sfpi::vFloat inv_x2 = sfpu_reciprocal_iter<2>(x2);  // 1/x^2
+                    sfpi::vFloat inv_x4 = inv_x2 * inv_x2;              // 1/x^4
+                    sfpi::vFloat correction = 1.0f - inv_x2 + inv_x4;
+                    result = 1.0f - neg_x_exp * INV_SQRT_2PI * correction;
+                }
+            }
+            v_endif;
+        } else {
+            result = 1.0f;
+        }
+    }
     // Core region [-3, 3.1719]: GELU'(x) = 0.5 + x * h(x²)
     // Odd-function decomposition: GELU'(x) + GELU'(-x) = 1, so GELU'(x) - 0.5
     // is odd and can be written as x * h(x²). Degree-8 in u=x² (~12 ops vs ~32).


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes the FP32 half of `ttnn.gelu_bw`'s positive saturation. Relates to #54867.

`calculate_gelu_derivative_simple` saturates at `x >= 3.1719`, a threshold the surrounding comment documents as derived from exhaustive **BF16** research, and applies it unconditionally — including when `is_fp32_dest_acc_en` is true.

In BF16 that is correct, and this PR leaves the BF16 path byte-identical. In FP32 it is not: `GELU'(3.1719) = 1.00751`, and `GELU'` does not round to `1.0f` until `x ≈ 5.911`. So the branch clamps away the hump the same comment describes — *"GELU'(x) has a hump exceeding 1.0 for x in [0.77, 3.16]"* — and puts a **7.5e-3 step (~63,000 fp32 eps)** into a smooth function. `gelu_bw` computes `grad_out * GELU'(input)`, so it lands in gradients.

FP32 is a supported mode here rather than an accident: `gelu_bw_device_operation.cpp` accepts `DataType::FLOAT32`, `gelu_bw_program_factory.cpp` sets `fp32_dest_acc_en` from it, and this same function already branches on dtype one line away (`sfpu_reciprocal_iter<is_fp32_dest_acc_en ? 2 : 1>`). The saturation threshold just did not get the same treatment.

### Approach

Reuse what is already in this file. The reflection identity `GELU'(x) + GELU'(-x) = 1` turns the positive tail into the negative one:

`GELU'(x) = 1 - [(-x)·φ(x)·mills(x)]` via `x_times_exp_negative_tail(-x, t)`

whose argument is negative here — the sign it is written for — with the same Mills ratio correction as the negative branch. No new machinery, no new constants beyond `INV_SQRT_2PI`, which the negative branch already defines locally.

**The `x < 13.375f` guard is load-bearing, not defensive.** It mirrors the negative branch's cutoff. Without it, `x*x` overflows to `inf` for `x >= 1.85e19`, so `t = -inf` reaches the helper's round-to-nearest-int step. Past 13.375 the correction is already below one fp32 ulp of 1.0, so the guard is continuous (0.00 eps either side).

**The `3.1719` boundary is kept deliberately.** The reflection form overtakes the polynomial at `x ≈ 3.163`, slightly *before* it, and the polynomial degrades fast outside its fit range (1,902 eps at 3.25, 91,561 at 3.5) — so moving the boundary right is not an option; only changing the formula is.

### Measured

Source-faithful fp32 model of the kernel (each sfpi op rounded to fp32, `PolynomialEvaluator::eval`'s even/odd split reproduced) against `GELU'` evaluated in double:

| | before | after |
|---|---|---|
| worst FP32 error | **63,024 eps** | **142 eps** (445x better) |
| FP32 error, x ≥ 4 | 4,225 eps | ≤ 2.1 eps |
| BF16 output, 353 values in [3,20] | — | **bit-identical** |
| x < 3.1719 | — | unchanged |
| x = 20 … 3.4e38 | 1.0f | finite, exactly 1.0f |

### Tests

Three FP32 gtests in `test_gelu_bw_ulp.cpp`. `DataType::FLOAT32` did not appear anywhere in either gelu_bw test file before this, so the FP32 path had no coverage at all — the existing exhaustive BF16 sweep is correctly green, and the positive fixed probes (2.0 / 3.0 / 5.0) step straight over `[3.1719, 5.911)`.

- `DerivativePositiveTailFp32` — six points with absolute-error budgets, plus `EXPECT_GT(actual, 1.0f)`, since "exactly 1.0f" is the specific fingerprint of the clamp. **All six fail without this change.**
- `DerivativeFp32SaturatesEventually` — 6.0 … 3e38 stays finite and exactly 1.0f.
- `DerivativeFp32CoreRegionUnchanged` — control: `x < 3.1719` must not move.

Budgets are absolute error, not ULP: near 1.0 in FP32 the ULP count is dominated by the polynomial's own error rather than by the branch under test. The golden is the repo's existing `bf16_ulp_bw::gelu_derivative_exact`.

### Notes for reviewers

Two things I could not do, stated plainly so you can weigh the evidence:

1. **I have no device.** Every number above comes from the source-faithful fp32 model, not from silicon or ttsim. The model is gated on `GELU'(0) = 0.5` and `GELU'(x) + GELU'(-x) = 1`, and reproduces the kernel to 1.2e-05 inside the polynomial region — two orders of magnitude below the 7.5e-03 step being fixed. The reproduction script is in #54867.
2. **The three new gtests have not been executed** — they need hardware. What I verified is that each assertion's outcome flips across the fix in the model, and that every symbol they use already exists in the file.

So the parts most worth your attention are: whether `x_times_exp_negative_tail` is safe to call with the arguments I pass it on real hardware, and whether the FP32 error budgets match what you would want to hold long-term.

The `blackhole` copy of this function is byte-identical to the `wormhole_b0` one (the two files differ only in how `gelu_init` loads its LUT constants), so the same change is applied to both.

---
Written with assistance from Claude (Anthropic), and submitted on behalf of the account owner, who has reviewed this and takes responsibility for it. The measurements were re-derived locally; the even/odd polynomial evaluation order was corrected after reading `ckernel_sfpu_polyval.h`.
