### PR TITLE
[Bug fix] Align sparse MLA prefill index cache with decode

### DIFF
--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -940,6 +940,7 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
     ``"index": min`` when the index cache was validated — omitted, not defaulted to 1.0, when the model is
     dense or the trace carries no indexer-key golden (warned, not fatal — see below). Raises on an
     index-cache READ failure."""
+    from models.demos.deepseek_v3_d_p.tt.mla.indexer import normalized_hadamard_matrix
     from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import (
         _load_golden_index_k,
         _load_golden_kv_post,
@@ -1000,7 +1001,8 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
     # config 1: index cache (sparse/DSA only). Validated the SAME way as config 0 — read block-by-block
     # via the table, decode, and PCC vs the golden indexer key. Config 1 holds all layers on GLM-5.1 and
     # only the full-indexer layers on GLM-5.2, so iterate its OWN layer count, not NUM_LAYERS. The index
-    # cache is bf8 TILE, and the golden is already in the device rope frame (no re-interleave, unlike pe).
+    # cache is bf8 TILE. Its Hadamard transform is undone before comparing against the natural-basis
+    # golden, which is already in the device rope frame (no re-interleave, unlike pe).
     #
     # A trace can carry the KVPE golden but no indexer-key golden (some vllm dumps store only
     # dsa/dsa_topk_indices_layer_*). There is then nothing to PCC config 1 against, so warn and return the
@@ -1017,6 +1019,7 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
             return mins
 
         index_head_dim = ADAPTER.model_config.INDEX_HEAD_DIM
+        index_hadamard = normalized_hadamard_matrix(index_head_dim).float()
         n_index_layers = table.config(1).num_layers
         # Config 1 is published on the GLOBAL LAYER axis, same numbering as the golden: rows == full-indexer layer ids.
         full_layers = _full_indexer_layer_indices(NUM_LAYERS)
@@ -1049,6 +1052,10 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
             dev_ik = torch.cat(decoded_rows, dim=0)[:real_len]
 
             golden_ik = _load_golden_index_k(trace_dir, layer, real_len)
+            # Sparse prefill stores index keys in the decode indexer's orthonormal Hadamard basis.
+            # The trace golden is captured before that transform, so apply the symmetric,
+            # self-inverse H matrix once more to compare both tensors in the natural basis.
+            dev_ik = (dev_ik.float() @ index_hadamard).to(torch.bfloat16)
             _, pcc_index = comp_pcc(golden_ik, dev_ik)
             min_index = min(min_index, pcc_index)
             checked_index += 1

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -30,7 +30,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import (
 )
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
-from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import normalized_hadamard_matrix, num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_to_halfsplit_perm
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
@@ -203,7 +203,8 @@ def _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk, 
     """Read the block-cyclic indexer key cache back to a natural-order [S, index_head_dim] tensor in the
     CPU reference's RoPE frame, so it can be PCC'd against SparseMLAReference.index_cache.
 
-    Same SP-shard concat + block-cyclic un-rotation as the KVPE cache (blockcyclic_positions). The device
+    Same SP-shard concat + block-cyclic un-rotation as the KVPE cache (blockcyclic_positions). Undo the
+    indexer's orthonormal Hadamard transform before comparing with the untransformed CPU reference. The device
     stores the RoPE half INTERLEAVED for both variants (the indexed RoPE op is interleaved-only; the DS
     path permutes half-split->interleaved before it). The CPU reference stores it interleaved for GLM
     (index_rope_interleave=True) but HALF-SPLIT for DS, so for DS we reindex the device's RoPE dims back
@@ -216,6 +217,11 @@ def _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk, 
     p = blockcyclic_positions(sp, chunk, cache_sr.shape[2])
     nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
     nat[p] = cache_sr[0, 0]
+    # The Sylvester Hadamard matrix is symmetric and self-inverse, so applying it again restores the
+    # pre-transform key. Do this before the DS RoPE-frame permutation because the transform was applied
+    # while the key was still in the device's interleaved frame.
+    hadamard = normalized_hadamard_matrix(nat.shape[-1])
+    nat = (nat.float() @ hadamard.float()).to(torch.bfloat16)
     if not getattr(config, "index_rope_interleave", False):  # DS: device interleaved -> reference half-split
         rope_dim = config.qk_rope_head_dim
         perm = interleaved_to_halfsplit_perm(rope_dim)

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -31,6 +31,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
     ReuseIndexer,
     TtIndexer,
     indexer_layer_is_reused,
+    normalized_hadamard_matrix,
     resolve_has_indexer,
 )
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
@@ -42,6 +43,57 @@ from tests.ttnn.utils_for_testing import comp_pcc
 CACHE_DIR = Path("/tmp/DS_PREFILL_sparse_mla")
 SEQ_LEN = 256
 SP_AXIS, TP_AXIS = 0, 1
+
+
+# --------------------------------------------------------------------------------------------------
+# Host-only: the decode-compatible Hadamard is orthonormal, so applying it to both indexer operands
+# preserves their score while spreading values before cache quantization.
+# --------------------------------------------------------------------------------------------------
+def test_normalized_hadamard_preserves_indexer_scores():
+    h = normalized_hadamard_matrix(128).float()
+    identity = torch.eye(128)
+    torch.testing.assert_close(h.T @ h, identity, rtol=2e-3, atol=2e-3)
+
+    torch.manual_seed(0)
+    q = torch.randn(3, 128)
+    k = torch.randn(5, 128)
+    torch.testing.assert_close((q @ h) @ (k @ h).T, q @ k.T, rtol=2e-3, atol=2e-3)
+
+
+def test_normalized_hadamard_rejects_non_power_of_two(expect_error):
+    with expect_error(AssertionError, "power of two"):
+        normalized_hadamard_matrix(96)
+
+
+@pytest.mark.parametrize("slots", [1, 2])
+def test_sp1_kvpe_slice_materializes_only_multi_slot_cache(monkeypatch, slots):
+    """A single-slot full-range slice must remain an alias; only slot selection needs new DRAM storage."""
+    import models.demos.deepseek_v3_d_p.tt.mla.mla as mla_module
+
+    storage = SimpleNamespace(shape=(slots, 1, 64, 128))
+    cache = SimpleNamespace(storage=storage, format="format", geometry="geometry")
+    slice_calls = []
+
+    def fake_slice(tensor, starts, ends, **kwargs):
+        slice_calls.append((tensor, starts, ends, kwargs))
+        return tensor if not kwargs else SimpleNamespace(shape=(1, 1, 64, 128))
+
+    monkeypatch.setattr(ttnn, "slice", fake_slice)
+    monkeypatch.setattr(mla_module, "MlaKvCache", lambda **kwargs: SimpleNamespace(**kwargs))
+    self = SimpleNamespace(sp_factor=1)
+
+    gathered = ttMLA._gather_kvpe_prefix(
+        self, cache, cache_batch_idx=slots - 1, populated_global=64, block_cyclic_chunk_local=64
+    )
+
+    if slots == 1:
+        assert not slice_calls
+        assert gathered.storage is storage
+    else:
+        _, starts, _, kwargs = slice_calls[0]
+        assert starts[0] == slots - 1
+        assert kwargs["memory_config"] == ttnn.DRAM_MEMORY_CONFIG
+        assert gathered.storage is not storage
 
 
 # --------------------------------------------------------------------------------------------------

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -44,6 +44,7 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_p
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
     full_indexer_rank,
     get_fused_ring_host_timing,
+    normalized_hadamard_matrix,
     reset_fused_ring_host_timing,
     resolve_has_indexer,
 )
@@ -322,11 +323,13 @@ def _record_indexer_k_cache_pcc(
         return
     p = blockcyclic_positions(sp, CHUNK, seq_len_cache)
     rope = config.index_head_dim // 2  # [rope | nope]
+    index_hadamard = normalized_hadamard_matrix(config.index_head_dim).float()
     idx_min_pcc = {}
     for i in layers:
         # Compact index cache (GLM-5.2 cross-layer reuse): layer i's slot is its full-indexer rank, not i
         # (rank == i for glm_5_1, where every layer is full). Matches the indexer's own write addressing.
         dev_cache = unrotate_cache_layer(cache_full[full_indexer_rank(config, i)], p, total_len)
+        dev_cache = (dev_cache.float() @ index_hadamard).to(torch.bfloat16)
         g = _load_layer_rows(trace_dir, layout, "dsa", i, f"indexer_k_layer_{i}", 0, total_len)
         pcc_rope, pcc_nope = cache_half_pccs(g, dev_cache, rope, pe_interleave=False)
         idx_min_pcc[i] = min(pcc_nope, pcc_rope)
@@ -414,9 +417,10 @@ def _preload_indexer_k_prefix_from_trace(
     golden (glm_5_1: all; glm_5_2: 0-2 + every 4th); layer i is written to its compacted slot
     full_indexer_rank(config, i), and the cache is strided by the full-layer count over the built
     layers. The golden
-    index_head_dim key is [rope | nope] already in the device's interleaved basis (GLM), so it is written
-    verbatim -- no re-interleave (unlike KVPE's k_pe half-split -> interleaved). Rows past the trace are
-    random (timing-representative). Mirrors _preload_kvpe_prefix_from_trace otherwise."""
+    index_head_dim key is [rope | nope] already in the device's interleaved RoPE basis (GLM). Apply the
+    decode-compatible Hadamard before writing it; no RoPE re-interleave is needed (unlike KVPE's k_pe
+    half-split -> interleaved). Rows past the trace are random (timing-representative). Mirrors
+    _preload_kvpe_prefix_from_trace otherwise."""
     full_layers = [i for i in range(num_layers) if (trace_dir / "dsa" / f"indexer_k_layer_{i}").exists()]
     if not full_layers:
         logger.info(f"no indexer_k golden in trace {trace_dir}; leaving the indexer prefix zero")
@@ -429,12 +433,14 @@ def _preload_indexer_k_prefix_from_trace(
         f"({real_len} real from trace, {rand_len} random beyond the trace)"
     )
     cache_host = torch.zeros(num_slots, 1, seq_len_cache, index_head_dim, dtype=torch.bfloat16)
+    index_hadamard = normalized_hadamard_matrix(index_head_dim).float()
     gen = torch.Generator().manual_seed(2345)  # deterministic random tail (distinct from the KVPE seed)
     for i in full_layers:
         idx_prior = torch.randn(preload_isl, index_head_dim, generator=gen).to(torch.bfloat16)
         if real_len > 0:
             real = _load_layer_rows(trace_dir, layout, "dsa", i, f"indexer_k_layer_{i}", 0, real_len)
             idx_prior[:real_len] = real.to(torch.bfloat16)
+        idx_prior = (idx_prior.float() @ index_hadamard).to(torch.bfloat16)
         slot = full_indexer_rank(config, i)
         cache_host[slot, 0] = blockcyclic_cache_host(idx_prior, sp, CHUNK, seq_len_cache, index_head_dim)[0, 0]
     cache_shard_dims = [None, None]

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -50,6 +50,18 @@ def get_fused_ring_host_timing() -> tuple[int, float]:
     return _fused_ring_host_timing["calls"], _fused_ring_host_timing["seconds"]
 
 
+def normalized_hadamard_matrix(dim: int) -> torch.Tensor:
+    """Return the Sylvester-order orthonormal Hadamard matrix used by the decode indexer."""
+    assert dim > 0 and dim & (dim - 1) == 0, f"Hadamard dimension must be a power of two, got {dim}"
+    matrix = torch.ones(1, 1, dtype=torch.float32)
+    while matrix.shape[0] < dim:
+        matrix = torch.cat(
+            (torch.cat((matrix, matrix), dim=1), torch.cat((matrix, -matrix), dim=1)),
+            dim=0,
+        )
+    return (matrix * (dim**-0.5)).to(torch.bfloat16)
+
+
 class TtIndexer:
     """DSA lightning indexer for one MLA layer. Self-contained: owns the indexer weights, the
     grown-by-concat device index-key cache and the indexer RoPE tables, and runs its own TP/SP
@@ -336,10 +348,9 @@ class TtIndexer:
         # modes.
         # Block-cyclic key cache (persistent [num_users*_index_cache_layers,1,S/sp,D_idx]) is NOT owned
         # here: exactly like the MLA KVPE cache, the caller allocates it and passes it into
-        # forward(index_kv_cache=...) every call; the indexer never self-allocates it. write_k typecasts the
-        # roped key to the cache's dtype before the in-place write, so the caller controls the dtype (BF8
-        # validated — rotated + chunked suites match BF16 within bf16 noise, ~5e-4 PCC — so it can be
-        # allocated BF8 to halve mem).
+        # forward(index_kv_cache=...) every call; the indexer never self-allocates it. write_k applies the
+        # decode-compatible Hadamard transform and typecasts the key to the cache's dtype before the in-place
+        # write, so the caller controls the dtype.
         # GLM-5.2 cross-layer indexer reuse: the index key cache is allocated for full layers only, so this
         # layer writes/reads its compacted rank among them and the folded (user-major) slot stride is the
         # cache's full-layer count, not its layer count. _index_cache_layers is that stride.
@@ -413,6 +424,19 @@ class TtIndexer:
                 dtype=ttnn.bfloat16,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
             )
+        # Blaze stores and scores indexer keys in the orthonormal Hadamard basis. Apply the same
+        # transform to both Q and K so standalone prefill scores are unchanged while the persistent
+        # index cache remains byte-compatible with decode after migration.
+        hadamard = normalized_hadamard_matrix(self.index_args.index_head_dim).reshape(
+            1, 1, self.index_args.index_head_dim, self.index_args.index_head_dim
+        )
+        self._index_hadamard = ttnn.from_torch(
+            hadamard,
+            device=self.mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
 
     # Inlined TP/SP collectives — the indexer owns its own copy so it depends on tt_ccl, not on ttMLA
     # (the dense MLA forward keeps its own equivalents; both go through the same tt_ccl handles).
@@ -578,6 +602,15 @@ class TtIndexer:
         # compacted stride (_index_cache_layers) so it matches the cache_batch_idx computed in forward().
         cache_layer_idx = self._cache_slot(cache_layer_idx)
         k = self._bc_rope_pe(k, rope_tensors, start_pos)  # [1, 1, S/sp, D_idx] bf16
+        k_h = ttnn.matmul(
+            k,
+            self._index_hadamard,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.default_compute_kernel_config,
+        )
+        ttnn.deallocate(k)
+        k = k_h
         if k.dtype != index_kbuf.dtype:  # write dtype must match the cache (update_padded_kv_cache asserts)
             k = ttnn.typecast(k, index_kbuf.dtype)
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
@@ -650,14 +683,23 @@ class TtIndexer:
             self._idx_wq_b,
             compute_kernel_config=self.default_compute_kernel_config,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            # Keep indexer Q in BFP8 from its first materialization through scoring.
-            dtype=ttnn.bfloat8_b,
+            # Preserve the unquantized values through Hadamard, then materialize BFP8 once below.
+            dtype=ttnn.bfloat16,
         )  # [1, 1, S/sp, H_idx*D_idx] — ALL heads (wq_b replicated); queries stay SP-sharded (rotation-safe)
         q, _, _ = ttnn.experimental.nlp_create_qkv_heads(
             q, num_heads=a.index_n_heads, num_kv_heads=0, transpose_k_heads=False, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )  # [1, H_idx, S/sp, D_idx] — all heads resident
         # block-cyclic indexed rope (same op/tables as the key rope + MLA q_pe)
         q_dev = self._bc_rope_pe(q, rope_tensors, start_pos)
+        q_h = ttnn.matmul(
+            q_dev,
+            self._index_hadamard,
+            dtype=ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.default_compute_kernel_config,
+        )
+        ttnn.deallocate(q_dev)
+        q_dev = q_h
 
         # weights_proj: device stem -> FULL all-reduce over tp (all H_idx heads, matching the replicated
         # wq_b heads) -> scale -> [1, 1, S/sp, H_idx].

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1736,11 +1736,15 @@ class ttMLA:
             # behavior, where sparse_sdpa still needs a batch-1 cache. For a multi-slot cache this
             # slice creates owned transient storage that the caller releases; for a single-slot cache
             # it is a no-op alias of the persistent cache and must not be released by the caller.
-            gathered = ttnn.slice(
-                storage,
-                [slot_lo, 0, 0, 0],
-                [slot_lo + 1, 1, storage.shape[2], storage.shape[3]],
-            )
+            if storage.shape[0] == 1:
+                gathered = storage
+            else:
+                gathered = ttnn.slice(
+                    storage,
+                    [slot_lo, 0, 0, 0],
+                    [slot_lo + 1, 1, storage.shape[2], storage.shape[3]],
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
         else:
             # Block-cyclic storage is meaningful only in complete SP slabs. The new AG writes each
             # rank's active local prefix into its fixed worst-case slot, retaining the allocation and


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
GLM decode stores and scores lightning-indexer keys in the normalized H128 Walsh-Hadamard basis, while sparse MLA prefill previously wrote the post-RoPE key directly. A cache produced during prefill therefore entered decode in a different basis.

This change applies the normalized H128 transform after RoPE to both prefill indexer Q and K for every index-cache format. Transforming both operands preserves prefill scores, while storing transformed BFP8 keys makes the persistent index cache compatible with decode. Q remains BF16 through the transform and is materialized as BFP8 afterward.

Cache validation reverses the symmetric, self-inverse transform before comparing against the untransformed CPU reference. Host coverage checks orthogonality and score preservation.

The SP=1 multi-slot KVPE slice is also materialized in interleaved DRAM. Without an explicit output memory config, slice output planning constructed an invalid ninth DRAM-bank shard on an eight-bank Blackhole QuietBox.

### Performance impact
Realtime-profiler results on the QuietBox SP=1 x TP=4 proxy (640-token local chunk):

| KVPE format | Scenario | Added H128 Q+K time | Full measured time | Share |
| --- | ---: | ---: | ---: | ---: |
| BF16 | warm | 110.595 us | 4.135 ms | 2.7% |
| scaled FP8 | warm | 110.883 us | 3.736 ms | 3.0% |
| BF16 | cold, 11 chunks | 1.214 ms | 40.369 ms | 3.0% |
| scaled FP8 | cold, 11 chunks | 1.216 ms | 38.457 ms | 3.2% |
| BF16 | long | 111.520 us | 5.233 ms | 2.1% |
| scaled FP8 | long | 112.020 us | 5.035 ms | 2.2% |

The K transform is about 5.1 us and the Q transform about 105-107 us per chunk. These are correctness-first generic `ttnn.matmul` implementations and have not been tuned or replaced with the available specialized H128 machinery yet.

### Notes for reviewers
The Hadamard convention matches tt-blaze decode: Sylvester H128, normalized by 1/sqrt(128), applied after RoPE to the complete 128-dimensional index vector. Since H is symmetric, the row-vector prefill multiplication is equivalent to the decode implementation.

### Active CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/glm52-indexer-hadamard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/glm52-indexer-hadamard)
