### PR TITLE
#32620: Add supported dtypes and layouts tables to tensor-creation op docstrings

### DIFF
--- a/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
@@ -71,19 +71,30 @@ void bind_full(nb::module_& mod) {
 
         Args:
             shape (ttnn.Shape): The shape of the tensor.
-            fill_value (float): The value to fill the tensor with.
+            fill_value (float | int): The value to fill the tensor with.
             dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
             layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
             device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
-        Note:
-            ROW_MAJOR_LAYOUT requires last dimension (shape[-1]) to be a multiple of 2 with dtype BFLOAT16 or UINT16.
-            TILE_LAYOUT requires width (shape[-1]) and height (shape[-2]) dimension to be multiple of 32.
-
         Returns:
             ttnn.Tensor: A filled tensor of specified shape and value.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
+                 - TILE, ROW_MAJOR
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
+            ROW_MAJOR requires last dimension to be a multiple of 2 with dtype BFLOAT16 or UINT16.
+            TILE requires width and height dimensions to be multiples of 32.
         )doc";
 
     ttnn::bind_function<"full">(
@@ -134,14 +145,17 @@ void bind_zeros(nb::module_& mod) {
             ttnn.Tensor: A tensor filled with 0.0.
 
         Note:
-            Supported dtypes, layouts, and ranks:
+            Supported dtypes and layouts:
 
-        ================= =============== ========
-         Dtypes             Layouts       Ranks
-        ================= =============== ========
-        BFLOAT16, FLOAT32 ROW_MAJOR, TILE  2, 3, 4
-        ================= =============== ========
+            .. list-table::
+               :header-rows: 1
 
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
+                 - TILE, ROW_MAJOR
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
         )doc";
 
     ttnn::bind_function<"zeros">(
@@ -176,12 +190,23 @@ void bind_ones(nb::module_& mod) {
             device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
 
-        Note:
-            ROW_MAJOR_LAYOUT requires last dimension (shape[-1]) to be a multiple of 2 with dtype BFLOAT16 or UINT16.
-            TILE_LAYOUT requires requires width (shape[-1]), height (shape[-2]) dimension to be multiple of 32.
-
         Returns:
             ttnn.Tensor: A tensor filled with 1.0.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
+                 - TILE, ROW_MAJOR
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
+            ROW_MAJOR requires last dimension to be a multiple of 2 with dtype BFLOAT16 or UINT16.
+            TILE requires width and height dimensions to be multiples of 32.
         )doc";
 
     ttnn::bind_function<"ones">(
@@ -227,14 +252,27 @@ void bind_full_like(nb::module_& mod) {
         Args:
             tensor (ttnn.Tensor): The tensor to use as a template for the shape of the new tensor.
             fill_value (float | int): The value to fill the tensor with.
-            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
-            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
-            device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
+            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to the input tensor's dtype.
+            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to the input tensor's layout.
+            device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to the input tensor's device.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to the input tensor's memory config.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: A filled tensor.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
+                 - TILE, ROW_MAJOR
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
         )doc";
 
     ttnn::bind_function<"full_like">(
@@ -277,24 +315,27 @@ void bind_zeros_like(nb::module_& mod) {
 
         Args:
             tensor (ttnn.Tensor): The tensor to use as a template for the shape of the new tensor.
-            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
-            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
-            device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
+            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to the input tensor's dtype.
+            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to the input tensor's layout.
+            device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to the input tensor's device.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to the input tensor's memory config.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: A tensor filled with 0.0.
 
         Note:
-            Supported dtypes, layouts, and ranks:
+            Supported dtypes and layouts:
 
-        ================ =============== ========
-         types             Layouts       Ranks
-        ================ =============== ========
-        FLOAT16, FLOAT32 ROW_MAJOR, TILE  2, 3, 4
-        ================ =============== ========
+            .. list-table::
+               :header-rows: 1
 
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
+                 - TILE, ROW_MAJOR
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
         )doc";
 
     ttnn::bind_function<"zeros_like">(
@@ -326,14 +367,27 @@ void bind_ones_like(nb::module_& mod) {
 
         Args:
             tensor (ttnn.Tensor): The tensor to use as a template for the shape of the new tensor.
-            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
-            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
-            device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
+            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to the input tensor's dtype.
+            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to the input tensor's layout.
+            device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to the input tensor's device.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to the input tensor's memory config.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: A tensor filled with 1.0.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
+                 - TILE, ROW_MAJOR
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
         )doc";
 
     ttnn::bind_function<"ones_like">(
@@ -377,13 +431,28 @@ void bind_arange(nb::module_& mod) {
             start (int, optional): The start of the range. Defaults to 0.
             end (int): The end of the range (exclusive).
             step (int, optional): The step size between consecutive values. Defaults to 1.
+
+        Keyword Args:
             dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `ttnn.bfloat16`.
-            device (ttnn.Device, optional): The device where the tensor will be allocated. Defaults to `None`.
+            device (ttnn.Device | ttnn.MeshDevice, optional): The device where the tensor will be allocated. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration for the tensor. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
             layout (ttnn.Layout, optional): The tensor layout. Defaults to `ttnn.ROW_MAJOR`.
 
         Returns:
             ttnn.Tensor: A tensor containing evenly spaced values within the specified range.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, UINT16, UINT32, INT32
+                 - TILE, ROW_MAJOR
+
+            `step` must be non-zero, and its sign must match the direction from `start` to `end`.
         )doc";
 
     ttnn::bind_function<"arange">(
@@ -434,15 +503,17 @@ void bind_empty(nb::module_& mod) {
             ttnn.Tensor: The output uninitialized tensor.
 
         Note:
-            Supported dtypes, layouts, and ranks:
+            Supported dtypes and layouts:
 
-        ================= =============== ========
-         Dtypes             Layouts       Ranks
-        ================= =============== ========
-        BFLOAT16, FLOAT32 ROW_MAJOR, TILE  2, 3, 4
-        BFLOAT_8             TILE          2, 3, 4
-        ================= =============== ========
+            .. list-table::
+               :header-rows: 1
 
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32
+                 - TILE, ROW_MAJOR
+               * - BFLOAT8_B
+                 - TILE
         )doc";
 
     ttnn::bind_function<"empty">(
@@ -481,6 +552,19 @@ void bind_empty_like(nb::module_& mod) {
 
         Returns:
             ttnn.Tensor: The output uninitialized tensor with the same shape as the input tensor.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32
+                 - TILE, ROW_MAJOR
+               * - BFLOAT8_B
+                 - TILE
         )doc";
 
     ttnn::bind_function<"empty_like">(
@@ -549,18 +633,32 @@ Tensor from_buffer_impl(
 // Helper function to bind from_buffer operation
 void bind_from_buffer(nb::module_& mod) {
     const auto* doc = R"doc(
-        Creates a device tensor with values from a buffer of the specified, data type, layout, and memory configuration.
+        Creates a device tensor with values from a buffer of the specified data type, layout, and memory configuration.
 
         Args:
             buffer (List[Any]): The buffer to be used to create the tensor.
             shape (ttnn.Shape): The shape of the tensor to be created.
             dtype (ttnn.DataType): The tensor data type.
             device (ttnn.Device | ttnn.MeshDevice): The device where the tensor will be allocated.
-            layout (ttnn.Layout, optional): The tensor layout. Defaults to `ttnn.ROW_MAJOR` unless `dtype` is `ttnn.bfloat4` or `ttnn.bfloat8`, in which case it defaults to `ttnn.TILE`.
+            layout (ttnn.Layout, optional): The tensor layout. Defaults to `ttnn.ROW_MAJOR`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration for the operation. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
 
         Returns:
             ttnn.Tensor: A tensor with the values from the buffer.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32, UINT8, INT8, UINT16, UINT32, INT32
+                 - TILE, ROW_MAJOR
+
+            The buffer element type must be compatible with `dtype`.
+            BFLOAT8_B, BFLOAT4_B, and FP8_E4M3 are not supported for host-side construction.
         )doc";
 
     ttnn::bind_function<"from_buffer">(

--- a/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
@@ -156,6 +156,8 @@ void bind_zeros(nb::module_& mod) {
                  - TILE, ROW_MAJOR
 
             BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
+            ROW_MAJOR requires last dimension to be a multiple of 2 with dtype BFLOAT16 or UINT16.
+            TILE requires width and height dimensions to be multiples of 32.
         )doc";
 
     ttnn::bind_function<"zeros">(
@@ -273,6 +275,8 @@ void bind_full_like(nb::module_& mod) {
                  - TILE, ROW_MAJOR
 
             BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
+            ROW_MAJOR requires last dimension to be a multiple of 2 with dtype BFLOAT16 or UINT16.
+            TILE requires width and height dimensions to be multiples of 32.
         )doc";
 
     ttnn::bind_function<"full_like">(
@@ -336,6 +340,8 @@ void bind_zeros_like(nb::module_& mod) {
                  - TILE, ROW_MAJOR
 
             BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
+            ROW_MAJOR requires last dimension to be a multiple of 2 with dtype BFLOAT16 or UINT16.
+            TILE requires width and height dimensions to be multiples of 32.
         )doc";
 
     ttnn::bind_function<"zeros_like">(
@@ -388,6 +394,8 @@ void bind_ones_like(nb::module_& mod) {
                  - TILE, ROW_MAJOR
 
             BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
+            ROW_MAJOR requires last dimension to be a multiple of 2 with dtype BFLOAT16 or UINT16.
+            TILE requires width and height dimensions to be multiples of 32.
         )doc";
 
     ttnn::bind_function<"ones_like">(
@@ -510,10 +518,10 @@ void bind_empty(nb::module_& mod) {
 
                * - Dtypes
                  - Layouts
-               * - BFLOAT16, FLOAT32
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
                  - TILE, ROW_MAJOR
-               * - BFLOAT8_B
-                 - TILE
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
         )doc";
 
     ttnn::bind_function<"empty">(
@@ -561,10 +569,10 @@ void bind_empty_like(nb::module_& mod) {
 
                * - Dtypes
                  - Layouts
-               * - BFLOAT16, FLOAT32
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, UINT8, UINT16, UINT32, INT8, INT32
                  - TILE, ROW_MAJOR
-               * - BFLOAT8_B
-                 - TILE
+
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
         )doc";
 
     ttnn::bind_function<"empty_like">(

--- a/ttnn/cpp/ttnn/operations/rand/rand_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand_nanobind.cpp
@@ -58,14 +58,10 @@ void bind_rand_operation(nb::module_& mod) {
 
                * - Dtypes
                  - Layouts
-               * - BFLOAT16, FLOAT32
-                 - TILE, ROW_MAJOR
-               * - BFLOAT8_B, BFLOAT4_B, INT8, INT32, UINT16, UINT32
+               * - BFLOAT16, FLOAT32, BFLOAT8_B, BFLOAT4_B, INT8, INT32, UINT16, UINT32
                  - TILE, ROW_MAJOR
 
-            BFLOAT16 and FLOAT32 are generated natively; the other dtypes are produced by typecasting a FLOAT32
-            draw, so output values are not guaranteed to remain in [`low`, `high`). UINT8 and FP8_E4M3 are not
-            supported.
+            BFLOAT8_B and BFLOAT4_B are supported only on TILE layout.
         )doc";
 
     ttnn::bind_function<"rand">(

--- a/ttnn/cpp/ttnn/operations/rand/rand_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand_nanobind.cpp
@@ -30,15 +30,15 @@ void bind_rand_operation(nb::module_& mod) {
             uniform distribution. DataType.uint8 and fp8_e4m3 are not supported.
 
         Args:
-            shape (list[int]) - a list of integers defining the shape of the output tensor.
+            shape (list[int]): A list of integers defining the shape of the output tensor.
+            device (ttnn.Device | ttnn.MeshDevice): The device on which the tensor will be allocated.
 
-        Keyword args:
-            device (ttnn.Device | ttnn.MeshDevice, optional): The device on which the tensor will be allocated. Defaults to `None`.
-            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to ttnn.bfloat16.
-            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to ttnn.TILE_LAYOUT.
+        Keyword Args:
+            dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `ttnn.bfloat16`.
+            layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `ttnn.TILE_LAYOUT`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
-            low (float, optional): The lower bound of the range (inclusive).
-            high (float, optional): The upper bound of the range (exclusive).
+            low (float, optional): The lower bound of the range (inclusive). Defaults to 0.0.
+            high (float, optional): The upper bound of the range (exclusive). Defaults to 1.0.
             seed (int, optional): An optional seed to initialize the random number generator
                                 for reproducible results. Defaults to 0.
             mesh_mapper (ttnn.MeshMapperConfig, optional): Distribution strategy for multi-device tensors.
@@ -49,6 +49,23 @@ void bind_rand_operation(nb::module_& mod) {
 
         Returns:
             ttnn.Tensor: A tensor with specified shape, dtype, and layout containing random values.
+
+        Note:
+            Supported dtypes and layouts:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+               * - BFLOAT16, FLOAT32
+                 - TILE, ROW_MAJOR
+               * - BFLOAT8_B, BFLOAT4_B, INT8, INT32, UINT16, UINT32
+                 - TILE, ROW_MAJOR
+
+            BFLOAT16 and FLOAT32 are generated natively; the other dtypes are produced by typecasting a FLOAT32
+            draw, so output values are not guaranteed to remain in [`low`, `high`). UINT8 and FP8_E4M3 are not
+            supported.
         )doc";
 
     ttnn::bind_function<"rand">(


### PR DESCRIPTION
### Ticket
Link to Github Issue #32620

### Problem
`ttnn.arange`, `empty_like`, `ones_like`, `ones`, `full`, `full_like`, `rand`, and `from_buffer` in `creation_nanobind.cpp`/`rand_nanobind.cpp` render without a "Supported dtypes and layouts" table, and `ttnn.rand`'s `shape` param has no description — breaking the docstring shape the L2-nightly example extraction relies on.

### Fix
Rewrite the 11 tensor-creation docstrings to the peer single-row `.. list-table::` + prose-caveat shape (matches `binary_nanobind.cpp:267-277`, `ternary_nanobind.cpp:42-53`, `sort_nanobind.cpp`) using each op's actual `full_impl`/`from_buffer`/`arange`/`tensor_spec.cpp:validate_dtype_and_layout` coverage. Drop the stale `Ranks 2, 3, 4` column (no rank guard in `full_impl`) and the stale `TILE-default-when-dtype=BFLOAT4/8_B` clause from `from_buffer` (`creation.cpp:328` fixes `ROW_MAJOR`, `from_buffer_impl` throws for block-float before the default fires — clause was unreachable). L2-nightly examples remain driven by `tests/ttnn/docs_examples/test_tensor_creation_examples.py` + `examples_mapping.py`, with `docs/source/ttnn/_ext/doc_modifier.py` auto-injecting the rendered `Example:` block per page (16/16 pass locally).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/tensor_creation_docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/tensor_creation_docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/tensor_creation_docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/tensor_creation_docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/tensor_creation_docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/tensor_creation_docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/tensor_creation_docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/tensor_creation_docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/tensor_creation_docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/tensor_creation_docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/tensor_creation_docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/tensor_creation_docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/tensor_creation_docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/tensor_creation_docs)

