### PR TITLE
copy_dest_values: move opaque bits, not a converted float

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -14,12 +15,41 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+// A Dst-to-Dst copy must not convert.
+//
+// GetSfpLoadStoreInstrMod picks a *type conversion* mode for the float formats (FP16A / FP16B /
+// FP32), and SFPSTORE flushes denormals to zero as part of that conversion, so the float spelling
+// silently drops every subnormal it is asked to copy: all 254 bf16 subnormals, measured identically
+// on Blackhole and Wormhole. The ISA documentation names the escape - use an opaque integer mode
+// instead of the float one - and the where kernel already does this by hand for Float16_b.
+//
+// So map each conversion mode onto the opaque integer mode of the same width. The bfp* and integer
+// formats already carry opaque bits and pass through untouched. This costs nothing: the mode is a
+// 4-bit immediate in the same SFPLOAD / SFPSTORE pair.
+template <DataFormat DATA_FORMAT, bool is_fp32_dest_acc_en>
+constexpr InstrModLoadStore GetSfpCopyInstrMod() {
+    constexpr InstrModLoadStore conv = GetSfpLoadStoreInstrMod<DATA_FORMAT, is_fp32_dest_acc_en>();
+    return (conv == InstrModLoadStore::FP32)                                        ? InstrModLoadStore::INT32
+           : (conv == InstrModLoadStore::FP16A || conv == InstrModLoadStore::FP16B) ? InstrModLoadStore::LO16
+                                                                                    : conv;
+}
+
+// The mapping, pinned. A copy of a 16-bit Dst word must move opaque 16 bits, and of a 32-bit word
+// opaque 32 bits; nothing here may name a float mode.
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16_b, false>() == InstrModLoadStore::LO16);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16_b, true>() == InstrModLoadStore::INT32);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16, false>() == InstrModLoadStore::LO16);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16, true>() == InstrModLoadStore::INT32);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float32, false>() == InstrModLoadStore::INT32);
+static_assert(GetSfpCopyInstrMod<DataFormat::Bfp8_b, false>() == InstrModLoadStore::DEFAULT);
+
 // Generalized copy_dest_value that works with any DataFormat
-template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
-    constexpr InstrModLoadStore instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
+template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+void copy_dest_value(
+    const std::uint32_t dst_index_in, const std::uint32_t dst_index_out, const std::uint32_t /* unused */) {
+    constexpr InstrModLoadStore instr_mod_index = GetSfpCopyInstrMod<DATA_FORMAT, is_fp32_dest_acc_en>();
     // size of each tile in Dest is 64 rows
-    constexpr uint dst_tile_size = 64;
+    constexpr std::uint32_t dst_tile_size = 64;
     for (int d = 0; d < ITERATIONS; d++) {
         // For some reason using __builtin_rvtt_sfp{load,store} here
         // results in test failures.  The compiler unrolls this loop
@@ -36,11 +66,13 @@ void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const ui
 // Deprecated: Use the DataFormat template parameter version instead
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 [[deprecated("Use copy_dest_value<DataFormat, APPROXIMATION_MODE, ITERATIONS> instead")]]
-void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
+void copy_dest_value(
+    const std::uint32_t dst_index_in, const std::uint32_t dst_index_out, const std::uint32_t /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
         // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-        constexpr uint dst_tile_size_sfpi = 32;
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vFloat(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] =
+            sfpi::vFloat(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -14,12 +15,41 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+// A Dst-to-Dst copy must not convert.
+//
+// GetSfpLoadStoreInstrMod picks a *type conversion* mode for the float formats (FP16A / FP16B /
+// FP32), and SFPSTORE flushes denormals to zero as part of that conversion, so the float spelling
+// silently drops every subnormal it is asked to copy: all 254 bf16 subnormals, measured identically
+// on Blackhole and Wormhole. The ISA documentation names the escape - use an opaque integer mode
+// instead of the float one - and the where kernel already does this by hand for Float16_b.
+//
+// So map each conversion mode onto the opaque integer mode of the same width. The bfp* and integer
+// formats already carry opaque bits and pass through untouched. This costs nothing: the mode is a
+// 4-bit immediate in the same SFPLOAD / SFPSTORE pair.
+template <DataFormat DATA_FORMAT, bool is_fp32_dest_acc_en>
+constexpr InstrModLoadStore GetSfpCopyInstrMod() {
+    constexpr InstrModLoadStore conv = GetSfpLoadStoreInstrMod<DATA_FORMAT, is_fp32_dest_acc_en>();
+    return (conv == InstrModLoadStore::FP32)                                        ? InstrModLoadStore::INT32
+           : (conv == InstrModLoadStore::FP16A || conv == InstrModLoadStore::FP16B) ? InstrModLoadStore::LO16
+                                                                                    : conv;
+}
+
+// The mapping, pinned. A copy of a 16-bit Dst word must move opaque 16 bits, and of a 32-bit word
+// opaque 32 bits; nothing here may name a float mode.
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16_b, false>() == InstrModLoadStore::LO16);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16_b, true>() == InstrModLoadStore::INT32);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16, false>() == InstrModLoadStore::LO16);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float16, true>() == InstrModLoadStore::INT32);
+static_assert(GetSfpCopyInstrMod<DataFormat::Float32, false>() == InstrModLoadStore::INT32);
+static_assert(GetSfpCopyInstrMod<DataFormat::Bfp8_b, false>() == InstrModLoadStore::DEFAULT);
+
 // Generalized copy_dest_value that works with any DataFormat
-template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
-    constexpr InstrModLoadStore instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
+template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+void copy_dest_value(
+    const std::uint32_t dst_index_in, const std::uint32_t dst_index_out, const std::uint32_t /* unused */) {
+    constexpr InstrModLoadStore instr_mod_index = GetSfpCopyInstrMod<DATA_FORMAT, is_fp32_dest_acc_en>();
     // size of each tile in Dest is 64 rows
-    constexpr uint dst_tile_size = 64;
+    constexpr std::uint32_t dst_tile_size = 64;
     for (int d = 0; d < ITERATIONS; d++) {
         // For some reason using __builtin_rvtt_sfp{load,store} here
         // results in test failures.  The compiler unrolls this loop
@@ -36,11 +66,13 @@ void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const ui
 // Deprecated: Use the DataFormat template parameter version instead
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 [[deprecated("Use copy_dest_value<DataFormat, APPROXIMATION_MODE, ITERATIONS> instead")]]
-void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
+void copy_dest_value(
+    const std::uint32_t dst_index_in, const std::uint32_t dst_index_out, const std::uint32_t /* unused */) {
     for (int d = 0; d < ITERATIONS; d++) {
         // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-        constexpr uint dst_tile_size_sfpi = 32;
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vFloat(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] =
+            sfpi::vFloat(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/inc/api/compute/copy_dest_values.h
+++ b/tt_metal/hw/inc/api/compute/copy_dest_values.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common_globals.h"
 #ifdef TRISC_MATH
 #include "ckernel_sfpu_copy_dest_values.h"
@@ -30,12 +31,12 @@ namespace ckernel {
  */
 // clang-format on
 template <DataFormat DATA_FORMAT>
-ALWI void copy_dest_values(uint32_t idst_in, uint32_t idst_out) {
+ALWI void copy_dest_values(std::uint32_t idst_in, std::uint32_t idst_out) {
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
         copy_dest_value,
-        (DATA_FORMAT, false /*APPROXIMATE*/),
+        (DATA_FORMAT, false /*APPROXIMATE*/, DST_ACCUM_MODE),
         idst_in,
         idst_out,
         0 /*unused*/,
@@ -58,7 +59,7 @@ ALWI void copy_dest_values(uint32_t idst_in, uint32_t idst_out) {
  */
 // clang-format on
 [[deprecated("Use copy_dest_values<DataFormat> instead")]]
-ALWI void copy_dest_values(uint32_t idst_in, uint32_t idst_out) {
+ALWI void copy_dest_values(std::uint32_t idst_in, std::uint32_t idst_out) {
     // Routes through the deprecated 1-template-arg `copy_dest_value<APPROXIMATE>` overload in
     // ckernel::sfpu (the format-agnostic sfpi::vFloat path). New code should use the
     // DataFormat-templated overload above.


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #54899.

`copy_dest_value` took its SFPLOAD/SFPSTORE mode from `GetSfpLoadStoreInstrMod`, which returns a **type conversion** mode for the float formats. `SFPSTORE` flushes denormals to zero as part of that conversion (`SFPSTORE.md:48`), so an operation named "copy" silently dropped every subnormal it was asked to move — all 254 of them, on both architectures.

Two changes, both in the same direction:

1. **Map each conversion mode onto the opaque integer mode of the same width** — `FP32 -> INT32`, `FP16A`/`FP16B` -> `LO16`, everything else untouched. This is the escape the ISA documentation names (`SFPSTORE.md:52`), and the in-tree precedent is one layer away: `_calculate_where_` already hand-picks `LO16` for `Float16_b` (`ckernel_sfpu_where.h:29`) rather than going through `GetSfpLoadStoreInstrMod`. Deriving the copy mode *from* the conversion mode rather than restating the format list means the two cannot drift apart, and the mapping is pinned with `static_assert`.

2. **Thread `DST_ACCUM_MODE` through.** The call site had `DST_ACCUM_MODE` in hand but did not pass it, so `GetSfpLoadStoreInstrMod<DATA_FORMAT>` always took the `is_fp32_dest_acc_en = false` default. With fp32 dest-accumulation a `Float16_b` datum sits in Dst as a full 32-bit word, so the copy was using 16-bit access on a 32-bit datum. `ckernel_sfpu_reduce.h:1958` already passes both arguments; this one did not.

## Correctness

**Bit preservation, all 65,536 bfloat16 patterns.** Measured by keeping the original raw bits in a spare LReg, using each architecture's own `ADDR_MOD`, running the copy with the mode under test for both load and store, re-reading raw, and emitting a boolean where the bits changed — a boolean survives the packer, so the surrounding bf16 pipeline cannot mask the result:

| copy mode | words changed | subnormals (254) | NaNs (254) | normals + zeros |
|---|---:|---:|---:|---:|
| `FP16B` (before), P300 | 254 | **254** | 0 | 0 |
| `FP16B` (before), N300 | 254 | **254** | 0 | 0 |
| `LO16` (after), both | **0** | 0 | 0 | 0 |

NaN payloads were already safe: the fp32 the load builds from a bf16 has 16 zero mantissa bits, so the store's truncation has nothing to remove. The loss is subnormals and nothing else, identically on both architectures, which is what the documented functional model says should happen.

**No regression in the one shipping consumer.** `ttnn.gelu_bw` (`approximate="tanh"`) is the only ttnn op that reaches this API, through `copy_dest_values<Float16_b>` and `<Float32>`. Output digests are **bit-identical before and after**, on both machines and both dtypes, across three passes each: bf16 `91cefe41ffa44679` on both machines; fp32 `70779e9c637e1315` (P300) and `9272af27ae6461db` (N300). PCC unchanged at 0.999971 / 1.000000.

It is bit-identical for a reason worth stating: `gelu_bw` copies `tanh(inner)` and `1 - tanh^2` into slots that immediately feed float arithmetic, and SFPU arithmetic flushes subnormals on its own, so the copy's flush was never visible there. The defect bites when the copy feeds a raw-bit reader instead — the zero comparators — which is how it was found.

## Cost

Free, by construction and by measurement. The mode is a 4-bit immediate in the same `TT_SFPLOAD` / `TT_SFPSTORE` pair; the instruction count does not change. A zone around the copy itself, 3072 samples: **48.0 cycles for both modes on P300, 49.0 for both on N300.**

`ttnn.gelu_bw` wall clock, median of 20 calls, three passes per arm, microseconds:

| | P300 before | P300 after | N300 before | N300 after |
|---|---|---|---|---|
| bfloat16 | 56.52 / 56.98 / 56.31 | 56.18 / 56.29 / 56.29 | 95.91 / 96.30 | 96.16 / 97.57 |
| float32 | 46.56 / 46.61 / 47.05 | 45.69 / 47.18 / 46.82 | 81.87 / 80.25 | 80.79 / 79.37 |

Dispatches 1 to 1.

## Tests

The mapping is pinned in the header with `static_assert`, so a future edit to `GetSfpLoadStoreInstrMod` that reintroduced a float mode for a copy would fail to build rather than silently start dropping subnormals.

The bit-preservation table above is the behavioural test, but it needs a kernel that can read Dst raw on both sides of the copy, which is not reachable from a ttnn unit test — the API is called from compute kernels, not from python. It was run as a probe kernel installed under an existing op's entry point. The reachable regression coverage is `ttnn.gelu_bw`, which is bit-identical above.

## Not covered

- **The `is_fp32_dest_acc_en = true` path is reasoned, not measured for subnormal preservation.** Its mode choice is exercised — `gelu_bw`'s `Float32` kernel takes `FP32 -> INT32` and is bit-identical — but no fp32 subnormal was placed in Dst to confirm the flush is gone, because the surrounding pipeline flushes them before Dst.
- **The deprecated `copy_dest_value<APPROXIMATION_MODE>` overload** still goes through the `sfpi::vFloat` path and still converts. It is left alone as deprecated.
- **Quasar** has no `copy_dest_values` kernel, so only the two architectures that do are touched.

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `04cf22f7ee` (P300), `bef164b30a9` (N300)
* Hardware: N300 and P300
