### PR TITLE
[Cleanup] Use SemVer instead of semver_t

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -213,7 +213,7 @@ public:
     const std::unordered_map<std::string, std::string>& get_host_mobo_name_map() const { return host_to_mobo_name_; }
     const std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() const { return host_to_rank_; }
     const ExitNodeConnectionTable& get_exit_node_connection_table() const { return exit_node_connection_table_; }
-    const tt::umd::semver_t& get_ethernet_firmware_version() const { return ethernet_firmware_version_; }
+    const tt::umd::SemVer& get_ethernet_firmware_version() const { return ethernet_firmware_version_; }
     const std::optional<tt::umd::FirmwareBundleVersion>& get_firmware_bundle_version() const {
         return firmware_bundle_version_;
     }
@@ -236,7 +236,7 @@ public:
     std::unordered_map<std::string, std::string>& get_host_mobo_name_map() { return host_to_mobo_name_; }
     std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() { return host_to_rank_; }
     ExitNodeConnectionTable& get_exit_node_connection_table() { return exit_node_connection_table_; }
-    tt::umd::semver_t& get_ethernet_firmware_version() { return ethernet_firmware_version_; }
+    tt::umd::SemVer& get_ethernet_firmware_version() { return ethernet_firmware_version_; }
     std::optional<tt::umd::FirmwareBundleVersion>& get_firmware_bundle_version() { return firmware_bundle_version_; }
     std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>>&
     get_pcie_devices_per_tray() {
@@ -259,7 +259,7 @@ private:
     std::unordered_map<std::string, uint32_t> host_to_rank_;
     ExitNodeConnectionTable exit_node_connection_table_;
     bool all_hostnames_unique_ = true;
-    tt::umd::semver_t ethernet_firmware_version_;
+    tt::umd::SemVer ethernet_firmware_version_;
     std::optional<tt::umd::FirmwareBundleVersion> firmware_bundle_version_;
     std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>> pcie_devices_per_tray_;
     std::unordered_map<std::string, std::unordered_map<uint32_t, ASICLocation>> pcie_id_to_asic_location_;

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -97,7 +97,7 @@ void PhysicalSystemDescriptor::clear() {
     local_hostname_.clear();
     local_rank_ = 0;
     all_hostnames_unique_ = true;
-    ethernet_firmware_version_ = tt::umd::semver_t(0, 0, 0);
+    ethernet_firmware_version_ = tt::umd::SemVer(0, 0, 0);
 }
 
 void PhysicalSystemDescriptor::merge(PhysicalSystemDescriptor&& other) {

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -252,7 +252,7 @@ uint32_t get_chip_id_for_asic(const umd::ClusterDescriptor& cluster_desc, AsicID
 
 void validate_eth_fw_versions(
     PhysicalSystemDescriptor& psd,
-    const tt::umd::semver_t& peer_ethernet_firmware_version,
+    const tt::umd::SemVer& peer_ethernet_firmware_version,
     const std::string& my_host_name,
     const std::string& peer_host_name) {
     TT_FATAL(
@@ -750,7 +750,7 @@ PhysicalSystemDescriptor run_local_discovery(
 
     psd.get_system_graph().host_connectivity_graph[hostname_key] = {};
     // Get Ethernet Firmware Version from the driver - Initialize to 0 if not available
-    psd.get_ethernet_firmware_version() = cluster_desc.get_cluster_eth_fw_version().value_or(tt::umd::semver_t(0, 0, 0));
+    psd.get_ethernet_firmware_version() = cluster_desc.get_cluster_eth_fw_version().value_or(tt::umd::SemVer(0, 0, 0));
     // Get Firmware Bundle Version from the driver
     psd.get_firmware_bundle_version() = cluster_desc.get_cluster_firmware_bundle_version();
 

--- a/tt_metal/llrt/firmware_capability.cpp
+++ b/tt_metal/llrt/firmware_capability.cpp
@@ -23,7 +23,7 @@ void compare_requested_and_actual_capabilities(
 
     switch (arch) {
         case tt::ARCH::BLACKHOLE: {
-            constexpr tt::umd::semver_t k_min_2_erisc_version(1, 7, 0);
+            constexpr tt::umd::SemVer k_min_2_erisc_version(1, 7, 0);
             // If ethernet firmware cannot be queried assume it's ok
             // This occurs on the simulator
             const bool eth_fw_ok = !fw_versions.eth_fw || (fw_versions.eth_fw.value() >= k_min_2_erisc_version);

--- a/tt_metal/llrt/firmware_capability.hpp
+++ b/tt_metal/llrt/firmware_capability.hpp
@@ -12,7 +12,7 @@
 namespace tt::tt_metal {
 
 struct FirmwareVersions {
-    std::optional<tt::umd::semver_t> eth_fw;
+    std::optional<tt::umd::SemVer> eth_fw;
     std::optional<tt::umd::FirmwareBundleVersion> firmware_bundle;
 };
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -342,7 +342,7 @@ public:
     using DispatchFeatureQueryFunc = std::function<bool(DispatchFeature)>;
     using SetIRAMTextSizeFunc = std::function<void(
         dev_msgs::launch_msg_t::View, HalProgrammableCoreType, HalProcessorClassType, uint32_t, uint32_t)>;
-    using VerifyFwVersionFunc = std::function<bool(tt::umd::semver_t)>;
+    using VerifyFwVersionFunc = std::function<bool(tt::umd::SemVer)>;
 
 private:
     tt::ARCH arch_;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1061,7 +1061,7 @@ std::unique_ptr<tt::umd::SysmemBuffer> Cluster::map_sysmem_buffer(
     return sysmem_manager->map_sysmem_buffer(buffer, sysmem_buffer_size, map_to_noc);
 }
 
-std::optional<tt::umd::semver_t> Cluster::get_ethernet_firmware_version() const {
+std::optional<tt::umd::SemVer> Cluster::get_ethernet_firmware_version() const {
     return this->driver_->get_ethernet_firmware_version();
 }
 
@@ -1599,7 +1599,7 @@ bool Cluster::supports_ethernet_link_retraining() const {
         return true;
     }
     if (this->arch_ == tt::ARCH::BLACKHOLE) {
-        return this->get_ethernet_firmware_version() >= tt::umd::semver_t(1, 9, 0);
+        return this->get_ethernet_firmware_version() >= tt::umd::SemVer(1, 9, 0);
     }
     return false;
 }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -133,7 +133,7 @@ public:
     std::optional<int> get_physical_slot(ChipId chip) const;
 
     //! device driver and misc apis
-    std::optional<tt::umd::semver_t> get_ethernet_firmware_version() const;
+    std::optional<tt::umd::SemVer> get_ethernet_firmware_version() const;
 
     void deassert_risc_reset_at_core(
         const tt_cxy_pair& core, const tt::umd::RiscType& soft_resets, bool staggered_start = true) const;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Change all uses of the type `semver_t` to `SemVer`. The `semver_t` alias will be removed in UMD.

### Notes for reviewers
N/A

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aleksamarkovic/semver_t)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aleksamarkovic/semver_t)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aleksamarkovic/semver_t)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aleksamarkovic/semver_t)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aleksamarkovic/semver_t)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aleksamarkovic/semver_t)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aleksamarkovic/semver_t)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aleksamarkovic/semver_t)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aleksamarkovic/semver_t)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aleksamarkovic/semver_t)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aleksamarkovic/semver_t)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aleksamarkovic/semver_t)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aleksamarkovic/semver_t)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aleksamarkovic/semver_t)