### PR TITLE
fix: reorder addcdiv computation to prevent intermediate overflow

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -32,7 +32,7 @@ inline void calculate_addcdiv(
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        sfpi::vFloat result = in0 + (value_float * (in1 * sfpu_reciprocal_iter<2>(in2)));
         if constexpr (!is_fp32_dest_acc_en) {
             result = float32_to_bf16_rne(result);
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -34,7 +34,7 @@ inline void calculate_addcdiv(
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        sfpi::vFloat result = in0 + (value_float * (in1 * sfpu_reciprocal_iter<2>(in2)));
         if constexpr (!is_fp32_dest_acc_en) {
             result = float32_to_bf16_rne(result);
         }


### PR DESCRIPTION
Fixes #54055

## Problem

The SFPU kernel for `ttnn.addcdiv` computed:

```
in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2))
```

Due to C++ left-associativity, this forms `in1 * value` first, which overflows to `+/-inf` when `|in1 * value| > FLT_MAX` — even though the mathematically exact result `in0 + value*(in1/in2)` is finite.

## Root Cause

C++ left-associativity makes the expression:
```
in0 + ((in1 * value_float) * recip(in2))
```

The scaled numerator `in1 * value` is formed **before** the division is applied.

## Fix

Reorder to divide first, then multiply by value:

```
in0 + (value_float * (in1 * sfpu_reciprocal_iter<2>(in2)))
```

This matches `torch.addcdiv` behavior (golden reference), where the intermediate quotient `tensor1/tensor2` is modest.

## Files Changed

- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h`
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h`

Both files had the identical fix applied.
