### PR TITLE
[Feature] Consume the prebuilt tests image in PR Gate sdk examples

### DIFF
--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -19,13 +19,16 @@ name: "Cleanup prebuilt tests images"
 # hours is roughly N divided by the hourly push rate, so N = 4800 buys about a
 # day at ~200/hour.
 #
-# A day is chosen for the RE-RUN window, not for queue time. Measured, the gap
-# between an image being pushed and the last consumer pulling it is 9 min in PR
-# Gate and 28 min in Merge Gate, which ~100 versions would cover. But GitHub
-# allows re-running a job for 30 days and a re-run pulls the same ref, so N sets
-# how far back a leg can be re-run. Too small a value deletes an image out from
-# under a queued or re-run leg, which fails at container startup with no
-# fallback, because container.image is resolved before any step runs.
+# A day is chosen deliberately, and it defines a SUPPORTED RE-RUN WINDOW of
+# about a day. GitHub allows re-running a job for 30 days, but retaining that
+# long would mean ~144,000 versions, so we do not. Re-running an individual leg
+# after roughly a day fails at container startup, because container.image is
+# resolved before any step runs and there is no fallback at that point. Re-run
+# the whole workflow instead: that rebuilds the image and works at any age.
+#
+# A day is far more than the in-run need. Measured, the gap between an image
+# being pushed and the last consumer pulling it is 9 min in PR Gate and 28 min
+# in Merge Gate, which ~100 versions would cover.
 #
 # Recompute N if the push rate changes: wiring more consumers raises it, and
 # building one image per run instead of two would halve it.

--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -11,17 +11,21 @@ name: "Cleanup prebuilt tests images"
 # retention is lower than the number says.
 #
 # The action deletes at most 100 versions per run, which is why the schedule is
-# every 30 minutes rather than daily. PR Gate builds two images per run and
-# Merge Gate four, at roughly 600 runs/day each, so ~3,600 versions/day or
-# ~150/hour against 48 x 100 deletions.
+# every 15 minutes rather than daily. Both gates build four images per run at
+# roughly 600 runs/day each, so ~4,800 versions/day or ~200/hour against
+# 96 x 100 deletions. Every 30 minutes would be exactly break-even.
 #
 # min-versions-to-keep is sized from that RATE, not picked round: retention in
-# hours is roughly N divided by the hourly push rate. An image must outlive the
-# gap between its build and the last consumer pulling it, and a hardware leg can
-# sit queued for hours, so N = 3600 buys about a day at ~150/hour. Too small a
-# value deletes an image out from under a queued leg, which fails at container
-# startup with no fallback, because container.image is resolved before any step
-# runs.
+# hours is roughly N divided by the hourly push rate, so N = 4800 buys about a
+# day at ~200/hour.
+#
+# A day is chosen for the RE-RUN window, not for queue time. Measured, the gap
+# between an image being pushed and the last consumer pulling it is 9 min in PR
+# Gate and 28 min in Merge Gate, which ~100 versions would cover. But GitHub
+# allows re-running a job for 30 days and a re-run pulls the same ref, so N sets
+# how far back a leg can be re-run. Too small a value deletes an image out from
+# under a queued or re-run leg, which fails at container startup with no
+# fallback, because container.image is resolved before any step runs.
 #
 # Recompute N if the push rate changes: wiring more consumers raises it, and
 # building one image per run instead of two would halve it.
@@ -34,14 +38,14 @@ permissions:
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       min-versions-to-keep:
         description: "Newest versions to keep. Set very high for a safe no-op run."
         required: false
         type: string
-        default: "3600"
+        default: "4800"
 
 jobs:
   cleanup:
@@ -56,13 +60,13 @@ jobs:
           owner: tenstorrent
           package-name: tt-metal/prebuilt-tests-image
           package-type: container
-          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '3600' }}
+          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '4800' }}
 
       # A GC that silently falls behind looks exactly like one that is working.
       - name: Report what is left
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KEEP: ${{ inputs.min-versions-to-keep || '3600' }}
+          KEEP: ${{ inputs.min-versions-to-keep || '4800' }}
         run: |
           set -euo pipefail
           COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-image" --jq '.version_count')

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -304,15 +304,40 @@ jobs:
       ttnn-import-artifact-id: ${{ needs.asan-build.outputs.ttnn-import-artifact-id }}
       build-type: 'ASan'
 
-  runtime-examples:
-    needs: [ asan-build, find-changed-files ]
+  build-runtime-examples-image:
+    needs: [ asan-build, build-docker-images, find-changed-files ]
     if: ${{
         github.ref_name == 'main' ||
         needs.find-changed-files.outputs.cmake-changed == 'true' ||
         needs.find-changed-files.outputs.tt-metalium-changed == 'true'
       }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
+      # Canonical ref: the producer is GitHub-hosted and cannot reach Harbor.
+      base-image: ${{ needs.build-docker-images.outputs.basic-dev-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: |
+        PRODUCT=tt-metalium
+        PROFILE=examples
+
+  runtime-examples:
+    needs: [ asan-build, find-changed-files, build-docker-images, build-runtime-examples-image ]
+    # Not !failure(): a failed image build must still let examples use the artifact.
+    if: ${{ !cancelled() && needs.asan-build.result == 'success' && (
+        github.ref_name == 'main' ||
+        needs.find-changed-files.outputs.cmake-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-metalium-changed == 'true')
+      }}
     uses: ./.github/workflows/sdk-examples.yaml
     with:
+      # Empty on forks or a failed build; examples then use the artifact.
+      prebuilt-image: ${{ needs.build-runtime-examples-image.outputs.image }}
       docker-image: ${{ needs.asan-build.outputs.basic-dev-docker-image }}
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-metalium
@@ -321,16 +346,42 @@ jobs:
       per-test-timeout: 15
     secrets: inherit
 
-  ttnn-examples:
-    needs: [ asan-build, find-changed-files ]
+  build-ttnn-examples-image:
+    needs: [ asan-build, build-docker-images, find-changed-files ]
     if: ${{
         github.ref_name == 'main' ||
         needs.find-changed-files.outputs.cmake-changed == 'true' ||
         needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
         needs.find-changed-files.outputs.tt-nn-changed == 'true'
       }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
+      # Canonical ref: the producer is GitHub-hosted and cannot reach Harbor.
+      base-image: ${{ needs.build-docker-images.outputs.basic-dev-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: |
+        PRODUCT=tt-nn
+        PROFILE=examples
+
+  ttnn-examples:
+    needs: [ asan-build, find-changed-files, build-docker-images, build-ttnn-examples-image ]
+    # Not !failure(): a failed image build must still let examples use the artifact.
+    if: ${{ !cancelled() && needs.asan-build.result == 'success' && (
+        github.ref_name == 'main' ||
+        needs.find-changed-files.outputs.cmake-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-nn-changed == 'true')
+      }}
     uses: ./.github/workflows/sdk-examples.yaml
     with:
+      # Empty on forks or a failed build; examples then use the artifact.
+      prebuilt-image: ${{ needs.build-ttnn-examples-image.outputs.image }}
       docker-image: ${{ needs.asan-build.outputs.basic-dev-docker-image }}
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-nn

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -9,6 +9,14 @@ on:
       package-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Image with the packages already installed. When set it replaces
+          docker-image and the download and install steps are skipped. Empty
+          means the artifact path, which is what forks always get.
       enabled-skus:
         required: false
         type: string
@@ -90,7 +98,8 @@ jobs:
     timeout-minutes: ${{ matrix.test-group.timeout }}
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      # A prebuilt image already carries the packages and needs no Harbor prefix.
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       volumes:
         - /work
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -111,12 +120,14 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - uses: ./.github/actions/download-artifact-with-retry
+        if: ${{ inputs.prebuilt-image == '' }}
         timeout-minutes: 15
         with:
           name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
           path: /work/pkgs/
 
       - name: Install packages
+        if: ${{ inputs.prebuilt-image == '' }}
         timeout-minutes: 10
         run: |
           set -euo pipefail

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -61,6 +61,100 @@ jobs:
       dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
       build-args: PRODUCT=tt-metalium
 
+  bake-smoke-ttnn:
+    name: "Bake smoke / tt-nn"
+    needs: build
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
+      base-image: ${{ needs.build.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: |
+        PRODUCT=tt-nn
+        PROFILE=smoke
+
+  bake-examples-runtime:
+    name: "Bake examples / tt-metalium"
+    needs: build
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
+      base-image: ${{ needs.build.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: |
+        PRODUCT=tt-metalium
+        PROFILE=examples
+
+  bake-examples-ttnn:
+    name: "Bake examples / tt-nn"
+    needs: build
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
+      base-image: ${{ needs.build.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: |
+        PRODUCT=tt-nn
+        PROFILE=examples
+
+  # Package selection is the thing most likely to break silently: a wrong set
+  # still builds and publishes. Checking the manifest of every combination costs
+  # no hardware, so only the smoke image needs a real test leg below.
+  verify-payloads:
+    name: "Check every image carries the right packages"
+    needs: [bake, bake-smoke-ttnn, bake-examples-runtime, bake-examples-ttnn]
+    if: ${{ needs.bake.outputs.image != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assert each payload
+        env:
+          SMOKE_METALIUM: ${{ needs.bake.outputs.image }}
+          SMOKE_TTNN: ${{ needs.bake-smoke-ttnn.outputs.image }}
+          EXAMPLES_METALIUM: ${{ needs.bake-examples-runtime.outputs.image }}
+          EXAMPLES_TTNN: ${{ needs.bake-examples-ttnn.outputs.image }}
+        run: |
+          set -euo pipefail
+          check() {
+            local ref="$1"; shift
+            echo "::group::${ref}"
+            local manifest
+            manifest=$(docker run --rm --entrypoint cat "${ref}" /etc/prebuilt-tests-manifest)
+            echo "${manifest}"
+            for pkg in "$@"; do
+              grep -qE "^${pkg} " <<<"${manifest}" \
+                || { echo "::error::${ref} is missing ${pkg}"; exit 1; }
+            done
+            echo "::endgroup::"
+          }
+          check "$SMOKE_METALIUM"    tt-metalium tt-metalium-validation
+          check "$SMOKE_TTNN"        tt-metalium tt-nn tt-nn-validation
+          check "$EXAMPLES_METALIUM" tt-metalium tt-metalium-dev tt-metalium-examples
+          check "$EXAMPLES_TTNN"     tt-metalium tt-metalium-dev tt-nn tt-nn-dev tt-nn-examples
+
   verify:
     name: "Run a test from the image"
     needs: bake

--- a/dockerfile/Dockerfile.prebuilt-tests-packages
+++ b/dockerfile/Dockerfile.prebuilt-tests-packages
@@ -25,7 +25,7 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN --mount=type=bind,source=artifact,target=/tmp/pkgs \
     shopt -s nullglob \
     && case "${PROFILE}:${PRODUCT}" in \
-        smoke:*) \
+        smoke:tt-metalium|smoke:tt-nn) \
             base=( /tmp/pkgs/tt-metalium_*.deb /tmp/pkgs/tt-metalium-jit_*.deb /tmp/pkgs/tt-metalium-validation_*.deb ); \
             product=( "/tmp/pkgs/${PRODUCT}"_*.deb "/tmp/pkgs/${PRODUCT}"-validation_*.deb ); \
             extra=() ;; \

--- a/dockerfile/Dockerfile.prebuilt-tests-packages
+++ b/dockerfile/Dockerfile.prebuilt-tests-packages
@@ -1,42 +1,49 @@
-# Test image, package payload: the build's .deb packages installed into the
-# image a hardware test job already pulls, so the job downloads no artifact and
-# runs no install step. Built by .github/workflows/build-prebuilt-tests-image.yaml, which
-# puts the packages artifact at artifact/ in the build context.
+# Test image: the build's .deb packages installed into the image a hardware test
+# job already pulls, so the job downloads no artifact and runs no install step.
+# Built by .github/workflows/build-prebuilt-tests-image.yaml, which puts the
+# packages artifact at artifact/ in the build context.
 
 # The producer always passes BASE; the default is only so this builds standalone.
 ARG BASE=ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-24.04-ci-test-amd64:latest
 FROM ${BASE}
 
-# Which validation packages to install; mirrors smoke.yaml's `product` input.
+# Which consumer this image is for. smoke.yaml and basic.yaml install the same
+# set; sdk-examples.yaml installs the -dev and -examples packages instead, plus
+# libprotobuf-dev which it otherwise pulls from the network on every leg.
+ARG PROFILE=smoke
+# Which product's packages to add; mirrors the consumers' `product` input.
 ARG PRODUCT=tt-metalium
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
-# Bind-mounted, not COPYed: a COPY layer would carry the whole ~636 MB of debs
-# (and the .ddebs) in the image forever, which is most of the saving.
+# Bind-mounted, not COPYed: a COPY layer would keep the whole deb set in the
+# image forever, which is most of the saving.
 #
-# Same package set smoke.yaml installs, and for the same reason: apt will not
-# resolve dependencies from files on disk unless told about all of them.
-# tt-metalium-jit is absent on use-system-sfpi builds, hence nullglob.
+# tt-metalium-jit is absent on use-system-sfpi builds, hence nullglob. The
+# product-specific set is checked separately, or a misspelled PRODUCT would be
+# satisfied by the tt-metalium packages alone and publish without its payload.
 RUN --mount=type=bind,source=artifact,target=/tmp/pkgs \
     shopt -s nullglob \
-    && pkgs=( \
-        /tmp/pkgs/tt-metalium_*.deb \
-        /tmp/pkgs/tt-metalium-jit_*.deb \
-        /tmp/pkgs/tt-metalium-validation_*.deb \
-        "/tmp/pkgs/${PRODUCT}"_*.deb \
-        "/tmp/pkgs/${PRODUCT}"-validation_*.deb \
-    ) \
-    && if [ "${#pkgs[@]}" -eq 0 ]; then echo "No packages matched in artifact/" >&2; exit 1; fi \
-    && product=( "/tmp/pkgs/${PRODUCT}"_*.deb "/tmp/pkgs/${PRODUCT}"-validation_*.deb ) \
-    && if [ "${#product[@]}" -eq 0 ]; then \
-        echo "No packages matched PRODUCT=${PRODUCT} in artifact/" >&2; \
-        echo "Without this the tt-metalium packages alone satisfy the check above" >&2; \
-        echo "and the image publishes without the payload the caller asked for." >&2; \
-        exit 1; \
-       fi \
+    && case "${PROFILE}:${PRODUCT}" in \
+        smoke:*) \
+            base=( /tmp/pkgs/tt-metalium_*.deb /tmp/pkgs/tt-metalium-jit_*.deb /tmp/pkgs/tt-metalium-validation_*.deb ); \
+            product=( "/tmp/pkgs/${PRODUCT}"_*.deb "/tmp/pkgs/${PRODUCT}"-validation_*.deb ); \
+            extra=() ;; \
+        examples:tt-metalium) \
+            base=( /tmp/pkgs/tt-metalium_*.deb /tmp/pkgs/tt-metalium-jit_*.deb /tmp/pkgs/tt-metalium-dev_*.deb ); \
+            product=( /tmp/pkgs/tt-metalium-examples_*.deb ); \
+            extra=( libprotobuf-dev ) ;; \
+        examples:tt-nn) \
+            base=( /tmp/pkgs/tt-metalium_*.deb /tmp/pkgs/tt-metalium-jit_*.deb /tmp/pkgs/tt-metalium-dev_*.deb ); \
+            product=( /tmp/pkgs/tt-nn_*.deb /tmp/pkgs/tt-nn-dev_*.deb /tmp/pkgs/tt-nn-examples_*.deb ); \
+            extra=( libprotobuf-dev ) ;; \
+        *) echo "Unsupported PROFILE=${PROFILE} PRODUCT=${PRODUCT}" >&2; exit 1 ;; \
+       esac \
+    && if [ "${#base[@]}" -eq 0 ]; then echo "No packages matched in artifact/" >&2; exit 1; fi \
+    && if [ "${#product[@]}" -eq 0 ]; then echo "No packages matched PRODUCT=${PRODUCT} in artifact/" >&2; exit 1; fi \
     && apt-get update \
-    && apt-get install -y "${pkgs[@]}" \
+    && if [ "${#extra[@]}" -gt 0 ]; then DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y -q "${extra[@]}"; fi \
+    && apt-get install -y "${base[@]}" "${product[@]}" \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg-query -W -f='${Package} ${Version}\n' | grep -E '^tt-' \
         > /etc/prebuilt-tests-manifest


### PR DESCRIPTION
### PR Category

Feature

### Summary

PR Gate's sdk-examples legs download the build artifact and install it before they can run anything, then fetch `libprotobuf-dev` from the network on top. This wires them to the prebuilt image from #54412, so none of that is needed.

With this, every consumer of the packages artifact in both gates uses the image. It is also the one that should move time to green rather than only capacity, since `runtime sdk examples` is the longest job in a PR Gate run.

Stacked on #54711 and targeting its branch.

### Notes for reviewers

- `sdk-examples.yaml` installs a different package set from smoke and basic: the `-dev` and `-examples` packages rather than `-validation`, plus `libprotobuf-dev` which it pulls from the network on every leg. That install moves into the image.
- Rather than a second Dockerfile, `Dockerfile.prebuilt-tests-packages` gains a `PROFILE` arg. It defaults to `smoke`, so the four existing bake jobs are unchanged and only the two new ones pass `PROFILE=examples`. Verified against a real build for all four valid combinations plus an unknown profile and an unknown product, which both fail before any install.
- `base-image` comes from `build-docker-images.outputs.basic-dev-tag` rather than `asan-build`. The latter is Harbor-prefixed and the producer runs GitHub-hosted with no Harbor access. Same reason the smoke wiring uses the canonical `ci-test` tag.
- Both consumers gate on `!cancelled() && needs.asan-build.result == 'success'` so a skipped image build on forks, or a failed one, still lets examples run on the artifact path.
- The `Set up ASan environment` step reads `clang-20 -print-resource-dir` inside the container. That comes from the base image and is unaffected by which path supplied the packages, so it behaves the same either way.
- Cleanup moves to every 15 minutes with retention 4800. Both gates now build four images per run, so roughly 4,800 versions a day against a hard limit of 100 deletions per run. Retention is sized for the re-run window rather than queue time: measured, the gap between an image being pushed and the last consumer pulling it is 9 minutes in PR Gate and 28 in Merge Gate, but a job can be re-run for 30 days and a re-run pulls the same ref.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-examples)