### PR TITLE
[skip ci] MINFRA-1683: Remove check for no retrying between 6 and 10 am PT

### DIFF
--- a/.github/workflows/_auto-retry-nightly-workflows.yaml
+++ b/.github/workflows/_auto-retry-nightly-workflows.yaml
@@ -64,7 +64,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MAX_ATTEMPTS=3
-          CURRENT_HOUR=$(date +"%H")
 
           # Fetch workflow run details
           run_details=$(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }} 2>&1)
@@ -92,9 +91,6 @@ jobs:
             should_continue=false
           elif [[ "$conclusion" != "failure" ]]; then
             echo "::notice title=no-continue-did-not-fail::This workflow did not fail. Not re-trying"
-            should_continue=false
-          elif [[ "$CURRENT_HOUR" -lt 6 || "$CURRENT_HOUR" -ge 23 ]]; then
-            echo "::notice title=no-continue-outside-hours::This workflow is outside of the hours of 6am-10pm PT. Not re-trying"
             should_continue=false
           else
             should_continue=true


### PR DESCRIPTION
https://tenstorrent.atlassian.net/browse/MINFRA-1683
### PR Category
Cleanup

### Summary
Nightly workflows are currently prevented from retrying between 6 and 10 am PT. This affects users who need retries during that time. (Package and release being one of them)

### Notes for reviewers
 Removing checks

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dpopov-remove-time-retry-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dpopov-remove-time-retry-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dpopov-remove-time-retry-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dpopov-remove-time-retry-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dpopov-remove-time-retry-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dpopov-remove-time-retry-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dpopov-remove-time-retry-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dpopov-remove-time-retry-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dpopov-remove-time-retry-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dpopov-remove-time-retry-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dpopov-remove-time-retry-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dpopov-remove-time-retry-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dpopov-remove-time-retry-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dpopov-remove-time-retry-check)