### PR TITLE
#54915: right-size the interleaved eltwise worker grid

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -435,31 +435,33 @@ def test_quantization_per_channel_4d(device, x0, x1, x2, x3, input_dtype):
 # kernels used
 @pytest.mark.parametrize("input_dtype", [ttnn.float32, ttnn.bfloat16])
 def test_quantization_per_tensor_program_cache(device, input_dtype):
-    torch.manual_seed(0)
+    def sweep():
+        torch.manual_seed(0)  # identical data both passes; only the cache state differs
+        for dim in [1, 2, 3, 4]:
+            for i in range(5):
+                # Each iteration gets completely different input tensors, quant ranges, etc.
+                input_tr = torch.rand([30 + i] * dim, dtype=torch.float32)
 
-    num_program_cache_entries_list = []
+                scale, zero_point = calculate_scale_zero_point_per_tensor(input_tr, -120 + i, 121 - i)
+                scale_r, zero_point_r = calculate_scale_zero_point_per_tensor(input_tr, -50 - i, 42 + i)
 
-    for dim in [1, 2, 3, 4]:
-        for i in range(5):
-            # Each iteration gets completely different input tensors, quant ranges, etc.
-            input_tr = torch.rand([30 + i] * dim, dtype=torch.float32)
+                input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+                quantized_tt = ttnn.quantize(input_tt, scale, zero_point)
+                requantized_tt = ttnn.requantize(quantized_tt, scale, zero_point, scale_r, zero_point_r)
+                derequantized_tt = ttnn.dequantize(requantized_tt, scale_r, zero_point_r, dtype=input_dtype)
+                result_tr = ttnn.to_torch(derequantized_tt)
 
-            scale, zero_point = calculate_scale_zero_point_per_tensor(input_tr, -120 + i, 121 - i)
-            scale_r, zero_point_r = calculate_scale_zero_point_per_tensor(input_tr, -50 - i, 42 + i)
+                check_pcc(input_tr, result_tr, False)
+                check_match_ratio(input_tr, result_tr, input_dtype)
 
-            input_tt = ttnn.from_torch(input_tr, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-            quantized_tt = ttnn.quantize(input_tt, scale, zero_point)
-            requantized_tt = ttnn.requantize(quantized_tt, scale, zero_point, scale_r, zero_point_r)
-            derequantized_tt = ttnn.dequantize(requantized_tt, scale_r, zero_point_r, dtype=input_dtype)
-            result_tr = ttnn.to_torch(derequantized_tt)
-
-            check_pcc(input_tr, result_tr, False)
-            check_match_ratio(input_tr, result_tr, input_dtype)
-
-            num_program_cache_entries_list.append(device.num_program_cache_entries())
-
-    assert num_program_cache_entries_list[0] > 0
-    assert max(num_program_cache_entries_list) == min(num_program_cache_entries_list)
+    # First pass may create one entry per (op, worker-grid bucket): the interleaved default
+    # grid is right-sized to the tensor volume, so volumes in different buckets get separate
+    # (logarithmically many) entries. A second identical pass must be all cache hits.
+    sweep()
+    entries_after_first = device.num_program_cache_entries()
+    assert entries_after_first > 0
+    sweep()
+    assert device.num_program_cache_entries() == entries_after_first
 
 
 @pytest.mark.parametrize("x0", [32])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -28,6 +28,11 @@ Fields correctly excluded from hash (handled by override_runtime_arguments):
   kernel defines), and on the accessor path the TensorAccessor's page geometry is
   baked into the program. So sharded operands and sharded outputs each contribute
   their tensor shape in pages to the key (issue #54138)
+  Within the interleaved case this now means: shapes whose right-sized worker grid is the
+  same share an entry (the worker grid IS hashed and is sized from the tensor volume:
+  max(ceil(sqrt(tiles)), ceil(tiles/cap)) cores, cap 8 tiles/core for plain binary, 4 with
+  an SFPU activation chain, power-of-two rounded); volumes in different buckets get
+  separate entries
 - scalar.has_value(): not in attribute_values(), but compute_program_hash branches
   on input_tensor_b presence
 - input_dtype: not in attribute_values(), but compute_program_hash includes input
@@ -110,17 +115,18 @@ def test_ng_cache_reuse_same_config(device, isolate_program_cache):
 @pytest.mark.parametrize(
     "shape_first, shape_second",
     [
-        ([1, 1, 32, 64], [1, 1, 128, 256]),  # grow volume
-        ([1, 1, 128, 256], [1, 1, 32, 64]),  # shrink volume
+        ([1, 1, 32, 160], [1, 1, 128, 128]),  # grow volume: 5 tiles -> 16 tiles, same 4-core bucket
+        ([1, 1, 128, 128], [1, 1, 32, 160]),  # shrink volume
     ],
 )
 def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, shape_first, shape_second):
     """binary_ng re-applies all per-dispatch state on a cache hit via override_runtime_arguments
-    (#48928). An in-place add (output_tensor aliases input) with different logical shapes shares one
-    cache entry (volume is excluded from the hash), so the second call is a cache HIT that reuses the
-    first program WITHOUT rebuild. binary_ng's override_runtime_arguments must re-derive every per-core
-    arg for the current shape or the reused program corrupts the result. Regression guard for the
-    in-place cache-hit path (the SDXL silu / moreh class of bug)."""
+    (#48928). An in-place add (output_tensor aliases input) with different logical shapes in the same
+    worker-grid bucket shares one cache entry (volume is excluded from the hash within a bucket), so
+    the second call is a cache HIT that reuses the first program WITHOUT rebuild. binary_ng's
+    override_runtime_arguments must re-derive every per-core arg for the current shape or the reused
+    program corrupts the result. Regression guard for the in-place cache-hit path (the SDXL silu /
+    moreh class of bug)."""
 
     def inplace_add(shape, seed):
         torch.manual_seed(seed)
@@ -441,10 +447,11 @@ def test_ng_different_input_dtypes_same_output_dtype(device, isolate_program_cac
 
 
 def test_ng_cache_reuse_different_logical_shapes(device, isolate_program_cache):
-    """Different logical shapes share 1 cache entry, different outputs (by design).
-    logical_shape is correctly excluded from compute_program_hash();
-    override_runtime_arguments handles shape differences at runtime."""
-    torch_ref1, tt_out1 = run_binary_ng_op(device, ttnn.add, [1, 1, 32, 32], [1, 1, 32, 32], dtype=ttnn.float32)
+    """Logical shapes in the same worker-grid bucket share 1 cache entry, different outputs
+    (by design). logical_shape is correctly excluded from compute_program_hash();
+    override_runtime_arguments handles shape differences at runtime. A volume in a different
+    bucket gets its own right-sized worker grid and therefore its own entry."""
+    torch_ref1, tt_out1 = run_binary_ng_op(device, ttnn.add, [1, 1, 32, 64], [1, 1, 32, 64], dtype=ttnn.float32)
     assert_with_pcc(torch_ref1, tt_out1, 0.9999)
 
     torch_ref2, tt_out2 = run_binary_ng_op(device, ttnn.add, [1, 1, 64, 64], [1, 1, 64, 64], dtype=ttnn.float32)
@@ -453,12 +460,18 @@ def test_ng_cache_reuse_different_logical_shapes(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 1
     assert tt_out1.shape != tt_out2.shape
 
+    # 16 tiles: next bucket (4 cores) -> one new entry
+    torch_ref3, tt_out3 = run_binary_ng_op(device, ttnn.add, [1, 1, 128, 128], [1, 1, 128, 128], dtype=ttnn.float32)
+    assert_with_pcc(torch_ref3, tt_out3, 0.9999)
+
+    assert device.cache_entries_counter.total == 2
+
 
 def test_ng_cache_reuse_different_logical_shapes_correctness(device, isolate_program_cache):
-    """Correctness across multiple logical shapes sharing a single cache entry.
+    """Correctness across multiple logical shapes sharing a single cache entry
+    (6, 9 and 16 tiles all right-size to the same 4-core worker grid).
     override_runtime_arguments correctly updates runtime args for each shape."""
-    for shape_dim in [32, 64, 128]:
-        shape = [1, 1, shape_dim, shape_dim]
+    for shape in [[1, 1, 64, 96], [1, 1, 96, 96], [1, 1, 128, 128]]:
         torch_a = torch.rand(shape, dtype=torch.float32)
         torch_b = torch.rand(shape, dtype=torch.float32)
 
@@ -722,3 +735,20 @@ def test_ng_where_scalar_preallocated_output_dtype(device, isolate_program_cache
 
     ref = torch.where(pred.bool(), t_true.float(), torch.full(shape, scalar_false))
     assert_with_pcc(ref, ttnn.to_torch(res).float(), 0.999)
+
+
+def test_ng_cache_worker_grid_buckets(device, isolate_program_cache):
+    """Bucket boundaries of the right-sized interleaved worker grid: tile counts mapping to the
+    same bucket share one entry, crossing a boundary adds exactly one. Also guards worker_grid
+    being part of the attribute hash — without it, differently-sized grids would collide on one
+    entry and reuse a program whose kernels live on the wrong cores."""
+    for shape, expected_total in [
+        ([1, 1, 32, 32], 1),  # 1 tile -> 1-core bucket
+        ([1, 1, 32, 64], 2),  # 2 tiles -> 2-core bucket
+        ([1, 1, 64, 64], 2),  # 4 tiles -> same 2-core bucket (hit)
+        ([1, 1, 32, 160], 3),  # 5 tiles -> 4-core bucket
+        ([1, 1, 128, 128], 3),  # 16 tiles -> same 4-core bucket (hit)
+    ]:
+        torch_ref, tt_out = run_binary_ng_op(device, ttnn.add, shape, shape, dtype=ttnn.float32)
+        assert_with_pcc(torch_ref, tt_out, 0.9999)
+        assert device.cache_entries_counter.total == expected_total, f"after {shape}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
@@ -29,6 +29,13 @@ cache entry and override_runtime_arguments re-applies the new shape's work split
 on the hit. Because addresses are re-derived from the actual current tensors
 (never inferred from Buffer* identity), in-place (out=x) and mixed in-place/
 out-of-place reuse of one cache entry stay correct by construction.
+
+The interleaved default worker grid is right-sized to the tensor volume
+(right_size_worker_grid: max(ceil(sqrt(tiles)), ceil(tiles/cap)) cores, cap 4
+tiles/core for unary SFPU work, rounded up to a power of two, full grid once
+that reaches it). The worker grid is hashed, so volume-sharing of one cache
+entry holds WITHIN a bucket; volumes in different buckets get separate entries
+(logarithmically many).
 """
 
 import pytest
@@ -94,19 +101,27 @@ def test_unary_cache_reuse_same_volume_different_shapes(device):
 
 
 def test_unary_cache_reuse_different_volumes(device):
-    """TILE layout: different volumes -> still 1 cache entry.
-    unary uses runtime tile counts (not compile-time), so different volumes
-    share the same compiled program. override_runtime_arguments handles the
-    different per-core tile distributions on cache hit."""
+    """TILE layout: different volumes in the same worker-grid bucket -> 1 cache entry.
+    unary uses runtime tile counts (not compile-time), so volumes whose right-sized
+    worker grid is the same share one compiled program; override_runtime_arguments
+    re-applies the per-core tile distribution on every hit. A volume in a different
+    bucket gets its own right-sized grid and therefore its own entry."""
     device.cache_entries_counter.reset()
 
-    torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, [1, 1, 32, 32], dtype=ttnn.float32)
+    # 2 tiles and 4 tiles: same right-sized grid (2 cores)
+    torch_ref1, tt_out1 = run_unary_op(device, ttnn.relu, [1, 1, 32, 64], dtype=ttnn.float32)
     assert_equal(torch_ref1, tt_out1)
 
     torch_ref2, tt_out2 = run_unary_op(device, ttnn.relu, [1, 1, 64, 64], dtype=ttnn.float32)
     assert_equal(torch_ref2, tt_out2)
 
     assert device.cache_entries_counter.total == 1
+
+    # 16 tiles: next bucket (4 cores) -> one new entry
+    torch_ref3, tt_out3 = run_unary_op(device, ttnn.relu, [1, 1, 128, 128], dtype=ttnn.float32)
+    assert_equal(torch_ref3, tt_out3)
+
+    assert device.cache_entries_counter.total == 2
 
 
 # =============================================================================
@@ -355,16 +370,17 @@ def test_unary_sharded_mixed_inplace_outofplace(device, first_inplace):
 @pytest.mark.parametrize(
     "shape_first, shape_second",
     [
-        ([1, 1, 32, 64], [1, 1, 128, 256]),  # grow volume
-        ([1, 1, 128, 256], [1, 1, 32, 64]),  # shrink volume
+        ([1, 1, 32, 160], [1, 1, 128, 128]),  # grow volume: 5 tiles -> 16 tiles, same 4-core bucket
+        ([1, 1, 128, 128], [1, 1, 32, 160]),  # shrink volume
     ],
 )
 def test_unary_inplace_cache_reuse_different_shapes(device, shape_first, shape_second):
     """MIGRATION GUARD (override_runtime_arguments): interleaved TILE in-place relu (output_tensor
-    aliases the input) reused across DIFFERENT logical shapes sharing ONE cache entry (TILE layout
-    excludes volume from compute_program_hash). The second call is a cache HIT that reuses the first
-    program WITHOUT rebuild; override_runtime_arguments must re-derive every per-core work-split arg
-    (per-core tile counts, start_tile_id, and the work-core set itself) for the new shape, or the
+    aliases the input) reused across DIFFERENT logical shapes sharing ONE cache entry (both volumes
+    right-size to the same worker grid, and within a bucket TILE layout excludes volume from
+    compute_program_hash). The second call is a cache HIT that reuses the first program WITHOUT
+    rebuild; override_runtime_arguments must re-derive every per-core work-split arg (per-core tile
+    counts, start_tile_id, and the uneven group-1/group-2 partition) for the new shape, or the
     reused program corrupts the result. Interleaved analog of the SDXL in-place silu class of bug."""
     device.cache_entries_counter.reset()
 
@@ -440,3 +456,21 @@ def test_unary_inplace_cache_hit_interleaved_readdresses(device):
 
     # One shared program reused across all four differently-addressed in-place hits.
     assert device.cache_entries_counter.total == 1
+
+
+def test_unary_cache_worker_grid_buckets(device):
+    """Bucket boundaries of the right-sized interleaved worker grid: tile counts mapping to the
+    same bucket share one entry, crossing a boundary adds exactly one. Buckets are grid-size
+    independent at these volumes (1 tile -> 1 core, 2-4 tiles -> 2, 5-16 tiles -> 4)."""
+    device.cache_entries_counter.reset()
+
+    for shape, expected_total in [
+        ([1, 1, 32, 32], 1),  # 1 tile -> 1-core bucket
+        ([1, 1, 32, 64], 2),  # 2 tiles -> 2-core bucket
+        ([1, 1, 64, 64], 2),  # 4 tiles -> same 2-core bucket (hit)
+        ([1, 1, 32, 160], 3),  # 5 tiles -> 4-core bucket
+        ([1, 1, 128, 128], 3),  # 16 tiles -> same 4-core bucket (hit)
+    ]:
+        torch_ref, tt_out = run_unary_op(device, ttnn.relu, shape, dtype=ttnn.float32)
+        assert_equal(torch_ref, tt_out)
+        assert device.cache_entries_counter.total == expected_total, f"after {shape}"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.hpp"
 #include "ttnn/operations/eltwise/binary/common/binary_op_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_utils.hpp"
 #include "binary_ng_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <cmath>
@@ -144,12 +145,46 @@ CoreRangeSet get_worker_grid(
     const std::optional<Tensor>& output_tensor,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const MemoryConfig& memory_config_actual) {
+    const MemoryConfig& memory_config_actual,
+    uint32_t max_tiles_per_core) {
     // If sub_core_grids is provided, use it directly
     if (sub_core_grids.has_value()) {
         log_debug(tt::LogOp, "Using provided sub_core_grids for worker grid {}", sub_core_grids->str());
         return sub_core_grids.value();
     }
+
+    // Fully interleaved calls may run on a work-sized sub-grid; any sharded tensor pins the
+    // worker grid to the full sub-device worker set the shard grid lives in.
+    const bool all_interleaved = !input_tensor_a.is_sharded() &&
+                                 !(input_tensor_b != nullptr && input_tensor_b->is_sharded()) &&
+                                 !memory_config_actual.is_sharded() &&
+                                 !(output_tensor.has_value() && output_tensor->is_sharded());
+    auto interleaved_grid = [&](const CoreRangeSet& full_grid) -> CoreRangeSet {
+        if (!all_interleaved) {
+            return full_grid;
+        }
+        const auto tile_hw = input_tensor_a.tensor_spec().tile().get_tile_hw();
+        uint64_t volume = 1;
+        if (output_tensor.has_value()) {
+            volume = output_tensor->physical_volume();
+        } else if (input_tensor_b != nullptr) {
+            // Padded broadcast volume: per-dim max, right-aligned. Padding is monotone, so the
+            // max of the padded dims equals the padded output dim for broadcast-compatible
+            // inputs; sizing only needs the approximation.
+            const auto& pa = input_tensor_a.padded_shape();
+            const auto& pb = input_tensor_b->padded_shape();
+            const int rank = std::max<int>(pa.rank(), pb.rank());
+            for (int i = -1; i >= -rank; --i) {
+                const uint64_t da = (-i <= static_cast<int>(pa.rank())) ? pa[i] : 1;
+                const uint64_t db = (-i <= static_cast<int>(pb.rank())) ? pb[i] : 1;
+                volume *= std::max(da, db);
+            }
+        } else {
+            volume = input_tensor_a.physical_volume();
+        }
+        const uint64_t num_tiles = (volume + tile_hw - 1) / tile_hw;
+        return unary::right_size_worker_grid(full_grid, num_tiles, max_tiles_per_core);
+    };
 
     auto get_tensor_grid = [](const Tensor& tensor) -> CoreRangeSet {
         const auto& grid = tensor.shard_spec()->grid;
@@ -195,7 +230,8 @@ CoreRangeSet get_worker_grid(
         log_debug(
             tt::LogOp, "Using all worker cores of the device for worker grid, output or memory config not sharded");
         auto* device = input_tensor_a.device();
-        return device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+        return interleaved_grid(
+            device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front()));
     }
 
     if (is_native_L1_sharding(
@@ -220,7 +256,8 @@ CoreRangeSet get_worker_grid(
     // use all worker cores of the device
     log_debug(tt::LogOp, "Using all worker cores of the device for worker grid");
     auto* device = input_tensor_a.device();
-    return device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+    return interleaved_grid(
+        device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front()));
 }
 
 SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint32_t b_h, uint32_t b_w) {
@@ -712,7 +749,15 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
                                           // dtype depending on which LLK is meant to be used.
         output_dtype,
         ttnn::operations::binary_ng::get_worker_grid(
-            input_tensor_a, &input_tensor_b, output_tensor, memory_config, resolved_sub_core_grids, mem_config_actual),
+            input_tensor_a,
+            &input_tensor_b,
+            output_tensor,
+            memory_config,
+            resolved_sub_core_grids,
+            mem_config_actual,
+            // Plain FPU binary work takes 8 tiles/core; an SFPU activation chain gets the
+            // measured heavy-op cap of 4 (see right_size_worker_grid).
+            (lhs_activations.empty() && rhs_activations.empty() && post_activations.empty()) ? 8 : 4),
         std::nullopt,
         resolved_sub_core_grids,
         sub_device_id,
@@ -809,7 +854,13 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         input_tensor_a.dtype(),
         output_dtype,
         ttnn::operations::binary_ng::get_worker_grid(
-            input_tensor_a, nullptr, output_tensor, memory_config, resolved_sub_core_grids, mem_config_actual),
+            input_tensor_a,
+            nullptr,
+            output_tensor,
+            memory_config,
+            resolved_sub_core_grids,
+            mem_config_actual,
+            (lhs_activations.empty() && rhs_activations.empty() && post_activations.empty()) ? 8 : 4),
         std::nullopt,
         resolved_sub_core_grids,
         sub_device_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.cpp
@@ -5,6 +5,10 @@
 #include "ttnn/operations/eltwise/unary/common/unary_utils.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
+#include <tt-metalium/work_split.hpp>
+
+#include <bit>
+#include <cmath>
 #include <mutex>
 
 namespace ttnn::operations::unary {
@@ -128,6 +132,39 @@ tt::tt_metal::ShardSpec adjust_to_shape(
     return ret;
 }
 
+CoreRangeSet right_size_worker_grid(const CoreRangeSet& full_grid, uint64_t num_tiles, uint32_t max_tiles_per_core) {
+    const uint32_t full_cores = full_grid.num_cores();
+    if (full_cores <= 1 || num_tiles == 0 || max_tiles_per_core == 0) {
+        return full_grid;
+    }
+    const auto sqrt_cores = static_cast<uint64_t>(std::ceil(std::sqrt(static_cast<double>(num_tiles))));
+    const uint64_t target =
+        std::bit_ceil(std::max<uint64_t>(sqrt_cores, (num_tiles + max_tiles_per_core - 1) / max_tiles_per_core));
+    if (target >= full_cores) {
+        return full_grid;
+    }
+    const auto& ranges = full_grid.ranges();
+    if (ranges.size() == 1) {
+        const CoreRange& cr = *ranges.begin();
+        const uint32_t grid_w = cr.end_coord.x - cr.start_coord.x + 1;
+        uint32_t w = target;
+        uint32_t h = 1;
+        if (target > grid_w) {
+            h = (target + grid_w - 1) / grid_w;
+            w = (target + h - 1) / h;
+        }
+        if (w * h >= full_cores) {
+            return full_grid;
+        }
+        return CoreRangeSet(
+            CoreRange(cr.start_coord, CoreCoord(cr.start_coord.x + w - 1, cr.start_coord.y + h - 1)));
+    }
+    // Non-rectangular worker set (custom sub-device configurations): first `target` cores in
+    // row-major order.
+    return tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+        ranges.begin()->start_coord, target, full_grid, /*row_wise=*/true);
+}
+
 CoreRangeSet get_worker_grid(
     const Tensor& input_tensor,
     const std::optional<Tensor>& output_tensor,
@@ -138,6 +175,21 @@ CoreRangeSet get_worker_grid(
         log_debug(tt::LogOp, "Unary: Using provided sub_core_grids for worker grid {}", sub_core_grids->str());
         return sub_core_grids.value();
     }
+
+    // Fully interleaved calls may run on a work-sized sub-grid; any sharded tensor pins the
+    // worker grid to the full sub-device worker set the shard grid lives in.
+    const bool all_interleaved = !input_tensor.is_sharded() && !memory_config_actual.is_sharded() &&
+                                 !(output_tensor.has_value() && output_tensor->is_sharded());
+    auto interleaved_grid = [&](const CoreRangeSet& full_grid) -> CoreRangeSet {
+        if (!all_interleaved) {
+            return full_grid;
+        }
+        const auto tile_hw = input_tensor.tensor_spec().tile().get_tile_hw();
+        const uint64_t num_tiles = (input_tensor.physical_volume() + tile_hw - 1) / tile_hw;
+        // Unary work is an SFPU chain: cap at 4 tiles/core (measured bound below which the
+        // heaviest SFPU unaries never lose to the full grid on either architecture).
+        return right_size_worker_grid(full_grid, num_tiles, 4);
+    };
 
     auto get_tensor_grid = [](const Tensor& tensor) -> CoreRangeSet {
         const auto& grid = tensor.shard_spec()->grid;
@@ -174,8 +226,8 @@ CoreRangeSet get_worker_grid(
     if (output_tensor.has_value() || memory_config.has_value()) {
         log_debug(tt::LogOp, "Unary: Using all worker cores (output or memory config not sharded)");
         auto* device = input_tensor.device();
-        return device->worker_cores(
-            tt::tt_metal::HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+        return interleaved_grid(device->worker_cores(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front()));
     }
 
     if (input_tensor.is_sharded() && is_native_L1_sharding(input_tensor.tensor_spec(), memory_config_actual)) {
@@ -186,7 +238,8 @@ CoreRangeSet get_worker_grid(
 
     log_debug(tt::LogOp, "Unary: Using all worker cores of the device");
     auto* device = input_tensor.device();
-    return device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+    return interleaved_grid(
+        device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front()));
 }
 
 tt::tt_metal::ShardSpec generate_shard_spec_all_cores(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.hpp
@@ -34,6 +34,23 @@ CoreRangeSet get_worker_grid(
     const std::optional<CoreRangeSet>& sub_core_grids,
     const tt::tt_metal::MemoryConfig& memory_config_actual);
 
+/** Right-size an interleaved eltwise worker grid to the work size.
+ *
+ * The per-call cost of an interleaved eltwise program scales with the grid its kernels are
+ * created on, not with the active work: every core of the worker grid gets kernels, and every
+ * program-cache hit rewrites every core's runtime args. At a handful of tiles per core that
+ * overhead dominates the op. This returns a contiguous sub-grid of `full_grid` sized
+ * max(ceil(sqrt(num_tiles)), ceil(num_tiles/max_tiles_per_core)) — the measured optimum for
+ * light eltwise ops (sqrt) with the per-core work capped so compute-heavy SFPU ops do not
+ * regress (4 tiles/core for SFPU-chain work, 8 for plain binary FPU work) — rounded up to a
+ * power of two so the number of distinct grids (each one is a separate program-cache entry,
+ * since the worker grid is hashed) stays logarithmic. Returns `full_grid` unchanged once the
+ * target reaches the full grid, so large-tensor calls keep today's grid and cache entry.
+ * Shared by the unary and binary_ng interleaved default paths.
+ */
+CoreRangeSet right_size_worker_grid(
+    const CoreRangeSet& full_grid, uint64_t num_tiles, uint32_t max_tiles_per_core);
+
 tt::tt_metal::ShardSpec adjust_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
 


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Fixes #54915.

For interleaved tensors, the unary and binary_ng factories create kernels on the **entire worker grid** and every program-cache hit rewrites runtime args for every core of that grid, so the per-call cost scales with the grid, not the workload — flat ~24 µs on P300's 110-core grid and ~48 µs (binary) on N300's 64-core grid from 1 tile to 1024. #54915 measured that a right-sized `sub_core_grids` is faster below ~256 tiles, bit-identically — 2.0-3.5x for binary and 1.0-1.9x for unary on current `main`.

This makes that the default. `get_worker_grid` (unary and binary_ng) now sizes the interleaved default grid as `max(ceil(sqrt(tiles)), ceil(tiles/cap))` cores — the sqrt term is the measured optimum for light ops; the per-core cap is the measured bound below which no swept op loses to the full grid on either architecture (**4 tiles/core** for SFPU-chain work: unary, and binary with activations; **8** for plain FPU binary) — rounded up to a power of two, and snapped to the full grid once the target reaches it (large tensors keep today's grid and cache entry). The grid is a contiguous rectangle from the worker-grid origin; non-rectangular sub-device worker sets take the first N cores row-major.

The program cache forks per bucket instead of per volume. No hashing change is needed: both factories already key on the worker grid — unary in its `to_hash`, and binary_ng in its attribute tuple, which gained `worker_grid` upstream while this branch was in flight (an earlier revision of this branch added it, and that part of the diff is now gone). Distinct buckets are logarithmic in the grid (≤8 per op config on P300), and volumes within a bucket share one entry exactly as before — `override_runtime_arguments` re-splits on every hit unchanged. Explicit `sub_core_grids` and every sharded path are untouched.

## Cost

Batched sync-bounded protocol (5 warm-ups, 5 runs × 50 calls, one `synchronize_device` per run, median; re-measure once if run spread >10%), shape `[1,1,32,32·T]` TILE DRAM interleaved. Base is the same tree at `7db779f57c2` with the three source files reverted.

### In-tree A/B on current `main` (7db779f57c2), P300

Rebased onto `main` and measured as an in-tree A/B of the default call path: base is the same tree with the three source files reverted. The branch's original tables were taken at `b2e77906b92`, and `unary_program_factory.cpp` has since had a large refactor that roughly **halved the unary default** (~24 µs -> ~12.2 µs), so the unary win is much smaller than it was; the binary default is unchanged at ~24-25 µs. Median µs/call, 5x50 calls:

| tiles | add | multiply | exp | silu |
|---|---|---|---|---|
| 1 | 24.12 -> 7.35 (**3.28x**) | 23.88 -> 7.33 (**3.26x**) | 11.79 -> 6.14 (1.92x) | 11.78 -> 6.07 (1.94x) |
| 16 | 23.70 -> 7.55 (**3.14x**) | 23.31 -> 7.78 (**3.00x**) | 12.01 -> 6.26 (1.92x) | 12.05 -> 6.30 (1.91x) |
| 64 | 23.94 -> 8.23 (**2.91x**) | 24.07 -> 8.15 (**2.95x**) | 11.85 -> 6.90 (1.72x) | 11.85 -> 7.04 (1.68x) |
| 80 | 23.96 -> 9.38 (**2.55x**) | 23.69 -> 9.30 (**2.55x**) | 11.82 -> 7.92 (1.49x) | 11.90 -> 7.91 (1.50x) |
| 142 | 24.37 -> 12.06 (**2.02x**) | 24.68 -> 12.27 (**2.01x**) | 12.32 -> 9.74 (1.26x) | 12.50 -> 9.85 (1.27x) |
| 160 | 24.73 -> 12.41 (1.99x) | 24.70 -> 12.49 (1.98x) | 12.19 -> 9.87 (1.24x) | 12.33 -> 9.87 (1.25x) |
| 256 | 24.85 -> 12.51 (1.99x) | 24.52 -> 12.55 (1.95x) | 12.21 -> 9.78 (1.25x) | 12.31 -> 9.92 (1.24x) |
| 1024 | 25.11 -> 24.70 (1.02x) | 24.97 -> 25.01 (1.00x) | 12.25 -> 12.14 (1.01x) | 12.47 -> 12.29 (1.01x) |

80, 142 and 160 tiles are the shapes real decode paths use: mamba's residual stream and `d_inner`, and falcon7b's hidden state. At 1024 tiles the policy is the full grid, so the program is identical to base and the +-2% is run-to-run spread.

### N300, same commit

The worker grid is 64 cores rather than 110, so the default wastes less and the win is smaller. Stock build of the same commit driven through `sub_core_grids`, which builds the identical program:

| op class | 1 t | 16 t | 64 t | 256 t | 1024 t |
|---|---|---|---|---|---|
| binary, tensor operand (10 ops) | 1.69-1.81x | 1.64-1.72x | 1.61-1.71x | 1.29-1.36x | 0.98-1.01x |
| binary, scalar operand | 1.88-1.94x | 1.81-1.84x | 1.71-1.75x | 1.33-1.35x | — |
| unary (`exp` `gelu` `i0` `erfinv`) | 1.25-1.29x | 1.16-1.26x | 1.17-1.20x | 0.97-0.98x | 1.00x |

At the decode shapes: mamba 80 t 1.57x / 1.56x / 1.08x (add / mul / silu), falcon7b 142 t 1.25x / 1.26x / 0.98x, mamba 160 t 1.38x / 1.27x / 0.97x.

### Ternary must not take this treatment

`ttnn.where` on three tensors goes through `ternary_device_operation.cpp:17`, a different `get_worker_grid` that this change does not touch. That is deliberate: forcing the same policy onto it through `sub_core_grids` helps below 16 tiles and then collapses.

| tiles | 1 | 16 | 64 | 128 | 256 | 512 |
|---|---|---|---|---|---|---|
| ternary under this policy | 1.19x | 1.16x | **0.70x** | **0.71x** | **0.64x** | **0.52x** |

Its default is already flat at ~8 µs against ~24 µs for a plain binary, so the ternary factory is doing something better already. An earlier revision of this PR proposed extending the remedy there as a follow-up; that was wrong.

### L1 occupancy

The kernel binaries are written per core into the `kernel_config` region, so the grid decides the L1 footprint of a call. Loadable text+data for `ttnn.add` (bf16, interleaved), read from the JIT build output with `riscv-tt-elf-size`:

| | bytes |
|---|---|
| compute TRISC0 / TRISC1 / TRISC2 | 1,592 / 1,156 / 2,716 |
| dataflow reader / writer | 756 / 1,016 |
| **per core** | **7,236** |

| shape | full grid (110 cores) | right-sized | saved |
|---|---|---|---|
| 1 tile | 777.3 KB | 7.1 KB (1 core) | **770.2 KB (99%)** |
| 16 tiles | 777.3 KB | 28.3 KB (4 cores) | **749.0 KB (96%)** |
| 64 tiles | 777.3 KB | 56.5 KB (8 cores) | **720.8 KB (93%)** |
| 256 tiles | 777.3 KB | 113.1 KB (16 cores) | **664.2 KB (85%)** |

`add` is the small end: heavier SFPU ops have larger compute kernels. Program-cache entries hold no L1 of their own — `kernel_config` is a fixed per-core-type ring buffer (`dispatch.cpp:2617-2634`) and `reserve_space_in_kernel_config_buffer` takes from it at dispatch time — so bucketing does not multiply the footprint; only the number of cores written to changes.

### What the bucketing costs

Measured on a stock build by varying `sub_core_grids`, which forks the cache exactly as the `worker_grid` bucketing does. 8 distinct grids produce **8 cache entries and no more**; first call per bucket is **0.17–0.41 ms**; a warm cycle over all 8 runs at 12.44 µs/call with the entry count unchanged.

Cycling between buckets costs nothing measurable:

| | µs/call | spread |
|---|---|---|
| 16t on 4 cores, repeated | 7.23 | 4.8% |
| 1024t on 110 cores, repeated | 24.61 | 1.7% |
| **alternating the two** | **16.16** | 0.6% |
| expected if switching were free | 15.92 | |
| **-> overhead** | **+1.5%** | |
| control: 4-core grid alternating with *itself* | 7.15 | 2.1% |
| alternating 4-core and 8-core grids | 7.50 | 6.0% |
| **-> overhead, tight pair** | **+1.1%** | |

The control fixes the noise floor at about 1%, so +1.1–1.5% is at or just above it — against a 2.0-2.55x steady-state win at real decode shapes.

## Correctness

**Bit-identity on current `main`, with the fix as the default**: right-sized default vs an explicit full grid, seeded inputs, `add` / `multiply` / `subtract` / `exp` / `silu` / `gelu` at 1, 5, 16, 64, 80, 100, 142, 160, 256 and 512 tiles — **60 of 60 cells bit-identical**.

**No op regresses.** Right-sized default vs an explicit full grid on the same build, for the ops a restricted grid could plausibly hurt: `i0` / `gelu` / `erfinv` are 0.59-1.00x from 64 to 1024 tiles (faster or equal everywhere, no cell above 1.05x), and `where` — which this change does not touch — is 0.97-1.00x from 142 to 1024 tiles.

- **Exhaustive bf16**: all 65,536 bit patterns through `exp`, `gelu`, `relu`, `add`, `mul` at 64-tile and 32-tile shapes (multi-core policy grids), bf16 and fp32 inputs — 30 cells, every output **bit-identical** to the base build's full-grid results.
- The policy sweep bit-compared every measured cell against the default grid on both machines (508 restricted cells, 0 mismatches).
- **Within-bucket cache hits**: one grid shared across volumes 65–128 (uneven splits, active↔noop flips on an RM case, in-place variants) — correct on every hit, one cache entry per grid (probe on base via `sub_core_grids` = the identical path, re-run on this build).

## Tests

- Suites re-run on this build: the three files this PR migrates **9025 passed, 1 xfailed**; `test_binary_bcast.py` **3848 passed** (broadcast paths through the resized grids); `test_unary_subcoregrids.py` and `test_backward_gelu.py` **46 passed** (the latter's cache asserts are unchanged — fixed shape).
- `test_unary_program_cache.py` and `test_binary_ng_program_cache.py` updated where they pinned the old one-entry-per-volume contract: the migration guards keep their intent with same-bucket volume pairs (5→16 tiles on one 4-core grid, uneven group-1/group-2 splits), and new bucket-boundary tests pin the new contract — the binary one also pins the worker_grid hash as a regression guard (without it, differently-sized grids would collide on one entry); both new tests fail on base as intended, confirmed by running the same files against a build of this tree with the change reverted, where the bucket-boundary assert fails `1 == 2`. `test_quantization.py`'s per-tensor cache test asserted entry-count equality across differently-sized iterations; it now asserts the surviving invariant — a second identical pass is all cache hits (seeded per pass).
- Cache accounting: an 11-size sweep (1–1024 tiles) creates 8 entries per op (was 1); each new bucket pays one program creation on first call (<0.5 ms warm-process), JIT binaries are shared across buckets (same kernels, same defines).

## Not covered

- N300 in-tree A/B not run (no writable build there); the N300 column is the stock build driven through `sub_core_grids`, which constructs byte-identical programs to this change's default (same `worker_grid` attribute, same factory path). The measured policy cells and bit-identity above cover it.
- Sharded paths and non-eltwise families: untouched, unmeasured (issue scope).
- **Ternary is out of scope and must stay so.** See the table above: the same policy costs 0.52-0.71x on `where` from 64 tiles up. `where_ttt` has its own `get_worker_grid` and this change does not touch it.
- **The per-core cap is wrong for heavy SFPU binaries.** `logaddexp` falls to 1.29x at 64-256 tiles under the binary cap of 8; it belongs on the SFPU cap of 4 or its own.
- Workloads asserting exact eltwise cache-entry counts outside these two test files would see counts change (bounded by the bucket count).

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `7db779f57c2` (current `main`) on both machines — P300 as an in-tree A/B of this branch against the same tree with the change reverted, N300 as a stock build of the same commit driven through `sub_core_grids`, which constructs the identical program. The branch was rebased onto `main` for this: `unary_program_factory.cpp` had a large refactor that halved the unary default, and `binary_ng_device_operation.cpp` drifted +119/-6.
* Hardware: N300 and P300