### PR TITLE
[LLK] Fix LLK_ASSERT expansion in SDPA math wrapper

### DIFF
--- a/tt_metal/hw/inc/api/compute/experimental/sdpa.h
+++ b/tt_metal/hw/inc/api/compute/experimental/sdpa.h
@@ -383,9 +383,9 @@ void compute_sdpa_chunk(
     // OV-trim (ov_kt_dim < chunk_size on the masked last chunk) keeps the exp->OV SFPU_FPU handshake
     // balanced ONLY when the whole chunk is a single signal group
     // TODO: support finer granularity via an aggregate end-of-remainder drain if needed.
-    MATH((LLK_ASSERT(
+    MATH(LLK_ASSERT(
         ov_kt_dim == chunk_size || exp_signal_granularity == chunk_size,
-        "OV-trim (ov_kt_dim != chunk_size) requires exp_signal_granularity == chunk_size")));
+        "OV-trim (ov_kt_dim != chunk_size) requires exp_signal_granularity == chunk_size"));
     sdpa_custom_mm_reuse_dest_srcb_block_init_short(cb_q, ov_cb, cb_out, transpose_v, chunk_size, num_tiles_v);
     sdpa_custom_mm_reuse_dest_srcb_block<output_granularity, exp_signal_granularity>(
         cb_q,


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Remove the redundant expression parentheses around the statement-style `LLK_ASSERT` in the experimental SDPA compute API. With LLK asserts enabled, the old form expanded to an invalid parenthesized `do { ... } while (0)` statement and prevented the flash MLA and SDPA kernels from compiling. The assertion remains scoped to the math TRISC through `MATH`.

Fixes #54817

### Notes for reviewers

The change is limited to the `LLK_ASSERT` call site; `LLK_ASSERT` and `MATH` themselves are unchanged.

Verification:

- `pre-commit run --files tt_metal/hw/inc/api/compute/experimental/sdpa.h` passed.
- The previously failing [Ubuntu 24.04 Blackhole DeepSeek slow-dispatch job](https://github.com/tenstorrent/tt-metal/actions/runs/33390185992/job/99487454040) passed with 955 tests, 0 failures, and 0 errors. All 28 flash MLA, 3 SDPA, and 8 SDPA-tail cases that previously failed ran without failures or skips.