### PR TITLE
fix(sfpu): addcdiv — apply reciprocal before scaling by value (fixes #54055)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -489,3 +489,61 @@ def test_ternary_addcmul_cache_hit_refreshes_operand_addresses(device):
     assert_with_pcc(reference(2), ttnn.to_torch(out1).float(), 0.99)
 
     device.disable_and_clear_program_cache()
+
+
+@pytest.mark.parametrize(
+    ("in0_val", "in1_val", "in2_val", "value", "expected"),
+    [
+        # #54055 overflow cases: |in1 * value| > FLT_MAX, yet in0 + value * (in1 / in2) is finite.
+        # The kernel used to form in1 * value first -> +/-inf; dividing first keeps it finite.
+        (0.0, 3.0e38, 8.0, 4.0, 1.5e38),
+        (0.0, 3.0e38, 16.0, 10.0, 1.875e38),
+        (1.0, 2.0e38, 4.0, 3.0, 1.5e38),
+        (0.0, 1.0e38, 100.0, 50.0, 5.0e37),
+        (-2.0, 3.0e38, 8.0, 4.0, 1.5e38),
+        # ordinary-magnitude controls: must keep their exact values after the reorder
+        (5.0, 1.0, 2.0, 4.0, 7.0),
+        (0.0, 6.0, 3.0, 7.0, 14.0),
+    ],
+)
+def test_addcdiv_divides_before_scaling(device, in0_val, in1_val, in2_val, value, expected):
+    """Regression guard: addcdiv must apply 1/in2 before scaling by value (#54055).
+
+    The SFPU kernel previously computed `in0 + (in1 * value_float * recip(in2))` left-associatively:
+    `in1 * value_float` is rounded in the destination register *before* the reciprocal participates,
+    so for |in1 * value| > FLT_MAX the intermediate overflows to +/-inf and poisons the lane -- even
+    when the exact result `in0 + value * (in1 / in2)` is an ordinary finite number, contradicting
+    torch.addcdiv's documented formula `input + value * (tensor1 / tensor2)`. Applying the reciprocal
+    before the scalar keeps these cases finite; inputs whose exact result truly overflows still
+    return inf.
+    """
+    shape = (1, 1, 32, 32)
+    in0 = ttnn.from_torch(
+        torch.full(shape, in0_val, dtype=torch.float32),
+        device=device,
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    in1 = ttnn.from_torch(
+        torch.full(shape, in1_val, dtype=torch.float32),
+        device=device,
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    in2 = ttnn.from_torch(
+        torch.full(shape, in2_val, dtype=torch.float32),
+        device=device,
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    out = ttnn.to_torch(ttnn.addcdiv(in0, in1, in2, value=value))
+    expected_t = torch.full(shape, expected, dtype=torch.float32)
+
+    assert torch.isfinite(out).all(), (
+        f"addcdiv returned a non-finite value (expected {expected}); "
+        f"got {out.flat[0].item()} -- in1 * value overflowed before the divide was applied"
+    )
+    assert torch.allclose(out, expected_t, rtol=1e-3), (
+        f"addcdiv mismatch: got {out.flat[0].item()}, expected {expected}"
+    )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -32,7 +32,11 @@ inline void calculate_addcdiv(
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        // Divide before scaling by value (matches torch.addcdiv's documented
+        // `input + value * (tensor1 / tensor2)` order): applying the reciprocal first keeps
+        // the intermediate in range -- `in1 * value_float` overflows to +/-inf whenever
+        // |in1 * value| > FLT_MAX, even when the exact result is finite (see #54055).
+        sfpi::vFloat result = in0 + ((in1 * sfpu_reciprocal_iter<2>(in2)) * value_float);
         if constexpr (!is_fp32_dest_acc_en) {
             result = float32_to_bf16_rne(result);
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -34,7 +34,11 @@ inline void calculate_addcdiv(
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        // Divide before scaling by value (matches torch.addcdiv's documented
+        // `input + value * (tensor1 / tensor2)` order): applying the reciprocal first keeps
+        // the intermediate in range -- `in1 * value_float` overflows to +/-inf whenever
+        // |in1 * value| > FLT_MAX, even when the exact result is finite (see #54055).
+        sfpi::vFloat result = in0 + ((in1 * sfpu_reciprocal_iter<2>(in2)) * value_float);
         if constexpr (!is_fp32_dest_acc_en) {
             result = float32_to_bf16_rne(result);
         }


### PR DESCRIPTION
Fixes #54055.

## Root cause (as reported)

`calculate_addcdiv` evaluated `in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2))`;
C++ left-associativity forms `in1 * value_float` **before** the reciprocal term, so the
intermediate overflows to +/-inf whenever |in1 * value| > FLT_MAX, even when the exact
result `in0 + value * (in1 / in2)` is an ordinary finite number. Each sfpi op is one SFP
instruction with no reassociation, so the overflow is real, not theoretical — the issue's
fp32 table (3e38 / 8 * 4 → inf, vs golden 1.5e38) reproduces it.

## Fix (2 lines, both arch copies)

`tt_metal/hw/ckernels/{wormhole_b0,blackhole}/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h`:

```diff
-        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        sfpi::vFloat result = in0 + ((in1 * sfpu_reciprocal_iter<2>(in2)) * value_float);
```

Divide first (matches the documented formula `input + value * (tensor1 / tensor2)`):
3e38 * recip(8) = 3.75e37 (finite) → * 4 = 1.5e38 (finite). Genuine final-result
overflows still correctly produce inf, as in torch.

## Regression test

`tests/ttnn/unit_tests/operations/eltwise/test_ternary.py` →
`test_addcdiv_divides_before_scaling`: the seven rows of the issue's table (five
overflow-set cases asserting finiteness + expected value, two ordinary-magnitude controls
asserting exact values), float32 full-tile, asserting `torch.isfinite` + allclose against
the documented golden (computed in fp32, independent of `torch.addcdiv`'s actual
reassociation).

## Note on the order debate

torch's C++ composite happens to reduce `input + value * t1 / t2` with left-to-right
associativity (cf. #35748), so *kernel vs actual torch* already agree on the overflow set —
what this PR changes is kernel vs **documented formula**: PyTorch's own docs state
`input + value * (tensor1 / tensor2)`. The issue's golden is the documented formula, and
this PR pins the kernel to it. Ordinary-magnitude inputs are unchanged in value (only
reassociation of one multiply), covered by the control rows.

### Payout wallet (Base USDC / EVM)

`0xDeB7a2C40E4BAe45f2427d5Af410C56F2AC5E4DC`
