### PR TITLE
[Cleanup] Change CoreCoord alias to use umd::CoreCoord

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -454,7 +454,7 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     auto grid_size = devices[0]->compute_with_storage_grid_size();
     for (auto i = 0; i < grid_size.x; i++) {
         for (auto j = 0; j < grid_size.y; j++) {
-            worker_logical_cores.push_back(tt::tt_metal::CoreCoord({i, j}));
+            worker_logical_cores.push_back(tt::tt_metal::CoreCoord(i, j));
         }
     }
 

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -400,7 +400,7 @@ void verify_results(
             for (auto& core_range : kernel->logical_coreranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                        CoreCoord logical_core({x, y});
+                        CoreCoord logical_core(x, y);
                         auto rt_args = kernel->common_runtime_args();
                         EXPECT_EQ(rt_args, common_rt_args) << "(common rta)";
                         verify_core_rt_args(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -391,7 +391,7 @@ int main(int argc, char** argv) {
     auto grid_size = mesh_device->compute_with_storage_grid_size();
     for (auto i = 0; i < grid_size.x; i++) {
         for (auto j = 0; j < grid_size.y; j++) {
-            worker_logical_cores.push_back(CoreCoord({i, j}));
+            worker_logical_cores.push_back(CoreCoord(i, j));
         }
     }
 

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -16,7 +16,8 @@
 #include <string>
 #include <vector>
 
-// UMD: re-exports tt_xy_pair, aliased as CoreCoord in this header.
+// UMD: re-exports tt::umd::CoreCoord, aliased as CoreCoord in this header.
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace ttsl::json {
@@ -28,7 +29,7 @@ struct to_json_t;
 
 namespace tt::tt_metal {
 
-using CoreCoord = tt_xy_pair;
+using CoreCoord = ::tt::umd::CoreCoord;
 
 class CoreRangeSet;
 
@@ -273,12 +274,7 @@ struct fmt::formatter<tt::tt_metal::CoreRange> {
     auto format(const tt::tt_metal::CoreRange& core_range, format_context& ctx) const -> format_context::iterator;
 };
 
-template <>
-struct fmt::formatter<tt::tt_metal::CoreCoord> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) const -> format_context::iterator;
-};
+// fmt::formatter<CoreCoord> is provided by UMD (umd/device/types/core_coordinates.hpp).
 
 namespace std {
 

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -654,13 +654,6 @@ bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b) { return !(a == b)
 
 }  // namespace tt::tt_metal
 
-auto fmt::formatter<tt::tt_metal::CoreCoord>::format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) const
-    -> format_context::iterator {
-    std::stringstream ss;
-    ss << core_coord.str();
-    return fmt::format_to(ctx.out(), "{}", ss.str());
-}
-
 auto fmt::formatter<CoreRange>::format(const CoreRange& core_range, format_context& ctx) const
     -> format_context::iterator {
     std::stringstream ss;

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -248,7 +248,9 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
 
     // Get SOC descriptor for eth core lookup
     const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-    auto eth_logical_core = soc_desc.get_eth_core_for_channel(location.eth_chan, CoordSystem::LOGICAL);
+    const tt::umd::CoreCoord umd_eth_logical_core =
+        soc_desc.get_eth_core_for_channel(location.eth_chan, CoordSystem::LOGICAL);
+    const tt::tt_metal::CoreCoord eth_logical_core{umd_eth_logical_core.x, umd_eth_logical_core.y};
 
     // Determine tensix config
     auto fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
@@ -948,7 +950,8 @@ void ComputeMeshRouterBuilder::create_kernel(tt::tt_metal::Program& program, con
     const auto device_id = control_plane.get_physical_chip_id_from_fabric_node_id(local_node_);
     const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
     const auto eth_chan = location_.eth_chan;
-    auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
+    const tt::umd::CoreCoord umd_eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
+    const tt::tt_metal::CoreCoord eth_logical_core{umd_eth_logical_core.x, umd_eth_logical_core.y};
 
     // Configure for host signal wait
     erisc_builder_->set_wait_for_host_signal(true);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2275,7 +2275,9 @@ std::unordered_set<tt::tt_metal::CoreCoord> ControlPlane::get_active_ethernet_co
         const auto& freq_retrain_eth_cores = cluster.get_eth_cores_with_frequent_retraining(chip_id);
         const auto& eth_routing_info = cluster.get_eth_routing_info(chip_id);
         for (const auto& eth_channel : logical_active_eth_channels) {
-            tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+            const tt::umd::CoreCoord umd_eth_core =
+                soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+            const tt::tt_metal::CoreCoord eth_core{umd_eth_core.x, umd_eth_core.y};
             const auto& routing_info = eth_routing_info.at(eth_core);
             if (routing_info == EthRouterMode::FABRIC_ROUTER && skip_reserved_cores) {
                 continue;
@@ -2300,8 +2302,9 @@ std::unordered_set<tt::tt_metal::CoreCoord> ControlPlane::get_active_ethernet_co
             }
             for (const auto& eth_channel : channels_to_skip) {
                 if (!logical_active_eth_channels.contains(eth_channel)) {
-                    tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
-                    active_ethernet_cores.insert(eth_core);
+                    const tt::umd::CoreCoord umd_eth_core =
+                        soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+                    active_ethernet_cores.insert({umd_eth_core.x, umd_eth_core.y});
                 }
             }
         }
@@ -2854,7 +2857,8 @@ std::vector<PortDescriptor> ControlPlane::gather_intermesh_cables_for_exit_nodes
         auto src_eth_chan = exit_node.eth_conn.src_chan;
         auto physical_chip_id = this->get_physical_chip_id_from_fabric_node_id(exit_node_fabric_node_id);
         const auto& soc_desc = this->cluster_.get().get_soc_desc(physical_chip_id);
-        auto eth_core = soc_desc.get_eth_core_for_channel(src_eth_chan, CoordSystem::LOGICAL);
+        const tt::umd::CoreCoord umd_eth_core = soc_desc.get_eth_core_for_channel(src_eth_chan, CoordSystem::LOGICAL);
+        const tt::tt_metal::CoreCoord eth_core{umd_eth_core.x, umd_eth_core.y};
         if (!this->cluster_.get().is_ethernet_link_up(physical_chip_id, eth_core)) {
             continue;
         }

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -52,10 +52,9 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
             "setup",
             logical_core.y,
             logical_core.x);
-        CoreCoord noc_core({
+        CoreCoord noc_core(
             static_cast<std::size_t>(config_->worker_log_to_virtual_routing_x.at(logical_core.x)),
-            static_cast<std::size_t>(config_->worker_log_to_virtual_routing_y.at(logical_core.y)),
-        });
+            static_cast<std::size_t>(config_->worker_log_to_virtual_routing_y.at(logical_core.y)));
         TT_ASSERT(
             config_->core_type_from_noc_coord_table.contains(noc_core),
             "Cannot find noc-coord=[.y={}, .x={}] in core_type_from_noc_coord_table... invalid AllocatorConfig setup",

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -132,7 +132,7 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.dispatch_cb_base = my_dispatch_constants.dispatch_buffer_base(cq_id_);
         static_config_.dispatch_cb_log_page_size = DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
         static_config_.dispatch_cb_pages = my_dispatch_constants.dispatch_buffer_pages();
-        static_config_.my_dispatch_cb_sem_id = tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+        static_config_.my_dispatch_cb_sem_id = tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
 
         static_config_.dispatch_cb_blocks = DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS;
         static_config_.command_queue_base_addr = command_queue_start_addr;
@@ -185,7 +185,7 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.dispatch_cb_base = my_dispatch_constants.dispatch_buffer_base(cq_id_);
         static_config_.dispatch_cb_log_page_size = DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
         static_config_.dispatch_cb_pages = my_dispatch_constants.dispatch_buffer_pages();
-        static_config_.my_dispatch_cb_sem_id = tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+        static_config_.my_dispatch_cb_sem_id = tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
 
         static_config_.dispatch_cb_blocks = DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS;
         static_config_.command_queue_base_addr = command_queue_start_addr;
@@ -218,7 +218,7 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.dispatch_cb_base = my_dispatch_constants.dispatch_buffer_base(cq_id_);
         static_config_.dispatch_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
         static_config_.dispatch_cb_pages = my_dispatch_constants.dispatch_buffer_pages();
-        static_config_.my_dispatch_cb_sem_id = tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+        static_config_.my_dispatch_cb_sem_id = tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
 
         static_config_.dispatch_cb_blocks = DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS;
         static_config_.command_queue_base_addr = 0;  // These are unused for DISPATCH_D
@@ -227,7 +227,7 @@ void DispatchKernel::GenerateStaticConfigs() {
 
         static_config_.prefetch_h_max_credits = my_dispatch_constants.prefetch_d_buffer_pages();
         static_config_.my_downstream_cb_sem_id = tt_metal::CreateSemaphore(
-            *program_, logical_core_, my_dispatch_constants.prefetch_d_buffer_pages(), GetCoreType());
+            *program_, CoreCoord(logical_core_.x, logical_core_.y), my_dispatch_constants.prefetch_d_buffer_pages(), GetCoreType());
 
         static_config_.packed_write_max_unicast_sub_cmds =
             device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -142,9 +142,9 @@ void DispatchSKernel::GenerateStaticConfigs() {
     static_config_.cb_log_page_size = DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE;
     static_config_.cb_size = my_dispatch_constants.dispatch_s_buffer_size();
     // used by dispatch_s to sync with prefetch
-    static_config_.my_dispatch_cb_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+    static_config_.my_dispatch_cb_sem_id = CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
     // used by dispatch_d to signal that its shutdown handoff is ready
-    static_config_.dispatch_d_shutdown_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+    static_config_.dispatch_d_shutdown_sem_id = CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
     static_config_.dispatch_s_sync_sem_base_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM, cq_id_);
     // used by dispatch_d to signal that dispatch_s can send go signal

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -331,9 +331,9 @@ KernelHandle FDKernel::configure_kernel_variant(
 }
 
 void FDKernel::create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes) {
-    attributes.worker_flow_control_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
-    attributes.worker_buffer_index_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
-    attributes.worker_teardown_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+    attributes.worker_flow_control_sem = tt::tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
+    attributes.worker_buffer_index_sem = tt::tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
+    attributes.worker_teardown_sem = tt::tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
 }
 
 void FDKernel::SetRuntimeArgs() {

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -118,7 +118,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         uint32_t issue_queue_size = is_mock ? 0x10000 : device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
         static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
-            *program_, logical_core_, my_dispatch_constants.dispatch_buffer_pages(), GetCoreType());
+            *program_, CoreCoord(logical_core_.x, logical_core_.y), my_dispatch_constants.dispatch_buffer_pages(), GetCoreType());
 
         static_config_.pcie_base = issue_queue_start_addr;
         static_config_.pcie_size = issue_queue_size;
@@ -136,7 +136,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.scratch_db_base = my_dispatch_constants.scratch_db_base(cq_id_);
         static_config_.scratch_db_size = my_dispatch_constants.scratch_db_size();
         static_config_.downstream_sync_sem_id =
-            tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+            tt::tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
         static_config_.ringbuffer_size = my_dispatch_constants.ringbuffer_size();
 
         // prefetch_d only
@@ -161,7 +161,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         }
         static_config_.dispatch_s_buffer_base = dispatch_s_buffer_base;
         static_config_.my_dispatch_s_cb_sem_id = tt::tt_metal::CreateSemaphore(
-            *program_, logical_core_, my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
+            *program_, CoreCoord(logical_core_.x, logical_core_.y), my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
         static_config_.dispatch_s_buffer_size = my_dispatch_constants.dispatch_s_buffer_size();
         static_config_.dispatch_s_cb_log_page_size = DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE;
     } else if (static_config_.is_h_variant.value()) {
@@ -197,11 +197,11 @@ void PrefetchKernel::GenerateStaticConfigs() {
 
         static_config_.cmddat_q_pages = my_dispatch_constants.prefetch_d_buffer_pages();
         static_config_.my_upstream_cb_sem_id =
-            tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+            tt::tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
 
         // Workaround for now. Need downstream to initialize my semaphore. Can't defer creating semaphore yet
         static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
-            *program_, logical_core_, my_dispatch_constants.prefetch_d_buffer_pages(), GetCoreType());
+            *program_, CoreCoord(logical_core_.x, logical_core_.y), my_dispatch_constants.prefetch_d_buffer_pages(), GetCoreType());
         static_config_.cmddat_q_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
 
         // PREFETCH_H has no DISPATCH_S
@@ -211,7 +211,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.dispatch_s_cb_log_page_size = 0;
     } else if (static_config_.is_d_variant.value()) {
         static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
-            *program_, logical_core_, my_dispatch_constants.dispatch_buffer_pages(), GetCoreType());
+            *program_, CoreCoord(logical_core_.x, logical_core_.y), my_dispatch_constants.dispatch_buffer_pages(), GetCoreType());
 
         static_config_.pcie_base = 0;
         static_config_.pcie_size = 0;
@@ -231,12 +231,12 @@ void PrefetchKernel::GenerateStaticConfigs() {
                                          (~(pcie_alignment - 1));
         static_config_.scratch_db_size = my_dispatch_constants.scratch_db_size();
         static_config_.downstream_sync_sem_id =
-            tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+            tt::tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
         static_config_.ringbuffer_size = my_dispatch_constants.ringbuffer_size();
 
         static_config_.cmddat_q_pages = my_dispatch_constants.prefetch_d_buffer_pages();
         static_config_.my_upstream_cb_sem_id =
-            tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+            tt::tt_metal::CreateSemaphore(*program_, CoreCoord(logical_core_.x, logical_core_.y), 0, GetCoreType());
         static_config_.cmddat_q_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
 
         uint32_t dispatch_s_buffer_base = 0xff;
@@ -255,7 +255,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         }
         static_config_.dispatch_s_buffer_base = dispatch_s_buffer_base;
         static_config_.my_dispatch_s_cb_sem_id = tt::tt_metal::CreateSemaphore(
-            *program_, logical_core_, my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
+            *program_, CoreCoord(logical_core_.x, logical_core_.y), my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
         static_config_.dispatch_s_buffer_size = my_dispatch_constants.dispatch_s_buffer_size();
         static_config_.dispatch_s_cb_log_page_size = get_dispatch_query_manager_ref().dispatch_s_enabled()
                                                          ? DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -156,7 +156,7 @@ Kernel::Kernel(
     tensor_binding_handles_(tensor_binding_handles),
     crta_layout_(crta_layout),
 
-    core_with_max_runtime_args_({0, 0}),
+    core_with_max_runtime_args_(0, 0),
     defines_(defines),
     watcher_assert_enabled_(
         tt::tt_metal::MetalContext::instance(context_id).rtoptions().get_watcher_enabled() &&
@@ -170,7 +170,7 @@ Kernel::Kernel(
         auto end = core_range.end_coord;
         for (auto x = start.x; x <= end.x; x++) {
             for (auto y = start.y; y <= end.y; y++) {
-                CoreCoord logical_core({x, y});
+                CoreCoord logical_core(x, y);
                 this->logical_cores_.insert(logical_core);
                 max_x = std::max(max_x, x);
                 max_y = std::max(max_y, y);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1626,10 +1626,11 @@ void DeviceProfiler::readRiscProfilerResults(
 
     // translate worker core virtual coord to phys coordinates
     const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
-    // disable linting here; slicing is __intended__
-    // NOLINTBEGIN
-    const CoreCoord phys_coord = soc_desc.translate_coord_to(worker_core, CoordSystem::TRANSLATED, CoordSystem::NOC0);
-    // NOLINTEND
+    // Drop UMD's core_type/coord_system tags: they take part in CoreCoord's ==/</hash, and
+    // device_markers_per_core_risc_map is keyed by untagged Metal coords.
+    const tt::umd::CoreCoord umd_phys_coord =
+        soc_desc.translate_coord_to(worker_core, CoordSystem::TRANSLATED, CoordSystem::NOC0);
+    const CoreCoord phys_coord{umd_phys_coord.x, umd_phys_coord.y};
     // helper function to lookup opname from runtime id if metadata is available
     auto getOpNameIfAvailable = [&metadata](auto device_id, auto runtime_id) {
         return (metadata.has_value()) ? metadata->get_op_name(device_id, runtime_id) : "";

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1279,7 +1279,7 @@ public:
             for (const CoreRange& core_range : ranges) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                        CoreCoord virtual_coord = device->virtual_core_from_logical_core(CoreCoord({x, y}), core_type);
+                        CoreCoord virtual_coord = device->virtual_core_from_logical_core(CoreCoord(x, y), core_type);
                         dst_noc_unicast_info.push_back(std::make_pair(virtual_coord, /*num_mcast_dests=*/0));
                     }
                 }
@@ -2265,7 +2265,7 @@ public:
                     for (const CoreRange& core_range : kernel_group->core_ranges.ranges()) {
                         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                                CoreCoord logical_coord({x, y});
+                                CoreCoord logical_coord(x, y);
                                 CoreCoord virtual_coord = device->virtual_core_from_logical_core(
                                     logical_coord, kernel_group->get_core_type());
                                 auto noc_xy = device->get_noc_unicast_encoding(constants.noc_index, virtual_coord);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1066,7 +1066,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                         if (not hal.get_supports_cbs(programmable_core_type_index)) {
                             continue;
                         }
-                        auto core = CoreCoord({x, y});
+                        auto core = CoreCoord(x, y);
                         auto local_val = per_core_local_cb_indices_.find(core);
                         if (local_val != per_core_local_cb_indices_.end() && local_val->second.any()) {
                             uint64_t used_cbs = local_val->second.to_ullong();
@@ -2164,7 +2164,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
         for (const CoreRange& core_range : ranges) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                    CoreCoord virtual_coord = device->virtual_core_from_logical_core(CoreCoord({x, y}), core_type);
+                    CoreCoord virtual_coord = device->virtual_core_from_logical_core(CoreCoord(x, y), core_type);
                     dst_noc_unicast_info.push_back(std::make_pair(virtual_coord, /*num_mcast_dests=*/0));
                 }
             }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1128,8 +1128,9 @@ std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> Cluster::get_et
             for (const auto& channel_pair :
                  this->get_cluster_desc()->get_directly_connected_ethernet_channels_between_chips(chip_id, other_chip_id)) {
                 EthernetChannel local_chip_chan = std::get<0>(channel_pair);
-                active_ethernet_cores.emplace_back(
-                    get_soc_desc(chip_id).get_eth_core_for_channel(local_chip_chan, CoordSystem::LOGICAL));
+                const tt::umd::CoreCoord eth_core =
+                    get_soc_desc(chip_id).get_eth_core_for_channel(local_chip_chan, CoordSystem::LOGICAL);
+                active_ethernet_cores.emplace_back(eth_core.x, eth_core.y);
             }
             connected_chips.insert({other_chip_id, active_ethernet_cores});
         } else {
@@ -1232,7 +1233,9 @@ void Cluster::initialize_ethernet_cores_router_mode() {
             // Mark all remaining ethernet cores as idle to be used by fabric
             const auto& soc_desc = get_soc_desc(chip_id);
             for (const auto& eth_channel : get_cluster_desc()->get_active_eth_channels(chip_id)) {
-                auto eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+                const tt::umd::CoreCoord umd_eth_core =
+                    soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+                const tt::tt_metal::CoreCoord eth_core{umd_eth_core.x, umd_eth_core.y};
                 // Chip ID is guaranteed to be present in device_eth_routing_info_, since it was populated above
                 auto& routing_info = this->device_eth_routing_info_[chip_id];
                 if (!routing_info.contains(eth_core)) {
@@ -1409,9 +1412,11 @@ std::tuple<ChipId, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_core
         std::get<1>(eth_core).str());
     auto connected_eth_core =
         this->get_cluster_desc()->get_chip_and_channel_of_remote_ethernet_core(std::get<0>(eth_core), eth_chan);
+    const tt::umd::CoreCoord connected_logical_core =
+        soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL);
     return std::make_tuple(
         std::get<0>(connected_eth_core),
-        soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL));
+        tt::tt_metal::CoreCoord{connected_logical_core.x, connected_logical_core.y});
 }
 
 // TODO: unify uint64_t with ChipUID
@@ -1435,9 +1440,11 @@ std::tuple<uint64_t, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_co
         local_eth_core.str());
 
     const auto& connected_eth_core = ethernet_connections_to_remote_cluster.at(local_chip_id).at(eth_chan);
+    const tt::umd::CoreCoord connected_logical_core =
+        soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL);
     return std::make_tuple(
         std::get<0>(connected_eth_core),
-        soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL));
+        tt::tt_metal::CoreCoord{connected_logical_core.x, connected_logical_core.y});
 }
 
 std::vector<tt::tt_metal::CoreCoord> Cluster::get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const {

--- a/tt_metal/programming_examples/matmul/matmul_common/bmm_op.hpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/bmm_op.hpp
@@ -10,11 +10,11 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
 
-#include <umd/device/types/xy_pair.hpp>
+#include <tt-metalium/core_coord.hpp>
 
 #include <tt-metalium/work_split.hpp>
 
-using CoreCoord = tt_xy_pair;
+using CoreCoord = tt::tt_metal::CoreCoord;
 
 inline std::vector<uint32_t> get_prime_factors(uint32_t n) {
     uint32_t i = 2;

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
@@ -71,7 +71,7 @@ void matmul_single_core(
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     Program program{};
     // Core range from x: [0, 0] to y: [0, 0] (single core at {0, 0})
-    CoreCoord core({0, 0});
+    CoreCoord core(0, 0);
 
     // Calcaulate the number of tiles for each dimension.
     uint32_t Mt = M / TILE_HEIGHT;

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -45,8 +45,10 @@ public:
             const auto& soc_desc = cluster.get_soc_desc(chip_id_src);
             // Build a mapping of (eth_core --> eth_chan)
             for (auto eth_chan = 0; eth_chan < soc_desc.get_num_eth_channels(); eth_chan++) {
-                auto eth_physical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::NOC0);
-                eth_core_to_channel_lookup_.emplace(std::make_tuple(chip_id_src, eth_physical_core), eth_chan);
+                const tt::umd::CoreCoord eth_physical_core =
+                    soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::NOC0);
+                eth_core_to_channel_lookup_.emplace(
+                    std::make_tuple(chip_id_src, CoreCoord{eth_physical_core.x, eth_physical_core.y}), eth_chan);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -215,7 +215,7 @@ ParallelConfig determine_parallel_config(
 
         uint32_t cores_x = block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_nhw : num_cores_c;
         uint32_t cores_y = block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_c : num_cores_nhw;
-        CoreRange core_range = CoreRange(CoreCoord({0, 0}), CoreCoord({cores_x - 1, cores_y - 1}));
+        CoreRange core_range = CoreRange(CoreCoord(0, 0), CoreCoord(cores_x - 1, cores_y - 1));
         grid = CoreRangeSet({core_range});
     } else if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED) {
         uint32_t input_channels_ntiles = tt::div_up(input_channels, effective_tile_width);
@@ -260,7 +260,7 @@ ParallelConfig determine_output_parallel_config(
                 block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_nhw : num_cores_c;
             const uint32_t cores_y =
                 block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_c : num_cores_nhw;
-            CoreRange core_range = CoreRange(CoreCoord({0, 0}), CoreCoord({cores_x - 1, cores_y - 1}));
+            CoreRange core_range = CoreRange(CoreCoord(0, 0), CoreCoord(cores_x - 1, cores_y - 1));
             output_parallel_config.grid = CoreRangeSet({core_range});
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -125,7 +125,7 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactorySingleRowSingleCore::
         const uint32_t core_grid_calculated_columns_number = Ht % compute_with_storage_grid_size.x;
 
         if (core_grid_calculated_rows_number == 0 && core_grid_calculated_columns_number == 0) {
-            core_range = CoreRangeSet(CoreCoord({0, 0}));
+            core_range = CoreRangeSet(CoreCoord(0, 0));
         } else if (core_grid_calculated_rows_number == 0) {
             core_range = CoreRangeSet(CoreRange({0, 0}, {core_grid_calculated_columns_number - 1, 0}));
         } else {
@@ -724,7 +724,7 @@ CoreRangeSet compute_cross_core_range(
             all_core_utilization_count % compute_with_storage_grid_size.x;
 
         if (core_grid_calculated_rows_number == 0 && core_grid_calculated_columns_number == 0) {
-            core_range = CoreRangeSet(CoreCoord({0, 0}));
+            core_range = CoreRangeSet(CoreCoord(0, 0));
         } else if (core_grid_calculated_rows_number == 0) {
             core_range = CoreRangeSet(CoreRange({0, 0}, {core_grid_calculated_columns_number - 1, 0}));
         } else {
@@ -1483,7 +1483,7 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactorySingleRowMultiCore::c
         const uint32_t core_grid_calculated_columns_number = total_work_units % compute_with_storage_grid_size.x;
 
         if (core_grid_calculated_rows_number == 0 && core_grid_calculated_columns_number == 0) {
-            core_range = CoreRangeSet(CoreCoord({0, 0}));
+            core_range = CoreRangeSet(CoreCoord(0, 0));
         } else if (core_grid_calculated_rows_number == 0) {
             core_range = CoreRangeSet(CoreRange({0, 0}, {core_grid_calculated_columns_number - 1, 0}));
         } else {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_program_factory.cpp
@@ -18,7 +18,7 @@ RotateHalfProgramFactory::cached_program_t RotateHalfProgramFactory::create(
 
     Program program{};
 
-    const CoreCoord core({0, 0});
+    const CoreCoord core(0, 0);
     CoreRange core_range(core, core);
 
     Tensor& output = tensor_return_value;

--- a/ttnn/examples/lab_eltwise_binary/lab_eltwise_binary.cpp
+++ b/ttnn/examples/lab_eltwise_binary/lab_eltwise_binary.cpp
@@ -110,7 +110,7 @@ ProgramState init_program() {
     tt::tt_metal::distributed::MeshCoordinateRange device_range =
         tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape());
     // This program uses only a single Tensix core at [0, 0].
-    tt::tt_metal::CoreCoord core({0, 0});
+    tt::tt_metal::CoreCoord core(0, 0);
     // Create a program object. A program is a collection of kernels that are executed on the device.
     // Kernels will be specified later.
     Program program = CreateProgram();


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Change CoreCoord alias to use umd::CoreCoord. xy_pair is an incomplete type and Metal should adopt the richer CoreCoord type with coordinate system information.

### Notes for reviewers
1. Look at `tt_metal/api/tt-metalium/core_coord.hpp` 
2. All other changes are related to ctors of umd::CoreCoord

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aleksamarkovic/corecoord)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aleksamarkovic/corecoord)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aleksamarkovic/corecoord)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aleksamarkovic/corecoord)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aleksamarkovic/corecoord)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aleksamarkovic/corecoord)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aleksamarkovic/corecoord)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aleksamarkovic/corecoord)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aleksamarkovic/corecoord)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aleksamarkovic/corecoord)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aleksamarkovic/corecoord)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aleksamarkovic/corecoord)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aleksamarkovic/corecoord)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aleksamarkovic/corecoord)