### PR TITLE
[Cleanup] Rename CoreCoord to xy_pair in tt_metal/llrt

### DIFF
--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -29,6 +29,7 @@ struct to_json_t;
 namespace tt::tt_metal {
 
 using CoreCoord = tt_xy_pair;
+using xy_pair = tt_xy_pair;
 
 class CoreRangeSet;
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -236,7 +236,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
     size_t start_x = compute_with_storage_start[0].as<size_t>();
     size_t start_y = compute_with_storage_start[1].as<size_t>();
 
-    tt::tt_metal::CoreCoord compute_grid_size;
+    tt::tt_metal::xy_pair compute_grid_size;
     // When slow dispatch is on, use full logical grid (no dispatch cores to reserve).
     // Quasar dispatch-engine FD uses dedicated dispatch tiles from the soc `dispatch:` list, so
     // Tensix workers listed under dispatch_cores in the fast-dispatch core descriptor YAML are not
@@ -257,7 +257,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
                 compute_grid_size.y);
         }
     } else {
-        compute_grid_size = tt::tt_metal::CoreCoord((end_x - start_x) + 1, (end_y - start_y) + 1);
+        compute_grid_size = tt::tt_metal::xy_pair((end_x - start_x) + 1, (end_y - start_y) + 1);
     }
 
     std::vector<RelativeCoreCoord> compute_cores;
@@ -275,9 +275,9 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
         dispatch_cores_string = "tg_dispatch_cores";
     }
 
-    tt::tt_metal::CoreCoord grid_size = get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    tt::tt_metal::xy_pair grid_size = get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     // For mock devices, control plane doesn't exist, use empty set
-    std::unordered_set<tt::tt_metal::CoreCoord> logical_active_eth_cores;
+    std::unordered_set<tt::tt_metal::xy_pair> logical_active_eth_cores;
     if (!get_cluster().is_mock_or_emulated()) {
         logical_active_eth_cores = get_control_plane().get_active_ethernet_cores(device_id);
     }
@@ -318,7 +318,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
         }
     }
 
-    std::vector<tt::tt_metal::CoreCoord> logical_compute_cores;
+    std::vector<tt::tt_metal::xy_pair> logical_compute_cores;
     logical_compute_cores.reserve(compute_cores.size());
     std::transform(
         compute_cores.cbegin(),
@@ -326,7 +326,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
         std::back_inserter(logical_compute_cores),
         [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
 
-    std::vector<tt::tt_metal::CoreCoord> logical_dispatch_cores;
+    std::vector<tt::tt_metal::xy_pair> logical_dispatch_cores;
     // In slow dispatch mode, no cores are reserved for dispatch. Quasar dispatch-engine FD sources
     // dispatch cores from the soc descriptor via get_quasar_dispatch_cores(), not Tensix YAML entries.
     if (fast_dispatch && !quasar_dispatch_engine_fd) {
@@ -339,7 +339,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
     }
 
     // Convert fabric mux cores to logical coordinates
-    std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores;
+    std::vector<tt::tt_metal::xy_pair> logical_fabric_mux_cores;
     logical_fabric_mux_cores.reserve(fabric_mux_cores.size());
     std::transform(
         fabric_mux_cores.cbegin(),
@@ -364,7 +364,7 @@ const tt::core_descriptor_t& MetalEnvImpl::get_core_descriptor_config(
 
 namespace tt {
 
-std::vector<tt::tt_metal::CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
+std::vector<tt::tt_metal::xy_pair> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     uint8_t num_hw_cqs,
@@ -427,8 +427,8 @@ std::vector<tt::tt_metal::CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_f
         return {};
     }
 
-    tt::tt_metal::CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-    std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores;
+    tt::tt_metal::xy_pair grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    std::vector<tt::tt_metal::xy_pair> logical_fabric_mux_cores;
     logical_fabric_mux_cores.reserve(desc_yaml["fabric_mux_cores"].size());
     for (const auto& core_node : desc_yaml["fabric_mux_cores"]) {
         if (!core_node.IsSequence()) {
@@ -465,9 +465,10 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
         const metal_SocDescriptor& soc_desc = env.get_cluster().get_soc_desc(device_id);
         // Get physical compute grid range based on SOC Desc and Logical Coords
         // Logical Worker Coords start at 0,0
-        tt::tt_metal::CoreCoord tensix_worker_start_phys = soc_desc.get_physical_tensix_core_from_logical(tt::tt_metal::CoreCoord(0, 0));
-        tt::tt_metal::CoreCoord tensix_worker_end_phys = soc_desc.get_physical_tensix_core_from_logical(
-            tt::tt_metal::CoreCoord(tensix_num_worker_cols - 1, tensix_num_worker_rows - 1));
+        tt::tt_metal::xy_pair tensix_worker_start_phys =
+            soc_desc.get_physical_tensix_core_from_logical(tt::tt_metal::xy_pair(0, 0));
+        tt::tt_metal::xy_pair tensix_worker_end_phys = soc_desc.get_physical_tensix_core_from_logical(
+            tt::tt_metal::xy_pair(tensix_num_worker_cols - 1, tensix_num_worker_rows - 1));
         CoreRange tensix_worker_physical_grid = CoreRange(tensix_worker_start_phys, tensix_worker_end_phys);
         physical_grid_config_cache.insert(
             {config_hash, std::make_tuple(tensix_num_worker_cores, tensix_worker_physical_grid)});

--- a/tt_metal/llrt/core_descriptor.hpp
+++ b/tt_metal/llrt/core_descriptor.hpp
@@ -32,7 +32,7 @@ inline const std::string& get_product_name(tt::ARCH arch, uint32_t num_harvested
     return product_name.at(arch).at(num_harvested_on_axis);
 }
 
-inline const tt::tt_metal::CoreCoord& get_compute_grid_size(
+inline const tt::tt_metal::xy_pair& get_compute_grid_size(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -41,7 +41,7 @@ inline const tt::tt_metal::CoreCoord& get_compute_grid_size(
     return core_desc.compute_grid_size;
 }
 
-inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_compute_cores(
+inline const std::vector<tt::tt_metal::xy_pair>& get_logical_compute_cores(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -50,7 +50,7 @@ inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_compute_cores(
     return core_desc.logical_compute_cores;
 }
 
-inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_dispatch_cores(
+inline const std::vector<tt::tt_metal::xy_pair>& get_logical_dispatch_cores(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -62,7 +62,7 @@ inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_dispatch_cores(
     return core_desc.logical_dispatch_cores;
 }
 
-inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_fabric_mux_cores(
+inline const std::vector<tt::tt_metal::xy_pair>& get_logical_fabric_mux_cores(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -80,7 +80,7 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
 // When FabricTensix is DISABLED, wormhole_b0_80_arch.yaml omits fabric_mux_cores, but the same tensix
 // locations are still reserved for fabric mux on boards that use the fabric-mux descriptor layout.
 // Used for heuristics (e.g. real-time profiler spare-core selection) that must not collide with mux rows/columns.
-std::vector<tt::tt_metal::CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
+std::vector<tt::tt_metal::xy_pair> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     uint8_t num_hw_cqs,

--- a/tt_metal/llrt/core_descriptor_types.hpp
+++ b/tt_metal/llrt/core_descriptor_types.hpp
@@ -12,14 +12,14 @@
 namespace tt {
 
 struct core_descriptor_t {
-    tt::tt_metal::CoreCoord compute_grid_size;
+    tt::tt_metal::xy_pair compute_grid_size;
     std::vector<tt_metal::RelativeCoreCoord> relative_compute_cores;
     std::vector<tt_metal::RelativeCoreCoord> relative_dispatch_cores;
     std::vector<tt_metal::RelativeCoreCoord> relative_fabric_mux_cores;
 
-    std::vector<tt::tt_metal::CoreCoord> logical_compute_cores;
-    std::vector<tt::tt_metal::CoreCoord> logical_dispatch_cores;
-    std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores;
+    std::vector<tt::tt_metal::xy_pair> logical_compute_cores;
+    std::vector<tt::tt_metal::xy_pair> logical_dispatch_cores;
+    std::vector<tt::tt_metal::xy_pair> logical_fabric_mux_cores;
 };
 
 }  // namespace tt

--- a/tt_metal/llrt/dispatch_engine_cores.cpp
+++ b/tt_metal/llrt/dispatch_engine_cores.cpp
@@ -21,16 +21,16 @@
 
 namespace {
 
-std::vector<tt::tt_metal::CoreCoord> get_quasar_tensix_fallback_dispatch_cores_from_yaml(
+std::vector<tt::tt_metal::xy_pair> get_quasar_tensix_fallback_dispatch_cores_from_yaml(
     tt::tt_metal::MetalEnvImpl& env,
     tt::ChipId device_id,
     uint8_t num_hw_cqs,
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     const tt::core_descriptor_t& core_desc = env.get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     if (!core_desc.relative_dispatch_cores.empty()) {
-        const tt::tt_metal::CoreCoord grid_size =
+        const tt::tt_metal::xy_pair grid_size =
             env.get_cluster().get_soc_desc(device_id).get_grid_size(tt::CoreType::TENSIX);
-        std::vector<tt::tt_metal::CoreCoord> logical_cores;
+        std::vector<tt::tt_metal::xy_pair> logical_cores;
         logical_cores.reserve(core_desc.relative_dispatch_cores.size());
         for (const tt::tt_metal::RelativeCoreCoord& rel_coord : core_desc.relative_dispatch_cores) {
             logical_cores.push_back(tt::tt_metal::get_core_coord_from_relative(rel_coord, grid_size));
@@ -47,11 +47,11 @@ std::vector<tt::tt_metal::CoreCoord> get_quasar_tensix_fallback_dispatch_cores_f
 // num_hw_cqs are unused; if fewer DEs than CQs, later CQs cycle through the DEs again.
 // Free DMs are auto-assigned at CreateDispatchEngineKernel time.
 void expand_quasar_dispatch_engine_pool_for_fd_assignment(
-    std::vector<tt::tt_metal::CoreCoord>& logical_cores, uint8_t num_hw_cqs) {
+    std::vector<tt::tt_metal::xy_pair>& logical_cores, uint8_t num_hw_cqs) {
     if (logical_cores.empty() || num_hw_cqs == 0) {
         return;
     }
-    const std::vector<tt::tt_metal::CoreCoord> available_des = std::move(logical_cores);
+    const std::vector<tt::tt_metal::xy_pair> available_des = std::move(logical_cores);
     logical_cores.clear();
     logical_cores.reserve(static_cast<size_t>(num_hw_cqs) * 2);
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; ++cq_id) {
@@ -77,7 +77,7 @@ std::size_t MetalEnvImpl::QuasarDispatchCoresCacheKeyHash::operator()(const Quas
            (static_cast<std::size_t>(key.use_tensix_fallback) << 25);
 }
 
-const std::vector<CoreCoord>& MetalEnvImpl::get_quasar_dispatch_cores(
+const std::vector<xy_pair>& MetalEnvImpl::get_quasar_dispatch_cores(
     ChipId device_id, uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) {
     TT_FATAL(
         get_cluster().arch() == tt::ARCH::QUASAR,
@@ -95,7 +95,7 @@ const std::vector<CoreCoord>& MetalEnvImpl::get_quasar_dispatch_cores(
         return quasar_dispatch_cores_cache_.at(key);
     }
 
-    std::vector<CoreCoord> logical_cores;
+    std::vector<xy_pair> logical_cores;
     if (use_tensix_fallback) {
         logical_cores = get_quasar_tensix_fallback_dispatch_cores_from_yaml(
             *this, device_id, num_hw_cqs, dispatch_core_config);
@@ -113,9 +113,9 @@ const std::vector<CoreCoord>& MetalEnvImpl::get_quasar_dispatch_cores(
 
 namespace tt::tt_metal::detail {
 
-std::vector<CoreCoord> get_quasar_soc_dispatch_engine_logical_cores(const metal_SocDescriptor& soc_desc) {
+std::vector<xy_pair> get_quasar_soc_dispatch_engine_logical_cores(const metal_SocDescriptor& soc_desc) {
     const auto dispatch_noc0_cores = soc_desc.get_cores(tt::CoreType::DISPATCH, tt::CoordSystem::NOC0);
-    std::vector<CoreCoord> logical_cores;
+    std::vector<xy_pair> logical_cores;
     logical_cores.reserve(dispatch_noc0_cores.size());
     for (size_t index = 0; index < dispatch_noc0_cores.size(); ++index) {
         logical_cores.emplace_back(static_cast<uint32_t>(index), 0);
@@ -181,7 +181,7 @@ CoreType resolve_dispatch_core_type(
 
 namespace {
 
-const std::vector<CoreCoord>& get_sd_cq_dispatch_cores(const tt::tt_metal::IDevice* device) {
+const std::vector<xy_pair>& get_sd_cq_dispatch_cores(const tt::tt_metal::IDevice* device) {
     auto& env = MetalEnvAccessor(MetalContext::instance().get_env()).impl();
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_config();
     return env.get_quasar_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
@@ -195,7 +195,7 @@ CoreType resolve_sd_cq_kernel_core_type(const tt::tt_metal::IDevice* device) {
     return tt::tt_metal::resolve_dispatch_core_type(env, device->id(), dispatch_core_config);
 }
 
-CoreCoord dispatch_engine_core(const tt::tt_metal::IDevice* device, uint32_t index) {
+xy_pair dispatch_engine_core(const tt::tt_metal::IDevice* device, uint32_t index) {
     TT_FATAL(device->arch() == tt::ARCH::QUASAR, "dispatch_engine_core is only valid on Quasar");
     const auto& cores = get_sd_cq_dispatch_cores(device);
     TT_FATAL(
@@ -207,30 +207,30 @@ CoreCoord dispatch_engine_core(const tt::tt_metal::IDevice* device, uint32_t ind
     return cores[index];
 }
 
-CoreCoord dispatch_engine_virtual_core(const tt::tt_metal::IDevice* device, uint32_t index) {
-    const CoreCoord logical_core = dispatch_engine_core(device, index);
+xy_pair dispatch_engine_virtual_core(const tt::tt_metal::IDevice* device, uint32_t index) {
+    const xy_pair logical_core = dispatch_engine_core(device, index);
     return device->virtual_core_from_logical_core(logical_core, CoreType::DISPATCH);
 }
 
-CoreCoord sd_cq_prefetch_core(const tt::tt_metal::IDevice* device) {
+xy_pair sd_cq_prefetch_core(const tt::tt_metal::IDevice* device) {
     // Only the Quasar dispatch-engine path uses synthetic dispatch cores. WH/BH and the Quasar
     // interim Tensix path (TT_METAL_TENSIX_DISPATCH_CORES=1, resolves to WORKER) keep the legacy
     // hardcoded worker logical core.
     if (resolve_sd_cq_kernel_core_type(device) == CoreType::DISPATCH) {
         return dispatch_engine_core(device, 0);
     }
-    return CoreCoord{0, 0};
+    return xy_pair{0, 0};
 }
 
-CoreCoord sd_cq_dispatch_core(const tt::tt_metal::IDevice* device) {
+xy_pair sd_cq_dispatch_core(const tt::tt_metal::IDevice* device) {
     if (resolve_sd_cq_kernel_core_type(device) == CoreType::DISPATCH) {
         return dispatch_engine_core(device, 0);
     }
     // Legacy interim placement: Quasar shares core {0,0} with prefetch; WH/BH uses a separate core.
-    return (device->arch() == tt::ARCH::QUASAR) ? CoreCoord{0, 0} : CoreCoord{4, 0};
+    return (device->arch() == tt::ARCH::QUASAR) ? xy_pair{0, 0} : xy_pair{4, 0};
 }
 
-CoreCoord sd_cq_virtual_core(const tt::tt_metal::IDevice* device, const CoreCoord& logical_core) {
+xy_pair sd_cq_virtual_core(const tt::tt_metal::IDevice* device, const xy_pair& logical_core) {
     return device->virtual_core_from_logical_core(logical_core, resolve_sd_cq_kernel_core_type(device));
 }
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -76,15 +76,15 @@ const ll_api::memory& get_risc_binary(
     return *ptr;
 }
 
-// CoreCoord core --> NOC coordinates ("functional workers" from the SOC descriptor)
+// xy_pair core --> NOC coordinates ("functional workers" from the SOC descriptor)
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
-tt::tt_metal::CoreCoord logical_core_from_ethernet_core(tt::ChipId chip_id, const tt::tt_metal::CoreCoord& ethernet_core) {
+tt::tt_metal::xy_pair logical_core_from_ethernet_core(tt::ChipId chip_id, const tt::tt_metal::xy_pair& ethernet_core) {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
         chip_id, ethernet_core);
 }
 
-tt_metal::HalProgrammableCoreType get_core_type(tt::ChipId chip_id, const tt::tt_metal::CoreCoord& virtual_core) {
+tt_metal::HalProgrammableCoreType get_core_type(tt::ChipId chip_id, const tt::tt_metal::xy_pair& virtual_core) {
     bool is_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, chip_id);
     bool is_active_eth_core = false;
     bool is_inactive_eth_core = false;
@@ -116,7 +116,7 @@ tt_metal::HalProgrammableCoreType get_core_type(tt::ChipId chip_id, const tt::tt
     return tt_metal::HalProgrammableCoreType::TENSIX;
 }
 
-void send_reset_go_signal(tt::ChipId chip, const tt::tt_metal::CoreCoord& virtual_core) {
+void send_reset_go_signal(tt::ChipId chip, const tt::tt_metal::xy_pair& virtual_core) {
     tt_metal::HalProgrammableCoreType dispatch_core_type = get_core_type(chip, virtual_core);
     const auto& hal = tt_metal::MetalContext::instance().hal();
     const auto& cluster = tt_metal::MetalContext::instance().get_cluster();
@@ -135,7 +135,7 @@ void send_reset_go_signal(tt::ChipId chip, const tt::tt_metal::CoreCoord& virtua
 
 void write_launch_msg_to_core(
     tt::ChipId chip,
-    tt::tt_metal::CoreCoord core,
+    tt::tt_metal::xy_pair core,
     tt_metal::dev_msgs::launch_msg_t::View msg,
     tt_metal::dev_msgs::go_msg_t::ConstView go_msg,
     bool send_go) {
@@ -156,7 +156,7 @@ void write_launch_msg_to_core(
 }
 
 ll_api::memory read_mem_from_core(
-    tt::ChipId chip, const tt::tt_metal::CoreCoord& core, const ll_api::memory& mem, uint64_t local_init_addr) {
+    tt::ChipId chip, const tt::tt_metal::xy_pair& core, const ll_api::memory& mem, uint64_t local_init_addr) {
     ll_api::memory read_mem;
     read_mem.fill_from_mem_template(mem, [&](std::vector<uint32_t>::iterator mem_ptr, uint64_t addr, uint32_t len) {
         uint64_t relo_addr = tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
@@ -169,7 +169,7 @@ ll_api::memory read_mem_from_core(
 bool test_load_write_read_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
-    const tt::tt_metal::CoreCoord& core,
+    const tt::tt_metal::xy_pair& core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx) {
@@ -214,8 +214,8 @@ bool test_load_write_read_risc_binary(
 bool test_load_multicast_write_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
-    const tt::tt_metal::CoreCoord& start_core,
-    const tt::tt_metal::CoreCoord& end_core,
+    const tt::tt_metal::xy_pair& start_core,
+    const tt::tt_metal::xy_pair& end_core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx) {
@@ -246,7 +246,8 @@ bool test_load_multicast_write_risc_binary(
     return true;
 }
 
-void write_binary_to_address(const ll_api::memory& mem, tt::ChipId chip_id, const tt::tt_metal::CoreCoord& core, uint32_t address) {
+void write_binary_to_address(
+    const ll_api::memory& mem, tt::ChipId chip_id, const tt::tt_metal::xy_pair& core, uint32_t address) {
     log_debug(tt::LogLLRuntime, "vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
     mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t /*addr*/, uint32_t len_words) {
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
@@ -258,7 +259,7 @@ namespace internal_ {
 
 namespace {
 
-bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const tt::tt_metal::CoreCoord& core, int run_state) {
+bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const tt::tt_metal::xy_pair& core, int run_state) {
     tt_metal::HalProgrammableCoreType dispatch_core_type = get_core_type(chip_id, core);
     const auto& hal = tt_metal::MetalContext::instance().hal();
     auto dev_msgs_factory = hal.get_dev_msgs_factory(dispatch_core_type);
@@ -288,7 +289,7 @@ bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const tt::tt_meta
     return get_mailbox_is_done(go_msg_addr);
 }
 
-void print_aerisc_training_status(tt::ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core) {
+void print_aerisc_training_status(tt::ChipId device_id, const tt::tt_metal::xy_pair& virtual_core) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {
         return;
@@ -371,7 +372,10 @@ void throw_if_watcher_tripped_in_test_mode(ChipId device_id) {
 }
 
 void wait_until_cores_done(
-    tt::ChipId device_id, int run_state, std::unordered_set<tt::tt_metal::CoreCoord>& not_done_phys_cores, int timeout_ms) {
+    tt::ChipId device_id,
+    int run_state,
+    std::unordered_set<tt::tt_metal::xy_pair>& not_done_phys_cores,
+    int timeout_ms) {
     // poll the cores until the set of not done cores is empty
     [[maybe_unused]] int loop_count = 1;
     auto start = std::chrono::high_resolution_clock::now();
@@ -438,8 +442,8 @@ void wait_until_cores_done(
     }
 }
 
-void wait_for_idle(ChipId device_id, const std::vector<std::vector<tt::tt_metal::CoreCoord>>& logical_cores) {
-    std::unordered_set<tt::tt_metal::CoreCoord> not_done_cores;
+void wait_for_idle(ChipId device_id, const std::vector<std::vector<tt::tt_metal::xy_pair>>& logical_cores) {
+    std::unordered_set<tt::tt_metal::xy_pair> not_done_cores;
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
@@ -456,7 +460,7 @@ void wait_for_idle(ChipId device_id, const std::vector<std::vector<tt::tt_metal:
 
 void send_msg_to_eth_mailbox(
     tt::ChipId device_id,
-    const tt::tt_metal::CoreCoord& virtual_core,
+    const tt::tt_metal::xy_pair& virtual_core,
     tt_metal::FWMailboxMsg msg_type,
     int mailbox_index,
     std::vector<uint32_t> args,
@@ -555,7 +559,7 @@ void send_msg_to_eth_mailbox(
 }
 
 void return_to_base_firmware_and_wait_for_heartbeat(
-    tt::ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, int timeout_ms) {
+    tt::ChipId device_id, const tt::tt_metal::xy_pair& virtual_core, int timeout_ms) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {
         TT_THROW("Ethernet mailbox API not supported on device {}", device_id);
@@ -597,7 +601,7 @@ void return_to_base_firmware_and_wait_for_heartbeat(
     }
 }
 
-void set_metal_eth_fw_run_flag(tt::ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, bool enable) {
+void set_metal_eth_fw_run_flag(tt::ChipId device_id, const tt::tt_metal::xy_pair& virtual_core, bool enable) {
     constexpr auto k_CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -31,15 +31,15 @@ const ll_api::memory& get_risc_binary(
     ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE,
     const std::function<void(ll_api::memory&)>& update_callback = nullptr);
 
-tt::tt_metal::CoreCoord logical_core_from_ethernet_core(ChipId chip_id, tt::tt_metal::CoreCoord& ethernet_core);
+tt::tt_metal::xy_pair logical_core_from_ethernet_core(ChipId chip_id, tt::tt_metal::xy_pair& ethernet_core);
 
-tt_metal::HalProgrammableCoreType get_core_type(ChipId chip_id, const tt::tt_metal::CoreCoord& virtual_core);
+tt_metal::HalProgrammableCoreType get_core_type(ChipId chip_id, const tt::tt_metal::xy_pair& virtual_core);
 
-void send_reset_go_signal(ChipId chip, const tt::tt_metal::CoreCoord& virtual_core);
+void send_reset_go_signal(ChipId chip, const tt::tt_metal::xy_pair& virtual_core);
 
 void write_launch_msg_to_core(
     ChipId chip,
-    tt::tt_metal::CoreCoord core,
+    tt::tt_metal::xy_pair core,
     tt_metal::dev_msgs::launch_msg_t::View msg,
     tt_metal::dev_msgs::go_msg_t::ConstView go_msg,
     bool send_go = true);
@@ -47,7 +47,7 @@ void write_launch_msg_to_core(
 bool test_load_write_read_risc_binary(
     const ll_api::memory& mem,
     ChipId chip_id,
-    const tt::tt_metal::CoreCoord& core,
+    const tt::tt_metal::xy_pair& core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx);
@@ -55,20 +55,24 @@ bool test_load_write_read_risc_binary(
 bool test_load_multicast_write_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
-    const tt::tt_metal::CoreCoord& start_core,
-    const tt::tt_metal::CoreCoord& end_core,
+    const tt::tt_metal::xy_pair& start_core,
+    const tt::tt_metal::xy_pair& end_core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx);
 
-void write_binary_to_address(const ll_api::memory& mem, ChipId chip_id, const tt::tt_metal::CoreCoord& core, uint32_t address);
+void write_binary_to_address(
+    const ll_api::memory& mem, ChipId chip_id, const tt::tt_metal::xy_pair& core, uint32_t address);
 
 namespace internal_ {
 
 void wait_until_cores_done(
-    ChipId device_id, int run_state, std::unordered_set<tt::tt_metal::CoreCoord>& not_done_phys_cores, int timeout_ms = 0);
+    ChipId device_id,
+    int run_state,
+    std::unordered_set<tt::tt_metal::xy_pair>& not_done_phys_cores,
+    int timeout_ms = 0);
 
-void wait_for_idle(ChipId device_id, const std::vector<std::vector<tt::tt_metal::CoreCoord>>& logical_cores);
+void wait_for_idle(ChipId device_id, const std::vector<std::vector<tt::tt_metal::xy_pair>>& logical_cores);
 
 // In test mode, return a watcher fault message if one was recorded, so host waits can unwind.
 std::optional<std::string> get_watcher_error_message_in_test_mode(ChipId device_id);
@@ -81,7 +85,7 @@ void throw_if_watcher_tripped_in_test_mode(ChipId device_id);
 // Maximum number of args depends on the architecture. Args not provided will be set to zero.
 void send_msg_to_eth_mailbox(
     ChipId device_id,
-    const tt::tt_metal::CoreCoord& virtual_core,
+    const tt::tt_metal::xy_pair& virtual_core,
     tt_metal::FWMailboxMsg msg_type,
     int mailbox_index,
     std::vector<uint32_t> args,
@@ -91,9 +95,9 @@ void send_msg_to_eth_mailbox(
 // Return to base firmware and wait for a heartbeat from the active ethernet core, if supported
 // Default timeout time empirically chosen to be 20 seconds to avoid timeouts
 void return_to_base_firmware_and_wait_for_heartbeat(
-    ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, int timeout_ms = 20000);
+    ChipId device_id, const tt::tt_metal::xy_pair& virtual_core, int timeout_ms = 20000);
 
-void set_metal_eth_fw_run_flag(ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, bool enable);
+void set_metal_eth_fw_run_flag(ChipId device_id, const tt::tt_metal::xy_pair& virtual_core, bool enable);
 
 }  // namespace internal_
 

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -30,7 +30,7 @@ size_t harvested_before(uint32_t dram_harvesting_mask, size_t channel) {
 }
 }  // namespace
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(
         dram_view < this->dram_view_worker_cores.size(),
         "dram_view={} must be within range of dram_view_worker_cores.size={}",
@@ -40,7 +40,7 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_
     return this->dram_view_worker_cores.at(dram_view).at(noc);
 };
 
-bool metal_SocDescriptor::is_noc0_dram_endpoint(const tt::tt_metal::CoreCoord& translated_coord) const {
+bool metal_SocDescriptor::is_noc0_dram_endpoint(const tt::tt_metal::xy_pair& translated_coord) const {
     // dram_view_worker_cores (and thus get_preferred_worker_core_for_dram_view) holds TRANSLATED
     // coords, so this compares like-for-like against a TRANSLATED argument. See the header note.
     for (size_t dram_view = 0; dram_view < this->dram_view_worker_cores.size(); ++dram_view) {
@@ -51,12 +51,12 @@ bool metal_SocDescriptor::is_noc0_dram_endpoint(const tt::tt_metal::CoreCoord& t
     return false;
 }
 
-std::vector<tt::tt_metal::CoreCoord> metal_SocDescriptor::get_metal_dram_cores(tt::CoordSystem coord_system) const {
+std::vector<tt::tt_metal::xy_pair> metal_SocDescriptor::get_metal_dram_cores(tt::CoordSystem coord_system) const {
     // Blackhole reserves each DRAM view's NOC0 worker endpoint for the syseng firmware; no other
     // architecture has that restriction (and future ones won't), so the exclusion is confined to this
     // one spot rather than every DRAM loop in Metal.
     const bool exclude_noc0_endpoints = (this->arch == tt::ARCH::BLACKHOLE);
-    std::vector<tt::tt_metal::CoreCoord> dram_cores;
+    std::vector<tt::tt_metal::xy_pair> dram_cores;
     const auto& umd_dram_cores = get_cores(tt::CoreType::DRAM, coord_system);
     dram_cores.reserve(umd_dram_cores.size());
     for (const tt::umd::CoreCoord& core : umd_dram_cores) {
@@ -79,8 +79,8 @@ std::vector<tt::tt_metal::CoreCoord> metal_SocDescriptor::get_metal_dram_cores(t
     return dram_cores;
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_from_translated(
-    const tt::tt_metal::CoreCoord& translated_coord) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_logical_dram_core_from_translated(
+    const tt::tt_metal::xy_pair& translated_coord) const {
     // A view can share its NOC endpoints with the other views carved out of the same channel, so this
     // returns the lowest view index that reaches translated_coord. Every such coord resolves back to
     // translated_coord through get_physical_dram_core_from_logical, which is what callers rely on; use
@@ -89,7 +89,7 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_from_translat
         const auto& endpoints = this->dram_bank_endpoint_coords[dram_view];
         for (size_t idx = 0; idx < endpoints.size(); ++idx) {
             if (endpoints[idx] == translated_coord) {
-                return tt::tt_metal::CoreCoord{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
+                return tt::tt_metal::xy_pair{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
             }
         }
     }
@@ -102,7 +102,7 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_from_translat
         this->dram_bank_endpoint_coords.size());
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(
         dram_view < this->dram_view_eth_cores.size(),
         "dram_view={} must be within range of dram_view_eth_cores.size={}",
@@ -112,14 +112,14 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_vie
     return this->dram_view_eth_cores.at(dram_view).at(noc);
 };
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_core_for_dram_view(int dram_view) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_logical_core_for_dram_view(int dram_view) const {
     const uint32_t num_dram_views = this->get_num_dram_views();
     TT_FATAL(
         dram_view < num_dram_views,
         "dram_view={} must be within range of num_dram_views={}",
         dram_view,
         num_dram_views);
-    return tt::tt_metal::CoreCoord(dram_view, 0);
+    return tt::tt_metal::xy_pair(dram_view, 0);
 }
 
 size_t metal_SocDescriptor::get_address_offset(int dram_view) const {
@@ -153,7 +153,7 @@ size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
 
 size_t metal_SocDescriptor::get_num_dram_views() const { return this->dram_view_eth_cores.size(); }
 
-int metal_SocDescriptor::get_dram_channel_from_logical_core(const tt::tt_metal::CoreCoord& logical_coord) const {
+int metal_SocDescriptor::get_dram_channel_from_logical_core(const tt::tt_metal::xy_pair& logical_coord) const {
     const uint32_t num_dram_views = this->get_num_dram_views();
     TT_FATAL(
         logical_coord.x < num_dram_views &&
@@ -165,25 +165,29 @@ int metal_SocDescriptor::get_dram_channel_from_logical_core(const tt::tt_metal::
     return logical_coord.x;
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_ethernet_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_physical_ethernet_core_from_logical(
+    const tt::tt_metal::xy_pair& logical_coord) const {
     tt::umd::CoreCoord physical_coord =
         translate_coord_to({logical_coord, tt::CoreType::ETH, tt::CoordSystem::LOGICAL}, tt::CoordSystem::NOC0);
     return {physical_coord.x, physical_coord.y};
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_ethernet_core_from_physical(const tt::tt_metal::CoreCoord& physical_coord) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_logical_ethernet_core_from_physical(
+    const tt::tt_metal::xy_pair& physical_coord) const {
     tt::umd::CoreCoord logical_coord =
         translate_coord_to({physical_coord, tt::CoreType::ETH, tt::CoordSystem::NOC0}, tt::CoordSystem::LOGICAL);
     return {logical_coord.x, logical_coord.y};
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_tensix_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_physical_tensix_core_from_logical(
+    const tt::tt_metal::xy_pair& logical_coord) const {
     tt::umd::CoreCoord physical_coord =
         translate_coord_to({logical_coord, tt::CoreType::TENSIX, tt::CoordSystem::LOGICAL}, tt::CoordSystem::NOC0);
     return {physical_coord.x, physical_coord.y};
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_physical_dram_core_from_logical(
+    const tt::tt_metal::xy_pair& logical_coord) const {
     TT_FATAL(
         logical_coord.x < dram_bank_endpoint_coords.size() &&
             logical_coord.y < dram_bank_endpoint_coords[logical_coord.x].size(),
@@ -194,10 +198,10 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical
     return dram_bank_endpoint_coords[logical_coord.x][logical_coord.y];
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const {
     const int channel = static_cast<int>(get_channel_for_dram_view(dram_view));
     const tt::umd::CoreCoord phys_umd = get_dram_core_for_channel(channel, subchannel, tt::CoordSystem::TRANSLATED);
-    const tt::tt_metal::CoreCoord phys{phys_umd.x, phys_umd.y};
+    const tt::tt_metal::xy_pair phys{phys_umd.x, phys_umd.y};
     TT_FATAL(
         dram_view >= 0 && static_cast<size_t>(dram_view) < dram_bank_endpoint_coords.size(),
         "dram_view {} out of range (num_views={})",
@@ -206,7 +210,7 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchanne
     const auto& endpoints = dram_bank_endpoint_coords[static_cast<size_t>(dram_view)];
     for (size_t idx = 0; idx < endpoints.size(); ++idx) {
         if (endpoints[idx] == phys) {
-            return tt::tt_metal::CoreCoord{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
+            return tt::tt_metal::xy_pair{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
         }
     }
     TT_THROW(
@@ -217,7 +221,8 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchanne
         phys.y);
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_dispatch_engine_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_physical_dispatch_engine_core_from_logical(
+    const tt::tt_metal::xy_pair& logical_coord) const {
     const auto dispatch_noc0_cores = get_cores(tt::CoreType::DISPATCH, tt::CoordSystem::NOC0);
     TT_FATAL(
         logical_coord.y == 0,
@@ -236,8 +241,8 @@ uint32_t metal_SocDescriptor::get_num_dispatch_engine_cores() const {
     return static_cast<uint32_t>(get_cores(tt::CoreType::DISPATCH, tt::CoordSystem::NOC0).size());
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_core_from_logical_core(
-    const tt::tt_metal::CoreCoord& logical_coord, const tt::CoreType& core_type) const {
+tt::tt_metal::xy_pair metal_SocDescriptor::get_physical_core_from_logical_core(
+    const tt::tt_metal::xy_pair& logical_coord, const tt::CoreType& core_type) const {
     switch (core_type) {
         case tt::CoreType::ETH: return this->get_physical_ethernet_core_from_logical(logical_coord);
         case tt::CoreType::WORKER: return this->get_physical_tensix_core_from_logical(logical_coord);
@@ -247,10 +252,12 @@ tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_core_from_logical_core
     }
 }
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_dram_grid_size() const { return tt::tt_metal::CoreCoord(this->get_num_dram_views(), 1); }
+tt::tt_metal::xy_pair metal_SocDescriptor::get_dram_grid_size() const {
+    return tt::tt_metal::xy_pair(this->get_num_dram_views(), 1);
+}
 
-tt::tt_metal::CoreCoord metal_SocDescriptor::get_dram_compute_grid_size() const {
-    return tt::tt_metal::CoreCoord(this->get_num_dram_views(), get_grid_size(tt::CoreType::DRAM).y);
+tt::tt_metal::xy_pair metal_SocDescriptor::get_dram_compute_grid_size() const {
+    return tt::tt_metal::xy_pair(this->get_num_dram_views(), get_grid_size(tt::CoreType::DRAM).y);
 }
 
 void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
@@ -283,7 +290,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         size_t address_offset = dram_view["address_offset"].as<size_t>();
 
         const auto eth_endpoint_ids = dram_view["eth_endpoint"].as<std::vector<int>>();
-        std::vector<tt::tt_metal::CoreCoord> eth_dram_cores;
+        std::vector<tt::tt_metal::xy_pair> eth_dram_cores;
         std::vector<size_t> eth_endpoints;
         eth_dram_cores.reserve(eth_endpoint_ids.size());
         eth_endpoints.reserve(eth_endpoint_ids.size());
@@ -301,7 +308,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         }
 
         const auto worker_endpoint_ids = dram_view["worker_endpoint"].as<std::vector<int>>();
-        std::vector<tt::tt_metal::CoreCoord> worker_dram_cores;
+        std::vector<tt::tt_metal::xy_pair> worker_dram_cores;
         std::vector<size_t> worker_endpoints;
         worker_dram_cores.reserve(worker_endpoint_ids.size());
         worker_endpoints.reserve(worker_endpoint_ids.size());
@@ -335,7 +342,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
             "DRAM view {} declares no worker_endpoint, so its logical y=0 would not name the NOC0 worker endpoint",
             this->dram_view_channels.size() - 1);
         std::vector<bool> placed(num_subchannels, false);
-        std::vector<tt::tt_metal::CoreCoord> bank_endpoints;
+        std::vector<tt::tt_metal::xy_pair> bank_endpoints;
         bank_endpoints.reserve(num_subchannels);
         const auto push_subchannel = [&](size_t sub) {
             placed[sub] = true;
@@ -369,11 +376,11 @@ void metal_SocDescriptor::generate_logical_eth_coords_mapping() {
 void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
 #if defined(TRACY_ENABLE)
     for (auto& core : get_cores(tt::CoreType::TENSIX, tt::CoordSystem::NOC0)) {
-        this->physical_routing_to_profiler_flat_id.emplace((tt::tt_metal::CoreCoord){core.x, core.y}, 0);
+        this->physical_routing_to_profiler_flat_id.emplace((tt::tt_metal::xy_pair){core.x, core.y}, 0);
     }
 
     for (auto& core : this->get_cores(tt::CoreType::ETH, tt::CoordSystem::NOC0)) {
-        this->physical_routing_to_profiler_flat_id.emplace((tt::tt_metal::CoreCoord){core.x, core.y}, 0);
+        this->physical_routing_to_profiler_flat_id.emplace((tt::tt_metal::xy_pair){core.x, core.y}, 0);
     }
 
     int flat_id = 0;

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -24,26 +24,27 @@
 struct metal_SocDescriptor : public tt::umd::SocDescriptor {
 public:
     std::vector<size_t> dram_view_channels;
-    std::vector<std::vector<tt::tt_metal::CoreCoord>>
-        dram_view_worker_cores;                               // per dram view preferred worker endpoints for each noc
-    std::vector<std::vector<tt::tt_metal::CoreCoord>> dram_view_eth_cores;  // per dram view preferred eth endpoints for each noc
+    std::vector<std::vector<tt::tt_metal::xy_pair>>
+        dram_view_worker_cores;  // per dram view preferred worker endpoints for each noc
+    std::vector<std::vector<tt::tt_metal::xy_pair>>
+        dram_view_eth_cores;                                  // per dram view preferred eth endpoints for each noc
     std::vector<size_t> dram_view_address_offsets;            // starting address offset
 
     // Per bank, ordered endpoint translated coordinates. The index is the y of a logical DRAM
-    // CoreCoord, and the order is by role so that y means the same thing on every device regardless
+    // xy_pair, and the order is by role so that y means the same thing on every device regardless
     // of DRAM harvesting: index 0 = worker endpoint for NOC 0, index 1 = worker endpoint for NOC 1
     // (when it is a different subchannel), then the bank's remaining subchannels ascending.
-    std::vector<std::vector<tt::tt_metal::CoreCoord>> dram_bank_endpoint_coords;
+    std::vector<std::vector<tt::tt_metal::xy_pair>> dram_bank_endpoint_coords;
 
     uint64_t dram_core_size{};
     uint64_t dram_view_size{};
 
-    std::map<tt::tt_metal::CoreCoord, int> logical_eth_core_to_chan_map;
+    std::map<tt::tt_metal::xy_pair, int> logical_eth_core_to_chan_map;
 
     metal_SocDescriptor(const SocDescriptor& other, const tt::BoardType& board_type);
 
-    tt::tt_metal::CoreCoord get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const;
-    tt::tt_metal::CoreCoord get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const;
+    tt::tt_metal::xy_pair get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const;
+    tt::tt_metal::xy_pair get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const;
 
     // The DRAM cores Metal may place kernels/firmware on, in the requested coordinate system. This is
     // the single source of truth for "usable DRAM cores": every DRAM loop in Metal (firmware init,
@@ -55,39 +56,40 @@ public:
     // A LOGICAL request returns Metal logical DRAM coords ({dram_view, dram_bank_endpoint_coords
     // index}, the space get_physical_dram_core_from_logical and CreateKernel(DramConfig) use), not
     // UMD's {channel, raw subchannel}.
-    std::vector<tt::tt_metal::CoreCoord> get_metal_dram_cores(tt::CoordSystem coord_system) const;
-    tt::tt_metal::CoreCoord get_logical_core_for_dram_view(int dram_view) const;
+    std::vector<tt::tt_metal::xy_pair> get_metal_dram_cores(tt::CoordSystem coord_system) const;
+    tt::tt_metal::xy_pair get_logical_core_for_dram_view(int dram_view) const;
     size_t get_address_offset(int dram_view) const;
     size_t get_channel_for_dram_view(int dram_view) const;
     size_t get_num_dram_views() const;
 
-    int get_dram_channel_from_logical_core(const tt::tt_metal::CoreCoord& logical_coord) const;
+    int get_dram_channel_from_logical_core(const tt::tt_metal::xy_pair& logical_coord) const;
 
-    tt::tt_metal::CoreCoord get_physical_ethernet_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
-    tt::tt_metal::CoreCoord get_logical_ethernet_core_from_physical(const tt::tt_metal::CoreCoord& physical_coord) const;
-    tt::tt_metal::CoreCoord get_physical_tensix_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
-    tt::tt_metal::CoreCoord get_physical_dram_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
-    // Map a DRAM view + hardware subchannel to the logical CoreCoord used by CreateKernel(DramConfig).
+    tt::tt_metal::xy_pair get_physical_ethernet_core_from_logical(const tt::tt_metal::xy_pair& logical_coord) const;
+    tt::tt_metal::xy_pair get_logical_ethernet_core_from_physical(const tt::tt_metal::xy_pair& physical_coord) const;
+    tt::tt_metal::xy_pair get_physical_tensix_core_from_logical(const tt::tt_metal::xy_pair& logical_coord) const;
+    tt::tt_metal::xy_pair get_physical_dram_core_from_logical(const tt::tt_metal::xy_pair& logical_coord) const;
+    // Map a DRAM view + hardware subchannel to the logical xy_pair used by CreateKernel(DramConfig).
     // logical.y indexes dram_bank_endpoint_coords (ordered by endpoint role), not the raw subchannel id.
-    tt::tt_metal::CoreCoord get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const;
+    tt::tt_metal::xy_pair get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const;
     // Same logical space as get_logical_dram_core_for_subchannel, keyed by a TRANSLATED coord. Inverse
     // of get_physical_dram_core_from_logical. A DRAM view is a dram_view_size window of one hardware
     // channel -- what Metal allocates against as a DRAM bank -- so a channel split into several views
     // (Wormhole: two 1 GB views per channel) has one set of NOC endpoints serving all of them. This
     // returns the lowest view reaching the coord; it round-trips, but is not the only answer.
-    tt::tt_metal::CoreCoord get_logical_dram_core_from_translated(
-        const tt::tt_metal::CoreCoord& translated_coord) const;
-    tt::tt_metal::CoreCoord get_physical_dispatch_engine_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
+    tt::tt_metal::xy_pair get_logical_dram_core_from_translated(const tt::tt_metal::xy_pair& translated_coord) const;
+    tt::tt_metal::xy_pair get_physical_dispatch_engine_core_from_logical(
+        const tt::tt_metal::xy_pair& logical_coord) const;
     uint32_t get_num_dispatch_engine_cores() const;
 
-    tt::tt_metal::CoreCoord get_physical_core_from_logical_core(const tt::tt_metal::CoreCoord& logical_coord, const tt::CoreType& core_type) const;
+    tt::tt_metal::xy_pair get_physical_core_from_logical_core(
+        const tt::tt_metal::xy_pair& logical_coord, const tt::CoreType& core_type) const;
 
-    tt::tt_metal::CoreCoord get_dram_grid_size() const;
-    tt::tt_metal::CoreCoord get_dram_compute_grid_size() const;
+    tt::tt_metal::xy_pair get_dram_grid_size() const;
+    tt::tt_metal::xy_pair get_dram_compute_grid_size() const;
 
     // Number of cores per DRAM bank ceiled to nearest integer
     int profiler_ceiled_core_count_perf_dram_bank = 0;
-    std::map<tt::tt_metal::CoreCoord, int32_t> physical_routing_to_profiler_flat_id;
+    std::map<tt::tt_metal::xy_pair, int32_t> physical_routing_to_profiler_flat_id;
 
 private:
     // Physical DRAM channel (device-descriptor numbering, with harvested-channel gaps) for a dram
@@ -98,7 +100,7 @@ private:
     // True if `translated_coord` is any DRAM view's NOC0 worker endpoint (the subchannel a NOC0 DRAM
     // access routes to) -- the syseng-owned endpoint excluded by get_metal_dram_cores on Blackhole.
     // Argument must be a TRANSLATED (UMD) coord; a metal-logical {view, subchannel} coord never matches.
-    bool is_noc0_dram_endpoint(const tt::tt_metal::CoreCoord& translated_coord) const;
+    bool is_noc0_dram_endpoint(const tt::tt_metal::xy_pair& translated_coord) const;
 
     void load_dram_metadata_from_device_descriptor();
     void generate_logical_eth_coords_mapping();

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -2020,7 +2020,7 @@ void RunTimeOptions::ParseFeatureEnv(RunTimeDebugFeatures feature, const tt_meta
 void RunTimeOptions::ParseFeatureCoreRange(
     RunTimeDebugFeatures feature, const std::string& env_var, CoreType core_type) {
     char* str = std::getenv(env_var.c_str());
-    std::vector<tt::tt_metal::CoreCoord> cores;
+    std::vector<tt::tt_metal::xy_pair> cores;
 
     // Check if "all" is specified, rather than a range of cores.
     feature_targets[feature].all_cores[core_type] = RunTimeDebugClassNoneSpecified;
@@ -2043,7 +2043,7 @@ void RunTimeOptions::ParseFeatureCoreRange(
         } else if (str[0] == '(') {
             if (strchr(str, '-')) {
                 // Assume this is a range
-                tt::tt_metal::CoreCoord start, end;
+                tt::tt_metal::xy_pair start, end;
                 if (sscanf(str, "(%zu,%zu)", &start.x, &start.y) != 2) {
                     TT_THROW("Invalid {}", env_var);
                 }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -80,7 +80,7 @@ extern const char* RunTimeDebugClassNames[RunTimeDebugClassCount];
 // TargetSelection stores the targets for a given debug feature. I.e. for which chips, cores, harts
 // to enable the feature.
 struct TargetSelection {
-    std::map<CoreType, std::vector<tt::tt_metal::CoreCoord>> cores;
+    std::map<CoreType, std::vector<tt::tt_metal::xy_pair>> cores;
     std::map<CoreType, int> all_cores;
     bool enabled{};
     std::vector<int> chip_ids;
@@ -555,10 +555,11 @@ public:
     bool get_feature_enabled(RunTimeDebugFeatures feature) const { return feature_targets[feature].enabled; }
     void set_feature_enabled(RunTimeDebugFeatures feature, bool enabled) { feature_targets[feature].enabled = enabled; }
     // Note: dprint cores are logical
-    const std::map<CoreType, std::vector<tt::tt_metal::CoreCoord>>& get_feature_cores(RunTimeDebugFeatures feature) const {
+    const std::map<CoreType, std::vector<tt::tt_metal::xy_pair>>& get_feature_cores(
+        RunTimeDebugFeatures feature) const {
         return feature_targets[feature].cores;
     }
-    void set_feature_cores(RunTimeDebugFeatures feature, std::map<CoreType, std::vector<tt::tt_metal::CoreCoord>> cores) {
+    void set_feature_cores(RunTimeDebugFeatures feature, std::map<CoreType, std::vector<tt::tt_metal::xy_pair>> cores) {
         feature_targets[feature].cores = std::move(cores);
     }
     // An alternative to setting cores by range, a flag to enable all.
@@ -569,8 +570,9 @@ public:
         return feature_targets[feature].all_cores.at(core_type);
     }
     // Note: core range is inclusive
-    void set_feature_core_range(RunTimeDebugFeatures feature, tt::tt_metal::CoreCoord start, tt::tt_metal::CoreCoord end, CoreType core_type) {
-        feature_targets[feature].cores[core_type] = std::vector<tt::tt_metal::CoreCoord>();
+    void set_feature_core_range(
+        RunTimeDebugFeatures feature, tt::tt_metal::xy_pair start, tt::tt_metal::xy_pair end, CoreType core_type) {
+        feature_targets[feature].cores[core_type] = std::vector<tt::tt_metal::xy_pair>();
         for (uint32_t x = start.x; x <= end.x; x++) {
             for (uint32_t y = start.y; y <= end.y; y++) {
                 feature_targets[feature].cores[core_type].push_back({x, y});

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -50,9 +50,9 @@ inline bool debug_valid_dram_l1_addr(const tt::tt_metal::Hal& hal, uint64_t addr
     return (addr >= noc_offset && addr + len <= noc_offset + size) || debug_valid_reg_addr(hal, addr, len);
 }
 
-static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, tt::tt_metal::CoreCoord core) {
+static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, tt::tt_metal::xy_pair core) {
     for (const tt::umd::CoreCoord& core_coord : coords) {
-        tt::tt_metal::CoreCoord item = {core_coord.x, core_coord.y};
+        tt::tt_metal::xy_pair item = {core_coord.x, core_coord.y};
         if (item == core) {
             return true;
         }
@@ -60,9 +60,11 @@ static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, tt::tt_
     return false;
 }
 
-static bool coord_found_p(const std::unordered_set<tt::tt_metal::CoreCoord>& coords, tt::tt_metal::CoreCoord core) { return coords.contains(core); }
+static bool coord_found_p(const std::unordered_set<tt::tt_metal::xy_pair>& coords, tt::tt_metal::xy_pair core) {
+    return coords.contains(core);
+}
 
-static std::string noc_address(tt::tt_metal::CoreCoord core, uint64_t a, uint32_t l) {
+static std::string noc_address(tt::tt_metal::xy_pair core, uint64_t a, uint32_t l) {
     std::stringstream ss;
     ss << "noc{" << core.str() << ", 0x" << std::setfill('0') << std::setw(8) << std::hex << a << ", " << std::dec << l
        << "}";
@@ -89,13 +91,13 @@ static void print_stack_trace() {
 static void watcher_sanitize_host_noc(
     const char* what,
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_eth_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_pcie_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_hw_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dispatch_cores,
-    const tt::tt_metal::CoreCoord& core,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_worker_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_eth_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_pcie_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dram_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dram_hw_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dispatch_cores,
+    const tt::tt_metal::xy_pair& core,
     uint64_t addr,
     uint32_t lbytes) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
@@ -163,13 +165,13 @@ static void watcher_sanitize_host_noc(
 
 inline void watcher_sanitize_host_noc_read(
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_eth_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_pcie_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_hw_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dispatch_cores,
-    const tt::tt_metal::CoreCoord& core,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_worker_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_eth_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_pcie_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dram_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dram_hw_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dispatch_cores,
+    const tt::tt_metal::xy_pair& core,
     uint64_t addr,
     uint32_t lbytes) {
     watcher_sanitize_host_noc(
@@ -188,13 +190,13 @@ inline void watcher_sanitize_host_noc_read(
 
 inline void watcher_sanitize_host_noc_write(
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_eth_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_pcie_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_hw_cores,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dispatch_cores,
-    const tt::tt_metal::CoreCoord& core,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_worker_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_eth_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_pcie_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dram_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dram_hw_cores,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_dispatch_cores,
+    const tt::tt_metal::xy_pair& core,
     uint64_t addr,
     uint32_t lbytes) {
     watcher_sanitize_host_noc(
@@ -213,9 +215,9 @@ inline void watcher_sanitize_host_noc_write(
 
 inline void watcher_sanitize_host_noc_multicast_write(
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
-    const tt::tt_metal::CoreCoord& core_start,
-    const tt::tt_metal::CoreCoord& core_end,
+    const std::unordered_set<tt::tt_metal::xy_pair>& virtual_worker_cores,
+    const tt::tt_metal::xy_pair& core_start,
+    const tt::tt_metal::xy_pair& core_end,
     uint64_t addr,
     uint32_t lbytes) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -414,7 +414,8 @@ void Cluster::get_metal_desc_from_tt_desc() {
     }
 }
 
-const std::unordered_map<tt::tt_metal::CoreCoord, int32_t>& Cluster::get_virtual_routing_to_profiler_flat_id(ChipId chip_id) const {
+const std::unordered_map<tt::tt_metal::xy_pair, int32_t>& Cluster::get_virtual_routing_to_profiler_flat_id(
+    ChipId chip_id) const {
     return this->virtual_routing_to_profiler_flat_id_.at(this->get_board_type(chip_id));
 }
 
@@ -654,32 +655,32 @@ void Cluster::generate_virtual_to_profiler_flat_id_mapping() {
 #endif
 }
 
-bool Cluster::is_worker_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const {
+bool Cluster::is_worker_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const {
     return this->virtual_worker_cores_.at(chip_id).contains(core);
 }
 
-bool Cluster::is_ethernet_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const {
+bool Cluster::is_ethernet_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const {
     return this->virtual_eth_cores_.contains(chip_id) and this->virtual_eth_cores_.at(chip_id).contains(core);
 }
 
-bool Cluster::is_dram_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const {
+bool Cluster::is_dram_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const {
     return this->virtual_dram_hw_cores_.contains(chip_id) and this->virtual_dram_hw_cores_.at(chip_id).contains(core);
 }
 
-bool Cluster::is_dispatch_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const {
+bool Cluster::is_dispatch_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const {
     return this->virtual_dispatch_cores_.contains(chip_id) and this->virtual_dispatch_cores_.at(chip_id).contains(core);
 }
 
-const std::unordered_set<tt::tt_metal::CoreCoord>& Cluster::get_virtual_worker_cores(ChipId chip_id) const {
+const std::unordered_set<tt::tt_metal::xy_pair>& Cluster::get_virtual_worker_cores(ChipId chip_id) const {
     return this->virtual_worker_cores_.at(chip_id);
 }
 
-const std::unordered_set<tt::tt_metal::CoreCoord>& Cluster::get_virtual_eth_cores(ChipId chip_id) const {
+const std::unordered_set<tt::tt_metal::xy_pair>& Cluster::get_virtual_eth_cores(ChipId chip_id) const {
     return this->virtual_eth_cores_.at(chip_id);
 }
 
-tt::tt_metal::CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
-    ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type) const {
+tt::tt_metal::xy_pair Cluster::get_virtual_coordinate_from_logical_coordinates(
+    ChipId chip_id, tt::tt_metal::xy_pair logical_coord, const CoreType& core_type) const {
     // TBD: Remove when all WORKER are rewritten to TENSIX
     CoreType core_type_to_use = core_type;
     if (core_type_to_use == CoreType::WORKER) {
@@ -698,8 +699,7 @@ tt::tt_metal::CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates
     }
 
     if (core_type == CoreType::DISPATCH) {
-        const tt::tt_metal::CoreCoord noc0_coord =
-            soc_desc.get_physical_dispatch_engine_core_from_logical(logical_coord);
+        const tt::tt_metal::xy_pair noc0_coord = soc_desc.get_physical_dispatch_engine_core_from_logical(logical_coord);
         tt::umd::CoreCoord translated_coord = soc_desc.translate_coord_to(
             {noc0_coord, CoreType::DISPATCH, CoordSystem::NOC0}, CoordSystem::TRANSLATED);
         return {translated_coord.x, translated_coord.y};
@@ -713,18 +713,19 @@ tt::tt_metal::CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates
 tt_cxy_pair Cluster::get_virtual_coordinate_from_logical_coordinates(
     tt_cxy_pair logical_coordinate, const CoreType& core_type) const {
     auto xy_virtual_coord = this->get_virtual_coordinate_from_logical_coordinates(
-        logical_coordinate.chip, tt::tt_metal::CoreCoord(logical_coordinate.x, logical_coordinate.y), core_type);
+        logical_coordinate.chip, tt::tt_metal::xy_pair(logical_coordinate.x, logical_coordinate.y), core_type);
     return tt_cxy_pair(logical_coordinate.chip, xy_virtual_coord);
 }
-tt::tt_metal::CoreCoord Cluster::get_virtual_coordinate_from_physical_coordinates(ChipId chip_id, tt::tt_metal::CoreCoord physical_coord) const {
+tt::tt_metal::xy_pair Cluster::get_virtual_coordinate_from_physical_coordinates(
+    ChipId chip_id, tt::tt_metal::xy_pair physical_coord) const {
     const auto& soc_desc = this->get_soc_desc(chip_id);
     tt::umd::CoreCoord translated_coord =
         soc_desc.translate_coord_to(physical_coord, CoordSystem::NOC0, CoordSystem::TRANSLATED);
     return {translated_coord.x, translated_coord.y};
 }
 
-tt::tt_metal::CoreCoord Cluster::get_physical_coordinate_from_logical_coordinates(
-    ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type, bool no_warn) const {
+tt::tt_metal::xy_pair Cluster::get_physical_coordinate_from_logical_coordinates(
+    ChipId chip_id, tt::tt_metal::xy_pair logical_coord, const CoreType& core_type, bool no_warn) const {
     if (!no_warn) {
         log_warning(
             tt::LogDevice,
@@ -735,7 +736,7 @@ tt::tt_metal::CoreCoord Cluster::get_physical_coordinate_from_logical_coordinate
     return soc_desc.get_physical_core_from_logical_core(logical_coord, core_type);
 }
 
-tt::tt_metal::CoreCoord Cluster::get_logical_ethernet_core_from_virtual(ChipId chip, tt::tt_metal::CoreCoord core) const {
+tt::tt_metal::xy_pair Cluster::get_logical_ethernet_core_from_virtual(ChipId chip, tt::tt_metal::xy_pair core) const {
     tt::umd::CoreCoord logical_core =
         get_soc_desc(chip).translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
     return {logical_core.x, logical_core.y};
@@ -824,7 +825,8 @@ void Cluster::write_dram_vec(
         dram_view,
         desc_to_use.get_num_dram_views());
 
-    tt::tt_metal::CoreCoord dram_core_coord = desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
+    tt::tt_metal::xy_pair dram_core_coord =
+        desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
     tt_cxy_pair dram_core = tt_cxy_pair(device_id, dram_core_coord.x, dram_core_coord.y);
     size_t offset = desc_to_use.get_address_offset(dram_view);
     write_core(mem_ptr, sz_in_bytes, tt_cxy_pair(device_id, dram_core.x, dram_core.y), addr + offset);
@@ -838,7 +840,8 @@ void Cluster::read_dram_vec(void* mem_ptr, uint32_t sz_in_bytes, ChipId device_i
         dram_view,
         desc_to_use.get_num_dram_views());
 
-    tt::tt_metal::CoreCoord dram_core_coord = desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
+    tt::tt_metal::xy_pair dram_core_coord =
+        desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
     tt_cxy_pair dram_core = tt_cxy_pair(device_id, dram_core_coord.x, dram_core_coord.y);
     size_t offset = desc_to_use.get_address_offset(dram_view);
     read_core(mem_ptr, sz_in_bytes, tt_cxy_pair(device_id, dram_core.x, dram_core.y), addr + offset);
@@ -1005,8 +1008,12 @@ void Cluster::noc_multicast_write(
 }
 
 void Cluster::noc_multicast_write(
-    const void* mem_ptr, uint32_t sz_in_bytes, ChipId chip_id, tt::tt_metal::CoreCoord core_start, tt::tt_metal::CoreCoord core_end, uint64_t addr)
-    const {
+    const void* mem_ptr,
+    uint32_t sz_in_bytes,
+    ChipId chip_id,
+    tt::tt_metal::xy_pair core_start,
+    tt::tt_metal::xy_pair core_end,
+    uint64_t addr) const {
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
     if (rtoptions_.get_watcher_enabled()) {
@@ -1113,9 +1120,9 @@ const std::unordered_set<ChipId>& Cluster::get_devices_controlled_by_mmio_device
     return llrt::get_devices_controlled_by_mmio_device(cluster_desc, mmio_device_id);
 }
 
-std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> Cluster::get_ethernet_cores_grouped_by_connected_chips(
+std::unordered_map<ChipId, std::vector<tt::tt_metal::xy_pair>> Cluster::get_ethernet_cores_grouped_by_connected_chips(
     ChipId chip_id) const {
-    std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> connected_chips;
+    std::unordered_map<ChipId, std::vector<tt::tt_metal::xy_pair>> connected_chips;
     const auto& all_eth_connections = this->get_cluster_desc()->get_ethernet_connections();
     if (!all_eth_connections.contains(chip_id)) {
         return {};
@@ -1123,7 +1130,7 @@ std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> Cluster::get_et
     for (const auto& [eth_chan, connected_chip_chan] : all_eth_connections.at(chip_id)) {
         const auto& other_chip_id = std::get<0>(connected_chip_chan);
         if (!connected_chips.contains(other_chip_id)) {
-            std::vector<tt::tt_metal::CoreCoord> active_ethernet_cores;
+            std::vector<tt::tt_metal::xy_pair> active_ethernet_cores;
 
             for (const auto& channel_pair :
                  this->get_cluster_desc()->get_directly_connected_ethernet_channels_between_chips(chip_id, other_chip_id)) {
@@ -1373,8 +1380,9 @@ std::set<tt_fabric::chan_id_t> Cluster::get_fabric_ethernet_channels(
     return fabric_ethernet_channels;
 }
 
-std::vector<tt::tt_metal::CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest(ChipId src_id, ChipId dst_id) const {
-    std::vector<tt::tt_metal::CoreCoord> fabric_ethernet_channels;
+std::vector<tt::tt_metal::xy_pair> Cluster::get_fabric_ethernet_routers_between_src_and_dest(
+    ChipId src_id, ChipId dst_id) const {
+    std::vector<tt::tt_metal::xy_pair> fabric_ethernet_channels;
     const auto& connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(src_id);
     TT_FATAL(connected_chips.contains(dst_id), "Dst Chip {} is not connected to Src Chip {}", dst_id, src_id);
     fabric_ethernet_channels.reserve(connected_chips.at(dst_id).size());
@@ -1386,13 +1394,14 @@ std::vector<tt::tt_metal::CoreCoord> Cluster::get_fabric_ethernet_routers_betwee
     return fabric_ethernet_channels;
 }
 
-bool Cluster::is_ethernet_link_up(ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const {
+bool Cluster::is_ethernet_link_up(ChipId chip_id, const tt::tt_metal::xy_pair& logical_core) const {
     const auto& soc_desc = get_soc_desc(chip_id);
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(logical_core);
     return this->get_cluster_desc()->ethernet_core_has_active_ethernet_link(chip_id, eth_chan);
 }
 
-std::tuple<ChipId, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const {
+std::tuple<ChipId, tt::tt_metal::xy_pair> Cluster::get_connected_ethernet_core(
+    std::tuple<ChipId, tt::tt_metal::xy_pair> eth_core) const {
     const auto& soc_desc = get_soc_desc(std::get<0>(eth_core));
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
     TT_FATAL(
@@ -1415,8 +1424,8 @@ std::tuple<ChipId, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_core
 }
 
 // TODO: unify uint64_t with ChipUID
-std::tuple<uint64_t, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_core_to_remote_mmio_device(
-    std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const {
+std::tuple<uint64_t, tt::tt_metal::xy_pair> Cluster::get_connected_ethernet_core_to_remote_mmio_device(
+    std::tuple<ChipId, tt::tt_metal::xy_pair> eth_core) const {
     const auto& soc_desc = get_soc_desc(std::get<0>(eth_core));
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
     TT_FATAL(
@@ -1440,7 +1449,7 @@ std::tuple<uint64_t, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_co
         soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL));
 }
 
-std::vector<tt::tt_metal::CoreCoord> Cluster::get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const {
+std::vector<tt::tt_metal::xy_pair> Cluster::get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const {
     const auto& local_ethernet_sockets = this->ethernet_sockets_.at(local_chip);
     TT_FATAL(
         local_ethernet_sockets.contains(remote_chip),
@@ -1450,12 +1459,13 @@ std::vector<tt::tt_metal::CoreCoord> Cluster::get_ethernet_sockets(ChipId local_
     return local_ethernet_sockets.at(remote_chip);
 }
 
-tt::tt_metal::CoreCoord Cluster::ethernet_core_from_logical_core(ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const {
+tt::tt_metal::xy_pair Cluster::ethernet_core_from_logical_core(
+    ChipId chip_id, const tt::tt_metal::xy_pair& logical_core) const {
     const metal_SocDescriptor& soc_desc = get_soc_desc(chip_id);
     return soc_desc.get_physical_ethernet_core_from_logical(logical_core);
 }
 
-tt::tt_metal::CoreCoord Cluster::get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const {
+tt::tt_metal::xy_pair Cluster::get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const {
     tt::umd::CoreCoord logical_coord =
         this->get_soc_desc(chip_id).get_eth_core_for_channel(channel, CoordSystem::LOGICAL);
     return this->get_virtual_coordinate_from_logical_coordinates(
@@ -1540,7 +1550,7 @@ std::uint32_t Cluster::get_ubb_asic_id(ChipId physical_chip_id) const {
     return ((unique_chip_id >> 56) & 0xFF);
 }
 
-bool Cluster::is_external_cable(ChipId physical_chip_id, tt::tt_metal::CoreCoord eth_core) const {
+bool Cluster::is_external_cable(ChipId physical_chip_id, tt::tt_metal::xy_pair eth_core) const {
     auto chan_id = this->get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
     bool is_external_cable = false;
     auto board_type = this->get_board_type(physical_chip_id);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -113,16 +113,16 @@ public:
     ARCH arch() const { return this->arch_; }
 
     const metal_SocDescriptor& get_soc_desc(ChipId chip) const;
-    tt::tt_metal::CoreCoord get_virtual_coordinate_from_logical_coordinates(
-        ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type) const;
-    tt::tt_metal::CoreCoord get_virtual_coordinate_from_physical_coordinates(
-        ChipId chip_id, tt::tt_metal::CoreCoord physical_coord) const;
+    tt::tt_metal::xy_pair get_virtual_coordinate_from_logical_coordinates(
+        ChipId chip_id, tt::tt_metal::xy_pair logical_coord, const CoreType& core_type) const;
+    tt::tt_metal::xy_pair get_virtual_coordinate_from_physical_coordinates(
+        ChipId chip_id, tt::tt_metal::xy_pair physical_coord) const;
     tt_cxy_pair get_virtual_coordinate_from_logical_coordinates(
         tt_cxy_pair logical_coordinate, const CoreType& core_type) const;
-    tt::tt_metal::CoreCoord get_physical_coordinate_from_logical_coordinates(
-        ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type, bool no_warn = false) const;
-    const std::unordered_set<tt::tt_metal::CoreCoord>& get_virtual_worker_cores(ChipId chip_id) const;
-    const std::unordered_set<tt::tt_metal::CoreCoord>& get_virtual_eth_cores(ChipId chip_id) const;
+    tt::tt_metal::xy_pair get_physical_coordinate_from_logical_coordinates(
+        ChipId chip_id, tt::tt_metal::xy_pair logical_coord, const CoreType& core_type, bool no_warn = false) const;
+    const std::unordered_set<tt::tt_metal::xy_pair>& get_virtual_worker_cores(ChipId chip_id) const;
+    const std::unordered_set<tt::tt_metal::xy_pair>& get_virtual_eth_cores(ChipId chip_id) const;
 
     uint32_t get_harvesting_mask(ChipId chip) const {
         return this->driver_->get_soc_descriptor(chip).harvesting_masks.tensix_harvesting_mask;
@@ -152,28 +152,28 @@ public:
     // Write to core without effects of write combining
     template <typename DType>
     void write_core_immediate(
-        ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
+        ChipId device_id, const tt::tt_metal::xy_pair& core, const std::span<DType>& hex_vec, uint64_t addr) const {
         write_core_immediate(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 
     // Write to core without effects of write combining
     template <typename DType>
     void write_core_immediate(
-        ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
+        ChipId device_id, const tt::tt_metal::xy_pair& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
         write_core_immediate(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 
     // Write span to core
     template <typename DType>
     void write_core(
-        ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
+        ChipId device_id, const tt::tt_metal::xy_pair& core, const std::span<DType>& hex_vec, uint64_t addr) const {
         write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 
     // Write vector to core
     template <typename DType>
     void write_core(
-        ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
+        ChipId device_id, const tt::tt_metal::xy_pair& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
         write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 
@@ -183,7 +183,7 @@ public:
 
     template <typename DType = uint32_t>
     [[nodiscard]] std::vector<DType> read_core(
-        ChipId chip, const tt::tt_metal::CoreCoord& core, uint64_t addr, uint32_t size) const {
+        ChipId chip, const tt::tt_metal::xy_pair& core, uint64_t addr, uint32_t size) const {
         std::vector<DType> read_hex_vec;
         read_core(read_hex_vec, size, tt_cxy_pair(chip, core), addr);
         return read_hex_vec;
@@ -196,8 +196,8 @@ public:
         const void* mem_ptr,
         uint32_t sz_in_bytes,
         ChipId chip_id,
-        tt::tt_metal::CoreCoord core_start,
-        tt::tt_metal::CoreCoord core_end,
+        tt::tt_metal::xy_pair core_start,
+        tt::tt_metal::xy_pair core_end,
         uint64_t addr) const;
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair& target) const {
@@ -276,26 +276,26 @@ public:
 
     // Returns whether `logical_core` has an eth link to a core on a connected chip
     // Cores that connect to another cluster will show up as connected
-    bool is_ethernet_link_up(ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const;
+    bool is_ethernet_link_up(ChipId chip_id, const tt::tt_metal::xy_pair& logical_core) const;
 
     // Returns connected ethernet core on the other chip
     // If the core is connected to a device not accessible through this Cluster, it will assert
-    std::tuple<ChipId, tt::tt_metal::CoreCoord> get_connected_ethernet_core(
-        std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const;
+    std::tuple<ChipId, tt::tt_metal::xy_pair> get_connected_ethernet_core(
+        std::tuple<ChipId, tt::tt_metal::xy_pair> eth_core) const;
 
     // Returns connected ethernet core on the other chip that is not managed by this Cluster
-    std::tuple<uint64_t, tt::tt_metal::CoreCoord> get_connected_ethernet_core_to_remote_mmio_device(
-        std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const;
+    std::tuple<uint64_t, tt::tt_metal::xy_pair> get_connected_ethernet_core_to_remote_mmio_device(
+        std::tuple<ChipId, tt::tt_metal::xy_pair> eth_core) const;
 
     // Returns a ethernet sockets between local chip and remote chip
     // get_ethernet_sockets(a, b)[0] is connected to get_ethernet_sockets(b, a)[0]
-    std::vector<tt::tt_metal::CoreCoord> get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const;
+    std::vector<tt::tt_metal::xy_pair> get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const;
     // Converts logical ethernet core coord to physical ethernet core coord
-    tt::tt_metal::CoreCoord ethernet_core_from_logical_core(
-        ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const;
+    tt::tt_metal::xy_pair ethernet_core_from_logical_core(
+        ChipId chip_id, const tt::tt_metal::xy_pair& logical_core) const;
 
     // Returns virtual eth coord from channel
-    tt::tt_metal::CoreCoord get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const;
+    tt::tt_metal::xy_pair get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const;
 
     // Internal routing for SD and FD enables launching user ethernet kernels and FD tunneling for all devices in the
     // cluster. When using multiple devices in a cluster, this should be the flow:
@@ -332,7 +332,7 @@ public:
     const std::unordered_set<ChipId>& get_devices_controlled_by_mmio_device(ChipId mmio_device_id) const;
 
     // Returns map of connected chip ids to active ethernet cores
-    std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> get_ethernet_cores_grouped_by_connected_chips(
+    std::unordered_map<ChipId, std::vector<tt::tt_metal::xy_pair>> get_ethernet_cores_grouped_by_connected_chips(
         ChipId chip_id) const;
 
     // Returns vector of unique tunnels originating from mmio device.
@@ -381,31 +381,31 @@ public:
         const tt::tt_fabric::ControlPlane& control_plane, ChipId chip_id) const;
 
     // Get fabric ethernet cores connecting src to dst
-    std::vector<tt::tt_metal::CoreCoord> get_fabric_ethernet_routers_between_src_and_dest(
+    std::vector<tt::tt_metal::xy_pair> get_fabric_ethernet_routers_between_src_and_dest(
         ChipId src_id, ChipId dst_id) const;
 
-    bool is_worker_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const;
-    bool is_ethernet_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const;
-    bool is_dram_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const;
-    bool is_dispatch_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const;
-    tt::tt_metal::CoreCoord get_logical_ethernet_core_from_virtual(ChipId chip, tt::tt_metal::CoreCoord core) const;
+    bool is_worker_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const;
+    bool is_ethernet_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const;
+    bool is_dram_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const;
+    bool is_dispatch_core(const tt::tt_metal::xy_pair& core, ChipId chip_id) const;
+    tt::tt_metal::xy_pair get_logical_ethernet_core_from_virtual(ChipId chip, tt::tt_metal::xy_pair core) const;
 
     // These two functions should be removed in favor of direct translation.
     std::unordered_map<int, int> get_worker_logical_to_virtual_x(ChipId chip_id) const;
     std::unordered_map<int, int> get_worker_logical_to_virtual_y(ChipId chip_id) const;
 
-    const std::unordered_map<tt::tt_metal::CoreCoord, int32_t>& get_virtual_routing_to_profiler_flat_id(
+    const std::unordered_map<tt::tt_metal::xy_pair, int32_t>& get_virtual_routing_to_profiler_flat_id(
         ChipId chip_id) const;
 
     std::uint32_t get_ubb_asic_id(ChipId physical_chip_id) const;
 
     // TODO: move to separate system descriptor class
     // return enum for connection type, Internal, QSFP, Other, Unknown
-    bool is_external_cable(ChipId physical_chip_id, tt::tt_metal::CoreCoord eth_core) const;
+    bool is_external_cable(ChipId physical_chip_id, tt::tt_metal::xy_pair eth_core) const;
 
     uint32_t get_alignment_requirements(ChipId chip_id, uint32_t size_in_bytes) const;
 
-    const std::unordered_set<tt::tt_metal::CoreCoord>& get_eth_cores_with_frequent_retraining(ChipId chip_id) const {
+    const std::unordered_set<tt::tt_metal::xy_pair>& get_eth_cores_with_frequent_retraining(ChipId chip_id) const {
         return this->frequent_retrain_cores_.at(chip_id);
     }
 
@@ -413,7 +413,7 @@ public:
     // Call after link retraining to allow continued operation without restarting the process.
     void rediscover_ethernet_links();
 
-    const std::unordered_map<tt::tt_metal::CoreCoord, EthRouterMode>& get_eth_routing_info(ChipId chip_id) const {
+    const std::unordered_map<tt::tt_metal::xy_pair, EthRouterMode>& get_eth_routing_info(ChipId chip_id) const {
         return this->device_eth_routing_info_.at(chip_id);
     }
 
@@ -462,15 +462,15 @@ private:
 
     // Data Structures Tracking Virtual Coordinates
     std::unordered_map<tt_cxy_pair, tt_cxy_pair> virtual_to_umd_coord_mapping_;
-    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_worker_cores_;
-    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_dispatch_cores_;
-    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_eth_cores_;
-    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_dram_cores_;
-    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_dram_hw_cores_;
-    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_pcie_cores_;
-    std::unordered_map<BoardType, std::unordered_map<tt::tt_metal::CoreCoord, int32_t>>
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::xy_pair>> virtual_worker_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::xy_pair>> virtual_dispatch_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::xy_pair>> virtual_eth_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::xy_pair>> virtual_dram_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::xy_pair>> virtual_dram_hw_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::xy_pair>> virtual_pcie_cores_;
+    std::unordered_map<BoardType, std::unordered_map<tt::tt_metal::xy_pair, int32_t>>
         virtual_routing_to_profiler_flat_id_;
-    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> frequent_retrain_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::xy_pair>> frequent_retrain_cores_;
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
     tt::tt_metal::ClusterType cluster_type_ = tt::tt_metal::ClusterType::INVALID;
@@ -496,9 +496,9 @@ private:
     std::unordered_map<ChipId, uint16_t> device_to_host_mem_channel_;
 
     // Mapping of each devices' ethernet routing mode
-    std::unordered_map<ChipId, std::unordered_map<tt::tt_metal::CoreCoord, EthRouterMode>> device_eth_routing_info_;
+    std::unordered_map<ChipId, std::unordered_map<tt::tt_metal::xy_pair, EthRouterMode>> device_eth_routing_info_;
 
-    std::unordered_map<ChipId, std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>>> ethernet_sockets_;
+    std::unordered_map<ChipId, std::unordered_map<ChipId, std::vector<tt::tt_metal::xy_pair>>> ethernet_sockets_;
 
     uint32_t routing_info_addr_ = 0;
     uint32_t retrain_count_addr_ = 0;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Related to: https://github.com/tenstorrent/tt-umd/issues/1216

`CoreCoord` and `xy_pair` are both aliases of `tt_xy_pair`, so this is a mechanical, source- and ABI-compatible rename, scoped to `tt_metal/llrt` only.

- Adds `using xy_pair = tt_xy_pair;` next to the existing `CoreCoord` alias in `tt_metal/api/tt-metalium/core_coord.hpp`.
- Replaces `CoreCoord` with `xy_pair` throughout `tt_metal/llrt` (234 occurrences across 13 files), including comment mentions of the type.

### Notes for reviewers
We're in a really tricky situation today, in UMD there's two coordinate types with separate purposes:
1. xy_pair, which is just two scalars, called **CoreCoord** in metal. An incomplete type that doesn't convey the coord. system and cannot be translated to other coord. system.
2. CoreCoord, which contains core type and coordinate system and completely covers xy_pair.

The UMD stance is that metal should adopt our complete CoreCoord and move away from its differently-named coordinate systems. There are many benefits to this, one of which is that coordinate correctness can be easily verified.

The way we will achieve this is:
1. Gradually remove the confusing `CoreCoord` alias and use `xy_pair`, which is the actual name of the type.
2. Move Metal's CoreCoord methods that are missing for umd::CoreCoord to UMD.
3. Gradually adapt metal to use umd::CoreCoord and its coordinate systems.

This is the first PR out of many for step 1, the type will be changed to xy_pair and then the alias to CoreCoord will be removed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amarkovic/llrt-corecoord-to-xy-pair)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amarkovic/llrt-corecoord-to-xy-pair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amarkovic/llrt-corecoord-to-xy-pair)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amarkovic/llrt-corecoord-to-xy-pair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amarkovic/llrt-corecoord-to-xy-pair)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amarkovic/llrt-corecoord-to-xy-pair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amarkovic/llrt-corecoord-to-xy-pair)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amarkovic/llrt-corecoord-to-xy-pair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amarkovic/llrt-corecoord-to-xy-pair)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amarkovic/llrt-corecoord-to-xy-pair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amarkovic/llrt-corecoord-to-xy-pair)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amarkovic/llrt-corecoord-to-xy-pair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amarkovic/llrt-corecoord-to-xy-pair)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amarkovic/llrt-corecoord-to-xy-pair)