### PR TITLE
[Cleanup] matmul: remove smuggled buffer-address seeds from descriptor runtime args

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_program_cache.py
@@ -103,3 +103,201 @@ def test_matmul_cache_miss_different_dtype(device, isolate_program_cache):
     assert (
         count == 2
     ), f"different dtype (bfloat16 vs float32) must produce 2 distinct cache entries, got {count} (dtype not keyed)"
+
+
+# ---------------------------------------------------------------------------
+# Cache-hit address patching (smuggled-pointer regression net)
+#
+# Every buffer address a matmul descriptor factory puts in a runtime arg is
+# declared as a tensor binding (KernelDescriptor::emplace_runtime_args); the arg
+# vectors hold a 0 placeholder in that slot. The framework patches bindings on a
+# program-cache hit, so a slot that lost its binding would keep the placeholder
+# (address 0) or a stale address from the cache-miss call. These tests force the
+# second call's tensors to land at DIFFERENT addresses than the first, so a
+# missing binding shows up as wrong data instead of passing by luck.
+# ---------------------------------------------------------------------------
+
+L1_WIDTH_SHARDED_3_CORES = ttnn.MemoryConfig(
+    memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    buffer_type=ttnn.BufferType.L1,
+    shard_spec=ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+        (32, 32),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    ),
+)
+
+DRAM_WIDTH_SHARDED_3_CORES = ttnn.MemoryConfig(
+    memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    buffer_type=ttnn.BufferType.DRAM,
+    shard_spec=ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+        (96, 32),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    ),
+)
+
+ADDRESS_PATCH_CASES = [
+    # (m, k, n, program_config, has_bias, in0_mem, in1_mem, out_mem)
+    (64, 32, 64, None, True, None, None, None),
+    (
+        32,
+        32,
+        64,
+        ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(2, 1),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        ),
+        True,
+        None,
+        None,
+        None,
+    ),
+    (
+        64,
+        32,
+        32,
+        ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(2, 1),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        True,
+        None,
+        None,
+        None,
+    ),
+    (
+        64,
+        32,
+        64,
+        ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(2, 2),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            transpose_mcast=False,
+            fused_activation=None,
+        ),
+        True,
+        None,
+        None,
+        None,
+    ),
+    (
+        32,
+        96,
+        32,
+        ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+            in0_block_w=1,
+            per_core_M=1,
+            per_core_N=1,
+            fused_activation=None,
+        ),
+        False,
+        L1_WIDTH_SHARDED_3_CORES,
+        DRAM_WIDTH_SHARDED_3_CORES,
+        ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+        ),
+    ),
+]
+
+ADDRESS_PATCH_IDS = ["default", "mcast_1d_in0", "mcast_1d_in1", "mcast_2d", "dram_sharded"]
+
+
+@pytest.mark.parametrize(
+    "m, k, n, program_config, has_bias, in0_mem, in1_mem, out_mem",
+    ADDRESS_PATCH_CASES,
+    ids=ADDRESS_PATCH_IDS,
+)
+def test_matmul_cache_hit_patches_addresses(
+    device, isolate_program_cache, m, k, n, program_config, has_bias, in0_mem, in1_mem, out_mem
+):
+    """Second (cache-hit) call with freshly-allocated tensors at new addresses must still be correct."""
+    torch.manual_seed(0)
+
+    def make_operands(seed):
+        torch.manual_seed(seed)
+        a = torch.randn((1, 1, m, k), dtype=torch.float32)
+        b = torch.randn((1, 1, k, n), dtype=torch.float32)
+        bias = torch.randn((1, 1, 1, n), dtype=torch.float32) if has_bias else None
+        ref = torch.matmul(a, b)
+        if has_bias:
+            ref = ref + bias
+        tt_a = ttnn.from_torch(
+            a,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=in0_mem or ttnn.DRAM_MEMORY_CONFIG,
+        )
+        tt_b = ttnn.from_torch(
+            b,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=in1_mem or ttnn.DRAM_MEMORY_CONFIG,
+        )
+        tt_bias = (
+            ttnn.from_torch(
+                bias,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            if has_bias
+            else None
+        )
+        return ref, tt_a, tt_b, tt_bias
+
+    def run(tt_a, tt_b, tt_bias):
+        kwargs = {}
+        if program_config is not None:
+            kwargs["program_config"] = program_config
+        if out_mem is not None:
+            kwargs["memory_config"] = out_mem
+        if tt_bias is not None:
+            return ttnn.linear(tt_a, tt_b, bias=tt_bias, **kwargs)
+        return ttnn.matmul(tt_a, tt_b, **kwargs)
+
+    # Only the matmul calls are measured; from_torch/to_torch may run device ops of their own.
+    # The first operand set stays alive so the second set is forced to different addresses.
+    ref1, a1, b1, bias1 = make_operands(0)
+    with device.cache_entries_counter.measure():
+        out1 = run(a1, b1, bias1)
+    torch_out1 = ttnn.to_torch(out1).to(torch.float32)
+
+    ref2, a2, b2, bias2 = make_operands(42)
+    moved = [a1.buffer_address() != a2.buffer_address(), b1.buffer_address() != b2.buffer_address()]
+    if has_bias:
+        moved.append(bias1.buffer_address() != bias2.buffer_address())
+    assert all(moved), f"operands did not move; the test cannot detect a stale address (moved={moved})"
+
+    with device.cache_entries_counter.measure():
+        out2 = run(a2, b2, bias2)
+    assert out1.buffer_address() != out2.buffer_address(), "output did not move"
+    torch_out2 = ttnn.to_torch(out2).to(torch.float32)
+
+    assert_with_pcc(ref1, torch_out1, 0.99)
+    assert_with_pcc(ref2, torch_out2, 0.99)
+
+    count = device.cache_entries_counter.total
+    assert count == 1, f"identical config twice must reuse 1 cache entry, got {count} (the hit path was not exercised)"

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1110,8 +1110,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             }
 
             // Bias base address; patched on program-cache hit by override_mcast_in0_program_parameters (idx 18).
-            mm_in1_sender_writer_args.push_back(
-                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+            mm_in1_sender_writer_args.push_back(bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
@@ -1932,7 +1931,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
             if (bias_tensor.has_value()) {
                 // Bias base address; patched on program-cache hit by override_mcast_in1_program_parameters (idx 18).
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());  // smuggled-rta-ok
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -3968,7 +3967,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
         else if (core == start_core) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                0u,                                                             // in0_tensor_addr placeholder
                 (std::uint32_t)in0_tensor_start_tile_id_stride * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
@@ -4007,7 +4006,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)in1_tensor.address(),
+                0u,                                                             // in1_tensor_addr placeholder
                 (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
                 (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
@@ -4020,7 +4019,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)out_tensor.address(),
+                0u,  // out_tensor_addr placeholder
                 ((std::uint32_t)output_idx_x * per_core_N) +
                     (output_idx_y * per_core_M * N)  // out_tensor_start_tile_id
             };
@@ -4053,9 +4052,8 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
                 mm_in1_sender_writer_args.push_back(0);
             }
 
-            // Bias base address placeholder; rebound to a tensor binding via in1_sender_variant[18] below.
-            mm_in1_sender_writer_args.push_back(
-                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
+            // in3 (bias) address placeholder; rebound to a tensor binding via in1_sender_variant[18] below.
+            mm_in1_sender_writer_args.push_back(0u);
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1240,7 +1240,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
         } else if (in1_idx == 0) {
             std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)in0_tensor.address(),
+                0u,                                                        // in0_tensor_addr placeholder
                 (std::uint32_t)in0_tensor_start_tile_id_stride * in0_idx,  // in0_tensor_start_tile_id
                 // in0 mcast args
                 (std::uint32_t)in0_mcast_start.x,  // in0_mcast_dest_noc_start_x
@@ -1292,7 +1292,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                 std::vector<uint32_t> mm_in1_sender_writer_args = {
                     // READER
                     // in1 tensor args
-                    (std::uint32_t)in1_tensor.address(),
+                    0u,                                                        // in1_tensor_addr placeholder
                     (std::uint32_t)in1_tensor_start_tile_id_stride * in1_idx,  // in1_tensor_start_tile_id
                     // in1 mcast args
                     (std::uint32_t)in1_mcast_start.x,  // in1_mcast_dest_noc_start_x
@@ -1305,7 +1305,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),
+                    0u,                                                                 // out_tensor_addr placeholder
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
@@ -1449,7 +1449,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
 
                     // WRITER
                     // out tensor args
-                    (std::uint32_t)out_tensor.address(),                                // out_tensor_addr
+                    0u,                                                                 // out_tensor_addr placeholder
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -760,8 +760,10 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         bool is_worker_core = true;
         std::vector<uint32_t> mm_in1_sender_writer_args;
         mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
-        mm_in1_sender_writer_args.push_back(in1_tensor.address());  // [1]: will be replaced by Buffer*
-        mm_in1_sender_writer_args.push_back(bias.has_value() ? bias->address() : 0u);  // [2]: may be replaced
+        // in1 [1] and bias [2] address placeholders; the real addresses come from the tensor
+        // bindings installed below, so a lost binding traps on address 0 instead of going stale.
+        mm_in1_sender_writer_args.push_back(0u);
+        mm_in1_sender_writer_args.push_back(0u);
 
         uint32_t vc = bank_id & 0x3;
         bank_ids.push_back(bank_id);


### PR DESCRIPTION
### Problem

Every buffer address the matmul `ProgramDescriptor` factories put in a runtime arg is already declared as a tensor binding via `KernelDescriptor::emplace_runtime_args`, so the framework patches it on a program-cache hit. Ten of those slots were nevertheless seeded with a raw `.address()` value that the binding then overwrote.

The seed is a dead value, but it makes a lost or mis-indexed binding **silent**: the cache-miss call is correct (it uses the raw seed) and only cache hits go stale. The bindings are installed by hand-counted index — e.g. `in1_sender_variant[18] = *bias_tensor` — which is exactly what drifts when the arg layout changes.

Only two of the ten were visible to `scripts/detect_smuggled_rta.py`. The detector matches `push_back(...address())` but not an address inside a braced init list, so the eight in the 1D/2D factories went unreported — matmul looked like 2 hits when it was really 10.

| factory | slots |
| --- | --- |
| `create_program_dram_sharded_descriptor` | in1, bias *(the 2 the detector flagged)* |
| `create_program_mcast_in0_descriptor` (1D) | in0, in1, out, bias |
| `create_program_mcast_in0_in1_descriptor` (2D) | in0, in1, out, out (receiver) |

### Change

Every descriptor-path address slot now holds `0u`. The address comes only from the binding, so a lost binding traps on address 0 instead of decaying into a stale-address bug. No arg ordering, count, or byte changes — pure construction-mechanism cleanup.

Also drops three `// smuggled-rta-ok` markers:
- one sat on a descriptor slot that **is** bound, mislabelling correct code as parked;
- the other two are on legacy `SetRuntimeArgs` paths that the detector no longer flags at all, so they suppressed nothing.

Legacy paths re-patched by `override_*_program_parameters` are left untouched (descriptors-only scope).

### Test

New `test_matmul_cache_hit_patches_addresses` in `tests/ttnn/unit_tests/operations/matmul/test_matmul_program_cache.py`, covering the default, 1D `mcast_in0`, 1D `mcast_in1`, 2D mcast and DRAM-sharded routings.

It keeps the first operand set alive so the cache-hit call's tensors are forced to land at different addresses, asserts they actually moved, then asserts PCC and a single cache entry. A `0u` placeholder that ever survived to the device fails loudly instead of silently — which turns "I read every index and they are all rebound" into a machine-checked invariant.

### Checks

- `scripts/detect_smuggled_rta.py` clean across the whole matmul tree.
- Full `pre-commit run` clean on all four files.
