### PR TITLE
Decouple HCA Compressor from HCA

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py
@@ -32,7 +32,8 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v4.modeling_deepseek_v4 imp
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
-from models.demos.deepseek_v3_d_p.tt.mla.heavily_compressed_attention import TtHCA, TtHCACompressor
+from models.demos.deepseek_v3_d_p.tt.mla.compressor import TtHCACompressor
+from models.demos.deepseek_v3_d_p.tt.mla.heavily_compressed_attention import TtHCA
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 # Real (pre-pad) prompt lengths. prepare_input pads each up to compress_rate*sp, so the ragged ones
@@ -299,7 +300,7 @@ def test_hca_forward_mesh(mesh_device, device_params, topology, seq_len, model_c
 
     tt_model = TtHCA.from_reference(mesh_device, ref, config, sp_axis=0, tp_axis=1, topology=topology)
 
-    hidden_padded, seq_len_actual = TtHCA.prepare_input(hidden, sp_factor, compress_rate)
+    hidden_padded, seq_len_actual = TtHCACompressor.prepare_input(hidden, sp_factor, compress_rate)
     logger.debug(f"mesh={tuple(mesh_device.shape)} S_real={seq_len_actual} S_pad={hidden_padded.shape[1]}")
     ms = tuple(mesh_device.shape)
     tt_input = ttnn.from_torch(

--- a/models/demos/deepseek_v3_d_p/tt/mla/compressor.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/compressor.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable TT compressor infrastructure and the HCA compressor."""
+
+from __future__ import annotations
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
+
+
+def rope_table_tokens(max_seq_len: int, chunk_tokens: int) -> int:
+    """Cover the context rounded to whole chunks plus one padded slab."""
+    return -(-int(max_seq_len) // chunk_tokens) * chunk_tokens + chunk_tokens
+
+
+class TtCompressorUtils:
+    """Mesh, tensor, and indexed-RoPE operations used by compressors and their consumers."""
+
+    def __init__(
+        self,
+        device,
+        *,
+        rotary_emb,
+        sp_axis: int,
+        tp_axis: int,
+        dtype,
+        weights_dtype,
+        memory_config,
+    ):
+        self.device = device
+        self.rotary_emb = rotary_emb
+        self.dtype = dtype
+        self.weights_dtype = weights_dtype
+        self.memory_config = memory_config
+        self.is_mesh = hasattr(device, "shape")
+        self.sp_axis, self.tp_axis = sp_axis, tp_axis
+        self.sp_factor = device.shape[sp_axis] if self.is_mesh else 1
+        self.tp_factor = device.shape[tp_axis] if self.is_mesh else 1
+
+    def to_tt_linear_weight(self, weight: torch.Tensor, tp_shard_dim: int | None = None):
+        torch_weight = weight.detach().transpose(-2, -1).contiguous().unsqueeze(0).unsqueeze(0)
+        return self.from_torch(
+            torch_weight, mesh_mapper=self.mesh_mapper(tp_dim=tp_shard_dim), dtype=self.weights_dtype
+        )
+
+    def from_torch(self, x: torch.Tensor, mesh_mapper=None, dtype=None, layout=ttnn.TILE_LAYOUT, on_device=True):
+        """Convert a host tensor, replicating it across a mesh by default."""
+        if self.is_mesh and mesh_mapper is None:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self.device)
+        tiled = on_device and layout == ttnn.TILE_LAYOUT
+        return ttnn.from_torch(
+            x,
+            device=self.device if on_device else None,
+            dtype=dtype or self.dtype,
+            layout=layout,
+            memory_config=self.memory_config if tiled else None,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def mesh_mapper(self, sp_dim: int | None = None, tp_dim: int | None = None):
+        """Map host dimensions onto the configured SP and TP mesh axes."""
+        if not self.is_mesh:
+            return None
+        dims = [None, None]
+        if sp_dim is not None and self.sp_factor > 1:
+            dims[self.sp_axis] = sp_dim
+        if tp_dim is not None and self.tp_factor > 1:
+            dims[self.tp_axis] = tp_dim
+        if dims == [None, None]:
+            return ttnn.ReplicateTensorToMesh(self.device)
+        return ttnn.ShardTensor2dMesh(self.device, mesh_shape=tuple(self.device.shape), dims=dims)
+
+    def scalar_buffer(self, dtype, shape=(1, 1, 1, 1), layout=ttnn.TILE_LAYOUT):
+        """Allocate a device scalar buffer that can be overwritten without reallocating."""
+        return self.from_torch(torch.zeros(*shape, dtype=torch.int32), dtype=dtype, layout=layout)
+
+    def push_scalar(self, buf, value):
+        """Overwrite a device buffer with one host scalar."""
+        host_dtype = torch.float32 if buf.dtype == ttnn.float32 else torch.int32
+        host = self.from_torch(
+            torch.full(tuple(buf.shape), value, dtype=host_dtype),
+            dtype=buf.dtype,
+            layout=buf.layout,
+            on_device=False,
+        )
+        ttnn.copy_host_to_device_tensor(host, buf)
+        return buf
+
+    def build_rope_table(self, count: int, stride: int):
+        """Build replicated cos/sin tables for compressed or token positions."""
+        positions = (torch.arange(count) * stride).unsqueeze(0)
+        cos, sin = self.rotary_emb(torch.zeros(1), position_ids=positions.to(torch.long), layer_type="compress")
+        return tuple(self.from_torch(t.repeat_interleave(2, dim=-1)) for t in (cos, sin))
+
+    def rope_index_base(self, rows: int):
+        """Build the constant and mutable halves of an indexed-RoPE gather index."""
+        const = self.from_torch(
+            torch.arange(self.sp_factor * rows, dtype=torch.int32).view(self.sp_factor, rows),
+            mesh_mapper=self.mesh_mapper(sp_dim=0),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        return const, self.scalar_buffer(ttnn.uint32, shape=(1, 1), layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    def rope_index(self, index_base, base: int):
+        """Build this slab's gather index from its constant and scalar halves."""
+        const, buf = index_base
+        return ttnn.add(const, self.push_scalar(buf, base))
+
+    def rope_gather(self, table, index):
+        """Gather indexed rows from a replicated RoPE table."""
+        out = []
+        for tensor in table:
+            gathered = ttnn.embedding(index, tensor, layout=ttnn.TILE_LAYOUT, dtype=self.dtype)
+            out.append(ttnn.reshape(gathered, [1, 1, gathered.shape[-2], gathered.shape[-1]]))
+        return tuple(out)
+
+
+class TtCompressorBase(LightweightModule):
+    """Common device, mesh, and input setup for TT compressor implementations."""
+
+    def __init__(
+        self,
+        device,
+        *,
+        rotary_emb,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
+        topology=ttnn.Topology.Linear,
+        dtype=ttnn.bfloat16,
+        weights_dtype=ttnn.bfloat8_b,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    ):
+        self.device = device
+        self.dtype = dtype
+        self.weights_dtype = weights_dtype
+        self.memory_config = memory_config
+        self.rotary_emb = rotary_emb
+
+        self.is_mesh = hasattr(device, "shape")
+        self.sp_axis, self.tp_axis = sp_axis, tp_axis
+        self.sp_factor = device.shape[sp_axis] if self.is_mesh else 1
+        self.tp_factor = device.shape[tp_axis] if self.is_mesh else 1
+        self.ccl_topology = topology
+        self.tt_ccl = get_tt_ccl(device) if (self.is_mesh and (self.sp_factor > 1 or self.tp_factor > 1)) else None
+        self.ccl_num_links = 2 if is_blackhole() else 1
+        self.ops = TtCompressorUtils(
+            device,
+            rotary_emb=rotary_emb,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            dtype=dtype,
+            weights_dtype=weights_dtype,
+            memory_config=memory_config,
+        )
+
+    @staticmethod
+    def prepare_input(hidden: torch.Tensor, sp_factor: int, compress_rate: int):
+        """Pad sequence rows so every SP shard owns whole compression windows."""
+        seq_len_actual = hidden.shape[1]
+        align = compress_rate * sp_factor
+        pad = (-seq_len_actual) % align
+        if pad:
+            hidden = torch.nn.functional.pad(hidden, (0, 0, 0, pad))
+        return hidden, seq_len_actual
+
+
+class TtHCACompressor(TtCompressorBase):
+    def __init__(
+        self,
+        device,
+        *,
+        kv_proj_weight: torch.Tensor,
+        gate_proj_weight: torch.Tensor,
+        position_bias: torch.Tensor,
+        kv_norm_weight: torch.Tensor,
+        head_dim: int,
+        compress_rate: int,
+        rope_head_dim: int,
+        rotary_emb,
+        rms_norm_eps: float = 1e-6,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
+        topology=ttnn.Topology.Linear,
+        dtype=ttnn.bfloat16,
+        weights_dtype=ttnn.bfloat8_b,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    ):
+        super().__init__(
+            device,
+            rotary_emb=rotary_emb,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            topology=topology,
+            dtype=dtype,
+            weights_dtype=weights_dtype,
+            memory_config=memory_config,
+        )
+        self.head_dim = int(head_dim)
+        self.compress_rate = int(compress_rate)
+        self.rope_head_dim = int(rope_head_dim)
+        self.rms_norm_eps = float(rms_norm_eps)
+
+        self.wkv = self.ops.to_tt_linear_weight(kv_proj_weight, tp_shard_dim=2)
+        self.wgate = self.ops.to_tt_linear_weight(gate_proj_weight, tp_shard_dim=2)
+        self.position_bias = self.ops.from_torch(
+            position_bias.detach().reshape(1, 1, self.compress_rate, self.head_dim)
+        )
+        self.kv_norm_weight = self.ops.from_torch(kv_norm_weight.detach().reshape(1, 1, 1, self.head_dim))
+        self.trans_mat = self.ops.from_torch(get_rot_transformation_mat())
+        self._entry_rope = None
+        self._entry_index = None
+        self._mask_consts = None
+
+    def alloc_tables(self, max_seq_len: int, chunk_tokens: int, mask_width: int):
+        """Build the indexed-RoPE and mask constants needed by forward."""
+        tokens = rope_table_tokens(max_seq_len, chunk_tokens)
+        self._entry_rope = self.ops.build_rope_table(-(-tokens // self.compress_rate), self.compress_rate)
+        self._entry_index = self.ops.rope_index_base(chunk_tokens // self.sp_factor // self.compress_rate)
+        self._mask_consts = self._build_mask_consts(chunk_tokens, mask_width)
+
+    @classmethod
+    def from_reference(cls, device, reference, config, **kwargs) -> "TtHCACompressor":
+        return cls(
+            device,
+            kv_proj_weight=reference.kv_proj.weight,
+            gate_proj_weight=reference.gate_proj.weight,
+            position_bias=reference.position_bias,
+            kv_norm_weight=reference.kv_norm.weight,
+            head_dim=config.head_dim,
+            compress_rate=config.compress_rates["heavily_compressed_attention"],
+            rope_head_dim=config.qk_rope_head_dim,
+            rotary_emb=reference.rotary_emb,
+            rms_norm_eps=config.rms_norm_eps,
+            **kwargs,
+        )
+
+    def _build_mask_consts(self, seq_global: int, width: int):
+        """Build the constant vectors and mutable scalars for the compressed mask."""
+        sp_mapper = self.ops.mesh_mapper(sp_dim=2)
+        rate = self.compress_rate
+        return {
+            "seq": seq_global,
+            "thr": self.ops.from_torch(
+                ((torch.arange(seq_global) + 1) // rate).float().view(1, 1, seq_global, 1),
+                sp_mapper,
+                dtype=ttnn.float32,
+            ),
+            "ic": self.ops.from_torch(
+                torch.arange(seq_global).float().view(1, 1, seq_global, 1),
+                sp_mapper,
+                dtype=ttnn.float32,
+            ),
+            "w": self.ops.from_torch(torch.arange(width).float().view(1, 1, 1, width), dtype=ttnn.float32),
+            "ec": self.ops.scalar_buffer(ttnn.float32),
+            "rl": self.ops.scalar_buffer(ttnn.float32),
+        }
+
+    def _mask_block(self, seq: int, first_window_position: int, seq_len_actual: int):
+        """Build additive compressed-cache mask columns on device."""
+        rate = self.compress_rate
+        seq_global = seq * self.sp_factor
+        consts = self._mask_consts
+        assert consts is not None and consts["seq"] == seq_global, (
+            f"mask constants cover {None if consts is None else consts['seq']} query rows but this call has "
+            f"{seq_global}; alloc_tables has to be given the slab forward is called with"
+        )
+        within = ttnn.lt(
+            consts["w"],
+            ttnn.add(
+                consts["thr"],
+                self.ops.push_scalar(consts["ec"], first_window_position // rate),
+            ),
+        )
+        live = ttnn.lt(consts["ic"], self.ops.push_scalar(consts["rl"], seq_len_actual))
+        return ttnn.typecast(ttnn.log(ttnn.multiply(within, live)), self.dtype)
+
+    def forward(
+        self,
+        hidden_states,
+        seq_len_actual: int | None = None,
+        first_window_position: int = 0,
+    ):
+        """Compress an SP/TP-sharded hidden-state slab and build its mask columns."""
+        input_shape = tuple(hidden_states.shape)
+        if len(input_shape) != 4 or input_shape[1] != 1:
+            raise ValueError(f"Expected hidden_states shape [B, 1, S, hidden], got {input_shape}")
+        batch, seq_len = input_shape[0], input_shape[2]
+        if seq_len_actual is None:
+            seq_len_actual = seq_len * self.sp_factor
+
+        kv = ttnn.linear(hidden_states, self.wkv, memory_config=self.memory_config)
+        gate = ttnn.linear(hidden_states, self.wgate, memory_config=self.memory_config)
+
+        if self.tp_factor > 1:
+            for name in ("kv", "gate"):
+                tensor = kv if name == "kv" else gate
+                tensor = ttnn.experimental.reduce_scatter_minimal_async(
+                    tensor,
+                    persistent_output_buffers=None,
+                    dim=3,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(
+                        cluster_axis=self.tp_axis
+                    ),
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                    num_links=self.ccl_num_links,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    topology=self.ccl_topology,
+                    cluster_axis=self.tp_axis,
+                )
+                tensor = ttnn.experimental.all_gather_async(
+                    tensor,
+                    dim=3,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(
+                        cluster_axis=self.tp_axis
+                    ),
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                    num_links=self.ccl_num_links,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    topology=self.ccl_topology,
+                    cluster_axis=self.tp_axis,
+                )
+                if name == "kv":
+                    kv = tensor
+                else:
+                    gate = tensor
+
+        n_windows = seq_len // self.compress_rate
+        t_real = seq_len_actual // self.compress_rate
+        assert n_windows > 0, (
+            f"each chip needs at least one whole compression window: {seq_len} rows is under "
+            f"compress_rate {self.compress_rate}; run prepare_input on the hidden states first"
+        )
+        gate = ttnn.reshape(gate, [batch, n_windows, self.compress_rate, self.head_dim])
+        gate = ttnn.add(gate, self.position_bias)
+        weights = ttnn.softmax(gate, dim=2, numeric_stable=True)
+
+        kv = ttnn.reshape(kv, [batch, n_windows, self.compress_rate, self.head_dim])
+        pooled = ttnn.sum(ttnn.multiply(kv, weights), dim=2)
+
+        compressed = ttnn.reshape(pooled, [batch, 1, n_windows, self.head_dim])
+        compressed = ttnn.rms_norm(compressed, weight=self.kv_norm_weight, epsilon=self.rms_norm_eps)
+
+        nope_dim = self.head_dim - self.rope_head_dim
+        nope = ttnn.slice(compressed, [0, 0, 0, 0], [batch, 1, n_windows, nope_dim])
+        rope = ttnn.slice(compressed, [0, 0, 0, nope_dim], [batch, 1, n_windows, self.head_dim])
+        idx = self.ops.rope_index(self._entry_index, first_window_position // self.compress_rate)
+        cos, sin = self.ops.rope_gather(self._entry_rope, idx)
+        rope = ttnn.experimental.rotary_embedding_llama(rope, cos, sin, self.trans_mat, is_decode_mode=False)
+        compressed_kv = ttnn.concat([nope, rope], dim=-1)
+
+        if self.sp_factor > 1:
+            compressed_kv = ttnn.experimental.all_gather_async(
+                compressed_kv,
+                dim=2,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
+                num_links=self.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.ccl_topology,
+                cluster_axis=self.sp_axis,
+            )
+
+        mask_block = None
+        if seq_len_actual > 1 and t_real > 0:
+            mask_block = self._mask_block(seq_len, first_window_position, seq_len_actual)
+
+        return compressed_kv, mask_block

--- a/models/demos/deepseek_v3_d_p/tt/mla/heavily_compressed_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/heavily_compressed_attention.py
@@ -12,6 +12,7 @@ import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tt.mla.compressor import TtCompressorUtils, TtHCACompressor, rope_table_tokens
 from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
@@ -21,361 +22,6 @@ def _cache_write_rows(chunk_entries: int) -> int:
     the last tile. The cache is written a whole tile at a time, so this rounds up to whole tiles -- 64 rows
     for a 4096-token chunk, 96 for 5120."""
     return -(-(ttnn.TILE_SIZE - 1 + chunk_entries) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
-
-
-def _rope_table_tokens(max_seq_len: int, chunk_tokens: int) -> int:
-    """How many token positions a rope table has to cover: the context rounded up to whole chunks, plus one
-    chunk more, because the last chunk's padded slab runs past the end of the real context."""
-    return -(-int(max_seq_len) // chunk_tokens) * chunk_tokens + chunk_tokens
-
-
-class _TtHCABase(LightweightModule):
-    """Helpers shared by the compressor and the block. Subclasses must set ``device`` / ``dtype`` /
-    ``weights_dtype`` / ``memory_config`` / ``rotary_emb`` and the mesh attributes before calling these."""
-
-    @staticmethod
-    def prepare_input(hidden: torch.Tensor, sp_factor: int, compress_rate: int):
-        """Pad seq up to a multiple of ``compress_rate * sp_factor`` so each SP shard holds whole
-        compression windows. Must run before sharding: appending per-chip would land mid-sequence.
-        Pad rows are causally masked downstream and trimmed via the returned ``seq_len_actual``."""
-        seq_len_actual = hidden.shape[1]
-        align = compress_rate * sp_factor
-        pad = (-seq_len_actual) % align
-        if pad:
-            hidden = torch.nn.functional.pad(hidden, (0, 0, 0, pad))
-        return hidden, seq_len_actual
-
-    def _to_tt_linear_weight(self, weight: torch.Tensor, tp_shard_dim: int | None = None):
-        torch_weight = weight.detach().transpose(-2, -1).contiguous().unsqueeze(0).unsqueeze(0)
-        return self._from_torch(
-            torch_weight, mesh_mapper=self._mesh_mapper(tp_dim=tp_shard_dim), dtype=self.weights_dtype
-        )
-
-    def _from_torch(self, x: torch.Tensor, mesh_mapper=None, dtype=None, layout=ttnn.TILE_LAYOUT, on_device=True):
-        """Replicated across the mesh unless a mapper is given. ``on_device=False`` leaves it on host, which
-        is what ``copy_host_to_device_tensor`` takes as its source."""
-        if self.is_mesh and mesh_mapper is None:
-            mesh_mapper = ttnn.ReplicateTensorToMesh(self.device)
-        tiled = on_device and layout == ttnn.TILE_LAYOUT
-        return ttnn.from_torch(
-            x,
-            device=self.device if on_device else None,
-            dtype=dtype or self.dtype,
-            layout=layout,
-            memory_config=self.memory_config if tiled else None,
-            mesh_mapper=mesh_mapper,
-        )
-
-    def _mesh_mapper(self, sp_dim: int | None = None, tp_dim: int | None = None):
-        """How one host tensor lands on the mesh: split ``sp_dim`` across the SP axis, ``tp_dim`` across the
-        TP axis, replicate along whichever axis is left. Both None means fully replicated; a single device
-        needs no mapper."""
-        if not self.is_mesh:
-            return None
-        dims = [None, None]
-        if sp_dim is not None and self.sp_factor > 1:
-            dims[self.sp_axis] = sp_dim
-        if tp_dim is not None and self.tp_factor > 1:
-            dims[self.tp_axis] = tp_dim
-        if dims == [None, None]:
-            return ttnn.ReplicateTensorToMesh(self.device)
-        return ttnn.ShardTensor2dMesh(self.device, mesh_shape=tuple(self.device.shape), dims=dims)
-
-    def _scalar_buffer(self, dtype, shape=(1, 1, 1, 1), layout=ttnn.TILE_LAYOUT):
-        """A one-element device tensor, allocated once and then overwritten by ``_push_scalar``. Values
-        that change every chunk live here so forward never has to allocate."""
-        return self._from_torch(torch.zeros(*shape, dtype=torch.int32), dtype=dtype, layout=layout)
-
-    def _push_scalar(self, buf, v):
-        """Overwrite an existing device buffer with one value -- the only thing forward still sends from
-        host."""
-        host_dtype = torch.float32 if buf.dtype == ttnn.float32 else torch.int32
-        host = self._from_torch(
-            torch.full(tuple(buf.shape), v, dtype=host_dtype), dtype=buf.dtype, layout=buf.layout, on_device=False
-        )
-        ttnn.copy_host_to_device_tensor(host, buf)
-        return buf
-
-    def _build_rope_table(self, count: int, stride: int):
-        """cos/sin for every position this layer can ever rotate by, built once. forward only gathers rows
-        out of it.
-
-        Kept whole on every chip rather than split, because which rows a chip needs moves with the chunk:
-        chip c reads from ``kv_actual + c*local``, which walks out of any fixed slice. A row is 128 B, so
-        the table is 14 MB for a 56K-token context -- cheap enough to keep whole."""
-        positions = (torch.arange(count) * stride).unsqueeze(0)
-        cos, sin = self.rotary_emb(torch.zeros(1), position_ids=positions.to(torch.long), layer_type="compress")
-        pair = []
-        for t in (cos, sin):
-            t = t.repeat_interleave(2, dim=-1)  # [1, count, rope_head_dim]
-            pair.append(self._from_torch(t))
-        return tuple(pair)
-
-    def _rope_index_base(self, rows: int):
-        """The gather index is ``base + c*rows + r``. This builds the constant ``c*rows + r`` half, split so
-        chip c holds its own row, plus an empty buffer for ``base``. Only ``base`` moves between chunks, so
-        forward pushes 4 bytes instead of computing the whole index on host."""
-        const = self._from_torch(
-            torch.arange(self.sp_factor * rows, dtype=torch.int32).view(self.sp_factor, rows),
-            mesh_mapper=self._mesh_mapper(sp_dim=0),
-            dtype=ttnn.uint32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        return const, self._scalar_buffer(ttnn.uint32, shape=(1, 1), layout=ttnn.ROW_MAJOR_LAYOUT)
-
-    def _rope_index(self, index_base, base: int):
-        """This chunk's gather index, built on device from the constant half plus a 4-byte base."""
-        const, buf = index_base
-        return ttnn.add(const, self._push_scalar(buf, base))
-
-    def _rope_gather(self, table, index):
-        """Pick this chunk's rows out of the table. ttnn.embedding looks rows up by index, so unlike
-        ttnn.slice it needs no tile-aligned start -- the compressor's start ``entry_count + c*n_windows``
-        rarely is one. The index is data, not part of the program, so every chunk reuses one program."""
-        out = []
-        for t in table:
-            g = ttnn.embedding(index, t, layout=ttnn.TILE_LAYOUT, dtype=self.dtype)
-            out.append(ttnn.reshape(g, [1, 1, g.shape[-2], g.shape[-1]]))
-        return tuple(out)
-
-
-class TtHCACompressor(_TtHCABase):
-    def __init__(
-        self,
-        device,
-        *,
-        kv_proj_weight: torch.Tensor,
-        gate_proj_weight: torch.Tensor,
-        position_bias: torch.Tensor,
-        kv_norm_weight: torch.Tensor,
-        head_dim: int,
-        compress_rate: int,
-        rope_head_dim: int,
-        rotary_emb,
-        rms_norm_eps: float = 1e-6,
-        sp_axis: int = 0,
-        tp_axis: int = 1,
-        topology=ttnn.Topology.Linear,
-        dtype=ttnn.bfloat16,
-        weights_dtype=ttnn.bfloat8_b,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    ):
-        self.device = device
-        self.dtype = dtype
-        self.weights_dtype = weights_dtype
-        self.memory_config = memory_config
-        self.head_dim = int(head_dim)
-        self.compress_rate = int(compress_rate)
-        self.rope_head_dim = int(rope_head_dim)
-        self.rotary_emb = rotary_emb
-        self.rms_norm_eps = float(rms_norm_eps)
-
-        self.is_mesh = hasattr(device, "shape")
-        self.sp_axis, self.tp_axis = sp_axis, tp_axis
-        self.sp_factor = device.shape[sp_axis] if self.is_mesh else 1
-        self.tp_factor = device.shape[tp_axis] if self.is_mesh else 1
-        self.ccl_topology = topology
-        self.tt_ccl = get_tt_ccl(device) if (self.is_mesh and (self.sp_factor > 1 or self.tp_factor > 1)) else None
-        self.ccl_num_links = 2 if is_blackhole() else 1
-
-        self.wkv = self._to_tt_linear_weight(kv_proj_weight, tp_shard_dim=2)
-        self.wgate = self._to_tt_linear_weight(gate_proj_weight, tp_shard_dim=2)
-        self.position_bias = self._from_torch(position_bias.detach().reshape(1, 1, self.compress_rate, self.head_dim))
-        self.kv_norm_weight = self._from_torch(kv_norm_weight.detach().reshape(1, 1, 1, self.head_dim))
-        self.trans_mat = self._from_torch(get_rot_transformation_mat())
-        # All three come from alloc_tables, which every caller has to run before forward.
-        self._entry_rope = None
-        self._entry_index = None
-        self._mask_consts = None
-
-    def alloc_tables(self, max_seq_len: int, chunk_tokens: int, mask_width: int):
-        """Build every host tensor forward would otherwise need: the rope table it gathers from, the
-        constant half of the gather index, and the mask block's index vectors.
-
-        ``mask_width`` is the compressed cache's capacity, which only the block knows -- taking it as an
-        argument keeps that formula in one place. It becomes the width of the mask block forward returns."""
-        tokens = _rope_table_tokens(max_seq_len, chunk_tokens)
-        self._entry_rope = self._build_rope_table(-(-tokens // self.compress_rate), self.compress_rate)
-        self._entry_index = self._rope_index_base(chunk_tokens // self.sp_factor // self.compress_rate)
-        self._mask_consts = self._build_mask_consts(chunk_tokens, mask_width)
-
-    @classmethod
-    def from_reference(cls, device, reference, config, **kwargs) -> "TtHCACompressor":
-        return cls(
-            device,
-            kv_proj_weight=reference.kv_proj.weight,
-            gate_proj_weight=reference.gate_proj.weight,
-            position_bias=reference.position_bias,
-            kv_norm_weight=reference.kv_norm.weight,
-            head_dim=config.head_dim,
-            compress_rate=config.compress_rates["heavily_compressed_attention"],
-            rope_head_dim=config.qk_rope_head_dim,
-            rotary_emb=reference.rotary_emb,
-            rms_norm_eps=config.rms_norm_eps,
-            **kwargs,
-        )
-
-    def _build_mask_consts(self, seq_global: int, width: int):
-        """The parts of the compressed mask block that never change, built once by ``alloc_tables``.
-
-        ``thr[j] = (j+1)//rate`` counts the entries this chunk has finished by query row j; ``ic[j] = j``
-        and ``w[k] = k`` are plain index vectors; ``ec`` and ``rl`` are the two numbers that change every
-        chunk (entries already in the cache, real query rows). ``seq`` is not a tensor -- it records how
-        many query rows these cover, which ``_mask_block`` checks its call against.
-
-        ``thr`` and ``ic`` count GLOBAL query rows, so they are SP-sharded like the mask they feed. ``w``
-        counts cache columns, which are the same on every chip, so it is replicated.
-
-        float32 and not bfloat16: these are whole numbers up to width-1, and bfloat16 stops being exact
-        above 256 -- measured, it misses 640 of 328K mask elements at 300 entries."""
-        sp_mapper = self._mesh_mapper(sp_dim=2)
-        rate = self.compress_rate
-        return {
-            "seq": seq_global,
-            "thr": self._from_torch(
-                ((torch.arange(seq_global) + 1) // rate).float().view(1, 1, seq_global, 1),
-                sp_mapper,
-                dtype=ttnn.float32,
-            ),
-            "ic": self._from_torch(
-                torch.arange(seq_global).float().view(1, 1, seq_global, 1), sp_mapper, dtype=ttnn.float32
-            ),
-            "w": self._from_torch(torch.arange(width).float().view(1, 1, 1, width), dtype=ttnn.float32),
-            "ec": self._scalar_buffer(ttnn.float32),
-            "rl": self._scalar_buffer(ttnn.float32),
-        }
-
-    def _mask_block(self, seq: int, first_window_position: int, seq_len_actual: int):
-        """The mask's compressed columns, built on device: 0 where a query may attend an entry, -inf else.
-
-        Query row j may attend entry w while ``w < ec + thr[j]`` (both from ``_build_mask_consts``), so the
-        whole block is one broadcast comparison. The zeros over older entries, the staircase over this
-        chunk's, and the -inf tail over entries not written yet all come out of that single condition --
-        which is what lets the width stay at the full cache capacity and the shape never change.
-
-        ``log`` turns the 1/0 of a comparison into the 0/-inf an additive mask needs: ttnn gives
-        log(1) = 0 and log(0) = -inf exactly."""
-        rate = self.compress_rate
-        # seq is this chip's row count; the index vectors are global and sharded, so each chip ends up
-        # comparing its own rows.
-        seq_global = seq * self.sp_factor
-        c = self._mask_consts
-        assert c is not None and c["seq"] == seq_global, (
-            f"mask constants cover {None if c is None else c['seq']} query rows but this call has "
-            f"{seq_global}; alloc_tables has to be given the slab forward is called with"
-        )
-        within = ttnn.lt(c["w"], ttnn.add(c["thr"], self._push_scalar(c["ec"], first_window_position // rate)))
-        live = ttnn.lt(c["ic"], self._push_scalar(c["rl"], seq_len_actual))  # pad query rows attend nothing
-        return ttnn.typecast(ttnn.log(ttnn.multiply(within, live)), self.dtype)
-
-    def forward(
-        self,
-        hidden_states,
-        seq_len_actual: int | None = None,
-        first_window_position: int = 0,
-    ):
-        """[B, 1, S_pad/sp, hidden/tp] -> compressed_kv [B, 1, S_pad/compress_rate, head_dim] (replicated),
-        plus the mask's compressed columns [B, 1, S_pad, mask_width].
-
-        ``seq_len_actual`` is the real pre-pad length (``None`` = the whole padded slab).
-        ``first_window_position`` is the global token position of this call's first window; without it a
-        later chunk would rotate its entries as if the sequence restarted.
-
-        The output width follows the padded tensor, not the real length -- trailing pad-derived entries
-        are left in so the shape stays fixed across chunks. The caller tracks how many are real and the
-        mask -infs the rest."""
-        input_shape = tuple(hidden_states.shape)
-        if len(input_shape) != 4 or input_shape[1] != 1:
-            raise ValueError(f"Expected hidden_states shape [B, 1, S, hidden], got {input_shape}")
-        batch, seq_len = input_shape[0], input_shape[2]
-        if seq_len_actual is None:
-            seq_len_actual = seq_len * self.sp_factor
-
-        kv = ttnn.linear(hidden_states, self.wkv, memory_config=self.memory_config)
-        gate = ttnn.linear(hidden_states, self.wgate, memory_config=self.memory_config)
-
-        # Row-parallel weights leave a partial sum on every chip -> TP all-reduce (RS + AG).
-        if self.tp_factor > 1:
-            for name in ("kv", "gate"):
-                t = kv if name == "kv" else gate
-                t = ttnn.experimental.reduce_scatter_minimal_async(
-                    t,
-                    persistent_output_buffers=None,
-                    dim=3,
-                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(
-                        cluster_axis=self.tp_axis
-                    ),
-                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
-                    num_links=self.ccl_num_links,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    topology=self.ccl_topology,
-                    cluster_axis=self.tp_axis,
-                )
-                t = ttnn.experimental.all_gather_async(
-                    t,
-                    dim=3,
-                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(
-                        cluster_axis=self.tp_axis
-                    ),
-                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
-                    num_links=self.ccl_num_links,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    topology=self.ccl_topology,
-                    cluster_axis=self.tp_axis,
-                )
-                if name == "kv":
-                    kv = t
-                else:
-                    gate = t
-
-        n_windows = seq_len // self.compress_rate  # windows this chip owns
-        t_real = seq_len_actual // self.compress_rate
-        # prepare_input pads the sequence to a multiple of compress_rate * sp_factor, so every chip is
-        # left with at least one whole window. Asserted and not handled: the empty-slab branch this
-        # replaces was the last thing building a host tensor inside forward.
-        assert n_windows > 0, (
-            f"each chip needs at least one whole compression window: {seq_len} rows is under "
-            f"compress_rate {self.compress_rate}; run prepare_input on the hidden states first"
-        )
-        gate = ttnn.reshape(gate, [batch, n_windows, self.compress_rate, self.head_dim])
-        gate = ttnn.add(gate, self.position_bias)
-        weights = ttnn.softmax(gate, dim=2, numeric_stable=True)
-
-        kv = ttnn.reshape(kv, [batch, n_windows, self.compress_rate, self.head_dim])
-        pooled = ttnn.sum(ttnn.multiply(kv, weights), dim=2)
-
-        compressed = ttnn.reshape(pooled, [batch, 1, n_windows, self.head_dim])
-        compressed = ttnn.rms_norm(compressed, weight=self.kv_norm_weight, epsilon=self.rms_norm_eps)
-
-        nope_dim = self.head_dim - self.rope_head_dim
-        nope = ttnn.slice(compressed, [0, 0, 0, 0], [batch, 1, n_windows, nope_dim])
-        rope = ttnn.slice(compressed, [0, 0, 0, nope_dim], [batch, 1, n_windows, self.head_dim])
-        # Index is in ENTRIES: table row k carries position k*compress_rate, so the window's position
-        # has to be divided back down.
-        idx = self._rope_index(self._entry_index, first_window_position // self.compress_rate)
-        cos, sin = self._rope_gather(self._entry_rope, idx)
-        rope = ttnn.experimental.rotary_embedding_llama(rope, cos, sin, self.trans_mat, is_decode_mode=False)
-        compressed_kv = ttnn.concat([nope, rope], dim=-1)
-
-        if self.sp_factor > 1:
-            compressed_kv = ttnn.experimental.all_gather_async(
-                compressed_kv,
-                dim=2,
-                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
-                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
-                num_links=self.ccl_num_links,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                topology=self.ccl_topology,
-                cluster_axis=self.sp_axis,
-            )
-
-        # Spans the whole cache, not just this call's entries: the queries can see earlier chunks' too,
-        # and a fixed width is what keeps the shape constant.
-        mask_block = None
-        if seq_len_actual > 1 and t_real > 0:
-            mask_block = self._mask_block(seq_len, first_window_position, seq_len_actual)
-
-        return compressed_kv, mask_block
 
 
 class TtHCAState:
@@ -396,7 +42,7 @@ class TtHCAState:
         self.kv_actual = 0
 
 
-class TtHCA(_TtHCABase):
+class TtHCA(LightweightModule):
     """HCA block: query/kv stems + compressor + attention core + grouped output projection.
 
     Block I/O is ``[B, 1, S/sp, hidden/tp]``, so layers chain without a reshard."""
@@ -448,18 +94,27 @@ class TtHCA(_TtHCABase):
         self.tp_ccl_topology = topology
         self.tt_ccl = get_tt_ccl(device) if (self.is_mesh and (self.sp_factor > 1 or self.tp_factor > 1)) else None
         self.ccl_num_links = 2 if is_blackhole() else 1
+        self.ops = TtCompressorUtils(
+            device,
+            rotary_emb=rotary_emb,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            dtype=dtype,
+            weights_dtype=weights_dtype,
+            memory_config=memory_config,
+        )
 
         # Pre-divided by scale: SDPA scales BOTH QK and the sink internally, the reference scales only
         # QK -- dividing here cancels the kernel's extra multiply. TP-sharded to match the query heads.
         sinks_host = sinks.detach().reshape(1, self.num_heads, 1, 1) / self.scaling
-        self.sinks_sdpa = self._from_torch(sinks_host, mesh_mapper=self._mesh_mapper(tp_dim=1))
+        self.sinks_sdpa = self.ops.from_torch(sinks_host, mesh_mapper=self.ops.mesh_mapper(tp_dim=1))
 
-        self.wq_a = self._to_tt_linear_weight(q_a_proj_weight, tp_shard_dim=2)
-        self.wq_b = self._to_tt_linear_weight(q_b_proj_weight, tp_shard_dim=3)
-        self.q_a_norm_weight = self._from_torch(q_a_norm_weight.detach().reshape(1, 1, 1, -1))
-        self.q_b_norm_weight = self._from_torch(torch.ones(1, 1, 1, self.head_dim))
-        self.wkv = self._to_tt_linear_weight(kv_proj_weight, tp_shard_dim=2)
-        self.kv_norm_weight = self._from_torch(kv_norm_weight.detach().reshape(1, 1, 1, self.head_dim))
+        self.wq_a = self.ops.to_tt_linear_weight(q_a_proj_weight, tp_shard_dim=2)
+        self.wq_b = self.ops.to_tt_linear_weight(q_b_proj_weight, tp_shard_dim=3)
+        self.q_a_norm_weight = self.ops.from_torch(q_a_norm_weight.detach().reshape(1, 1, 1, -1))
+        self.q_b_norm_weight = self.ops.from_torch(torch.ones(1, 1, 1, self.head_dim))
+        self.wkv = self.ops.to_tt_linear_weight(kv_proj_weight, tp_shard_dim=2)
+        self.kv_norm_weight = self.ops.from_torch(kv_norm_weight.detach().reshape(1, 1, 1, self.head_dim))
 
         # o_a_proj is block-diagonal over o_groups. Groups partition the heads, so a TP chip owns whole
         # groups: keep it as ONE batched weight sharded on the group axis and run a single batched
@@ -467,10 +122,12 @@ class TtHCA(_TtHCABase):
         self.o_groups = int(o_groups)
         in_per_group = self.num_heads * self.head_dim // self.o_groups
         o_a_grouped = o_a_proj_weight.detach().view(self.o_groups, -1, in_per_group).transpose(1, 2).unsqueeze(0)
-        self.wo_a = self._from_torch(o_a_grouped, mesh_mapper=self._mesh_mapper(tp_dim=1), dtype=self.weights_dtype)
-        self.wo_b = self._to_tt_linear_weight(o_b_proj_weight, tp_shard_dim=2)
+        self.wo_a = self.ops.from_torch(
+            o_a_grouped, mesh_mapper=self.ops.mesh_mapper(tp_dim=1), dtype=self.weights_dtype
+        )
+        self.wo_b = self.ops.to_tt_linear_weight(o_b_proj_weight, tp_shard_dim=2)
 
-        self.trans_mat = self._from_torch(get_rot_transformation_mat())
+        self.trans_mat = self.ops.from_torch(get_rot_transformation_mat())
         # Everything below comes from alloc_state, which every caller has to run before forward.
         self._shift_cache = {}
         self._take_cache = {}
@@ -497,27 +154,29 @@ class TtHCA(_TtHCABase):
         carry, sw = self.sliding_window, self.sliding_window
         raw = carry + seq_global
         sk_pad = -(-(raw + cap) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
-        sp_mapper = self._mesh_mapper(sp_dim=2)
+        sp_mapper = self.ops.mesh_mapper(sp_dim=2)
 
-        ic = self._from_torch(torch.arange(seq_global).float().view(1, 1, seq_global, 1), sp_mapper, dtype=ttnn.float32)
-        ic_lo = self._from_torch(
+        ic = self.ops.from_torch(
+            torch.arange(seq_global).float().view(1, 1, seq_global, 1), sp_mapper, dtype=ttnn.float32
+        )
+        ic_lo = self.ops.from_torch(
             (torch.arange(seq_global) - sw).float().view(1, 1, seq_global, 1), sp_mapper, dtype=ttnn.float32
         )
-        jc = self._from_torch((torch.arange(raw) - carry).float().view(1, 1, 1, raw), dtype=ttnn.float32)
+        jc = self.ops.from_torch((torch.arange(raw) - carry).float().view(1, 1, 1, raw), dtype=ttnn.float32)
 
         # j <= i  and  i - j < sw, both with kv_actual cancelled
         sliding = ttnn.typecast(ttnn.log(ttnn.multiply(ttnn.le(jc, ic), ttnn.gt(jc, ic_lo))), self.dtype)
 
         zero_seq = ttnn.multiply(ic, 0.0)
         blank = ttnn.typecast(
-            ttnn.add(zero_seq, self._from_torch(torch.zeros(1, 1, 1, cap), dtype=ttnn.float32)), self.dtype
+            ttnn.add(zero_seq, self.ops.from_torch(torch.zeros(1, 1, 1, cap), dtype=ttnn.float32)), self.dtype
         )
         parts = [sliding, blank]
         pad_w = sk_pad - raw - cap
         if pad_w:
             parts.append(
                 ttnn.typecast(
-                    ttnn.log(ttnn.add(zero_seq, self._from_torch(torch.zeros(1, 1, 1, pad_w), dtype=ttnn.float32))),
+                    ttnn.log(ttnn.add(zero_seq, self.ops.from_torch(torch.zeros(1, 1, 1, pad_w), dtype=ttnn.float32))),
                     self.dtype,
                 )
             )
@@ -526,14 +185,14 @@ class TtHCA(_TtHCABase):
         # SDPA pads a non-tile-multiple Sk with zeros, and a supplied mask reads those columns as 0, which
         # means "attend". So the kv side gets real zero rows and the mask -infs their columns.
         sk = raw + cap
-        self._kv_pad = self._from_torch(torch.zeros(1, 1, sk_pad - sk, self.head_dim)) if sk_pad > sk else None
+        self._kv_pad = self.ops.from_torch(torch.zeros(1, 1, sk_pad - sk, self.head_dim)) if sk_pad > sk else None
 
         # Both versions of the [seq, carry] slab are kept and forward writes the right one. Keeping a
         # second full mask instead cost 1.1 ms on device for the same information.
         self._carry_cols = {
             False: ttnn.slice(sliding, [0, 0, 0, 0], [1, 1, sliding.shape[2], carry]),
             True: ttnn.typecast(
-                ttnn.log(ttnn.multiply(zero_seq, self._from_torch(torch.zeros(1, 1, 1, carry), dtype=ttnn.float32))),
+                ttnn.log(ttnn.multiply(zero_seq, self.ops.from_torch(torch.zeros(1, 1, 1, carry), dtype=ttnn.float32))),
                 self.dtype,
             ),
         }
@@ -570,12 +229,12 @@ class TtHCA(_TtHCABase):
 
         # One rope table per state, so forward only gathers. This one has a row per TOKEN; the compressor
         # builds its own, with a row per ENTRY.
-        self._slab_rope = self._build_rope_table(_rope_table_tokens(max_seq_len, chunk), 1)
-        self._slab_index = self._rope_index_base(chunk // self.sp_factor)
+        self._slab_rope = self.ops.build_rope_table(rope_table_tokens(max_seq_len, chunk), 1)
+        self._slab_index = self.ops.rope_index_base(chunk // self.sp_factor)
         return TtHCAState(
-            compressed_kv=self._from_torch(torch.zeros(batch, 1, capacity, self.head_dim)),
-            sliding_carry=self._from_torch(torch.zeros(batch, 1, self.sliding_window, self.head_dim)),
-            tail=self._from_torch(torch.zeros(batch, 1, ttnn.TILE_SIZE, self.head_dim)),
+            compressed_kv=self.ops.from_torch(torch.zeros(batch, 1, capacity, self.head_dim)),
+            sliding_carry=self.ops.from_torch(torch.zeros(batch, 1, self.sliding_window, self.head_dim)),
+            tail=self.ops.from_torch(torch.zeros(batch, 1, ttnn.TILE_SIZE, self.head_dim)),
             max_seq_len=max_seq_len,
         )
 
@@ -845,7 +504,7 @@ class TtHCA(_TtHCABase):
             rows = torch.arange(r_e + width)
             shift = torch.zeros(1, 1, buf, tile + width)
             shift[0, 0, rows, rows + (tile - r_e)] = 1.0
-            self._shift_cache[(r_e, width)] = self._from_torch(shift)
+            self._shift_cache[(r_e, width)] = self.ops.from_torch(shift)
 
         # The take matrix is keyed on r_e + n_new and not r_e + width: the whole padded width is written,
         # but entry_count only advances by the real entries. Rows before the tile's first live entry stay
@@ -854,7 +513,7 @@ class TtHCA(_TtHCABase):
             rows = torch.arange(tile - s % tile, tile)
             take = torch.zeros(1, 1, tile, buf)
             take[0, 0, rows, rows + s - tile] = 1.0
-            self._take_cache[s] = self._from_torch(take)
+            self._take_cache[s] = self.ops.from_torch(take)
 
     def _carry_key(self, real_len):
         """The carry index is tabulated per whole compression window. A ragged chunk rounds down, which is
@@ -872,7 +531,7 @@ class TtHCA(_TtHCABase):
         )
 
         def idx(vals):
-            return self._from_torch(
+            return self.ops.from_torch(
                 torch.tensor(vals, dtype=torch.int32), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
             )
 
@@ -966,7 +625,8 @@ class TtHCA(_TtHCABase):
         )
 
         # One rotation for the whole padded slab, shared by both stems and the output un-rope.
-        cos, sin = self._rope_gather(self._slab_rope, self._rope_index(self._slab_index, state.kv_actual))
+        slab_index = self.ops.rope_index(self._slab_index, state.kv_actual)
+        cos, sin = self.ops.rope_gather(self._slab_rope, slab_index)
         q = self._q_stem(hidden_states, cos, sin)
         sliding_kv = self._kv_stem(hidden_states, cos, sin)
         new_entries, mask_block = self.compressor(


### PR DESCRIPTION
### PR Category
Refactor
### Summary
CSA can reuse the compressor module already developed for HCA to a large extent. This PR decouples the Compressor module from HCA to avoid collision during the development of CSA while further changes to HCA are being done.

What has been done:

1. Add [models/demos/deepseek_v3_d_p/tt/mla/compressor.py](models/demos/deepseek_v3_d_p/tt/mla/compressor.py) containing public TtCompressorBase and the existing TtHCACompressor implementation. Move compressor-specific input padding, scalar buffers, mask construction, table allocation, factory construction, and forward logic there without changing numerical behavior.
5. Extract the tensor conversion, mesh mapping, and indexed-RoPE helpers currently supplied by _TtHCABase into a neutral composed utility in [models/demos/deepseek_v3_d_p/tt/mla/compressor.py](models/demos/deepseek_v3_d_p/tt/mla/compressor.py). Both TtCompressorBase and TtHCA will use this utility, but neither will inherit from the other or from a shared attention/compressor base.
9. Refactor [models/demos/deepseek_v3_d_p/tt/mla/heavily_compressed_attention.py](models/demos/deepseek_v3_d_p/tt/mla/heavily_compressed_attention.py): remove _TtHCABase and the in-file compressor, make TtHCA(LightweightModule), import TtHCACompressor from compressor.py, and retain HCA-only state/cache/attention behavior. Keep TtHCA.from_reference constructing the compressor with matching mesh and dtype configuration.
13. Update [models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py](models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py) to import TtHCACompressor from the new module and use its prepare_input API for both compressor and full-HCA tests. The performance test keeps importing TtHCA from its existing module.
14. 
### Notes for reviewers

- [x] [Blaze Models Prefill tests]https://github.com/tenstorrent/tt-metal/actions/runs/33399741912

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ddjekic/ds_v4_csa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ddjekic/ds_v4_csa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ddjekic/ds_v4_csa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ddjekic/ds_v4_csa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ddjekic/ds_v4_csa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ddjekic/ds_v4_csa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ddjekic/ds_v4_csa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ddjekic/ds_v4_csa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ddjekic/ds_v4_csa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ddjekic/ds_v4_csa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ddjekic/ds_v4_csa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ddjekic/ds_v4_csa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ddjekic/ds_v4_csa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ddjekic/ds_v4_csa)