### PR TITLE
[LLK] Fix operand-derived binary TensorShape handling

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
@@ -53,7 +53,7 @@ inline void llk_math_reduce_block_max_row_mop_config(const ckernel::TensorShape&
  * for general-purpose block reduction across multiple tiles.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en>
-inline void llk_math_reduce_block_max_row(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+inline void llk_math_reduce_block_max_row(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
 
     _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en>(dst_index, tensor_shape);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
@@ -57,7 +57,7 @@ inline void llk_math_reduce_block_max_row_mop_config_runtime(
  */
 template <bool is_fp32_dest_acc_en>
 inline void llk_math_reduce_block_max_row_runtime(
-    const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+    const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
 
     _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, tensor_shape);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -17,7 +17,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false>
-inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
     _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en>(dst_index, tensor_shape);
 }
@@ -44,6 +44,4 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
     _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity>(tensor_shape);
 }
 
-inline void llk_math_reduce_uninit() {
-    _llk_math_reduce_uninit_();
-}
+inline void llk_math_reduce_uninit() { _llk_math_reduce_uninit_(); }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_reduce.h"
 
@@ -97,7 +98,7 @@ inline void llk_math_reduce_uninit(const std::uint32_t operandA) {
  * @param tensor_shape: Tile shape determining face count and dest stride. int FPU path requires default 32x32.
  */
 template <PoolType type, ReduceDim dim, bool is_int_fpu_en = false>
-inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape) {
     if constexpr (is_int_fpu_en) {
         LLK_ASSERT(
             tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim &&

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_api.h
@@ -48,7 +48,7 @@ inline void llk_math_reduce_block_max_row_init(const ckernel::TensorShape& tenso
  * for general-purpose block reduction across multiple tiles.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en>
-inline void llk_math_reduce_block_max_row(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+inline void llk_math_reduce_block_max_row(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
 
     _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en>(dst_index, tensor_shape);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
@@ -57,7 +57,7 @@ inline void llk_math_reduce_block_max_row_mop_config_runtime(
  */
 template <bool is_fp32_dest_acc_en>
 inline void llk_math_reduce_block_max_row_runtime(
-    const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+    const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
 
     _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index, tensor_shape);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -17,7 +17,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false>
-inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape) {
+inline void llk_math_reduce(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape) {
     LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
     _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en>(dst_index, tensor_shape);
 }
@@ -44,6 +44,4 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
     _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity>(tensor_shape);
 }
 
-inline void llk_math_reduce_uninit([[maybe_unused]] const std::uint32_t operandA = 0) {
-    _llk_math_reduce_uninit_();
-}
+inline void llk_math_reduce_uninit([[maybe_unused]] const std::uint32_t operandA = 0) { _llk_math_reduce_uninit_(); }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -102,7 +102,7 @@ inline void _bcast_cols_op_()
  */
 template <EltwiseBinaryType eltwise_binary_type>
 inline void _llk_math_bcast_cols_reuse_custom_(
-    const std::uint32_t ct_dim = 1, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
+    const std::uint32_t ct_dim = 1, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
 {
     static_assert(
         eltwise_binary_type == EltwiseBinaryType::ELWMUL || eltwise_binary_type == EltwiseBinaryType::ELWSUB,

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -206,7 +206,7 @@ inline void _llk_math_mul_reduce_scalar_init_()
  * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile)
  */
 template <MathFidelity math_fidelity>
-inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -132,7 +132,7 @@ inline void reduce_max_row_configure_addrmod_reinit_minimal()
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape tensor_shape)
 {
     // Constraint on the outerloop and innerloop dim
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
@@ -270,7 +270,7 @@ inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShap
  * Use when the MOP was clobbered (e.g., by eltwise binary ops) but the replay buffer is intact.
  */
 template <std::uint32_t block_ct_dim>
-inline void _llk_math_reduce_block_max_row_mop_reprogram_only_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_mop_reprogram_only_(const ckernel::TensorShape tensor_shape)
 {
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
@@ -359,7 +359,7 @@ inline void _llk_math_reduce_block_max_row_uninit_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -155,7 +155,7 @@ inline void reduce_max_row_configure_addrmod_reinit_minimal_runtime()
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape tensor_shape)
 {
     // Constraint on the outerloop and innerloop dim
     // static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
@@ -359,7 +359,7 @@ inline void _llk_math_reduce_block_max_row_uninit_runtime_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
     // Packer indexes at the 32x32 slot stride regardless of the operand's face count.

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -66,7 +66,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
@@ -94,9 +94,12 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape
     // y_dim = number of faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile). Hardcoding 4 makes the
     // unpacker stride a full 32x32 tile between block tiles, over-reading the next tile (out-of-bounds
     // / wrong tile) for a genuine 16x32 operand.
-    if (tensor_shape.num_faces_r_dim == 1) {
+    if (tensor_shape.num_faces_r_dim == 1)
+    {
         TTI_SETDMAREG(0, 2 /* y_dim: 2 faces (16x32 tiny tile) */, 0, LO_16(p_gpr_unpack::TMP0));
-    } else {
+    }
+    else
+    {
         TTI_SETDMAREG(0, 4 /* y_dim: 4 faces (32x32 tile) */, 0, LO_16(p_gpr_unpack::TMP0));
     }
     TTI_SETDMAREG(0, 1 /* z_dim */, 0, HI_16(p_gpr_unpack::TMP0));

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -63,7 +63,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape& tensor_shape)
+inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
@@ -91,9 +91,12 @@ inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t bloc
     // y_dim = number of faces (4 for a 32x32 tile, 2 for a 16x32 tiny tile). Hardcoding 4 makes the
     // unpacker stride a full 32x32 tile between block tiles, over-reading the next tile (out-of-bounds
     // / wrong tile) for a genuine 16x32 operand.
-    if (tensor_shape.num_faces_r_dim == 1) {
+    if (tensor_shape.num_faces_r_dim == 1)
+    {
         TTI_SETDMAREG(0, 2 /* y_dim: 2 faces (16x32 tiny tile) */, 0, LO_16(p_gpr_unpack::TMP0));
-    } else {
+    }
+    else
+    {
         TTI_SETDMAREG(0, 4 /* y_dim: 4 faces (32x32 tile) */, 0, LO_16(p_gpr_unpack::TMP0));
     }
     TTI_SETDMAREG(0, 1 /* z_dim */, 0, HI_16(p_gpr_unpack::TMP0));

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -20,7 +20,7 @@ using namespace ckernel::unpacker;
 
 // SDPA-specific custom init for the blocked sub+bcast(col) unpack flow.
 // @param tensor_shape Shape of the operand tile (2 faces for 16x32 tiny tiles, 4 faces for full 32x32 tiles).
-inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -112,7 +112,7 @@ inline auto eltwise_binary_func(std::uint8_t clr_src, std::uint8_t acc_to_dest, 
  * @param tensor_shape: Tensor shape describing tile dimensions
  */
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_dest, const ckernel::TensorShape &tensor_shape)
+inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_dest, const ckernel::TensorShape tensor_shape)
 {
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
@@ -201,7 +201,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
  * @note @ref _llk_math_eltwise_binary_standard_ runs the configured op with matching template args.
  */
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType src_b_bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
+inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t acc_to_dest)
 {
     LLK_VALIDATE_TENSOR_SHAPE_MATH("_llk_math_eltwise_binary_standard_init_", tensor_shape);
 
@@ -231,7 +231,7 @@ template <
     DstSync Dst,
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index)
+inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape tensor_shape, std::uint32_t dst_index)
 {
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
@@ -361,7 +361,7 @@ inline void eltwise_binary_reuse_dest_as_src()
  * @param tensor_shape: Tensor shape describing tile dimensions
  */
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc_to_dest, const ckernel::TensorShape &tensor_shape)
+inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc_to_dest, const ckernel::TensorShape tensor_shape)
 {
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
@@ -446,7 +446,7 @@ template <
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity                   = MathFidelity::LoFi,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA>
-inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
+inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t acc_to_dest)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_init_ for no dest reuse");
     LLK_VALIDATE_TENSOR_SHAPE_MATH("_llk_math_eltwise_binary_with_dest_reuse_init_", tensor_shape);
@@ -525,7 +525,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest>
-inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc)
+inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc)
 {
     const std::uint32_t num_faces       = tensor_shape.total_num_faces();
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
@@ -631,7 +631,7 @@ template <
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity                   = MathFidelity::LoFi,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
+inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t acc_to_dest)
 {
     if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::NONE)
     {
@@ -674,7 +674,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity                   = MathFidelity::LoFi,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc = false)
+inline void _llk_math_eltwise_binary_(const ckernel::TensorShape tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc = false)
 {
     // Zero-flag leak guard. ELWADD/ELWMUL/ELWSUB honor ALU_ACC_CTRL_Zero_Flag_disabled_src; a prior
     // copy_init/datacopy op leaking PRESERVE here changes denormal Src results. eltwise_binary_init

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -255,7 +255,7 @@ inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
  *       function, and @ref _llk_math_reduce_uninit_ after it to restore modified state.
  */
 template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool is_int_fpu_en = false>
-inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape)
 {
     LLK_VALIDATE_TENSOR_SHAPE_MATH("_llk_math_reduce_", tensor_shape);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
@@ -35,7 +35,7 @@ using namespace ckernel::unpacker;
  * @note For REDUCE_SCALAR operations, SrcA is cleared before unpacking because SrcA is clobbered in the Math kernel.
  */
 template <PoolType pool_type, ReduceDim reduce_dim>
-inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor_shape)
+inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_mop_config_", tensor_shape);
@@ -103,7 +103,7 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
  * @ref _llk_math_reduce_init_ is the matching init on the math thread (this is the scaler operand unpack pairing).
  */
 template <PoolType pool_type, ReduceDim reduce_dim>
-inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
+inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_init_", tensor_shape);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -44,7 +44,7 @@ using namespace ckernel::math;
  * @note @ref _llk_math_sub_bcast_cols_reuse_custom_ runs the configured op on this thread.
  */
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType broadcast_type>
-inline void _llk_math_eltwise_binary_init_custom_([[maybe_unused]] const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+inline void _llk_math_eltwise_binary_init_custom_([[maybe_unused]] const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     static_assert(broadcast_type == BroadcastType::COL, "custom sub bcast-col path supports COL broadcast only");
     static_assert(eltwise_binary_type == EltwiseBinaryType::ELWSUB, "custom sub bcast-col path supports ELWSUB only");
@@ -72,7 +72,7 @@ inline void _llk_math_eltwise_binary_init_custom_([[maybe_unused]] const ckernel
  *       that slot; see @ref _sfpu_configure_addrmod_. ADDR_MOD_5/6 are left holding this op's values.
  */
 inline void _llk_math_sub_bcast_cols_reuse_custom_(
-    const std::uint32_t ct_dim = 1, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
+    const std::uint32_t ct_dim = 1, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
 {
     LLK_ASSERT(validate_tensor_shape_sub_bcast_col_custom_(tensor_shape), "custom sub bcast-col path supports 32x32 and 16x32 tiles only");
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -32,7 +32,7 @@ using namespace ckernel;
  * @note On the math thread, pair with @ref _llk_math_eltwise_binary_init_custom_ (T1); on pack, with @ref _llk_pack_init_ (T2).
  * @note @ref _llk_unpack_AB_sub_bcast_col_custom_ is the matching execute call on this thread.
  */
-inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     // One predicate for all three threads; see @ref validate_tensor_shape_sub_bcast_col_custom_ for why
     // this path is stricter than validate_tensor_shape_tile_dependent_ops_.

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -118,7 +118,7 @@ inline void _reduce_row_pool_face_pair_()
  * Full 32x32 tiles only — tiny tiles are not supported for Int8→Int32 reduce.
  */
 template <PoolType POOL_TYPE>
-inline void _llk_math_reduce_row_int32_fpu_(const TensorShape& tensor_shape)
+inline void _llk_math_reduce_row_int32_fpu_(const TensorShape tensor_shape)
 {
     LLK_ASSERT(
         tensor_shape.face_r_dim == DEFAULT_TENSOR_SHAPE.face_r_dim && tensor_shape.face_c_dim == DEFAULT_TENSOR_SHAPE.face_c_dim &&
@@ -169,7 +169,7 @@ inline void _llk_math_reduce_col_mop_config_(const TensorShape& tensor_shape)
     const std::uint32_t MOP_INNER_LOOP = (tensor_shape.total_num_faces() >= 2) ? (tensor_shape.total_num_faces() >> 1) : tensor_shape.total_num_faces();
     constexpr std::uint32_t NUM_FIDELITY_PHASES = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 0 : to_underlying(MATH_FIDELITY_TYPE) - 1;
     constexpr bool RUN_FID_LOOPS           = (MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi && (POOL_TYPE == PoolType::AVG || POOL_TYPE == PoolType::SUM));
-    constexpr std::uint32_t replay_buf_len      = 2 + (RUN_FID_LOOPS ? 2 * NUM_FIDELITY_PHASES : 0);
+    constexpr std::uint32_t replay_buf_len = 2 + (RUN_FID_LOOPS ? 2 * NUM_FIDELITY_PHASES : 0);
 
     load_replay_buf(
         0,
@@ -333,8 +333,8 @@ inline void _llk_math_reduce_row_mop_config_(const TensorShape& tensor_shape)
             TTI_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_D, 0, p_setrwc::SET_B);
         });
 
-    const std::uint32_t replay           = TT_OP_REPLAY(0, main_len, 0, 0, 0, 0);
-    const std::uint32_t dest_inc_32      = TT_OP_REPLAY(main_len, tail_len, 0, 0, 0, 0);
+    const std::uint32_t replay      = TT_OP_REPLAY(0, main_len, 0, 0, 0, 0);
+    const std::uint32_t dest_inc_32 = TT_OP_REPLAY(main_len, tail_len, 0, 0, 0, 0);
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, replay, dest_inc_32);
     temp.set_last_inner_loop_instr(TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD));
@@ -496,7 +496,7 @@ inline void _llk_math_reduce_addrmod_(const TensorShape& tensor_shape)
  * @note @ref _llk_math_reduce_ runs the configured reduction with matching template args.
  */
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE, bool is_int_fpu_en = false>
-inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
+inline void _llk_math_reduce_init_(const TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     _llk_math_reduce_addrmod_<REDUCE_DIMENSION, MATH_FIDELITY_TYPE>(tensor_shape);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -220,7 +220,7 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
  * @note @ref _llk_math_eltwise_unary_broadcast_ runs the configured op with matching template args.
  */
 template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest>
-inline void _llk_math_eltwise_unary_broadcast_init_(const TensorShape& tensor_shape)
+inline void _llk_math_eltwise_unary_broadcast_init_(const TensorShape tensor_shape)
 {
     LLK_ASSERT(
         tensor_shape.face_r_dim == MAX_FACE_R_DIM && tensor_shape.num_faces_r_dim == MAX_NUM_FACES_R_DIM && tensor_shape.num_faces_c_dim == MAX_NUM_FACES_C_DIM,

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
@@ -84,7 +84,7 @@ inline void _llk_unpack_reduce_mop_config_(
  */
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION>
 inline void _llk_unpack_reduce_init_(
-    const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const TensorShape& tensor_shape, const std::uint32_t num_tiles = NUM_TILES)
+    const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const TensorShape tensor_shape, const std::uint32_t num_tiles = NUM_TILES)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW));

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce_col_tilizeA_strided.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce_col_tilizeA_strided.h
@@ -123,7 +123,7 @@ inline void _llk_unpack_reduce_col_tilizeA_strided_tiny_tiles_mop_config_(const 
  */
 template <PoolType POOL_TYPE>
 inline void _llk_unpack_reduce_col_tilizeA_strided_init_(
-    const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const std::uint32_t full_ct_dim, const TensorShape& tensor_shape)
+    const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const std::uint32_t full_ct_dim, const TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -150,7 +150,7 @@ inline void _llk_unpack_unary_operand_mop_config_(const std::uint32_t buf_desc_i
  * @note Does NOT support tiny-tiles
  */
 template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
-inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const TensorShape& tensor_shape)
+inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const TensorShape tensor_shape)
 {
     static_assert((UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B), "UNP_SEL can only be p_unpacr::UNP_A or p_unpacr::UNP_B for unpack transpose");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -85,7 +85,7 @@ inline void _llk_math_eltwise_binary_uninit_custom_()
 //                     callers (e.g. the fuser LoopBlockRow driver) advance this per block-row so each row
 //                     lands on its own dest slots; single-tile-row callers leave it at 0.
 inline void _llk_math_sub_bcast_cols_reuse_custom_(
-    const std::uint32_t ct_dim = 1, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
+    const std::uint32_t ct_dim = 1, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t dst_index = 0)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -206,7 +206,7 @@ inline void _llk_math_mul_reduce_scalar_init_()
  * @param tensor_shape Shape of the operand tile (4 faces for 32x32, 2 faces for a 16x32 tiny tile)
  */
 template <MathFidelity math_fidelity>
-inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -104,7 +104,7 @@ inline void reduce_max_row_configure_addrmod()
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape tensor_shape)
 {
     // Constraint on the outerloop and innerloop dim
     static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
@@ -289,7 +289,7 @@ inline void _llk_math_reduce_block_max_row_uninit_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -67,7 +67,7 @@ inline void reduce_max_row_configure_addrmod_reinit_runtime()
  * Use the standard reduce MOP configuration with _llk_math_reduce_init_ for general-purpose reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t block_ct_dim, const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
@@ -269,7 +269,7 @@ inline void _llk_math_reduce_block_max_row_uninit_runtime_()
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
     // Packer indexes at the 32x32 slot stride regardless of the operand's face count.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -66,7 +66,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
+inline void _llk_unpack_AB_reduce_block_max_row_init_(const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -63,7 +63,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
  * Use the standard _llk_unpack_AB_reduce_init_ for general-purpose reduction operations.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape& tensor_shape)
+inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger, const ckernel::TensorShape tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -21,7 +21,7 @@ using namespace ckernel::unpacker;
 
 // Custom init for the blocked sub+bcast(col) unpack flow.
 // @param tensor_shape Shape of the operand tile (2 faces for 16x32 tiny tiles, 4 faces for full 32x32 tiles).
-inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
+inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -109,7 +109,7 @@ inline auto eltwise_binary_func(std::uint8_t clr_src, std::uint8_t acc_to_dest, 
  * @param tensor_shape: Tensor shape describing tile dimensions
  */
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_dest, const ckernel::TensorShape &tensor_shape)
+inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_dest, const ckernel::TensorShape tensor_shape)
 {
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
@@ -196,7 +196,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
  * @note @ref _llk_math_eltwise_binary_standard_ runs the configured op with matching template args.
  */
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType src_b_bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
+inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t acc_to_dest)
 {
     LLK_VALIDATE_TENSOR_SHAPE_MATH("_llk_math_eltwise_binary_standard_init_", tensor_shape);
 
@@ -226,7 +226,7 @@ template <
     DstSync Dst,
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index)
+inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape tensor_shape, std::uint32_t dst_index)
 {
     LLK_VALIDATE_TENSOR_SHAPE_MATH("_llk_math_eltwise_binary_standard_", tensor_shape);
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
@@ -356,7 +356,7 @@ inline void eltwise_binary_reuse_dest_as_src()
  * @param tensor_shape: Tensor shape describing tile dimensions
  */
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
-inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc_to_dest, const ckernel::TensorShape &tensor_shape)
+inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc_to_dest, const ckernel::TensorShape tensor_shape)
 {
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
@@ -441,7 +441,7 @@ template <
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity                   = MathFidelity::LoFi,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA>
-inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
+inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t acc_to_dest)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_init_ for no dest reuse");
     LLK_VALIDATE_TENSOR_SHAPE_MATH("_llk_math_eltwise_binary_with_dest_reuse_init_", tensor_shape);
@@ -528,7 +528,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest>
-inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc)
+inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_ for no dest reuse");
     static_assert(
@@ -633,7 +633,7 @@ template <
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity                   = MathFidelity::LoFi,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
+inline void _llk_math_eltwise_binary_init_(const ckernel::TensorShape tensor_shape, const std::uint32_t acc_to_dest)
 {
     if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::NONE)
     {
@@ -676,7 +676,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity                   = MathFidelity::LoFi,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void _llk_math_eltwise_binary_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc = false)
+inline void _llk_math_eltwise_binary_(const ckernel::TensorShape tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc = false)
 {
     // Zero-flag leak guard. ELWADD/ELWMUL/ELWSUB honor ALU_ACC_CTRL_Zero_Flag_disabled_src; a prior
     // copy_init/datacopy op leaking PRESERVE here changes denormal Src results. eltwise_binary_init

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -246,7 +246,7 @@ inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
  *       function, and @ref _llk_math_reduce_uninit_ after it to restore modified state.
  */
 template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool is_int_fpu_en = false>
-inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
+inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape tensor_shape)
 {
     LLK_VALIDATE_TENSOR_SHAPE_MATH("_llk_math_reduce_", tensor_shape);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -33,7 +33,7 @@ using namespace ckernel::unpacker;
  * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim)
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const ckernel::TensorShape &tensor_shape)
+inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const ckernel::TensorShape tensor_shape)
 {
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
@@ -43,7 +43,7 @@ using namespace ckernel::unpacker;
  * @note For REDUCE_SCALAR operations, SrcA is cleared before unpacking because SrcA is clobbered in the Math kernel.
  */
 template <PoolType pool_type, ReduceDim reduce_dim>
-inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor_shape)
+inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_mop_config_", tensor_shape);
@@ -106,7 +106,7 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
  * @ref _llk_math_reduce_init_ is the matching init on the math thread (this is the scaler operand unpack pairing).
  */
 template <PoolType pool_type, ReduceDim reduce_dim>
-inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
+inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_init_", tensor_shape);


### PR DESCRIPTION
## Summary

- pass the packed 4-byte binary `TensorShape` by value throughout the Wormhole and Blackhole math paths
- give initialization, MOP configuration, dispatch, standard execution, and destination reuse one consistent calling convention
- avoid the failing stack-backed reference code generation in LLK-assert builds

## Root cause

The failing convolution supplies `TensorShape {16,16,2,2}`, which is already present in LLK math coverage, so the assertion is a false positive rather than missing coverage. `TensorShape` consists of four 1-byte members, and with `const TensorShape&` GCC emits a 4-byte `sw` to place it on the stack followed almost immediately by an overlapping 1-byte `lbu` that reads an individual member for the LLK coverage check. This generated path does not guarantee that the wider store has completed before the narrower overlapping load, so the checker can observe a stale stack byte and interpret the shape as uncovered. Passing `TensorShape` by value lets GCC prove the independent 4-byte value is already covered and optimize the problematic `lbu` out of the normal execution path. The by-value build passes the original hardware test, and a reference-preserving experiment also passes when instruction spacing is added, confirming both the store-to-load hazard and that no coverage entry is needed.

## Testing

- `pre-commit run --files tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h` passed
- existing standard binary and destination-reuse LLK simulator cases passed on Wormhole and Blackhole (4 tests)
- `cmake --build build_Release --target ttnn --parallel 32` passed on `wh-15`
- the exact issue #54881 convolution passed on a Wormhole N150 with `TT_METAL_LLK_ASSERTS=1` and a cold JIT cache: 1 passed in 8.70s, PCC 0.9999486804909324, 0/30 cache hits

Fixes #54881

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue_54881)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue_54881)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/issue_54881)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/issue_54881)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue_54881)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue_54881)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue_54881)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue_54881)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue_54881)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue_54881)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue_54881)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue_54881)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue_54881)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue_54881)
