### PR TITLE
[Quasar] Replace TEN-4746 copy_tile drain with dummy_unpack() helper

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
@@ -4,9 +4,9 @@ copy_tile
 =========
 
 .. doxygenfunction:: copy_init
-.. doxygenfunction:: copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE())
-.. doxygenfunction:: copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index)
-.. doxygenfunction:: copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles)
-.. doxygenfunction:: copy_block_matmul_partials(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles)
-.. doxygenfunction:: copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0)
-.. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, uint32_t transpose_within_16x16_face = false, uint32_t call_line = __builtin_LINE())
+.. doxygenfunction:: copy_tile_init
+.. doxygenfunction:: copy_tile
+.. doxygenfunction:: copy_block
+.. doxygenfunction:: copy_block_matmul_partials
+.. doxygenfunction:: copy_tile_to_dst_init_short_with_dt
+.. doxygenfunction:: copy_tile_to_dst_init_short

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
@@ -3,7 +3,7 @@
 copy_tile
 =========
 
-.. doxygenfunction:: copy_init(uint32_t cbid, uint32_t transpose = 0, uint32_t transpose_within_16x16_face = false, uint32_t call_line = __builtin_LINE())
+.. doxygenfunction:: copy_init
 .. doxygenfunction:: copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index)
 .. doxygenfunction:: copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -120,7 +120,7 @@ inline void llk_unpack_A_block(
  * in-flight op; it clears SrcA only (the next op re-unpacks it) and reads nothing from L1. Kernels do not
  * need this in normal operation -- use it only for debug when an explicit SrcA flush is wanted.
  */
-inline void llk_unpack_dummy() {
+inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id) {
     TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
     TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, 0, 0, 0, 0, ckernel::p_unpacr_nop::CLR_SRC_0, ckernel::p_unpacr_nop::CLR_SRC);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -6,6 +6,10 @@
 #include <cstdint>
 #include "llk_unpack_A.h"
 #include "llk_unpack_common_api.h"
+// llk_unpack_dummy(): debug-only SrcA flush on WH/BH (no WAIT/POP ordering role), defined in the debug
+// folder. Pulled in only so the shared compute-API dummy_unpack() resolves; on Quasar the same call is a
+// required TEN-4746 drain primitive defined inline in that arch's llk_unpack_A_api.h.
+#include "debug/llk_unpack_dummy.h"
 
 /*************************************************************************
  * LLK UNPACK A
@@ -111,23 +115,6 @@ inline void llk_unpack_A_block(
         address += offset_address;
         WAYPOINT("UPAD");
     }
-}
-
-/**
- * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear then a clear-SrcA UNPACR_NOP (no CB read, no DEST
- *        write). Reads nothing from L1.
- *
- * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
- * in-flight op; SrcA is cleared only (the next op re-unpacks it). WH/BH have no WAIT/POP ordering
- * requirement, so this is a debug-only flush -- use it only when an explicit SrcA flush is wanted. (On
- * Quasar the same call is a required drain primitive; see that arch's llk_unpack_dummy.)
- *
- * @param dfb_id  Unused on WH/BH; accepted only to match the Quasar signature, where it names the drained
- *                dataflow buffer.
- */
-inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id) {
-    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
-    TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, 0, 0, 0, 0, ckernel::p_unpacr_nop::CLR_SRC_0, ckernel::p_unpacr_nop::CLR_SRC);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -113,6 +113,18 @@ inline void llk_unpack_A_block(
     }
 }
 
+/**
+ * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear (stalling the unpacker) then a clear-SrcA UNPACR_NOP.
+ *
+ * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
+ * in-flight op; it clears SrcA only (the next op re-unpacks it) and reads nothing from L1. Kernels do not
+ * need this in normal operation -- use it only for debug when an explicit SrcA flush is wanted.
+ */
+inline void llk_unpack_dummy() {
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
+    TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, 0, 0, 0, 0, ckernel::p_unpacr_nop::CLR_SRC_0, ckernel::p_unpacr_nop::CLR_SRC);
+}
+
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_A_uninit() {
     _llk_unpack_A_uninit_<BType>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -114,11 +114,16 @@ inline void llk_unpack_A_block(
 }
 
 /**
- * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear (stalling the unpacker) then a clear-SrcA UNPACR_NOP.
+ * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear then a clear-SrcA UNPACR_NOP (no CB read, no DEST
+ *        write). Reads nothing from L1.
  *
  * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
- * in-flight op; it clears SrcA only (the next op re-unpacks it) and reads nothing from L1. Kernels do not
- * need this in normal operation -- use it only for debug when an explicit SrcA flush is wanted.
+ * in-flight op; SrcA is cleared only (the next op re-unpacks it). WH/BH have no WAIT/POP ordering
+ * requirement, so this is a debug-only flush -- use it only when an explicit SrcA flush is wanted. (On
+ * Quasar the same call is a required drain primitive; see that arch's llk_unpack_dummy.)
+ *
+ * @param dfb_id  Unused on WH/BH; accepted only to match the Quasar signature, where it names the drained
+ *                dataflow buffer.
  */
 inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id) {
     TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -193,5 +193,20 @@ inline void llk_unpack_A_block(
     }
 }
 
+/**
+ * @brief Drain / flow-control NOP for the unpacker (no CB read, no DEST write).
+ *
+ * Issues a STALLWAIT on SrcA-clear followed by a clear-SrcA UNPACR_NOP. Used between cb_wait_front and
+ * cb_pop_front to order a POP_TILES after its WAIT_TILES with a real unpacker op (TEN-4746 / #48552)
+ * without consuming a tile: a bare TTI_NOP / DMANOP issues no unpacker transaction and does not satisfy
+ * the ordering, while a real read (UNPACR_TILE) is heavier and, if partial, corrupts PACKER_L1_ACC offsets.
+ * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
+ * in-flight op. Clears SrcA only (the next op re-unpacks it) and reads nothing from L1.
+ */
+inline void llk_unpack_dummy() {
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, 0, 0, p_stall::SRCA_CLR);
+    TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, 0, 0, p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC);
+}
+
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_A_uninit() {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -194,19 +194,18 @@ inline void llk_unpack_A_block(
 }
 
 /**
- * @brief Drain / flow-control NOP for the unpacker (no CB read, no DEST write).
+ * @brief Drain the unpacker without consuming a tile: STALLWAIT on SrcA-clear then a clear-SrcA
+ *        UNPACR_NOP (no CB read, no DEST write). Reads nothing from L1.
  *
- * Issues a STALLWAIT on SrcA-clear followed by a clear-SrcA UNPACR_NOP. Used between cb_wait_front and
- * cb_pop_front to order a POP_TILES after its WAIT_TILES with a real unpacker op (TEN-4746 / #48552)
- * without consuming a tile: a bare TTI_NOP / DMANOP issues no unpacker transaction and does not satisfy
- * the ordering. The UNPACR_NOP is a real unpacker TDMA that re-samples the WAIT_TILES stall for this
- * engine, so it orders the following POP after the WAIT even though it reads no tile (a real UNPACR_TILE
- * is heavier and, if partial, corrupts PACKER_L1_ACC offsets -- but this reads nothing from L1, so L1_ACC
- * is untouched). The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank
- * still owned by an in-flight op. Clears SrcA only (the next op re-unpacks it).
+ * Call between llk_wait_tiles and llk_pop_tiles to drain a buffer whose data is not needed. Unlike the
+ * WH/BH version -- a debug-only SrcA flush with no ordering role -- this is a required Quasar primitive:
+ * the UNPACR_NOP is a real unpacker TDMA that orders the POP_TILES after its WAIT_TILES on dfb_id
+ * (TEN-4746 / #48552). Because it reads nothing, PACKER_L1_ACC is undisturbed. The STALLWAIT ensures
+ * SrcA is free before the clear, so it cannot clobber a SrcA bank still owned by an in-flight op; SrcA is
+ * cleared only (the next op re-unpacks it).
  *
- * dfb_id is the dataflow buffer being drained: the UNPACR_NOP satisfies the TEN-4746 ordering for it, so
- * disarm the per-dfb guard (llk_wait_tiles armed it; without this the following llk_pop_tiles asserts).
+ * @param dfb_id  The dataflow buffer being drained. Disarms the TEN-4746 tile-counter guard that
+ *                llk_wait_tiles armed for it (llk_pop_tiles asserts the buffer was disarmed).
  */
 inline void llk_unpack_dummy(const std::uint32_t dfb_id) {
     TTI_STALLWAIT(p_stall::STALL_UNPACK, 0, 0, p_stall::SRCA_CLR);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -194,18 +194,18 @@ inline void llk_unpack_A_block(
 }
 
 /**
- * @brief Drain the unpacker without consuming a tile: STALLWAIT on SrcA-clear then a clear-SrcA
- *        UNPACR_NOP (no CB read, no DEST write). Reads nothing from L1.
+ * @brief Toggle the unpacker engine to order a POP after its WAIT: STALLWAIT on SrcA-clear then a
+ *        clear-SrcA UNPACR_NOP (no CB read, no DEST write, no pop). Reads nothing from L1.
  *
- * Call between llk_wait_tiles and llk_pop_tiles to drain a buffer whose data is not needed. Unlike the
- * WH/BH version -- a debug-only SrcA flush with no ordering role -- this is a required Quasar primitive:
- * the UNPACR_NOP is a real unpacker TDMA that orders the POP_TILES after its WAIT_TILES on dfb_id
- * (TEN-4746 / #48552). Because it reads nothing, PACKER_L1_ACC is undisturbed. The STALLWAIT ensures
- * SrcA is free before the clear, so it cannot clobber a SrcA bank still owned by an in-flight op; SrcA is
- * cleared only (the next op re-unpacks it).
+ * Call between llk_wait_tiles and llk_pop_tiles on a buffer that is being drained (by llk_pop_tiles) but
+ * whose data is not needed. Unlike the WH/BH version -- a debug-only SrcA flush with no ordering role --
+ * this is a required Quasar primitive: the UNPACR_NOP is a real unpacker TDMA that orders the POP_TILES
+ * after its WAIT_TILES on dfb_id (TEN-4746 / #48552). Because it reads nothing, PACKER_L1_ACC is
+ * undisturbed. The STALLWAIT ensures SrcA is free before the clear, so it cannot clobber a SrcA bank
+ * still owned by an in-flight op; SrcA is cleared only (the next op re-unpacks it).
  *
- * @param dfb_id  The dataflow buffer being drained. Disarms the TEN-4746 tile-counter guard that
- *                llk_wait_tiles armed for it (llk_pop_tiles asserts the buffer was disarmed).
+ * @param dfb_id  The dataflow buffer whose WAIT/POP this orders. Disarms the TEN-4746 tile-counter guard
+ *                that llk_wait_tiles armed for it (llk_pop_tiles asserts the buffer was disarmed).
  */
 inline void llk_unpack_dummy(const std::uint32_t dfb_id) {
     TTI_STALLWAIT(p_stall::STALL_UNPACK, 0, 0, p_stall::SRCA_CLR);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -199,13 +199,19 @@ inline void llk_unpack_A_block(
  * Issues a STALLWAIT on SrcA-clear followed by a clear-SrcA UNPACR_NOP. Used between cb_wait_front and
  * cb_pop_front to order a POP_TILES after its WAIT_TILES with a real unpacker op (TEN-4746 / #48552)
  * without consuming a tile: a bare TTI_NOP / DMANOP issues no unpacker transaction and does not satisfy
- * the ordering, while a real read (UNPACR_TILE) is heavier and, if partial, corrupts PACKER_L1_ACC offsets.
- * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
- * in-flight op. Clears SrcA only (the next op re-unpacks it) and reads nothing from L1.
+ * the ordering. The UNPACR_NOP is a real unpacker TDMA that re-samples the WAIT_TILES stall for this
+ * engine, so it orders the following POP after the WAIT even though it reads no tile (a real UNPACR_TILE
+ * is heavier and, if partial, corrupts PACKER_L1_ACC offsets -- but this reads nothing from L1, so L1_ACC
+ * is untouched). The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank
+ * still owned by an in-flight op. Clears SrcA only (the next op re-unpacks it).
+ *
+ * dfb_id is the dataflow buffer being drained: the UNPACR_NOP satisfies the TEN-4746 ordering for it, so
+ * disarm the per-dfb guard (llk_wait_tiles armed it; without this the following llk_pop_tiles asserts).
  */
-inline void llk_unpack_dummy() {
+inline void llk_unpack_dummy(const std::uint32_t dfb_id) {
     TTI_STALLWAIT(p_stall::STALL_UNPACK, 0, 0, p_stall::SRCA_CLR);
     TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, 0, 0, p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC);
+    LLK_TDMA_GUARD_NOTE_TDMA(dfb_id);  // TEN-4746: UNPACR_NOP orders POP after WAIT -> disarm this dfb
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -93,11 +93,16 @@ inline void llk_unpack_A_block(
 }
 
 /**
- * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear (stalling the unpacker) then a clear-SrcA UNPACR_NOP.
+ * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear then a clear-SrcA UNPACR_NOP (no CB read, no DEST
+ *        write). Reads nothing from L1.
  *
  * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
- * in-flight op; it clears SrcA only (the next op re-unpacks it) and reads nothing from L1. Kernels do not
- * need this in normal operation -- use it only for debug when an explicit SrcA flush is wanted.
+ * in-flight op; SrcA is cleared only (the next op re-unpacks it). WH/BH have no WAIT/POP ordering
+ * requirement, so this is a debug-only flush -- use it only when an explicit SrcA flush is wanted. (On
+ * Quasar the same call is a required drain primitive; see that arch's llk_unpack_dummy.)
+ *
+ * @param dfb_id  Unused on WH/BH; accepted only to match the Quasar signature, where it names the drained
+ *                dataflow buffer.
  */
 inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id) {
     TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -99,7 +99,7 @@ inline void llk_unpack_A_block(
  * in-flight op; it clears SrcA only (the next op re-unpacks it) and reads nothing from L1. Kernels do not
  * need this in normal operation -- use it only for debug when an explicit SrcA flush is wanted.
  */
-inline void llk_unpack_dummy() {
+inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id) {
     TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
     TTI_UNPACR_NOP(ckernel::SrcA, ckernel::p_unpacr_nop::UNP_ZEROSRC);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -6,6 +6,10 @@
 #include <cstdint>
 #include "llk_unpack_A.h"
 #include "llk_unpack_common_api.h"
+// llk_unpack_dummy(): debug-only SrcA flush on WH/BH (no WAIT/POP ordering role), defined in the debug
+// folder. Pulled in only so the shared compute-API dummy_unpack() resolves; on Quasar the same call is a
+// required TEN-4746 drain primitive defined inline in that arch's llk_unpack_A_api.h.
+#include "debug/llk_unpack_dummy.h"
 
 /*************************************************************************
  * LLK UNPACK A
@@ -90,23 +94,6 @@ inline void llk_unpack_A_block(
         address += offset_address;
         WAYPOINT("UPAD");
     }
-}
-
-/**
- * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear then a clear-SrcA UNPACR_NOP (no CB read, no DEST
- *        write). Reads nothing from L1.
- *
- * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
- * in-flight op; SrcA is cleared only (the next op re-unpacks it). WH/BH have no WAIT/POP ordering
- * requirement, so this is a debug-only flush -- use it only when an explicit SrcA flush is wanted. (On
- * Quasar the same call is a required drain primitive; see that arch's llk_unpack_dummy.)
- *
- * @param dfb_id  Unused on WH/BH; accepted only to match the Quasar signature, where it names the drained
- *                dataflow buffer.
- */
-inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id) {
-    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
-    TTI_UNPACR_NOP(ckernel::SrcA, ckernel::p_unpacr_nop::UNP_ZEROSRC);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_A.h"
 #include "llk_unpack_common_api.h"
 
@@ -82,13 +83,25 @@ inline void llk_unpack_A_block(
 
     LLK_ASSERT(cb_access_within_bounds(operand_id, start_tile_index, ntiles), "Block tile read exceeds CB boundary");
 
-    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+    for (std::uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");
         _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
             address, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
         address += offset_address;
         WAYPOINT("UPAD");
     }
+}
+
+/**
+ * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear (stalling the unpacker) then a clear-SrcA UNPACR_NOP.
+ *
+ * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
+ * in-flight op; it clears SrcA only (the next op re-unpacks it) and reads nothing from L1. Kernels do not
+ * need this in normal operation -- use it only for debug when an explicit SrcA flush is wanted.
+ */
+inline void llk_unpack_dummy() {
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
+    TTI_UNPACR_NOP(ckernel::SrcA, ckernel::p_unpacr_nop::UNP_ZEROSRC);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -77,22 +77,23 @@ ALWI void copy_init(
 }
 // clang-format off
 /**
- * Issue a single lightweight clear-SrcA unpacker op (UNPACR_NOP, no dvalid) on circular buffer cb_id.
- * Intended to be called between cb_wait_front and cb_pop_front when a circular buffer must be
- * drained/flow-controlled without a real consume. This satisfies the unpacker's requirement that a
- * POP_TILES be ordered after its WAIT_TILES by a real unpacker op (Quasar TEN-4746 / #48552) -- a bare
- * TTI_NOP/DMANOP does NOT (they issue no unpacker transaction); the UNPACR_NOP is a real unpacker TDMA
- * that re-samples the WAIT_TILES stall for the engine. A real read (copy_tile / UNPACR_TILE) is heavier
- * and, if partial, corrupts PACKER_L1_ACC offsets -- but this reads nothing, so L1_ACC is untouched. It
- * clears SrcA only (harmless: the next op re-unpacks SrcA) and never reads the CB.
+ * Drains one entry from the input CB without consuming a tile: issues a single clear-SrcA unpacker
+ * NOP (no CB read, no DST write). Call it between cb_wait_front and cb_pop_front when a CB must be
+ * drained or flow-controlled but its tile data is not needed.
  *
- * cb_id is the buffer being drained; Quasar uses it to disarm that buffer's TEN-4746 tile-counter guard
- * (armed by the preceding cb_wait_front). The clear is preceded by a STALLWAIT on SrcA-clear (stalling
- * the unpacker) so the NOP cannot clobber the SrcA bank while another op still holds it. Each arch
- * supplies its own llk_unpack_dummy() with the matching STALLWAIT + UNPACR_NOP encoding. Outside Quasar
- * there is no such ordering requirement, so this is just a SrcA flush -- not needed unless for debug.
+ * On Quasar this is required: the hardware needs a real unpacker op between a WAIT_TILES and its
+ * POP_TILES on the same CB, or the POP can retire before the tiles are available (TEN-4746 / #48552).
+ * The NOP satisfies that ordering while reading nothing, so it does not disturb PACKER_L1_ACC. On WH/BH
+ * there is no such ordering requirement and this compiles to a bare SrcA flush. Each architecture
+ * supplies its own llk_unpack_dummy(); this helper dispatches to it through UNPACK(...). This call is
+ * only available on the compute engine.
+ *
  * Return value: None
- */
+ *
+ * | Argument | Description                        | Data type | Valid range | required |
+ * |----------|------------------------------------|-----------|-------------|----------|
+ * | cb_id    | The identifier of the CB to drain  | uint32_t  | 0 to 31     | True     |
+ * */
 // clang-format on
 ALWI void dummy_unpack(std::uint32_t cb_id) { UNPACK((llk_unpack_dummy(cb_id))); }
 

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -77,22 +77,22 @@ ALWI void copy_init(
 }
 // clang-format off
 /**
- * Drains one entry from the input CB without consuming a tile: issues a single clear-SrcA unpacker
- * NOP (no CB read, no DST write). Call it between cb_wait_front and cb_pop_front when a CB must be
- * drained or flow-controlled but its tile data is not needed.
+ * Issues a single clear-SrcA unpacker NOP: it toggles the unpacker engine only -- no CB read, no DST
+ * write, and it does NOT pop/drain the CB (the surrounding cb_pop_front does that). Call it between
+ * cb_wait_front and cb_pop_front when a CB is being drained but its tile data is not needed.
  *
  * On Quasar this is required: the hardware needs a real unpacker op between a WAIT_TILES and its
  * POP_TILES on the same CB, or the POP can retire before the tiles are available (TEN-4746 / #48552).
- * The NOP satisfies that ordering while reading nothing, so it does not disturb PACKER_L1_ACC. On WH/BH
- * there is no such ordering requirement and this compiles to a bare SrcA flush. Each architecture
- * supplies its own llk_unpack_dummy(); this helper dispatches to it through UNPACK(...). This call is
- * only available on the compute engine.
+ * This NOP steps the unpacker to satisfy that ordering while reading nothing, so it does not disturb
+ * PACKER_L1_ACC. On WH/BH there is no such ordering requirement and this compiles to a bare SrcA flush.
+ * Each architecture supplies its own llk_unpack_dummy(); this helper dispatches to it through
+ * UNPACK(...). This call is only available on the compute engine.
  *
  * Return value: None
  *
- * | Argument | Description                        | Data type | Valid range | required |
- * |----------|------------------------------------|-----------|-------------|----------|
- * | cb_id    | The identifier of the CB to drain  | uint32_t  | 0 to 31     | True     |
+ * | Argument | Description                                             | Data type | Valid range | required |
+ * |----------|---------------------------------------------------------|-----------|-------------|----------|
+ * | cb_id    | The identifier of the CB whose WAIT/POP this orders      | uint32_t  | 0 to 31     | True     |
  * */
 // clang-format on
 ALWI void dummy_unpack(std::uint32_t cb_id) { UNPACK((llk_unpack_dummy(cb_id))); }

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -71,6 +71,23 @@ ALWI void copy_init(
         cbid)));
 #endif
 }
+// clang-format off
+/**
+ * Issue a single lightweight clear-SrcA unpacker op (UNPACR_NOP, no dvalid). Intended to be called between
+ * cb_wait_front and cb_pop_front when a circular buffer must be drained/flow-controlled without a real
+ * consume. On Quasar this satisfies the unpacker's requirement that a POP_TILES be ordered after its
+ * WAIT_TILES by a real unpacker op (TEN-4746 / #48552) -- a bare TTI_NOP/DMANOP does NOT (they issue no
+ * unpacker transaction), and a real read (copy_tile / UNPACR_TILE) is heavier and, if partial, corrupts
+ * PACKER_L1_ACC offsets. This clears SrcA only (harmless: the next op re-unpacks SrcA) and never reads the
+ * CB, so it is correct and side-effect free. On WH/BH there is no such HW ordering bug, so this is a no-op.
+ * Return value: None
+ */
+// clang-format on
+ALWI void dummy_unpack() {
+#ifdef ARCH_QUASAR
+    UNPACK(TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, 0, 0, p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC));
+#endif
+}
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -77,22 +77,24 @@ ALWI void copy_init(
 }
 // clang-format off
 /**
- * Issue a single lightweight clear-SrcA unpacker op (UNPACR_NOP, no dvalid). Intended to be called between
- * cb_wait_front and cb_pop_front when a circular buffer must be drained/flow-controlled without a real
- * consume. This satisfies the unpacker's requirement that a POP_TILES be ordered after its WAIT_TILES by a
- * real unpacker op (Quasar TEN-4746 / #48552) -- a bare TTI_NOP/DMANOP does NOT (they issue no unpacker
- * transaction), and a real read (copy_tile / UNPACR_TILE) is heavier and, if partial, corrupts
- * PACKER_L1_ACC offsets. This clears SrcA only (harmless: the next op re-unpacks SrcA) and never reads the
- * CB, so it is correct and side-effect free.
+ * Issue a single lightweight clear-SrcA unpacker op (UNPACR_NOP, no dvalid) on circular buffer cb_id.
+ * Intended to be called between cb_wait_front and cb_pop_front when a circular buffer must be
+ * drained/flow-controlled without a real consume. This satisfies the unpacker's requirement that a
+ * POP_TILES be ordered after its WAIT_TILES by a real unpacker op (Quasar TEN-4746 / #48552) -- a bare
+ * TTI_NOP/DMANOP does NOT (they issue no unpacker transaction); the UNPACR_NOP is a real unpacker TDMA
+ * that re-samples the WAIT_TILES stall for the engine. A real read (copy_tile / UNPACR_TILE) is heavier
+ * and, if partial, corrupts PACKER_L1_ACC offsets -- but this reads nothing, so L1_ACC is untouched. It
+ * clears SrcA only (harmless: the next op re-unpacks SrcA) and never reads the CB.
  *
- * The clear is preceded by a STALLWAIT on SrcA-clear (stalling the unpacker) so the NOP cannot clobber the
- * SrcA bank while another op still holds it -- we only clear once SrcA is no longer in use. Each arch
+ * cb_id is the buffer being drained; Quasar uses it to disarm that buffer's TEN-4746 tile-counter guard
+ * (armed by the preceding cb_wait_front). The clear is preceded by a STALLWAIT on SrcA-clear (stalling
+ * the unpacker) so the NOP cannot clobber the SrcA bank while another op still holds it. Each arch
  * supplies its own llk_unpack_dummy() with the matching STALLWAIT + UNPACR_NOP encoding. Outside Quasar
  * there is no such ordering requirement, so this is just a SrcA flush -- not needed unless for debug.
  * Return value: None
  */
 // clang-format on
-ALWI void dummy_unpack() { UNPACK((llk_unpack_dummy())); }
+ALWI void dummy_unpack(std::uint32_t cb_id) { UNPACK((llk_unpack_dummy(cb_id))); }
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common_globals.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
@@ -44,10 +45,10 @@ namespace ckernel {
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void copy_init(
-    uint32_t cbid,
-    uint32_t transpose = 0,
-    uint32_t transpose_within_16x16_face = false,
-    uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t cbid,
+    std::uint32_t transpose = 0,
+    std::uint32_t transpose_within_16x16_face = false,
+    std::uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
 #ifndef ARCH_QUASAR
     state_configure(cbid, call_line);
@@ -67,27 +68,31 @@ ALWI void copy_init(
     // config: records no format-reconfig diff, so single-SrcA reconfig tracking is unchanged. Not on Quasar.
     MATH((ckernel::math::_configure_copy_zero_flag_state_(get_operand_dst_format(cbid))));
 #else
-    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, UnpackToDestEn>(
-        cbid)));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          DataCopyType::A2D,
+          is_fp32_dest_acc_en,
+          BroadcastType::NONE,
+          UnpackToDestEn>(cbid)));
 #endif
 }
 // clang-format off
 /**
  * Issue a single lightweight clear-SrcA unpacker op (UNPACR_NOP, no dvalid). Intended to be called between
  * cb_wait_front and cb_pop_front when a circular buffer must be drained/flow-controlled without a real
- * consume. On Quasar this satisfies the unpacker's requirement that a POP_TILES be ordered after its
- * WAIT_TILES by a real unpacker op (TEN-4746 / #48552) -- a bare TTI_NOP/DMANOP does NOT (they issue no
- * unpacker transaction), and a real read (copy_tile / UNPACR_TILE) is heavier and, if partial, corrupts
+ * consume. This satisfies the unpacker's requirement that a POP_TILES be ordered after its WAIT_TILES by a
+ * real unpacker op (Quasar TEN-4746 / #48552) -- a bare TTI_NOP/DMANOP does NOT (they issue no unpacker
+ * transaction), and a real read (copy_tile / UNPACR_TILE) is heavier and, if partial, corrupts
  * PACKER_L1_ACC offsets. This clears SrcA only (harmless: the next op re-unpacks SrcA) and never reads the
- * CB, so it is correct and side-effect free. On WH/BH there is no such HW ordering bug, so this is a no-op.
+ * CB, so it is correct and side-effect free.
+ *
+ * The clear is preceded by a STALLWAIT on SrcA-clear (stalling the unpacker) so the NOP cannot clobber the
+ * SrcA bank while another op still holds it -- we only clear once SrcA is no longer in use. Each arch
+ * supplies its own llk_unpack_dummy() with the matching STALLWAIT + UNPACR_NOP encoding. Outside Quasar
+ * there is no such ordering requirement, so this is just a SrcA flush -- not needed unless for debug.
  * Return value: None
  */
 // clang-format on
-ALWI void dummy_unpack() {
-#ifdef ARCH_QUASAR
-    UNPACK(TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, 0, 0, p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC));
-#endif
-}
+ALWI void dummy_unpack() { UNPACK((llk_unpack_dummy())); }
 
 // clang-format off
 /**
@@ -111,7 +116,7 @@ ALWI void dummy_unpack() {
  * */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index) {
+ALWI void copy_tile(std::uint32_t in_cb_id, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
 #ifndef ARCH_QUASAR
     LLK_SAN_FUNCTION();
 #endif
@@ -147,14 +152,21 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
  * */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
+ALWI void copy_block(
+    std::uint32_t in_cb_id,
+    std::uint32_t start_in_tile_index,
+    std::uint32_t start_dst_tile_index,
+    std::uint32_t ntiles) {
 #ifndef ARCH_QUASAR
     LLK_SAN_FUNCTION();
 #endif
     UNPACK((llk_unpack_A_block<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         in_cb_id, start_in_tile_index, ntiles)));
-    MATH((llk_math_eltwise_unary_datacopy_block<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, UnpackToDestEn>(
-        start_dst_tile_index, ntiles, in_cb_id)));
+    MATH((llk_math_eltwise_unary_datacopy_block<
+          DataCopyType::A2D,
+          is_fp32_dest_acc_en,
+          BroadcastType::NONE,
+          UnpackToDestEn>(start_dst_tile_index, ntiles, in_cb_id)));
 }
 
 // =====================================================================================================================
@@ -179,7 +191,7 @@ ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t s
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated("Renamed to copy_init(). This will be removed after 20-09-2026.")]] ALWI void copy_tile_init(
-    uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t cbid, std::uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
     copy_init<is_fp32_dest_acc_en>(cbid, 0, false, call_line);
 }
@@ -199,10 +211,10 @@ template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated("Renamed to copy_init(). This will be removed after 20-09-2026.")]] ALWI void copy_tile_to_dst_init_short(
-    uint32_t cbid,
-    uint32_t transpose = 0,
-    uint32_t transpose_within_16x16_face = false,
-    uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t cbid,
+    std::uint32_t transpose = 0,
+    std::uint32_t transpose_within_16x16_face = false,
+    std::uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
     copy_init<is_fp32_dest_acc_en>(cbid, transpose, transpose_within_16x16_face, call_line);
 }
@@ -225,7 +237,7 @@ template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated(
     "Call reconfig_data_format_srca(old, new) then copy_init(new, transpose). This will be removed after "
     "20-09-2026.")]] ALWI void
-copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0) {
+copy_tile_to_dst_init_short_with_dt(std::uint32_t old_cbid, std::uint32_t new_cbid, std::uint32_t transpose = 0) {
     LLK_SAN_FUNCTION();
     // This reconfig call checks if old operand has different data format to
     // new operand idx, otherwise no reconfig call occurs
@@ -252,7 +264,10 @@ copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32
 // clang-format on
 [[deprecated("Use copy_block(); copy_block_matmul_partials will be removed after August 15th, 2026.")]] ALWI void
 copy_block_matmul_partials(
-    uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
+    std::uint32_t in_cb_id,
+    std::uint32_t start_in_tile_index,
+    std::uint32_t start_dst_tile_index,
+    std::uint32_t ntiles) {
     copy_block(in_cb_id, start_in_tile_index, start_dst_tile_index, ntiles);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/debug/llk_unpack_dummy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/debug/llk_unpack_dummy.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Debug-only SrcA flush for Blackhole.
+//
+// Unlike Quasar -- where llk_unpack_dummy is a required drain primitive that orders a POP_TILES after
+// its WAIT_TILES (TEN-4746) -- Blackhole has no such WAIT/POP ordering requirement, so this call has no
+// functional role in a kernel. It is provided only so the shared compute-API dummy_unpack() resolves on
+// every architecture; use it directly only for debug, when an explicit SrcA flush is wanted.
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_ops.h"
+
+/**
+ * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear then a clear-SrcA UNPACR_NOP (no CB read, no DEST
+ *        write). Reads nothing from L1.
+ *
+ * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
+ * in-flight op; SrcA is cleared only (the next op re-unpacks it). WH/BH have no WAIT/POP ordering
+ * requirement, so this is a debug-only flush. (On Quasar the same call is a required drain primitive; see
+ * that arch's llk_unpack_dummy.)
+ *
+ * @param dfb_id  Unused on Blackhole; accepted only to match the Quasar signature, where it names the
+ *                drained dataflow buffer.
+ */
+inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id)
+{
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
+    TTI_UNPACR_NOP(ckernel::SrcA, 0, 0, 0, 0, 0, 0, ckernel::p_unpacr_nop::CLR_SRC_0, ckernel::p_unpacr_nop::CLR_SRC);
+}

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/debug/llk_unpack_dummy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/debug/llk_unpack_dummy.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Debug-only SrcA flush for Wormhole B0.
+//
+// Unlike Quasar -- where llk_unpack_dummy is a required drain primitive that orders a POP_TILES after
+// its WAIT_TILES (TEN-4746) -- Wormhole B0 has no such WAIT/POP ordering requirement, so this call has
+// no functional role in a kernel. It is provided only so the shared compute-API dummy_unpack() resolves
+// on every architecture; use it directly only for debug, when an explicit SrcA flush is wanted.
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_ops.h"
+
+/**
+ * @brief Flush the SrcA bank: STALLWAIT on SrcA-clear then a clear-SrcA UNPACR_NOP (no CB read, no DEST
+ *        write). Reads nothing from L1.
+ *
+ * The STALLWAIT ensures SrcA is free before the clear, so this cannot clobber a SrcA bank still owned by an
+ * in-flight op; SrcA is cleared only (the next op re-unpacks it). WH/BH have no WAIT/POP ordering
+ * requirement, so this is a debug-only flush. (On Quasar the same call is a required drain primitive; see
+ * that arch's llk_unpack_dummy.)
+ *
+ * @param dfb_id  Unused on WH/BH; accepted only to match the Quasar signature, where it names the drained
+ *                dataflow buffer.
+ */
+inline void llk_unpack_dummy([[maybe_unused]] const std::uint32_t dfb_id)
+{
+    TTI_STALLWAIT(ckernel::p_stall::STALL_UNPACK, ckernel::p_stall::SRCA_CLR);
+    TTI_UNPACR_NOP(ckernel::SrcA, ckernel::p_unpacr_nop::UNP_ZEROSRC);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
@@ -444,7 +444,7 @@ void kernel_main() {
                         // and is a no-op on WH/BH. Replaces the old copy_tile-drain dance.
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
-                            dummy_unpack();
+                            dummy_unpack(mm_partials_cb_id);
                             mm_partials_cb.pop_front(out_subblock_num_tiles);
                         }
                     }
@@ -457,7 +457,7 @@ void kernel_main() {
                         // on mm_partials via a clear-SrcA UNPACR_NOP; no-op on WH/BH.
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
-                            dummy_unpack();
+                            dummy_unpack(mm_partials_cb_id);
                             mm_partials_cb.pop_front(out_subblock_num_tiles);
                         }
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
@@ -438,10 +438,9 @@ void kernel_main() {
 #ifdef PACKER_L1_ACC
 #ifdef FUSE_BIAS
                     if (block < num_blocks_inner_dim - 1) {
-                        // [#48552] TEN-4746: a bare wait_front->pop_front on mm_partials traps the Quasar unpacker
-                        // (POP_TILES races past WAIT_TILES). dummy_unpack() issues the single clear-SrcA
-                        // UNPACR_NOP that orders POP after WAIT; it reads nothing (no PACKER_L1_ACC disturbance)
-                        // and is a no-op on WH/BH. Replaces the old copy_tile-drain dance.
+                        // TEN-4746 (#48552): drain mm_partials without consuming it. dummy_unpack() orders the
+                        // POP after the WAIT via a clear-SrcA UNPACR_NOP (required on Quasar, no-op on WH/BH);
+                        // it reads nothing, so PACKER_L1_ACC is undisturbed.
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
                             dummy_unpack(mm_partials_cb_id);
@@ -453,8 +452,7 @@ void kernel_main() {
 #else
                     // Last iteration does spill and reload to output buffer
                     if (block < num_blocks_inner_dim - 2) {
-                        // [#48552] TEN-4746 (see the FUSE_BIAS drain above): dummy_unpack() orders POP after WAIT
-                        // on mm_partials via a clear-SrcA UNPACR_NOP; no-op on WH/BH.
+                        // TEN-4746 (#48552): drain mm_partials without consuming it (see the FUSE_BIAS drain above).
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
                             dummy_unpack(mm_partials_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
@@ -439,59 +439,27 @@ void kernel_main() {
 #ifdef FUSE_BIAS
                     if (block < num_blocks_inner_dim - 1) {
                         // [#48552] TEN-4746: a bare wait_front->pop_front on mm_partials traps the Quasar unpacker
-                        // (POP_TILES races past WAIT_TILES -> TILE_COUNTERS 0x10000). Interpose a REAL unpack TDMA
-                        // (dummy copy_tile of tile 0) between wait and pop -- NOP/DMANOP/TTI_NOP are INSUFFICIENT
-                        // (LLK-team guidance + abhullar/pop-wait-fix 69014037a + our TTI_NOP-fails/DPRINT-works
-                        // bisection). NB the old "wait_front increments must be identical" rationale for the
-                        // stepped loop is FALSE (only num_entries<=capacity is enforced) but the loop is harmless.
-#ifdef ARCH_QUASAR
-                        reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
-                        copy_init(mm_partials_cb_id);
-#endif
+                        // (POP_TILES races past WAIT_TILES). dummy_unpack() issues the single clear-SrcA
+                        // UNPACR_NOP that orders POP after WAIT; it reads nothing (no PACKER_L1_ACC disturbance)
+                        // and is a no-op on WH/BH. Replaces the old copy_tile-drain dance.
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
-#ifdef ARCH_QUASAR
-                            tile_regs_acquire();
-                            copy_tile(mm_partials_cb_id, /*in_tile_index=*/0, /*dst_tile_index=*/0);
-                            tile_regs_commit();
-                            tile_regs_wait();
-                            tile_regs_release();
-#endif
+                            dummy_unpack();
                             mm_partials_cb.pop_front(out_subblock_num_tiles);
                         }
-#ifdef ARCH_QUASAR
-                        reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
-                        matmul_block_init(
-                            in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
-#endif
                     }
                     // never reload when with bias, bias uses interm buffer
                     enable_reload = false;
 #else
                     // Last iteration does spill and reload to output buffer
                     if (block < num_blocks_inner_dim - 2) {
-                        // [#48552] TEN-4746 interpose (see the FUSE_BIAS drain above): REAL unpack TDMA
-                        // (dummy copy_tile of tile 0) between the bare wait_front/pop_front on mm_partials.
-#ifdef ARCH_QUASAR
-                        reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
-                        copy_init(mm_partials_cb_id);
-#endif
+                        // [#48552] TEN-4746 (see the FUSE_BIAS drain above): dummy_unpack() orders POP after WAIT
+                        // on mm_partials via a clear-SrcA UNPACR_NOP; no-op on WH/BH.
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
-#ifdef ARCH_QUASAR
-                            tile_regs_acquire();
-                            copy_tile(mm_partials_cb_id, /*in_tile_index=*/0, /*dst_tile_index=*/0);
-                            tile_regs_commit();
-                            tile_regs_wait();
-                            tile_regs_release();
-#endif
+                            dummy_unpack();
                             mm_partials_cb.pop_front(out_subblock_num_tiles);
                         }
-#ifdef ARCH_QUASAR
-                        reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
-                        matmul_block_init(
-                            in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
-#endif
                     }
                     if (block == num_blocks_inner_dim - 2) {
                         enable_reload = true;


### PR DESCRIPTION
The Quasar matmul kernel bmm_large_block_zm_fused_bias_activation_metal2.cpp drains the mm_partials CB between wait_front/pop_front purely for flow control (PACKER_L1_ACC path). A bare wait->pop trips the Quasar unpacker (TEN-4746: POP_TILES resolves before WAIT_TILES because the tile-counter compare is only re-sampled by a real same-engine TDMA on the dfb). The existing workaround interposed a full copy_tile plus a reconfig + matmul_block_init bracket to restore matmul state -- ~20 lines and an in-kernel ARCH_QUASAR block per drain.

Replace it with a single clear-SrcA unpacker op wrapped in a new compute-API helper, ckernel::dummy_unpack() (tile_move_copy.h):

    UNPACK(TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, 0, 0,
                          p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC));

A clear-source op is a real unpacker transaction, so it satisfies the POP-after-WAIT ordering that a bare NOP/DMANOP/TTI_NOP cannot; but unlike copy_tile it does not read the CB, so it leaves the PACKER_L1_ACC offset bookkeeping untouched (no reconfig / matmul_block_init needed). Clearing SrcA is harmless -- the next matmul re-unpacks SrcA. On WH/BH there is no such HW ordering bug, so dummy_unpack() compiles to nothing.

Both TEN-4746 drain loops now read wait_front(); dummy_unpack(); pop_front(); and carry no ARCH_QUASAR ifdef. The two genuine mm_partials consumes (copy_block reload, add_tiles bias) are unchanged.

Validated on the 2x3 Zebu emulator: resnet50 quasar fc linear (test_resnet50_fc_linear) passes, 20/20 deterministic.

### PR Category
#54329 

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-dummy-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/quasar-dummy-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-dummy-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/quasar-dummy-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/quasar-dummy-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/quasar-dummy-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/quasar-dummy-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/quasar-dummy-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/quasar-dummy-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/quasar-dummy-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/quasar-dummy-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/quasar-dummy-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/quasar-dummy-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/quasar-dummy-unpack)