### PR TITLE
[Quasar] Use compute APIs instead of llk_ in binary and binary_ng, call hw_startup once, drop redundant pack reconfig

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
 #endif
 
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -52,7 +52,7 @@ void kernel_main() {
     copy_init(cb_in0.get_id());
 
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -85,7 +85,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_post_lhs_id, cb_post_rhs_id, cb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_post_lhs.get_id(), cb_post_rhs.get_id(), cb_out.get_id());
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_post_lhs.get_id(), cb_post_rhs.get_id(), cb_out.get_id());
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -128,7 +128,7 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_post_lhs_id, cb_out_id);
     copy_init(cb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -104,7 +104,7 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_post_lhs_id, cb_out_id);
     copy_init(cb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -96,7 +96,7 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_post_lhs_id, cb_out_id);
     copy_init(cb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_col_bcast_dfb.cpp
@@ -79,7 +79,6 @@ ALWI void process_tile(
     pack_init(dfb_llk_post_id);
 #endif
     reconfig_data_format(dfb_bcast_id, dfb_bcast_id);
-    pack_reconfig_data_format(dfb_llk_post_id);
     unary_bcast_init<BroadcastType::COL>(dfb_bcast_id);
 
     tile_regs_acquire();
@@ -92,16 +91,13 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
+#if defined(ARCH_BLACKHOLE)
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+#elif defined(ARCH_QUASAR)
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.
     pack_init(dfb_out_id);
-#endif
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #endif
 
     // Broadcast operand's activation chain runs ONCE (its expanded tile is reused across the row).
@@ -182,7 +178,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_post_rhs_id, dfb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_bcast_dfb.cpp
@@ -69,7 +69,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_post_rhs_id, dfb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
@@ -85,7 +85,6 @@ void kernel_main() {
         pack_init(dfb_llk_post_id);
 #endif
         reconfig_data_format(dfb_bcast_id, dfb_bcast_id);
-        pack_reconfig_data_format(dfb_llk_post_id);
         unary_bcast_init<BroadcastType::ROW>(dfb_bcast_id);
 
         tile_regs_acquire();
@@ -99,16 +98,13 @@ void kernel_main() {
         dfb_bcast.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
+#if defined(ARCH_BLACKHOLE)
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+#elif defined(ARCH_QUASAR)
         // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without
         // this the gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out)
         // writes the wrong buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.
         pack_init(dfb_out_id);
-#endif
-#if defined(ARCH_BLACKHOLE)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #endif
 
         // --- Binary op (verbatim from eltwise_binary_no_bcast_dfb.cpp's body, single tile). ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_col_bcast_dfb.cpp
@@ -91,7 +91,6 @@ ALWI void process_tile(
         pack_init(dfb_llk_post_id);
 #endif
         reconfig_data_format(dfb_raw_row_id, dfb_raw_row_id);
-        pack_reconfig_data_format(dfb_llk_post_id);
         unary_bcast_init<BroadcastType::ROW>(dfb_raw_row_id);
 
         tile_regs_acquire();
@@ -105,16 +104,13 @@ ALWI void process_tile(
         dfb_raw_row.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
+#if defined(ARCH_BLACKHOLE)
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+#elif defined(ARCH_QUASAR)
         // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this
         // the gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the
         // wrong buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.
         pack_init(dfb_out_id);
-#endif
-#if defined(ARCH_BLACKHOLE)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #endif
 
         // ROW operand's activation chain (reads the expanded llk_post tile). No-op (post aliases llk_post)
@@ -183,7 +179,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_post_rhs_id, dfb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
     // freq/tile_start reuse loop: freq = Wt tiles per COL broadcast, tile_start is the per-core column

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_bcast_dfb.cpp
@@ -82,7 +82,6 @@ ALWI void process_tile(
     pack_init(dfb_llk_post_id);
 #endif
     reconfig_data_format(dfb_bcast_id, dfb_bcast_id);
-    pack_reconfig_data_format(dfb_llk_post_id);
     unary_bcast_init<BroadcastType::SCALAR>(dfb_bcast_id);
 
     tile_regs_acquire();
@@ -95,16 +94,13 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
+#if defined(ARCH_BLACKHOLE)
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+#elif defined(ARCH_QUASAR)
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.
     pack_init(dfb_out_id);
-#endif
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #endif
 
     // Broadcast operand's activation chain runs ONCE (its expanded tile is reused across the whole slab).
@@ -186,7 +182,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_post_rhs_id, dfb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_post_rhs_id, dfb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
@@ -104,7 +104,7 @@ ALWI void process_tile(
     // for llk_post, so this is belt-and-suspenders on the LHS side.)
     pack_init(dfb_llk_post_id);
 #endif
-    compute_kernel_hw_startup(dfb_bcast_id, dfb_llk_post_id);
+    reconfig_data_format(dfb_bcast_id, dfb_bcast_id);
     unary_bcast_init<BroadcastType::COL>(dfb_bcast_id);
 
     tile_regs_acquire();
@@ -117,16 +117,13 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
+#if defined(ARCH_BLACKHOLE)
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+#elif defined(ARCH_QUASAR)
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.
     pack_init(dfb_out_id);
-#endif
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #endif
 
     // Broadcast operand's activation chain runs ONCE (its expanded tile is reused across the row).
@@ -239,7 +236,7 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_out_id);
     copy_init(dfb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
@@ -145,7 +145,7 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_out_id);
     copy_init(dfb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
@@ -103,14 +103,13 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_out_id);
     copy_init(dfb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
     BINARY_SFPU_INIT
 #endif
 
-    compute_kernel_hw_startup(dfb_bcast_id, dfb_llk_post_id);
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         // --- Broadcast pass: partial tile (from the reader) -> full tile in the intermediate llk_post. ---
         dfb_bcast.wait_front(num_tiles_per_cycle);
@@ -137,16 +136,13 @@ void kernel_main() {
         dfb_bcast.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
+#if defined(ARCH_BLACKHOLE)
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+#elif defined(ARCH_QUASAR)
         // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without
         // this the gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out)
         // writes the wrong buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.
         pack_init(dfb_out_id);
-#endif
-#if defined(ARCH_BLACKHOLE)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #endif
 
         // --- Binary op (SFPU path; mirrors eltwise_binary_sfpu_no_bcast_dfb.cpp's body, single tile). ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
@@ -99,7 +99,6 @@ ALWI void process_tile(
     PREPROCESS(BCAST_OP, dfb_pre_bcast_id, dfb_post_bcast_id, dfb_out_id, num_tiles_per_cycle);
     dfb_post_bcast.wait_front(num_tiles_per_cycle);
 
-    compute_kernel_hw_startup(dfb_raw_row_id, dfb_llk_post_id);
     for (uint32_t j = tile_start; j < freq; ++j) {
         // --- ROW broadcast pass (per iteration): the raw partial row tile -> full tile in llk_post.
         // Identical to the single-operand ROW kernel's broadcast pass (unary_bcast<ROW> + the two
@@ -127,14 +126,11 @@ ALWI void process_tile(
         dfb_raw_row.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
-        // Retarget the packer destination ring back to dfb_out for the binary-op pack below (see above).
-        pack_init(dfb_out_id);
-#endif
 #if defined(ARCH_BLACKHOLE)
         PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #elif defined(ARCH_QUASAR)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+        // Retarget the packer destination ring back to dfb_out for the binary-op pack below (see above).
+        pack_init(dfb_out_id);
 #endif
 
         // ROW operand's activation chain (reads the expanded llk_post tile). No-op (post aliases llk_post)
@@ -239,7 +235,7 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_out_id);
     copy_init(dfb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
@@ -106,7 +106,7 @@ ALWI void process_tile(
     // for llk_post, so this is belt-and-suspenders on the LHS side.)
     pack_init(dfb_llk_post_id);
 #endif
-    compute_kernel_hw_startup(dfb_bcast_id, dfb_llk_post_id);
+    reconfig_data_format(dfb_bcast_id, dfb_bcast_id);
     unary_bcast_init<BroadcastType::SCALAR>(dfb_bcast_id);
 
     tile_regs_acquire();
@@ -119,16 +119,13 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#ifdef ARCH_QUASAR
+#if defined(ARCH_BLACKHOLE)
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
+#elif defined(ARCH_QUASAR)
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.
     pack_init(dfb_out_id);
-#endif
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
 #endif
 
     // Broadcast operand's activation chain runs ONCE (its expanded tile is reused across the whole slab).
@@ -242,7 +239,7 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_out_id);
     copy_init(dfb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
@@ -148,7 +148,7 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_out_id);
     copy_init(dfb_post_lhs_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
@@ -48,7 +48,6 @@ ALWI void process_tile(
     exp_cb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
     reconfig_data_format(cb_bcast, cb_bcast);
-    pack_reconfig_data_format(cb_llk_post);
     unary_bcast_init<BroadcastType::COL>(cb_bcast);
     exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
@@ -138,7 +137,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_post_lhs, cb_post_rhs, cb_out);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_post_lhs, cb_post_rhs, cb_out);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
@@ -52,7 +52,6 @@ void kernel_main() {
         exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         pack_reconfig_data_format(cb_out, cb_llk_post);
         reconfig_data_format(cb_bcast, cb_bcast);
-        pack_reconfig_data_format(cb_llk_post);
         unary_bcast_init<BroadcastType::ROW>(cb_bcast);
 
         tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -48,7 +48,6 @@ ALWI void process_tile(
     DataflowBuffer exp_cb_post_bcast(CB_POST_BCAST);
     DataflowBuffer exp_cb_post_other(CB_POST_OTHER);
 
-    compute_kernel_hw_startup(cb_left, cb_right, cb_out);
     PREPROCESS(BCAST_OP, DataflowBuffer(CB_PRE_BCAST), exp_cb_post_bcast, exp_cb_out, num_tiles_per_cycle);
     exp_cb_post_bcast.wait_front(num_tiles_per_cycle);
 
@@ -57,7 +56,6 @@ ALWI void process_tile(
         exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
         pack_reconfig_data_format(cb_out, cb_llk_post);
         reconfig_data_format(cb_raw_other, cb_raw_other);
-        pack_reconfig_data_format(cb_llk_post);
         unary_bcast_init<BroadcastType::ROW>(cb_raw_other);
 
         tile_regs_acquire();
@@ -123,8 +121,9 @@ void kernel_main() {
     constexpr auto cb_post_rhs = HAS_ACTIVATIONS(RHS) ? tt::CBIndex::c_4 : cb_llk_post;
 #endif
 
+    compute_kernel_hw_startup(cb_post_lhs, cb_post_rhs, cb_out);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
     uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
@@ -48,7 +48,6 @@ ALWI void process_tile(
     exp_cb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
     reconfig_data_format(cb_bcast, cb_bcast);
-    pack_reconfig_data_format(cb_llk_post);
     unary_bcast_init<BroadcastType::SCALAR>(cb_bcast);
     exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
@@ -137,7 +136,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_post_lhs, cb_post_rhs, cb_out);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -66,7 +66,7 @@ ALWI void process_tile(
 
     exp_cb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
-    compute_kernel_hw_startup(cb_bcast, cb_llk_post);
+    reconfig_data_format(cb_bcast, cb_bcast);
     unary_bcast_init<BroadcastType::COL>(cb_bcast);
     exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
@@ -176,7 +176,7 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_post_lhs, cb_out);
     copy_init(cb_post_lhs);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -68,14 +68,13 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_post_lhs, cb_out);
     copy_init(cb_post_lhs);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
     BINARY_SFPU_INIT
 #endif
 
-    compute_kernel_hw_startup(cb_bcast, cb_llk_post);
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         exp_cb_bcast.wait_front(num_tiles_per_cycle);
         exp_cb_llk_post.reserve_back(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -72,7 +72,6 @@ ALWI void process_tile(
     PREPROCESS(BCAST_OP, DataflowBuffer(CB_PRE_BCAST), exp_cb_post_bcast, exp_cb_out, num_tiles_per_cycle);
     exp_cb_post_bcast.wait_front(num_tiles_per_cycle);
 
-    compute_kernel_hw_startup(cb_raw_other, cb_llk_post);
     for (uint32_t j = tile_start; j < freq; ++j) {
         exp_cb_raw_other.wait_front(num_tiles_per_cycle);
         exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
@@ -170,7 +169,7 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_post_lhs, cb_out);
 
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -66,7 +66,7 @@ ALWI void process_tile(
 
     exp_cb_bcast.wait_front(num_tiles_per_cycle);
     pack_reconfig_data_format(cb_out, cb_llk_post);
-    compute_kernel_hw_startup(cb_bcast, cb_llk_post);
+    reconfig_data_format(cb_bcast, cb_bcast);
     unary_bcast_init<BroadcastType::SCALAR>(cb_bcast);
     exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
     tile_regs_acquire();
@@ -176,7 +176,7 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_post_lhs, cb_out);
     copy_init(cb_post_lhs);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -45,11 +45,10 @@ void kernel_main() {
     DataflowBuffer exp_cb_left(cb_left);
     DataflowBuffer exp_cb_right(cb_right);
 
-    compute_kernel_hw_startup(cb_in0, cb_out);
-    copy_init(cb_in0);
+    compute_kernel_hw_startup(cb_left, cb_out);
+    copy_init(cb_left);
     BINARY_SFPU_INIT
 
-    compute_kernel_hw_startup(cb_bcast, cb_llk_post);
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         exp_cb_in0.wait_front(num_tiles_per_cycle);
         exp_cb_in1.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -53,7 +53,6 @@ ALWI void process_tile(
 
     exp_cb_bcast.wait_front(num_tiles_per_cycle);
 
-    compute_kernel_hw_startup(CB_OTHER, cb_llk_post);
     for (uint32_t j = tile_start; j < freq; ++j) {
         exp_cb_other.wait_front(num_tiles_per_cycle);
         exp_cb_llk_post.reserve_back(num_tiles_per_cycle);


### PR DESCRIPTION
### PR Category
Cleanup

### Issue
https://github.com/tenstorrent/tt-metal/issues/54329

### Summary
- Replace LLK API calls (`llk_pack_relu_config`) with compute APIs (`pack_relu_config` on Quasar) in experimental Quasar **binary** and **binary_ng**.
- Replace `llk_pack_hw_configure` LLK API calls with `pack_init` calls for Quasar. Quasar does not need both, and it does not need hw config.
- Call `compute_kernel_hw_startup` once at kernel start, not inside the loop.
- Drop the extra 1-arg `pack_reconfig_data_format` after a 2-arg switch to the same CB.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/resnet_cleanup_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/resnet_cleanup_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/resnet_cleanup_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/resnet_cleanup_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/resnet_cleanup_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/resnet_cleanup_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/resnet_cleanup_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/resnet_cleanup_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/resnet_cleanup_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/resnet_cleanup_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/resnet_cleanup_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/resnet_cleanup_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/resnet_cleanup_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/resnet_cleanup_v2)