### PR TITLE
[skip ci] produce_data: skip on forks

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -106,9 +106,14 @@ jobs:
     # or if it's triggered by `workflow_call` or `workflow_dispatch`.
     # Skip on forks — secrets (SFTP, Slack) are unavailable there and would
     # cause failures that spam fork owners with email notifications.
+    #
+    # Also skip when the triggering run originated from a fork
+    # (head_repository != this repo).
+    # Forks should not automatically trigger produce data jobs.
     if: >-
       ${{ (github.repository == 'tenstorrent/tt-metal' || github.repository == 'tenstorrent/tt-blaze') &&
           ((github.event_name == 'workflow_run' &&
+            github.event.workflow_run.head_repository.full_name == github.repository &&
             (github.event.workflow_run.conclusion == 'success' ||
              github.event.workflow_run.conclusion == 'failure' ||
              github.event.workflow_run.conclusion == 'cancelled')) ||
@@ -226,9 +231,12 @@ jobs:
     # or if it's triggered by `workflow_call` or `workflow_dispatch`.
     # Skip on forks — secrets (SFTP, Slack) are unavailable there and would
     # cause failures that spam fork owners with email notifications.
+    #
+    # Also skip fork-originated triggering runs (see produce-cicd-data above).
     if: >-
       ${{ github.repository == 'tenstorrent/tt-metal' &&
           ((github.event_name == 'workflow_run' &&
+            github.event.workflow_run.head_repository.full_name == github.repository &&
             (github.event.workflow_run.conclusion == 'success' ||
              github.event.workflow_run.conclusion == 'failure' ||
              github.event.workflow_run.conclusion == 'cancelled')) ||


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
On push (PR/Merge gate) runs on fork now enter a failure state due to expiry instead of staying pending with
`This workflow run required approval but was not approved before it expired.`

As a result, it fires off a produce data run (which fails due to having 0 jobs ran but still fires a notification)
Fix: disable produce data runs on forks

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/skip-produce-data-forks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/skip-produce-data-forks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/skip-produce-data-forks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/skip-produce-data-forks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/skip-produce-data-forks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/skip-produce-data-forks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/skip-produce-data-forks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/skip-produce-data-forks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/skip-produce-data-forks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/skip-produce-data-forks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/skip-produce-data-forks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/skip-produce-data-forks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/skip-produce-data-forks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/skip-produce-data-forks)