### PR TITLE
[Bug Fix] Fix mul reduce scalar zero-flag initialization

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
@@ -50,6 +50,9 @@ struct SumReduceScalarConfig {
     bool dst_full_sync = false;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
     uint32_t seed = 12345;
+    bool use_constant_input = false;
+    uint16_t constant_input_bits = 0;
+    bool expect_exact_zero = false;
 };
 
 bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumReduceScalarConfig& config) {
@@ -132,8 +135,15 @@ bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumR
     SetRuntimeArgs(program, sum_reduce_kernel, core, {config.num_tiles, std::bit_cast<uint32_t>(config.scaler)});
 
     uint32_t byte_size = config.num_tiles * tile_byte_size;
-    auto packed_input = test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        0, 1.0f, byte_size / sizeof(bfloat16), config.seed);
+    std::vector<uint32_t> packed_input;
+    if (config.use_constant_input) {
+        const uint32_t packed_value =
+            (static_cast<uint32_t>(config.constant_input_bits) << 16) | config.constant_input_bits;
+        packed_input.assign(byte_size / sizeof(uint32_t), packed_value);
+    } else {
+        packed_input = test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+            0, 1.0f, byte_size / sizeof(bfloat16), config.seed);
+    }
 
     auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, packed_input, /*blocking=*/true);
@@ -153,12 +163,14 @@ bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumR
     auto u16_src_vec = u16_from_u32_vector(packed_input);
 
     float golden_scalar = 0.0f;
-    for (uint16_t packed : u16_src_vec) {
-        golden_scalar += static_cast<float>(std::bit_cast<bfloat16>(packed));
+    if (!config.expect_exact_zero) {
+        for (uint16_t packed : u16_src_vec) {
+            golden_scalar += static_cast<float>(std::bit_cast<bfloat16>(packed));
+        }
+        // The scaler sits in SrcB for both GAPOOL passes (column accumulate and final
+        // collapse), so it multiplies the result twice.
+        golden_scalar *= config.scaler * config.scaler;
     }
-    // The scaler sits in SrcB for both GAPOOL passes (column accumulate and final
-    // collapse), so it multiplies the result twice.
-    golden_scalar *= config.scaler * config.scaler;
 
     // The reduced scalar lives in element [0] of the output tile, in the output CB's
     // format: raw fp32 with native fp32 DEST, otherwise the low bfloat16 of word 0.
@@ -190,6 +202,9 @@ bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumR
     const float rel_tol = (config.math_fidelity == MathFidelity::LoFi) ? 0.05f : 0.01f;
     const float abs_tol = 0.01f;
     const float tolerance = std::max(rel_tol * std::abs(golden_scalar), abs_tol);
+    if (config.expect_exact_zero) {
+        return device_scalar == 0.0f;
+    }
     return std::abs(device_scalar - golden_scalar) < tolerance;
 }
 
@@ -309,3 +324,20 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<bool>& info) {
         return info.param ? "SumReduceScalar_Scaler_2_fp32dest" : "SumReduceScalar_Scaler_0p5";
     });
+
+class SumReduceScalarZeroFlagTest : public LLKMeshDeviceSingleCardFixture {};
+
+TEST_F(SumReduceScalarZeroFlagTest, RestoresDefaultAfterCopyBeforeDenormalScaler) {
+    auto& mesh_device = *devices_[0];
+    constexpr uint16_t largest_finite_bfloat16 = 0x7f7f;
+    const float denormal_scaler = static_cast<float>(std::bit_cast<bfloat16>(uint16_t{1}));
+
+    ASSERT_TRUE(run_sum_reduce_scalar_test(
+        mesh_device,
+        {.num_tiles = 1,
+         .tile_height = 32,
+         .scaler = denormal_scaler,
+         .use_constant_input = true,
+         .constant_input_bits = largest_finite_bfloat16,
+         .expect_exact_zero = true}));
+}

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -186,13 +186,7 @@ inline void _llk_math_mul_reduce_scalar_init_()
     }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);
-
-    // NOTE: unlike the standard _llk_math_reduce_init_ and the block_max_row reduce, this init does not
-    // re-establish the DEFAULT zero-flag state, so after a copy_init/PRESERVE the GAPOOL/MOVB2A tail here
-    // runs at Zero_Flag_disabled_src=1 (keep) instead of the format-driven DEFAULT (flush). That differs
-    // only on denormals/-0.0 (keep can never corrupt a normal value), and test_sum_reduce_scalar uses
-    // normal inputs so it does not cover that case -- adding the reset like the other reduce inits is
-    // deferred to a directed denormal test. Tracked: tenstorrent/tt-metal#53055.
+    math::_configure_default_zero_flag_state_();
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -186,13 +186,7 @@ inline void _llk_math_mul_reduce_scalar_init_()
     }
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);
-
-    // NOTE: unlike the standard _llk_math_reduce_init_ and the block_max_row reduce, this init does not
-    // re-establish the DEFAULT zero-flag state, so after a copy_init/PRESERVE the GAPOOL/MOVB2A tail here
-    // runs at Zero_Flag_disabled_src=1 (keep) instead of the format-driven DEFAULT (flush). That differs
-    // only on denormals/-0.0 (keep can never corrupt a normal value), and test_sum_reduce_scalar uses
-    // normal inputs so it does not cover that case -- adding the reset like the other reduce inits is
-    // deferred to a directed denormal test. Tracked: tenstorrent/tt-metal#53055.
+    math::_configure_default_zero_flag_state_();
 }
 
 /**


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
- Restore the format-default source zero-flag state in experimental mul_reduce_scalar initialization on Wormhole and Blackhole.
- Prevent a preceding copy_init() from leaking PRESERVE mode into GAPOOL/MVMUL operations.
- Add a directed BF16-denormal regression test.

copy_init() configures ALU_ACC_CTRL_Zero_Flag_disabled_src to preserve denormal inputs. Unlike the standard reduce and block_max_row paths,  _llk_math_mul_reduce_scalar_init_() did not restore the format-derived default before executing its FPU reduction operations.

On silicon this changes denormal handling. TTSim rejects the leaked state with:

UnsupportedFunctionality: tensix_matmul_op: ALU_ACC_CTRL_Zero_Flag_disabled_src=1 (keep SrcB denormals) not modeled

Call _configure_default_zero_flag_state_() from the WH and BH scalar-reduce initialization paths. This follows the state-management contract already used by the other compute operations while preserving the behavior of copy_init() itself.

The new test:

- enters through the copy-based sum_reduce_scalar path, establishing PRESERVE state;
- uses the largest finite BF16 input and smallest BF16 subnormal scaler;
- verifies that the compute-default state flushes the scaler and produces exactly zero.

The test passes with this change and reproduces the original TTSim error when run against the pre-fix LLK source.

Closes #53055

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/reduce-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/reduce-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/reduce-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/reduce-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/reduce-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/reduce-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/reduce-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/reduce-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/reduce-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/reduce-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/reduce-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/reduce-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/reduce-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/reduce-bug)