### PR TITLE
[Feature] Dump soc descriptor in noc tracing

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -1235,7 +1235,7 @@ def test_noc_event_profiler():
 
         assert "arch_name" in soc_desc_data, "SoC descriptor missing 'arch_name' field"
         arch_name = soc_desc_data["arch_name"].upper()
-        expected_arch = ENV_VAR_ARCH_NAME.upper().replace("_", "")
+        expected_arch = ENV_VAR_ARCH_NAME.upper()
         assert (
             expected_arch in arch_name or arch_name in expected_arch
         ), f"SoC descriptor arch_name '{soc_desc_data['arch_name']}' does not match expected arch '{ENV_VAR_ARCH_NAME}'"

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -9,6 +9,7 @@ import inspect
 import pytest
 import subprocess
 import ast
+import yaml
 from loguru import logger
 from conftest import is_6u
 
@@ -1216,6 +1217,36 @@ def test_noc_event_profiler():
         ), f"plain NOC tracing must not record barrier events, got: {event_types}"
         assert len(noc_trace_data) == 4, f"unexpected noc trace events: {event_types}"
 
+    # Validate SoC descriptor is produced and contains valid grid/core data
+    expected_soc_descriptor_file = f"{PROFILER_ARTIFACTS_DIR}/noc_events_rpt/soc_descriptor.yaml"
+    assert os.path.isfile(
+        expected_soc_descriptor_file
+    ), f"SoC descriptor file not found at {expected_soc_descriptor_file}"
+
+    with open(expected_soc_descriptor_file, "r") as soc_desc_file:
+        soc_desc_data = yaml.safe_load(soc_desc_file)
+
+        # Verify required fields exist
+        assert "grid" in soc_desc_data, "SoC descriptor missing 'grid' field"
+        assert "x_size" in soc_desc_data["grid"], "SoC descriptor grid missing 'x_size'"
+        assert "y_size" in soc_desc_data["grid"], "SoC descriptor grid missing 'y_size'"
+        assert soc_desc_data["grid"]["x_size"] > 0, "SoC descriptor grid x_size must be positive"
+        assert soc_desc_data["grid"]["y_size"] > 0, "SoC descriptor grid y_size must be positive"
+
+        assert "arch_name" in soc_desc_data, "SoC descriptor missing 'arch_name' field"
+        arch_name = soc_desc_data["arch_name"].upper()
+        expected_arch = ENV_VAR_ARCH_NAME.upper().replace("_", "")
+        assert (
+            expected_arch in arch_name or arch_name in expected_arch
+        ), f"SoC descriptor arch_name '{soc_desc_data['arch_name']}' does not match expected arch '{ENV_VAR_ARCH_NAME}'"
+
+        assert "functional_workers" in soc_desc_data, "SoC descriptor missing 'functional_workers' field"
+        assert len(soc_desc_data["functional_workers"]) > 0, "SoC descriptor must have at least one functional worker"
+
+        # Verify DRAM channels exist (all architectures have DRAM)
+        assert "dram" in soc_desc_data, "SoC descriptor missing 'dram' field"
+        assert len(soc_desc_data["dram"]) > 0, "SoC descriptor must have at least one DRAM channel"
+
 
 @skip_for_blackhole()
 def test_fabric_event_profiler_1d():
@@ -1253,11 +1284,6 @@ def test_fabric_event_profiler_1d():
         except subprocess.CalledProcessError as e:
             ret_code = e.returncode
             assert ret_code == 0, f"test command '{test_bin}' returned unsuccessfully"
-
-        expected_cluster_coords_file = f"{PROFILER_LOGS_DIR}/cluster_coordinates.json"
-        assert os.path.isfile(
-            expected_cluster_coords_file
-        ), f"expected cluster coordinates file '{expected_cluster_coords_file}' does not exist"
 
         noc_trace_files = []
         for f in os.listdir(f"{PROFILER_LOGS_DIR}"):
@@ -1323,11 +1349,6 @@ def test_fabric_event_profiler_fabric_mux():
         except subprocess.CalledProcessError as e:
             ret_code = e.returncode
             assert ret_code == 0, f"test command '{test_bin}' returned unsuccessfully"
-
-        expected_cluster_coords_file = f"{PROFILER_LOGS_DIR}/cluster_coordinates.json"
-        assert os.path.isfile(
-            expected_cluster_coords_file
-        ), f"expected cluster coordinates file '{expected_cluster_coords_file}' does not exist"
 
         noc_trace_files = []
         for f in os.listdir(f"{PROFILER_LOGS_DIR}"):
@@ -1443,11 +1464,6 @@ def test_fabric_event_profiler_2d():
         except subprocess.CalledProcessError as e:
             ret_code = e.returncode
             assert ret_code == 0, f"test command '{test_bin}' returned unsuccessfully"
-
-        expected_cluster_coords_file = f"{PROFILER_LOGS_DIR}/cluster_coordinates.json"
-        assert os.path.isfile(
-            expected_cluster_coords_file
-        ), f"expected cluster coordinates file '{expected_cluster_coords_file}' does not exist"
 
         noc_trace_files = []
         for f in os.listdir(f"{PROFILER_LOGS_DIR}"):

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2635,6 +2635,18 @@ void DeviceProfiler::processResults(
 #endif
 }
 
+void DeviceProfiler::dumpSocDescriptor() const {
+    const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
+    if (!tt::filesystem::safe_is_directory(noc_trace_data_output_dir).value_or(false)) {
+        log_error(
+            tt::LogMetal,
+            "Could not dump soc descriptor to '{}' because the directory path could not be created!",
+            noc_trace_data_output_dir);
+        return;
+    }
+    soc_desc.serialize_to_file(noc_trace_data_output_dir / "soc_descriptor.yaml");
+}
+
 void DeviceProfiler::dumpRoutingInfo() const {
     tt::filesystem::safe_create_directories(noc_trace_data_output_dir);
     if (!tt::filesystem::safe_is_directory(noc_trace_data_output_dir).value_or(false)) {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2635,44 +2635,6 @@ void DeviceProfiler::processResults(
 #endif
 }
 
-void DeviceProfiler::dumpSocDescriptor() const {
-    const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
-    if (!tt::filesystem::safe_is_directory(noc_trace_data_output_dir).value_or(false)) {
-        log_error(
-            tt::LogMetal,
-            "Could not dump soc descriptor to '{}' because the directory path could not be created!",
-            noc_trace_data_output_dir);
-        return;
-    }
-    soc_desc.serialize_to_file(noc_trace_data_output_dir / "soc_descriptor.yaml");
-}
-
-void DeviceProfiler::dumpRoutingInfo() const {
-    tt::filesystem::safe_create_directories(noc_trace_data_output_dir);
-    if (!tt::filesystem::safe_is_directory(noc_trace_data_output_dir).value_or(false)) {
-        log_error(
-            tt::LogMetal,
-            "Could not dump topology to '{}' because the directory path could not be created!",
-            noc_trace_data_output_dir);
-        return;
-    }
-
-    tt::tt_metal::dumpRoutingInfo(noc_trace_data_output_dir / "topology.json");
-}
-
-void DeviceProfiler::dumpClusterCoordinates() const {
-    tt::filesystem::safe_create_directories(noc_trace_data_output_dir);
-    if (!tt::filesystem::safe_is_directory(noc_trace_data_output_dir).value_or(false)) {
-        log_error(
-            tt::LogMetal,
-            "Could not dump cluster coordinates to '{}' because the directory path could not be created!",
-            noc_trace_data_output_dir);
-        return;
-    }
-
-    tt::tt_metal::dumpClusterCoordinatesAsJson(noc_trace_data_output_dir / "cluster_coordinates.json");
-}
-
 bool isSyncInfoNewer(const SyncInfo& old_info, const SyncInfo& new_info) {
     return (
         (old_info.frequency == 0 && new_info.frequency != 0) ||

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -323,6 +323,8 @@ public:
 
     void dumpRoutingInfo() const;
 
+    void dumpSocDescriptor() const;
+
     void dumpClusterCoordinates() const;
 
     // Dump device results to files and tracy

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -300,6 +300,9 @@ public:
     // Freshen device logs
     void freshDeviceLog();
 
+    // Get the output dir for noc trace data
+    const std::filesystem::path& getNocTraceDataOutputDir() const { return noc_trace_data_output_dir; }
+
     // Change the output dir of device profile logs
     void setOutputDir(const std::string& new_output_dir);
 
@@ -320,12 +323,6 @@ public:
         ProfilerDataBufferSource data_source = ProfilerDataBufferSource::DRAM,
         const std::optional<ProfilerOptionalMetadata>& metadata = {},
         const std::optional<std::map<CoreCoord, std::set<tracy::RiscType>>>& riscs_to_include = {});
-
-    void dumpRoutingInfo() const;
-
-    void dumpSocDescriptor() const;
-
-    void dumpClusterCoordinates() const;
 
     // Dump device results to files and tracy
     void dumpDeviceResults(bool is_mid_run_dump = false);

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -64,6 +64,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <impl/debug/noc_debugging.hpp>
+#include "tools/profiler/noc_event_profiler_utils.hpp"
 
 #if !defined(TRACY_ENABLE) && defined(__clang__)
 #pragma clang diagnostic push
@@ -814,9 +815,8 @@ void InitDeviceProfiler(IDevice* device) {
     setControlBuffer(nullptr, device, control_buffer);
 
     if (MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
-        profiler.dumpRoutingInfo();
-        profiler.dumpSocDescriptor();
-        profiler.dumpClusterCoordinates();
+        tt::tt_metal::dumpRoutingInfo(profiler.getNocTraceDataOutputDir());
+        tt::tt_metal::dumpSocDescriptor(device, profiler.getNocTraceDataOutputDir());
     }
 #endif
 }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -815,6 +815,7 @@ void InitDeviceProfiler(IDevice* device) {
 
     if (MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
         profiler.dumpRoutingInfo();
+        profiler.dumpSocDescriptor();
         profiler.dumpClusterCoordinates();
     }
 #endif

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -815,7 +815,7 @@ void InitDeviceProfiler(IDevice* device) {
     setControlBuffer(nullptr, device, control_buffer);
 
     if (MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
-        tt::tt_metal::dumpRoutingInfo(profiler.getNocTraceDataOutputDir());
+        tt::tt_metal::dumpRoutingInfo(device, profiler.getNocTraceDataOutputDir());
         tt::tt_metal::dumpSocDescriptor(device, profiler.getNocTraceDataOutputDir());
     }
 #endif

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -17,6 +17,7 @@
 
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "common/filesystem_utils.hpp"
+#include "context/context_types.hpp"
 #include "tt_cluster.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "fabric/fabric_context.hpp"
@@ -66,7 +67,7 @@ private:
     EthCoreToChannelMap eth_core_to_channel_lookup_;
 };
 
-inline void dumpRoutingInfo(const std::filesystem::path& output_dir) {
+inline void dumpRoutingInfo(IDevice* device, const std::filesystem::path& output_dir) {
     tt::filesystem::safe_create_directories(output_dir);
     if (!tt::filesystem::safe_is_directory(output_dir).value_or(false)) {
         log_error(
@@ -79,7 +80,8 @@ inline void dumpRoutingInfo(const std::filesystem::path& output_dir) {
 
     nlohmann::ordered_json topology_json;
 
-    const Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    ContextId context_id = extract_context_id(device);
+    const Cluster& cluster = tt::tt_metal::MetalContext::instance(context_id).get_cluster();
 
     topology_json["mesh_shapes"] = nlohmann::ordered_json::array();
     for (const auto& [mesh_id, mesh_shape] : tt::tt_fabric::get_physical_mesh_shapes()) {
@@ -98,8 +100,9 @@ inline void dumpRoutingInfo(const std::filesystem::path& output_dir) {
             fabric_node_id.mesh_id.get(), fabric_node_id.chip_id};
     }
 
-    topology_json["fabric_config"] = enchantum::to_string(tt::tt_metal::MetalContext::instance().get_fabric_config());
-    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt_fabric::FabricConfig::DISABLED) {
+    topology_json["fabric_config"] =
+        enchantum::to_string(tt::tt_metal::MetalContext::instance(context_id).get_fabric_config());
+    if (tt::tt_metal::MetalContext::instance(context_id).get_fabric_config() != tt_fabric::FabricConfig::DISABLED) {
         topology_json["routing_planes"] = nlohmann::ordered_json::array();
         for (auto physical_chip_id : cluster.get_cluster_desc()->get_all_chips()) {
             auto fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(physical_chip_id);
@@ -176,7 +179,8 @@ inline void dumpSocDescriptor(IDevice* device, const std::filesystem::path& outp
         return;
     }
 
-    const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
+    ContextId context_id = extract_context_id(device);
+    const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device->id());
     soc_desc.serialize_to_file(output_dir / "soc_descriptor.yaml");
 }
 

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -16,6 +16,7 @@
 #include <fstream>
 
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include "common/filesystem_utils.hpp"
 #include "tt_cluster.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "fabric/fabric_context.hpp"
@@ -65,29 +66,17 @@ private:
     EthCoreToChannelMap eth_core_to_channel_lookup_;
 };
 
-inline void dumpClusterCoordinatesAsJson(const std::filesystem::path& filepath) {
-    Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-
-    nlohmann::ordered_json cluster_json;
-    cluster_json["physical_chip_to_eth_coord"] = nlohmann::ordered_json();
-    for (auto& [chip_id, eth_core] : cluster.get_user_chip_ethernet_coordinates()) {
-        EthCoord eth_coord = eth_core;
-        auto& entry = cluster_json["physical_chip_to_eth_coord"][std::to_string(chip_id)];
-        entry["rack"] = eth_coord.rack;
-        entry["shelf"] = eth_coord.shelf;
-        entry["x"] = eth_coord.x;
-        entry["y"] = eth_coord.y;
+inline void dumpRoutingInfo(const std::filesystem::path& output_dir) {
+    tt::filesystem::safe_create_directories(output_dir);
+    if (!tt::filesystem::safe_is_directory(output_dir).value_or(false)) {
+        log_error(
+            tt::LogMetal,
+            "Could not dump topology to '{}' because the directory path could not be created!",
+            output_dir);
+        return;
     }
+    const std::filesystem::path filepath = output_dir / "topology.json";
 
-    std::ofstream cluster_json_ofs(filepath);
-    if (cluster_json_ofs.is_open()) {
-        cluster_json_ofs << cluster_json.dump(2);
-    } else {
-        log_error(tt::LogMetal, "Failed to open file '{}' for dumping cluster coordinate map", filepath.string());
-    }
-}
-
-inline void dumpRoutingInfo(const std::filesystem::path& filepath) {
     nlohmann::ordered_json topology_json;
 
     const Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
@@ -175,6 +164,20 @@ inline std::tuple<int, int> get_routing_start_distance_and_range(uint8_t routing
     int start_distance = tt::tt_fabric::RoutingFields::HOP_DISTANCE_MASK & routing_fields_value;
     int range = routing_fields_value >> tt::tt_fabric::RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH;
     return {start_distance, range};
+}
+
+inline void dumpSocDescriptor(IDevice* device, const std::filesystem::path& output_dir) {
+    tt::filesystem::safe_create_directories(output_dir);
+    if (!tt::filesystem::safe_is_directory(output_dir).value_or(false)) {
+        log_error(
+            tt::LogMetal,
+            "Could not dump soc descriptor to '{}' because the directory path could not be created!",
+            output_dir);
+        return;
+    }
+
+    const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
+    soc_desc.serialize_to_file(output_dir / "soc_descriptor.yaml");
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION

### PR Category
Feature

### Summary
Issue: https://github.com/tenstorrent/tt-npe/issues/132

Quasar will have custom SoC descriptors used by customers so we need to be able to dump this info for use by NPE to support these chips since NPE needs to know information about the grid (which NoC coordinates are tensix/dram/ethernet).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadeem/quasar_arch_support_part1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadeem/quasar_arch_support_part1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadeem/quasar_arch_support_part1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadeem/quasar_arch_support_part1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/quasar_arch_support_part1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/quasar_arch_support_part1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadeem/quasar_arch_support_part1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadeem/quasar_arch_support_part1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/quasar_arch_support_part1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/quasar_arch_support_part1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/quasar_arch_support_part1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/quasar_arch_support_part1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/quasar_arch_support_part1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/quasar_arch_support_part1)