### PR TITLE
Raise NUM_SEMAPHORES from 16 to 24

### DIFF
--- a/tt_metal/impl/buffers/semaphore.hpp
+++ b/tt_metal/impl/buffers/semaphore.hpp
@@ -13,7 +13,7 @@
 
 namespace tt::tt_metal {
 
-constexpr std::uint32_t NUM_SEMAPHORES = 16;
+constexpr std::uint32_t NUM_SEMAPHORES = 24;
 
 class Semaphore {
 public:


### PR DESCRIPTION
Pushing boundary for Program Sempahore limit a bit as might be necessary by future work

Finalize_sems sizes the region as (max_id + 1) * L1_ALIGNMENT, so a program that stays under 16 ids is unaffected and one that uses the new headroom costs 128 B more of kernel config.

Nothing outside this constant assumes 16. The two consumers derive from it (std::bitset<NUM_SEMAPHORES> plus a bound check in program.cpp and program_descriptors.cpp), and there are no device-side references at all -- get_semaphore() is sem_l1_base[type] + id * L1_ALIGNMENT with no bound.


### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=agupta/raise_num_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:agupta/raise_num_semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=agupta/raise_num_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:agupta/raise_num_semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=agupta/raise_num_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:agupta/raise_num_semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=agupta/raise_num_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:agupta/raise_num_semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=agupta/raise_num_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:agupta/raise_num_semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=agupta/raise_num_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:agupta/raise_num_semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=agupta/raise_num_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:agupta/raise_num_semaphores)