### PR TITLE
[Bug fix] Fix LLK tests so single-bank kernels work regardless of DRAM bank count

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -61,14 +61,14 @@ static vector<uint32_t> run_mxfp4_typecast(
     InterleavedBufferConfig src_config{
         .device = dev,
         .size = num_tiles * input_tile_size,
-        .page_size = input_tile_size,
+        .page_size = num_tiles * input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
         .device = dev,
         .size = num_tiles * output_tile_size,
-        .page_size = output_tile_size,
+        .page_size = num_tiles * output_tile_size,
         .buffer_type = BufferType::DRAM};
     auto dst_buffer = CreateBuffer(dst_config);
 
@@ -155,11 +155,12 @@ static vector<uint32_t> run_mxfp4_typecast(
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     detail::WriteToBuffer(src_buffer, src_vec);
-    // Pass aligned DRAM page stride so the reader/writer advance the DRAM
-    // pointer by the allocator's aligned_page_size (576 for MxFp4 on Quasar
-    // due to 64B DRAM alignment) while the DFB streams native 544-byte tiles.
-    uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
-    uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
+    // The direct reader/writer kernels address a single DRAM bank
+    // (bank_id 0). Use page_size = whole buffer so the allocator places the
+    // buffer in one bank, and advance the DRAM pointer by the native tile
+    // size, matching the host-side vector layout.
+    uint32_t src_dram_stride = input_tile_size;
+    uint32_t dst_dram_stride = output_tile_size;
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -62,14 +62,14 @@ static vector<uint32_t> run_mxfp6_typecast(
     InterleavedBufferConfig src_config{
         .device = dev,
         .size = num_tiles * input_tile_size,
-        .page_size = input_tile_size,
+        .page_size = num_tiles * input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
         .device = dev,
         .size = num_tiles * output_tile_size,
-        .page_size = output_tile_size,
+        .page_size = num_tiles * output_tile_size,
         .buffer_type = BufferType::DRAM};
     auto dst_buffer = CreateBuffer(dst_config);
 
@@ -160,8 +160,12 @@ static vector<uint32_t> run_mxfp6_typecast(
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     detail::WriteToBuffer(src_buffer, src_vec);
-    uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
-    uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
+    // The direct reader/writer kernels address a single DRAM bank
+    // (bank_id 0). Use page_size = whole buffer so the allocator places the
+    // buffer in one bank, and advance the DRAM pointer by the native tile
+    // size, matching the host-side vector layout.
+    uint32_t src_dram_stride = input_tile_size;
+    uint32_t dst_dram_stride = output_tile_size;
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -61,14 +61,14 @@ static vector<uint32_t> run_mxfp8_typecast(
     InterleavedBufferConfig src_config{
         .device = dev,
         .size = num_tiles * input_tile_size,
-        .page_size = input_tile_size,
+        .page_size = num_tiles * input_tile_size,
         .buffer_type = BufferType::DRAM};
     auto src_buffer = CreateBuffer(src_config);
 
     InterleavedBufferConfig dst_config{
         .device = dev,
         .size = num_tiles * output_tile_size,
-        .page_size = output_tile_size,
+        .page_size = num_tiles * output_tile_size,
         .buffer_type = BufferType::DRAM};
     auto dst_buffer = CreateBuffer(dst_config);
 
@@ -159,12 +159,12 @@ static vector<uint32_t> run_mxfp8_typecast(
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     detail::WriteToBuffer(src_buffer, src_vec);
-    // Pass aligned DRAM page stride so the reader/writer advance the DRAM
-    // pointer by the allocator's aligned_page_size while the DFB streams the
-    // native tile size (e.g. 1056 bytes for MxFp8 on Quasar; the allocator
-    // rounds up to 1088 due to 64B DRAM alignment).
-    uint32_t src_dram_stride = static_cast<uint32_t>(src_buffer->aligned_page_size());
-    uint32_t dst_dram_stride = static_cast<uint32_t>(dst_buffer->aligned_page_size());
+    // The direct reader/writer kernels address a single DRAM bank
+    // (bank_id 0). Use page_size = whole buffer so the allocator places the
+    // buffer in one bank, and advance the DRAM pointer by the native tile
+    // size, matching the host-side vector layout.
+    uint32_t src_dram_stride = input_tile_size;
+    uint32_t dst_dram_stride = output_tile_size;
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {

--- a/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
@@ -52,16 +52,19 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
 
     const std::uint32_t single_tile_size = 2 * 1024;  // Float16_b 32x32 tile
 
+    // The direct reader/writer kernels address a single DRAM bank (bank_id
+    // 0). Use page_size = whole buffer so the allocator places each buffer in
+    // one bank, and advance the DRAM pointer by the native tile size.
     distributed::ReplicatedBufferConfig src_global_config{.size = single_tile_size * TILES_STREAMED_PER_INPUT};
     distributed::DeviceLocalBufferConfig src_local_config{
-        .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
+        .page_size = single_tile_size * TILES_STREAMED_PER_INPUT, .buffer_type = BufferType::DRAM};
     auto src0_dram_buffer = distributed::MeshBuffer::create(src_global_config, src_local_config, mesh_device.get());
     auto src1_dram_buffer = distributed::MeshBuffer::create(src_global_config, src_local_config, mesh_device.get());
     auto src2_dram_buffer = distributed::MeshBuffer::create(src_global_config, src_local_config, mesh_device.get());
 
     auto dst_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = single_tile_size * TOTAL_TILES},
-        {.page_size = single_tile_size, .buffer_type = BufferType::DRAM},
+        {.page_size = single_tile_size * TOTAL_TILES, .buffer_type = BufferType::DRAM},
         mesh_device.get());
 
     const experimental::DFBSpecName IN0_DFB{"in0_dfb"};
@@ -192,10 +195,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, /*blocking=*/true);
     distributed::EnqueueWriteMeshBuffer(cq, src2_dram_buffer, src2_vec, /*blocking=*/true);
 
-    const std::uint32_t src_aligned_page_size =
-        static_cast<std::uint32_t>(src0_dram_buffer->get_reference_buffer()->aligned_page_size());
-    const std::uint32_t dst_aligned_page_size =
-        static_cast<std::uint32_t>(dst_dram_buffer->get_reference_buffer()->aligned_page_size());
+    const std::uint32_t src_aligned_page_size = single_tile_size;
+    const std::uint32_t dst_aligned_page_size = single_tile_size;
 
     auto reader_run_args = [&](const std::shared_ptr<distributed::MeshBuffer>& buf) {
         return experimental::MakeRuntimeArgsForSingleNode(

--- a/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
@@ -195,16 +195,13 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, /*blocking=*/true);
     distributed::EnqueueWriteMeshBuffer(cq, src2_dram_buffer, src2_vec, /*blocking=*/true);
 
-    const std::uint32_t src_aligned_page_size = single_tile_size;
-    const std::uint32_t dst_aligned_page_size = single_tile_size;
-
     auto reader_run_args = [&](const std::shared_ptr<distributed::MeshBuffer>& buf) {
         return experimental::MakeRuntimeArgsForSingleNode(
             node,
             {{"src_addr", buf->address()},
              {"src_bank_id", 0u},
              {"num_tiles", TILES_STREAMED_PER_INPUT},
-             {"dram_page_stride", src_aligned_page_size}});
+             {"dram_page_stride", single_tile_size}});
     };
 
     experimental::ProgramRunArgs params;
@@ -222,7 +219,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
                 {{"dst_addr", dst_dram_buffer->address()},
                  {"dst_bank_id", 0u},
                  {"num_tiles", TOTAL_TILES},
-                 {"dram_page_stride", dst_aligned_page_size}}),
+                 {"dram_page_stride", single_tile_size}}),
         },
     };
     experimental::SetProgramRunArgs(program, params);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Some LLK tests use reader and writer kernels that only ever touch one DRAM bank 0. However, the tests built each buffer with one page per tile, with the pages being interleaved across every DRAM bank.

With only one DRAM bank, this made no difference. Every tile still landed in bank 0, so the kernels worked.

With more than one DRAM bank, only some tiles landed in bank 0. The kernels read the wrong tiles, in the wrong order.

This change gives each buffer one page for the whole buffer, not one page per tile. A buffer with one page always sits in a single bank.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/fix_llk_dram_single_bank_page_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/fix_llk_dram_single_bank_page_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/fix_llk_dram_single_bank_page_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/fix_llk_dram_single_bank_page_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/fix_llk_dram_single_bank_page_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/fix_llk_dram_single_bank_page_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/fix_llk_dram_single_bank_page_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/fix_llk_dram_single_bank_page_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/fix_llk_dram_single_bank_page_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/fix_llk_dram_single_bank_page_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/fix_llk_dram_single_bank_page_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/fix_llk_dram_single_bank_page_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/fix_llk_dram_single_bank_page_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/fix_llk_dram_single_bank_page_size)