### PR TITLE
Fix physical chip access in memory benchmark

### DIFF
--- a/tt_metal/tools/mem_bench/device_utils.cpp
+++ b/tt_metal/tools/mem_bench/device_utils.cpp
@@ -13,6 +13,7 @@
 #include "core_coord.hpp"
 #include "device_utils.hpp"
 #include "kernel_types.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 class Program;
@@ -26,7 +27,7 @@ std::vector<uint32_t> read_cores(distributed::MeshDevice* device, const CoreRang
     for (size_t xi = cores.start_coord.x; xi <= cores.end_coord.x; ++xi) {
         for (size_t yi = cores.start_coord.y; yi <= cores.end_coord.y; ++yi) {
             std::vector<uint32_t> single_data;
-            tt::tt_metal::detail::ReadFromDeviceL1(device, CoreCoord{xi, yi}, addr, sizeof(uint32_t), single_data);
+            slow_dispatch::ReadFromL1(*device, CoreCoord{xi, yi}, addr, sizeof(uint32_t), single_data);
             data.push_back(single_data[0]);
         }
     }

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -184,8 +184,8 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
     }
 
     auto src_data = generate_random_src_data(ctx.total_size);
-    auto* hugepage = get_hugepage(device->id(), 0);
-    auto hugepage_size = get_hugepage_size(device->id());
+    auto* hugepage = get_hugepage(device_id, 0);
+    auto hugepage_size = get_hugepage_size(device_id);
 
     for ([[maybe_unused]] auto _ : state) {
         auto pgm = CreateProgram();
@@ -249,11 +249,11 @@ TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) 
     };
 
     auto src_data = generate_random_src_data(ctx.total_size);
-    auto device_hugepage_size = get_hugepage_size(device->id());
+    auto device_hugepage_size = get_hugepage_size(device_id);
 
     // 2nd open device is not required
-    auto* host_hugepage = get_hugepage(device->id() + 1, 0);
-    auto host_hugepage_size = get_hugepage_size(device->id() + 1);
+    auto* host_hugepage = get_hugepage(device_id + 1, 0);
+    auto host_hugepage_size = get_hugepage_size(device_id + 1);
 
     for ([[maybe_unused]] auto _ : state) {
         auto pgm = CreateProgram();
@@ -398,8 +398,8 @@ TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
     };
 
     auto src_data = generate_random_src_data(ctx.total_size);
-    auto* hugepage = get_hugepage(device->id(), 0);
-    auto hugepage_size = get_hugepage_size(device->id());
+    auto* hugepage = get_hugepage(device_id, 0);
+    auto hugepage_size = get_hugepage_size(device_id);
 
     // Don't need to separate device results
     // Readers will have 0 bytes written


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Fixes #54879

Memory benchmark crashes after this change https://github.com/tenstorrent/tt-metal/pull/54238

The fix is to use the physical ChipId (device_id from create_unit_meshes) for hugepage lookups in mem_bench.cpp, not `MeshDevice::id()` which is only valid as a mesh handle, not as an argument to UMD chip/board mapping.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
Passing mem_bench run: https://github.com/tenstorrent/tt-metal/actions/runs/33435229668

_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov/54879)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov/54879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov/54879)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov/54879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov/54879)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov/54879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov/54879)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov/54879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov/54879)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov/54879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov/54879)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov/54879)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov/54879)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov/54879)