### PR TITLE
[Bug fix] [emule] Mainline remaining Blaze fork fixes

### DIFF
--- a/tests/tt_metal/tt_metal/api/emule/test_emule_host_wait.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_emule_host_wait.cpp
@@ -106,6 +106,87 @@ TEST_F(EmuleHostWait, HostFedPollQuiescesToHostWaitAndPumpsToCompletion) {
     EXPECT_EQ(entries.load(), 1u);
 }
 
+// A peer-fed socket can be causally downstream of the host-fed source. The external host root is
+// sufficient to suspend the whole chain; requiring every poller to be host-fed would misdiagnose
+// a normal pipeline as a device-only deadlock.
+TEST_F(EmuleHostWait, HostFedPollWithCausalD2DPollResumes) {
+    std::atomic<bool> host_ready{false};
+    std::atomic<bool> downstream_ready{false};
+
+    spawn_fiber(
+        [&host_ready, &downstream_ready] {
+            auto& sched = FiberScheduler::instance();
+            while (!host_ready.load(std::memory_order_acquire)) {
+                sched.note_socket_poll_wait(/*waiting=*/true, /*host_fed=*/true);
+                sched.yield();
+            }
+            sched.note_socket_poll_wait(/*waiting=*/false, /*host_fed=*/true);
+            downstream_ready.store(true, std::memory_order_release);
+        },
+        2,
+        "h2d_pipeline_source");
+    spawn_fiber(polling_body(&downstream_ready, /*host_fed=*/false, nullptr), 3, "d2d_pipeline_receiver");
+
+    auto& sched = FiberScheduler::instance();
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    ASSERT_EQ(sched.pump(), RunOutcome::HostWait) << "a dry pump must preserve the causal host wait";
+
+    host_ready.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+}
+
+// A later host page may be absent while the current page still has runnable work deferred to
+// quiescence. The spin-release HostWait path must service that work before handing control back;
+// otherwise every D2H pump suspends on the next-page H2D poll and strands the current-page producer.
+TEST_F(EmuleHostWait, DeferredProducerRunsBeforeDownstreamHostWait) {
+    std::atomic<bool> next_host_page_ready{false};
+    std::atomic<bool> current_page_published{false};
+
+    spawn_fiber(polling_body(&next_host_page_ready, /*host_fed=*/true, nullptr), 4, "next_page_h2d_receiver_poll");
+    spawn_fiber(
+        polling_body(&current_page_published, /*host_fed=*/false, nullptr), 5, "current_page_d2d_receiver_poll");
+    spawn_fiber(
+        [&current_page_published] {
+            auto& sched = FiberScheduler::instance();
+            sched.quiescence_park();
+            current_page_published.store(true, std::memory_order_release);
+        },
+        6,
+        "current_page_deferred_producer");
+
+    auto& sched = FiberScheduler::instance();
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    EXPECT_TRUE(current_page_published.load(std::memory_order_acquire))
+        << "HostWait stranded runnable current-page work behind a next-page host poll";
+
+    // Complete the future host dependency so the process-global scheduler registry is clean.
+    next_host_page_ready.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+}
+
+// The existential host root must not become a sticky exemption. Once it clears, an unrelated
+// peer-fed poll remains a genuine d2d-only deadlock and must retain the peer diagnostic.
+TEST_F(EmuleHostWait, D2DPollStillDeadlocksAfterHostPollClears) {
+    arm_fast_watchdog();
+    EXPECT_DEATH(
+        {
+            std::atomic<bool> host_ready{false};
+            std::atomic<bool> peer_never_ready{false};
+            spawn_fiber(polling_body(&host_ready, /*host_fed=*/true, nullptr), 4, "h2d_pipeline_source");
+            spawn_fiber(polling_body(&peer_never_ready, /*host_fed=*/false, nullptr), 5, "d2d_pipeline_receiver");
+
+            auto& sched = FiberScheduler::instance();
+            if (sched.run_persistent() != RunOutcome::HostWait) {
+                std::exit(2);
+            }
+            host_ready.store(true, std::memory_order_release);
+            (void)sched.pump();
+            std::exit(3);
+        },
+        "spin-polling a d2d socket");
+    disarm_fast_watchdog();
+}
+
 // A d2d sender is a PEER, so dying on this regex proves the attribution, not just the outcome.
 TEST_F(EmuleHostWait, PeerFedPollIsNamedAsPeerFedInTheDump) {
     arm_fast_watchdog();

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -286,7 +286,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_SameAddressTempBuffer_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the owner's full range is still live.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -398,9 +398,14 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                 }
                 last_parked_sig_ = sig;
                 last_parked_sig_valid_ = true;
-                // Yield-spin HostWait trigger: all waits host-fed, or peer-parked but N releases moved nothing.
+                // Yield-spin HostWait trigger: a host-fed root may have downstream peer work, but
+                // quiescence-deferred fibers are runnable internal work and must get at least one
+                // release first. Otherwise a next-page H2D poll can suspend the run while the
+                // current page's deferred producer is still waiting to publish to a d2d consumer.
+                const bool internal_work_needs_repoll =
+                    !quiescence_deferred_.empty() || any_parked_non_socket();
                 if (persistent_ && any_waiting_on_host() &&
-                    (!any_parked_non_socket() || barren_releases_ >= barren_release_limit)) {
+                    (!internal_work_needs_repoll || barren_releases_ >= barren_release_limit)) {
                     host_wait_ = true;
                     abort_flag_ = true;
                     cv_.notify_all();


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Mainlines the two fixups that are still outstanding from `emule-blaze-metal-fork` after the Blaze uplift in [tenstorrent/tt-emule-blaze#383](https://github.com/tenstorrent/tt-emule-blaze/pull/383).

- Drain quiescence-deferred scheduler work before reporting a host wait. Without this, a current-page D2D producer can remain stranded when a downstream next-page host poll is observed.
- Add focused host-wait regression coverage, including the original three fork tests.
- Update the remaining emule ASAN test to the public moving `LaunchProgram` API used by current Metal.

The scheduler change and tests preserve Muhammad Wasif Kamran as the original author. Current `main` has already subsumed the other fork test cleanup, so it is intentionally omitted here.

### Notes for reviewers

The functional review focus is `emule_fiber_scheduler.cpp`: `run_scheduler()` now releases deferred internal work and retries runnable fibers before deciding that every live fiber is host-fed.

Fork audit against current `main`:

- fabric routing/source shadow fix: already mainlined
- runtime-argument patching fix: already mainlined
- deferred-work host-wait fix: carried here
- moving `LaunchProgram` test call: carried here
- unused device-local test cleanup: already subsumed by newer fixture code

Validation:

- `git diff --check origin/main...HEAD`: pass
- full `TT_METAL_USE_EMULE=ON` Clang 20 build from current Metal `main`: pass
- `EmuleHostWait.*`: 19/19 pass
- `UnitMeshFixture.OOB_Tensor_SameAddressTempBuffer_NoViolation`: compiles; local runtime validation is blocked by an unrelated current-main/emule JIT include-resolution gap for `noc_address_backend.h`, so CI remains the runtime authority for that test

The local build used the published multi-rank emule dependency needed by current Metal main plus the kernel-patcher call-form compatibility from the Blaze uplift. No temporary emule branch was pushed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/mainline-emule-fork-fixups)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/mainline-emule-fork-fixups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/mainline-emule-fork-fixups)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/mainline-emule-fork-fixups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/mainline-emule-fork-fixups)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/mainline-emule-fork-fixups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/mainline-emule-fork-fixups)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/mainline-emule-fork-fixups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/mainline-emule-fork-fixups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/mainline-emule-fork-fixups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/mainline-emule-fork-fixups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/mainline-emule-fork-fixups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/mainline-emule-fork-fixups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/mainline-emule-fork-fixups)