### PR TITLE
Let a spec factory build a different program per mesh coordinate

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -159,7 +159,7 @@ struct MeshWorkloadSpecFactory {
     }
 };
 
-// Same, plus a per-coordinate cache-hit run-args refresh.
+// Same, plus a per-range cache-hit run-args refresh.
 struct MeshWorkloadSpecFactoryWithOverride {
     static ttnn::device_operation::MeshWorkloadArtifacts create_mesh_workload_artifacts(
         const OperationAttributes& /*attrs*/,
@@ -172,7 +172,7 @@ struct MeshWorkloadSpecFactoryWithOverride {
         const OperationAttributes& /*attrs*/,
         const Tensor& /*tensor_args*/,
         Tensor& /*tensor_return_value*/,
-        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+        const ttnn::MeshCoordinateRange& /*range*/) {
         return {};
     }
 };
@@ -485,7 +485,7 @@ struct PerCoordProdAllFactoryWithOverride : PerCoordProdAllFactory {
         const Op::operation_attributes_t& attrs,
         const Op::tensor_args_t& tensor_args,
         Op::tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+        const ttnn::MeshCoordinateRange& range) {
         ++override_calls;
         return Op::ProdAllProgramFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value).run_params;
     }

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
 #include <gmock/gmock.h>
 #include <type_traits>
 
@@ -473,6 +474,57 @@ TEST_F(LaunchOperation2x4Test, MeshWorkloadSpecAdapterMapsProgramsPerCoordinate)
         }
         EXPECT_EQ(static_cast<const void*>(sv.op_owned_tensors.get()), first_resources) << "range " << range;
     }
+}
+
+// Same per-coordinate mapping, but with an override so the cache-hit path takes the
+// UpdateProgramRunArgs branch instead of the tensor-only refresh.
+struct PerCoordProdAllFactoryWithOverride : PerCoordProdAllFactory {
+    static std::atomic<int> override_calls;
+
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
+        const Op::operation_attributes_t& attrs,
+        const Op::tensor_args_t& tensor_args,
+        Op::tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+        ++override_calls;
+        return Op::ProdAllProgramFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value).run_params;
+    }
+};
+std::atomic<int> PerCoordProdAllFactoryWithOverride::override_calls{0};
+
+TEST_F(LaunchOperation2x4Test, MeshWorkloadSpecAdapterAppliesDescriptorOnCacheHit) {
+    using Op = ttnn::prim::ProdAllDeviceOperation;
+    using Adapter =
+        device_operation::MeshDeviceOperationAdapter<Op>::MeshWorkloadSpecFactoryAdapter<PerCoordProdAllFactory>;
+    using OverrideAdapter = device_operation::MeshDeviceOperationAdapter<Op>::MeshWorkloadSpecFactoryAdapter<
+        PerCoordProdAllFactoryWithOverride>;
+    static_assert(!Adapter::has_override_runtime_arguments());
+    static_assert(OverrideAdapter::has_override_runtime_arguments());
+
+    auto input = make_tensor_with_num_shards(8, mesh_device_.get());
+    Op::operation_attributes_t attrs{.output_mem_config = MemoryConfig{}};
+    Op::tensor_args_t tensor_args{.input = input};
+    auto output = Op::create_output_tensors(attrs, tensor_args);
+
+    ttnn::MeshCoordinateRangeSet tensor_coords;
+    tensor_coords.merge(ttnn::MeshCoordinateRange(mesh_device_->shape()));
+
+    // Tensor-refresh branch: a second apply must not disturb the per-coordinate mapping.
+    auto cached = Adapter::create_mesh_workload(attrs, tensor_coords, tensor_args, output);
+    const auto ranges_before = cached.workload.get_programs().size();
+    Adapter::apply_descriptor(cached, attrs, tensor_args, output);
+    EXPECT_EQ(cached.workload.get_programs().size(), ranges_before);
+    for (const auto& [range, program] : cached.workload.get_programs()) {
+        EXPECT_TRUE(cached.shared_variables.contains(range)) << "range " << range;
+    }
+
+    // Override branch: called once per range, not once for the whole workload.
+    PerCoordProdAllFactoryWithOverride::override_calls = 0;
+    auto override_cached = OverrideAdapter::create_mesh_workload(attrs, tensor_coords, tensor_args, output);
+    const auto override_ranges = override_cached.workload.get_programs().size();
+    EXPECT_GT(override_ranges, 1u);
+    OverrideAdapter::apply_descriptor(override_cached, attrs, tensor_args, output);
+    EXPECT_EQ(PerCoordProdAllFactoryWithOverride::override_calls.load(), static_cast<int>(override_ranges));
 }
 
 TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterProgramsOnUniformTensorCoords) {

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -485,7 +485,7 @@ struct PerCoordProdAllFactoryWithOverride : PerCoordProdAllFactory {
         const Op::operation_attributes_t& attrs,
         const Op::tensor_args_t& tensor_args,
         Op::tensor_return_value_t& tensor_return_value,
-        const ttnn::MeshCoordinateRange& range) {
+        const ttnn::MeshCoordinateRange& /*range*/) {
         ++override_calls;
         return Op::ProdAllProgramFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value).run_params;
     }

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -465,15 +465,6 @@ TEST_F(LaunchOperation2x4Test, MeshWorkloadSpecAdapterMapsProgramsPerCoordinate)
     EXPECT_GT(expected, 0u);
     EXPECT_EQ(cached.workload.get_programs().size(), expected);
     EXPECT_EQ(cached.shared_variables.size(), expected);
-
-    // Workload-scoped, not per-device: every range shares one parked resource vector.
-    const auto* first_resources = static_cast<const void*>(nullptr);
-    for (const auto& [range, sv] : cached.shared_variables) {
-        if (first_resources == nullptr) {
-            first_resources = static_cast<const void*>(sv.op_owned_tensors.get());
-        }
-        EXPECT_EQ(static_cast<const void*>(sv.op_owned_tensors.get()), first_resources) << "range " << range;
-    }
 }
 
 // Same per-coordinate mapping, but with an override so the cache-hit path takes the

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -146,6 +146,35 @@ struct CustomProgramSpecFactory {
     }
 };
 
+// Per-coordinate variants of both flavors: create_program_artifacts takes the MeshCoordinate, so the
+// adapter calls it once per coordinate and each call may return its own spec and run args.
+struct PerCoordProgramSpecFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const OperationAttributes& /*attrs*/,
+        const Tensor& /*tensor_args*/,
+        Tensor& /*tensor_return_value*/,
+        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+        return ttnn::device_operation::ProgramArtifacts{};
+    }
+};
+
+struct PerCoordCustomProgramSpecFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const OperationAttributes& /*attrs*/,
+        const Tensor& /*tensor_args*/,
+        Tensor& /*tensor_return_value*/,
+        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+        return ttnn::device_operation::ProgramArtifacts{};
+    }
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
+        const OperationAttributes& /*attrs*/,
+        const Tensor& /*tensor_args*/,
+        Tensor& /*tensor_return_value*/,
+        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/ = std::nullopt) {
+        return {};
+    }
+};
+
 // Minimal device operation supplying just the typedefs the adapter inherits.
 struct ProgramSpecMinimalOp {
     using operation_attributes_t = OperationAttributes;
@@ -167,6 +196,22 @@ static_assert(!ttnn::device_operation::ProgramFactoryConcept<CustomProgramSpecFa
 static_assert(!ttnn::device_operation::MeshWorkloadFactoryConcept<CustomProgramSpecFactory>);
 static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<CustomProgramSpecFactory>);
 
+// Taking the coordinate doesn't change which flavor a factory is.
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<PerCoordProgramSpecFactory>);
+static_assert(!ttnn::device_operation::CustomProgramSpecFactoryConcept<PerCoordProgramSpecFactory>);
+static_assert(ttnn::device_operation::CustomProgramSpecFactoryConcept<PerCoordCustomProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<PerCoordCustomProgramSpecFactory>);
+
+template <typename Factory>
+using SpecAdapter =
+    device_operation::MeshDeviceOperationAdapter<ProgramSpecMinimalOp>::ProgramSpecMeshWorkloadFactoryAdapter<Factory>;
+
+// The mesh-wide vs per-coordinate build path is picked by this predicate; pin both directions.
+static_assert(SpecAdapter<PerCoordProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
+static_assert(SpecAdapter<PerCoordCustomProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
+static_assert(!SpecAdapter<ProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
+static_assert(!SpecAdapter<CustomProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
+
 // Compile-coverage: taking the adapter methods' addresses ODR-uses them, forcing
 // the (otherwise un-instantiated) bodies to compile. Never dispatched.
 TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
@@ -180,6 +225,13 @@ TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
         ProgramSpecMinimalOp>::CustomProgramSpecMeshWorkloadFactoryAdapter<CustomProgramSpecFactory>;
     [[maybe_unused]] auto ccreate = &CustomAdapter::create_mesh_workload;
     [[maybe_unused]] auto capply = &CustomAdapter::apply_descriptor;
+
+    // The per-coordinate build path is a separate if-constexpr branch; instantiate it too.
+    [[maybe_unused]] auto pcreate = &SpecAdapter<PerCoordProgramSpecFactory>::create_mesh_workload;
+    using PerCoordCustomAdapter = device_operation::MeshDeviceOperationAdapter<
+        ProgramSpecMinimalOp>::CustomProgramSpecMeshWorkloadFactoryAdapter<PerCoordCustomProgramSpecFactory>;
+    [[maybe_unused]] auto pccreate = &PerCoordCustomAdapter::create_mesh_workload;
+    [[maybe_unused]] auto pcapply = &PerCoordCustomAdapter::apply_descriptor;
     SUCCEED();
 }
 

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -146,31 +146,32 @@ struct CustomProgramSpecFactory {
     }
 };
 
-// Per-coordinate variants of both flavors: create_program_artifacts takes the MeshCoordinate, so the
-// adapter calls it once per coordinate and each call may return its own spec and run args.
-struct PerCoordProgramSpecFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+// Programs vary across the mesh: one call returns workload-scoped resources plus a program per
+// coordinate range.
+struct MeshWorkloadSpecFactory {
+    static ttnn::device_operation::MeshWorkloadArtifacts create_mesh_workload_artifacts(
         const OperationAttributes& /*attrs*/,
         const Tensor& /*tensor_args*/,
         Tensor& /*tensor_return_value*/,
-        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-        return ttnn::device_operation::ProgramArtifacts{};
+        const ttnn::MeshCoordinateRangeSet& /*tensor_coords*/) {
+        return ttnn::device_operation::MeshWorkloadArtifacts{};
     }
 };
 
-struct PerCoordCustomProgramSpecFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+// Same, plus a per-coordinate cache-hit run-args refresh.
+struct MeshWorkloadSpecFactoryWithOverride {
+    static ttnn::device_operation::MeshWorkloadArtifacts create_mesh_workload_artifacts(
         const OperationAttributes& /*attrs*/,
         const Tensor& /*tensor_args*/,
         Tensor& /*tensor_return_value*/,
-        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-        return ttnn::device_operation::ProgramArtifacts{};
+        const ttnn::MeshCoordinateRangeSet& /*tensor_coords*/) {
+        return ttnn::device_operation::MeshWorkloadArtifacts{};
     }
     static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
         const OperationAttributes& /*attrs*/,
         const Tensor& /*tensor_args*/,
         Tensor& /*tensor_return_value*/,
-        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/ = std::nullopt) {
+        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
         return {};
     }
 };
@@ -196,21 +197,27 @@ static_assert(!ttnn::device_operation::ProgramFactoryConcept<CustomProgramSpecFa
 static_assert(!ttnn::device_operation::MeshWorkloadFactoryConcept<CustomProgramSpecFactory>);
 static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<CustomProgramSpecFactory>);
 
-// Taking the coordinate doesn't change which flavor a factory is.
-static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<PerCoordProgramSpecFactory>);
-static_assert(!ttnn::device_operation::CustomProgramSpecFactoryConcept<PerCoordProgramSpecFactory>);
-static_assert(ttnn::device_operation::CustomProgramSpecFactoryConcept<PerCoordCustomProgramSpecFactory>);
-static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<PerCoordCustomProgramSpecFactory>);
+// A mesh-workload factory is its own flavor, and an override doesn't pull it into the others.
+static_assert(ttnn::device_operation::MeshWorkloadSpecFactoryConcept<MeshWorkloadSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<MeshWorkloadSpecFactory>);
+static_assert(!ttnn::device_operation::CustomProgramSpecFactoryConcept<MeshWorkloadSpecFactory>);
+static_assert(ttnn::device_operation::MeshWorkloadSpecFactoryConcept<MeshWorkloadSpecFactoryWithOverride>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<MeshWorkloadSpecFactoryWithOverride>);
+static_assert(!ttnn::device_operation::CustomProgramSpecFactoryConcept<MeshWorkloadSpecFactoryWithOverride>);
+
+// Every flavor is exactly one alternative as far as a program_factory_t variant is concerned.
+static_assert(ttnn::device_operation::AllFactoriesValid<std::variant<ProgramSpecFactory>>);
+static_assert(ttnn::device_operation::AllFactoriesValid<std::variant<CustomProgramSpecFactory>>);
+static_assert(ttnn::device_operation::AllFactoriesValid<std::variant<MeshWorkloadSpecFactory>>);
+static_assert(ttnn::device_operation::AllFactoriesValid<std::variant<MeshWorkloadSpecFactoryWithOverride>>);
 
 template <typename Factory>
-using SpecAdapter =
-    device_operation::MeshDeviceOperationAdapter<ProgramSpecMinimalOp>::ProgramSpecMeshWorkloadFactoryAdapter<Factory>;
+using WorkloadSpecAdapter =
+    device_operation::MeshDeviceOperationAdapter<ProgramSpecMinimalOp>::MeshWorkloadSpecFactoryAdapter<Factory>;
 
-// The mesh-wide vs per-coordinate build path is picked by this predicate; pin both directions.
-static_assert(SpecAdapter<PerCoordProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
-static_assert(SpecAdapter<PerCoordCustomProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
-static_assert(!SpecAdapter<ProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
-static_assert(!SpecAdapter<CustomProgramSpecFactory>::create_program_artifacts_uses_mesh_dispatch_coordinate());
+// The cache-hit path forks on this; pin both directions.
+static_assert(!WorkloadSpecAdapter<MeshWorkloadSpecFactory>::has_override_runtime_arguments());
+static_assert(WorkloadSpecAdapter<MeshWorkloadSpecFactoryWithOverride>::has_override_runtime_arguments());
 
 // Compile-coverage: taking the adapter methods' addresses ODR-uses them, forcing
 // the (otherwise un-instantiated) bodies to compile. Never dispatched.
@@ -226,12 +233,11 @@ TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
     [[maybe_unused]] auto ccreate = &CustomAdapter::create_mesh_workload;
     [[maybe_unused]] auto capply = &CustomAdapter::apply_descriptor;
 
-    // The per-coordinate build path is a separate if-constexpr branch; instantiate it too.
-    [[maybe_unused]] auto pcreate = &SpecAdapter<PerCoordProgramSpecFactory>::create_mesh_workload;
-    using PerCoordCustomAdapter = device_operation::MeshDeviceOperationAdapter<
-        ProgramSpecMinimalOp>::CustomProgramSpecMeshWorkloadFactoryAdapter<PerCoordCustomProgramSpecFactory>;
-    [[maybe_unused]] auto pccreate = &PerCoordCustomAdapter::create_mesh_workload;
-    [[maybe_unused]] auto pcapply = &PerCoordCustomAdapter::apply_descriptor;
+    // The mesh-workload adapter is a separate template; instantiate both its hit-path branches.
+    [[maybe_unused]] auto wcreate = &WorkloadSpecAdapter<MeshWorkloadSpecFactory>::create_mesh_workload;
+    [[maybe_unused]] auto wapply = &WorkloadSpecAdapter<MeshWorkloadSpecFactory>::apply_descriptor;
+    [[maybe_unused]] auto wocreate = &WorkloadSpecAdapter<MeshWorkloadSpecFactoryWithOverride>::create_mesh_workload;
+    [[maybe_unused]] auto woapply = &WorkloadSpecAdapter<MeshWorkloadSpecFactoryWithOverride>::apply_descriptor;
     SUCCEED();
 }
 
@@ -401,29 +407,40 @@ TEST_F(LaunchOperation2x4Test, CachingHeterogeneousDispatch) {
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 2);
 }
 
-// Idle on odd columns, real spec elsewhere, so one create_mesh_workload exercises coordinate
-// enumeration, per-coordinate specs, and the empty-spec skip together.
+// Emits a program only for non-idle coordinates, so one create_mesh_workload covers the range split
+// and the sharing of workload-scoped resources.
 struct PerCoordProdAllFactory {
     using Op = ttnn::prim::ProdAllDeviceOperation;
     static bool is_idle(const ttnn::MeshCoordinate& coord) { return coord[1] % 2 == 1; }
 
-    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+    static ttnn::device_operation::MeshWorkloadArtifacts create_mesh_workload_artifacts(
         const Op::operation_attributes_t& attrs,
         const Op::tensor_args_t& tensor_args,
         Op::tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-        if (mesh_dispatch_coordinate.has_value() && is_idle(*mesh_dispatch_coordinate)) {
-            return {};
+        const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+        ttnn::device_operation::MeshWorkloadArtifacts artifacts;
+        for (const auto& range : tensor_coords.ranges()) {
+            for (const auto& coord : range) {
+                if (is_idle(coord)) {
+                    continue;
+                }
+                auto program =
+                    Op::ProdAllProgramFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+                artifacts.programs.push_back(
+                    {.range = ttnn::MeshCoordinateRange(coord),
+                     .spec = std::move(program.spec),
+                     .run_params = std::move(program.run_params)});
+            }
         }
-        return Op::ProdAllProgramFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+        return artifacts;
     }
 };
 
-TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterPerCoordinateSkipsIdleCoords) {
+TEST_F(LaunchOperation2x4Test, MeshWorkloadSpecAdapterMapsProgramsPerCoordinate) {
     using Op = ttnn::prim::ProdAllDeviceOperation;
     using Adapter =
-        device_operation::MeshDeviceOperationAdapter<Op>::ProgramSpecMeshWorkloadFactoryAdapter<PerCoordProdAllFactory>;
-    static_assert(Adapter::create_program_artifacts_uses_mesh_dispatch_coordinate());
+        device_operation::MeshDeviceOperationAdapter<Op>::MeshWorkloadSpecFactoryAdapter<PerCoordProdAllFactory>;
+    static_assert(ttnn::device_operation::MeshWorkloadSpecFactoryConcept<PerCoordProdAllFactory>);
 
     auto input = make_tensor_with_num_shards(8, mesh_device_.get());
     Op::operation_attributes_t attrs{.output_mem_config = MemoryConfig{}};
@@ -447,6 +464,15 @@ TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterPerCoordinateSkipsIdleCoords) {
     EXPECT_GT(expected, 0u);
     EXPECT_EQ(cached.workload.get_programs().size(), expected);
     EXPECT_EQ(cached.shared_variables.size(), expected);
+
+    // Workload-scoped, not per-device: every range shares one parked resource vector.
+    const auto* first_resources = static_cast<const void*>(nullptr);
+    for (const auto& [range, sv] : cached.shared_variables) {
+        if (first_resources == nullptr) {
+            first_resources = static_cast<const void*>(sv.op_owned_tensors.get());
+        }
+        EXPECT_EQ(static_cast<const void*>(sv.op_owned_tensors.get()), first_resources) << "range " << range;
+    }
 }
 
 TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterProgramsOnUniformTensorCoords) {

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -401,6 +401,54 @@ TEST_F(LaunchOperation2x4Test, CachingHeterogeneousDispatch) {
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 2);
 }
 
+// Idle on odd columns, real spec elsewhere, so one create_mesh_workload exercises coordinate
+// enumeration, per-coordinate specs, and the empty-spec skip together.
+struct PerCoordProdAllFactory {
+    using Op = ttnn::prim::ProdAllDeviceOperation;
+    static bool is_idle(const ttnn::MeshCoordinate& coord) { return coord[1] % 2 == 1; }
+
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const Op::operation_attributes_t& attrs,
+        const Op::tensor_args_t& tensor_args,
+        Op::tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+        if (mesh_dispatch_coordinate.has_value() && is_idle(*mesh_dispatch_coordinate)) {
+            return {};
+        }
+        return Op::ProdAllProgramFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+    }
+};
+
+TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterPerCoordinateSkipsIdleCoords) {
+    using Op = ttnn::prim::ProdAllDeviceOperation;
+    using Adapter =
+        device_operation::MeshDeviceOperationAdapter<Op>::ProgramSpecMeshWorkloadFactoryAdapter<PerCoordProdAllFactory>;
+    static_assert(Adapter::create_program_artifacts_uses_mesh_dispatch_coordinate());
+
+    auto input = make_tensor_with_num_shards(8, mesh_device_.get());
+    Op::operation_attributes_t attrs{.output_mem_config = MemoryConfig{}};
+    Op::tensor_args_t tensor_args{.input = input};
+    auto output = Op::create_output_tensors(attrs, tensor_args);
+
+    ttnn::MeshCoordinateRangeSet tensor_coords;
+    tensor_coords.merge(ttnn::MeshCoordinateRange(mesh_device_->shape()));
+
+    auto cached = Adapter::create_mesh_workload(attrs, tensor_coords, tensor_args, output);
+
+    // One single-coordinate program per non-idle coordinate; idle ones contribute nothing.
+    size_t expected = 0;
+    for (const auto& coord : ttnn::MeshCoordinateRange(mesh_device_->shape())) {
+        const ttnn::MeshCoordinateRange range(coord);
+        const bool idle = PerCoordProdAllFactory::is_idle(coord);
+        EXPECT_EQ(cached.workload.get_programs().contains(range), !idle) << "coord " << coord;
+        EXPECT_EQ(cached.shared_variables.contains(range), !idle) << "coord " << coord;
+        expected += idle ? 0 : 1;
+    }
+    EXPECT_GT(expected, 0u);
+    EXPECT_EQ(cached.workload.get_programs().size(), expected);
+    EXPECT_EQ(cached.shared_variables.size(), expected);
+}
+
 TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterProgramsOnUniformTensorCoords) {
     using Op = ttnn::prim::ProdAllDeviceOperation;
     using Adapter = device_operation::MeshDeviceOperationAdapter<Op>::ProgramSpecMeshWorkloadFactoryAdapter<

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -224,7 +224,7 @@ void enqueue_mesh_workload(
 
 // Dispatches `fn` to `program_factory` through either the `MeshWorkloadFactoryConcept` directly, or through the adapted
 // path for `ProgramFactoryConcept` / `ProgramDescriptorFactoryConcept` / `ProgramSpecFactoryConcept` /
-// `CustomProgramSpecFactoryConcept` factories.
+// `CustomProgramSpecFactoryConcept` / `MeshWorkloadSpecFactoryConcept` factories.
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t, typename ProgramFactory, typename Fn>
 void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, const Fn& fn) {
     std::visit(
@@ -246,6 +246,10 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
             [&]<CustomProgramSpecFactoryConcept T>(const T&) {
                 using AdaptedMeshWorkloadFactory =
                     mesh_device_operation_t::template CustomProgramSpecMeshWorkloadFactoryAdapter<T>;
+                fn.template operator()<AdaptedMeshWorkloadFactory>();
+            },
+            [&]<MeshWorkloadSpecFactoryConcept T>(const T&) {
+                using AdaptedMeshWorkloadFactory = mesh_device_operation_t::template MeshWorkloadSpecFactoryAdapter<T>;
                 fn.template operator()<AdaptedMeshWorkloadFactory>();
             },
             [&]<MeshWorkloadFactoryConcept WorkloadFactory>(const WorkloadFactory&) {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -884,6 +884,14 @@ public:
             };
         }
 
+        // An overload set makes &create_program_artifacts ambiguous, which ProgramSpecFactoryConcept
+        // keys on, so the factory would silently stop matching instead of failing here.
+        static_assert(
+            !(create_program_artifacts_uses_mesh_dispatch_coordinate() &&
+              !requires { &SpecFactory::create_program_artifacts; }),
+            "create_program_artifacts is an overload set. Declare exactly one signature -- take the "
+            "MeshCoordinate as a defaulted parameter if the factory needs both call shapes.");
+
         // Resolve one artifacts' tensor bindings and park its op-owned tensors. Consumes
         // artifacts.op_owned_tensors; a vector move keeps the run_params references valid.
         static shared_variables_t make_shared_variables(
@@ -935,8 +943,12 @@ public:
                 for (const auto& coord : tensor_coords.coords()) {
                     auto artifacts = SpecFactory::create_program_artifacts(
                         attrs, tensor_args, tensor_return_value, std::optional<ttnn::MeshCoordinate>(coord));
-                    // No kernels means no work at this coordinate, as in the ProgramDescriptor path.
-                    if (artifacts.spec.kernels.empty()) {
+                    // No resources at all means no work here, as in the ProgramDescriptor path. A
+                    // partially populated spec falls through to MakeProgramFromSpec, which rejects it.
+                    const auto& spec = artifacts.spec;
+                    if (spec.kernels.empty() && spec.dataflow_buffers.empty() &&
+                        spec.cross_node_dataflow_buffers.empty() && spec.semaphores.empty() &&
+                        spec.scratchpads.empty() && spec.work_units.empty()) {
                         continue;
                     }
                     const ttnn::MeshCoordinateRange range(coord);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -810,6 +810,43 @@ public:
             std::size_t tensor_idx;
         };
 
+        // Shared by both spec adapters: the SPMD one and the per-range MeshWorkload one.
+        struct SpecSharedVariables {
+            std::vector<ResolvedTensorBinding> bindings;
+            // Op-owned tensors produced by the factory, parked here so the (move-only) MeshTensors
+            // outlive the cache miss and every program on the occupied ranges can reference them.
+            // Shared ownership keeps the device allocation alive for the life of the cache entry.
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
+        };
+
+        // Cache-hit tensor refresh, shared so the two adapters' hit paths cannot drift apart.
+        template <typename CachedWorkload>
+        static void refresh_tensor_args(
+            CachedWorkload& cached_workload,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            const auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                const auto& sv = cached_workload.shared_variables.at(coordinate_range);
+
+                // Reproduce the cache-miss enumeration: fresh io tensors, then the
+                // parked op-owned tensors (stable addresses, retrieved from the cache).
+                auto mesh_tensors = io_mesh_tensors;
+                if (sv.op_owned_tensors) {
+                    for (const auto& op_owned_tensor : *sv.op_owned_tensors) {
+                        mesh_tensors.push_back(std::cref(op_owned_tensor));
+                    }
+                }
+
+                tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
+                for (const auto& b : sv.bindings) {
+                    fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
+                }
+                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args, skip_validation);
+            }
+        }
+
         // Metal 2.0's MakeMeshWorkloadFromSpecs needs a MeshDevice; pull it from the first device
         // tensor reachable from tensor_args, falling back to tensor_return_value for output-only
         // ops (e.g. rand) whose tensor_args carry no input tensor.
@@ -880,14 +917,21 @@ public:
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
         using ResolvedTensorBinding = typename SpecBindingSupport::ResolvedTensorBinding;
 
-        struct shared_variables_t {
-            std::vector<ResolvedTensorBinding> bindings;
-            // Op-owned tensors produced by the factory, parked here so the
-            // (move-only) MeshTensors outlive the cache miss and every program
-            // on the occupied ranges can reference them. Shared ownership keeps
-            // the device allocation alive for the life of the cache entry.
-            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
-        };
+        // MeshWorkloadSpecFactoryConcept keys on &T::create_mesh_workload_artifacts, which is
+        // ill-formed for an overload set, so such a factory lands here and is silently replicated.
+        static_assert(
+            !requires(
+                const operation_attributes_t& attrs,
+                const tensor_args_t& tensor_args,
+                tensor_return_value_t& tensor_return_value,
+                const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+                SpecFactory::create_mesh_workload_artifacts(attrs, tensor_args, tensor_return_value, tensor_coords);
+            },
+            "This factory is callable as create_mesh_workload_artifacts but did not match "
+            "MeshWorkloadSpecFactoryConcept, so its per-coordinate programs would be silently replaced by one "
+            "spec replicated across the mesh. Declare exactly one create_mesh_workload_artifacts signature.");
+
+        using shared_variables_t = typename SpecBindingSupport::SpecSharedVariables;
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
         // Resolve one artifacts' tensor bindings and park its op-owned tensors. Consumes
@@ -952,26 +996,7 @@ public:
             const operation_attributes_t& /*attrs*/,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
-            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
-            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                const auto& sv = cached_workload.shared_variables.at(coordinate_range);
-
-                // Reproduce the cache-miss enumeration: fresh io tensors, then the
-                // parked op-owned tensors (stable addresses, retrieved from the cache).
-                auto mesh_tensors = io_mesh_tensors;
-                if (sv.op_owned_tensors) {
-                    for (const auto& op_owned_tensor : *sv.op_owned_tensors) {
-                        mesh_tensors.push_back(std::cref(op_owned_tensor));
-                    }
-                }
-
-                tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
-                for (const auto& b : sv.bindings) {
-                    fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
-                }
-                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args, skip_validation);
-            }
+            SpecBindingSupport::refresh_tensor_args(cached_workload, tensor_args, tensor_return_value);
         }
     };
 
@@ -979,7 +1004,7 @@ public:
     // cache-hit path calls the factory's override_runtime_arguments and applies the returned
     // ProgramRunArgs via UpdateProgramRunArgs instead of the base's tensor-only UpdateTensorArgs.
     // The miss path applies create_program_artifacts' run args, not the override, so per-coordinate
-    // run args must come from a per-coordinate create_program_artifacts.
+    // run args must come from a MeshWorkloadSpecFactoryConcept factory's create_mesh_workload_artifacts.
     template <CustomProgramSpecFactoryConcept CustomSpecFactory>
     struct CustomProgramSpecMeshWorkloadFactoryAdapter : ProgramSpecMeshWorkloadFactoryAdapter<CustomSpecFactory> {
         using Base = ProgramSpecMeshWorkloadFactoryAdapter<CustomSpecFactory>;
@@ -1020,11 +1045,7 @@ public:
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
         using ResolvedTensorBinding = typename SpecBindingSupport::ResolvedTensorBinding;
 
-        struct shared_variables_t {
-            std::vector<ResolvedTensorBinding> bindings;
-            // Workload-scoped, shared by every range: see MeshWorkloadArtifacts.
-            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
-        };
+        using shared_variables_t = typename SpecBindingSupport::SpecSharedVariables;
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
         static consteval bool has_override_runtime_arguments() {
@@ -1036,6 +1057,12 @@ public:
                 WorkloadSpecFactory::override_runtime_arguments(attrs, tensor_args, tensor_return_value, coord);
             };
         }
+
+        // Otherwise a near-miss signature leaves run args stale on every hit with nothing to say why.
+        static_assert(
+            !detail::HasSpecRuntimeArgsOverride<WorkloadSpecFactory> || has_override_runtime_arguments(),
+            "override_runtime_arguments must take (operation_attributes_t, tensor_args_t, tensor_return_value_t, "
+            "const std::optional<MeshCoordinate>&) to be called on the cache-hit path.");
 
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
@@ -1061,13 +1088,29 @@ public:
             std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramRunArgs> run_params;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (auto& per_coord : artifacts.programs) {
+                // Metal catches overlapping ranges but never sees an exact duplicate, and it only
+                // checks the mesh extent, so equality and tensor_coords containment land here.
+                for (const auto& coord : per_coord.range) {
+                    const bool covered = std::any_of(
+                        tensor_coords.ranges().begin(),
+                        tensor_coords.ranges().end(),
+                        [&coord](const auto& tensor_range) { return tensor_range.contains(coord); });
+                    TT_FATAL(
+                        covered,
+                        "create_mesh_workload_artifacts returned range {} covering {}, which is outside tensor_coords "
+                        "{}: that program would bind tensors the device holds no shard of",
+                        per_coord.range,
+                        coord,
+                        tensor_coords);
+                }
+                const auto [_, inserted] = program_specs.emplace(per_coord.range, std::move(per_coord.spec));
+                TT_FATAL(inserted, "create_mesh_workload_artifacts returned range {} twice", per_coord.range);
                 shared_variables.emplace(
                     per_coord.range,
                     shared_variables_t{
                         .bindings =
                             SpecBindingSupport::resolve_bindings(per_coord.run_params.tensor_args, mesh_tensors),
                         .op_owned_tensors = op_owned_tensors});
-                program_specs.emplace(per_coord.range, std::move(per_coord.spec));
                 run_params.emplace(per_coord.range, std::move(per_coord.run_params));
             }
 
@@ -1083,8 +1126,8 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
             if constexpr (has_override_runtime_arguments()) {
+                const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
                 for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                     auto run_args = WorkloadSpecFactory::override_runtime_arguments(
                         attrs,
@@ -1094,21 +1137,7 @@ public:
                     tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args, skip_validation);
                 }
             } else {
-                const auto io_mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
-                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                    const auto& sv = cached_workload.shared_variables.at(coordinate_range);
-                    auto mesh_tensors = io_mesh_tensors;
-                    if (sv.op_owned_tensors) {
-                        for (const auto& op_owned_tensor : *sv.op_owned_tensors) {
-                            mesh_tensors.push_back(std::cref(op_owned_tensor));
-                        }
-                    }
-                    tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
-                    for (const auto& b : sv.bindings) {
-                        fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
-                    }
-                    tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args, skip_validation);
-                }
+                SpecBindingSupport::refresh_tensor_args(cached_workload, tensor_args, tensor_return_value);
             }
         }
     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -1037,7 +1037,8 @@ public:
     // Resources are parked once and shared by every range's shared_variables.
     //
     // On cache hit the adapter refreshes tensor bindings per range, or calls the factory's
-    // override_runtime_arguments(attrs, args, ret, coord) if it declares one.
+    // override_runtime_arguments(attrs, args, ret, range) if it declares one. The range is passed
+    // whole: one Program backs it, so the run args it returns apply to every device in it.
     // -----------------------------------------------------------------------
     template <MeshWorkloadSpecFactoryConcept WorkloadSpecFactory>
     struct MeshWorkloadSpecFactoryAdapter : SpecBindingSupport {
@@ -1053,8 +1054,8 @@ public:
                 const operation_attributes_t& attrs,
                 const tensor_args_t& tensor_args,
                 tensor_return_value_t& tensor_return_value,
-                const std::optional<ttnn::MeshCoordinate>& coord) {
-                WorkloadSpecFactory::override_runtime_arguments(attrs, tensor_args, tensor_return_value, coord);
+                const ttnn::MeshCoordinateRange& range) {
+                WorkloadSpecFactory::override_runtime_arguments(attrs, tensor_args, tensor_return_value, range);
             };
         }
 
@@ -1062,7 +1063,8 @@ public:
         static_assert(
             !detail::HasSpecRuntimeArgsOverride<WorkloadSpecFactory> || has_override_runtime_arguments(),
             "override_runtime_arguments must take (operation_attributes_t, tensor_args_t, tensor_return_value_t, "
-            "const std::optional<MeshCoordinate>&) to be called on the cache-hit path.");
+            "const MeshCoordinateRange&) to be called on the cache-hit path. It is called once per range, "
+            "not once per device.");
 
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
@@ -1130,10 +1132,7 @@ public:
                 const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
                 for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                     auto run_args = WorkloadSpecFactory::override_runtime_arguments(
-                        attrs,
-                        tensor_args,
-                        tensor_return_value,
-                        std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                        attrs, tensor_args, tensor_return_value, coordinate_range);
                     tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args, skip_validation);
                 }
             } else {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -774,9 +774,8 @@ public:
     // ProgramSpec + ProgramRunArgs + any op-owned tensors). The adapter maps
     // that same ProgramSpec onto every range in tensor_coords via
     // experimental::MakeMeshWorkloadFromSpecs (occupancy = mesh devices that
-    // hold a tensor shard). A factory taking the per-coord MeshCoordinate is
-    // instead called once per coordinate, each call free to return its own spec
-    // and run args (MPMD, or SPMD with per-device run args).
+    // hold a tensor shard). A factory whose programs vary across the mesh is a
+    // MeshWorkloadSpecFactoryConcept instead.
     //
     // On cache miss: the adapter calls create_program_artifacts once, builds a
     // MeshWorkload via MakeMeshWorkloadFromSpecs, resolves each TensorArgument
@@ -796,37 +795,44 @@ public:
     // Contract: every TensorArgument returned by the factory must reference a
     // MeshTensor reachable from tensor_args / tensor_return_value, or one of the
     // MeshTensors the factory placed in ProgramArtifacts::op_owned_tensors.
-    // -----------------------------------------------------------------------
-    template <typename SpecFactory>
-    struct ProgramSpecMeshWorkloadFactoryAdapter {
+    // Binding machinery shared by every spec-path adapter: it depends only on the op's tensor
+    // types, not on which factory concept produced the artifacts.
+    struct SpecBindingSupport {
         using TensorParamName = tt::tt_metal::experimental::TensorParamName;
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
 
-        // Stored across cache entries: for each TensorArgument in a program's
-        // ProgramRunArgs, which tensor (by index into the deterministic
-        // enumeration of io tensors followed by op-owned tensors) it was bound
-        // to. Pointer identity is only valid within a single call; the index is
-        // stable across calls.
+        // Stored across cache entries: for each TensorArgument in a program's ProgramRunArgs, which
+        // tensor (by index into the deterministic enumeration of io tensors followed by op-owned
+        // tensors) it was bound to. Pointer identity is only valid within a single call; the index
+        // is stable across calls.
         struct ResolvedTensorBinding {
             TensorParamName tensor_parameter_name;
             std::size_t tensor_idx;
         };
 
-        struct shared_variables_t {
-            std::vector<ResolvedTensorBinding> bindings;
-            // Op-owned tensors produced by the factory, parked here so the
-            // (move-only) MeshTensors outlive the cache miss and every program
-            // on the occupied ranges can reference them. Shared ownership keeps
-            // the device allocation alive for the life of the cache entry.
-            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
-        };
-        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+        // Metal 2.0's MakeMeshWorkloadFromSpecs needs a MeshDevice; pull it from the first device
+        // tensor reachable from tensor_args, falling back to tensor_return_value for output-only
+        // ops (e.g. rand) whose tensor_args carry no input tensor.
+        static tt::tt_metal::distributed::MeshDevice* source_mesh_device(
+            const tensor_args_t& tensor_args, const tensor_return_value_t& tensor_return_value) {
+            auto first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_args);
+            if (!first_tensor.has_value()) {
+                first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_return_value);
+            }
+            TT_FATAL(
+                first_tensor.has_value(),
+                "ProgramSpec factory adapter requires at least one Tensor in tensor_args or "
+                "tensor_return_value to source the MeshDevice");
+            auto* mesh_device = first_tensor.value().device();
+            TT_FATAL(
+                mesh_device != nullptr,
+                "The sourced tensor (from tensor_args or tensor_return_value) must be allocated on a MeshDevice");
+            return mesh_device;
+        }
 
-        // Walk tensor_args and tensor_return_value via reflection, collecting
-        // the MeshTensor of every Tensor leaf. The walk order is deterministic
-        // (reflection-driven, stable across calls), so the resulting indices
-        // are stable across calls. Metal 2.0 analog of the descriptor adapter's
-        // collect_tensor_buffers, at the MeshTensor level instead of Buffer*.
+        // Walk tensor_args and tensor_return_value via reflection, collecting the MeshTensor of
+        // every Tensor leaf. The walk order is deterministic (reflection-driven, stable across
+        // calls), so the resulting indices are stable across calls.
         static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_mesh_tensors(
             const tensor_args_t& tensor_args, const tensor_return_value_t& tensor_return_value) {
             std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> result;
@@ -836,18 +842,14 @@ public:
             return result;
         }
 
-        // Match each TensorArgument's MeshTensor reference back to its index in the
-        // combined enumeration (io tensors followed by op-owned tensors).
-        // Cache-miss path only. TT_FATALs on a TensorArgument that references
-        // neither an io tensor nor a factory op-owned tensor.
+        // Match each TensorArgument's MeshTensor reference back to its index in the combined
+        // enumeration (io tensors followed by op-owned tensors). Cache-miss path only.
         //
-        // NOTE on host perf: the index-based binding scheme is what makes a
-        // fast cache-hit path possible, but the current straightforward
-        // implementation isn't there yet — the enumeration returns a heap
-        // std::vector, and apply_descriptor builds a fresh TensorArgument
-        // table each dispatch. Both costs are fixable by mirroring the
-        // descriptor adapter's compile-time-unrolled walker + SmallVector +
-        // cached TensorArgument storage pattern. Deferred pending profiling.
+        // NOTE on host perf: the index-based binding scheme is what makes a fast cache-hit path
+        // possible, but the current straightforward implementation isn't there yet -- the
+        // enumeration returns a heap std::vector, and apply_descriptor builds a fresh
+        // TensorArgument table each dispatch. Both costs are fixable by mirroring the descriptor
+        // adapter's compile-time-unrolled walker + SmallVector + cached storage pattern.
         static std::vector<ResolvedTensorBinding> resolve_bindings(
             const tt::tt_metal::experimental::Table<TensorParamName, TensorArgument>& factory_tensor_args,
             const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& mesh_tensors) {
@@ -869,28 +871,24 @@ public:
             }
             return bindings;
         }
+    };
 
-        // Whether create_program_artifacts wants the per-coord MeshCoordinate — spec-path
-        // counterpart of create_descriptor_uses_mesh_dispatch_coordinate(). Declare exactly one
-        // signature: an overload set makes &T::create_program_artifacts ambiguous.
-        static consteval bool create_program_artifacts_uses_mesh_dispatch_coordinate() {
-            return requires(
-                const operation_attributes_t& attrs,
-                const tensor_args_t& tensor_args,
-                tensor_return_value_t& tensor_return_value,
-                const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-                SpecFactory::create_program_artifacts(
-                    attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
-            };
-        }
+    // -----------------------------------------------------------------------
+    template <typename SpecFactory>
+    struct ProgramSpecMeshWorkloadFactoryAdapter : SpecBindingSupport {
+        using TensorParamName = tt::tt_metal::experimental::TensorParamName;
+        using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
+        using ResolvedTensorBinding = typename SpecBindingSupport::ResolvedTensorBinding;
 
-        // An overload set makes &create_program_artifacts ambiguous, which ProgramSpecFactoryConcept
-        // keys on, so the factory would silently stop matching instead of failing here.
-        static_assert(
-            !(create_program_artifacts_uses_mesh_dispatch_coordinate() &&
-              !requires { &SpecFactory::create_program_artifacts; }),
-            "create_program_artifacts is an overload set. Declare exactly one signature -- take the "
-            "MeshCoordinate as a defaulted parameter if the factory needs both call shapes.");
+        struct shared_variables_t {
+            std::vector<ResolvedTensorBinding> bindings;
+            // Op-owned tensors produced by the factory, parked here so the
+            // (move-only) MeshTensors outlive the cache miss and every program
+            // on the occupied ranges can reference them. Shared ownership keeps
+            // the device allocation alive for the life of the cache entry.
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
+        };
+        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
         // Resolve one artifacts' tensor bindings and park its op-owned tensors. Consumes
         // artifacts.op_owned_tensors; a vector move keeps the run_params references valid.
@@ -902,7 +900,7 @@ public:
                 mesh_tensors.push_back(std::cref(op_owned_tensor));
             }
             return shared_variables_t{
-                .bindings = resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors),
+                .bindings = SpecBindingSupport::resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors),
                 .op_owned_tensors =
                     std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors))};
         }
@@ -912,26 +910,12 @@ public:
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            // Metal 2.0's MakeMeshWorkloadFromSpecs needs a MeshDevice; pull from the first
-            // device tensor reachable from tensor_args, falling back to tensor_return_value
-            // for output-only ops (e.g. rand) whose tensor_args carry no input tensor.
-            auto first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_args);
-            if (!first_tensor.has_value()) {
-                first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_return_value);
-            }
-            TT_FATAL(
-                first_tensor.has_value(),
-                "ProgramSpec factory adapter requires at least one Tensor in tensor_args or "
-                "tensor_return_value to source the MeshDevice");
-            auto* mesh_device = first_tensor.value().device();
-            TT_FATAL(
-                mesh_device != nullptr,
-                "The sourced tensor (from tensor_args or tensor_return_value) must be allocated on a MeshDevice");
+            auto* mesh_device = SpecBindingSupport::source_mesh_device(tensor_args, tensor_return_value);
 
             // Enumerate io tensors (inputs + outputs); each artifacts appends its own
             // op-owned tensors. resolve_bindings maps each TensorArgument to an index in
             // this combined order, which the cache-hit path reproduces.
-            const auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            const auto io_mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
 
             // What each occupied range runs, plus the TTNN cache state (bindings and parked
             // op-owned tensors) the cache-hit path needs — held independently of the MeshWorkload.
@@ -939,33 +923,14 @@ public:
             std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramRunArgs> run_params;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
-            if constexpr (create_program_artifacts_uses_mesh_dispatch_coordinate()) {
-                for (const auto& coord : tensor_coords.coords()) {
-                    auto artifacts = SpecFactory::create_program_artifacts(
-                        attrs, tensor_args, tensor_return_value, std::optional<ttnn::MeshCoordinate>(coord));
-                    // No resources at all means no work here, as in the ProgramDescriptor path. A
-                    // partially populated spec falls through to MakeProgramFromSpec, which rejects it.
-                    const auto& spec = artifacts.spec;
-                    if (spec.kernels.empty() && spec.dataflow_buffers.empty() &&
-                        spec.cross_node_dataflow_buffers.empty() && spec.semaphores.empty() &&
-                        spec.scratchpads.empty() && spec.work_units.empty()) {
-                        continue;
-                    }
-                    const ttnn::MeshCoordinateRange range(coord);
-                    shared_variables.emplace(range, make_shared_variables(artifacts, io_mesh_tensors));
-                    program_specs.emplace(range, std::move(artifacts.spec));
-                    run_params.emplace(range, std::move(artifacts.run_params));
-                }
-            } else {
-                // One ProgramArtifacts mapped onto every occupied range; bindings and op-owned
-                // tensors are identical for every program built from it.
-                auto artifacts = SpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
-                auto sv = make_shared_variables(artifacts, io_mesh_tensors);
-                for (const auto& range : tensor_coords.ranges()) {
-                    shared_variables.emplace(range, sv);
-                    program_specs.emplace(range, artifacts.spec);
-                    run_params.emplace(range, artifacts.run_params);
-                }
+            // One ProgramArtifacts mapped onto every occupied range; bindings and op-owned tensors
+            // are identical for every program built from it.
+            auto artifacts = SpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+            auto sv = make_shared_variables(artifacts, io_mesh_tensors);
+            for (const auto& range : tensor_coords.ranges()) {
+                shared_variables.emplace(range, sv);
+                program_specs.emplace(range, artifacts.spec);
+                run_params.emplace(range, artifacts.run_params);
             }
 
             // Cache miss is the cold path: always validate here, so every cached program was
@@ -987,7 +952,7 @@ public:
             const operation_attributes_t& /*attrs*/,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            auto io_mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
             const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 const auto& sv = cached_workload.shared_variables.at(coordinate_range);
@@ -1033,6 +998,117 @@ public:
                     tensor_return_value,
                     std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
                 tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args, skip_validation);
+            }
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // MeshWorkloadSpecFactoryAdapter
+    //
+    // Adapts a MeshWorkloadSpecFactoryConcept factory: one create_mesh_workload_artifacts call
+    // returns the workload-scoped resources plus a ProgramSpec and ProgramRunArgs per coordinate
+    // range, which the adapter realises into a MeshWorkload via MakeMeshWorkloadFromSpecs.
+    //
+    // Resources are parked once and shared by every range's shared_variables.
+    //
+    // On cache hit the adapter refreshes tensor bindings per range, or calls the factory's
+    // override_runtime_arguments(attrs, args, ret, coord) if it declares one.
+    // -----------------------------------------------------------------------
+    template <MeshWorkloadSpecFactoryConcept WorkloadSpecFactory>
+    struct MeshWorkloadSpecFactoryAdapter : SpecBindingSupport {
+        using TensorParamName = tt::tt_metal::experimental::TensorParamName;
+        using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
+        using ResolvedTensorBinding = typename SpecBindingSupport::ResolvedTensorBinding;
+
+        struct shared_variables_t {
+            std::vector<ResolvedTensorBinding> bindings;
+            // Workload-scoped, shared by every range: see MeshWorkloadArtifacts.
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
+        };
+        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        static consteval bool has_override_runtime_arguments() {
+            return requires(
+                const operation_attributes_t& attrs,
+                const tensor_args_t& tensor_args,
+                tensor_return_value_t& tensor_return_value,
+                const std::optional<ttnn::MeshCoordinate>& coord) {
+                WorkloadSpecFactory::override_runtime_arguments(attrs, tensor_args, tensor_return_value, coord);
+            };
+        }
+
+        static auto create_mesh_workload(
+            const operation_attributes_t& attrs,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            auto* mesh_device = SpecBindingSupport::source_mesh_device(tensor_args, tensor_return_value);
+
+            auto artifacts = WorkloadSpecFactory::create_mesh_workload_artifacts(
+                attrs, tensor_args, tensor_return_value, tensor_coords);
+            TT_FATAL(!artifacts.programs.empty(), "create_mesh_workload_artifacts returned no programs");
+
+            // Park the workload-scoped resources first: run_params may reference the owned tensors,
+            // and a vector move preserves element addresses.
+            auto op_owned_tensors =
+                std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
+            auto mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
+            for (const auto& op_owned_tensor : *op_owned_tensors) {
+                mesh_tensors.push_back(std::cref(op_owned_tensor));
+            }
+
+            std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramSpec> program_specs;
+            std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramRunArgs> run_params;
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+            for (auto& per_coord : artifacts.programs) {
+                shared_variables.emplace(
+                    per_coord.range,
+                    shared_variables_t{
+                        .bindings =
+                            SpecBindingSupport::resolve_bindings(per_coord.run_params.tensor_args, mesh_tensors),
+                        .op_owned_tensors = op_owned_tensors});
+                program_specs.emplace(per_coord.range, std::move(per_coord.spec));
+                run_params.emplace(per_coord.range, std::move(per_coord.run_params));
+            }
+
+            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
+            for (auto& [range, program] : mesh_workload.get_programs()) {
+                tt::tt_metal::experimental::SetProgramRunArgs(program, run_params.at(range));
+            }
+            return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+        }
+
+        static void apply_descriptor(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
+            if constexpr (has_override_runtime_arguments()) {
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    auto run_args = WorkloadSpecFactory::override_runtime_arguments(
+                        attrs,
+                        tensor_args,
+                        tensor_return_value,
+                        std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args, skip_validation);
+                }
+            } else {
+                const auto io_mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    const auto& sv = cached_workload.shared_variables.at(coordinate_range);
+                    auto mesh_tensors = io_mesh_tensors;
+                    if (sv.op_owned_tensors) {
+                        for (const auto& op_owned_tensor : *sv.op_owned_tensors) {
+                            mesh_tensors.push_back(std::cref(op_owned_tensor));
+                        }
+                    }
+                    tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
+                    for (const auto& b : sv.bindings) {
+                        fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
+                    }
+                    tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args, skip_validation);
+                }
             }
         }
     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -1077,14 +1077,7 @@ public:
                 attrs, tensor_args, tensor_return_value, tensor_coords);
             TT_FATAL(!artifacts.programs.empty(), "create_mesh_workload_artifacts returned no programs");
 
-            // Park the workload-scoped resources first: run_params may reference the owned tensors,
-            // and a vector move preserves element addresses.
-            auto op_owned_tensors =
-                std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
-            auto mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
-            for (const auto& op_owned_tensor : *op_owned_tensors) {
-                mesh_tensors.push_back(std::cref(op_owned_tensor));
-            }
+            const auto mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
 
             std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramSpec> program_specs;
             std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramRunArgs> run_params;
@@ -1111,8 +1104,7 @@ public:
                     per_coord.range,
                     shared_variables_t{
                         .bindings =
-                            SpecBindingSupport::resolve_bindings(per_coord.run_params.tensor_args, mesh_tensors),
-                        .op_owned_tensors = op_owned_tensors});
+                            SpecBindingSupport::resolve_bindings(per_coord.run_params.tensor_args, mesh_tensors)});
                 run_params.emplace(per_coord.range, std::move(per_coord.run_params));
             }
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -774,7 +774,9 @@ public:
     // ProgramSpec + ProgramRunArgs + any op-owned tensors). The adapter maps
     // that same ProgramSpec onto every range in tensor_coords via
     // experimental::MakeMeshWorkloadFromSpecs (occupancy = mesh devices that
-    // hold a tensor shard).
+    // hold a tensor shard). A factory taking the per-coord MeshCoordinate is
+    // instead called once per coordinate, each call free to return its own spec
+    // and run args (MPMD, or SPMD with per-device run args).
     //
     // On cache miss: the adapter calls create_program_artifacts once, builds a
     // MeshWorkload via MakeMeshWorkloadFromSpecs, resolves each TensorArgument
@@ -794,8 +796,6 @@ public:
     // Contract: every TensorArgument returned by the factory must reference a
     // MeshTensor reachable from tensor_args / tensor_return_value, or one of the
     // MeshTensors the factory placed in ProgramArtifacts::op_owned_tensors.
-    //
-    // TODO: consider replacing with a general MeshWorkloadSpecFactoryAdapter?
     // -----------------------------------------------------------------------
     template <typename SpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
@@ -870,6 +870,35 @@ public:
             return bindings;
         }
 
+        // Whether create_program_artifacts wants the per-coord MeshCoordinate — spec-path
+        // counterpart of create_descriptor_uses_mesh_dispatch_coordinate(). Declare exactly one
+        // signature: an overload set makes &T::create_program_artifacts ambiguous.
+        static consteval bool create_program_artifacts_uses_mesh_dispatch_coordinate() {
+            return requires(
+                const operation_attributes_t& attrs,
+                const tensor_args_t& tensor_args,
+                tensor_return_value_t& tensor_return_value,
+                const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+                SpecFactory::create_program_artifacts(
+                    attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+            };
+        }
+
+        // Resolve one artifacts' tensor bindings and park its op-owned tensors. Consumes
+        // artifacts.op_owned_tensors; a vector move keeps the run_params references valid.
+        static shared_variables_t make_shared_variables(
+            ProgramArtifacts& artifacts,
+            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& io_mesh_tensors) {
+            auto mesh_tensors = io_mesh_tensors;
+            for (const auto& op_owned_tensor : artifacts.op_owned_tensors) {
+                mesh_tensors.push_back(std::cref(op_owned_tensor));
+            }
+            return shared_variables_t{
+                .bindings = resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors),
+                .op_owned_tensors =
+                    std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors))};
+        }
+
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
@@ -891,49 +920,47 @@ public:
                 mesh_device != nullptr,
                 "The sourced tensor (from tensor_args or tensor_return_value) must be allocated on a MeshDevice");
 
-            // The factory produces a single ProgramArtifacts; the adapter maps that same
-            // ProgramSpec onto every range in tensor_coords (occupancy). Bindings derive
-            // from the (single) set of factory tensor_args and are identical for every
-            // stamped program; copy per range into the cached shared state.
-            auto artifacts = SpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+            // Enumerate io tensors (inputs + outputs); each artifacts appends its own
+            // op-owned tensors. resolve_bindings maps each TensorArgument to an index in
+            // this combined order, which the cache-hit path reproduces.
+            const auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
 
-            // Enumerate io tensors (inputs + outputs), then append the factory's
-            // op-owned tensors. resolve_bindings maps each TensorArgument to an
-            // index in this combined order, which the cache-hit path reproduces.
-            auto mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-            for (const auto& op_owned_tensor : artifacts.op_owned_tensors) {
-                mesh_tensors.push_back(std::cref(op_owned_tensor));
-            }
-            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors);
-
-            // Park op-owned tensors in a shared vector so the move-only MeshTensors
-            // outlive this call and every program on the occupied ranges can reference them.
-            // (A vector move preserves element addresses, so the references held by
-            // artifacts.run_params stay valid for the SetProgramRunArgs calls below.)
-            auto op_owned_tensors =
-                std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
-
-            // Map the factory's ProgramSpec onto every occupied range and materialize
-            // the MeshWorkload. Cache miss is the cold path: always validate here, so
-            // every cached program was built from a checked spec. validate_program_args
-            // only gates the hit-path re-checks.
+            // What each occupied range runs, plus the TTNN cache state (bindings and parked
+            // op-owned tensors) the cache-hit path needs — held independently of the MeshWorkload.
             std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramSpec> program_specs;
-            for (const auto& range : tensor_coords.ranges()) {
-                program_specs.emplace(range, artifacts.spec);
-            }
-            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
-
-            // Apply the factory's initial ProgramRunArgs to each MeshWorkload program.
-            for (auto& [range, program] : mesh_workload.get_programs()) {
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-            }
-
-            // shared_variables is TTNN cache state, independent of the MeshWorkload:
-            // per-range bindings and parked op-owned tensors for the cache-hit path.
+            std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramRunArgs> run_params;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-            for (const auto& range : tensor_coords.ranges()) {
-                shared_variables.emplace(
-                    range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
+
+            if constexpr (create_program_artifacts_uses_mesh_dispatch_coordinate()) {
+                for (const auto& coord : tensor_coords.coords()) {
+                    auto artifacts = SpecFactory::create_program_artifacts(
+                        attrs, tensor_args, tensor_return_value, std::optional<ttnn::MeshCoordinate>(coord));
+                    // No kernels means no work at this coordinate, as in the ProgramDescriptor path.
+                    if (artifacts.spec.kernels.empty()) {
+                        continue;
+                    }
+                    const ttnn::MeshCoordinateRange range(coord);
+                    shared_variables.emplace(range, make_shared_variables(artifacts, io_mesh_tensors));
+                    program_specs.emplace(range, std::move(artifacts.spec));
+                    run_params.emplace(range, std::move(artifacts.run_params));
+                }
+            } else {
+                // One ProgramArtifacts mapped onto every occupied range; bindings and op-owned
+                // tensors are identical for every program built from it.
+                auto artifacts = SpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+                auto sv = make_shared_variables(artifacts, io_mesh_tensors);
+                for (const auto& range : tensor_coords.ranges()) {
+                    shared_variables.emplace(range, sv);
+                    program_specs.emplace(range, artifacts.spec);
+                    run_params.emplace(range, artifacts.run_params);
+                }
+            }
+
+            // Cache miss is the cold path: always validate here, so every cached program was
+            // built from a checked spec. validate_program_args only gates the hit-path re-checks.
+            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
+            for (auto& [range, program] : mesh_workload.get_programs()) {
+                tt::tt_metal::experimental::SetProgramRunArgs(program, run_params.at(range));
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
         }
@@ -974,6 +1001,8 @@ public:
     // Like ProgramSpecMeshWorkloadFactoryAdapter (cache-miss build inherited unchanged), but the
     // cache-hit path calls the factory's override_runtime_arguments and applies the returned
     // ProgramRunArgs via UpdateProgramRunArgs instead of the base's tensor-only UpdateTensorArgs.
+    // The miss path applies create_program_artifacts' run args, not the override, so per-coordinate
+    // run args must come from a per-coordinate create_program_artifacts.
     template <CustomProgramSpecFactoryConcept CustomSpecFactory>
     struct CustomProgramSpecMeshWorkloadFactoryAdapter : ProgramSpecMeshWorkloadFactoryAdapter<CustomSpecFactory> {
         using Base = ProgramSpecMeshWorkloadFactoryAdapter<CustomSpecFactory>;

--- a/ttnn/api/ttnn/metal_v2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal_v2_artifacts.hpp
@@ -19,8 +19,8 @@ namespace ttnn::device_operation {
 // create_program_artifacts method; the framework adapter maps that same spec
 // onto tensor_coords via experimental::MakeMeshWorkloadFromSpecs.
 //
-// A future MeshWorkloadSpecFactoryConcept will return a different (multi-program)
-// artifact type for ops whose programs vary across the mesh.
+// Ops whose programs vary across the mesh return one of these per coordinate, from
+// the create_program_artifacts overload taking a MeshCoordinate.
 struct ProgramArtifacts {
     tt::tt_metal::experimental::ProgramSpec spec;
     tt::tt_metal::experimental::ProgramRunArgs run_params;

--- a/ttnn/api/ttnn/metal_v2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal_v2_artifacts.hpp
@@ -39,10 +39,8 @@ struct ProgramArtifacts {
 // factory allocates, plus the per-coordinate programs that reference them. Splits the same way
 // tt::tt_metal::WorkloadDescriptor does, for the same reasons.
 struct MeshWorkloadArtifacts {
-    // Parked for the cache entry's lifetime, so the allocation outlives the miss at a stable address.
-    std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
-
     // Semaphores for cross-device sync belong here once Metal 2.0 has its own semaphore object.
+    // No op-owned tensors: a MeshTensor spans the mesh, so op-allocated scratch stays SPMD-only.
 
     // Range-keyed: a program uniform over part of the mesh is one entry covering that range.
     struct PerCoordProgram {

--- a/ttnn/api/ttnn/metal_v2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal_v2_artifacts.hpp
@@ -10,6 +10,8 @@
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 
+#include "ttnn/distributed/types.hpp"
+
 namespace ttnn::device_operation {
 
 // Build product of a Metal 2.0 op-porting stepping-stone factory: the immutable
@@ -19,8 +21,8 @@ namespace ttnn::device_operation {
 // create_program_artifacts method; the framework adapter maps that same spec
 // onto tensor_coords via experimental::MakeMeshWorkloadFromSpecs.
 //
-// Ops whose programs vary across the mesh return one of these per coordinate, from
-// the create_program_artifacts overload taking a MeshCoordinate.
+// This artifact is SPMD-shaped: one program, replicated. Ops whose programs vary
+// across the mesh return MeshWorkloadArtifacts instead.
 struct ProgramArtifacts {
     tt::tt_metal::experimental::ProgramSpec spec;
     tt::tt_metal::experimental::ProgramRunArgs run_params;
@@ -31,6 +33,24 @@ struct ProgramArtifacts {
     // address across dispatches. Any TensorArgument in `run_params` may reference
     // one of these (by reference) in addition to the op's io tensors.
     std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
+};
+
+// Build product of a MeshWorkloadSpecFactoryConcept factory: the workload-scoped resources the
+// factory allocates, plus the per-coordinate programs that reference them. Splits the same way
+// tt::tt_metal::WorkloadDescriptor does, for the same reasons.
+struct MeshWorkloadArtifacts {
+    // Parked for the cache entry's lifetime, so the allocation outlives the miss at a stable address.
+    std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
+
+    // Semaphores for cross-device sync belong here once Metal 2.0 has its own semaphore object.
+
+    // Range-keyed: a program uniform over part of the mesh is one entry covering that range.
+    struct PerCoordProgram {
+        ttnn::MeshCoordinateRange range;
+        tt::tt_metal::experimental::ProgramSpec spec;
+        tt::tt_metal::experimental::ProgramRunArgs run_params;
+    };
+    std::vector<PerCoordProgram> programs;
 };
 
 }  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -115,7 +115,9 @@ concept HasSpecRuntimeArgsOverride = requires {
 };
 }  // namespace detail
 
-// Base spec factory: cache hit refreshes only tensor bindings.
+// Base spec factory: cache hit refreshes only tensor bindings. create_program_artifacts takes
+// (attrs, tensor_args, tensor_return_value), optionally + a MeshCoordinate to vary per device;
+// declare exactly one of the two, since an overload set defeats the check below.
 template <typename T>
 concept ProgramSpecFactoryConcept =
     requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> &&

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -120,6 +120,12 @@ concept HasSpecRuntimeArgsOverride = requires {
 //   static MeshWorkloadArtifacts create_mesh_workload_artifacts(
 //       const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&,
 //       const ttnn::MeshCoordinateRangeSet& tensor_coords);
+// Optionally, to refresh run args on a cache hit:
+//   static ProgramRunArgs override_runtime_arguments(
+//       const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&,
+//       const ttnn::MeshCoordinateRange& range);
+// One Program backs a whole range, so the override is called once per range and takes the range
+// rather than a coordinate: what it returns applies to every device the range covers.
 template <typename T>
 concept MeshWorkloadSpecFactoryConcept = requires {
     &T::create_mesh_workload_artifacts;

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -115,13 +115,23 @@ concept HasSpecRuntimeArgsOverride = requires {
 };
 }  // namespace detail
 
-// Base spec factory: cache hit refreshes only tensor bindings. create_program_artifacts takes
-// (attrs, tensor_args, tensor_return_value), optionally + a MeshCoordinate to vary per device;
-// declare exactly one of the two, since an overload set defeats the check below.
+// A factory whose programs vary across the mesh: one call returns the workload-scoped resources
+// plus a ProgramSpec and ProgramRunArgs per coordinate range.
+//   static MeshWorkloadArtifacts create_mesh_workload_artifacts(
+//       const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&,
+//       const ttnn::MeshCoordinateRangeSet& tensor_coords);
+template <typename T>
+concept MeshWorkloadSpecFactoryConcept = requires {
+    &T::create_mesh_workload_artifacts;
+} && !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+
+// Base spec factory: cache hit refreshes only tensor bindings. SPMD-shaped -- one ProgramSpec,
+// replicated across the mesh. A factory whose programs differ per device is a
+// MeshWorkloadSpecFactoryConcept instead.
 template <typename T>
 concept ProgramSpecFactoryConcept =
     requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> &&
-    !ProgramDescriptorFactoryConcept<T> && !detail::HasSpecRuntimeArgsOverride<T>;
+    !ProgramDescriptorFactoryConcept<T> && !MeshWorkloadSpecFactoryConcept<T> && !detail::HasSpecRuntimeArgsOverride<T>;
 
 // Spec factory that additionally re-applies per-dispatch runtime args on every cache hit: its
 // override_runtime_arguments returns a ProgramRunArgs applied via UpdateProgramRunArgs (the
@@ -134,7 +144,7 @@ concept ProgramSpecFactoryConcept =
 template <typename T>
 concept CustomProgramSpecFactoryConcept =
     requires { &T::create_program_artifacts; } && detail::HasSpecRuntimeArgsOverride<T> && !ProgramFactoryConcept<T> &&
-    !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+    !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T> && !MeshWorkloadSpecFactoryConcept<T>;
 
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).
@@ -173,7 +183,7 @@ concept HasSelectProgramFactory = requires(
 
 // Validate that all variant alternatives in a program_factory_t satisfy exactly one of
 // ProgramFactoryConcept, MeshWorkloadFactoryConcept, ProgramDescriptorFactoryConcept,
-// ProgramSpecFactoryConcept, or CustomProgramSpecFactoryConcept.
+// ProgramSpecFactoryConcept, CustomProgramSpecFactoryConcept, or MeshWorkloadSpecFactoryConcept.
 namespace detail {
 template <typename Variant, std::size_t... Is>
 consteval bool all_factories_valid(std::index_sequence<Is...>) {
@@ -182,7 +192,8 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
           MeshWorkloadFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           ProgramDescriptorFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>> +
-          CustomProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
+          CustomProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>> +
+          MeshWorkloadSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
 }  // namespace detail


### PR DESCRIPTION
Right now a spec factory gets asked for its `ProgramArtifacts` exactly once, and the adapter maps that one `ProgramSpec` onto every range of the mesh. Fine for SPMD, but it makes two things impossible: an op whose program differs per device, and an op that wants the same program everywhere with different run args per device. Both keep coming up as "needs TTNN infra support" when people look at porting ops to the Metal 2.0 spec path.

The metal side isn't the problem. `MakeMeshWorkloadFromSpecs` already takes a range-to-spec map and runs distinct specs on distinct devices. The adapter just never had a way for a factory to say "my programs vary".

So this adds a factory concept for exactly that:

```cpp
static MeshWorkloadArtifacts create_mesh_workload_artifacts(
    const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&,
    const ttnn::MeshCoordinateRangeSet& tensor_coords);
```

One call returns the workload-scoped resources plus a `ProgramSpec` and `ProgramRunArgs` per coordinate range. A program uniform over part of the mesh is one entry covering that range, so you don't have to emit one per device. `MeshWorkloadSpecFactoryConcept` is mutually exclusive with the other four, so the "exactly one concept per `program_factory_t` alternative" rule still holds and existing factories classify the same as before.

Optionally declare a cache-hit refresh:

```cpp
static ProgramRunArgs override_runtime_arguments(
    const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&,
    const ttnn::MeshCoordinateRange& range);
```

It takes the range rather than a coordinate because one Program backs the whole range, so what it returns applies to every device the range covers. Handing it a coordinate invited factories to derive per-device args and get device 0's values replicated with nothing complaining.

Guardrails, since these failure modes are all quiet ones:

* A near-miss `override_runtime_arguments` signature is a compile error instead of a silent fallback to the tensor-only refresh.
* Two entries with the same range, or a range outside `tensor_coords`, are fatal. Metal catches overlapping ranges but never sees an exact duplicate, and it only checks the mesh extent.
* A factory declaring `create_mesh_workload_artifacts` as an overload set is rejected. Address-of an overload set is ill-formed, so the concept goes false and the factory would quietly fall through to the SPMD path and get one spec replicated across the mesh.

Not in here: GlobalSemaphore. The spec API only has program-scoped `SemaphoreSpec` today, so CCL-style cross-device sync is still blocked on the metal side. Separate problem, separate owner.

### Testing

Runtime coverage on the 2x4 fixture. One test builds a workload from a factory that leaves odd columns idle and asserts per-coordinate presence and absence, plus that every range shares one parked resource vector. A second drives both cache-hit branches, and for the override branch asserts it fires once per range rather than once per workload, which is the part that would regress silently.

Compile coverage pins the classification in both directions so a refactor can't flip everything onto one path.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/spec-per-coordinate-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/spec-per-coordinate-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/spec-per-coordinate-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/spec-per-coordinate-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/spec-per-coordinate-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/spec-per-coordinate-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/spec-per-coordinate-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/spec-per-coordinate-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/spec-per-coordinate-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/spec-per-coordinate-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/spec-per-coordinate-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/spec-per-coordinate-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/spec-per-coordinate-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/spec-per-coordinate-artifacts)