### PR TITLE
[Bug fix] Fix Quasar V1 zeroing command buffer reset

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl
@@ -85,14 +85,14 @@ inline void Noc::write_zeros_l1_barrier() const {
         // Spin until all per-backend split packets ack.
     }
     // The zero borrowed cmd buffer 0 in a non-write configuration (iDMA zero mode + VC
-    // autoincrement). Now that every packet has acked, reset it and reprogram the standard
-    // write-ready config so the next noc_async_write on cmd buffer 0 behaves normally. This
-    // is done here, after the ack, rather than in async_write_zeros: init_wr_cmd_buf() resets
-    // cmd buffer 0, and resetting before the ack could disturb the pending iDMA ack we just
-    // waited on.
-    //
-    // TODO: Quasar has architecture different enough that we may want to get out of using
-    // noc_nonblocking_api. Refactor this when we move away from it.
+    // autoincrement). Now that every packet has acked, reset it. V2 uses the overlay command
+    // buffer for normal writes, so restore its write-ready configuration. V1 performs normal
+    // writes through memory-mapped NoC registers and only needs the borrowed overlay buffer
+    // reset. Resetting before the ack could disturb the pending iDMA ack we just waited on.
+#ifdef NOC_API_V2
     init_wr_cmd_buf(noc_local_xy());
+#else
+    overlay::reset_cmdbuf_0();
+#endif
     NOC_ZERO_MODE_EXIT();  // cmd buffer 0 restored; NoC writes are safe again
 }


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
Fixes QSR failures with TTSim which does not support NOC_API_V2 yet.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/qsr-jit-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/qsr-jit-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/qsr-jit-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/qsr-jit-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/qsr-jit-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/qsr-jit-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/qsr-jit-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/qsr-jit-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/qsr-jit-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/qsr-jit-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/qsr-jit-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/qsr-jit-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/qsr-jit-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/qsr-jit-fix)