### PR TITLE
[Emule] Support fused DSpark Galaxy execution

### DIFF
--- a/tests/tt_metal/tt_metal/api/emule/test_emule_host_wait.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_emule_host_wait.cpp
@@ -106,6 +106,87 @@ TEST_F(EmuleHostWait, HostFedPollQuiescesToHostWaitAndPumpsToCompletion) {
     EXPECT_EQ(entries.load(), 1u);
 }
 
+// A peer-fed socket can be causally downstream of the host-fed source. The external host root is
+// sufficient to suspend the whole chain; requiring every poller to be host-fed would misdiagnose
+// a normal pipeline as a device-only deadlock.
+TEST_F(EmuleHostWait, HostFedPollWithCausalD2DPollResumes) {
+    std::atomic<bool> host_ready{false};
+    std::atomic<bool> downstream_ready{false};
+
+    spawn_fiber(
+        [&host_ready, &downstream_ready] {
+            auto& sched = FiberScheduler::instance();
+            while (!host_ready.load(std::memory_order_acquire)) {
+                sched.note_socket_poll_wait(/*waiting=*/true, /*host_fed=*/true);
+                sched.yield();
+            }
+            sched.note_socket_poll_wait(/*waiting=*/false, /*host_fed=*/true);
+            downstream_ready.store(true, std::memory_order_release);
+        },
+        2,
+        "h2d_pipeline_source");
+    spawn_fiber(polling_body(&downstream_ready, /*host_fed=*/false, nullptr), 3, "d2d_pipeline_receiver");
+
+    auto& sched = FiberScheduler::instance();
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    ASSERT_EQ(sched.pump(), RunOutcome::HostWait) << "a dry pump must preserve the causal host wait";
+
+    host_ready.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+}
+
+// A later host page may be absent while the current page still has runnable work deferred to
+// quiescence. The spin-release HostWait path must service that work before handing control back;
+// otherwise every D2H pump suspends on the next-page H2D poll and strands the current-page producer.
+TEST_F(EmuleHostWait, DeferredProducerRunsBeforeDownstreamHostWait) {
+    std::atomic<bool> next_host_page_ready{false};
+    std::atomic<bool> current_page_published{false};
+
+    spawn_fiber(polling_body(&next_host_page_ready, /*host_fed=*/true, nullptr), 4, "next_page_h2d_receiver_poll");
+    spawn_fiber(
+        polling_body(&current_page_published, /*host_fed=*/false, nullptr), 5, "current_page_d2d_receiver_poll");
+    spawn_fiber(
+        [&current_page_published] {
+            auto& sched = FiberScheduler::instance();
+            sched.quiescence_park();
+            current_page_published.store(true, std::memory_order_release);
+        },
+        6,
+        "current_page_deferred_producer");
+
+    auto& sched = FiberScheduler::instance();
+    ASSERT_EQ(sched.run_persistent(), RunOutcome::HostWait);
+    EXPECT_TRUE(current_page_published.load(std::memory_order_acquire))
+        << "HostWait stranded runnable current-page work behind a next-page host poll";
+
+    // Complete the future host dependency so the process-global scheduler registry is clean.
+    next_host_page_ready.store(true, std::memory_order_release);
+    ASSERT_EQ(sched.pump(), RunOutcome::Completed);
+}
+
+// The existential host root must not become a sticky exemption. Once it clears, an unrelated
+// peer-fed poll remains a genuine d2d-only deadlock and must retain the peer diagnostic.
+TEST_F(EmuleHostWait, D2DPollStillDeadlocksAfterHostPollClears) {
+    arm_fast_watchdog();
+    EXPECT_DEATH(
+        {
+            std::atomic<bool> host_ready{false};
+            std::atomic<bool> peer_never_ready{false};
+            spawn_fiber(polling_body(&host_ready, /*host_fed=*/true, nullptr), 4, "h2d_pipeline_source");
+            spawn_fiber(polling_body(&peer_never_ready, /*host_fed=*/false, nullptr), 5, "d2d_pipeline_receiver");
+
+            auto& sched = FiberScheduler::instance();
+            if (sched.run_persistent() != RunOutcome::HostWait) {
+                std::exit(2);
+            }
+            host_ready.store(true, std::memory_order_release);
+            (void)sched.pump();
+            std::exit(3);
+        },
+        "spin-polling a d2d socket");
+    disarm_fast_watchdog();
+}
+
 // A d2d sender is a PEER, so dying on this regex proves the attribution, not just the outcome.
 TEST_F(EmuleHostWait, PeerFedPollIsNamedAsPeerFedInTheDump) {
     arm_fast_watchdog();

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -202,7 +202,6 @@ TEST_F(MeshDeviceFixture, Semaphore_RelayUnicast_NoViolation) {
 TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
     uint32_t sem_id = CreateSemaphore(program, logical_core, /*initial_value=*/0);

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -286,7 +286,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_SameAddressTempBuffer_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the owner's full range is still live.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -33,7 +33,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <regex>
 #include <semaphore>
 #include <set>
 #include <sstream>
@@ -975,39 +974,8 @@ static std::function<void()> jit_compile_kernel(
     // (mhartid, fence) and raw L1 arg-val pointer casts. -I kernel_dir (below)
     // keeps relative includes in the patched file resolvable.
     std::string patched_kernel_path = dir + "/patched_kernel.cpp";
-    // WORKAROUND: see tt-emule/.claude/skills/workarounds (WA-2).
-    // The fabric mux (tt_fabric_mux.cpp) is a transport-layer aggregation kernel: workers write packets
-    // into its L1 channels and it forwards them over ethernet. emule has no ethernet — WorkerToFabricMux
-    // Sender teleports each packet straight to its final destination (same as the no-mux direct path),
-    // so the mux has nothing to do. The real kernel is also persistent (loops until an external
-    // termination signal) and pulls in erisc firmware emule doesn't model, which would both fail to
-    // compile and hang emule's run-to-completion join. Substitute a no-op kernel: it compiles, exits
-    // immediately, and the teleporting mux sender carries the data. (Mirrors how emule collapses the eth
-    // router/switch into the teleport — the mux is the worker-side half of that same transport.)
-    if (std::filesystem::path(abs_kernel).filename() == "tt_fabric_mux.cpp") {
-        std::ofstream f(patched_kernel_path);
-        if (!f) {
-            throw std::runtime_error("jit_compile_kernel: cannot write mux stub " + patched_kernel_path);
-        }
-        f << "// emule no-op stub for tt_fabric_mux.cpp (the teleporting mux sender carries the data).\n"
-          << "#include \"api/dataflow/dataflow_api.h\"\n"
-          << "void kernel_main() {}\n";
-    } else {
-        // Kernel include roots (ttnn/, tt_metal/) parsed from the JIT -I flags so the patcher
-        // can reach + patch shared kernel helpers that live in another directory (the raw-L1-deref
-        // idioms in e.g. kernel_lib/*.inl). The emule shadow roots are checked first, so jit_hw
-        // headers are never patched.
-        std::vector<std::string> kernel_inc_roots;
-        {
-            static const std::regex inc_flag_re(R"RE(-I"([^"]+)")RE");
-            for (std::sregex_iterator it(extra_include_flags.begin(), extra_include_flags.end(), inc_flag_re), end;
-                 it != end; ++it) {
-                kernel_inc_roots.push_back((*it)[1].str());
-            }
-        }
-        const std::vector<std::string> emule_inc_roots = {jit_inc, parent_inc};
-        tt::emule::patch_kernel_source(abs_kernel, patched_kernel_path, kernel_inc_roots, emule_inc_roots);
-    }
+    const std::vector<std::string> emule_inc_roots = {jit_inc, parent_inc};
+    tt::emule::patch_kernel_source(abs_kernel, patched_kernel_path, extra_include_flags, emule_inc_roots);
 
     ////////////////////////////////////////////////////////////
     // Blaze-only experimental named args
@@ -1368,6 +1336,31 @@ static std::string resolve_kernel_source_path(const KernelSource& ksrc, std::vec
     return src_path;
 }
 
+// A same-relative-path source in jit_hw is emule's implementation of a Metal file kernel.
+static std::string resolve_emule_kernel_source_shadow(const std::string& src_path, ContextId context_id) {
+    std::error_code ec;
+    const auto source = std::filesystem::weakly_canonical(src_path, ec);
+    if (ec) {
+        return src_path;
+    }
+    const auto root =
+        std::filesystem::weakly_canonical(MetalContext::instance(context_id).rtoptions().get_root_dir(), ec);
+    if (ec) {
+        return src_path;
+    }
+    const auto relative = source.lexically_relative(root);
+    if (relative.empty() || relative.is_absolute() || *relative.begin() == "..") {
+        return src_path;
+    }
+
+    const auto shadow = std::filesystem::path(TT_EMULE_JIT_INCLUDE_DIR) / relative;
+    if (!std::filesystem::is_regular_file(shadow, ec) || ec) {
+        return src_path;
+    }
+    log_debug(tt::LogMetal, "Using emule kernel source shadow {} for {}", shadow.string(), source.string());
+    return shadow.string();
+}
+
 // Build the full defines map for a kernel: subclass-derived + arch + emulator
 // constants (banking, alignments, worker maps, sem base, CB tile sizes).
 static std::map<std::string, std::string> build_kernel_defines(
@@ -1695,6 +1688,9 @@ static void collect_kernels(
         for (auto& [kernel_id, kernel] : kernels) {
             const auto& ksrc = kernel->kernel_source();
             std::string src_path = resolve_kernel_source_path(ksrc, inline_src_temps);
+            if (ksrc.source_type_ == KernelSource::FILE_PATH) {
+                src_path = resolve_emule_kernel_source_shadow(src_path, impl.get_context_id());
+            }
 
             // Thread each kernel's configured include roots into its JIT -I flags.
             // Kernels can declare extra include paths (Kernel::process_include_paths)
@@ -2216,7 +2212,6 @@ static std::unordered_map<uint64_t, tt_emule::Core*>* build_core_map(
 static std::mutex g_fabric_route_mutex;
 // (src_chip << 3 | dir) -> ordered chips at distance 1,2,... in that direction (cached; topology is static).
 static std::unordered_map<uint32_t, std::vector<uint32_t>> g_fabric_walk_cache;
-
 // Immediate same-mesh neighbor physical chip of `chip` in `dir`, or -1 if none.
 static int __emule_fabric_dir_neighbor(
     tt::tt_fabric::ControlPlane& cp, uint32_t chip, tt::tt_fabric::RoutingDirection dir) {
@@ -2352,6 +2347,7 @@ constexpr uint32_t UNSET = 0, UNICAST_1D = 1, UNICAST_2D = 2, MCAST_1D = 3, MCAS
 struct EmuleRoute {
     uint32_t kind = 0, a = 0, b = 0, c = 0, d = 0, e = 0, f = 0;
     uint32_t dir_index = 0;  // 1D: which of the worker's connections (fwd=0/bwd=1), set at send time
+    uint32_t eth_channel = 0xFFFFFFFF;  // VC0 connection identity, set at send time
     // Mux-path direction hint (preferred over the range-match heuristic), set at send time:
     uint32_t mux_x = 0xFFFF, mux_y = 0xFFFF;   // worker's mux NOC (TRANSLATED) coords (fabric MUX path)
 };
@@ -2381,11 +2377,12 @@ extern "C" void __emule_fabric_set_route(
 // Record a 1D send's per-connection direction signals: the fwd/bwd conn_index (direct path) and the
 // worker's mux NOC coords (MUX path); 0xFFFF means unset. See tt-emule docs/fabric-ccl-emulation.md.
 extern "C" void __emule_fabric_set_route_dir(
-    uint32_t hdr, uint32_t conn_index, uint32_t mux_x, uint32_t mux_y) {
+    uint32_t hdr, uint32_t conn_index, uint32_t eth_channel, uint32_t mux_x, uint32_t mux_y) {
     emule_require_self(__func__);  // keys through __emule_self->bridge_l1 via emule_route_key
     std::lock_guard<std::mutex> lk(g_route_meta_mu);
     auto& r = g_route_meta[emule_route_key(hdr)];
     r.dir_index = conn_index;
+    r.eth_channel = eth_channel;
     r.mux_x = mux_x;
     r.mux_y = mux_y;
 }
@@ -2439,18 +2436,14 @@ static std::unordered_map<uint32_t, std::vector<ConnRoute>> g_conn_route;
 // payloads to the wrong chip. Per-worker keying also removes the cross-thread append race, since one
 // worker's connections are recorded by one thread in order.
 static std::unordered_map<uint64_t, std::vector<ConnRoute>> g_worker_conns;
-// Persistent UNDIRECTED ring adjacency (chip -> ring-neighbor chips), accumulated across ALL ops and never
-// reset: the physical ethernet ring is static, but each op's senders open only the connection(s) they use,
-// so any single op's g_conn_route is an incomplete, per-chip one-sided view. The ring walk needs the full
-// undirected topology to traverse the turning Hamiltonian cycle without dead-ending at a chip that opened
-// only one direction this op. Direction (which way a send goes) still comes from per-op g_conn_route; only
-// the ring *connectivity* comes from here. See tt-emule docs/fabric-ccl-emulation.md.
+// Per-op UNDIRECTED ring adjacency. Each program captures and restores its own topology.
 static std::unordered_map<uint32_t, std::set<uint32_t>> g_ring_adj;
 // Per-op reset flag: cleared at each new op's first connection-record so a later op's different line
 // orientation can't corrupt the src-keyed, direction-deduped table. See tt-emule docs/fabric-ccl-emulation.md.
 static std::atomic<bool> g_conn_route_dirty{true};
-// Per-worker resolved line direction, keyed (src<<32 | wx<<16 | wy): on the MUX path the sender carries no
-// direction, so infer it once from a multicast's range and reuse for that worker's unicasts. Reset per op.
+// Per-worker resolved line direction, keyed (src<<32 | wx<<16 | wy): on a path with neither a worker-owned
+// connection sequence nor MUX coordinates, infer it from a multicast's range and reuse it for unicasts.
+// Reset per op.
 // See tt-emule docs/fabric-ccl-emulation.md.
 static std::unordered_map<uint64_t, uint32_t> g_worker_dir;
 // Per-mux-core line direction, keyed (src<<32 | logical_x<<16 | logical_y): the mux→EDM append records the
@@ -2467,11 +2460,12 @@ extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t w
         g_worker_conns.clear();
         g_worker_dir.clear();
         g_mux_dir.clear();
+        g_ring_adj.clear();
     }
     // Record the connection-owner core's (the mux core, on the MUX path) direction, keyed by its LOGICAL
     // coords — before the per-direction dedup below, which is for the src-keyed g_conn_route only.
     g_mux_dir[__emule_worker_key(src, wx, wy)] = dir;
-    // Accumulate the undirected ring edge (persistent; unaffected by the per-op reset above).
+    // Accumulate the undirected ring edge for this op.
     g_ring_adj[src].insert(neighbor);
     g_ring_adj[neighbor].insert(src);
     // Per-worker, in open order — this is what a sender's dir_index indexes.
@@ -2494,7 +2488,7 @@ extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t w
 }
 
 // Ordered ring members at distance 1,2,... from `src` in `start_dir`: first hop from g_conn_route[src], then
-// follow the persistent undirected adjacency g_ring_adj (unvisited non-prev neighbor), tracing the turning
+// follow the program's undirected adjacency g_ring_adj (unvisited non-prev neighbor), tracing the turning
 // Hamiltonian cycle the compass walk can't. Stops at a dead end / cycle close; empty if src/start_dir was
 // never recorded. TT_FATALs if a chip has >1 continuation (cross-axis edges from another op's collective,
 // not disambiguable from the undirected union) rather than misroute. See docs/fabric-ccl-emulation.md.
@@ -2516,7 +2510,7 @@ static std::vector<uint32_t> __emule_fabric_walk_ring(uint32_t src, uint32_t sta
         return walk;  // start direction not recorded — caller falls back
     }
     walk.push_back(static_cast<uint32_t>(first));
-    // Traverse the persistent UNDIRECTED ring adjacency: g_conn_route only fixes the FIRST hop's direction;
+    // Traverse the program's UNDIRECTED ring adjacency: g_conn_route only fixes the FIRST hop's direction;
     // connectivity comes from g_ring_adj so a chip that opened one connection this op doesn't dead-end.
     std::set<uint32_t> visited{src, static_cast<uint32_t>(first)};
     uint32_t prev = src, cur = static_cast<uint32_t>(first);
@@ -2587,21 +2581,52 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
         } catch (...) {
         }
     } else if (r.kind == emule_route_kind::MCAST_2D) {
-        // 2D line multicast: {c,d,e,f}={E,W,N,S} per-direction hop counts; walk each non-zero direction.
+        // Mesh multicast first routes to (a,b). The hop counts are interpreted from that start node.
         using RD = tt::tt_fabric::RoutingDirection;
-        const std::pair<RD, uint32_t> dirs[4] = {{RD::E, r.c}, {RD::W, r.d}, {RD::N, r.e}, {RD::S, r.f}};
-        std::vector<uint32_t> tgts;
-        for (const auto& [dir, hops] : dirs) {
-            if (hops == 0) {
-                continue;
+        try {
+            const uint32_t start_chip = static_cast<uint32_t>(cp.get_physical_chip_id_from_fabric_node_id(
+                tt::tt_fabric::FabricNodeId(tt::tt_fabric::MeshId{r.b}, r.a)));
+            std::vector<uint32_t> tgts;
+            auto append_unique = [&](uint32_t chip) {
+                if (std::find(tgts.begin(), tgts.end(), chip) == tgts.end()) {
+                    tgts.push_back(chip);
+                }
+            };
+            auto append_branch = [&](uint32_t root, RD dir, uint32_t hops) {
+                const auto& walk = __emule_fabric_walk(root, dir);
+                for (uint32_t k = 0; k < hops && k < walk.size(); ++k) {
+                    append_unique(walk[k]);
+                }
+            };
+
+            const uint32_t spine_hops = r.e != 0 ? r.e : r.f;
+            if (spine_hops != 0) {
+                const RD spine_dir = r.e != 0 ? RD::N : RD::S;
+                uint32_t root = start_chip;
+                for (uint32_t spine_index = 0; spine_index < spine_hops; ++spine_index) {
+                    append_unique(root);
+                    append_branch(root, RD::E, r.c);
+                    append_branch(root, RD::W, r.d);
+                    const auto& spine_walk = __emule_fabric_walk(root, spine_dir);
+                    if (spine_index + 1 < spine_hops) {
+                        if (spine_walk.empty()) {
+                            break;
+                        }
+                        root = spine_walk[0];
+                    }
+                }
+            } else {
+                append_unique(start_chip);
+                const RD line_dir = r.c != 0 ? RD::E : RD::W;
+                const uint32_t line_hops = r.c != 0 ? r.c : r.d;
+                if (line_hops > 1) {
+                    append_branch(start_chip, line_dir, line_hops - 1);
+                }
             }
-            const auto& walk = __emule_fabric_walk(src_chip, dir);
-            for (uint32_t k = 0; k < hops && k < walk.size(); ++k) {
-                tgts.push_back(walk[k]);
+            if (!tgts.empty()) {
+                return tgts;
             }
-        }
-        if (!tgts.empty()) {
-            return tgts;
+        } catch (...) {
         }
     } else if (r.kind == emule_route_kind::MCAST_1D || r.kind == emule_route_kind::UNICAST_1D) {
         // 1D MUX path carries no direction tag: infer the worker's direction from a multicast's range and
@@ -2630,7 +2655,15 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
         // fallback for senders whose connections were recorded under another core (MUX).
         const std::vector<ConnRoute>& idx_conns = wconns.empty() ? conns : wconns;
         int dir = -1;
-        // (1) Mux-core direction: translate the worker's mux NOC coords to the mux's LOGICAL core and look up
+        // (1) VC0 channel identity: silicon indexes its connection table with this channel. Derive the same
+        // direction from the control plane rather than duplicating the binding in fabric.cpp.
+        if (r.eth_channel != 0xFFFFFFFF) {
+            auto& cp = MetalContext::instance().get_control_plane();
+            const auto src_node = cp.get_fabric_node_id_from_physical_chip_id(static_cast<ChipId>(src_chip));
+            dir = static_cast<int>(
+                cp.eth_direction_to_routing_direction(cp.get_eth_chan_direction(src_node, r.eth_channel)));
+        }
+        // (2) Mux-core direction: translate the worker's mux NOC coords to the mux's LOGICAL core and look up
         // the direction the mux→EDM append recorded. Resolves ring, where the range-match below cannot.
         if (dir < 0 && r.mux_x != 0xFFFF) {
             auto* src_obj = get_sw_emulated_chip(src_chip);
@@ -2648,7 +2681,7 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
                 }
             }
         }
-        // (2) Fallback — range-match heuristic (and its cached g_worker_dir / conn-index), used only when the
+        // (3) Fallback — range-match heuristic (and its cached g_worker_dir / conn-index), used only when the
         // mux signal above is absent. See tt-emule docs/fabric-ccl-emulation.md.
         if (dir < 0 && r.kind == emule_route_kind::MCAST_1D) {
             const uint32_t range = r.b ? r.b : 1;
@@ -2675,10 +2708,14 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
                 std::lock_guard<std::mutex> lk(g_conn_route_mu);
                 g_worker_dir[wkey] = static_cast<uint32_t>(dir);
             }
-        } else if (dir < 0) {  // UNICAST_1D — reuse this worker's multicast-inferred direction; else the conn index
+        } else if (dir < 0) {  // UNICAST_1D
             std::lock_guard<std::mutex> lk(g_conn_route_mu);
-            auto wit = g_worker_dir.find(wkey);
-            if (wit != g_worker_dir.end()) {
+            // A direct sender's connection index refers to this worker's open sequence. Prefer that exact
+            // mapping over the one-direction cache: a bidirectional collective can send equal hop counts on
+            // both connections, so one cached direction cannot represent both slots.
+            if (!wconns.empty()) {
+                dir = static_cast<int>(wconns[r.dir_index < wconns.size() ? r.dir_index : 0].dir);
+            } else if (auto wit = g_worker_dir.find(wkey); wit != g_worker_dir.end()) {
                 dir = static_cast<int>(wit->second);
             } else if (!idx_conns.empty()) {
                 dir = static_cast<int>(idx_conns[r.dir_index < idx_conns.size() ? r.dir_index : 0].dir);
@@ -3514,11 +3551,13 @@ static constexpr size_t kMaxResolvedPrograms = 256;
 // intervening op leaves the globals holding ITS routes. Routing is a property of the program (like the
 // compiled kernels), so capture it once (first resolve) and restore it into the globals at each dispatch.
 // Deliberately NOT LRU-bounded (unlike g_resolved_programs): tiny, and must outlive kernel-cache eviction so
-// a re-resolved program keeps its own routes. g_ring_adj (physical ring) stays global; g_worker_dir is a
-// run-time cache, re-derived per op. See docs/fabric-ccl-emulation.md.
+// a re-resolved program keeps its own routes. g_worker_dir is a run-time cache, re-derived per op.
+// See docs/fabric-ccl-emulation.md.
 struct ProgramRoutes {
     std::unordered_map<uint32_t, std::vector<ConnRoute>> conn_route;
+    std::unordered_map<uint64_t, std::vector<ConnRoute>> worker_conns;
     std::unordered_map<uint64_t, uint32_t> mux_dir;
+    std::unordered_map<uint32_t, std::set<uint32_t>> ring_adj;
 };
 static std::unordered_map<ProgramId, ProgramRoutes> g_program_routes;
 
@@ -3824,7 +3863,7 @@ static std::shared_ptr<ResolvedProgram> prepare_program(IDevice* device, Program
     {
         std::lock_guard<std::mutex> lk(g_conn_route_mu);
         if (g_program_routes.find(pid) == g_program_routes.end()) {
-            g_program_routes[pid] = ProgramRoutes{g_conn_route, g_mux_dir};
+            g_program_routes[pid] = ProgramRoutes{g_conn_route, g_worker_conns, g_mux_dir, g_ring_adj};
         }
     }
 
@@ -3892,7 +3931,9 @@ void execute_program_emulated(IDevice* device, Program& program) {
         std::lock_guard<std::mutex> lk(g_conn_route_mu);
         if (auto rit = g_program_routes.find(pid); rit != g_program_routes.end()) {
             g_conn_route = rit->second.conn_route;
+            g_worker_conns = rit->second.worker_conns;
             g_mux_dir = rit->second.mux_dir;
+            g_ring_adj = rit->second.ring_adj;
         }
         g_worker_dir.clear();
     }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -3578,6 +3578,11 @@ static void launch_cores(
     // (yields its worker) instead of blocking an OS thread — no thread ceiling, no spin.
     // See docs/fiber-engine.md.
     auto& sched = tt::tt_metal::emule_fiber::FiberScheduler::instance();
+    const uint32_t fabric_device_id =
+        tt::tt_metal::MetalContext::instance()
+            .get_control_plane()
+            .get_fabric_node_id_from_physical_chip_id(device_id)
+            .chip_id;
 
     // The fibers borrow the per-core DFB interface arrays; own them here so they
     // outlive run_until_idle.
@@ -3666,6 +3671,7 @@ static void launch_cores(
             ctx->core_obj = core;
             ctx->device = nullptr;
             ctx->chip_id = static_cast<uint32_t>(device_id);
+            ctx->fabric_device_id = fabric_device_id;
             ctx->core_map = core_map_ptr;
             ctx->neo_id = ki.is_tensix ? ki.processor_id : 0;
             ctx->trisc_id = 0;

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -45,8 +45,6 @@ extern thread_local uint8_t my_logical_y_;
 
 namespace tt::tt_metal::emule_fiber {
 
-namespace {
-
 enum class FiberState : uint8_t { Ready, Running, Parked, QuiescenceDeferred, Done };
 
 struct Fiber {
@@ -83,6 +81,8 @@ struct Fiber {
         }
     }
 };
+
+namespace {
 
 // Per-worker state. Fibers are pinned (Fiber::home), so a fiber always runs on the
 // same worker — these are read/written only by that worker.

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -398,9 +398,14 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                 }
                 last_parked_sig_ = sig;
                 last_parked_sig_valid_ = true;
-                // Yield-spin HostWait trigger: all waits host-fed, or peer-parked but N releases moved nothing.
+                // Yield-spin HostWait trigger: a host-fed root may have downstream peer work, but
+                // quiescence-deferred fibers are runnable internal work and must get at least one
+                // release first. Otherwise a next-page H2D poll can suspend the run while the
+                // current page's deferred producer is still waiting to publish to a d2d consumer.
+                const bool internal_work_needs_repoll =
+                    !quiescence_deferred_.empty() || any_parked_non_socket();
                 if (persistent_ && any_waiting_on_host() &&
-                    (!any_parked_non_socket() || barren_releases_ >= barren_release_limit)) {
+                    (!internal_work_needs_repoll || barren_releases_ >= barren_release_limit)) {
                     host_wait_ = true;
                     abort_flag_ = true;
                     cv_.notify_all();


### PR DESCRIPTION
## Summary

- carry the current tt-metal emulator routing and deferred-host-wait
  prerequisites used by the private Blaze emulator stack
- use the updated emule source-shadow and fabric-routing implementation
- map every emulated physical chip ID to its topology-local fabric device ID
  before launching worker fibers
- expose that fabric ID to DSpark's compiled TP8 routing tables so a Galaxy's
  permuted physical IDs do not select the wrong route

This is the tt-metal dependency for
[tt-lang-ops-and-models PR #54](https://github.com/tenstorrent/tt-lang-ops-and-models/pull/54)
and the companion `tt-emule-blaze` branch `kostas/dspark_tt_emule`.

The branch includes the emulator prerequisites already accumulated on
`emule-blaze-metal-fork`, followed by the DSpark-specific fabric-device-ID
commit `cd188fc194`.

## Verification

- full emule-enabled tt-metal/TTNN build: PASS
- DSpark residual, RMSNorm, standalone SDPA, and one-layer fused probes: PASS
- one-layer fused probe with ASAN: PASS
- one-layer TP8 probe on a 32-chip emulated Galaxy: PASS
- TP8 probe verifies one dispatch and golden matching

## Limitations

- This validates simulator routing and synchronization semantics, not physical
  Ethernet performance or timing.
- The Galaxy test executes one DSpark layer and does not use a physical SC24.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=emule-blaze-metal-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:emule-blaze-metal-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=emule-blaze-metal-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:emule-blaze-metal-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=emule-blaze-metal-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:emule-blaze-metal-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=emule-blaze-metal-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:emule-blaze-metal-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=emule-blaze-metal-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:emule-blaze-metal-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=emule-blaze-metal-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:emule-blaze-metal-fork)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=emule-blaze-metal-fork)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:emule-blaze-metal-fork)