### PR TITLE
Allowing tt-triage to run scripts from additional directories

### DIFF
--- a/tools/tests/triage/additional_scripts/additional_provider.py
+++ b/tools/tests/triage/additional_scripts/additional_provider.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    additional_provider
+
+Description:
+    Test fixture for --additional-scripts-directory. A data provider that lives in an additional
+    scripts directory, so check_additional_directory can depend on a sibling in its own directory.
+
+Owner:
+    tt-vjovanovic
+"""
+
+from triage import ScriptConfig, run_script
+from ttexalens.context import Context
+
+script_config = ScriptConfig(data_provider=True)
+
+
+def run(args, context: Context) -> str:
+    return "additional_provider"
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/tests/triage/additional_scripts/check_additional_directory.py
+++ b/tools/tests/triage/additional_scripts/check_additional_directory.py
@@ -19,7 +19,6 @@ Owner:
 
 from dataclasses import dataclass
 
-from additional_extra_provider import run as get_extra_provider
 from additional_provider import run as get_provider
 from triage import ScriptConfig, run_script, triage_field
 from ttexalens.context import Context
@@ -38,8 +37,12 @@ class AdditionalDirectoryRow:
 
 
 def run(args, context: Context) -> list[AdditionalDirectoryRow]:
-    # Both providers live in additional directories and are imported by bare module name, which
-    # only works because those directories were put on sys.path when the flag was resolved.
+    # additional_provider is a sibling, so a module-scope import of it works anywhere. This one
+    # lives in a *different* scripts directory, so it is imported here instead: by the time run()
+    # is called triage has put that directory on sys.path. At module scope it would be too early
+    # when this file is executed directly, and making that work is the script's own job.
+    from additional_extra_provider import run as get_extra_provider
+
     dependencies = ", ".join([get_provider(args, context), get_extra_provider(args, context)])
     print(f"{SUCCESS_MESSAGE} (dependencies: {dependencies})")
     return [AdditionalDirectoryRow(message=SUCCESS_MESSAGE, dependencies=dependencies)]

--- a/tools/tests/triage/additional_scripts/check_additional_directory.py
+++ b/tools/tests/triage/additional_scripts/check_additional_directory.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    check_additional_directory
+
+Description:
+    Test fixture for --additional-scripts-directory. Lives in an additional scripts directory and
+    depends on a script in each place a bare dependency name can resolve: system_info (built-in,
+    in tools/triage), additional_provider (its own directory) and additional_extra_provider (a
+    second additional directory). Prints a message the test asserts on.
+
+Owner:
+    tt-vjovanovic
+"""
+
+from dataclasses import dataclass
+
+from additional_extra_provider import run as get_extra_provider
+from additional_provider import run as get_provider
+from triage import ScriptConfig, run_script, triage_field
+from ttexalens.context import Context
+
+SUCCESS_MESSAGE = "check_additional_directory ran from an additional scripts directory"
+
+script_config = ScriptConfig(
+    depends=["system_info", "additional_provider", "additional_extra_provider"],
+)
+
+
+@dataclass
+class AdditionalDirectoryRow:
+    message: str = triage_field("Message")
+    dependencies: str = triage_field("Dependencies")
+
+
+def run(args, context: Context) -> list[AdditionalDirectoryRow]:
+    # Both providers live in additional directories and are imported by bare module name, which
+    # only works because those directories were put on sys.path when the flag was resolved.
+    dependencies = ", ".join([get_provider(args, context), get_extra_provider(args, context)])
+    print(f"{SUCCESS_MESSAGE} (dependencies: {dependencies})")
+    return [AdditionalDirectoryRow(message=SUCCESS_MESSAGE, dependencies=dependencies)]
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/tests/triage/additional_scripts_broken/__init__.py
+++ b/tools/tests/triage/additional_scripts_broken/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Test fixture. A consuming repo's scripts directory is often a package, so this file exists to prove
+# triage never loads it as a triage script: it would be imported under the module name '__init__',
+# running someone's package init out of context. Deliberately left with no code to execute.

--- a/tools/tests/triage/additional_scripts_broken/additional_provider.py
+++ b/tools/tests/triage/additional_scripts_broken/additional_provider.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    additional_provider
+
+Description:
+    Test fixture: deliberately reuses the file name of additional_scripts/additional_provider.py.
+    Only one file can own the module name, so discovery must drop this copy rather than run it in
+    place of the other one.
+
+Owner:
+    tt-vjovanovic
+"""
+
+from triage import ScriptConfig, run_script
+from ttexalens.context import Context
+
+script_config = ScriptConfig(data_provider=True)
+
+
+def run(args, context: Context) -> str:
+    raise AssertionError("the shadowed copy of additional_provider must never run")
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/tests/triage/additional_scripts_broken/broken_dependency_check.py
+++ b/tools/tests/triage/additional_scripts_broken/broken_dependency_check.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    broken_dependency_check
+
+Description:
+    Test fixture: declares a dependency on a script that does not exist anywhere on the search path.
+    Loading it must report which script wanted what, and where it looked.
+
+Owner:
+    tt-vjovanovic
+"""
+
+from triage import ScriptConfig, run_script
+from ttexalens.context import Context
+
+script_config = ScriptConfig(depends=["no_such_provider"])
+
+
+def run(args, context: Context) -> None:
+    raise AssertionError("broken_dependency_check must never run: its dependency cannot be resolved")
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/tests/triage/additional_scripts_broken/cli_tool.py
+++ b/tools/tests/triage/additional_scripts_broken/cli_tool.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Test fixture: not a triage script at all, but an ordinary command line tool that parses arguments
+# at import time. Discovery imports every .py in a directory it is given, so this exits during
+# import - and SystemExit is not an Exception. Skipping it must not end the whole triage run.
+
+import sys
+
+sys.exit(2)

--- a/tools/tests/triage/additional_scripts_extra/additional_extra_provider.py
+++ b/tools/tests/triage/additional_scripts_extra/additional_extra_provider.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    additional_extra_provider
+
+Description:
+    Test fixture for --additional-scripts-directory. A data provider in a second additional scripts
+    directory, so check_additional_directory can depend across two additional directories.
+
+Owner:
+    tt-vjovanovic
+"""
+
+from triage import ScriptConfig, run_script
+from ttexalens.context import Context
+
+script_config = ScriptConfig(data_provider=True)
+
+
+def run(args, context: Context) -> str:
+    return "additional_extra_provider"
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/tests/triage/additional_scripts_extra/check_extra_directory.py
+++ b/tools/tests/triage/additional_scripts_extra/check_extra_directory.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    check_extra_directory
+
+Description:
+    Test fixture: depends only on a script sitting next to it, and imports nothing from any other
+    directory. That makes it loadable with no --additional-scripts-directory at all, which is how a
+    script run directly from a consuming repo finds the scripts beside it.
+
+Owner:
+    tt-vjovanovic
+"""
+
+from dataclasses import dataclass
+
+from additional_extra_provider import run as get_extra_provider
+from triage import ScriptConfig, run_script, triage_field
+from ttexalens.context import Context
+
+script_config = ScriptConfig(depends=["additional_extra_provider"])
+
+
+@dataclass
+class ExtraDirectoryRow:
+    dependency: str = triage_field("Dependency")
+
+
+def run(args, context: Context) -> list[ExtraDirectoryRow]:
+    return [ExtraDirectoryRow(dependency=get_extra_provider(args, context))]
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/tests/triage/test_additional_scripts_directory.py
+++ b/tools/tests/triage/test_additional_scripts_directory.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Unit tests for --additional-scripts-directory. These need no hardware - the fixture scripts under
+# additional_scripts/ and additional_scripts_extra/ ignore the context, so run_script() can be
+# driven with a stub one. additional_scripts_broken/ holds the things that are supposed to go wrong:
+# a dependency that does not exist, a file name that collides with another directory's, a module that
+# exits at import, and a package __init__.py that must never be loaded as a script.
+
+import os
+import sys
+
+import pytest
+
+
+metal_home = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+triage_home = os.path.join(metal_home, "tools", "triage")
+sys.path.insert(0, triage_home)
+
+
+from triage import ScriptArguments, TTTriageError, TriageScript, resolve_scripts_directories, run_script
+
+# Realpath'd, because that is the spelling triage normalises every directory to - so these constants
+# can be compared directly against what it discovers and reports.
+TESTS_HOME = os.path.realpath(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_DIRECTORY = os.path.join(TESTS_HOME, "additional_scripts")
+EXTRA_SCRIPTS_DIRECTORY = os.path.join(TESTS_HOME, "additional_scripts_extra")
+BROKEN_SCRIPTS_DIRECTORY = os.path.join(TESTS_HOME, "additional_scripts_broken")
+
+# Printed by additional_scripts/check_additional_directory.py. Spelled out here rather than imported
+# so the assertion is on what the script actually writes to stdout.
+SUCCESS_MESSAGE = "check_additional_directory ran from an additional scripts directory"
+
+
+class StubContext:
+    """Stands in for a ttexalens Context. The fixture scripts never touch it."""
+
+
+@pytest.fixture(autouse=True)
+def isolate_module_state():
+    """Undo the sys.path and sys.modules writes that resolving directories and loading scripts do.
+
+    Scripts are imported by bare module name, and the directories stay on sys.path for the rest of
+    the run by design - which would leak into the other test files sharing this pytest process.
+    """
+    saved_path = list(sys.path)
+    saved_modules = set(sys.modules)
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_path
+        for name in set(sys.modules) - saved_modules:
+            del sys.modules[name]
+
+
+def make_args(*directories: str) -> ScriptArguments:
+    return ScriptArguments({"--additional-scripts-directory": list(directories)})
+
+
+def both_directories() -> ScriptArguments:
+    return make_args(SCRIPTS_DIRECTORY, EXTRA_SCRIPTS_DIRECTORY)
+
+
+@pytest.fixture
+def scripts_directories() -> list[str]:
+    """The full search list - built-in plus both fixture directories - as every entry point builds it.
+
+    Loading and discovery need this: resolving is what puts the directories on sys.path, so without
+    it check_additional_directory cannot import the provider that lives in the other directory.
+    """
+    return resolve_scripts_directories(both_directories())
+
+
+def test_script_in_additional_directory_runs_by_bare_name(capsys):
+    """The whole feature end to end: --run=<name> resolves out of tree, and the script runs."""
+    result = run_script(
+        script_path="check_additional_directory",
+        args=both_directories(),
+        context=StubContext(),
+        return_result=True,
+    )
+
+    assert SUCCESS_MESSAGE in capsys.readouterr().out
+    assert [row.message for row in result] == [SUCCESS_MESSAGE]
+    # Proof the two providers really ran and were reached through their own directories.
+    assert result[0].dependencies == "additional_provider, additional_extra_provider"
+
+
+def test_flag_is_honoured_without_main():
+    """run_script() is a second entry point; the directories must be read there too, not just main()."""
+    result = run_script(
+        script_path=os.path.join(SCRIPTS_DIRECTORY, "check_additional_directory.py"),
+        args=None,
+        context=StubContext(),
+        argv=[f"--additional-scripts-directory={EXTRA_SCRIPTS_DIRECTORY}"],
+        return_result=True,
+    )
+
+    assert [row.message for row in result] == [SUCCESS_MESSAGE]
+
+
+def test_bare_dependency_names_resolve_in_every_searched_directory(scripts_directories):
+    """system_info is built-in, additional_provider is a sibling, the third is in the other directory."""
+    script_path = os.path.join(SCRIPTS_DIRECTORY, "check_additional_directory.py")
+    scripts = TriageScript.load_all(script_path, scripts_directories)
+
+    assert set(scripts[script_path].config.depends) == {
+        os.path.join(triage_home, "system_info.py"),
+        os.path.join(SCRIPTS_DIRECTORY, "additional_provider.py"),
+        os.path.join(EXTRA_SCRIPTS_DIRECTORY, "additional_extra_provider.py"),
+    }
+
+
+def test_missing_dependency_names_the_script_that_wants_it():
+    """A typo in `depends` must say who asked for what, not surface as a bare ModuleNotFoundError."""
+    broken = os.path.join(BROKEN_SCRIPTS_DIRECTORY, "broken_dependency_check.py")
+
+    with pytest.raises(TTTriageError) as excinfo:  # allow-pytest.raises: no expect_error fixture
+        TriageScript.load_all(broken)
+
+    message = str(excinfo.value)
+    assert "broken_dependency_check.py depends on no_such_provider.py" in message
+    assert "does not exist" in message
+    # The directories it looked in are listed, so the author can see why it was not found.
+    assert BROKEN_SCRIPTS_DIRECTORY in message and os.path.realpath(triage_home) in message
+
+
+def test_dependency_search_path_lists_each_directory_once(scripts_directories):
+    """A script's own directory is usually already in the list; it must not be searched twice."""
+    for directory, script_name in [
+        (triage_home, "system_info.py"),
+        (SCRIPTS_DIRECTORY, "additional_provider.py"),
+        (EXTRA_SCRIPTS_DIRECTORY, "additional_extra_provider.py"),
+    ]:
+        script = TriageScript.load(os.path.join(directory, script_name), scripts_directories)
+
+        search_path = script.dependency_search_path
+        assert len(search_path) == len(set(search_path)), search_path
+        # The script's own directory still wins, so a sibling beats a same-named built-in.
+        assert search_path[0] == os.path.realpath(directory)
+        assert set(search_path) == set(scripts_directories)
+
+
+def test_discovery_spans_built_in_and_additional_directories(scripts_directories):
+    scripts = TriageScript.discover_all(scripts_directories)
+
+    names = {os.path.basename(path) for path in scripts}
+    assert {"check_additional_directory.py", "additional_provider.py", "additional_extra_provider.py"} <= names
+    assert "system_info.py" in names, "built-in scripts must still be discovered"
+
+
+def test_script_directory_is_searched_even_when_not_passed_as_a_flag():
+    """Running an out-of-tree script directly must resolve a dependency sitting next to it."""
+    consumer = os.path.join(EXTRA_SCRIPTS_DIRECTORY, "check_extra_directory.py")
+
+    # No additional directories at all - the script's own directory comes first in the search path.
+    scripts = TriageScript.load_all(consumer)
+
+    sibling = os.path.join(EXTRA_SCRIPTS_DIRECTORY, "additional_extra_provider.py")
+    assert scripts[consumer].config.depends == [sibling]
+    assert [s.name for s in scripts[consumer].depends] == ["additional_extra_provider.py"]
+
+
+def test_package_init_is_not_treated_as_a_script():
+    """A consuming repo's __init__.py must not be imported as a module named '__init__'."""
+    scripts = TriageScript.discover_all([BROKEN_SCRIPTS_DIRECTORY])
+
+    assert "__init__.py" not in {os.path.basename(path) for path in scripts}
+    # It was skipped by name, not imported and then rejected.
+    assert "__init__" not in sys.modules
+
+
+def test_one_directory_under_several_spellings_is_scanned_once(scripts_directories):
+    spellings = [
+        SCRIPTS_DIRECTORY,
+        SCRIPTS_DIRECTORY + os.sep,
+        os.path.join(SCRIPTS_DIRECTORY, "..", "additional_scripts"),
+    ]
+    scripts = TriageScript.discover_all(spellings)
+
+    assert sorted(os.path.basename(path) for path in scripts) == [
+        "additional_provider.py",
+        "check_additional_directory.py",
+    ]
+
+
+def test_same_file_name_in_two_directories_loses_the_shadowed_copy():
+    """Only one file can own a module name, so the shadowed copy is skipped rather than run."""
+    real = os.path.join(SCRIPTS_DIRECTORY, "additional_provider.py")
+    shadowed = os.path.join(BROKEN_SCRIPTS_DIRECTORY, "additional_provider.py")
+
+    scripts = TriageScript.discover_all([SCRIPTS_DIRECTORY, BROKEN_SCRIPTS_DIRECTORY])
+
+    # The real one is kept; the copy is dropped instead of quietly replacing it.
+    assert real in scripts
+    assert shadowed not in scripts
+
+    # Asking for the shadowed copy by path says exactly what happened, rather than running the
+    # other file under this path.
+    with pytest.raises(ValueError, match="already resolves to"):  # allow-pytest.raises: no expect_error fixture
+        TriageScript.load(shadowed)
+
+
+def test_module_that_exits_at_import_does_not_end_the_run():
+    """Discovery imports every .py in a directory the user named; SystemExit is not an Exception."""
+    scripts = TriageScript.discover_all([BROKEN_SCRIPTS_DIRECTORY])
+
+    names = {os.path.basename(path) for path in scripts}
+    assert "cli_tool.py" not in names
+    # The run survives it: the other scripts in the same directory are still discovered.
+    assert "broken_dependency_check.py" in names
+
+
+def test_directories_are_validated_deduplicated_and_importable():
+    directories = resolve_scripts_directories(make_args(SCRIPTS_DIRECTORY, SCRIPTS_DIRECTORY + os.sep))
+
+    # One list, built-in first, each directory once - so no caller has to prepend the built-in one.
+    assert directories == [os.path.realpath(triage_home), os.path.realpath(SCRIPTS_DIRECTORY)]
+    assert directories[1] in sys.path
+
+
+def test_missing_directory_is_reported_with_the_spelling_the_user_gave():
+    missing = "/no/such/scripts/dir"
+    expected = f"{missing} is not a directory"
+
+    with pytest.raises(TTTriageError, match=expected):  # allow-pytest.raises: no expect_error fixture
+        resolve_scripts_directories(make_args(missing))
+
+
+def test_no_flag_still_yields_the_built_in_directory():
+    assert resolve_scripts_directories(ScriptArguments({})) == [os.path.realpath(triage_home)]
+
+
+def test_naming_the_built_in_directory_with_the_flag_is_a_no_op():
+    """Dedupe covers it, so there is no special case to keep in sync."""
+    assert resolve_scripts_directories(make_args(triage_home)) == [os.path.realpath(triage_home)]
+    assert resolve_scripts_directories(make_args(triage_home + os.sep)) == [os.path.realpath(triage_home)]

--- a/tools/tests/triage/test_additional_scripts_directory.py
+++ b/tools/tests/triage/test_additional_scripts_directory.py
@@ -9,6 +9,7 @@
 # exits at import, and a package __init__.py that must never be loaded as a script.
 
 import os
+import subprocess
 import sys
 
 import pytest
@@ -98,6 +99,40 @@ def test_flag_is_honoured_without_main():
     )
 
     assert [row.message for row in result] == [SUCCESS_MESSAGE]
+
+
+# docopt accepts any unambiguous abbreviation of a long option, so each of these reaches
+def test_script_run_directly_resolves_dependencies_in_every_scripts_directory():
+    """The documented standalone command, in a real subprocess.
+
+    A script run directly is never told its own directory, so triage has to add it to the scripts
+    directories itself, alongside the built-in one and whatever the flag named. Nothing here relies
+    on triage arranging the script's module-scope imports; the script does that for itself.
+    """
+    script = os.path.join(SCRIPTS_DIRECTORY, "check_additional_directory.py")
+
+    # --help makes run_script() print usage and exit 0, so no device is needed. Getting that far
+    # means the script and all three of its dependencies loaded, across all three directories.
+    result = subprocess.run(
+        [sys.executable, script, f"--additional-scripts-directory={EXTRA_SCRIPTS_DIRECTORY}", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={**os.environ, "PYTHONPATH": triage_home},
+    )
+
+    assert "ModuleNotFoundError" not in result.stderr, result.stderr
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def test_empty_directory_value_is_rejected_rather_than_meaning_the_current_directory():
+    """`--additional-scripts-directory=` (an unset variable in a wrapper) must not adopt the cwd.
+
+    "" normalises to the working directory, which would quietly become a scripts directory - and
+    discovery imports every .py in a scripts directory.
+    """
+    with pytest.raises(TTTriageError, match="empty value"):  # allow-pytest.raises: no expect_error fixture
+        resolve_scripts_directories(make_args(""))
 
 
 def test_bare_dependency_names_resolve_in_every_searched_directory(scripts_directories):

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,30 +5,31 @@
 
 """
 Usage:
-    triage [--noc-id=<id>] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--print-elf-cache-stats] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>] [--sqlite-output-path=<path>]
+    triage [--noc-id=<id>] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--print-elf-cache-stats] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>] [--sqlite-output-path=<path>] [--additional-scripts-directory=<dir>]...
 
 Options:
-    --remote-exalens                 Connect to remote exalens server.
-    --remote-server=<remote-server>  Specify the remote server to connect to. [default: localhost]
-    --remote-port=<remote-port>      Specify the remote server port. [default: 5555]
-    --noc-id=<id>                    NOC used for device communication (0/NOC0, 1/NOC1, 2/SYSTEM_NOC, case-insensitive). Defaults to the tt-exalens default.
-    --verbosity=<verbosity>          Choose output verbosity. 1: ERROR, 2: WARN, 3: INFO, 4: VERBOSE, 5: DEBUG. [default: 3]
-    --run=<script>                   Run specific script(s) by name. If not provided, all scripts will be run. [default: all]
-    --skip-version-check             Do not enforce debugger version check. [default: False]
-    --print-script-times             Print the execution time of each script. [default: False]
-    -v                               Increase verbosity level (can be repeated: -v, -vv, -vvv).
-                                     Controls which columns/fields are displayed:
-                                     Level 0 (default): Essential fields (Kernel ID:Name, Go Message, Subdevice, Preload, Waypoint, PC, Callstack)
-                                     Level 1 (-v): Include detailed dispatcher fields (Firmware/Kernel Path, Host Assigned ID, Kernel Offset, Previous Kernel)
-                                     Level 2 (-vv): Include internal debug fields (RD PTR, Base, Offset, Kernel XIP Path)
-    --disable-colors                 Disable colored output. [default: False]
-    --disable-progress               Disable progress bars. [default: False]
-    --disable-elf-cache              Re-parse ELF files on every access instead of caching. [default: False]
-    --print-elf-cache-stats          Print ELF cache statistics at the end of the run. [default: False]
-    --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
-    --llm-output                     Replace Rich tables on the console with a machine-readable report (CSV-formatted tables). Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
-    --llm-output-path=<path>         Additionally write the machine-readable report to <path>. Can be combined with --llm-output; without it, Rich output still goes to the console.
-    --sqlite-output-path=<path>      Additionally write a SQLite database to <path>, with one table per script that returns non-empty tabular data; check-only output is stored in the diagnostics table.
+    --remote-exalens                      Connect to remote exalens server.
+    --remote-server=<remote-server>       Specify the remote server to connect to. [default: localhost]
+    --remote-port=<remote-port>           Specify the remote server port. [default: 5555]
+    --noc-id=<id>                         NOC used for device communication (0/NOC0, 1/NOC1, 2/SYSTEM_NOC, case-insensitive). Defaults to the tt-exalens default.
+    --verbosity=<verbosity>               Choose output verbosity. 1: ERROR, 2: WARN, 3: INFO, 4: VERBOSE, 5: DEBUG. [default: 3]
+    --run=<script>                        Run specific script(s) by name. If not provided, all scripts will be run. [default: all]
+    --skip-version-check                  Do not enforce debugger version check. [default: False]
+    --print-script-times                  Print the execution time of each script. [default: False]
+    -v                                    Increase verbosity level (can be repeated: -v, -vv, -vvv).
+                                          Controls which columns/fields are displayed:
+                                          Level 0 (default): Essential fields (Kernel ID:Name, Go Message, Subdevice, Preload, Waypoint, PC, Callstack)
+                                          Level 1 (-v): Include detailed dispatcher fields (Firmware/Kernel Path, Host Assigned ID, Kernel Offset, Previous Kernel)
+                                          Level 2 (-vv): Include internal debug fields (RD PTR, Base, Offset, Kernel XIP Path)
+    --disable-colors                      Disable colored output. [default: False]
+    --disable-progress                    Disable progress bars. [default: False]
+    --disable-elf-cache                   Re-parse ELF files on every access instead of caching. [default: False]
+    --print-elf-cache-stats               Print ELF cache statistics at the end of the run. [default: False]
+    --triage-summary-path=<path>          Write a triage summary file to the given path (used by CI for hang reports).
+    --llm-output                          Replace Rich tables on the console with a machine-readable report (CSV-formatted tables). Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
+    --llm-output-path=<path>              Additionally write the machine-readable report to <path>. Can be combined with --llm-output; without it, Rich output still goes to the console.
+    --sqlite-output-path=<path>           Additionally write a SQLite database to <path>, with one table per script that returns non-empty tabular data; check-only output is stored in the diagnostics table.
+    --additional-scripts-directory=<dir>  Discover triage scripts in <dir> too. Repeat for several directories. Scripts are imported by module name, so file names there must not repeat a file name used in tools/triage.
 
 Description:
     Diagnoses Tenstorrent AI hardware by performing comprehensive health checks on ARC processors, NOC connectivity, L1 memory, and RISC-V cores.
@@ -55,7 +56,7 @@ from time import time
 import traceback
 import sys
 import utils
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 import re
 
@@ -108,6 +109,14 @@ def _raise_open_file_limit(desired: int = 65536) -> None:
         utils.WARN(
             f"Failed to raise open file limit: {e}. This may cause issues when processing many ELF files. Consider increasing the limit manually (ulimit -n {desired})."
         )
+
+
+def _normalize_path(path: str) -> str:
+    return os.path.realpath(os.path.expanduser(path))
+
+
+BUILTIN_SCRIPTS_DIRECTORY = _normalize_path(os.path.dirname(__file__))
+DEFAULT_SCRIPTS_DIRECTORIES: tuple[str, ...] = (BUILTIN_SCRIPTS_DIRECTORY,)
 
 
 class ScriptPriority(Enum):
@@ -238,6 +247,7 @@ class TriageScript:
     module: ModuleType
     run_method: Callable[..., Any]
     documentation: str
+    dependency_search_path: list[str] = field(default_factory=list)
     depends: list["TriageScript"] = field(default_factory=list)
     failed: bool = False
     failure_message: str | None = None
@@ -271,7 +281,7 @@ class TriageScript:
                 raise
 
     @staticmethod
-    def load(script_path: str) -> "TriageScript":
+    def load(script_path: str, scripts_directories: Sequence[str] = DEFAULT_SCRIPTS_DIRECTORIES) -> "TriageScript":
         script_path = os.path.abspath(script_path)
         base_path = os.path.dirname(script_path)
         appended = False
@@ -281,6 +291,14 @@ class TriageScript:
         try:
             script_name = os.path.splitext(os.path.basename(script_path))[0]
             script_module = importlib.import_module(script_name)
+
+            # Check that the imported module corresponds to the expected script file.
+            module_file = getattr(script_module, "__file__", None)
+            if module_file is None or os.path.realpath(module_file) != os.path.realpath(script_path):
+                raise ValueError(
+                    f"Script {script_path} cannot be imported: module name '{script_name}' already "
+                    f"resolves to {module_file}. Rename the script so its file name is unique."
+                )
 
             # Check if script has a configuration. The value comes from a dynamically imported
             # user module, so it may be missing/None at runtime even though the declared type isn't.
@@ -313,6 +331,7 @@ class TriageScript:
                     f"Script {script_path} does not have a valid run method with two arguments (args, context)."
                 )
 
+            search_path = _dedupe_directories([base_path, *scripts_directories])
             triage_script = TriageScript(
                 name=os.path.basename(script_path),
                 path=script_path,
@@ -320,6 +339,7 @@ class TriageScript:
                 module=script_module,
                 run_method=run_method,
                 documentation=script_module.__doc__,
+                dependency_search_path=search_path,
             )
 
             # 'depends' comes from a user-authored module and may be None or contain non-str
@@ -330,7 +350,11 @@ class TriageScript:
                 triage_script.config.depends = []
             else:
                 normalized = [dep if isinstance(dep, str) and dep.endswith(".py") else f"{dep}.py" for dep in depends]
-                triage_script.config.depends = [os.path.join(base_path, dep) for dep in normalized]
+                resolved_depends = []
+                for dep in normalized:
+                    candidates = [os.path.join(directory, dep) for directory in search_path]
+                    resolved_depends.append(next((c for c in candidates if os.path.exists(c)), candidates[0]))
+                triage_script.config.depends = resolved_depends
 
             return triage_script
         finally:
@@ -338,20 +362,27 @@ class TriageScript:
                 sys.path.remove(base_path)
 
     @staticmethod
-    def load_all(script_path: str) -> dict[str, "TriageScript"]:
+    def load_all(
+        script_path: str, scripts_directories: Sequence[str] = DEFAULT_SCRIPTS_DIRECTORIES
+    ) -> dict[str, "TriageScript"]:
         scripts: dict[str, TriageScript] = {}
-        loading: list[str] = []
-        script = TriageScript.load(script_path)
+        script = TriageScript.load(script_path, scripts_directories)
         scripts[script_path] = script
 
         # Load all dependencies
-        loading.extend(script.config.depends)
+        loading: list[tuple[str, TriageScript]] = [(dep, script) for dep in script.config.depends]
         while len(loading) > 0:
-            loading_script = loading.pop(0)
+            loading_script, required_by = loading.pop(0)
             if loading_script not in scripts:
-                script = TriageScript.load(loading_script)
+                if not os.path.exists(loading_script):
+                    searched = ", ".join(required_by.dependency_search_path)
+                    raise TTTriageError(
+                        f"{required_by.name} depends on {os.path.basename(loading_script)}, which does not exist "
+                        f"({loading_script}). Bare dependency names are searched for in: {searched}."
+                    )
+                script = TriageScript.load(loading_script, scripts_directories)
                 scripts[loading_script] = script
-                loading.extend(script.config.depends)
+                loading.extend((dep, script) for dep in script.config.depends)
 
         # Update dependencies in scripts
         for script in scripts.values():
@@ -361,18 +392,29 @@ class TriageScript:
         return scripts
 
     @staticmethod
-    def discover_all_in_directory(directory: str) -> dict[str, "TriageScript"]:
-        directory = os.path.abspath(directory)
+    def discover_all(directories: Sequence[str]) -> dict[str, "TriageScript"]:
+        directories = _dedupe_directories(directories)
         scripts: dict[str, TriageScript] = {}
-        for fname in os.listdir(directory):
-            if not fname.endswith(".py") or fname == os.path.basename(__file__):
+        for directory in directories:
+            scripts.update(TriageScript.discover_all_in_directory(directory, directories))
+        return scripts
+
+    @staticmethod
+    def discover_all_in_directory(
+        directory: str, scripts_directories: Sequence[str] = DEFAULT_SCRIPTS_DIRECTORIES
+    ) -> dict[str, "TriageScript"]:
+        directory = _normalize_path(directory)
+        scripts: dict[str, TriageScript] = {}
+        for fname in _python_file_names(directory):
+            if fname == os.path.basename(__file__):
                 continue
             script_path = os.path.join(directory, fname)
             try:
-                triage_script = TriageScript.load(script_path)
+                triage_script = TriageScript.load(script_path, scripts_directories)
                 if triage_script.config.disabled:
                     continue
-            except Exception:
+            except (Exception, SystemExit) as e:
+                utils.VERBOSE(f"Skipping {script_path}: {type(e).__name__}: {e}")
                 continue
             scripts[script_path] = triage_script
         return scripts
@@ -475,6 +517,53 @@ def create_progress() -> Progress:
         transient=True,
         disable=progress_disabled,
     )
+
+
+def _dedupe_directories(directories: Sequence[str]) -> list[str]:
+    deduped: list[str] = []
+    for directory in directories:
+        resolved = _normalize_path(directory)
+        if resolved not in deduped:
+            deduped.append(resolved)
+    return deduped
+
+
+def _python_file_names(directory: str) -> list[str]:
+    return sorted(f for f in os.listdir(directory) if f.endswith(".py") and f != "__init__.py")
+
+
+def _warn_on_shadowed_module_names(directories: Sequence[str]) -> None:
+    owner = {fname: BUILTIN_SCRIPTS_DIRECTORY for fname in _python_file_names(BUILTIN_SCRIPTS_DIRECTORY)}
+    for directory in directories:
+        shadowed = []
+        for fname in _python_file_names(directory):
+            if fname in owner:
+                shadowed.append(f"{fname} (also in {owner[fname]})")
+            else:
+                owner[fname] = directory
+        if shadowed:
+            utils.WARN(
+                f"{directory}: {', '.join(shadowed)}. Everything is imported by module name, so only the "
+                f"first copy is ever used. Rename them to keep them usable."
+            )
+
+
+def resolve_scripts_directories(args: ScriptArguments) -> list[str]:
+    requested: list[str] = args["--additional-scripts-directory"] or []
+    for directory in requested:
+        if not os.path.isdir(_normalize_path(directory)):
+            raise TTTriageError(f"--additional-scripts-directory {directory} is not a directory.")
+
+    # Built-in directory first, so it wins every lookup and naming it with the flag is a no-op.
+    directories = _dedupe_directories([BUILTIN_SCRIPTS_DIRECTORY, *requested])
+
+    # Everything except the built-in directory, which is importable already.
+    additional = directories[1:]
+    _warn_on_shadowed_module_names(additional)
+    for directory in additional:
+        if directory not in sys.path:
+            sys.path.append(directory)
+    return directories
 
 
 def process_arguments(args: ScriptArguments) -> None:
@@ -888,8 +977,14 @@ def run_script(
     context: Context | None = None,
     argv: list[str] | None = None,
     return_result: bool = False,
+    scripts_directories: Sequence[str] | None = None,
 ) -> Any:
     force_exit = False
+
+    if scripts_directories is None:
+        scripts_directories = resolve_scripts_directories(
+            args if args is not None else parse_arguments(only_triage_script_args=True, argv=argv)
+        )
 
     # Resolve script path
     if script_path is None:
@@ -902,22 +997,25 @@ def run_script(
     else:
         if not script_path.endswith(".py"):
             script_path = script_path + ".py"
-        application_path = os.path.dirname(__file__)
-        if not os.path.isabs(script_path):
-            script_path = os.path.join(application_path, script_path)
-        script_path = os.path.abspath(script_path)
-        if not os.path.exists(script_path):
-            raise FileNotFoundError(f"Script {script_path} does not exist.")
+        if os.path.isabs(script_path):
+            candidates = [script_path]
+        else:
+            candidates = [os.path.join(directory, script_path) for directory in scripts_directories]
+        found = next((os.path.abspath(c) for c in candidates if os.path.exists(c)), None)
+        if found is None:
+            searched = ", ".join(os.path.abspath(c) for c in candidates)
+            raise FileNotFoundError(f"Script {script_path} does not exist. Looked in: {searched}.")
+        script_path = found
 
     # Load script and its dependencies (drives execution order).
-    scripts = TriageScript.load_all(script_path)
+    scripts = TriageScript.load_all(script_path, scripts_directories)
 
     # Find execution order of scripts
     script_queue = resolve_execution_order(scripts)
 
     # Parse arguments using every script's options
     if args is None:
-        all_scripts = TriageScript.discover_all_in_directory(os.path.dirname(script_path))
+        all_scripts = TriageScript.discover_all([os.path.dirname(script_path), *scripts_directories])
         # Ensure the target and its deps are present even if discovery missed them somehow.
         for path, script in scripts.items():
             all_scripts.setdefault(path, script)
@@ -969,10 +1067,10 @@ def main():
     triage_start = time()
 
     # Parse only tt-triage script arguments first to initialize logging and console
-    parse_arguments(only_triage_script_args=True)
+    bootstrap_args = parse_arguments(only_triage_script_args=True)
 
-    # Enumerate all scripts in application directory
-    application_path = os.path.abspath(os.path.dirname(__file__))
+    # Read before discovery: this is the full set of directories that gets discovered.
+    scripts_directories = resolve_scripts_directories(bootstrap_args)
 
     # To avoid multiple imports of this script, we add it to sys.modules
     my_name = os.path.splitext(os.path.basename(__file__))[0]
@@ -981,7 +1079,7 @@ def main():
 
     # Load tt-triage scripts
     # TODO: do we need to check for subdirectories?
-    scripts = TriageScript.discover_all_in_directory(application_path)
+    scripts = TriageScript.discover_all(scripts_directories)
 
     # Resolve dependencies
     for script in scripts.values():
@@ -989,7 +1087,8 @@ def main():
             if dep in scripts:
                 script.depends.append(scripts[dep])
             else:
-                utils.ERROR(f"Dependency {dep} for script {script.name} not found.")
+                searched = ", ".join(script.dependency_search_path)
+                utils.ERROR(f"Dependency {dep} for script {script.name} not found (searched {searched}).")
                 script.failed = True
                 script.failure_message = f"Dependency {dep} not found."
 
@@ -1013,7 +1112,7 @@ def main():
             progress.update(scripts_task, total=len(args["--run"]))
             for script_name in args["--run"]:
                 progress.update(scripts_task, description=f"Running {script_name}")
-                run_script(script_name, args, context)
+                run_script(script_name, args, context, scripts_directories=scripts_directories)
                 progress.advance(scripts_task)
         else:
             # Execute all scripts

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -551,6 +551,8 @@ def _warn_on_shadowed_module_names(directories: Sequence[str]) -> None:
 def resolve_scripts_directories(args: ScriptArguments) -> list[str]:
     requested: list[str] = args["--additional-scripts-directory"] or []
     for directory in requested:
+        if not directory:
+            raise TTTriageError("--additional-scripts-directory was given an empty value.")
         if not os.path.isdir(_normalize_path(directory)):
             raise TTTriageError(f"--additional-scripts-directory {directory} is not a directory.")
 
@@ -1007,6 +1009,9 @@ def run_script(
             raise FileNotFoundError(f"Script {script_path} does not exist. Looked in: {searched}.")
         script_path = found
 
+    # Add script path to list of directories
+    scripts_directories = _dedupe_directories([*scripts_directories, os.path.dirname(script_path)])
+
     # Load script and its dependencies (drives execution order).
     scripts = TriageScript.load_all(script_path, scripts_directories)
 
@@ -1015,7 +1020,7 @@ def run_script(
 
     # Parse arguments using every script's options
     if args is None:
-        all_scripts = TriageScript.discover_all([os.path.dirname(script_path), *scripts_directories])
+        all_scripts = TriageScript.discover_all(scripts_directories)
         # Ensure the target and its deps are present even if discovery missed them somehow.
         for path, script in scripts.items():
             all_scripts.setdefault(path, script)

--- a/tools/triage/tt-triage.md
+++ b/tools/triage/tt-triage.md
@@ -12,6 +12,28 @@ You can run `tt-triage` by executing `tools/tt-triage.py`.
 1. The script must define a global variable `script_config` of type `ScriptConfig`.
 2. The script must define a `run` method with two arguments: `(args, context)`. `args` contains the parsed arguments for all scripts. `context` is a ttexalens `Context` object.
 
+## Scripts outside tools/triage
+
+`--additional-scripts-directory=<dir>` adds `<dir>` to the search, alongside `tools/triage`. Repeat the option to add several directories. This lets a consuming repository keep its own triage scripts in its own tree while still using the built-in ones:
+
+```bash
+./tools/tt-triage.py --additional-scripts-directory=/path/to/my/custom/triage/scripts
+```
+
+Scripts in those directories are discovered, executed and given their arguments exactly like the built-in ones, and they may depend on built-in scripts by name. Each directory is also put on `sys.path`, so a script can import its siblings.
+
+The option is read before discovery on every entry point, so it works the same way when a single script is run directly (see [Enabling standalone script execution](#enabling-standalone-script-execution)):
+
+```bash
+python /path/to/my/custom/triage/scripts/my_check.py --additional-scripts-directory=/path/to/my/other/triage/scripts
+```
+
+A script run directly does not need the flag for its own directory - that is always searched. A script and the scripts it depends on can sit side by side and be run with no options at all; the flag is only needed to reach scripts in *other* directories.
+
+One limitation with `tt-run-triage`: its host-side argument check only knows the built-in scripts, so if a script in an additional directory defines its own options, passing them through `tt-run-triage` is rejected before the ranks start. Run `triage.py` under `tt-run` directly in that case.
+
+**File names must be unique across all searched directories.** Scripts and their helper modules are imported by bare module name, so if two directories both contain `device_info.py`, only one of them can ever be imported under that name. `tt-triage` warns about the repeated names at startup and skips the shadowed script rather than running the wrong file under its path. That warning is the signal to watch for: `--run=<name>` resolves to the first match, which is the built-in one, so it runs the built-in script without complaining. Pointing at the shadowed file by path does report which file the name really resolved to. This applies to helper modules too - a `utils.py` next to your scripts would be shadowed by `tools/triage/utils.py`. `__init__.py` is exempt, since it is never loaded as a script.
+
 There are two types of scripts:
 - Data provider
 - State checker
@@ -139,6 +161,8 @@ If you set `data_provider` to `True`, your script is treated as a data provider 
 If you set `disabled` to `True`, your script will not be executed (and all scripts that depend on it will fail).
 
 `depends` is a list of scripts that your script depends on. Scripts that perform checks per device depend on the `check_per_device` script. Scripts that depend on checking operations, kernels, or firmware depend on the `dispatcher_data` script.
+
+A bare dependency name is looked for next to your script first, then in `tools/triage`, then in the directories given by `--additional-scripts-directory`, in the order they were given; the first match wins. An absolute path is used as given. This is what lets a script outside `tools/triage` depend on a built-in provider such as `run_checks` by name.
 
 ## Additional pip requirements
 


### PR DESCRIPTION
Add support for additional scripts directories in command-line options, enhancing the triage tool's flexibility. This change allows users to specify custom directories for triage scripts, improving usability in consuming repositories.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/triage_additional_scripts_dirs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/triage_additional_scripts_dirs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/triage_additional_scripts_dirs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/triage_additional_scripts_dirs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/triage_additional_scripts_dirs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/triage_additional_scripts_dirs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/triage_additional_scripts_dirs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/triage_additional_scripts_dirs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/triage_additional_scripts_dirs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/triage_additional_scripts_dirs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/triage_additional_scripts_dirs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/triage_additional_scripts_dirs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/triage_additional_scripts_dirs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/triage_additional_scripts_dirs)