### PR TITLE
[Cleanup] Refactor Metal 2.0 hardware configs away from `std::variant`.

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -300,7 +300,7 @@ void run_benchmark_case_base(DfbInitTimingBenchContext& ctx) {
     const experimental::KernelSpecName CONSUMER{"consumer"};
     const experimental::TensorParamName IN_TENSOR{"in_tensor"};
 
-    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementGen2Config{};
+    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementHardwareConfig{};
 
     auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(ENTRY_SIZE, NUM_ENTRIES));
 
@@ -331,7 +331,7 @@ void run_benchmark_case_base(DfbInitTimingBenchContext& ctx) {
         .num_threads = NUM_CONSUMERS,
         .dfb_bindings = {experimental::StridedConsumerOf(DFB, "in")},
         .compile_time_args = {{"num_entries_per_consumer", NUM_ENTRIES_PER_CONSUMER}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{
@@ -380,7 +380,7 @@ void run_benchmark_case_two(DfbInitTimingBenchContext& ctx) {
     const experimental::KernelSpecName COMPUTE{"compute"};
     const experimental::KernelSpecName WRITER{"writer_dm"};
 
-    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementHardwareConfig{};
 
     experimental::DataflowBufferSpec dfb_ss_spec = MakeBenchDfbSpec(DFB_SS, ENTRY_SIZE, NUM_ENTRIES);
     experimental::DataflowBufferSpec dfb_sa_spec = MakeBenchDfbSpec(DFB_SA, ENTRY_SIZE, NUM_ENTRIES);
@@ -404,12 +404,13 @@ void run_benchmark_case_two(DfbInitTimingBenchContext& ctx) {
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg_compute.cpp",
         .num_threads = NUM_IN_THREADS,
-        .dfb_bindings = {
-            experimental::StridedConsumerOf(DFB_SS, "ss_in"),
-            experimental::AllConsumerOf(DFB_SA, "sa_in"),
-            experimental::ProducerOf(DFB_T6, "t6_out"),
-        },
-        .hw_config = experimental::ComputeGen2Config{},
+        .dfb_bindings =
+            {
+                experimental::StridedConsumerOf(DFB_SS, "ss_in"),
+                experimental::AllConsumerOf(DFB_SA, "sa_in"),
+                experimental::ProducerOf(DFB_T6, "t6_out"),
+            },
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     // Writer DM: STRIDED consumer on DFB_T6
@@ -480,7 +481,7 @@ void run_benchmark_case_four(DfbInitTimingBenchContext& ctx) {
     const experimental::KernelSpecName READER{"reader_dm"};
     const experimental::KernelSpecName COMPUTE{"compute"};
 
-    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementHardwareConfig{};
 
     // Reader DM: 4 STRIDED producers on all three DFBs
     experimental::KernelSpec reader_spec{
@@ -500,12 +501,13 @@ void run_benchmark_case_four(DfbInitTimingBenchContext& ctx) {
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst_compute.cpp",
         .num_threads = NUM_CONSUMERS,
-        .dfb_bindings = {
-            experimental::AllConsumerOf(DFB0, "in0"),
-            experimental::AllConsumerOf(DFB1, "in1"),
-            experimental::AllConsumerOf(DFB2, "in2"),
-        },
-        .hw_config = experimental::ComputeGen2Config{},
+        .dfb_bindings =
+            {
+                experimental::AllConsumerOf(DFB0, "in0"),
+                experimental::AllConsumerOf(DFB1, "in1"),
+                experimental::AllConsumerOf(DFB2, "in2"),
+            },
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{
@@ -566,7 +568,7 @@ void run_benchmark_case_three(DfbInitTimingBenchContext& ctx) {
     const experimental::KernelSpecName READER{"reader_dm"};
     const experimental::KernelSpecName COMPUTE{"compute"};
 
-    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementHardwareConfig{};
 
     // Reader DM: 4 STRIDED producers on all three DFBs.
     experimental::KernelSpec reader_spec{
@@ -586,12 +588,13 @@ void run_benchmark_case_three(DfbInitTimingBenchContext& ctx) {
         .unique_id = COMPUTE,
         .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg2_compute.cpp",
         .num_threads = NUM_CONSUMERS,
-        .dfb_bindings = {
-            experimental::StridedConsumerOf(DFB0, "in0"),
-            experimental::StridedConsumerOf(DFB1, "in1"),
-            experimental::StridedConsumerOf(DFB2, "in2"),
-        },
-        .hw_config = experimental::ComputeGen2Config{},
+        .dfb_bindings =
+            {
+                experimental::StridedConsumerOf(DFB0, "in0"),
+                experimental::StridedConsumerOf(DFB1, "in1"),
+                experimental::StridedConsumerOf(DFB2, "in2"),
+            },
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{
@@ -660,7 +663,7 @@ void run_benchmark_case_five(DfbInitTimingBenchContext& ctx) {
         return experimental::DFBSpecName{std::string("dfb_") + group + std::to_string(i)};
     };
 
-    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementHardwareConfig{};
 
     // Each reader: single DM, 1Sx4A, 16 reads per DFB (full ring).
     const char* READER_SRC =
@@ -705,7 +708,7 @@ void run_benchmark_case_five(DfbInitTimingBenchContext& ctx) {
         .source = COMPUTE_SRC,
         .num_threads = 4,
         .dfb_bindings = compute_bindings,
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     });
 
     // 12 DFB specs: 3 per group × 4 groups.
@@ -1273,7 +1276,7 @@ void run_benchmark_case_six_debug_implicit_sync_program_spec(DfbInitTimingBenchC
     const experimental::KernelSpecName CONSUMER{"consumer"};
     const experimental::TensorParamName IN_TENSOR{"in_tensor"};
 
-    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementGen2Config{};
+    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementHardwareConfig{};
 
     auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(ENTRY_SIZE, NUM_ENTRIES));
 
@@ -1304,7 +1307,7 @@ void run_benchmark_case_six_debug_implicit_sync_program_spec(DfbInitTimingBenchC
         .num_threads = NUM_CONSUMERS,
         .dfb_bindings = {experimental::AllConsumerOf(DFB, "in")},
         .compile_time_args = {{"num_entries_per_consumer", NUM_ENTRIES}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -131,14 +131,17 @@ inline m2::KernelSpec make_dm_kernel(
     const std::string& source_path,
     uint8_t num_threads = 1,
     std::vector<m2::DFBSpecName> disable_implicit_sync_for = {}) {
+    m2::DataMovementHardwareConfig dm{};
+    if (!disable_implicit_sync_for.empty()) {
+        dm.config_2xx = m2::DataMovementHardwareConfig::DataMovement2XXConfig{
+            .disable_dfb_implicit_sync_for = std::move(disable_implicit_sync_for),
+        };
+    }
     return m2::KernelSpec{
         .unique_id = unique_id,
         .source = std::filesystem::path{source_path},
         .num_threads = num_threads,
-        .hw_config =
-            m2::DataMovementGen2Config{
-                .disable_dfb_implicit_sync_for = std::move(disable_implicit_sync_for),
-            },
+        .hw_config = std::move(dm),
     };
 }
 
@@ -148,15 +151,16 @@ inline m2::KernelSpec make_compute_kernel(
         .unique_id = unique_id,
         .source = std::filesystem::path{source_path},
         .num_threads = num_threads,
-        .hw_config = m2::ComputeGen2Config{},
+        .hw_config = m2::ComputeHardwareConfig{},
     };
 }
 
 inline void disable_implicit_sync_for(m2::KernelSpec& kernel, m2::DFBSpecName dfb_name) {
     auto& dm_cfg = std::get<m2::DataMovementHardwareConfig>(kernel.hw_config);
-    TT_FATAL(std::holds_alternative<m2::DataMovementGen2Config>(dm_cfg), "Can only set implicit sync for Gen2 Kernel");
-    auto& gen2_cfg = std::get<m2::DataMovementGen2Config>(dm_cfg);
-    gen2_cfg.disable_dfb_implicit_sync_for.push_back(std::move(dfb_name));
+    if (!dm_cfg.config_2xx.has_value()) {
+        dm_cfg.config_2xx = m2::DataMovementHardwareConfig::DataMovement2XXConfig{};
+    }
+    dm_cfg.config_2xx->disable_dfb_implicit_sync_for.push_back(std::move(dfb_name));
 }
 
 inline void maybe_disable_implicit_sync(m2::KernelSpec& kernel, bool implicit_sync, m2::DFBSpecName dfb_name) {
@@ -361,16 +365,18 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
     } else {
         // WH/BH: Gen1 config (Gen1 has no implicit sync, so no disable knob needed).
         if (p.producer_type == M2PorCType::DM) {
-            producer.hw_config =
-                m2::DataMovementGen1Config{.processor = tt::tt_metal::DataMovementProcessor::RISCV_0};
+            producer.hw_config = m2::DataMovementHardwareConfig{
+                .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                    .processor = tt::tt_metal::DataMovementProcessor::RISCV_0}};
         } else {
-            producer.hw_config = m2::ComputeGen1Config{};
+            producer.hw_config = m2::ComputeHardwareConfig{};
         }
         if (p.consumer_type == M2PorCType::DM) {
-            consumer.hw_config = m2::DataMovementGen1Config{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = tt::tt_metal::NOC::NOC_1};
+            consumer.hw_config = m2::DataMovementHardwareConfig{
+                .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                    .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = tt::tt_metal::NOC::NOC_1}};
         } else {
-            consumer.hw_config = m2::ComputeGen1Config{};
+            consumer.hw_config = m2::ComputeHardwareConfig{};
         }
     }
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -41,25 +41,27 @@ namespace {
 
 using namespace experimental;
 
-constexpr const char* ALIAS_PRODUCER_KERNEL =
-    "tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp";
-constexpr const char* ALIAS_CONSUMER_KERNEL =
-    "tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp";
+constexpr const char* ALIAS_PRODUCER_KERNEL = "tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp";
+constexpr const char* ALIAS_CONSUMER_KERNEL = "tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp";
 
 inline TensorSpec make_alias_dram_tensor_spec(uint32_t entry_size, uint32_t num_entries) {
     const uint32_t words = entry_size / sizeof(uint32_t);
     return TensorSpec(
         Shape{num_entries, words},
-        TensorLayout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR),
-                     MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM}));
+        TensorLayout(
+            DataType::UINT32,
+            PageConfig(Layout::ROW_MAJOR),
+            MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM}));
 }
 
 inline TensorSpec make_alias_l1_tensor_spec(uint32_t entry_size, uint32_t num_entries) {
     const uint32_t total_words = num_entries * entry_size / sizeof(uint32_t);
     return TensorSpec(
         Shape{1, total_words},
-        TensorLayout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR),
-                     MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1}));
+        TensorLayout(
+            DataType::UINT32,
+            PageConfig(Layout::ROW_MAJOR),
+            MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1}));
 }
 
 // Build a DataflowBufferConfig for direct-API tests (no kernel compilation).
@@ -80,11 +82,11 @@ inline dfb::DataflowBufferConfig make_1sx1s_config(uint32_t entry_size, uint32_t
 }
 
 struct AliasDFBProgramComponents {
-    ProgramSpec       spec;
-    MeshTensor        in_a;
-    MeshTensor        in_b;
-    MeshTensor        out_a;
-    MeshTensor        out_b;
+    ProgramSpec spec;
+    MeshTensor in_a;
+    MeshTensor in_b;
+    MeshTensor out_a;
+    MeshTensor out_b;
 };
 
 AliasDFBProgramComponents make_alias_dfb_program_spec(
@@ -114,11 +116,17 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
     DataMovementHardwareConfig producer_cfg;
     DataMovementHardwareConfig consumer_cfg;
     if (mesh_device.arch() == ARCH::QUASAR) {
-        producer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-        consumer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        producer_cfg = DataMovementHardwareConfig{
+            .config_2xx = DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true}};
+        consumer_cfg = DataMovementHardwareConfig{
+            .config_2xx = DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true}};
     } else {
-        producer_cfg = DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
-        consumer_cfg = DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+        producer_cfg = DataMovementHardwareConfig{
+            .config_1xx =
+                DataMovementHardwareConfig::DataMovement1XXConfig{.processor = DataMovementProcessor::RISCV_0}};
+        consumer_cfg = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
     }
 
     DataflowBufferSpec dfb_a{
@@ -229,10 +237,7 @@ void run_alias_dfb_program(
     uint8_t num_producers = 1,
     uint8_t num_consumers = 1) {
     auto [spec, in_a, in_b, out_a, out_b] = make_alias_dfb_program_spec(
-        mesh_device, node,
-        entry_size_a, num_entries_a,
-        entry_size_b, num_entries_b,
-        num_producers, num_consumers);
+        mesh_device, node, entry_size_a, num_entries_a, entry_size_b, num_entries_b, num_producers, num_consumers);
 
     Program program = MakeProgramFromSpec(mesh_device, spec);
 
@@ -286,19 +291,17 @@ void run_alias_dfb_program(
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
     slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
 
-    EXPECT_EQ(result_a, input_a)
-        << "Phase A output mismatch: DFB_A data did not round-trip correctly";
-    EXPECT_EQ(result_b, input_b)
-        << "Phase B output mismatch: DFB_B (alias) data did not round-trip correctly";
+    EXPECT_EQ(result_a, input_a) << "Phase A output mismatch: DFB_A data did not round-trip correctly";
+    EXPECT_EQ(result_b, input_b) << "Phase B output mismatch: DFB_B (alias) data did not round-trip correctly";
 }
 
 struct AliasBorrowedDFBComponents {
-    ProgramSpec  spec;
-    MeshTensor   in_a;
-    MeshTensor   in_b;
-    MeshTensor   out_a;
-    MeshTensor   out_b;
-    MeshTensor   ring_tensor;  // L1 tensor that backs dfb
+    ProgramSpec spec;
+    MeshTensor in_a;
+    MeshTensor in_b;
+    MeshTensor out_a;
+    MeshTensor out_b;
+    MeshTensor ring_tensor;  // L1 tensor that backs dfb
 };
 
 AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
@@ -317,11 +320,17 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
     DataMovementHardwareConfig producer_cfg;
     DataMovementHardwareConfig consumer_cfg;
     if (mesh_device.arch() == ARCH::QUASAR) {
-        producer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-        consumer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        producer_cfg = DataMovementHardwareConfig{
+            .config_2xx = DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true}};
+        consumer_cfg = DataMovementHardwareConfig{
+            .config_2xx = DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true}};
     } else {
-        producer_cfg = DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
-        consumer_cfg = DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+        producer_cfg = DataMovementHardwareConfig{
+            .config_1xx =
+                DataMovementHardwareConfig::DataMovement1XXConfig{.processor = DataMovementProcessor::RISCV_0}};
+        consumer_cfg = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
     }
 
     // dfb_borrowed: backed by ring_tensor (L1)
@@ -449,10 +458,7 @@ TEST_F(UnitMeshFixture, AliasDFBAddressEquality1Sx1S) {
 
     EXPECT_EQ(addr_a, addr_b) << "Aliased DFBs must share the same L1 base address";
 
-    log_info(
-        tt::LogTest,
-        "AliasDFB_AddressEquality_1Sx1S: addr_a=0x{:x}  addr_b=0x{:x}",
-        addr_a, addr_b);
+    log_info(tt::LogTest, "AliasDFB_AddressEquality_1Sx1S: addr_a=0x{:x}  addr_b=0x{:x}", addr_a, addr_b);
 }
 
 TEST_F(UnitMeshFixture, AliasDFBDataFlow1Sx1S) {
@@ -682,8 +688,7 @@ TEST_F(UnitMeshFixture, AliasDFBAllocSecondarySkipped) {
 
     // addr_c must follow the primary's footprint, not the secondary's.
     const uint32_t group_end = addr_a + cfg_a.entry_size * cfg_a.num_entries;
-    EXPECT_GE(addr_c, group_end)
-        << "Non-aliased DFB_C must start after the alias group";
+    EXPECT_GE(addr_c, group_end) << "Non-aliased DFB_C must start after the alias group";
     EXPECT_LT(addr_c, group_end + cfg_b.entry_size * cfg_b.num_entries)
         << "Allocator double-counted the secondary: addr_c is too far";
 }
@@ -691,8 +696,8 @@ TEST_F(UnitMeshFixture, AliasDFBAllocSecondarySkipped) {
 TEST_F(UnitMeshFixture, AliasDFBAlloc3Way) {
     const CoreCoord core{0, 0};
 
-    const auto cfg_a = make_1sx1s_config(512,  8);
-    const auto cfg_b = make_1sx1s_config(256,  16);
+    const auto cfg_a = make_1sx1s_config(512, 8);
+    const auto cfg_b = make_1sx1s_config(256, 16);
     const auto cfg_c = make_1sx1s_config(1024, 4);
 
     Program program = CreateProgram();
@@ -712,10 +717,7 @@ TEST_F(UnitMeshFixture, AliasDFBAlloc3Way) {
     EXPECT_EQ(addr_a, addr_b) << "DFB_B must share DFB_A's address";
     EXPECT_EQ(addr_a, addr_c) << "DFB_C must share DFB_A's address";
 
-    log_info(
-        tt::LogTest,
-        "AliasDFB_Alloc_3Way: addr_a=0x{:x}  addr_b=0x{:x}  addr_c=0x{:x}",
-        addr_a, addr_b, addr_c);
+    log_info(tt::LogTest, "AliasDFB_Alloc_3Way: addr_a=0x{:x}  addr_b=0x{:x}  addr_c=0x{:x}", addr_a, addr_b, addr_c);
 }
 
 TEST_F(UnitMeshFixture, AliasDFBAgreedGroupResize) {
@@ -763,8 +765,8 @@ TEST_F(UnitMeshFixture, AliasDFBAgreedGroupResize) {
 
 TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryAddressEquality) {
     const NodeCoord node{0, 0};
-    constexpr uint32_t kEntrySize   = 512;
-    constexpr uint32_t kNumEntries  = 8;
+    constexpr uint32_t kEntrySize = 512;
+    constexpr uint32_t kNumEntries = 8;
 
     auto [spec, in_a, in_b, out_a, out_b, ring] =
         make_alias_borrowed_dfb_program_spec(this->device(), node, kEntrySize, kNumEntries);
@@ -806,26 +808,26 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryAddressEquality) {
     SetProgramRunArgs(program, run_params);
 
     const uint32_t id_borrowed = program.impl().get_dfb_handle("dfb_borrowed");
-    const uint32_t id_alias    = program.impl().get_dfb_handle("dfb_alias");
+    const uint32_t id_alias = program.impl().get_dfb_handle("dfb_alias");
 
     const uint32_t addr_borrowed = program.impl().get_dataflow_buffer(id_borrowed)->uniform_alloc_addr();
-    const uint32_t addr_alias    = program.impl().get_dataflow_buffer(id_alias)->uniform_alloc_addr();
+    const uint32_t addr_alias = program.impl().get_dataflow_buffer(id_alias)->uniform_alloc_addr();
     const uint32_t ring_addr = static_cast<uint32_t>(ring.mesh_buffer().address());
 
-    EXPECT_EQ(addr_borrowed, ring_addr)
-        << "dfb_borrowed must resolve to the ring tensor's L1 address";
-    EXPECT_EQ(addr_alias, ring_addr)
-        << "dfb_alias must inherit the ring tensor's L1 address via alias propagation";
+    EXPECT_EQ(addr_borrowed, ring_addr) << "dfb_borrowed must resolve to the ring tensor's L1 address";
+    EXPECT_EQ(addr_alias, ring_addr) << "dfb_alias must inherit the ring tensor's L1 address via alias propagation";
 
     log_info(
         tt::LogTest,
         "AliasDFB_BorrowedMemory_AddressEquality: addr_borrowed=0x{:x}  addr_alias=0x{:x}  ring=0x{:x}",
-        addr_borrowed, addr_alias, ring_addr);
+        addr_borrowed,
+        addr_alias,
+        ring_addr);
 }
 
 TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     const NodeCoord node{0, 0};
-    constexpr uint32_t kEntrySize  = 512;
+    constexpr uint32_t kEntrySize = 512;
     constexpr uint32_t kNumEntries = 8;
 
     auto [spec, in_a, in_b, out_a, out_b, ring] =
@@ -880,10 +882,8 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
     slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
 
-    EXPECT_EQ(result_a, input_a)
-        << "Phase A (dfb_borrowed) data did not round-trip correctly";
-    EXPECT_EQ(result_b, input_b)
-        << "Phase B (dfb_alias via borrowed L1) data did not round-trip correctly";
+    EXPECT_EQ(result_a, input_a) << "Phase A (dfb_borrowed) data did not round-trip correctly";
+    EXPECT_EQ(result_b, input_b) << "Phase B (dfb_alias via borrowed L1) data did not round-trip correctly";
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -43,16 +43,13 @@ using test_helpers::MakeMinimalGen2DMKernel;
 using test_helpers::MakeMinimalWorkUnit;
 
 // Kernel paths shared with the standard DFB tests.
-constexpr const char* DFB_PRODUCER_KERNEL =
-    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp";
-constexpr const char* DFB_DM_CONSUMER_KERNEL =
-    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp";
-constexpr const char* DFB_TENSIX_CONSUMER_KERNEL =
-    "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp";
+constexpr const char* DFB_PRODUCER_KERNEL = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp";
+constexpr const char* DFB_DM_CONSUMER_KERNEL = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp";
+constexpr const char* DFB_TENSIX_CONSUMER_KERNEL = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp";
 
 inline TensorSpec make_flat_dram_tensor_spec(uint32_t entry_size, uint32_t total_entries) {
     const uint32_t entry_size_words = entry_size / sizeof(uint32_t);
-    auto page_config   = PageConfig(Layout::ROW_MAJOR);
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto tensor_layout = TensorLayout(DataType::UINT32, page_config, memory_config);
     return TensorSpec(Shape{total_entries, entry_size_words}, tensor_layout);
@@ -64,20 +61,20 @@ inline TensorSpec make_flat_l1_tensor_spec(uint32_t entry_size, uint32_t total_e
     // distinct L1 banks (cores), leaving only one page's worth of bytes per bank and
     // failing the borrowed-DFB size check in AttachBorrowedDFBBuffers.
     const uint32_t total_words = total_entries * entry_size / sizeof(uint32_t);
-    auto page_config   = PageConfig(Layout::ROW_MAJOR);
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1};
     auto tensor_layout = TensorLayout(DataType::UINT32, page_config, memory_config);
     return TensorSpec(Shape{1, total_words}, tensor_layout);
 }
 
 struct BorrowedDFBTestConfig {
-    uint32_t num_entries      = 16;
-    uint32_t entry_size       = 256;   // bytes
-    uint32_t num_producers    = 1;
-    uint32_t num_consumers    = 1;
-    DFBAccessPattern cap      = DFBAccessPattern::STRIDED;  // producer is always STRIDED
-    bool tensix_consumer      = false;
-    bool verify_data          = false;
+    uint32_t num_entries = 16;
+    uint32_t entry_size = 256;  // bytes
+    uint32_t num_producers = 1;
+    uint32_t num_consumers = 1;
+    DFBAccessPattern cap = DFBAccessPattern::STRIDED;  // producer is always STRIDED
+    bool tensix_consumer = false;
+    bool verify_data = false;
     std::optional<uint32_t> num_entries_override = std::nullopt;
     bool expect_attach_fatal = false;
 };
@@ -92,11 +89,9 @@ void run_borrowed_memory_dfb_program(
 
     constexpr uint32_t implicit_sync = 0;
 
-    const uint32_t entries_per_producer =
-        (cfg.num_entries + cfg.num_producers - 1) / cfg.num_producers;
+    const uint32_t entries_per_producer = (cfg.num_entries + cfg.num_producers - 1) / cfg.num_producers;
     const uint32_t entries_per_consumer =
-        is_all ? cfg.num_entries
-               : (cfg.num_entries + cfg.num_consumers - 1) / cfg.num_consumers;
+        is_all ? cfg.num_entries : (cfg.num_entries + cfg.num_consumers - 1) / cfg.num_consumers;
 
     // For a single-core run: chunk_offset=0, entries_per_core=num_entries.
     const uint32_t entries_per_core = cfg.num_entries;
@@ -114,8 +109,8 @@ void run_borrowed_memory_dfb_program(
     producer_spec.source = DFB_PRODUCER_KERNEL;
     producer_spec.compile_time_args = {
         {"num_entries_per_producer", entries_per_producer},
-        {"implicit_sync",            implicit_sync},
-        {"num_producers",            cfg.num_producers},
+        {"implicit_sync", implicit_sync},
+        {"num_producers", cfg.num_producers},
     };
     producer_spec.runtime_arg_schema.runtime_arg_names = {"chunk_offset", "entries_per_core"};
     producer_spec.tensor_bindings = {
@@ -143,9 +138,9 @@ void run_borrowed_memory_dfb_program(
         consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
         consumer_spec.compile_time_args = {
             {"num_entries_per_consumer", entries_per_consumer},
-            {"blocked_consumer",         static_cast<uint32_t>(is_all ? 1u : 0u)},
-            {"implicit_sync",            implicit_sync},
-            {"num_consumers",            cfg.num_consumers},
+            {"blocked_consumer", static_cast<uint32_t>(is_all ? 1u : 0u)},
+            {"implicit_sync", implicit_sync},
+            {"num_consumers", cfg.num_consumers},
         };
         consumer_spec.runtime_arg_schema.runtime_arg_names = {"chunk_offset", "entries_per_core"};
         consumer_spec.tensor_bindings = {{
@@ -163,13 +158,11 @@ void run_borrowed_memory_dfb_program(
     // Disable implicit sync on the borrowed DFB for every DM endpoint (Gen2 only;
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
-        auto& producer_hw_config =
-            std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(producer_spec.hw_config));
-        producer_hw_config.disable_dfb_implicit_sync_for_all = true;
+        std::get<DataMovementHardwareConfig>(producer_spec.hw_config).config_2xx =
+            DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
         if (!cfg.tensix_consumer) {
-            auto& consumer_hw_config =
-                std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(consumer_spec.hw_config));
-            consumer_hw_config.disable_dfb_implicit_sync_for_all = true;
+            std::get<DataMovementHardwareConfig>(consumer_spec.hw_config).config_2xx =
+                DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
         }
     }
 
@@ -183,8 +176,8 @@ void run_borrowed_memory_dfb_program(
     };
 
     // --- TensorParameters ---
-    const TensorSpec src_spec  = make_flat_dram_tensor_spec(cfg.entry_size, cfg.num_entries);
-    const TensorSpec dst_spec  = make_flat_dram_tensor_spec(cfg.entry_size, cfg.num_entries);
+    const TensorSpec src_spec = make_flat_dram_tensor_spec(cfg.entry_size, cfg.num_entries);
+    const TensorSpec dst_spec = make_flat_dram_tensor_spec(cfg.entry_size, cfg.num_entries);
     const TensorSpec ring_spec = make_flat_l1_tensor_spec(cfg.entry_size, cfg.num_entries);
 
     spec.tensor_parameters.push_back({.unique_id = experimental::TensorParamName{"src_tensor"}, .spec = src_spec});
@@ -194,9 +187,9 @@ void run_borrowed_memory_dfb_program(
     spec.tensor_parameters.push_back(
         {.unique_id = experimental::TensorParamName{"dfb_ring_tensor"}, .spec = ring_spec});
 
-    spec.kernels          = {producer_spec, consumer_spec};
+    spec.kernels = {producer_spec, consumer_spec};
     spec.dataflow_buffers = {dfb_spec};
-    spec.work_units       = {MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+    spec.work_units = {MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     // -----------------------------------------------------------------------
     // Create program and allocate tensors
@@ -289,9 +282,9 @@ void run_update_address_test(
     std::optional<uint32_t> reentry_num_entries_override = std::nullopt) {
     const ARCH arch = mesh_device.arch();
 
-    constexpr uint32_t num_entries  = 16;
-    constexpr uint32_t entry_size   = 256;
-    constexpr uint32_t total_words  = num_entries * entry_size / sizeof(uint32_t);
+    constexpr uint32_t num_entries = 16;
+    constexpr uint32_t entry_size = 256;
+    constexpr uint32_t total_words = num_entries * entry_size / sizeof(uint32_t);
     constexpr uint32_t implicit_sync = 0;
 
     // -----------------------------------------------------------------------
@@ -307,8 +300,8 @@ void run_update_address_test(
     producer_spec.source = DFB_PRODUCER_KERNEL;
     producer_spec.compile_time_args = {
         {"num_entries_per_producer", num_entries},
-        {"implicit_sync",            implicit_sync},
-        {"num_producers",            1u},
+        {"implicit_sync", implicit_sync},
+        {"num_producers", 1u},
     };
     producer_spec.runtime_arg_schema.runtime_arg_names = {"chunk_offset", "entries_per_core"};
     producer_spec.tensor_bindings = {
@@ -323,9 +316,9 @@ void run_update_address_test(
     consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
     consumer_spec.compile_time_args = {
         {"num_entries_per_consumer", num_entries},
-        {"blocked_consumer",         0u},
-        {"implicit_sync",            implicit_sync},
-        {"num_consumers",            1u},
+        {"blocked_consumer", 0u},
+        {"implicit_sync", implicit_sync},
+        {"num_consumers", 1u},
     };
     consumer_spec.runtime_arg_schema.runtime_arg_names = {"chunk_offset", "entries_per_core"};
     consumer_spec.tensor_bindings = {{
@@ -337,12 +330,10 @@ void run_update_address_test(
     // Disable implicit sync on the borrowed DFB for both DM endpoints (Gen2 only;
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
-        auto& producer_hw_config =
-            std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(producer_spec.hw_config));
-        auto& consumer_hw_config =
-            std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(consumer_spec.hw_config));
-        producer_hw_config.disable_dfb_implicit_sync_for_all = true;
-        consumer_hw_config.disable_dfb_implicit_sync_for_all = true;
+        std::get<DataMovementHardwareConfig>(producer_spec.hw_config).config_2xx =
+            DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
+        std::get<DataMovementHardwareConfig>(consumer_spec.hw_config).config_2xx =
+            DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
     }
 
     DataflowBufferSpec dfb_spec{
@@ -353,8 +344,8 @@ void run_update_address_test(
         .borrowed_from = experimental::TensorParamName{"dfb_ring_tensor"},
     };
 
-    const TensorSpec src_spec  = make_flat_dram_tensor_spec(entry_size, num_entries);
-    const TensorSpec dst_spec  = make_flat_dram_tensor_spec(entry_size, num_entries);
+    const TensorSpec src_spec = make_flat_dram_tensor_spec(entry_size, num_entries);
+    const TensorSpec dst_spec = make_flat_dram_tensor_spec(entry_size, num_entries);
     const TensorSpec ring_spec = make_flat_l1_tensor_spec(entry_size, num_entries);
 
     spec.tensor_parameters = {
@@ -362,9 +353,9 @@ void run_update_address_test(
         {.unique_id = experimental::TensorParamName{"dst_tensor"}, .spec = dst_spec},
         {.unique_id = experimental::TensorParamName{"dfb_ring_tensor"}, .spec = ring_spec},
     };
-    spec.kernels          = {producer_spec, consumer_spec};
+    spec.kernels = {producer_spec, consumer_spec};
     spec.dataflow_buffers = {dfb_spec};
-    spec.work_units       = {MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+    spec.work_units = {MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
     auto device_range = distributed::MeshCoordinateRange(mesh_device.shape());
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -72,13 +72,7 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     // Per thread: {tile0[0], tile0[1], tile1[0], tile1[1], get_tile_address(1)[0],
     //             read_tile_value<uint16_t>(1)[0], read_tile_value<uint16_t>(1)[1]}
     const std::vector<DataT> expected_per_thread = {
-        tile0_val0,
-        tile0_val1,
-        tile1_val0,
-        tile1_val1,
-        tile1_val0,
-        tile1_val0_lo,
-        tile1_val0_hi};
+        tile0_val0, tile0_val1, tile1_val0, tile1_val1, tile1_val0, tile1_val0_lo, tile1_val0_hi};
     // UNPACK, MATH, and PACK each write expected_per_thread to a distinct L1 slot.
     std::vector<DataT> expected_scalar_reads;
     expected_scalar_reads.reserve(num_results_per_thread * num_trisc_threads);
@@ -122,7 +116,10 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
                 {"num_producers", num_producers},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"chunk_offset", "entries_per_core"}},
-        .hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0},
+        .hw_config =
+            m2::DataMovementHardwareConfig{
+                .config_1xx =
+                    m2::DataMovementHardwareConfig::DataMovement1XXConfig{.processor = DataMovementProcessor::RISCV_0}},
     };
 
     m2::KernelSpec consumer{
@@ -136,7 +133,7 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
               .access_pattern = m2::DFBAccessPattern::STRIDED}},
         .compile_time_args = {{"num_entries_per_consumer", num_entries}},
         .runtime_arg_schema = {.runtime_arg_names = {"result_l1_addr"}},
-        .hw_config = m2::ComputeGen1Config{},
+        .hw_config = m2::ComputeHardwareConfig{},
     };
 
     m2::WorkUnitSpec wu{.name = "wu", .kernels = {PRODUCER, CONSUMER}, .target_nodes = node};
@@ -190,9 +187,7 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     ASSERT_EQ(scalar_results.size(), expected_scalar_reads.size());
     for (uint32_t thread = 0; thread < num_trisc_threads; ++thread) {
         const auto begin = scalar_results.begin() + thread * num_results_per_thread;
-        EXPECT_EQ(
-            std::vector<DataT>(begin, begin + num_results_per_thread),
-            expected_per_thread)
+        EXPECT_EQ(std::vector<DataT>(begin, begin + num_results_per_thread), expected_per_thread)
             << "TRISC thread slot " << thread;
     }
 }
@@ -249,16 +244,12 @@ inline uint32_t expected_strided_ring_span_bytes(
 }
 
 inline ExtentRecord expected_strided_extent(
-    uint32_t entry_size,
-    uint32_t num_entries,
-    uint32_t num_producers,
-    uint32_t num_consumers,
-    bool is_producer) {
+    uint32_t entry_size, uint32_t num_entries, uint32_t num_producers, uint32_t num_consumers, bool is_producer) {
     const auto layout = compute_strided_layout(num_entries, entry_size, num_producers, num_consumers, is_producer);
     const uint32_t total_bytes = num_entries * entry_size;
     const uint32_t num_endpoint_threads = is_producer ? num_producers : num_consumers;
-    const uint32_t ring_span_bytes = expected_strided_ring_span_bytes(
-        entry_size, layout.ring_bytes, layout.num_tcs_on_risc, num_endpoint_threads);
+    const uint32_t ring_span_bytes =
+        expected_strided_ring_span_bytes(entry_size, layout.ring_bytes, layout.num_tcs_on_risc, num_endpoint_threads);
     return ExtentRecord{
         entry_size,
         entry_size * layout.stride_in_entries,
@@ -273,11 +264,7 @@ inline ExtentRecord expected_strided_extent(
 
 // ALL consumer (cap=ALL): capacity/stride follow num_producers; TC counts match DMTensix ALL.
 inline ExtentRecord expected_all_extent(
-    uint32_t entry_size,
-    uint32_t num_entries,
-    uint32_t num_producers,
-    uint32_t num_consumers,
-    bool is_producer) {
+    uint32_t entry_size, uint32_t num_entries, uint32_t num_producers, uint32_t num_consumers, bool is_producer) {
     (void)num_consumers;
     const uint32_t capacity = num_entries / num_producers;
     const uint32_t stride_in_entries = 1;
@@ -394,11 +381,15 @@ void run_extent_probe(distributed::MeshDevice& mesh_device, const ExtentProbePar
     m2::DataMovementHardwareConfig producer_hw;
     m2::ComputeHardwareConfig consumer_hw;
     if (is_quasar) {
-        producer_hw = m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for = {DFB}};
-        consumer_hw = m2::ComputeGen2Config{};
+        producer_hw = m2::DataMovementHardwareConfig{
+            .config_2xx =
+                m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for = {DFB}}};
+        consumer_hw = m2::ComputeHardwareConfig{};
     } else {
-        producer_hw = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
-        consumer_hw = m2::ComputeGen1Config{};
+        producer_hw = m2::DataMovementHardwareConfig{
+            .config_1xx =
+                m2::DataMovementHardwareConfig::DataMovement1XXConfig{.processor = DataMovementProcessor::RISCV_0}};
+        consumer_hw = m2::ComputeHardwareConfig{};
     }
 
     m2::KernelSpec producer{
@@ -452,8 +443,7 @@ void run_extent_probe(distributed::MeshDevice& mesh_device, const ExtentProbePar
 
     Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
-    const uint32_t producer_records =
-        params.num_producers * params.producer.num_tc_snapshots;
+    const uint32_t producer_records = params.num_producers * params.producer.num_tc_snapshots;
     const uint32_t consumer_records = params.consumer.num_tc_snapshots;
     const uint32_t producer_result_l1 =
         allocate_l1_result_region(mesh_device, (producer_records + consumer_records) * extent_record_bytes);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -47,8 +47,12 @@ void apply_gen1_dm_configs(m2::KernelSpec& producer, m2::KernelSpec& consumer, d
     if (mesh_device.arch() == ARCH::QUASAR) {
         return;
     }
-    producer.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
-    consumer.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+    producer.hw_config = m2::DataMovementHardwareConfig{
+        .config_1xx =
+            m2::DataMovementHardwareConfig::DataMovement1XXConfig{.processor = DataMovementProcessor::RISCV_0}};
+    consumer.hw_config = m2::DataMovementHardwareConfig{
+        .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
 }
 
 void expect_half_grid_slots_packed(Program& program, uint32_t num_dfbs_per_half, bool /*is_quasar*/) {
@@ -77,7 +81,9 @@ m2::KernelSpec make_touch_producer(const std::string& name, uint32_t num_dfbs, d
     kernel.compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}};
     kernel.compile_time_args = {{"implicit_sync", implicit_sync ? 1u : 0u}};
     if (!implicit_sync) {
-        kernel.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
+        kernel.hw_config = m2::DataMovementHardwareConfig{
+            .config_1xx =
+                m2::DataMovementHardwareConfig::DataMovement1XXConfig{.processor = DataMovementProcessor::RISCV_0}};
     }
     return kernel;
 }
@@ -91,7 +97,9 @@ m2::KernelSpec make_touch_consumer(
     kernel.compile_time_args = {{"implicit_sync", implicit_sync ? 1u : 0u}, {"touched_magic", touched_magic}};
     kernel.runtime_arg_schema = {.runtime_arg_names = {"result_l1_addr"}};
     if (!implicit_sync) {
-        kernel.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+        kernel.hw_config = m2::DataMovementHardwareConfig{
+            .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
     }
     return kernel;
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -78,7 +78,7 @@ static void run_intra_tensix_dfb_program(
                 {"entries_per_neo", entries_per_neo},
                 {"words_per_entry", words_per_entry},
             },
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -46,13 +46,15 @@ static void run_dfb_size_override_test(
     experimental::DataMovementHardwareConfig dm_producer_cfg;
     experimental::DataMovementHardwareConfig dm_consumer_cfg;
     if (mesh_device.arch() == ARCH::QUASAR) {
-        dm_producer_cfg = experimental::DataMovementGen2Config{};
-        dm_consumer_cfg = experimental::DataMovementGen2Config{};
+        dm_producer_cfg = experimental::DataMovementHardwareConfig{};
+        dm_consumer_cfg = experimental::DataMovementHardwareConfig{};
     } else {
-        dm_producer_cfg =
-            experimental::DataMovementGen1Config{.processor = tt::tt_metal::DataMovementProcessor::RISCV_0};
-        dm_consumer_cfg = experimental::DataMovementGen1Config{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = tt::tt_metal::NOC::NOC_1};
+        dm_producer_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0}};
+        dm_consumer_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = tt::tt_metal::NOC::NOC_1}};
     }
 
     experimental::KernelSpec producer_spec{
@@ -89,12 +91,10 @@ static void run_dfb_size_override_test(
     };
     // Implicit sync is gen2 only
     if (mesh_device.arch() == ARCH::QUASAR && !implicit_sync) {
-        auto& producer_hw_config = std::get<experimental::DataMovementGen2Config>(
-            std::get<experimental::DataMovementHardwareConfig>(producer_spec.hw_config));
-        auto& consumer_hw_config = std::get<experimental::DataMovementGen2Config>(
-            std::get<experimental::DataMovementHardwareConfig>(consumer_spec.hw_config));
-        producer_hw_config.disable_dfb_implicit_sync_for_all = true;
-        consumer_hw_config.disable_dfb_implicit_sync_for_all = true;
+        std::get<experimental::DataMovementHardwareConfig>(producer_spec.hw_config).config_2xx =
+            experimental::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
+        std::get<experimental::DataMovementHardwareConfig>(consumer_spec.hw_config).config_2xx =
+            experimental::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
     }
 
     const CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
@@ -105,7 +105,7 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(distributed::MeshDevice& me
         .num_threads = static_cast<uint8_t>(p.num_producers),
         .dfb_bindings = {experimental::ProducerOf(DFB_NAME, "out")},
         .runtime_arg_schema = {.runtime_arg_names = rta_names},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
@@ -118,7 +118,7 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(distributed::MeshDevice& me
             .access_pattern = consumer_pattern,
         }},
         .runtime_arg_schema = {.runtime_arg_names = rta_names},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     std::vector<experimental::SemaphoreSpec> semaphores;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -83,7 +83,7 @@ inline KernelSpec MakeMinimalGen2DMKernel(std::string name, uint32_t num_threads
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = num_threads,
-        .hw_config = DataMovementGen2Config{},
+        .hw_config = DataMovementHardwareConfig{},
     };
 }
 
@@ -102,28 +102,29 @@ inline KernelSpec MakeMinimalGen1DMKernel(
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = 1,
-        .hw_config = DataMovementGen1Config{.processor = processor, .noc = noc}};
+        .hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{.processor = processor, .noc = noc}}};
 }
 
 // Helper to create a minimal valid KernelSpec for data movement whose Gen1 config is built
-// from the READER role via CreateReaderGen1DataMovementConfig (Gen1/WH/BH).
+// from the READER role via CreateReaderDataMovementConfig (Gen1/WH/BH).
 inline KernelSpec MakeMinimalReaderDMKernel(std::string name) {
     return KernelSpec{
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = 1,
-        .hw_config = CreateReaderGen1DataMovementConfig(),
+        .hw_config = CreateReaderDataMovementConfig(),
     };
 }
 
 // Helper to create a minimal valid KernelSpec for data movement whose Gen1 config is built
-// from the WRITER role via CreateWriterGen1DataMovementConfig (Gen1/WH/BH).
+// from the WRITER role via CreateWriterDataMovementConfig (Gen1/WH/BH).
 inline KernelSpec MakeMinimalWriterDMKernel(std::string name) {
     return KernelSpec{
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = 1,
-        .hw_config = CreateWriterGen1DataMovementConfig(),
+        .hw_config = CreateWriterDataMovementConfig(),
     };
 }
 
@@ -133,7 +134,7 @@ inline KernelSpec MakeMinimalGen2ComputeKernel(std::string name, uint32_t num_th
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = num_threads,
-        .hw_config = ComputeGen2Config{},
+        .hw_config = ComputeHardwareConfig{},
     };
 }
 
@@ -143,7 +144,7 @@ inline KernelSpec MakeMinimalGen1ComputeKernel(std::string name, uint32_t num_th
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = num_threads,
-        .hw_config = ComputeGen1Config{},
+        .hw_config = ComputeHardwareConfig{},
     };
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -17,8 +17,6 @@
 //   7. Aggregate type enforcement (designated initializers must work!)
 // Wormhole (Gen1):
 //   8. Gen1 specific tests
-// Device-free:
-//   9. ComputeHardwareConfig common-field accessors
 //
 //---------------------------------------------------------------------------------
 // These unit tests use shortcut functions to create minimal valid ProgramSpec
@@ -119,11 +117,17 @@ static_assert(hashable_v<TensorBinding>, "TensorBinding must be hashable via tts
 // Kernel hardware configs
 static_assert(
     hashable_v<DataMovementHardwareConfig>, "DataMovementHardwareConfig must be hashable via ttsl reflection");
-static_assert(hashable_v<DataMovementGen1Config>, "DataMovementGen1Config must be hashable via ttsl reflection");
-static_assert(hashable_v<DataMovementGen2Config>, "DataMovementGen2Config must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<DataMovementHardwareConfig::DataMovement1XXConfig>,
+    "DataMovement1XXConfig must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<DataMovementHardwareConfig::DataMovement2XXConfig>,
+    "DataMovement2XXConfig must be hashable via ttsl reflection");
 static_assert(hashable_v<ComputeHardwareConfig>, "ComputeHardwareConfig must be hashable via ttsl reflection");
-static_assert(hashable_v<ComputeGen1Config>, "ComputeGen1Config must be hashable via ttsl reflection");
-static_assert(hashable_v<ComputeGen2Config>, "ComputeGen2Config must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<ComputeHardwareConfig::Compute1XXConfig>, "Compute1XXConfig must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<ComputeHardwareConfig::Compute2XXConfig>, "Compute2XXConfig must be hashable via ttsl reflection");
 
 // Per-spec advanced options
 static_assert(hashable_v<KernelAdvancedOptions>, "KernelAdvancedOptions must be hashable via ttsl reflection");
@@ -184,7 +188,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_DuplicateKernelNameFails) {
 
     // Add a kernel with duplicate name
     auto duplicate_kernel = MakeMinimalGen2DMKernel("dm_kernel");
-    duplicate_kernel.hw_config = DataMovementGen2Config{};
+    duplicate_kernel.hw_config = DataMovementHardwareConfig{};
     spec.kernels.push_back(duplicate_kernel);
 
     EXPECT_THAT(
@@ -889,9 +893,10 @@ TEST_F(ProgramSpecTestQuasar, CPU_DisableImplicitSyncForAllDisablesProducerSide)
 
         auto dm_kernel = MakeMinimalGen2DMKernel("dm_kernel");
         auto compute_kernel = MakeMinimalGen2ComputeKernel("compute_kernel");
-        auto& dm_hw_config =
-            std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(dm_kernel.hw_config));
-        dm_hw_config.disable_dfb_implicit_sync_for_all = disable_all;
+        if (disable_all) {
+            std::get<DataMovementHardwareConfig>(dm_kernel.hw_config).config_2xx =
+                DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
+        }
 
         auto dfb = MakeMinimalDFB("dfb_0");
         dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -932,9 +937,8 @@ TEST_F(ProgramSpecTestQuasar, CPU_DisableImplicitSyncForAllDisagreementAcrossPro
 
     // producer1 hammers implicit sync off; producer2 leaves it on. Both bind the same DFB on
     // the producer side, so the per-side opt-out disagrees and validation must reject.
-    DataMovementGen2Config& producer1_hw_config =
-        std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(producer1.hw_config));
-    producer1_hw_config.disable_dfb_implicit_sync_for_all = true;
+    std::get<DataMovementHardwareConfig>(producer1.hw_config).config_2xx =
+        DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -968,12 +972,10 @@ TEST_F(ProgramSpecTestQuasar, CPU_DisableImplicitSyncForAllAgreesWithExplicitLis
 
     // producer1 opts out via the per-kernel hammer; producer2 opts the same DFB out by name.
     // Both express the same per-side decision (disable), so they agree and the side lowers off.
-    DataMovementGen2Config& producer1_hw_config =
-        std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(producer1.hw_config));
-    DataMovementGen2Config& producer2_hw_config =
-        std::get<DataMovementGen2Config>(std::get<DataMovementHardwareConfig>(producer2.hw_config));
-    producer1_hw_config.disable_dfb_implicit_sync_for_all = true;
-    producer2_hw_config.disable_dfb_implicit_sync_for.push_back(DFBSpecName{"dfb"});
+    std::get<DataMovementHardwareConfig>(producer1.hw_config).config_2xx =
+        DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
+    std::get<DataMovementHardwareConfig>(producer2.hw_config).config_2xx =
+        DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for = {DFBSpecName{"dfb"}}};
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -1058,66 +1060,20 @@ TEST_F(ProgramSpecTestQuasar, CPU_ComputeKernelExceedingMaxThreadsFails) {
             "KernelSpec 'kernel' has too many threads. The architecture supports up to 4 for compute kernels")));
 }
 
-TEST_F(ProgramSpecTestQuasar, CPU_DMKernelWithGen1ConfigFails) {
-    // The config's generation must match the target platform: on Gen2 (Quasar) a DM kernel must
-    // carry a DataMovementGen2Config. Supplying an explicit Gen1 config is a hard error — it is not
-    // silently substituted with a default Gen2 config.
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "test_program";
-
-    auto kernel = MakeMinimalGen2DMKernel("kernel");
-    // Replace the default Gen2 config with an explicit Gen1 config (wrong generation for Quasar).
-    auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-    dm_config = DataMovementGen1Config{
-        .processor = DataMovementProcessor::RISCV_0,
-        .noc = NOC::RISCV_0_default,
-        .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
-    };
-
-    spec.kernels = {kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("holds a DataMovementGen1Config")));
-}
-
-TEST_F(ProgramSpecTestQuasar, CPU_DMKernelWithDefaultGen2ConfigSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_DMKernelWithDefaultConfigSucceeds) {
     // On Gen2 a DM kernel needs no explicit tuning: Gen2 has a unified NOC and fully automated DM
-    // placement, and a default Gen2Config (empty disable_dfb_implicit_sync_for) is all that's required.
+    // placement. A default DataMovementHardwareConfig{} (no generation extras) is all that's required.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.name = "test_program";
 
-    // MakeMinimalGen2DMKernel already holds a default Gen2Config.
     auto kernel = MakeMinimalGen2DMKernel("kernel");
 
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
-}
-
-TEST_F(ProgramSpecTestQuasar, CPU_RoleBasedGen1ConfigOnGen2Fails) {
-    // MakeMinimalReaderDMKernel builds a Gen1 placement (DataMovementGen1Config), which
-    // is the wrong generation for Gen2 (Quasar): the platform requires a DataMovementGen2Config, so the
-    // mismatch is a hard error rather than a silently-ignored role hint.
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "test_program";
-
-    auto kernel = MakeMinimalReaderDMKernel("kernel");
-
-    spec.kernels = {kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("holds a DataMovementGen1Config")));
 }
 
 // Cross-node DFBs are part of the API surface but not yet supported by the runtime.
@@ -1764,7 +1720,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_ComputeConfigUnpackToDestModeReferencesUnbound
 
     // Set an unpack_modes entry referencing a DFB this kernel doesn't bind
     // (in this case, a DFB that doesn't exist in the spec at all).
-    auto& compute_config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(consumer.hw_config));
+    auto& compute_config = std::get<ComputeHardwareConfig>(consumer.hw_config);
     compute_config.unpack_modes = {{DFBSpecName{"nonexistent_dfb"}, UnpackMode::UnpackToDest}};
 
     auto dfb = MakeMinimalDFB("dfb");
@@ -1795,7 +1751,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_NonFP32DFBWithExplicitDefaultUnpackToDestModeS
     ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToSrc}};
         }
     }
@@ -1810,7 +1766,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_NonFP32DFBWithUnpackToDestFp32ModeSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b (non-FP32)
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             config.enable_32_bit_dest = true;
             config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToDest}};
         }
@@ -1828,7 +1784,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_FP32ConsumerWithFp32DestAccEnAndNoEntryFails) 
     }
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             config.enable_32_bit_dest = true;
         }
     }
@@ -1863,7 +1819,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_FP32ProducerOnlyBindingDoesNotRequireEntry) {
     spec.name = "test_program";
 
     auto producer_compute = MakeMinimalGen2ComputeKernel("producer_compute");
-    auto& producer_config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(producer_compute.hw_config));
+    auto& producer_config = std::get<ComputeHardwareConfig>(producer_compute.hw_config);
     producer_config.enable_32_bit_dest = true;
 
     auto consumer_dm = MakeMinimalGen2DMKernel("consumer_dm");
@@ -1891,7 +1847,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestFp32OnProducerBindingSucceeds) {
     spec.name = "test_program";
 
     auto producer_compute = MakeMinimalGen2ComputeKernel("producer_compute");
-    auto& producer_config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(producer_compute.hw_config));
+    auto& producer_config = std::get<ComputeHardwareConfig>(producer_compute.hw_config);
     producer_config.enable_32_bit_dest = true;
     producer_config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToDest}};
 
@@ -1922,7 +1878,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestFp32WithoutFp32DestAccEnFails) {
     }
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             // enable_32_bit_dest stays at its default (false).
             config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToDest}};
         }
@@ -1940,7 +1896,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_ConsumerUnpackToDestBelow32BitWithoutEnableSuc
     ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b, consumed by compute_kernel
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             // enable_32_bit_dest stays at its default (false).
             config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToDest}};
         }
@@ -1958,7 +1914,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_FP32DFBWithDefaultUnpackToDestModeSucceeds) {
     }
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             config.enable_32_bit_dest = true;
             config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToSrc}};
         }
@@ -2468,7 +2424,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_ComputeConfigMathFidelitySucceeds) {
     // Find the compute kernel and set math fidelity options
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             config.fpu_math_fidelity = MathFidelity::LoFi;
             config.enable_32_bit_dest = true;
             config.sfpu_precision_mode = tt::tt_metal::Precision::Approximate;
@@ -2490,7 +2446,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_ValidUnpackToDestModeSucceeds) {
     }
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             config.enable_32_bit_dest = true;
             config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToDest}};
         }
@@ -2524,7 +2480,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestModePlacedAtDfbIdSlot) {
     consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_0"}, "in0"));
     consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_1"}, "in1"));
 
-    auto& compute_config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(consumer.hw_config));
+    auto& compute_config = std::get<ComputeHardwareConfig>(consumer.hw_config);
     compute_config.enable_32_bit_dest = true;
     compute_config.unpack_modes = {{DFBSpecName{"dfb_1"}, UnpackMode::UnpackToDest}};
 
@@ -2555,7 +2511,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestModePlacedAtDfbIdSlot) {
 // ComputeConfig / QuasarComputeConfig translation at the boundary where the
 // field rename is absorbed (MakeGen1ComputeConfig / MakeGen2ComputeConfig).
 //
-// Several of these knobs are performance / numerical-precision settings that do
+// Several of these fields are performance / numerical-precision settings that do
 // NOT change a functional pass/fail result, so a flipped inversion
 // (dst_full_sync_en <-> double_buffer_dest) or a wrong precision-enum direction
 // would be invisible to the behavioral tests. Asserting the internal values
@@ -2564,27 +2520,27 @@ TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestModePlacedAtDfbIdSlot) {
 // testable here; the TTNN ComputeKernelConfig -> public bridge lives above this
 // layer and is out of scope for a Metal unit test.)
 
-TEST_F(ProgramSpecTestQuasar, CPU_ComputeGen2ConfigDefaultsMapToInternalDefaults) {
-    // A default ComputeGen2Config{} must yield the historical internal QuasarComputeConfig defaults.
-    ProgramSpec spec = MakeMinimalValidProgramSpec();  // compute_kernel carries a default ComputeGen2Config
+TEST_F(ProgramSpecTestQuasar, CPU_ComputeHardwareConfigDefaultsMapToInternalDefaults) {
+    // A default ComputeHardwareConfig{} must yield the historical internal QuasarComputeConfig defaults.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();  // compute_kernel carries a default ComputeHardwareConfig
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     const auto built_variant = program.impl().get_kernel_by_spec_name("compute_kernel")->config();
     const auto& built = std::get<experimental::quasar::QuasarComputeConfig>(built_variant);
     EXPECT_EQ(built.math_fidelity, MathFidelity::HiFi4);
     EXPECT_FALSE(built.fp32_dest_acc_en);
-    EXPECT_FALSE(built.dst_full_sync_en);      // double_buffer_dest defaults true -> !true
-    EXPECT_FALSE(built.math_approx_mode);      // sfpu_precision_mode defaults Precise
+    EXPECT_FALSE(built.dst_full_sync_en);  // double_buffer_dest defaults true -> !true
+    EXPECT_FALSE(built.math_approx_mode);  // sfpu_precision_mode defaults Precise
 }
 
-TEST_F(ProgramSpecTestQuasar, CPU_ComputeGen2ConfigInversionAndEnumMapToInternal) {
+TEST_F(ProgramSpecTestQuasar, CPU_ComputeHardwareConfigInversionAndEnumMapToInternal) {
     // Non-default polarity: the double_buffer_dest inversion and the SFPU precision-enum mapping
     // must reach the internal config correctly. Guards the case a defaults-only check would miss
     // (a flip compensated by a changed default).
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen2Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             config.double_buffer_dest = false;                                  // -> internal dst_full_sync_en == true
             config.sfpu_precision_mode = tt::tt_metal::Precision::Approximate;  // -> internal math_approx_mode == true
         }
@@ -2874,10 +2830,18 @@ static_assert(
     "DataflowBufferSpec must remain an aggregate to support designated initializers");
 static_assert(
     std::is_aggregate_v<SemaphoreSpec>, "SemaphoreSpec must remain an aggregate to support designated initializers");
-static_assert(std::is_aggregate_v<DataMovementGen1Config>, "DataMovementGen1Config must remain an aggregate");
-static_assert(std::is_aggregate_v<DataMovementGen2Config>, "DataMovementGen2Config must remain an aggregate");
-static_assert(std::is_aggregate_v<ComputeGen1Config>, "ComputeGen1Config must remain an aggregate");
-static_assert(std::is_aggregate_v<ComputeGen2Config>, "ComputeGen2Config must remain an aggregate");
+static_assert(std::is_aggregate_v<DataMovementHardwareConfig>, "DataMovementHardwareConfig must remain an aggregate");
+static_assert(
+    std::is_aggregate_v<DataMovementHardwareConfig::DataMovement1XXConfig>,
+    "DataMovement1XXConfig must remain an aggregate");
+static_assert(
+    std::is_aggregate_v<DataMovementHardwareConfig::DataMovement2XXConfig>,
+    "DataMovement2XXConfig must remain an aggregate");
+static_assert(std::is_aggregate_v<ComputeHardwareConfig>, "ComputeHardwareConfig must remain an aggregate");
+static_assert(
+    std::is_aggregate_v<ComputeHardwareConfig::Compute1XXConfig>, "Compute1XXConfig must remain an aggregate");
+static_assert(
+    std::is_aggregate_v<ComputeHardwareConfig::Compute2XXConfig>, "Compute2XXConfig must remain an aggregate");
 static_assert(
     std::is_aggregate_v<KernelSpec::CompilerOptions>,
     "CompilerOptions must remain an aggregate to support designated initializers");
@@ -2902,7 +2866,7 @@ TEST(AggregateSpecTypes, CPU_KernelSpecDesignatedInitializers) {
         .unique_id = KernelSpecName{"my_dm_kernel"},
         .source = KernelSpec::SourceCode{"void kernel_main() {}"},
         .num_threads = 2,
-        .hw_config = DataMovementGen2Config{},
+        .hw_config = DataMovementHardwareConfig{},
     };
 
     EXPECT_EQ(dm_kernel.unique_id.get(), "my_dm_kernel");
@@ -2920,10 +2884,8 @@ TEST(AggregateSpecTypes, CPU_KernelSpecDesignatedInitializers) {
             },
         .hw_config =
             ComputeHardwareConfig{
-                ComputeGen2Config{
-                    .fpu_math_fidelity = MathFidelity::LoFi,
-                    .enable_32_bit_dest = true,
-                },
+                .fpu_math_fidelity = MathFidelity::LoFi,
+                .enable_32_bit_dest = true,
             },
     };
 
@@ -3010,7 +2972,7 @@ TEST(AggregateSpecTypes, CPU_KernelSpecNamedRuntimeArgsDesignatedInitializers) {
             KernelSpec::RuntimeArgSchema{
                 .runtime_arg_names = {"input_ptr"},
             },
-        .hw_config = DataMovementGen2Config{},
+        .hw_config = DataMovementHardwareConfig{},
     };
     EXPECT_EQ(k.runtime_arg_schema.runtime_arg_names.size(), 1u);
 }
@@ -3045,7 +3007,7 @@ TEST(AggregateSpecTypes, CPU_ProgramSpecDesignatedInitializers) {
                                 .access_pattern = DFBAccessPattern::STRIDED,
                             },
                         },
-                    .hw_config = DataMovementGen2Config{},
+                    .hw_config = DataMovementHardwareConfig{},
                 },
                 KernelSpec{
                     .unique_id = KernelSpecName{"consumer"},
@@ -3110,7 +3072,7 @@ TEST(AggregateSpecTypes, CPU_NestedStructsDesignatedInitializers) {
     };
     EXPECT_EQ(opts.defines.size(), 2u);
 
-    DataMovementGen1Config gen1{
+    DataMovementHardwareConfig::DataMovement1XXConfig gen1{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
         .noc = tt::tt_metal::NOC::RISCV_1_default,
         .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
@@ -3156,10 +3118,10 @@ protected:
 };
 
 // Gen1 counterpart of the compute-config translation-stability tests (the Gen2 pair lives in the
-// Quasar suite): a default ComputeGen1Config{} must yield the historical internal ComputeConfig
-// defaults. Guards the perf/precision knobs that don't move a functional pass/fail result.
-TEST_F(ProgramSpecTestGen1, CPU_ComputeGen1ConfigDefaultsMapToInternalDefaults) {
-    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();  // compute_kernel carries a default ComputeGen1Config
+// Quasar suite): a default ComputeHardwareConfig{} must yield the historical internal ComputeConfig
+// defaults. Guards the perf/precision settings that don't move a functional pass/fail result.
+TEST_F(ProgramSpecTestGen1, CPU_ComputeHardwareConfigDefaultsMapToInternalDefaults) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();  // compute_kernel carries a default ComputeHardwareConfig
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     const auto built_variant = program.impl().get_kernel_by_spec_name("compute_kernel")->config();
@@ -3249,7 +3211,7 @@ TEST_F(ProgramSpecTestGen1, CPU_ConsumerUnpackToDestBelow32BitWithoutEnableFails
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();  // dfb_0 is Float16_b, consumed by compute_kernel
     for (auto& kernel : spec.kernels) {
         if (kernel.is_compute_kernel()) {
-            auto& config = std::get<ComputeGen1Config>(std::get<ComputeHardwareConfig>(kernel.hw_config));
+            auto& config = std::get<ComputeHardwareConfig>(kernel.hw_config);
             // enable_32_bit_dest stays at its default (false).
             config.unpack_modes = {{DFBSpecName{"dfb_0"}, UnpackMode::UnpackToDest}};
         }
@@ -3500,25 +3462,6 @@ TEST_F(ProgramSpecTestGen1, CPU_MultiThreadedComputeKernelFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("does not support multi-threaded kernels")));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_DMKernelWithGen2ConfigFails) {
-    // The config's generation must match the target platform: on Gen1 (WH/BH) a DM kernel carrying a
-    // Gen2 config is a hard error — it has no way to resolve its processor/NOC placement.
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "test_program";
-
-    // MakeMinimalGen2DMKernel produces a gen2 (Quasar) DM config (no Gen1Config).
-    auto kernel = MakeMinimalGen2DMKernel("dm_kernel");
-
-    spec.kernels = {kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
-
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("holds a DataMovementGen2Config")));
-}
-
 TEST_F(ProgramSpecTestGen1, CPU_ProcessorConflictFails) {
     // Two DM kernels both targeting RISCV_0 on the same node
     NodeCoord node{0, 0};
@@ -3550,8 +3493,8 @@ TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsSameNocDedicatedFails) {
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
     // Force both onto NOC_0 (the helper would otherwise assign complementary NOCs). noc_mode
     // defaults to DM_DEDICATED_NOC.
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k0.hw_config)).noc = NOC::NOC_0;
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k1.hw_config)).noc = NOC::NOC_0;
+    (*std::get<DataMovementHardwareConfig>(k0.hw_config).config_1xx).noc = NOC::NOC_0;
+    (*std::get<DataMovementHardwareConfig>(k1.hw_config).config_1xx).noc = NOC::NOC_0;
 
     spec.kernels = {k0, k1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
@@ -3570,8 +3513,8 @@ TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsDistinctNocDedicatedSucceeds) {
 
     auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k0.hw_config)).noc = NOC::NOC_0;
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k1.hw_config)).noc = NOC::NOC_1;
+    (*std::get<DataMovementHardwareConfig>(k0.hw_config).config_1xx).noc = NOC::NOC_0;
+    (*std::get<DataMovementHardwareConfig>(k1.hw_config).config_1xx).noc = NOC::NOC_1;
 
     spec.kernels = {k0, k1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
@@ -3590,10 +3533,10 @@ TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsSameNocDynamicSucceeds) {
 
     auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
-    auto& cfg0 = std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k0.hw_config));
+    auto& cfg0 = (*std::get<DataMovementHardwareConfig>(k0.hw_config).config_1xx);
     cfg0.noc = NOC::NOC_0;
     cfg0.noc_mode = NOC_MODE::DM_DYNAMIC_NOC;
-    auto& cfg1 = std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k1.hw_config));
+    auto& cfg1 = (*std::get<DataMovementHardwareConfig>(k1.hw_config).config_1xx);
     cfg1.noc = NOC::NOC_0;
     cfg1.noc_mode = NOC_MODE::DM_DYNAMIC_NOC;
 
@@ -3601,6 +3544,25 @@ TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsSameNocDynamicSucceeds) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_DMKernelWithoutGen1SpecificFails) {
+    // Gen1 DM has no default processor/NOC. A disengaged config_1xx is rejected at
+    // validation, not later at lowering.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto kernel = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_0);
+    std::get<DataMovementHardwareConfig>(kernel.hw_config).config_1xx.reset();
+
+    spec.kernels = {kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("has no config_1xx processor/NOC")));
 }
 
 TEST_F(ProgramSpecTestGen1, CPU_DMProcessorBeyondRiscv1Fails) {
@@ -3612,8 +3574,7 @@ TEST_F(ProgramSpecTestGen1, CPU_DMProcessorBeyondRiscv1Fails) {
     spec.name = "test_program";
 
     auto kernel = MakeMinimalGen1DMKernel("dm_kernel", DataMovementProcessor::RISCV_0);
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(kernel.hw_config)).processor =
-        DataMovementProcessor::RISCV_2;
+    (*std::get<DataMovementHardwareConfig>(kernel.hw_config).config_1xx).processor = DataMovementProcessor::RISCV_2;
 
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
@@ -3635,10 +3596,8 @@ TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsMixedNocModeFails) {
     // neither the processor nor the NOC-distinctness check fires — only the mode disagreement trips.
     auto k0 = MakeMinimalGen1DMKernel("k0", DataMovementProcessor::RISCV_0);
     auto k1 = MakeMinimalGen1DMKernel("k1", DataMovementProcessor::RISCV_1);
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k0.hw_config)).noc_mode =
-        NOC_MODE::DM_DEDICATED_NOC;
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k1.hw_config)).noc_mode =
-        NOC_MODE::DM_DYNAMIC_NOC;
+    (*std::get<DataMovementHardwareConfig>(k0.hw_config).config_1xx).noc_mode = NOC_MODE::DM_DEDICATED_NOC;
+    (*std::get<DataMovementHardwareConfig>(k1.hw_config).config_1xx).noc_mode = NOC_MODE::DM_DYNAMIC_NOC;
 
     spec.kernels = {k0, k1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
@@ -3683,10 +3642,8 @@ TEST_F(ProgramSpecTestGen1, CPU_DMKernelsDifferentNocModesOnDistinctNodesSucceed
 
     auto k_a = MakeMinimalGen1DMKernel("k_a", DataMovementProcessor::RISCV_0);
     auto k_b = MakeMinimalGen1DMKernel("k_b", DataMovementProcessor::RISCV_0);
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k_a.hw_config)).noc_mode =
-        NOC_MODE::DM_DEDICATED_NOC;
-    std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(k_b.hw_config)).noc_mode =
-        NOC_MODE::DM_DEDICATED_NOC;
+    (*std::get<DataMovementHardwareConfig>(k_a.hw_config).config_1xx).noc_mode = NOC_MODE::DM_DEDICATED_NOC;
+    (*std::get<DataMovementHardwareConfig>(k_b.hw_config).config_1xx).noc_mode = NOC_MODE::DM_DEDICATED_NOC;
 
     spec.kernels = {k_a, k_b};
     spec.work_units = std::vector<WorkUnitSpec>{
@@ -5554,9 +5511,7 @@ TEST_F(ProgramSpecTestGen1, CPU_CompilerIncludePathsForwardedToKernelConfig) {
 // bound to the same producer/consumer kernels in a single WorkUnit on a single node.
 namespace {
 ProgramSpec MakeAliasProgramSpec(
-    const NodeCoord& node,
-    const DataflowBufferSpec& dfb_a,
-    const DataflowBufferSpec& dfb_b) {
+    const NodeCoord& node, const DataflowBufferSpec& dfb_a, const DataflowBufferSpec& dfb_b) {
     ProgramSpec spec;
 
     KernelSpec producer = MakeMinimalGen2DMKernel("producer_kernel");
@@ -5587,8 +5542,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnMismatchedTotalSize) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("different total sizes")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("different total sizes")));
 }
 
 TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnAsymmetricDeclaration) {
@@ -5636,8 +5590,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBMatmulStyleSucceeds) {
     ProgramSpec spec;
     spec.kernels = {producer, consumer, other};
     spec.dataflow_buffers = {dfb_a, dfb_b};
-    spec.work_units = {
-        MakeMinimalWorkUnit("wu", node, {"producer_kernel", "consumer_kernel", "other_kernel"})};
+    spec.work_units = {MakeMinimalWorkUnit("wu", node, {"producer_kernel", "consumer_kernel", "other_kernel"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -5709,181 +5662,5 @@ TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnInconsistentBorrowedFrom) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("inconsistent borrowed_from")));
 }
 
-//---------------------------------------------------------------------------------
-// 9. ComputeHardwareConfig common-field accessors
-//
-// Device-free; no fixture needed.
-//
-// ComputeHardwareConfig is a std::variant<ComputeGen1Config, ComputeGen2Config>, and the accessors
-// exist to hide that variant for the fields both alternatives share. The failure they can plausibly
-// hide is a copy-paste one: an accessor wired to the wrong member, or one that happens to work for
-// the alternative someone tested and not the other.
-//
-// Two things below are load-bearing against exactly that:
-//   - Every check runs against BOTH alternatives, via helpers templated on the alternative type, so
-//     neither generation can be covered by accident alone.
-//   - The two bool fields are checked at values OPPOSITE each other (and opposite their defaults),
-//     so an accessor pointing at the wrong bool cannot pass. Their differing defaults
-//     (enable_32_bit_dest = false, double_buffer_dest = true) make even the untouched-config read
-//     discriminating.
-//
-// The static_asserts pin the return types, which are a deliberate design decision rather than an
-// accident: the mutable accessors return references so callers can assign through them, the const
-// accessors return the small scalars by value (no reference into a temporary variant, no pointless
-// indirection) and unpack_modes by const reference (it is a container; copying it on every read
-// would be wasteful, and callers expect a view).
-//---------------------------------------------------------------------------------
-
-// Non-default values for every common field. Each differs from the field's default, so an accessor
-// that read a hardcoded default, or that never wrote, fails. The bools are opposite each other.
-constexpr MathFidelity kAccessorFidelity = MathFidelity::LoFi;    // default HiFi4
-constexpr Precision kAccessorPrecision = Precision::Approximate;  // default Precise
-constexpr bool kAccessor32BitDest = true;                         // default false
-constexpr bool kAccessorDoubleBuffer = false;                     // default true
-
-const DFBSpecName kAccessorDfbA{"accessor_dfb_a"};
-const DFBSpecName kAccessorDfbB{"accessor_dfb_b"};
-
-using MutableComputeConfig = ComputeHardwareConfig&;
-using ConstComputeConfig = const ComputeHardwareConfig&;
-
-static_assert(std::is_same_v<decltype(fpu_math_fidelity(std::declval<MutableComputeConfig>())), MathFidelity&>);
-static_assert(std::is_same_v<decltype(fpu_math_fidelity(std::declval<ConstComputeConfig>())), MathFidelity>);
-static_assert(std::is_same_v<decltype(sfpu_precision_mode(std::declval<MutableComputeConfig>())), Precision&>);
-static_assert(std::is_same_v<decltype(sfpu_precision_mode(std::declval<ConstComputeConfig>())), Precision>);
-static_assert(std::is_same_v<decltype(enable_32_bit_dest(std::declval<MutableComputeConfig>())), bool&>);
-static_assert(std::is_same_v<decltype(enable_32_bit_dest(std::declval<ConstComputeConfig>())), bool>);
-static_assert(std::is_same_v<decltype(double_buffer_dest(std::declval<MutableComputeConfig>())), bool&>);
-static_assert(std::is_same_v<decltype(double_buffer_dest(std::declval<ConstComputeConfig>())), bool>);
-static_assert(std::is_same_v<decltype(unpack_modes(std::declval<MutableComputeConfig>())), ComputeUnpackModes&>);
-static_assert(std::is_same_v<decltype(unpack_modes(std::declval<ConstComputeConfig>())), const ComputeUnpackModes&>);
-
-// unpack_modes is the one accessor returning a reference from a const config, so it carries a
-// deleted rvalue overload to stop a caller binding that reference into a temporary. Assert the
-// deletion bites — and assert the lvalue forms still compile, because without those positive
-// controls a mere typo here would satisfy the negative assertion vacuously.
-template <typename Config>
-concept UnpackModesAcceptsLvalue = requires(Config& config) { unpack_modes(config); };
-template <typename Config>
-concept UnpackModesAcceptsRvalue = requires(Config config) { unpack_modes(std::move(config)); };
-
-static_assert(UnpackModesAcceptsLvalue<ComputeHardwareConfig>);
-static_assert(UnpackModesAcceptsLvalue<const ComputeHardwareConfig>);
-static_assert(!UnpackModesAcceptsRvalue<ComputeHardwareConfig>);
-static_assert(!UnpackModesAcceptsRvalue<const ComputeHardwareConfig>);
-
-// Reading an untouched config through the accessors must yield the alternative's own defaults.
-template <typename GenConfig>
-void CheckAccessorDefaultsReadThrough() {
-    const ComputeHardwareConfig config{GenConfig{}};
-    const GenConfig defaults{};
-
-    EXPECT_EQ(fpu_math_fidelity(config), defaults.fpu_math_fidelity);
-    EXPECT_EQ(sfpu_precision_mode(config), defaults.sfpu_precision_mode);
-    EXPECT_EQ(enable_32_bit_dest(config), defaults.enable_32_bit_dest);
-    EXPECT_EQ(double_buffer_dest(config), defaults.double_buffer_dest);
-    EXPECT_TRUE(unpack_modes(config).empty());
-}
-
-// Writing through the mutable accessors must land on the held alternative's actual members, and the
-// const accessors must read back what was written.
-template <typename GenConfig>
-void CheckAccessorWritesLandOnHeldAlternative() {
-    ComputeHardwareConfig config{GenConfig{}};
-
-    fpu_math_fidelity(config) = kAccessorFidelity;
-    sfpu_precision_mode(config) = kAccessorPrecision;
-    enable_32_bit_dest(config) = kAccessor32BitDest;
-    double_buffer_dest(config) = kAccessorDoubleBuffer;
-
-    // Bind the returned reference and use it repeatedly — the usage the header documents.
-    auto& dfb_unpack_modes = unpack_modes(config);
-    dfb_unpack_modes.emplace(kAccessorDfbA, UnpackMode::UnpackToDest);
-    dfb_unpack_modes.emplace(kAccessorDfbB, UnpackMode::UnpackToSrc);
-
-    // Reach past the accessors: the writes must be visible on the held alternative itself. This is
-    // what catches an accessor that targets the wrong member.
-    const GenConfig& held = std::get<GenConfig>(config);
-    EXPECT_EQ(held.fpu_math_fidelity, kAccessorFidelity);
-    EXPECT_EQ(held.sfpu_precision_mode, kAccessorPrecision);
-    EXPECT_EQ(held.enable_32_bit_dest, kAccessor32BitDest);
-    EXPECT_EQ(held.double_buffer_dest, kAccessorDoubleBuffer);
-
-    const ComputeUnpackModes expected_modes{
-        {kAccessorDfbA, UnpackMode::UnpackToDest},
-        {kAccessorDfbB, UnpackMode::UnpackToSrc},
-    };
-    EXPECT_EQ(held.unpack_modes, expected_modes)
-        << "unpack_modes() handed back a copy rather than a view onto the held alternative";
-
-    // And the const accessors report the same values.
-    const ComputeHardwareConfig& const_config = config;
-    EXPECT_EQ(fpu_math_fidelity(const_config), kAccessorFidelity);
-    EXPECT_EQ(sfpu_precision_mode(const_config), kAccessorPrecision);
-    EXPECT_EQ(enable_32_bit_dest(const_config), kAccessor32BitDest);
-    EXPECT_EQ(double_buffer_dest(const_config), kAccessorDoubleBuffer);
-    EXPECT_EQ(unpack_modes(const_config), expected_modes);
-}
-
-// An accessor must never reach into the alternative that is NOT held. Assigning a fresh alternative
-// over the variant has to be reflected immediately. This is the retargeting case that makes
-// std::get<ComputeGen1Config> throw, and the reason these accessors exist.
-template <typename FromConfig, typename ToConfig>
-void CheckAccessorsFollowTheHeldAlternative() {
-    ComputeHardwareConfig config{FromConfig{}};
-    fpu_math_fidelity(config) = kAccessorFidelity;
-    enable_32_bit_dest(config) = kAccessor32BitDest;
-
-    config = ToConfig{};  // switch alternatives; the accessors must now see ToConfig's defaults
-
-    const ToConfig defaults{};
-    EXPECT_EQ(fpu_math_fidelity(config), defaults.fpu_math_fidelity);
-    EXPECT_EQ(enable_32_bit_dest(config), defaults.enable_32_bit_dest);
-
-    // ...and writing still works after the switch.
-    fpu_math_fidelity(config) = kAccessorFidelity;
-    EXPECT_EQ(std::get<ToConfig>(config).fpu_math_fidelity, kAccessorFidelity);
-}
-
-TEST(ComputeHardwareConfigAccessors, CPU_Gen1DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen1Config>(); }
-
-TEST(ComputeHardwareConfigAccessors, CPU_Gen2DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen2Config>(); }
-
-TEST(ComputeHardwareConfigAccessors, CPU_Gen1WritesLandOnHeldAlternative) {
-    CheckAccessorWritesLandOnHeldAlternative<ComputeGen1Config>();
-}
-
-TEST(ComputeHardwareConfigAccessors, CPU_Gen2WritesLandOnHeldAlternative) {
-    CheckAccessorWritesLandOnHeldAlternative<ComputeGen2Config>();
-}
-
-TEST(ComputeHardwareConfigAccessors, CPU_FollowsSwitchFromGen1ToGen2) {
-    CheckAccessorsFollowTheHeldAlternative<ComputeGen1Config, ComputeGen2Config>();
-}
-
-TEST(ComputeHardwareConfigAccessors, CPU_FollowsSwitchFromGen2ToGen1) {
-    CheckAccessorsFollowTheHeldAlternative<ComputeGen2Config, ComputeGen1Config>();
-}
-
 }  // namespace
 }  // namespace tt::tt_metal::experimental
-
-namespace {
-
-// Op code calls these accessors unqualified from its own namespace, which only works if they are
-// found by ADL on ComputeHardwareConfig. The checks above cannot show that: they live inside
-// tt::tt_metal::experimental, where ordinary lookup finds the accessors regardless. This probe sits
-// outside that namespace, so ADL is the only thing that can resolve the names.
-template <typename Config>
-concept ComputeAccessorsFoundByAdl = requires(Config& config) {
-    fpu_math_fidelity(config);
-    sfpu_precision_mode(config);
-    enable_32_bit_dest(config);
-    double_buffer_dest(config);
-    unpack_modes(config);
-};
-
-static_assert(ComputeAccessorsFoundByAdl<tt::tt_metal::experimental::ComputeHardwareConfig>);
-static_assert(ComputeAccessorsFoundByAdl<const tt::tt_metal::experimental::ComputeHardwareConfig>);
-
-}  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -604,7 +604,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
             "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = SemaphoreSpecName{"only_sem"}, .accessor_name = "signal"}},
-        .hw_config = CreateWriterGen1DataMovementConfig(),
+        .hw_config = CreateWriterDataMovementConfig(),
     };
     KernelSpec consumer{
         .unique_id = KernelSpecName{"consumer"},
@@ -613,7 +613,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
             "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = SemaphoreSpecName{"only_sem"}, .accessor_name = "waiter"}},
-        .hw_config = CreateReaderGen1DataMovementConfig(),
+        .hw_config = CreateReaderDataMovementConfig(),
     };
 
     // A WorkUnitSpec describes the kernels that run on a shared set of nodes.
@@ -922,7 +922,11 @@ TEST_F(ProgramSpecHWTest, ScratchpadWriteReadback) {
             {
                 .runtime_arg_names = {"report_addr"},
             },
-        .hw_config = DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .config_1xx =
+                    DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}},
     };
     dm_kernel.scratchpad_bindings.push_back(
         KernelSpec::ScratchpadBinding{.scratchpad_spec_name = ScratchpadSpecName{"pad"}, .accessor_name = "pad"});

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_scratchpad_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_scratchpad_hw.cpp
@@ -81,7 +81,10 @@ TEST_F(UnitMeshCQSingleCardFixture, ScratchpadWriteReadback) {
                 .runtime_arg_names = {"report_addr"},
             },
         .hw_config =
-            experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0},
+            experimental::DataMovementHardwareConfig{
+                .config_1xx =
+                    experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}},
     };
     dm_kernel.scratchpad_bindings.push_back(experimental::KernelSpec::ScratchpadBinding{
         .scratchpad_spec_name = experimental::ScratchpadSpecName{"pad"}, .accessor_name = "pad"});
@@ -206,7 +209,10 @@ TEST_F(UnitMeshCQSingleCardFixture, ScratchpadNocEndpoints) {
                 .runtime_arg_names = {"remote_noc_x", "remote_noc_y", "src_addr", "dst_addr", "report_addr"},
             },
         .hw_config =
-            experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0},
+            experimental::DataMovementHardwareConfig{
+                .config_1xx =
+                    experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}},
     };
     dm_kernel.scratchpad_bindings.push_back(experimental::KernelSpec::ScratchpadBinding{
         .scratchpad_spec_name = experimental::ScratchpadSpecName{"pad"}, .accessor_name = "pad"});

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -241,13 +241,15 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     experimental::DataMovementHardwareConfig reader_dm_cfg;
     experimental::DataMovementHardwareConfig writer_dm_cfg;
     if (is_quasar) {
-        reader_dm_cfg = experimental::DataMovementGen2Config{};
-        writer_dm_cfg = experimental::DataMovementGen2Config{};
+        reader_dm_cfg = experimental::DataMovementHardwareConfig{};
+        writer_dm_cfg = experimental::DataMovementHardwareConfig{};
     } else {
-        reader_dm_cfg = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
-        writer_dm_cfg = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        reader_dm_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
+        writer_dm_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
 
     experimental::KernelSpec reader_spec{
@@ -419,13 +421,15 @@ bool reader_datacopy_writer(
     experimental::DataMovementHardwareConfig reader_dm_cfg;
     experimental::DataMovementHardwareConfig writer_dm_cfg;
     if (is_quasar) {
-        reader_dm_cfg = experimental::DataMovementGen2Config{};
-        writer_dm_cfg = experimental::DataMovementGen2Config{};
+        reader_dm_cfg = experimental::DataMovementHardwareConfig{};
+        writer_dm_cfg = experimental::DataMovementHardwareConfig{};
     } else {
-        reader_dm_cfg = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
-        writer_dm_cfg = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        reader_dm_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
+        writer_dm_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
 
     experimental::KernelSpec reader_spec{
@@ -456,18 +460,18 @@ bool reader_datacopy_writer(
                                   (test_config.l1_input_data_format == tt::DataFormat::Int32) ||
                                   (test_config.l1_input_data_format == tt::DataFormat::UInt32);
     experimental::ComputeHardwareConfig compute_hw_config;
-    experimental::ComputeUnpackModes unpack_modes{};
+    experimental::ComputeHardwareConfig::ComputeUnpackModes unpack_modes{};
     if (test_config.l1_input_data_format == tt::DataFormat::Float32) {
         unpack_modes = {{INPUT_DFB, tt::tt_metal::UnpackMode::UnpackToDest}};
     }
     if (is_quasar) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
             .unpack_modes = unpack_modes,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
             .unpack_modes = unpack_modes,

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -124,10 +124,11 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
     // kernel; on WH/BH the legacy DM was a single RISCV_0 thread.
     experimental::DataMovementHardwareConfig dm_cfg;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        dm_cfg = experimental::DataMovementGen2Config{};
+        dm_cfg = experimental::DataMovementHardwareConfig{};
     } else {
-        dm_cfg = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        dm_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     const bool is_quasar = MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR;
     const uint32_t num_threads = is_quasar ? kQuasarNumUserDms : 1u;
@@ -231,7 +232,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
                 "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp",
             .num_threads = dm_processors_per_kernel,
             .compiler_options = {.defines = defines_vec},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
             .advanced_options =
                 experimental::KernelAdvancedOptions{
                     .num_runtime_varargs = num_runtime_args,
@@ -1137,7 +1138,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {K1, K2}, .target_nodes = core_range_set};
@@ -1192,7 +1193,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarUpdateProgramRunArgs) {
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = unit_tests::runtime_args::kQuasarNumUserDms,
         .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = core_range_set};
     experimental::ProgramSpec spec{

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -114,11 +114,14 @@ TensorSpec make_flat_dram_tensor_spec(uint32_t page_size_bytes, uint32_t num_pag
 
 experimental::DataMovementHardwareConfig make_dm_config(tt::ARCH arch, DataMovementProcessor processor, NOC noc) {
     if (arch == tt::ARCH::QUASAR) {
-        return experimental::DataMovementGen2Config{
-            .disable_dfb_implicit_sync_for_all = true,
-        };
+        return experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true,
+            }};
     }
-    return experimental::DataMovementGen1Config{.processor = processor, .noc = noc};
+    return experimental::DataMovementHardwareConfig{
+        .config_1xx =
+            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{.processor = processor, .noc = noc}};
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -251,7 +251,7 @@ void RunNoOpProgram(distributed::MeshDevice& target, const std::string& label) {
 
 // Minimal Gen1 Metal 2.0 ProgramSpec: one no-op DM kernel on node (0, 0).
 experimental::ProgramSpec MakeMinimalNoOpProgramSpec() {
-    using experimental::DataMovementGen1Config;
+    using experimental::DataMovementHardwareConfig;
     using experimental::KernelSpec;
     using experimental::KernelSpecName;
     using experimental::NodeCoord;
@@ -264,10 +264,12 @@ experimental::ProgramSpec MakeMinimalNoOpProgramSpec() {
         .source = KernelSpec::SourceCode{"void kernel_main() {}"},
         .num_threads = 1,
         .hw_config =
-            DataMovementGen1Config{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::NOC_0,
-            },
+            DataMovementHardwareConfig{
+                .config_1xx =
+                    DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                        .noc = NOC::NOC_0,
+                    }},
     };
 
     return ProgramSpec{

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -130,12 +130,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
 
     DataMovementHardwareConfig requestor_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        requestor_hw_config = DataMovementGen2Config{};
+        requestor_hw_config = DataMovementHardwareConfig{};
     } else {
-        requestor_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = test_config.noc_id,
-        };
+        requestor_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec requestor_spec{
         .unique_id = KernelSpecName{"requestor"},

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -136,12 +136,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
 
     DataMovementHardwareConfig sender_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        sender_hw_config = DataMovementGen2Config{};
+        sender_hw_config = DataMovementHardwareConfig{};
     } else {
-        sender_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = test_config.noc_id,
-        };
+        sender_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec sender_spec{
         .unique_id = KernelSpecName{"sender"},

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -114,7 +114,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
              {"host_dst_pcie_addr", host_dst_pcie_addr},
              {"l1_staging_addr", l1_staging_addr},
              {"transfer_size_bytes", kTransferSizeBytes}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -109,12 +109,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
 
     DataMovementHardwareConfig reader_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = DataMovementGen2Config{};
+        reader_hw_config = DataMovementHardwareConfig{};
     } else {
-        reader_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-        };
+        reader_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+            }};
     }
     KernelSpec reader_spec{
         .unique_id = KernelSpecName{"reader"},

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -94,12 +94,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
 
     DataMovementHardwareConfig reader_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = DataMovementGen2Config{};
+        reader_hw_config = DataMovementHardwareConfig{};
     } else {
-        reader_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-        };
+        reader_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+            }};
     }
     KernelSpec reader_spec{
         .unique_id = KernelSpecName{"reader"},
@@ -117,12 +118,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
 
     DataMovementHardwareConfig writer_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = DataMovementGen2Config{};
+        writer_hw_config = DataMovementHardwareConfig{};
     } else {
-        writer_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-        };
+        writer_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+            }};
     }
     KernelSpec writer_spec{
         .unique_id = KernelSpecName{"writer"},

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -90,12 +90,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
 
     DataMovementHardwareConfig sender_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        sender_hw_config = DataMovementGen2Config{};
+        sender_hw_config = DataMovementHardwareConfig{};
     } else {
-        sender_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = test_config.noc_id,
-        };
+        sender_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec sender_spec{
         .unique_id = KernelSpecName{"sender"},

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
@@ -100,12 +100,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
 
     DataMovementHardwareConfig sender_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        sender_hw_config = DataMovementGen2Config{};
+        sender_hw_config = DataMovementHardwareConfig{};
     } else {
-        sender_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = test_config.noc_id,
-        };
+        sender_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec sender_spec{
         .unique_id = KernelSpecName{"sender"},
@@ -126,12 +127,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
 
     DataMovementHardwareConfig receiver_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        receiver_hw_config = DataMovementGen2Config{};
+        receiver_hw_config = DataMovementHardwareConfig{};
     } else {
-        receiver_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = test_config.noc_id,
-        };
+        receiver_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec receiver_spec{
         .unique_id = KernelSpecName{"receiver"},

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -135,10 +135,11 @@ bool run_noc_api_latency_test(
 
     DataMovementHardwareConfig noc_kernel_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        noc_kernel_hw_config = DataMovementGen2Config{};
+        noc_kernel_hw_config = DataMovementHardwareConfig{};
     } else {
-        noc_kernel_hw_config = DataMovementGen1Config{
-            .processor = riscv, .noc = test_config.noc_id, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
+        noc_kernel_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = riscv, .noc = test_config.noc_id, .noc_mode = NOC_MODE::DM_DEDICATED_NOC}};
     }
     ProgramSpec spec{
         .name = "noc_api_latency_test",

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -109,12 +109,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
 
     DataMovementHardwareConfig gatherer_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        gatherer_hw_config = DataMovementGen2Config{};
+        gatherer_hw_config = DataMovementHardwareConfig{};
     } else {
-        gatherer_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = test_config.noc_id,
-        };
+        gatherer_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec gatherer_spec{
         .unique_id = KernelSpecName{"gatherer"},

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -83,12 +83,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
 
     DataMovementHardwareConfig requestor_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        requestor_hw_config = DataMovementGen2Config{};
+        requestor_hw_config = DataMovementHardwareConfig{};
     } else {
-        requestor_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = test_config.noc_id,
-        };
+        requestor_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec requestor_spec{
         .unique_id = KernelSpecName{"requestor"},

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -81,12 +81,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
 
     DataMovementHardwareConfig kspec_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        kspec_hw_config = DataMovementGen2Config{};
+        kspec_hw_config = DataMovementHardwareConfig{};
     } else {
-        kspec_hw_config = DataMovementGen1Config{
-            .processor = proc,
-            .noc = noc,
-        };
+        kspec_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = proc,
+                .noc = noc,
+            }};
     }
     KernelSpec kspec{
         .unique_id = KernelSpecName{"one_packet_kernel"},

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -243,12 +243,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
 
         DataMovementHardwareConfig sender_hw_config;
         if (device->arch() == tt::ARCH::QUASAR) {
-            sender_hw_config = DataMovementGen2Config{};
+            sender_hw_config = DataMovementHardwareConfig{};
         } else {
-            sender_hw_config = DataMovementGen1Config{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = test_config.noc_id,
-            };
+            sender_hw_config = DataMovementHardwareConfig{
+                .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                    .processor = DataMovementProcessor::RISCV_0,
+                    .noc = test_config.noc_id,
+                }};
         }
         KernelSpec sender_spec{
             .unique_id = KernelSpecName{"sender"},

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -102,12 +102,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
 
     DataMovementHardwareConfig sender_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        sender_hw_config = DataMovementGen2Config{};
+        sender_hw_config = DataMovementHardwareConfig{};
     } else {
-        sender_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = test_config.noc_id,
-        };
+        sender_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec sender_spec{
         .unique_id = KernelSpecName{"sender"},

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -33,7 +33,7 @@ struct L2FlushTestConfig {
     uint32_t base_addr;
     uint32_t num_words;
     uint32_t value;
-    uint32_t test_mode;  // 0=flush_line, 1=flush_range, 2=flush_full, 3=invalidate_line
+    uint32_t test_mode;             // 0=flush_line, 1=flush_range, 2=flush_full, 3=invalidate_line
     bool expect_new_values = true;  // true for flush tests, false for invalidate tests
 };
 
@@ -58,7 +58,7 @@ bool run_l2_flush_test(distributed::MeshDevice& mesh_device, const L2FlushTestCo
                 .runtime_arg_names = {"base_addr", "test_mode"},
                 .common_runtime_arg_names = {"value", "num_words"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -98,8 +98,8 @@ bool run_l2_flush_test(distributed::MeshDevice& mesh_device, const L2FlushTestCo
     for (uint32_t i = 0; i < config.num_words; i++) {
         uint32_t expected = config.expect_new_values ? (config.value + i) : old_value;
         if (output_data[i] != expected) {
-            log_error(tt::LogTest, "Mismatch at index {}: expected 0x{:08x}, got 0x{:08x}",
-                      i, expected, output_data[i]);
+            log_error(
+                tt::LogTest, "Mismatch at index {}: expected 0x{:08x}, got 0x{:08x}", i, expected, output_data[i]);
             pass = false;
         }
     }
@@ -115,7 +115,7 @@ struct L1DCacheTestConfig {
     uint32_t base_addr;
     uint32_t num_words;
     uint32_t value;
-    uint32_t test_mode;  // 0=flush_line, 1=flush_full, 2=invalidate_line, 3=invalidate_full
+    uint32_t test_mode;      // 0=flush_line, 1=flush_full, 2=invalidate_line, 3=invalidate_full
     bool expect_new_values;  // true for flush tests, false for invalidate tests
 };
 
@@ -140,7 +140,7 @@ bool run_l1_dcache_test(distributed::MeshDevice& mesh_device, const L1DCacheTest
                 .runtime_arg_names = {"base_addr", "test_mode"},
                 .common_runtime_arg_names = {"value", "num_words"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -180,8 +180,8 @@ bool run_l1_dcache_test(distributed::MeshDevice& mesh_device, const L1DCacheTest
     for (uint32_t i = 0; i < config.num_words; i++) {
         uint32_t expected = config.expect_new_values ? (config.value + i) : old_value;
         if (output_data[i] != expected) {
-            log_error(tt::LogTest, "Mismatch at index {}: expected 0x{:08x}, got 0x{:08x}",
-                      i, expected, output_data[i]);
+            log_error(
+                tt::LogTest, "Mismatch at index {}: expected 0x{:08x}, got 0x{:08x}", i, expected, output_data[i]);
             pass = false;
         }
     }
@@ -248,7 +248,7 @@ TEST_F(QuasarL2CacheOps, InvalidateLine) {
         .base_addr = 100 * 1024,
         .num_words = 16,
         .value = 0x99990000,
-        .test_mode = 3,  // invalidate line
+        .test_mode = 3,             // invalidate line
         .expect_new_values = false  // Invalidate doesn't write back, so old values should remain
     };
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(this->device(), config));
@@ -265,7 +265,7 @@ TEST_F(QuasarL2CacheOps, InvalidateFreshRead) {
         .base_addr = 100 * 1024,
         .num_words = 16,
         .value = 0xFE5A0000,
-        .test_mode = 4,  // invalidate fresh read
+        .test_mode = 4,            // invalidate fresh read
         .expect_new_values = true  // After invalidation, new values written via uncached path should be visible
     };
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(this->device(), config));
@@ -317,7 +317,7 @@ TEST_F(QuasarL1DCacheOps, InvalidateLine) {
         .base_addr = 100 * 1024,
         .num_words = 16,
         .value = 0x33330000,
-        .test_mode = 2,  // invalidate line
+        .test_mode = 2,             // invalidate line
         .expect_new_values = false  // should see old values
     };
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));
@@ -333,7 +333,7 @@ TEST_F(QuasarL1DCacheOps, InvalidateFull) {
         .base_addr = 100 * 1024,
         .num_words = 16,
         .value = 0x44440000,
-        .test_mode = 3,  // invalidate full
+        .test_mode = 3,             // invalidate full
         .expect_new_values = false  // should see old values
     };
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));
@@ -350,7 +350,7 @@ TEST_F(QuasarL1DCacheOps, InvalidateFreshRead) {
         .base_addr = 100 * 1024,
         .num_words = 16,
         .value = 0xFE5B0000,
-        .test_mode = 4,  // invalidate fresh read
+        .test_mode = 4,            // invalidate fresh read
         .expect_new_values = true  // After invalidation, new values written via uncached path should be visible
     };
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -46,7 +46,7 @@ bool run_cache_write(distributed::MeshDevice& mesh_device, std::uint32_t size_by
             {
                 .runtime_arg_names = {"base_addr", "size_bytes", "write_path", "num_iterations", "test_id"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
     experimental::ProgramSpec spec{.name = "cache_write_perf", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
@@ -43,7 +43,7 @@ bool run_addrgen_test(
             {{"src_stride_en", src_stride_en},
              {"dst_stride_en", dst_stride_en},
              {"num_of_addresses", num_of_addresses}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -41,7 +41,7 @@ void run_kernel(
         .source = kernel_path,
         .num_threads = 1,
         .compile_time_args = std::move(compile_time_args),
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
@@ -36,7 +36,7 @@ bool run_im2col_test(
         .source = kernel_path,
         .num_threads = 1,
         .compile_time_args = {{"num_of_addresses", num_of_addresses}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
@@ -112,12 +112,13 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
 
     DataMovementHardwareConfig sender_hw_config;
     if (device->arch() == tt::ARCH::QUASAR) {
-        sender_hw_config = DataMovementGen2Config{};
+        sender_hw_config = DataMovementHardwareConfig{};
     } else {
-        sender_hw_config = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = test_config.noc_id,
-        };
+        sender_hw_config = DataMovementHardwareConfig{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+            }};
     }
     KernelSpec sender_spec{
         .unique_id = KernelSpecName{"trid_sender"},

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -87,7 +87,9 @@ protected:
     void RunTestOnDevice(
         const std::function<void(T*, std::shared_ptr<distributed::MeshDevice>)>& run_function,
         const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-        auto run_function_no_args = [this, run_function, mesh_device]() { run_function(static_cast<T*>(this), mesh_device); };
+        auto run_function_no_args = [this, run_function, mesh_device]() {
+            run_function(static_cast<T*>(this), mesh_device);
+        };
         MeshDispatchFixture::RunTestOnDevice(run_function_no_args, mesh_device);
     }
 };
@@ -111,7 +113,9 @@ public:
         // increase because we'll likely check in the middle of a dump.
         if (wait_for_dump) {
             int curr_count = MetalContext::instance().watcher_server()->dump_count();
-            while (MetalContext::instance().watcher_server()->dump_count() < curr_count + 2) {;}
+            while (MetalContext::instance().watcher_server()->dump_count() < curr_count + 2) {
+                ;
+            }
         }
     }
 
@@ -125,7 +129,8 @@ protected:
     bool test_mode_previous{};
     void SetUp() override {
         // Initialize log file name once during setup
-        log_file_name = tt::tt_metal::MetalContext::instance().rtoptions().get_logs_dir() + "generated/watcher/watcher.log";
+        log_file_name =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_logs_dir() + "generated/watcher/watcher.log";
 
         // Enable watcher for this test, save the previous state so we can restore it later.
         watcher_previous_enabled = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled();
@@ -193,15 +198,25 @@ public:
         delayed_cores[CoreType::WORKER] = {{0, 0}, {1, 1}};
 
         // Store the previous state of the watcher features
-        saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay] = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(tt::llrt::RunTimeDebugFeatureReadDebugDelay);
-        saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay] = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(tt::llrt::RunTimeDebugFeatureWriteDebugDelay);
-        saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay] = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(tt::llrt::RunTimeDebugFeatureAtomicDebugDelay);
+        saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay] =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(
+                tt::llrt::RunTimeDebugFeatureReadDebugDelay);
+        saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay] =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(
+                tt::llrt::RunTimeDebugFeatureWriteDebugDelay);
+        saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay] =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(
+                tt::llrt::RunTimeDebugFeatureAtomicDebugDelay);
 
         // Enable read and write debug delay for the test core
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureReadDebugDelay, true);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(tt::llrt::RunTimeDebugFeatureReadDebugDelay, delayed_cores);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, true);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, delayed_cores);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(
+            tt::llrt::RunTimeDebugFeatureReadDebugDelay, true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(
+            tt::llrt::RunTimeDebugFeatureReadDebugDelay, delayed_cores);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(
+            tt::llrt::RunTimeDebugFeatureWriteDebugDelay, true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(
+            tt::llrt::RunTimeDebugFeatureWriteDebugDelay, delayed_cores);
 
         // Call parent
         MeshWatcherFixture::SetUp();
@@ -212,9 +227,15 @@ public:
         MeshWatcherFixture::TearDown();
 
         // Restore
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(tt::llrt::RunTimeDebugFeatureReadDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay]);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay]);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(tt::llrt::RunTimeDebugFeatureAtomicDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay]);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(
+            tt::llrt::RunTimeDebugFeatureReadDebugDelay,
+            saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay]);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(
+            tt::llrt::RunTimeDebugFeatureWriteDebugDelay,
+            saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay]);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(
+            tt::llrt::RunTimeDebugFeatureAtomicDebugDelay,
+            saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay]);
     }
 };
 
@@ -431,9 +452,11 @@ public:
     // Hardware config for a single-threaded data-movement kernel, portable across generations.
     static experimental::DataMovementHardwareConfig SingleThreadDmConfig(tt::ARCH arch) {
         if (arch == tt::ARCH::QUASAR) {
-            return experimental::DataMovementGen2Config{};
+            return experimental::DataMovementHardwareConfig{};
         }
-        return experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0};
+        return experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}};
     }
 
     // Compiles the kernel and returns the path to its ELF, so the caller can inspect the binary.
@@ -587,4 +610,4 @@ protected:
     }
 };
 
-} // namespace tt::tt_metal
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
@@ -180,8 +180,8 @@ const std::vector<std::string> field_names_unpack_config_wormhole_or_blackhole =
     "reserved_4",
     "fifo_size",
     "reserved_5"};
-const std::vector<uint32_t> field_values_unpack_config_wormhole_or_blackhole = {0, 1, 2, 0, 1, 1, 0, 3,  0, 0,  16,
-                                                                                5, 6, 0, 0, 2, 3, 0, 0,  0, 0,  0};
+const std::vector<uint32_t> field_values_unpack_config_wormhole_or_blackhole = {0, 1, 2, 0, 1, 1, 0, 3, 0, 0, 16,
+                                                                                5, 6, 0, 0, 2, 3, 0, 0, 0, 0, 0};
 
 const std::vector<std::string> field_names_pack_config_blackhole = {
     "row_ptr_section_size",
@@ -281,9 +281,9 @@ static std::string int_to_hex(int value) {
 static Program make_writer_program(distributed::MeshDevice& mesh_device, const ConfigRegPrintTestConfig& config) {
     experimental::ComputeHardwareConfig hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        hw_config = experimental::ComputeGen2Config{};
+        hw_config = experimental::ComputeHardwareConfig{};
     } else {
-        hw_config = experimental::ComputeGen1Config{};
+        hw_config = experimental::ComputeHardwareConfig{};
     }
 
     const experimental::KernelSpecName kKernel{"config_reg_writer"};

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -75,7 +75,7 @@ experimental::ProgramSpec MakeQuasarPrintSpec(
             .unique_id = experimental::KernelSpecName{"dm_print"},
             .source = std::filesystem::path{kernel_path},
             .num_threads = dm_threads,
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
             .advanced_options = experimental::KernelAdvancedOptions{.num_runtime_varargs = 1},
         });
         placed.push_back(experimental::KernelSpecName{"dm_print"});
@@ -85,7 +85,7 @@ experimental::ProgramSpec MakeQuasarPrintSpec(
             .unique_id = experimental::KernelSpecName{"compute_print"},
             .source = std::filesystem::path{kernel_path},
             .num_threads = compute_engines,
-            .hw_config = experimental::ComputeGen2Config{},
+            .hw_config = experimental::ComputeHardwareConfig{},
             .advanced_options = experimental::KernelAdvancedOptions{.num_runtime_varargs = 1},
         });
         placed.push_back(experimental::KernelSpecName{"compute_print"});
@@ -101,9 +101,9 @@ experimental::ProgramSpec MakeComputePrintSpec(
     tt::ARCH arch, std::string_view kernel_path, const experimental::NodeCoord& node = kDefaultPrintNode) {
     experimental::ComputeHardwareConfig hw_config;
     if (arch == tt::ARCH::QUASAR) {
-        hw_config = experimental::ComputeGen2Config{};
+        hw_config = experimental::ComputeHardwareConfig{};
     } else {
-        hw_config = experimental::ComputeGen1Config{};
+        hw_config = experimental::ComputeHardwareConfig{};
     }
 
     const experimental::KernelSpecName name{"compute_print"};

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
@@ -70,22 +70,26 @@ Program MakeTensixPrependProgram(distributed::MeshDevice& mesh_device, const Cor
                  .source = source,
                  .num_threads = 1,
                  .hw_config =
-                     experimental::DataMovementGen1Config{
-                         .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0},
+                     experimental::DataMovementHardwareConfig{
+                         .config_1xx =
+                             experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}},
              },
              experimental::KernelSpec{
                  .unique_id = kNcrisc,
                  .source = source,
                  .num_threads = 1,
                  .hw_config =
-                     experimental::DataMovementGen1Config{
-                         .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1},
+                     experimental::DataMovementHardwareConfig{
+                         .config_1xx =
+                             experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                 .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}},
              },
              experimental::KernelSpec{
                  .unique_id = kCompute,
                  .source = source,
                  .num_threads = 1,
-                 .hw_config = experimental::ComputeGen1Config{},
+                 .hw_config = experimental::ComputeHardwareConfig{},
              }},
         .work_units = {experimental::WorkUnitSpec{
             .name = "main", .kernels = {kBrisc, kNcrisc, kCompute}, .target_nodes = experimental::NodeRange{cores}}},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -108,28 +108,28 @@ static void RunTest(
                         uint32_t target_thread_id = static_cast<uint32_t>(processor.processor_type) - kFirstUserDm;
                         assert_kernel_spec.num_threads = 6;
                         assert_kernel_spec.compile_time_args = {{"target_thread_id", target_thread_id}};
-                        assert_kernel_spec.hw_config = experimental::DataMovementGen2Config{};
+                        assert_kernel_spec.hw_config = experimental::DataMovementHardwareConfig{};
                     } else {
                         assert_kernel_spec.num_threads = 1;
-                        assert_kernel_spec.hw_config = experimental::DataMovementGen1Config{
-                            .processor = gen1_processor,
-                            .noc = gen1_noc,
-                        };
+                        assert_kernel_spec.hw_config = experimental::DataMovementHardwareConfig{
+                            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = gen1_processor,
+                                .noc = gen1_noc,
+                            }};
                     }
                     break;
                 }
                 case HalProcessorClassType::COMPUTE: {
                     uint32_t trisc_id = static_cast<uint32_t>(processor.processor_type);
                     assert_kernel_spec.num_threads = 1;
-                    assert_kernel_spec.compiler_options = {
-                        .defines = {{fmt::format("TRISC{}", trisc_id), "1"}}};
+                    assert_kernel_spec.compiler_options = {.defines = {{fmt::format("TRISC{}", trisc_id), "1"}}};
                     // Bind trisc_id so the kernel can early-return on TRISCs that aren't the target
                     // of a Quasar compute HW-fault test.
                     assert_kernel_spec.compile_time_args = {{"trisc_id", trisc_id}};
                     if (is_quasar) {
-                        assert_kernel_spec.hw_config = experimental::ComputeGen2Config{};
+                        assert_kernel_spec.hw_config = experimental::ComputeHardwareConfig{};
                     } else {
-                        assert_kernel_spec.hw_config = experimental::ComputeGen1Config{};
+                        assert_kernel_spec.hw_config = experimental::ComputeHardwareConfig{};
                     }
                     break;
                 }
@@ -205,9 +205,7 @@ static void RunTest(
                 kernel,
                 logical_core,
                 dm_processor,
-                experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = 1,
-                    .is_legacy_kernel = true});
+                experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .is_legacy_kernel = true});
             break;
         }
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
@@ -293,9 +291,7 @@ static void RunTest(
         switch (hw_assert_cause) {
             // ERROR_TRISC<n>, illegal access.
             case 5:
-            case 7:
-                hw_assert_cause = (trisc << 8) | static_cast<uint32_t>(TriscRiscErrors::L1_ILLEGAL_ACCESS);
-                break;
+            case 7: hw_assert_cause = (trisc << 8) | static_cast<uint32_t>(TriscRiscErrors::L1_ILLEGAL_ACCESS); break;
             // ILLEGAL_INSTRUCTION_TRISC<n>, backwards numbered, plus the opcode the kernel hits.
             case 8:
                 hw_assert_cause =
@@ -377,7 +373,7 @@ static void RunTest(
         EXPECT_EQ(expected, exception);
     }
 }
-}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 
 // Test parameters structure
 struct WatcherTestParams {
@@ -573,8 +569,7 @@ INSTANTIATE_TEST_SUITE_P(
         // These report the PC up front, same as the DM faults.
         HwFaultMessageParams{
             "Trisc0TtiBufferHang", 0x0016, 0x1234, {"at PC 0x00001234", "Neo 0 TRISC0", "TTI_BUFFER_HANG"}, {}},
-        HwFaultMessageParams{
-            "Trisc1MemReadNoResponse", 0x0119, 0x1234, {"Neo 0 TRISC1", "MEM_READ_NO_RESPONSE"}, {}},
+        HwFaultMessageParams{"Trisc1MemReadNoResponse", 0x0119, 0x1234, {"Neo 0 TRISC1", "MEM_READ_NO_RESPONSE"}, {}},
         HwFaultMessageParams{"Trisc2StackOverflow", 0x021f, 0x1234, {"Neo 0 TRISC2", "STACK_OVERFLOW"}, {}},
         HwFaultMessageParams{"Trisc3L1IllegalAccess", 0x0328, 0x1234, {"Neo 0 TRISC3", "L1_ILLEGAL_ACCESS"}, {}},
         HwFaultMessageParams{"Neo3Trisc1", 0xc128, 0x1234, {"Neo 3 TRISC1", "L1_ILLEGAL_ACCESS"}, {}},
@@ -611,8 +606,7 @@ INSTANTIATE_TEST_SUITE_P(
         // Sticky bitmask, so both bits can be set at once.
         HwFaultMessageParams{"SfpuCcStackOverflow", 0x0e01, 0, {"SFPU", "CC_STACK_OVERFLOW"}, {"CC_STACK_UNDERFLOW"}},
         HwFaultMessageParams{"SfpuCcStackUnderflow", 0x0e02, 0, {"SFPU", "CC_STACK_UNDERFLOW"}, {}},
-        HwFaultMessageParams{
-            "SfpuCcStackBothBits", 0x0e03, 0, {"SFPU", "CC_STACK_OVERFLOW + CC_STACK_UNDERFLOW"}, {}},
+        HwFaultMessageParams{"SfpuCcStackBothBits", 0x0e03, 0, {"SFPU", "CC_STACK_OVERFLOW + CC_STACK_UNDERFLOW"}, {}},
 
         // No error index on these, so nothing in parens.
         HwFaultMessageParams{"EdcFatal", 0x0a00, 0, {"EDC_FATAL_ERROR"}, {"(", "TRISC"}},
@@ -650,8 +644,7 @@ TEST(WatcherHwFaultMessage, ReportsEveryNeoAndTrisc) {
 // Block 32 is the one an exclusive bound misses.
 TEST(WatcherHwFaultMessage, IllegalInstructionThreadOrderIsReversed) {
     for (uint32_t block = 32; block <= 35; block++) {
-        const std::string msg =
-            get_debug_assert_message(dev_msgs::DebugAssertHwFault, 0, (block << 8) | 0x41);
+        const std::string msg = get_debug_assert_message(dev_msgs::DebugAssertHwFault, 0, (block << 8) | 0x41);
         EXPECT_NE(msg.find(fmt::format("Neo 0 TRISC{}", 35 - block)), std::string::npos) << msg;
     }
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -72,9 +72,11 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                                 : tt::tt_metal::NOC::RISCV_0_default;
             experimental::DataMovementHardwareConfig dm_cfg;
             if (is_quasar) {
-                dm_cfg = experimental::DataMovementGen2Config{};
+                dm_cfg = experimental::DataMovementHardwareConfig{};
             } else {
-                dm_cfg = experimental::DataMovementGen1Config{.processor = gen1_proc, .noc = gen1_noc};
+                dm_cfg = experimental::DataMovementHardwareConfig{
+                    .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = gen1_proc, .noc = gen1_noc}};
             }
             kernel_specs.push_back(experimental::KernelSpec{
                 .unique_id = experimental::KernelSpecName{name},
@@ -105,7 +107,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             .source = path_metal2,
             .num_threads = 1,
             .runtime_arg_schema = {.common_runtime_arg_names = {"wait_cycles"}},
-            .hw_config = experimental::ComputeGen1Config{},
+            .hw_config = experimental::ComputeHardwareConfig{},
         });
         kernel_names.emplace_back(compute_kernel_name);
         params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -107,13 +107,14 @@ void RunTest(
                         // Launch on all 6 user DM threads (DM0/DM1 are reserved for the runtime) and filter in-kernel.
                         kernel_spec.num_threads = 6;
                         kernel_spec.compile_time_args["dm_id"] = processor.processor_type;
-                        kernel_spec.hw_config = experimental::DataMovementGen2Config{};
+                        kernel_spec.hw_config = experimental::DataMovementHardwareConfig{};
                     } else {
-                        kernel_spec.hw_config = experimental::DataMovementGen1Config{
-                            .processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type),
-                            .noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
-                                                                   : tt_metal::NOC::RISCV_1_default,
-                        };
+                        kernel_spec.hw_config = experimental::DataMovementHardwareConfig{
+                            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type),
+                                .noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
+                                                                       : tt_metal::NOC::RISCV_1_default,
+                            }};
                     }
                     break;
                 }
@@ -123,9 +124,9 @@ void RunTest(
                         {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}};
                     if (is_quasar) {
                         kernel_spec.num_threads = 1;
-                        kernel_spec.hw_config = experimental::ComputeGen2Config{};
+                        kernel_spec.hw_config = experimental::ComputeHardwareConfig{};
                     } else {
-                        kernel_spec.hw_config = experimental::ComputeGen1Config{};
+                        kernel_spec.hw_config = experimental::ComputeHardwareConfig{};
                     }
                     break;
                 }
@@ -233,12 +234,12 @@ void RunMultiWriterTest(MeshWatcherFixture* fixture, const std::shared_ptr<distr
             "dm",
             {.num_threads = 6,
              .compiler_options = {.defines = {{"MULTI_DM_TEST", "1"}}},
-             .hw_config = experimental::DataMovementGen2Config{}});
+             .hw_config = experimental::DataMovementHardwareConfig{}});
         add_spec(
             "compute",
             {.num_threads = 4,
              .compiler_options = {.defines = {{"MULTI_DM_TEST", "1"}}},
-             .hw_config = experimental::ComputeGen2Config{}});
+             .hw_config = experimental::ComputeHardwareConfig{}});
         // DM0/DM1 are reserved, so the 6 launched threads land on DM2...DM7. COMPUTE follows the 8
         // DM entries in the HAL index.
         append_expected_writers(expected, [](uint32_t dm) { return fmt::format("DM{}", dm); }, 6, 2);
@@ -246,13 +247,15 @@ void RunMultiWriterTest(MeshWatcherFixture* fixture, const std::shared_ptr<distr
     } else {
         add_spec(
             "brisc",
-            {.hw_config = experimental::DataMovementGen1Config{
-                 .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}});
+            {.hw_config = experimental::DataMovementHardwareConfig{
+                 .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                     .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}}});
         add_spec(
             "ncrisc",
-            {.hw_config = experimental::DataMovementGen1Config{
-                 .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}});
-        // One ComputeGen1Config kernel builds all 3 TRISC binaries; each needs its own define.
+            {.hw_config = experimental::DataMovementHardwareConfig{
+                 .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                     .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}}});
+        // One ComputeHardwareConfig kernel builds all 3 TRISC binaries; each needs its own define.
         add_spec(
             "trisc",
             {.compiler_options =
@@ -260,7 +263,7 @@ void RunMultiWriterTest(MeshWatcherFixture* fixture, const std::shared_ptr<distr
                       {{"WATCHER_RINGBUF_TRISC0", "1"},
                        {"WATCHER_RINGBUF_TRISC1", "1"},
                        {"WATCHER_RINGBUF_TRISC2", "1"}}},
-             .hw_config = experimental::ComputeGen1Config{}});
+             .hw_config = experimental::ComputeHardwareConfig{}});
         append_expected_writers(expected, tensix_name, 5);
     }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -149,7 +149,10 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
             .num_threads = 1,
             .compile_time_args = {{"l1_scratch_addr", l1_unreserved_base}},
             .hw_config =
-                experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0},
+                experimental::DataMovementHardwareConfig{
+                    .config_1xx =
+                        experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}},
         };
         experimental::KernelSpec compute_spec{
             .unique_id = COMPUTE_KERNEL_NAME,
@@ -262,9 +265,11 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     // Provide both gen1 and gen2 configs so the runtime selects the one matching the current arch.
     experimental::DataMovementHardwareConfig dm_cfg;
     if (is_quasar) {
-        dm_cfg = experimental::DataMovementGen2Config{};
+        dm_cfg = experimental::DataMovementHardwareConfig{};
     } else {
-        dm_cfg = experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0};
+        dm_cfg = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}};
     }
 
     experimental::KernelSpec dm_spec{
@@ -407,18 +412,19 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
         if (is_quasar) {
             kspec.num_threads = num_dms_;
             kspec.compile_time_args = {{"dm_id", 0}};
-            kspec.hw_config = experimental::DataMovementGen2Config{};
+            kspec.hw_config = experimental::DataMovementHardwareConfig{};
         } else {
             kspec.num_threads = 1;
-            kspec.hw_config =
-                experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0};
+            kspec.hw_config = experimental::DataMovementHardwareConfig{
+                .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0}};
         }
     } else if (params.processor_class == HalProcessorClassType::COMPUTE) {
         kspec.num_threads = 1;  // On Quasar, only 1 NEO Cluster; gen1 has a single compute group.
         if (is_quasar) {
-            kspec.hw_config = experimental::ComputeGen2Config{};
+            kspec.hw_config = experimental::ComputeHardwareConfig{};
         } else {
-            kspec.hw_config = experimental::ComputeGen1Config{};
+            kspec.hw_config = experimental::ComputeHardwareConfig{};
         }
     } else {
         TT_THROW("Unsupported processor class");
@@ -477,7 +483,7 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
         .compiler_options =
             {.defines = {{"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}}},
         .compile_time_args = {{"num_dms", num_dms_}, {"l1_sync_addr", l1_unreserved_base}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
         .advanced_options =
             experimental::KernelAdvancedOptions{
                 .num_runtime_varargs = default_rtas.size(),

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -260,9 +260,11 @@ void RunTestOnCore(
         auto gen1_noc = use_ncrisc ? tt_metal::NOC::RISCV_1_default : tt_metal::NOC::RISCV_0_default;
         experimental::DataMovementHardwareConfig dm_cfg;
         if (is_quasar) {
-            dm_cfg = experimental::DataMovementGen2Config{};
+            dm_cfg = experimental::DataMovementHardwareConfig{};
         } else {
-            dm_cfg = experimental::DataMovementGen1Config{.processor = gen1_processor, .noc = gen1_noc};
+            dm_cfg = experimental::DataMovementHardwareConfig{
+                .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                    .processor = gen1_processor, .noc = gen1_noc}};
         }
         uint32_t num_threads = is_quasar ? 6u : 1u;
         if (!is_quasar) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -89,7 +89,7 @@ void RunOneTest(
                 .source = path_metal2,
                 .num_threads = dms_per_kernel,
                 .compile_time_args = {{"usage", free}},
-                .hw_config = experimental::DataMovementGen2Config{},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             });
             kernel_names.emplace_back(name);
         }
@@ -101,7 +101,7 @@ void RunOneTest(
             // all Neos; each Neo internally runs the kernel on its 4 TRISCs.
             .num_threads = 4,
             .compile_time_args = {{"usage", free}},
-            .hw_config = experimental::ComputeGen2Config{},
+            .hw_config = experimental::ComputeHardwareConfig{},
         });
         kernel_names.push_back(COMPUTE_NAME);
     } else {
@@ -117,7 +117,11 @@ void RunOneTest(
                 .source = path_metal2,
                 .num_threads = 1,
                 .compile_time_args = {{"usage", free}},
-                .hw_config = experimental::DataMovementGen1Config{.processor = processor, .noc = noc},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = processor, .noc = noc}},
             });
             kernel_names.emplace_back(name);
         }
@@ -188,7 +192,7 @@ void RunOneTest(
     EXPECT_TRUE(FileContainsAllStringsInOrder(fixture->log_file_name, expected));
 }
 
-} // namespace
+}  // namespace
 
 struct StackUsageTestParams {
     std::string test_name;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -81,7 +81,11 @@ void RunTest(
         .compiler_options = {.defines = {{"DFB_PRODUCER", "1"}}},
         .dfb_bindings = {experimental::ProducerOf(TILE_COUNTER_DFB, "tile_counter_dfb")},
         .compile_time_args = {{"num_entries", NUM_ENTRIES_PER_PRODUCER}},
-        .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .config_2xx =
+                    experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                        .disable_dfb_implicit_sync_for_all = true}},
     };
 
     // NEO compute consumer kernel (4 threads = 4 Neo clusters)
@@ -101,7 +105,7 @@ void RunTest(
             {{"num_entries", entries_per_consumer},
              {"num_consumers_to_run", NUM_CONSUMERS_TO_RUN},
              {"sync_flag_addr", tensix_sync_addr}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -86,9 +86,11 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                                 : tt::tt_metal::NOC::RISCV_0_default;
             experimental::DataMovementHardwareConfig dm_cfg;
             if (is_quasar) {
-                dm_cfg = experimental::DataMovementGen2Config{};
+                dm_cfg = experimental::DataMovementHardwareConfig{};
             } else {
-                dm_cfg = experimental::DataMovementGen1Config{.processor = gen1_proc, .noc = gen1_noc};
+                dm_cfg = experimental::DataMovementHardwareConfig{
+                    .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = gen1_proc, .noc = gen1_noc}};
             }
             kernel_specs.push_back(experimental::KernelSpec{
                 .unique_id = experimental::KernelSpecName{name},
@@ -109,11 +111,11 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     if (is_quasar) {
         constexpr uint32_t kQuasarUserDmCores = 6;
         add_dm_kernel("wp_dm", kQuasarUserDmCores, std::nullopt);
-        compute_config = experimental::ComputeGen2Config{};
+        compute_config = experimental::ComputeHardwareConfig{};
     } else {
         add_dm_kernel("wp_brisc", 1, tt::tt_metal::DataMovementProcessor::RISCV_0);
         add_dm_kernel("wp_ncrisc", 1, tt::tt_metal::DataMovementProcessor::RISCV_1);
-        compute_config = experimental::ComputeGen1Config{};
+        compute_config = experimental::ComputeHardwareConfig{};
     }
     kernel_specs.push_back(experimental::KernelSpec{
         .unique_id = compute_kernel_name,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_zero_mode_guard.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_zero_mode_guard.cpp
@@ -48,7 +48,9 @@ constexpr uint32_t kScratchBytes = 8 * 1024;
 constexpr uint32_t kZeroBytes = 2 * 1024;
 
 experimental::DataMovementHardwareConfig make_hw_config() {
-    return experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+    return experimental::DataMovementHardwareConfig{
+        .config_2xx =
+            experimental::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true}};
 }
 
 Program make_program(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -238,7 +238,8 @@ TEST_F(MeshDispatchFixture, EthTestInitLocalMemory) {
 
     // TODO: tweak when FD supports idle eth
     const bool is_idle_eth = this->slow_dispatch_;
-    const auto& eth_cores = is_idle_eth ? device->get_inactive_ethernet_cores() : device->get_active_ethernet_cores(true);
+    const auto& eth_cores =
+        is_idle_eth ? device->get_inactive_ethernet_cores() : device->get_active_ethernet_cores(true);
 
     if (eth_cores.empty()) {
         log_info(
@@ -258,14 +259,22 @@ TEST_F(MeshDispatchFixture, EthTestInitLocalMemory) {
     for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
         DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
         CoreCoord eth_core = *eth_cores.begin();
-        log_info(tt::LogTest, "Adding {} ethernet DM{} {}", this->slow_dispatch_ ? "idle" : "active", erisc_idx, eth_core.str());
+        log_info(
+            tt::LogTest,
+            "Adding {} ethernet DM{} {}",
+            this->slow_dispatch_ ? "idle" : "active",
+            erisc_idx,
+            eth_core.str());
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
         CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/misc/local_mem.cpp",
             eth_core,
-            tt::tt_metal::EthernetConfig{.eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::RECEIVER, .noc = static_cast<NOC>(erisc_idx), .processor = dm_processor});
+            tt::tt_metal::EthernetConfig{
+                .eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::RECEIVER,
+                .noc = static_cast<NOC>(erisc_idx),
+                .processor = dm_processor});
 
         workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
@@ -328,8 +337,8 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
             Program program;
 
             CircularBufferConfig cb_config = CircularBufferConfig(cb_size, intermediate_and_out_data_format_spec)
-                                                .set_page_size(intermediate_cb, single_tile_size)
-                                                .set_page_size(out_cb, single_tile_size);
+                                                 .set_page_size(intermediate_cb, single_tile_size)
+                                                 .set_page_size(out_cb, single_tile_size);
             CreateCircularBuffer(program, core_coord, cb_config);
 
             CreateKernel(
@@ -507,18 +516,17 @@ Program create_quasar_l1_write_program(
         .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = 1,
         .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::ProgramSpec spec{
         .name = "quasar_dispatch_s_test",
         .kernels = {dm_kernel_spec},
-        .work_units =
-            {experimental::WorkUnitSpec{
-                .name = "main",
-                .kernels = {dm_kernel_name},
-                .target_nodes = node,
-            }},
+        .work_units = {experimental::WorkUnitSpec{
+            .name = "main",
+            .kernels = {dm_kernel_name},
+            .target_nodes = node,
+        }},
     };
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -253,10 +253,13 @@ static void matmul_tile_block(
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -291,10 +294,13 @@ static void matmul_tile_block(
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -334,13 +340,13 @@ static void matmul_tile_block(
 
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device->arch() == ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .fpu_math_fidelity = cfg.math_fidelity,
             .enable_32_bit_dest = cfg.fp32_dest_acc_en,
             .double_buffer_dest = !cfg.dst_full_sync_en,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .fpu_math_fidelity = cfg.math_fidelity,
             .enable_32_bit_dest = cfg.fp32_dest_acc_en,
             .double_buffer_dest = !cfg.dst_full_sync_en,

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -97,26 +97,32 @@ constexpr float k_broadcast_rtol = 0.0155;
 // the processor/NOC pair per direction. Identical for every runner in this file, hence the helpers.
 experimental::DataMovementHardwareConfig make_reader_hw_config(const distributed::MeshDevice& mesh_device) {
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        return experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        return experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     }
-    return experimental::DataMovementGen1Config{
-        .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+    return experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
 }
 
 experimental::DataMovementHardwareConfig make_writer_hw_config(const distributed::MeshDevice& mesh_device) {
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        return experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        return experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     }
-    return experimental::DataMovementGen1Config{
-        .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+    return experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
 }
 
 experimental::ComputeHardwareConfig make_compute_hw_config(
     const distributed::MeshDevice& mesh_device, MathFidelity math_fidelity) {
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        return experimental::ComputeGen2Config{.fpu_math_fidelity = math_fidelity};
+        return experimental::ComputeHardwareConfig{.fpu_math_fidelity = math_fidelity};
     }
-    return experimental::ComputeGen1Config{.fpu_math_fidelity = math_fidelity};
+    return experimental::ComputeHardwareConfig{.fpu_math_fidelity = math_fidelity};
 }
 
 struct BroadcastConfig {

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -122,10 +122,13 @@ void run_single_core_copy_block_matmul_partials(
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -141,10 +144,13 @@ void run_single_core_copy_block_matmul_partials(
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -168,18 +174,18 @@ void run_single_core_copy_block_matmul_partials(
         // When fp32_dest_acc_en is true the src DFB is Float32 and the compute kernel
         // consumes it, so the Metal 2.0 host API requires an explicit unpack_modes entry.
         // UnpackToSrc is unpack via SrcA/B, ~19-bit precision.
-        experimental::ComputeUnpackModes unpack_modes{};
+        experimental::ComputeHardwareConfig::ComputeUnpackModes unpack_modes{};
         if (test_config.fp32_dest_acc_en) {
             unpack_modes = {{SRC0_DFB, tt::tt_metal::UnpackMode::UnpackToSrc}};
         }
         if (mesh_device->arch() == tt::ARCH::QUASAR) {
-            compute_hw_config = experimental::ComputeGen2Config{
+            compute_hw_config = experimental::ComputeHardwareConfig{
                 .enable_32_bit_dest = test_config.fp32_dest_acc_en,
                 .double_buffer_dest = !test_config.dst_full_sync_en,
                 .unpack_modes = unpack_modes,
             };
         } else {
-            compute_hw_config = experimental::ComputeGen1Config{
+            compute_hw_config = experimental::ComputeHardwareConfig{
                 .enable_32_bit_dest = test_config.fp32_dest_acc_en,
                 .double_buffer_dest = !test_config.dst_full_sync_en,
                 .unpack_modes = unpack_modes,

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -93,7 +93,7 @@ static vector<uint32_t> run_mxfp4_typecast(
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .runtime_arg_schema = {.runtime_arg_names = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec writer_spec{
@@ -104,7 +104,7 @@ static vector<uint32_t> run_mxfp4_typecast(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec compute_spec{
@@ -128,7 +128,7 @@ static vector<uint32_t> run_mxfp4_typecast(
              }},
         .compile_time_args = {{"per_core_tile_cnt", num_tiles}},
         .hw_config =
-            experimental::ComputeGen2Config{
+            experimental::ComputeHardwareConfig{
                 .enable_32_bit_dest = fp32_dest_acc_en,
             },
     };
@@ -191,23 +191,23 @@ static vector<uint32_t> run_mxfp4_typecast(
 // Data generators follow the fp8_typecast tests' convention: generate
 // row-major floats in U(0, rand_max_float) + offset, then pack into tiles.
 static vector<uint32_t> create_random_vector_of_mxfp4(
-	uint32_t num_bytes, int rand_max_float, int seed, float offset = 0.0f) {
-	uint32_t single_tile_size = tt::tile_size(tt::DataFormat::MxFp4);
-	TT_FATAL(
-		num_bytes % single_tile_size == 0,
-		"num_bytes {} must be divisible by MXFP4 tile_size {}",
-		num_bytes,
-		single_tile_size);
-	uint32_t num_tiles = num_bytes / single_tile_size;
+    uint32_t num_bytes, int rand_max_float, int seed, float offset = 0.0f) {
+    uint32_t single_tile_size = tt::tile_size(tt::DataFormat::MxFp4);
+    TT_FATAL(
+        num_bytes % single_tile_size == 0,
+        "num_bytes {} must be divisible by MXFP4 tile_size {}",
+        num_bytes,
+        single_tile_size);
+    uint32_t num_tiles = num_bytes / single_tile_size;
 
-	std::mt19937 rng(seed);
-	std::uniform_real_distribution<float> dist(0.0f, static_cast<float>(rand_max_float));
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(0.0f, static_cast<float>(rand_max_float));
 
-	constexpr uint32_t kNumFloatsPerTile = 1024;
-	vector<float> fp32_vec(num_tiles * kNumFloatsPerTile);
-	for (float& v : fp32_vec) {
-		v = dist(rng) + offset;
-	}
+    constexpr uint32_t kNumFloatsPerTile = 1024;
+    vector<float> fp32_vec(num_tiles * kNumFloatsPerTile);
+    for (float& v : fp32_vec) {
+        v = dist(rng) + offset;
+    }
 
     vector<uint32_t> packed =
         pack_as_mx_tiles(tt::DataFormat::MxFp4, ttsl::make_const_span(fp32_vec), /*row_major_input=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -97,7 +97,7 @@ static vector<uint32_t> run_mxfp6_typecast(
             .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec writer_spec{
@@ -111,7 +111,7 @@ static vector<uint32_t> run_mxfp6_typecast(
             .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec compute_spec{
@@ -133,7 +133,7 @@ static vector<uint32_t> run_mxfp6_typecast(
              }},
         .compile_time_args = {{"per_core_tile_cnt", num_tiles}},
         .hw_config =
-            experimental::ComputeGen2Config{
+            experimental::ComputeHardwareConfig{
                 .enable_32_bit_dest = fp32_dest_acc_en,
             },
     };

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -96,7 +96,7 @@ static vector<uint32_t> run_mxfp8_typecast(
             .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec writer_spec{
@@ -110,7 +110,7 @@ static vector<uint32_t> run_mxfp8_typecast(
             .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec compute_spec{
@@ -132,7 +132,7 @@ static vector<uint32_t> run_mxfp8_typecast(
              }},
         .compile_time_args = {{"per_core_tile_cnt", num_tiles}},
         .hw_config =
-            experimental::ComputeGen2Config{
+            experimental::ComputeHardwareConfig{
                 .enable_32_bit_dest = fp32_dest_acc_en,
             },
     };

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -85,7 +85,7 @@ static vector<uint32_t> run_mxint_typecast(
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .runtime_arg_schema = {.runtime_arg_names = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec writer_spec{
@@ -94,7 +94,7 @@ static vector<uint32_t> run_mxint_typecast(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec compute_spec{
@@ -116,7 +116,7 @@ static vector<uint32_t> run_mxint_typecast(
              }},
         .compile_time_args = {{"per_core_tile_cnt", num_tiles}},
         .hw_config =
-            experimental::ComputeGen2Config{
+            experimental::ComputeHardwareConfig{
                 .enable_32_bit_dest = fp32_dest_acc_en,
             },
     };

--- a/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
@@ -109,7 +109,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
             .num_threads = 1,
             .dfb_bindings = {experimental::ProducerOf(dfb, "out")},
             .runtime_arg_schema = {.runtime_arg_names = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
     experimental::KernelSpec reader0_spec = make_reader_spec(IN0_DFB);
@@ -125,7 +125,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec compute_spec{
@@ -158,7 +158,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
                  .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_args = {{"num_cycles", NUM_CYCLES}, {"num_loops", NUM_LOOPS}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -455,7 +455,11 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
                   "src5_addr",
                   "src5_bank_id",
                   "num_tiles"}},
-        .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .config_2xx =
+                    experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                        .disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer_spec{
@@ -469,7 +473,11 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
             .access_pattern = DFBAccess::STRIDED,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "bank_id", "num_tiles"}},
-        .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .config_2xx =
+                    experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                        .disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec compute_spec{
@@ -485,7 +493,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
              dfb_binding(INP5_DFB, DFBEndpoint::CONSUMER),
              dfb_binding(OUT_DFB, DFBEndpoint::PRODUCER)},
         .hw_config =
-            experimental::ComputeGen2Config{
+            experimental::ComputeHardwareConfig{
                 .fpu_math_fidelity = MathFidelity::HiFi4,
                 .enable_32_bit_dest = true,
                 .unpack_modes =
@@ -766,7 +774,11 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
             .num_threads = 1,
             .dfb_bindings = {experimental::ConsumerOf(out_dfb, "in")},
             .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "bank_id", "num_tiles"}},
-            .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+            .hw_config =
+                experimental::DataMovementHardwareConfig{
+                    .config_2xx =
+                        experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                            .disable_dfb_implicit_sync_for_all = true}},
         };
     };
 
@@ -796,7 +808,11 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
                   "src5_addr",
                   "src5_bank_id",
                   "num_tiles"}},
-        .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .config_2xx =
+                    experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                        .disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::KernelSpec writer0_spec = make_writer_spec(WRITER0, OUT0_DFB);
@@ -818,7 +834,7 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
              dfb_binding(OUT1_DFB, DFBEndpoint::PRODUCER),
              dfb_binding(OUT2_DFB, DFBEndpoint::PRODUCER)},
         .hw_config =
-            experimental::ComputeGen2Config{
+            experimental::ComputeHardwareConfig{
                 .fpu_math_fidelity = MathFidelity::HiFi4,
                 .enable_32_bit_dest = true,
                 .unpack_modes =

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -376,10 +376,13 @@ void run_single_core_reduce_program(
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -407,10 +410,13 @@ void run_single_core_reduce_program(
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -426,13 +432,13 @@ void run_single_core_reduce_program(
 
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .fpu_math_fidelity = test_config.math_fidelity,
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .fpu_math_fidelity = test_config.math_fidelity,
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -77,7 +77,9 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"square", {{"SFPU_OP_CHAIN_0", "square_tile_init(); square_tile(0);"}}},
     {"negative", {{"SFPU_OP_CHAIN_0", "negative_tile_init(); negative_tile(0);"}}},
     {"softplus",
-     {{"SFPU_OP_CHAIN_0", "softplus_tile_init(); softplus_tile(0, /* beta */ 0x3F800000u, /* recip */0x3F800000u, /* threshold */ 0x41A00000u);"}}},
+     {{"SFPU_OP_CHAIN_0",
+       "softplus_tile_init(); softplus_tile(0, /* beta */ 0x3F800000u, /* recip */0x3F800000u, /* threshold */ "
+       "0x41A00000u);"}}},
     {"clamp", {{"SFPU_OP_CHAIN_0", "clamp_tile_init(); clamp_tile(0, 0xBF800000u, 0x3F800000u);"}}},  // [-1.0f, 1.0f]
     // Comparison-to-zero family (unary): result = 1.0f if predicate(x, 0) else 0.0f.
     {"eqz", {{"SFPU_OP_CHAIN_0", "eqz_tile_init(); eqz_tile(0);"}}},
@@ -649,8 +651,9 @@ struct SfpuConfig {
     CoreRangeSet cores;
     std::string sfpu_op;
     bool approx_mode = true;
-    bool dst_full_sync_en = true;      // SyncFull by default (matches today's implicit behavior)
-    bool unpack_to_dest = false;       // route input DFB to Dest (unpack_modes=UnpackToDest); pair with en_32bit_dest for 32-bit Dest
+    bool dst_full_sync_en = true;  // SyncFull by default (matches today's implicit behavior)
+    bool unpack_to_dest =
+        false;  // route input DFB to Dest (unpack_modes=UnpackToDest); pair with en_32bit_dest for 32-bit Dest
     bool en_32bit_dest = false;
 };
 
@@ -725,10 +728,13 @@ std::vector<uint32_t> run_sfpu_pipeline(
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
 
     experimental::KernelSpec reader_spec{
@@ -747,10 +753,13 @@ std::vector<uint32_t> run_sfpu_pipeline(
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
 
     experimental::KernelSpec writer_spec{
@@ -768,13 +777,13 @@ std::vector<uint32_t> run_sfpu_pipeline(
     };
 
     experimental::ComputeHardwareConfig compute_hw_config;
-    experimental::ComputeUnpackModes unpack_modes{};
+    experimental::ComputeHardwareConfig::ComputeUnpackModes unpack_modes{};
     if (test_config.unpack_to_dest) {
         unpack_modes = {{IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest}};
     }
     const bool fp32_dest_acc_en = test_config.en_32bit_dest;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .sfpu_precision_mode =
                 test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
             .enable_32_bit_dest = fp32_dest_acc_en,
@@ -782,7 +791,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
             .unpack_modes = unpack_modes,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .sfpu_precision_mode =
                 test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
             .enable_32_bit_dest = fp32_dest_acc_en,
@@ -952,7 +961,11 @@ experimental::KernelSpec make_writer_unary_quasar_spec(
             .access_pattern = experimental::DFBAccessPattern::STRIDED,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "bank_id", "num_tiles"}},
-        .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .config_2xx =
+                    experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                        .disable_dfb_implicit_sync_for_all = true}},
     };
 }
 
@@ -1081,18 +1094,22 @@ bool run_sfpu_binary_two_input_buffer(
              }},
         .runtime_arg_schema =
             {.runtime_arg_names = {"src0_addr", "src0_bank_id", "src1_addr", "src1_bank_id", "num_tiles"}},
-        .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .config_2xx =
+                    experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                        .disable_dfb_implicit_sync_for_all = true}},
     };
 
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .sfpu_precision_mode =
                 test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
             .enable_32_bit_dest = is_int8_op,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .sfpu_precision_mode =
                 test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
             .enable_32_bit_dest = is_int8_op,
@@ -1264,17 +1281,21 @@ bool run_sfpu_ternary_three_input_buffer(
                       "num_tiles",
                       "src2_addr",
                       "src2_bank_id"}},
-            .hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true},
+            .hw_config =
+                experimental::DataMovementHardwareConfig{
+                    .config_2xx =
+                        experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                            .disable_dfb_implicit_sync_for_all = true}},
         };
 
         experimental::ComputeHardwareConfig compute_hw_config;
         if (mesh_device->arch() == tt::ARCH::QUASAR) {
-            compute_hw_config = experimental::ComputeGen2Config{
+            compute_hw_config = experimental::ComputeHardwareConfig{
                 .sfpu_precision_mode =
                     test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
             };
         } else {
-            compute_hw_config = experimental::ComputeGen1Config{
+            compute_hw_config = experimental::ComputeHardwareConfig{
                 .sfpu_precision_mode =
                     test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
             };
@@ -1536,7 +1557,11 @@ void run_quasar_sfpu_unpack_to_dest_16b(
         .unpack_to_dest = true,  // 16-bit operand unpack-to-dest (fp32_dest_acc_en stays false)
     };
     log_info(
-        tt::LogTest, "Quasar SFPU 16b->DEST: op={} num_tiles={} dst_full_sync_en={}", sfpu_op, num_tiles, dst_full_sync_en);
+        tt::LogTest,
+        "Quasar SFPU 16b->DEST: op={} num_tiles={} dst_full_sync_en={}",
+        sfpu_op,
+        num_tiles,
+        dst_full_sync_en);
     EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_all_same_buffer(dev, cfg));
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -464,10 +464,13 @@ bool single_core_binary(
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -503,10 +506,13 @@ bool single_core_binary(
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -520,7 +526,7 @@ bool single_core_binary(
     };
 
     experimental::ComputeHardwareConfig compute_hw_config;
-    experimental::ComputeUnpackModes unpack_modes{};
+    experimental::ComputeHardwareConfig::ComputeUnpackModes unpack_modes{};
     if (test_config.l1_input_data_format == tt::DataFormat::Float32) {
         unpack_modes = {
             {INP0_DFB, tt::tt_metal::UnpackMode::UnpackToSrc},
@@ -529,13 +535,13 @@ bool single_core_binary(
         };
     }
     if (mesh_device->arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .fpu_math_fidelity = test_config.math_fidelity,
             .enable_32_bit_dest = test_config.enable_32_bit_dest,
             .unpack_modes = unpack_modes,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .fpu_math_fidelity = test_config.math_fidelity,
             .enable_32_bit_dest = test_config.enable_32_bit_dest,
             .unpack_modes = unpack_modes,

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -827,9 +827,7 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
             "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp",
             core,
             tt_metal::experimental::quasar::QuasarComputeConfig{
-                .num_threads_per_cluster = 1,
-                .compile_args = compute_compile_args,
-                .defines = compute_defines});
+                .num_threads_per_cluster = 1, .compile_args = compute_compile_args, .defines = compute_defines});
 
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
             program_, in0_id, reader_kernel, compute_kernel);
@@ -1050,15 +1048,21 @@ void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_devi
     experimental::DataMovementHardwareConfig writer_hw_config;
     experimental::ComputeHardwareConfig compute_hw_config;
     if (is_quasar) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-        compute_hw_config = experimental::ComputeGen2Config{.fpu_math_fidelity = test_config.math_fidelity};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
+        compute_hw_config = experimental::ComputeHardwareConfig{.fpu_math_fidelity = test_config.math_fidelity};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
-        compute_hw_config = experimental::ComputeGen1Config{.fpu_math_fidelity = test_config.math_fidelity};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
+        compute_hw_config = experimental::ComputeHardwareConfig{.fpu_math_fidelity = test_config.math_fidelity};
     }
 
     // Reads num_tiles into in0 and num_bcast_tiles into in1 from two DRAM buffers, which is exactly

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -204,10 +204,13 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -223,10 +226,13 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -254,18 +260,18 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
     const bool fp32_dest_acc_en =
         (test_config.data_format == tt::DataFormat::Float32 || test_config.data_format == tt::DataFormat::Int32);
     experimental::ComputeHardwareConfig compute_hw_config;
-    experimental::ComputeUnpackModes unpack_modes{};
+    experimental::ComputeHardwareConfig::ComputeUnpackModes unpack_modes{};
     if (test_config.unpack_to_dest) {
         unpack_modes = {{INPUT_DFB, tt::tt_metal::UnpackMode::UnpackToDest}};
     }
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
             .unpack_modes = unpack_modes,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
             .unpack_modes = unpack_modes,

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -324,10 +324,13 @@ void run_single_core_unary_broadcast_quasar(
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -341,10 +344,13 @@ void run_single_core_unary_broadcast_quasar(
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -378,7 +384,7 @@ void run_single_core_unary_broadcast_quasar(
                  .access_pattern = experimental::DFBAccessPattern::STRIDED,
              }},
         .compile_time_args = {{"per_core_block_cnt", num_blocks}, {"per_core_block_dim", block_size}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -279,10 +279,11 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{};
+        reader_hw_config = experimental::DataMovementHardwareConfig{};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -295,10 +296,11 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{};
+        writer_hw_config = experimental::DataMovementHardwareConfig{};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -344,12 +346,12 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
 
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
         };
@@ -607,10 +609,13 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
 
     experimental::DataMovementHardwareConfig reader_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        reader_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        reader_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}};
     }
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -637,10 +642,13 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
 
     experimental::DataMovementHardwareConfig writer_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = true}};
     } else {
-        writer_hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        writer_hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}};
     }
     experimental::KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -662,12 +670,12 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
 
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
         };
@@ -1011,7 +1019,7 @@ static void run_quasar_tilize_untilize_test(
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .runtime_arg_schema = {.runtime_arg_names = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec writer_spec{
@@ -1022,7 +1030,7 @@ static void run_quasar_tilize_untilize_test(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     std::string compute_kernel;
@@ -1056,12 +1064,12 @@ static void run_quasar_tilize_untilize_test(
 
     experimental::ComputeHardwareConfig compute_hw_config;
     if (mesh_device.arch() == tt::ARCH::QUASAR) {
-        compute_hw_config = experimental::ComputeGen2Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !dst_full_sync_en,
         };
     } else {
-        compute_hw_config = experimental::ComputeGen1Config{
+        compute_hw_config = experimental::ComputeHardwareConfig{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !dst_full_sync_en,
         };

--- a/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_scoped_lock.cpp
@@ -711,10 +711,12 @@ void run_dfb_scoped_lock_test(
 
     // The two DM kernels claim different NOCs, so the consumer takes whichever one the producer did not.
     const NOC consumer_noc = (producer_noc == NOC::NOC_0) ? NOC::NOC_1 : NOC::NOC_0;
-    const experimental::DataMovementHardwareConfig dm_producer_cfg =
-        experimental::DataMovementGen1Config{.processor = producer_processor, .noc = producer_noc};
-    const experimental::DataMovementHardwareConfig dm_consumer_cfg =
-        experimental::DataMovementGen1Config{.processor = consumer_processor, .noc = consumer_noc};
+    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = producer_processor, .noc = producer_noc}};
+    const experimental::DataMovementHardwareConfig dm_consumer_cfg = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = consumer_processor, .noc = consumer_noc}};
 
     experimental::KernelSpec producer_spec{
         .unique_id = PRODUCER,
@@ -866,7 +868,11 @@ void run_dfb_region_cleared_between_launches_test(
         .num_threads = 1,
         .runtime_arg_schema =
             {.runtime_arg_names = {"src_buffer_addr", "write_size", "self_noc_x", "self_noc_y", "target_addr"}},
-        .hw_config = experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0},
+        .hw_config =
+            experimental::DataMovementHardwareConfig{
+                .config_1xx =
+                    experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = DataMovementProcessor::RISCV_0}},
     };
     experimental::WorkUnitSpec writer_wu{.name = "main", .kernels = {WRITER}, .target_nodes = core};
     experimental::ProgramSpec writer_program_spec{
@@ -939,10 +945,12 @@ void run_dfb_scoped_lock_xcore_test(
     experimental::SemaphoreSpec sem_written{
         .unique_id = SEM_WRITTEN, .target_nodes = experimental::NodeRange{locker_core, writer_core}};
 
-    const experimental::DataMovementHardwareConfig dm_rv0 =
-        experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
-    const experimental::DataMovementHardwareConfig dm_rv1 =
-        experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+    const experimental::DataMovementHardwareConfig dm_rv0 = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_0}};
+    const experimental::DataMovementHardwareConfig dm_rv1 = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
 
     experimental::KernelSpec locker_spec{
         .unique_id = LOCKER,
@@ -1080,10 +1088,12 @@ void run_dfb_mcast_loopback_unlocked_test(
         .data_format_metadata = tt::DataFormat::Float16_b,
     };
 
-    const experimental::DataMovementHardwareConfig dm_producer_cfg =
-        experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
-    const experimental::DataMovementHardwareConfig dm_consumer_cfg =
-        experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_0}};
+    const experimental::DataMovementHardwareConfig dm_consumer_cfg = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
 
     experimental::KernelSpec producer_spec{
         .unique_id = PRODUCER,
@@ -1214,10 +1224,12 @@ void run_dfb_mcast_xcore_locked_test(
     experimental::SemaphoreSpec sem_written{
         .unique_id = SEM_WRITTEN, .target_nodes = experimental::NodeRange{locker_core, writer_core}};
 
-    const experimental::DataMovementHardwareConfig dm_rv0 =
-        experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
-    const experimental::DataMovementHardwareConfig dm_rv1 =
-        experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+    const experimental::DataMovementHardwareConfig dm_rv0 = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_0}};
+    const experimental::DataMovementHardwareConfig dm_rv1 = experimental::DataMovementHardwareConfig{
+        .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
 
     experimental::KernelSpec locker_spec{
         .unique_id = LOCKER,

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -41,8 +41,8 @@ const experimental::KernelSpecName COMPUTE{"compute"};
 
 struct BmmParams {
     uint32_t Mt, Kt, Nt;
-    uint32_t B_total;       // total batch count (buffer sizing + validation)
-    uint32_t B_per_core;    // batch count per core (kernel runtime args)
+    uint32_t B_total;     // total batch count (buffer sizing + validation)
+    uint32_t B_per_core;  // batch count per core (kernel runtime args)
     uint32_t num_threads = 2;
     uint32_t num_input_tiles = 4;
     uint32_t num_output_tiles = 4;
@@ -91,15 +91,21 @@ experimental::ProgramSpec build_bmm_program_spec(
     experimental::DataMovementHardwareConfig writer_config;
     experimental::ComputeHardwareConfig compute_config;
     if (is_quasar) {
-        reader_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = !use_implicit_sync};
-        writer_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = !use_implicit_sync};
-        compute_config = experimental::ComputeGen2Config{};
+        reader_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = !use_implicit_sync}};
+        writer_config = experimental::DataMovementHardwareConfig{
+            .config_2xx = experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+                .disable_dfb_implicit_sync_for_all = !use_implicit_sync}};
+        compute_config = experimental::ComputeHardwareConfig{};
     } else {
-        reader_config = experimental::DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default};
-        writer_config = experimental::DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
-        compute_config = experimental::ComputeGen1Config{};
+        reader_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}};
+        writer_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}};
+        compute_config = experimental::ComputeHardwareConfig{};
     }
 
     experimental::DataflowBufferSpec src0_dfb_spec{
@@ -206,13 +212,20 @@ TEST_F(AnyDispatchMeshDeviceSingleCardFixture, Bmm) {
 
     BmmParams p;
     if (mesh_device.arch() != ARCH::QUASAR) {
-        p.Mt = 4; p.Kt = 2; p.Nt = 3;
-        p.B_total = 2; p.B_per_core = 2;
-        p.num_input_tiles = 2; p.num_output_tiles = 2;
+        p.Mt = 4;
+        p.Kt = 2;
+        p.Nt = 3;
+        p.B_total = 2;
+        p.B_per_core = 2;
+        p.num_input_tiles = 2;
+        p.num_output_tiles = 2;
         p.num_threads = 1;
     } else {
-        p.Mt = 2; p.Kt = 2; p.Nt = 2;
-        p.B_total = 1; p.B_per_core = 1;
+        p.Mt = 2;
+        p.Kt = 2;
+        p.Nt = 2;
+        p.B_total = 1;
+        p.B_per_core = 1;
         p.num_threads = 2;
     }
 
@@ -281,9 +294,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, BmmMultinode) {
     }
 
     BmmParams p;
-    p.Mt = 2; p.Kt = 2; p.Nt = 2;
-    p.B_total = 2;      // total batches across both cores
-    p.B_per_core = 1;   // each core computes exactly one batch
+    p.Mt = 2;
+    p.Kt = 2;
+    p.Nt = 2;
+    p.B_total = 2;     // total batches across both cores
+    p.B_per_core = 1;  // each core computes exactly one batch
     p.num_threads = 2;
 
     auto tensors = create_bmm_tensors(mesh_device, p);

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -70,7 +70,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
                 {
                     .runtime_arg_names = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
 
@@ -87,7 +87,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
                 {
                     .runtime_arg_names = {"dram_addr", "l1_addr", "dram_buffer_size", "dram_bank_id", "signal_value"},
                 },
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
 

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -75,7 +75,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
                 {
                     .runtime_arg_names = {"signal_address", "dram_dst_address", "dram_dst_bank_id", "l1_result_addr"},
                 },
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
 
@@ -128,11 +128,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     // Reference global addresses: DM 2-4 share one binary, DM 5-6 share another, DM 7 alone.
     auto slot_global_addr = [&dram_data](uint32_t dm) {
         const uint32_t offset = dm * TLS_CHECK_RESULT_SLOT_WORDS;
-        return (uint64_t)dram_data[offset + TLS_CHECK_GLOBAL_ADDR_LO] | ((uint64_t)dram_data[offset + TLS_CHECK_GLOBAL_ADDR_HI] << 32);
+        return (uint64_t)dram_data[offset + TLS_CHECK_GLOBAL_ADDR_LO] |
+               ((uint64_t)dram_data[offset + TLS_CHECK_GLOBAL_ADDR_HI] << 32);
     };
     auto slot_thread_local_addr = [&dram_data](uint32_t dm) {
         const uint32_t offset = dm * TLS_CHECK_RESULT_SLOT_WORDS;
-        return (uint64_t)dram_data[offset + TLS_CHECK_THREAD_LOCAL_ADDR_LO] | ((uint64_t)dram_data[offset + TLS_CHECK_THREAD_LOCAL_ADDR_HI] << 32);
+        return (uint64_t)dram_data[offset + TLS_CHECK_THREAD_LOCAL_ADDR_LO] |
+               ((uint64_t)dram_data[offset + TLS_CHECK_THREAD_LOCAL_ADDR_HI] << 32);
     };
     const uint64_t ref_addr_2_4 = slot_global_addr(2);
     const uint64_t ref_addr_5_6 = slot_global_addr(5);
@@ -309,7 +311,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
             {
                 .runtime_arg_names = {"signal_address", "l1_result_addr"},
             },
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -66,7 +66,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
                 {
                     .runtime_arg_names = {"a", "b"},
                 },
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
 

--- a/tests/tt_metal/tt_metal/test_noc_atomic_ops.cpp
+++ b/tests/tt_metal/tt_metal/test_noc_atomic_ops.cpp
@@ -83,7 +83,7 @@ protected:
                 .num_threads = num_dms_,
                 .compiler_options = {.defines = {{mode_define, "1"}}},
                 .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "increment_times"}},
-                .hw_config = experimental::DataMovementGen2Config{},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             });
             kernel_names.push_back(DM_KERNEL);
             params.kernel_run_args.push_back(make_run_params(DM_KERNEL));
@@ -97,9 +97,12 @@ protected:
                     .compiler_options = {.defines = {{mode_define, "1"}}},
                     .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "increment_times"}},
                     .hw_config =
-                        experimental::DataMovementGen1Config{
-                            .processor = static_cast<tt_metal::DataMovementProcessor>(dm_id),
-                            .noc = (dm_id == 1 ? NOC::RISCV_1_default : NOC::RISCV_0_default),
+                        experimental::DataMovementHardwareConfig{
+                            .config_1xx =
+                                experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                    .processor = static_cast<tt_metal::DataMovementProcessor>(dm_id),
+                                    .noc = (dm_id == 1 ? NOC::RISCV_1_default : NOC::RISCV_0_default),
+                                },
                         },
                 });
                 kernel_names.push_back(name);

--- a/tests/tt_metal/tt_metal/test_noc_self_atomic.cpp
+++ b/tests/tt_metal/tt_metal/test_noc_self_atomic.cpp
@@ -83,7 +83,7 @@ protected:
                 .source = kernel_src,
                 .num_threads = num_dms_,
                 .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "increment_times"}},
-                .hw_config = experimental::DataMovementGen2Config{},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             });
             kernel_names.push_back(DM_KERNEL);
             params.kernel_run_args.push_back(make_run_params(DM_KERNEL));
@@ -96,9 +96,12 @@ protected:
                     .num_threads = 1,
                     .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "increment_times"}},
                     .hw_config =
-                        experimental::DataMovementGen1Config{
-                            .processor = static_cast<tt_metal::DataMovementProcessor>(dm_id),
-                            .noc = (dm_id == 1 ? NOC::RISCV_1_default : NOC::RISCV_0_default),
+                        experimental::DataMovementHardwareConfig{
+                            .config_1xx =
+                                experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                    .processor = static_cast<tt_metal::DataMovementProcessor>(dm_id),
+                                    .noc = (dm_id == 1 ? NOC::RISCV_1_default : NOC::RISCV_0_default),
+                                },
                         },
                 });
                 kernel_names.push_back(name);
@@ -149,7 +152,7 @@ protected:
             .source = kernel_path_cacheline,
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"base_addr", "report_addr", "residency_addr"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
         experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = core};
         experimental::ProgramSpec spec{
@@ -193,7 +196,7 @@ protected:
             .num_threads = num_dms_,
             .runtime_arg_schema =
                 {.runtime_arg_names = {"sem_addr", "lock_addr", "ret_base", "increment_times", "mode", "pairs"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
         experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = core};
         experimental::ProgramSpec spec{
@@ -278,7 +281,7 @@ TEST_F(NocSelfAtomicFixture, TestSelfVsRemoteNodeNocAtomic) {
         .source = kernel_path_noc,
         .num_threads = 1,
         .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "increment_times"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::KernelSpec remote_spec{
         .unique_id = REMOTE_KERNEL,
@@ -286,13 +289,15 @@ TEST_F(NocSelfAtomicFixture, TestSelfVsRemoteNodeNocAtomic) {
         .num_threads = 1,
         .compiler_options = {.defines = {{"REMOTE_TARGET", "1"}}},
         .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "increment_times", "remote_noc_x", "remote_noc_y"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     if (!is_quasar) {
-        self_spec.hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
-        remote_spec.hw_config = experimental::DataMovementGen1Config{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
+        self_spec.hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}};
+        remote_spec.hw_config = experimental::DataMovementHardwareConfig{
+            .config_1xx = experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}};
     }
 
     experimental::WorkUnitSpec wu_0{.name = "wu_0", .kernels = {SELF_KERNEL}, .target_nodes = node_0};

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -83,7 +83,7 @@ void run_pack_relu_test(
         .num_threads = 1,
         .dfb_bindings = {experimental::ProducerOf(INPUT_DFB, "out")},
         .runtime_arg_schema = {.runtime_arg_names = {"src_addr", "src_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec writer_spec{
@@ -94,7 +94,7 @@ void run_pack_relu_test(
         .num_threads = 1,
         .dfb_bindings = {experimental::ConsumerOf(OUTPUT_DFB, "in")},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "dst_bank_id", "num_tiles", "dram_page_stride"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec compute_spec{
@@ -119,7 +119,7 @@ void run_pack_relu_test(
              }},
         .compile_time_args = {{"per_core_tile_cnt", num_tiles}},
         .runtime_arg_schema = {.runtime_arg_names = {"relu_config"}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu{

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -61,7 +61,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
             {
                 .runtime_arg_names = {"l1_address"},
             },
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -137,7 +137,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
             {
                 .runtime_arg_names = {"l1_address"},
             },
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -188,7 +188,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSing
 
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 1,
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::KernelSpec compute_kernel_spec_2{
@@ -197,7 +197,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSing
 
             OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 2,
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{

--- a/tests/tt_metal/tt_metal/test_quasar_events.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_events.cpp
@@ -37,7 +37,7 @@ distributed::MeshWorkload make_l1_write_workload(
         .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = 1,
         .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
     experimental::ProgramSpec spec{

--- a/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
@@ -62,7 +62,7 @@ distributed::MeshWorkload create_workload(
             .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         });
         wu_kernel_names.push_back(std::move(kernel_id));
     }
@@ -73,7 +73,7 @@ distributed::MeshWorkload create_workload(
         .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = kNumComputeNEOs,
         .runtime_arg_schema = {.runtime_arg_names = {"l1_address"}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     });
     wu_kernel_names.push_back(COMPUTE_KERNEL);
 
@@ -153,13 +153,13 @@ distributed::MeshWorkload create_multi_node_workload(
                  .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
                  .num_threads = 1,
                  .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-                 .hw_config = experimental::DataMovementGen2Config{}},
+                 .hw_config = experimental::DataMovementHardwareConfig{}},
              experimental::KernelSpec{
                  .unique_id = compute_kernel,
                  .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
                  .num_threads = kNumComputeNEOs,
                  .runtime_arg_schema = {.runtime_arg_names = {"l1_address"}},
-                 .hw_config = experimental::ComputeGen2Config{}}},
+                 .hw_config = experimental::ComputeHardwareConfig{}}},
         .work_units = {experimental::WorkUnitSpec{
             .name = "multi_node", .kernels = {dm_kernel, compute_kernel}, .target_nodes = node_range}},
     };

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -90,7 +90,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
             {
                 .runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec dm_transform_spec{
@@ -111,7 +111,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec dm_writer_spec{
@@ -126,7 +126,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
             {
                 .runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -253,7 +253,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec dm_writer_0_spec{
@@ -273,7 +273,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 .runtime_arg_names =
                     {"dram_addr", "l1_addr", "num_elements", "dram_bank_id", "remote_noc_x", "remote_noc_y"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec dm_reader_1_spec{
@@ -292,7 +292,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
             {
                 .runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec dm_transform_1_spec{
@@ -313,7 +313,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
                 {"buf_a", buf_a_addr},
                 {"buf_b", buf_b_addr},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::KernelSpec dm_writer_1_spec{
@@ -328,7 +328,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
             {
                 .runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec wu_core_0{
@@ -484,7 +484,7 @@ static void run_snake_chain(
             .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
-            .hw_config = experimental::DataMovementGen2Config{}};
+            .hw_config = experimental::DataMovementHardwareConfig{}};
         if (is_src) {
             reader.semaphore_bindings = {{.semaphore_spec_name = L0, .accessor_name = "sem"}};
         } else {
@@ -505,14 +505,14 @@ static void run_snake_chain(
                 {{.semaphore_spec_name = L0, .accessor_name = "sem_in"},
                  {.semaphore_spec_name = L1, .accessor_name = "sem_out"}},
             .compile_time_args = {{"num_elements", num_elements}, {"buf_a", buf_a}, {"buf_b", buf_b}},
-            .hw_config = experimental::DataMovementGen2Config{}});
+            .hw_config = experimental::DataMovementHardwareConfig{}});
 
         // Writer: sink writes final; others also increment the next node's cross sem.
         KernelSpec writer{
             .unique_id = WRITER,
             .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
             .num_threads = 1,
-            .hw_config = experimental::DataMovementGen2Config{}};
+            .hw_config = experimental::DataMovementHardwareConfig{}};
         const bool writer_relays = (!is_sink) || ring;  // ring: last node relays back to node[0]
         if (!writer_relays) {
             writer.runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}};
@@ -545,7 +545,7 @@ static void run_snake_chain(
                     {{.semaphore_spec_name = WRAP_L0, .accessor_name = "sem"},
                      {.semaphore_spec_name = WRAP, .accessor_name = "remote_sem"}},
                 .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
-                .hw_config = experimental::DataMovementGen2Config{}});
+                .hw_config = experimental::DataMovementHardwareConfig{}});
             wu_kernels.push_back(WRAP_READER);
             params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
                 .kernel = WRAP_READER,
@@ -718,7 +718,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanOutBroadcast) {
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = SEM, .accessor_name = "sem"}},
         .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
-        .hw_config = experimental::DataMovementGen2Config{}});
+        .hw_config = experimental::DataMovementHardwareConfig{}});
     spec.work_units.push_back(experimental::WorkUnitSpec{.name = "wu", .kernels = {READER}, .target_nodes = all_nodes});
     experimental::ProgramRunArgs params;
     experimental::ProgramRunArgs::KernelRunArgs kra{.kernel = READER};
@@ -793,14 +793,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = SEM, .accessor_name = "sem"}},
         .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
-        .hw_config = experimental::DataMovementGen2Config{}});
+        .hw_config = experimental::DataMovementHardwareConfig{}});
     spec.kernels.push_back(experimental::KernelSpec{
         .unique_id = WRITER,
         .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = SEM, .accessor_name = "sem"}},
         .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
-        .hw_config = experimental::DataMovementGen2Config{}});
+        .hw_config = experimental::DataMovementHardwareConfig{}});
     spec.work_units.push_back(
         experimental::WorkUnitSpec{.name = "wu", .kernels = {READER, WRITER}, .target_nodes = all_nodes});
 
@@ -940,7 +940,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
         .semaphore_bindings = {{.semaphore_spec_name = BARRIER, .accessor_name = "barrier_sem"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"remote_noc_x", "remote_noc_y", "is_target", "num_elements", "result_addr"}},
-        .hw_config = experimental::DataMovementGen2Config{}};
+        .hw_config = experimental::DataMovementHardwareConfig{}};
     spec.kernels.push_back(bk);
     spec.work_units.push_back(experimental::WorkUnitSpec{.name = "wu", .kernels = {BK}, .target_nodes = all_nodes});
 

--- a/tests/tt_metal/tt_metal/test_quasar_sub_devices.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_sub_devices.cpp
@@ -82,7 +82,7 @@ distributed::MeshWorkload create_l1_write_workload(
             .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-            .hw_config = experimental::DataMovementGen2Config{}}},
+            .hw_config = experimental::DataMovementHardwareConfig{}}},
         .work_units = {experimental::WorkUnitSpec{
             .name = "writer_" + id, .kernels = {kernel_name}, .target_nodes = target_nodes}},
     };
@@ -134,7 +134,7 @@ SyncWorkloads create_sync_workloads(
             .source = "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/persistent_waiter.cpp",
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "num_inc", "sync_core_x", "sync_core_y"}},
-            .hw_config = experimental::DataMovementGen2Config{}}},
+            .hw_config = experimental::DataMovementHardwareConfig{}}},
         .work_units = {experimental::WorkUnitSpec{
             .name = "waiter", .kernels = {waiter_kernel}, .target_nodes = experimental::NodeCoord(waiter_node)}},
     };
@@ -159,7 +159,7 @@ SyncWorkloads create_sync_workloads(
             .source = "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/syncer.cpp",
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"sem_addr"}},
-            .hw_config = experimental::DataMovementGen2Config{}}},
+            .hw_config = experimental::DataMovementHardwareConfig{}}},
         .work_units = {experimental::WorkUnitSpec{
             .name = "syncer", .kernels = {syncer_kernel}, .target_nodes = experimental::NodeCoord(syncer_node)}},
     };
@@ -180,7 +180,7 @@ SyncWorkloads create_sync_workloads(
             .source = "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/incrementer.cpp",
             .num_threads = 1,
             .runtime_arg_schema = {.runtime_arg_names = {"sem_addr", "waiter_core_x", "waiter_core_y"}},
-            .hw_config = experimental::DataMovementGen2Config{}}},
+            .hw_config = experimental::DataMovementHardwareConfig{}}},
         .work_units = {experimental::WorkUnitSpec{
             .name = "incrementer", .kernels = {incrementer_kernel}, .target_nodes = incrementer_nodes}},
     };

--- a/tests/tt_metal/tt_metal/test_quasar_trace.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_trace.cpp
@@ -46,7 +46,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceSingleReplay) {
         .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = 2,
         .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
     experimental::ProgramSpec spec{.name = "trace_test", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
@@ -108,7 +108,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceMultipleReplays) {
         .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = 2,
         .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
     experimental::ProgramSpec spec{
@@ -181,7 +181,7 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, QuasarTraceMultipleReplaysAcros
             .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
             .num_threads = 2,
             .runtime_arg_schema = {.runtime_arg_names = {"address"}, .common_runtime_arg_names = {"value"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
         experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
         experimental::ProgramSpec spec{

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -89,7 +89,7 @@ protected:
                 .num_threads = num_dms_,
                 .compiler_options = {.defines = defines_vec},
                 .runtime_arg_schema = {.runtime_arg_names = {"l1_counter_addr", "increment_times"}},
-                .hw_config = experimental::DataMovementGen2Config{},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             });
             kernel_names.push_back(DM_KERNEL);
             params.kernel_run_args.push_back(make_run_params(DM_KERNEL));
@@ -103,10 +103,12 @@ protected:
                     .compiler_options = {.defines = defines_vec},
                     .runtime_arg_schema = {.runtime_arg_names = {"l1_counter_addr", "increment_times"}},
                     .hw_config =
-                        experimental::DataMovementGen1Config{
-                            .processor = static_cast<tt_metal::DataMovementProcessor>(dm_id),
-                            .noc = (dm_id == 1 ? NOC::RISCV_1_default : NOC::RISCV_0_default),
-                        },
+                        experimental::DataMovementHardwareConfig{
+                            .config_1xx =
+                                experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                    .processor = static_cast<tt_metal::DataMovementProcessor>(dm_id),
+                                    .noc = (dm_id == 1 ? NOC::RISCV_1_default : NOC::RISCV_0_default),
+                                }},
                 });
                 kernel_names.push_back(name);
                 params.kernel_run_args.push_back(make_run_params(name));

--- a/tests/tt_metal/tt_metal/test_sem_scope.cpp
+++ b/tests/tt_metal/tt_metal/test_sem_scope.cpp
@@ -51,7 +51,7 @@ protected:
     void SetUp() override {
         MeshDispatchFixture::SetUp();
         if (arch_ != tt::ARCH::QUASAR) {
-            GTEST_SKIP() << "SemScope suite is Gen2 (Quasar) only: its specs use DataMovementGen2Config";
+            GTEST_SKIP() << "SemScope suite is Gen2 (Quasar) only: its specs use DataMovementHardwareConfig";
         }
         mesh_device_ = devices_[0];
         device_ = mesh_device_->get_devices()[0];
@@ -105,7 +105,7 @@ protected:
             .semaphore_bindings =
                 {{.semaphore_spec_name = experimental::SemaphoreSpecName{"counter_sem"}, .accessor_name = "counter"}},
             .runtime_arg_schema = {.runtime_arg_names = {"report_addr", "increment_times"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         });
         std::vector<experimental::WorkUnitSpec> work_units{experimental::WorkUnitSpec{
             .name = "main",
@@ -124,7 +124,7 @@ protected:
                 .runtime_arg_schema =
                     {.runtime_arg_names =
                          {"report_addr", "increment_times", "is_reporter", "barrier_idx", "wait_min_total"}},
-                .hw_config = experimental::DataMovementGen2Config{},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             });
             work_units.push_back(experimental::WorkUnitSpec{
                 .name = "observer",
@@ -215,7 +215,7 @@ protected:
                  {.semaphore_spec_name = experimental::SemaphoreSpecName{"done_sem"}, .accessor_name = "done"}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"report_addr", "increment_times", "num_threads", "self_noc_x", "self_noc_y"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
 
         experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = core};
@@ -300,7 +300,7 @@ protected:
                  {.semaphore_spec_name = experimental::SemaphoreSpecName{"external_sem"}, .accessor_name = "external"},
                  {.semaphore_spec_name = experimental::SemaphoreSpecName{"done_sem"}, .accessor_name = "done"}},
             .runtime_arg_schema = {.runtime_arg_names = {"report_addr", "increment_times", "num_threads"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
 
         experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = core};
@@ -366,7 +366,7 @@ protected:
             .semaphore_bindings =
                 {{.semaphore_spec_name = experimental::SemaphoreSpecName{"counter_sem"}, .accessor_name = "counter"}},
             .runtime_arg_schema = {.runtime_arg_names = {"increment_times", "remote_noc_x", "remote_noc_y"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
         experimental::KernelSpec receiver_spec{
             .unique_id = RECEIVER,
@@ -375,7 +375,7 @@ protected:
             .semaphore_bindings =
                 {{.semaphore_spec_name = experimental::SemaphoreSpecName{"counter_sem"}, .accessor_name = "counter"}},
             .runtime_arg_schema = {.runtime_arg_names = {"report_addr", "expected"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
 
         experimental::WorkUnitSpec wu_recv{.name = "wu_recv", .kernels = {RECEIVER}, .target_nodes = core};
@@ -469,7 +469,7 @@ protected:
                 .runtime_arg_schema =
                     {.runtime_arg_names =
                          {"report_addr", "increment_times", "is_reporter", "barrier_idx", "wait_min_total"}},
-                .hw_config = experimental::DataMovementGen2Config{},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             });
             bool placed = false;
             for (auto& [node, names] : by_node) {
@@ -817,7 +817,7 @@ TEST_F(SemScopeFixture, TestCensusTwoCachedSemsOneNodeBothCached) {
             .runtime_arg_schema =
                 {.runtime_arg_names =
                      {"report_addr", "increment_times", "is_reporter", "barrier_idx", "wait_min_total"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
     experimental::WorkUnitSpec wu{.name = "wu", .kernels = {KA, KB}, .target_nodes = core};
@@ -942,7 +942,7 @@ TEST_F(SemScopeFixture, TestCachedSeederImmuneToUserBarrierSlots) {
             .runtime_arg_schema =
                 {.runtime_arg_names =
                      {"report_addr", "increment_times", "is_reporter", "barrier_idx", "wait_min_total"}},
-            .hw_config = experimental::DataMovementGen2Config{},
+            .hw_config = experimental::DataMovementHardwareConfig{},
         };
     };
     experimental::WorkUnitSpec wu{.name = "wu", .kernels = {KA, KB}, .target_nodes = core};
@@ -1093,7 +1093,7 @@ TEST_F(SemScopeFixture, TestSameIdSemaphoresKeepDistinctScopes) {
             {{.semaphore_spec_name = experimental::SemaphoreSpecName{"sem_near"}, .accessor_name = "near_sem"},
              {.semaphore_spec_name = experimental::SemaphoreSpecName{"sem_far"}, .accessor_name = "far_sem"}},
         .runtime_arg_schema = {.runtime_arg_names = {"report_addr"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec wu{.name = "wu", .kernels = {K}, .target_nodes = core};
     experimental::ProgramSpec spec{
@@ -1135,7 +1135,7 @@ TEST_F(SemScopeFixture, TestDoubleBindingRejected) {
              {.semaphore_spec_name = experimental::SemaphoreSpecName{"counter_sem"}, .accessor_name = "counter_again"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"report_addr", "increment_times", "is_reporter", "barrier_idx", "wait_min_total"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec wu{.name = "main", .kernels = {K}, .target_nodes = core};
     experimental::ProgramSpec spec{.name = "sem_double_bind", .kernels = {ks}, .semaphores = {sem}, .work_units = {wu}};

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -77,7 +77,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
                 .runtime_arg_names = {"address"},
                 .common_runtime_arg_names = {"value"},
             },
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     experimental::WorkUnitSpec main_wu{
@@ -206,7 +206,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
         .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = 2,
         .runtime_arg_schema = {.runtime_arg_names = {"address", "value"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
 
     // Fan the SAME kernel to ALL 32 nodes.
@@ -296,7 +296,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
         .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 4,
         .runtime_arg_schema = {.runtime_arg_names = {"l1_address"}},
-        .hw_config = experimental::ComputeGen2Config{},
+        .hw_config = experimental::ComputeHardwareConfig{},
     };
 
     const experimental::NodeRange all_nodes(
@@ -394,7 +394,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridMulticastFanOut) {
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"value", "result_addr", "mcast_x_start", "mcast_y_start", "mcast_x_end", "mcast_y_end", "num_dests"}},
-        .hw_config = experimental::DataMovementGen2Config{},
+        .hw_config = experimental::DataMovementHardwareConfig{},
     };
     experimental::WorkUnitSpec wu{.name = "main", .kernels = {MCAST}, .target_nodes = src_node};
     experimental::ProgramSpec spec{.name = "grid_mcast_fanout", .kernels = {mcast_spec}, .work_units = {wu}};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
+#include <optional>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
@@ -21,6 +21,10 @@ namespace tt::tt_metal::experimental {
 // The ComputeHardwareConfig describes the configuration of the Tensix compute
 // accelerator hardware resources controlled by a compute kernel.
 //
+// Different generations of Tenstorrent accelerators have slightly different
+// Tensix compute hardware. The base compute configuration is architecture
+// agnostic, but some configuration options are architecture-specific.
+//
 // You must specify a ComputeHardwareConfig for every compute kernel.
 //
 // The Tensix Engine pipeline consists of Unpack, Math, and Pack stages.
@@ -31,12 +35,6 @@ namespace tt::tt_metal::experimental {
 //
 // The ComputeHardwareConfig configures this pipeline.
 //
-// Different generations of Tenstorrent accelerators have slightly different
-// Tensix compute hardware. The compute configuration is therefore generation-
-// specific (though many fields are common). ComputeHardwareConfig is a variant
-// object that holds one generation's config; you must specify the correct
-// config for the hardware your compute kernel will run on.
-//
 // NOTE: The Unpack, Math, and Pack stages are hardware pipeline stages internal
 //       to a single kernel thread. Not to be confused with KernelSpec::num_threads!
 //       In a multi-threaded compute kernel, each thread runs its own independent
@@ -44,13 +42,9 @@ namespace tt::tt_metal::experimental {
 //
 // ============================================================================
 
-// Type used for unpack_modes; see configuration structs below for details
-using ComputeUnpackModes = Table<DFBSpecName, tt::tt_metal::UnpackMode>;
+struct ComputeHardwareConfig {
+    // ---- Generation-agnostic ("common") fields ----
 
-// Compute configuration for Gen1 architectures:
-//  - Wormhole  (TT-1.1.0)
-//  - Blackhole (TT-1.2.0)
-struct ComputeGen1Config {
     ////////////////////////////////////////////////
     // General accuracy / performance tradeoffs
     ////////////////////////////////////////////////
@@ -63,12 +57,6 @@ struct ComputeGen1Config {
     // Accuracy / performance tradeoff for the SFPU transcendentals.
     // Select either fast-and-approximate mode or slow-and-precise mode.
     Precision sfpu_precision_mode = Precision::Precise;
-
-    // Pack stage precision tweak for block-float formats.
-    // Affects how exponents are reconciled when converting Dest contents to BFP in
-    // the Pack stage. Select either precise (slower) or approximate (faster).
-    // NOTE: This setting has no effect on non-BFP formats.
-    Precision bfp_pack_precision_mode = Precision::Approximate;
 
     /////////////////////////////////////
     // Dest register file configuration
@@ -111,132 +99,41 @@ struct ComputeGen1Config {
     //    (Precision is lost for FP32; 32-bit integers are truncated).
     //  - This is the fastest option on Wormhole and Blackhole.
     //
-    // UnpackToDest should be used (on Wormhole and Blackhole) only if:
+    // On 1st-gen architectures (1xx; Wormhole and Blackhole), UnpackToDest should be used only if:
     //  - The data format has 32-bit precision, AND enable_32_bit_dest is set to true
     //  - You want to preserve the full precision
     //  - The data will be consumed by the SFPU (not the FPU)
+    //
+    // On 2nd-gen architecture (2xx), there is NO performance penalty for unpacking directly to
+    // Dest, so UnpackMode=UnpackToDest is the preferred mode for any SFPU-consumed data.
     //
     // If no mode is specified for a (consumed-from) DFB, UnpackToSrc is assumed.
     // However, if enable_32_bit_dest is true and the DFB carries a 32-bit format, you must
     // EXPLICITLY specify an UnpackMode for that DFB. (Enforced by validation checks.)
     //
-    ComputeUnpackModes unpack_modes;
-};
-
-// Compute configuration for Gen2 architectures:
-//  - Quasar (TT-2.0.0)
-//  - Quasar derivatives (TT-2.0.x)
-struct ComputeGen2Config {
-    ////////////////////////////////////////////////
-    // General accuracy / performance tradeoffs
-    ////////////////////////////////////////////////
-
-    // See ComputeGen1Config for details on fpu_math_fidelity
-    MathFidelity fpu_math_fidelity = MathFidelity::HiFi4;
-
-    // See ComputeGen1Config for details on sfpu_precision_mode
-    Precision sfpu_precision_mode = Precision::Precise;
-
-    // Note: Gen2 architectures replace BFP data formats with MXFP formats;
-    //       the bfp_pack_precision_mode setting is not relevant for Gen2.
-
-    /////////////////////////////////////
-    // Dest register file configuration
-    /////////////////////////////////////
-
-    // See ComputeGen1Config for details on enable_32_bit_dest
-    bool enable_32_bit_dest = false;
-
-    // See ComputeGen1Config for details on double_buffer_dest
-    bool double_buffer_dest = true;
-
-    // See ComputeGen1Config for details on unpack_modes
-    //
-    // NOTE: On Gen2 architectures, there is NO performance penalty for unpacking directly to
-    //       Dest, so UnpackMode=UnpackToDest is the preferred mode for any SFPU-consumed data.
+    using ComputeUnpackModes = Table<DFBSpecName, tt::tt_metal::UnpackMode>;
     ComputeUnpackModes unpack_modes;
 
-    ///////////////////////////////////////////
-    // Temporary configs (these will change!)
-    ///////////////////////////////////////////
+    // ---- Generation-specific configs ----
+    // Optional and unset by default. Each config applies only to the architecture named in
+    // its header, and is ignored on any other.
+    // NOTE: The target architecture is selected at program construction time.
+    //       See MakeProgramFromSpec for more details.
 
-    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // ---- TT-1.x.x specific (Wormhole, Blackhole) ----
+    struct Compute1XXConfig {
+        // Pack-stage precision tweak for block-float formats.
+        // Affects how exponents are reconciled when converting Dest contents to BFP in
+        // the Pack stage. Select either precise (slower) or approximate (faster).
+        // NOTE: This setting has no effect on non-BFP formats.
+        Precision bfp_pack_precision_mode = Precision::Approximate;
+    };
+    std::optional<Compute1XXConfig> config_1xx = std::nullopt;
+
+    // ---- TT-2.x.x specific (Quasar and derivatives) ----
+    // Empty today.
+    struct Compute2XXConfig {};
+    std::optional<Compute2XXConfig> config_2xx = std::nullopt;
 };
-
-// A compute kernel's hardware config holds exactly one generation's config.
-using ComputeHardwareConfig = std::variant<ComputeGen1Config, ComputeGen2Config>;
-
-// ----------------------------------------------------------------------------
-//  Common-field accessors
-// ----------------------------------------------------------------------------
-//
-// Many compute settings are common to Gen1 and Gen2 architectures.
-//
-// Reaching a common field through the variant is syntactically awkward; you should not need
-// to know which alternative is held. For convenience, each common field is given an accessor
-// helper function here. (Generation-specific fields are not given accessors.)
-//
-// Each field has a mutable and a const accessor.
-//
-// The mutable accessor returns a reference, so you can assign through it:
-//
-//     enable_32_bit_dest(compute_hw) = true;
-//
-// or bind it and use it multiple times:
-//
-//     auto& dfb_unpack_modes = unpack_modes(compute_hw);
-//     dfb_unpack_modes.emplace(dfb1, UnpackMode::UnpackToDest);
-//     dfb_unpack_modes.emplace(dfb2, UnpackMode::UnpackToSrc);
-//
-// The const accessor returns the scalar fields by value, and unpack_modes (a container) by
-// const reference.
-//
-// For common fields, prefer this syntax over e.g. std::get<ComputeGen1Config>(config).field,
-// which throws if the wrong architecture is targeted.
-
-inline MathFidelity& fpu_math_fidelity(ComputeHardwareConfig& config) {
-    return std::visit([](auto& cfg) -> MathFidelity& { return cfg.fpu_math_fidelity; }, config);
-}
-
-inline MathFidelity fpu_math_fidelity(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> MathFidelity { return cfg.fpu_math_fidelity; }, config);
-}
-
-inline Precision& sfpu_precision_mode(ComputeHardwareConfig& config) {
-    return std::visit([](auto& cfg) -> Precision& { return cfg.sfpu_precision_mode; }, config);
-}
-
-inline Precision sfpu_precision_mode(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> Precision { return cfg.sfpu_precision_mode; }, config);
-}
-
-inline bool& enable_32_bit_dest(ComputeHardwareConfig& config) {
-    return std::visit([](auto& cfg) -> bool& { return cfg.enable_32_bit_dest; }, config);
-}
-
-inline bool enable_32_bit_dest(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> bool { return cfg.enable_32_bit_dest; }, config);
-}
-
-inline bool& double_buffer_dest(ComputeHardwareConfig& config) {
-    return std::visit([](auto& cfg) -> bool& { return cfg.double_buffer_dest; }, config);
-}
-
-inline bool double_buffer_dest(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> bool { return cfg.double_buffer_dest; }, config);
-}
-
-inline ComputeUnpackModes& unpack_modes(ComputeHardwareConfig& config) {
-    return std::visit([](auto& cfg) -> ComputeUnpackModes& { return cfg.unpack_modes; }, config);
-}
-
-inline const ComputeUnpackModes& unpack_modes(const ComputeHardwareConfig& config) {
-    return std::visit([](const auto& cfg) -> const ComputeUnpackModes& { return cfg.unpack_modes; }, config);
-}
-
-// Delete the rvalue overload of unpack_modes to prevent dangling references
-// (The mutable accessors can't bind a temporary, and the const scalars return by value,
-// so only this one needs it.)
-inline const ComputeUnpackModes& unpack_modes(const ComputeHardwareConfig&&) = delete;
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <variant>
+#include <optional>
 #include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
@@ -19,44 +19,61 @@ namespace tt::tt_metal::experimental {
 //
 // Describes the hardware resources controlled by a data movement ("DM") kernel.
 //
-// The DM hardware differs between Tenstorrent accelerators:
-//  - Gen1 architectures (Wormhole, Blackhole) and
-//  - Gen2 architectures (Quasar and derivatives).
-//
-// The DataMovementHardwareConfig is therefore generation-specific.
-// You must provide the variant that matches your kernel's target architecture.
-//
 // ============================================================================
 
-// The Gen1 data movement hardware config specifies which RISC-V core and which
-// NOC a kernel uses. This selection is performance-critical.
-//
-// The common case is handled for you by role-specific factory functions:
-//  - For a DM kernel that reads from DRAM: CreateReaderGen1DataMovementConfig()
-//  - For a DM kernel that writes to DRAM:  CreateWriterGen1DataMovementConfig()
-//
-// Power users can override these conventions by constructing a
-// DataMovementGen1Config directly.
-//
-struct DataMovementGen1Config {
-    // The RISC-V core that runs this DM kernel (RISCV_0 or RISCV_1)
-    // Each DM kernel on a node must be assigned to a unique RISC-V core
-    tt::tt_metal::DataMovementProcessor processor;
+struct DataMovementHardwareConfig {
+    // ---- Generation-specific configs ----
+    // Optional and unset by default. Each config applies only to the architecture named in
+    // its header, and is ignored on any other.
+    // NOTE: The target architecture is selected at program construction time.
+    //       See MakeProgramFromSpec for more details.
 
-    // The physical NOC that this DM kernel uses (NOC_0 or NOC_1)
-    tt::tt_metal::NOC noc;
+    // ---- TT-1.x.x specific (Wormhole, Blackhole) ----
+    //
+    // The common case is handled by role-specific factory functions:
+    //  - For a DM kernel that reads from DRAM: CreateReaderDataMovementConfig()
+    //  - For a DM kernel that writes to DRAM:  CreateWriterDataMovementConfig()
+    //
+    // Power users can override these conventions by constructing a
+    // DataMovement1XXConfig directly.
+    struct DataMovement1XXConfig {
+        // The RISC-V core that runs this DM kernel (RISCV_0 or RISCV_1)
+        // Each DM kernel on a node must be assigned to a unique RISC-V core
+        tt::tt_metal::DataMovementProcessor processor;
 
-    // NOC ownership model. Leave as DM_DEDICATED_NOC unless you specifically
-    // need both DM cores to share a single NOC (e.g. to keep the other NOC
-    // free for fabric/CCL traffic). Dynamic mode adds cross-core coordination
-    // overhead and must be set identically on both DM kernels on a node.
-    tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
+        // The physical NOC that this DM kernel uses (NOC_0 or NOC_1)
+        tt::tt_metal::NOC noc;
+
+        // NOC ownership model. Leave as DM_DEDICATED_NOC unless you specifically
+        // need both DM cores to share a single NOC (e.g. to keep the other NOC
+        // free for fabric/CCL traffic). Dynamic mode adds cross-core coordination
+        // overhead and must be set identically on both DM kernels on a node.
+        tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
+    };
+    // NOTE: If this kernel is built for TT-1.x.x, config_1xx must not be empty.
+    //       Processor and NOC have no default.
+    std::optional<DataMovement1XXConfig> config_1xx = std::nullopt;
+
+    // ---- TT-2.x.x specific (Quasar and derivatives) ----
+    struct DataMovement2XXConfig {
+        // Opt-out of DFB implicit sync (on a per-DFB basis)
+        //  - Implicit sync enables streamlined kernel-side syntax, but triggers ISR handling.
+        //  - Use this control to revert to legacy explicit sync APIs (for specific bound DFBs).
+        //  - Opting out is mainly for debug purposes, or for backwards-compatible code style.
+        // Any bound DFB not listed here will use implicit sync by default.
+        Group<DFBSpecName> disable_dfb_implicit_sync_for;
+
+        // Opt out of DFB implicit sync for ALL the DFBs this kernel binds.
+        // (The per-kernel hammer; equivalent to listing every bound DFB above.)
+        bool disable_dfb_implicit_sync_for_all = false;
+    };
+    std::optional<DataMovement2XXConfig> config_2xx = std::nullopt;
 };
 
 // Factory helper:
 // Default config for a reader DM kernel (i.e. that reads from DRAM)
-inline DataMovementGen1Config CreateReaderGen1DataMovementConfig() noexcept {
-    return DataMovementGen1Config{
+inline DataMovementHardwareConfig CreateReaderDataMovementConfig() noexcept {
+    return DataMovementHardwareConfig{
         // On Wormhole, RISCV_1 runs faster than RISCV_0 due to its dedicated
         // instruction memory. Since DM reader kernels are usually more complex than
         // DM writer kernels, prefer RISCV_1 for readers.
@@ -65,60 +82,44 @@ inline DataMovementGen1Config CreateReaderGen1DataMovementConfig() noexcept {
         //    so a large DM reader kernel may fail to fit. (Runtime error.)
         //  - On Blackhole, RISCV_0 and RISCV_1 have no meaningful performance difference;
         //    reader DM kernels are placed on RISCV_1 by convention only.
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+        .config_1xx =
+            DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
 
-        // It is more efficient to read from DRAM via NOC_0 on all Gen1 architectures.
-        // This is a subtle consequence of the device topology:
-        //  - NOC_0 routes east, then south (rows first)
-        //  - NOC_1 routes north, then west (columns first)
-        //  - DRAMs are in columns
-        // Return data from DRAM reads may cause NOC congestion if it flows column-first.
-        // Thus, prefer NOC_0 for DRAM reads.
-        .noc = tt::tt_metal::NOC::NOC_0,
+                // It is more efficient to read from DRAM via NOC_0 on all 1xx architectures.
+                // This is a subtle consequence of the device topology:
+                //  - NOC_0 routes east, then south (rows first)
+                //  - NOC_1 routes north, then west (columns first)
+                //  - DRAMs are in columns
+                // Return data from DRAM reads may cause NOC congestion if it flows column-first.
+                // Thus, prefer NOC_0 for DRAM reads.
+                .noc = tt::tt_metal::NOC::NOC_0,
 
-        // Dedicated NOC mode is the most bandwidth-efficient mode.
-        // (Dynamic NOC mode is generally only used to multiplex both DM cores onto a
-        // single NOC in order to reserve the other NOC for fabric traffic.)
-        .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+                // Dedicated NOC mode is the most bandwidth-efficient mode.
+                // (Dynamic NOC mode is generally only used to multiplex both DM cores onto a
+                // single NOC in order to reserve the other NOC for fabric traffic.)
+                .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+            },
     };
 }
 
 // Factory helper:
 // Default config for a writer DM kernel (i.e. that writes to DRAM)
-inline DataMovementGen1Config CreateWriterGen1DataMovementConfig() noexcept {
-    return DataMovementGen1Config{
-        // DM kernels on the same node must be assigned to different RISC-V cores.
-        // Since RISCV_1 is preferred for readers, place writers on RISCV_0.
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+inline DataMovementHardwareConfig CreateWriterDataMovementConfig() noexcept {
+    return DataMovementHardwareConfig{
+        .config_1xx =
+            DataMovementHardwareConfig::DataMovement1XXConfig{
+                // DM kernels on the same node must be assigned to different RISC-V cores.
+                // Since RISCV_1 is preferred for readers, place writers on RISCV_0.
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
 
-        // Since NOC_0 is preferred for DRAM reads, use NOC_1 for DRAM writes.
-        .noc = tt::tt_metal::NOC::NOC_1,
+                // Since NOC_0 is preferred for DRAM reads, use NOC_1 for DRAM writes.
+                .noc = tt::tt_metal::NOC::NOC_1,
 
-        // Prefer dedicated NOC mode for the same reasons as above.
-        .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+                // Prefer dedicated NOC mode for the same reasons as above.
+                .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+            },
     };
 }
-
-// ============================================================================
-
-// Gen2 architectures have a unified NOC and fully automated DM kernel core selection.
-// The DataMovementGen2Config controls whether the DFB implicit sync feature for DM
-// kernels is enabled or disabled.
-//
-struct DataMovementGen2Config {
-    // Opt-out of DFB implicit sync (on a per-DFB basis)
-    //  - Implicit sync enables streamlined kernel-side syntax, but triggers ISR handling.
-    //  - Use this control to revert to legacy explicit sync APIs (for specific bound DFBs).
-    //  - Opting out is mainly for debug purposes, or for backwards-compatible code style.
-    // Any bound DFB not listed here will use implicit sync by default.
-    Group<DFBSpecName> disable_dfb_implicit_sync_for;
-
-    // Opt out of DFB implicit sync for ALL the DFBs this kernel binds.
-    // (The per-kernel hammer; equivalent to listing every bound DFB above.)
-    bool disable_dfb_implicit_sync_for_all = false;
-};
-
-// A DM kernel's hardware config holds exactly one generation's config.
-using DataMovementHardwareConfig = std::variant<DataMovementGen1Config, DataMovementGen2Config>;
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -737,12 +737,16 @@ void ValidateNodeBounds(const ProgramSpec& spec, MetalContext& metal_ctx) {
     }
 }
 
-// Whether a Gen2 DM kernel opts out of implicit sync for a particular DFB.
+// Whether a DM kernel opts out of implicit sync for a particular DFB.
 // Two routes lead to the same opt-out:
 //   - disable_dfb_implicit_sync_for_all: the per-kernel hammer, covering every DFB the kernel binds.
 //   - disable_dfb_implicit_sync_for: an explicit per-DFB list.
-// Precondition: the caller has already established this is a DM kernel with a gen2_config.
-bool DmKernelDisablesImplicitSync(const DataMovementGen2Config& gen2_config, const DFBSpecName& dfb_name) {
+// If config_2xx is not engaged, implicit sync stays at its default (on for every bound DFB).
+bool DmKernelDisablesImplicitSync(const DataMovementHardwareConfig& dm_config, const DFBSpecName& dfb_name) {
+    if (!dm_config.config_2xx.has_value()) {
+        return false;
+    }
+    const auto& gen2_config = *dm_config.config_2xx;
     if (gen2_config.disable_dfb_implicit_sync_for_all) {
         return true;
     }
@@ -855,57 +859,30 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
-    // Validate hardware configs: a kernel's config generation must match the target platform. There
-    // is no implicit cross-generation substitution — supplying the wrong alternative results in direct error.
-    for (const auto& kernel : spec.kernels) {
-        if (kernel.is_data_movement_kernel()) {
+    // On Gen1, a DM kernel must supply config_1xx: processor and NOC have no
+    // default. Architecture still comes from the device, not from which optional is set.
+    // Gen1 has exactly two DM processors: RISCV_0 (BRISC) and RISCV_1 (NCRISC).
+    // RISCV_2..RISCV_7 exist only on Gen2/Quasar. Reject them here, mirroring the legacy
+    // CreateDataMovementKernel "DM0 or DM1 only" guard.
+    if (is_gen1_arch(hal)) {
+        for (const auto& kernel : spec.kernels) {
+            if (!kernel.is_data_movement_kernel()) {
+                continue;
+            }
             const auto& data_movement_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-
-            if (is_gen1_arch(hal)) {
-                TT_FATAL(
-                    std::holds_alternative<DataMovementGen1Config>(data_movement_config),
-                    "KernelSpec '{}' targets Gen1 (WH/BH) but its DataMovementHardwareConfig holds a "
-                    "DataMovementGen2Config. Supply a Gen1 config (e.g. "
-                    "CreateReaderGen1DataMovementConfig()/CreateWriterGen1DataMovementConfig()).",
-                    kernel.unique_id);
-
-                // Gen1 has exactly two DM processors: RISCV_0 (BRISC) and RISCV_1 (NCRISC).
-                // RISCV_2..RISCV_7 exist only on Gen2/Quasar. Reject them here, mirroring the legacy
-                // CreateDataMovementKernel "DM0 or DM1 only" guard. Resolving is safe now: the check
-                // above guarantees a role hint or an explicit Gen1 config is present.
-                const DataMovementProcessor processor =
-                    std::get<DataMovementGen1Config>(data_movement_config).processor;
-                TT_FATAL(
-                    processor == DataMovementProcessor::RISCV_0 || processor == DataMovementProcessor::RISCV_1,
-                    "KernelSpec '{}' targets Gen1 (WH/BH) but requests DM processor RISCV_{}. Gen1 has only "
-                    "RISCV_0 and RISCV_1; RISCV_2..RISCV_7 exist only on Gen2/Quasar.",
-                    kernel.unique_id,
-                    static_cast<int>(processor));
-            } else if (is_gen2_arch(hal)) {
-                TT_FATAL(
-                    std::holds_alternative<DataMovementGen2Config>(data_movement_config),
-                    "KernelSpec '{}' targets Gen2 (Quasar) but its DataMovementHardwareConfig holds a "
-                    "DataMovementGen1Config. Supply a Gen2 config (DataMovementGen2Config{{}}).",
-                    kernel.unique_id);
-            }
-        }
-
-        if (kernel.is_compute_kernel()) {
-            const auto& compute_config = std::get<ComputeHardwareConfig>(kernel.hw_config);
-
-            if (is_gen1_arch(hal)) {
-                TT_FATAL(
-                    std::holds_alternative<ComputeGen1Config>(compute_config),
-                    "KernelSpec '{}' targets Gen1 (WH/BH) but its ComputeHardwareConfig holds a "
-                    "ComputeGen2Config. Supply a Gen1 config (ComputeGen1Config).",
-                    kernel.unique_id);
-            } else if (is_gen2_arch(hal)) {
-                TT_FATAL(
-                    std::holds_alternative<ComputeGen2Config>(compute_config),
-                    "KernelSpec '{}' targets Gen2 (Quasar) but its ComputeHardwareConfig holds a "
-                    "ComputeGen1Config. Supply a Gen2 config (ComputeGen2Config).",
-                    kernel.unique_id);
-            }
+            TT_FATAL(
+                data_movement_config.config_1xx.has_value(),
+                "KernelSpec '{}' is a data-movement kernel on Gen1 but has no config_1xx processor/NOC. "
+                "Those settings are required to build a Gen1 data-movement kernel. Supply a DataMovement1XXConfig "
+                "(e.g. CreateReaderDataMovementConfig()/CreateWriterDataMovementConfig()).",
+                kernel.unique_id);
+            const DataMovementProcessor processor = data_movement_config.config_1xx->processor;
+            TT_FATAL(
+                processor == DataMovementProcessor::RISCV_0 || processor == DataMovementProcessor::RISCV_1,
+                "KernelSpec '{}' targets Gen1 (WH/BH) but requests DM processor RISCV_{}. Gen1 has only "
+                "RISCV_0 and RISCV_1; RISCV_2..RISCV_7 exist only on Gen2/Quasar.",
+                kernel.unique_id,
+                static_cast<int>(processor));
         }
     }
 
@@ -937,7 +914,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (!kernel.is_data_movement_kernel()) {
                 continue;
             }
-            const auto& gen1 = std::get<DataMovementGen1Config>(std::get<DataMovementHardwareConfig>(kernel.hw_config));
+            const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
+            if (!dm_config.config_1xx.has_value()) {
+                continue;
+            }
+            const auto& gen1 = *dm_config.config_1xx;
             const NodeRangeSet& nodes = collected.kernel_node_set.at(kernel.unique_id);
             for (const auto& range : nodes.ranges()) {
                 for (const auto& node : range) {
@@ -1033,11 +1014,9 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             continue;
         }
         const auto& compute_config = std::get<ComputeHardwareConfig>(kernel.hw_config);
-        const auto& unpack_modes =
-            std::visit([](const auto& config) -> const auto& { return config.unpack_modes; }, compute_config);
-        const bool enable_32_bit_dest =
-            std::visit([](const auto& config) { return config.enable_32_bit_dest; }, compute_config);
-        const bool is_gen2 = std::holds_alternative<ComputeGen2Config>(compute_config);
+        const auto& unpack_modes = compute_config.unpack_modes;
+        const bool enable_32_bit_dest = compute_config.enable_32_bit_dest;
+        const bool is_gen2 = is_gen2_arch(hal);
 
         // Index the kernel's DFB bindings: which it binds at all, and which it CONSUMES. A self-loop
         // DFB appears as two separate bindings (one PRODUCER, one CONSUMER — there is no BOTH endpoint
@@ -1155,9 +1134,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     //
     // Implicit sync is a Gen2-only, DM-only mechanism (ISR-based credit posting from NoC
     // transaction completion). A DM kernel can opt out per-DFB by listing the DFB's name in
-    // its Gen2Config::disable_dfb_implicit_sync_for vector, or opt out of all the DFBs it binds at
-    // once via Gen2Config::disable_dfb_implicit_sync_for_all. Either way the opt-out applies to the
-    // side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
+    // config_2xx->disable_dfb_implicit_sync_for, or opt out of all the DFBs it binds at
+    // once via config_2xx->disable_dfb_implicit_sync_for_all. If config_2xx is not
+    // engaged, implicit sync stays at its default (on for every bound DFB). Either way the
+    // opt-out applies to the side(s) of the DFB this kernel binds (producer, consumer, or
+    // both for a self-loop).
     //
     // Per-kernel rule: every listed name references a DFB the kernel binds (typo guard).
     //
@@ -1172,14 +1153,14 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 continue;
             }
             const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-            if (!std::holds_alternative<DataMovementGen2Config>(dm_config)) {
+            if (!dm_config.config_2xx.has_value()) {
                 continue;
             }
             std::unordered_set<DFBSpecName> bound_dfbs;
             for (const auto& binding : kernel.dfb_bindings) {
                 bound_dfbs.insert(binding.dfb_spec_name);
             }
-            for (const auto& dfb_name : std::get<DataMovementGen2Config>(dm_config).disable_dfb_implicit_sync_for) {
+            for (const auto& dfb_name : dm_config.config_2xx->disable_dfb_implicit_sync_for) {
                 TT_FATAL(
                     bound_dfbs.contains(dfb_name),
                     "Kernel '{}' disable_dfb_implicit_sync_for entry references DFB '{}', which the kernel does not "
@@ -1204,12 +1185,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                         continue;
                     }
                     const auto& dm_config = std::get<DataMovementHardwareConfig>(ep.kernel->hw_config);
-                    if (!std::holds_alternative<DataMovementGen2Config>(dm_config)) {
-                        // Gen1-only DM kernel — can't physically participate in Gen2 implicit sync; abstains.
+                    if (!is_gen2_arch(hal)) {
+                        // Gen1 device — can't physically participate in Gen2 implicit sync; abstains.
                         continue;
                     }
-                    const bool disables =
-                        DmKernelDisablesImplicitSync(std::get<DataMovementGen2Config>(dm_config), dfb_name);
+                    const bool disables = DmKernelDisablesImplicitSync(dm_config, dfb_name);
                     if (canonical == nullptr) {
                         canonical = ep.kernel;
                         canonical_disables = disables;
@@ -2253,7 +2233,13 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
     for (const KernelSpec& kernel : spec.kernels) {
         if (kernel.is_data_movement_kernel()) {
             const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-            const auto gen1 = std::get<DataMovementGen1Config>(dm_config);
+            TT_FATAL(
+                dm_config.config_1xx.has_value(),
+                "KernelSpec '{}' is a data-movement kernel on Gen1 but has no config_1xx processor/NOC. "
+                "Those settings are required to build a Gen1 data-movement kernel. Supply a DataMovement1XXConfig "
+                "(e.g. CreateReaderDataMovementConfig()/CreateWriterDataMovementConfig()).",
+                kernel.unique_id);
+            const auto& gen1 = *dm_config.config_1xx;
             result[&kernel] = static_cast<uint16_t>(1u << static_cast<uint8_t>(gen1.processor));
         } else {
             result[&kernel] = static_cast<uint16_t>(1u << GEN1_COMPUTE_RISC_BIT);
@@ -2689,10 +2675,8 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
             }
             any_dm = true;
             const auto& dm_config = std::get<DataMovementHardwareConfig>(ep.kernel->hw_config);
-            if (!std::holds_alternative<DataMovementGen2Config>(dm_config)) {
-                continue;
-            }
-            if (DmKernelDisablesImplicitSync(std::get<DataMovementGen2Config>(dm_config), dfb_spec->unique_id)) {
+            // config_2xx is unused on Gen1; implicit sync stays at the current default.
+            if (DmKernelDisablesImplicitSync(dm_config, dfb_spec->unique_id)) {
                 disabled = true;
             }
         }
@@ -2758,7 +2742,13 @@ std::map<std::string, std::string> to_defines_map(const KernelSpec::CompilerOpti
 DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_data_movement_kernel(), "Expected a DM kernel");
     const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel_spec.hw_config);
-    const auto gen1 = std::get<DataMovementGen1Config>(dm_config);
+    TT_FATAL(
+        dm_config.config_1xx.has_value(),
+        "KernelSpec '{}' is a data-movement kernel on Gen1 but has no config_1xx processor/NOC. "
+        "Those settings are required to build a Gen1 data-movement kernel. Supply a DataMovement1XXConfig "
+        "(e.g. CreateReaderDataMovementConfig()/CreateWriterDataMovementConfig()).",
+        kernel_spec.unique_id);
+    const auto& gen1 = *dm_config.config_1xx;
 
     return DataMovementConfig{
         .processor = gen1.processor,
@@ -2794,7 +2784,7 @@ DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
 // ----------------------------------------------------------------------------
 
 std::vector<UnpackToDestMode> BuildUnpackToDestModeVector(
-    const ComputeUnpackModes& user_modes, const DFBNameToSlotMap& dfb_name_to_slot, const Hal& hal) {
+    const ComputeHardwareConfig::ComputeUnpackModes& user_modes, const DFBNameToSlotMap& dfb_name_to_slot, const Hal& hal) {
     const uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     std::vector<UnpackToDestMode> unpack_modes(max_cbs, UnpackToDestMode::Default);
     for (const auto& [dfb_name, mode] : user_modes) {
@@ -2826,22 +2816,22 @@ ComputeConfig MakeGen1ComputeConfig(
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeHardwareConfig>(kernel_spec.hw_config);
 
-    TT_FATAL(
-        std::holds_alternative<ComputeGen1Config>(compute_config),
-        "Trying to construct a Gen1 compute config but the kernel's ComputeHardwareConfig does not hold a "
-        "ComputeGen1Config, generation mismatch, please provide the correctly typed hardware config.");
-    const auto& gen1 = std::get<ComputeGen1Config>(compute_config);
-
     std::vector<UnpackToDestMode> unpack_dst_modes =
-        BuildUnpackToDestModeVector(gen1.unpack_modes, dfb_name_to_slot, hal);
+        BuildUnpackToDestModeVector(compute_config.unpack_modes, dfb_name_to_slot, hal);
+
+    // bfp_pack_precision_mode is TT-1.x.x-only. If config_1xx is not engaged, use the
+    // historical default (Approximate).
+    const Precision bfp_pack_precision_mode = compute_config.config_1xx.has_value()
+                                                  ? compute_config.config_1xx->bfp_pack_precision_mode
+                                                  : Precision::Approximate;
 
     return ComputeConfig{
-        .math_fidelity = gen1.fpu_math_fidelity,
-        .fp32_dest_acc_en = gen1.enable_32_bit_dest,
-        .dst_full_sync_en = !gen1.double_buffer_dest,
+        .math_fidelity = compute_config.fpu_math_fidelity,
+        .fp32_dest_acc_en = compute_config.enable_32_bit_dest,
+        .dst_full_sync_en = !compute_config.double_buffer_dest,
         .unpack_to_dest_mode = unpack_dst_modes,
-        .bfp8_pack_precise = (gen1.bfp_pack_precision_mode == Precision::Precise),
-        .math_approx_mode = (gen1.sfpu_precision_mode == Precision::Approximate),
+        .bfp8_pack_precise = (bfp_pack_precision_mode == Precision::Precise),
+        .math_approx_mode = (compute_config.sfpu_precision_mode == Precision::Approximate),
         .compile_args = {},  // only named_compile_args is used
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),
@@ -2876,22 +2866,17 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
     const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot, const Hal& hal) {
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeHardwareConfig>(kernel_spec.hw_config);
-    TT_FATAL(
-        std::holds_alternative<ComputeGen2Config>(compute_config),
-        "Trying to construct a Gen2 compute config but the kernel's ComputeHardwareConfig does not hold a "
-        "ComputeGen2Config, generation mismatch, please provide the correctly typed hardware config.");
-    const auto& gen2 = std::get<ComputeGen2Config>(compute_config);
 
     std::vector<UnpackToDestMode> unpack_dst_modes =
-        BuildUnpackToDestModeVector(gen2.unpack_modes, dfb_name_to_slot, hal);
+        BuildUnpackToDestModeVector(compute_config.unpack_modes, dfb_name_to_slot, hal);
 
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
-        .math_fidelity = gen2.fpu_math_fidelity,
-        .fp32_dest_acc_en = gen2.enable_32_bit_dest,
-        .dst_full_sync_en = !gen2.double_buffer_dest,
+        .math_fidelity = compute_config.fpu_math_fidelity,
+        .fp32_dest_acc_en = compute_config.enable_32_bit_dest,
+        .dst_full_sync_en = !compute_config.double_buffer_dest,
         .unpack_to_dest_mode = unpack_dst_modes,
-        .math_approx_mode = (gen2.sfpu_precision_mode == Precision::Approximate),
+        .math_approx_mode = (compute_config.sfpu_precision_mode == Precision::Approximate),
         .compile_args = {},  // Compile args are passed via named_compile_args
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -47,14 +47,14 @@ bool RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                 .source = dm_src,
                 .num_threads = 6,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 4,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen2Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {DM_KERNEL, COMPUTE_KERNEL};
@@ -68,23 +68,29 @@ bool RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
             },
             experimental::KernelSpec{
                 .unique_id = NCRISC_KERNEL,
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen1Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {BRISC_KERNEL, NCRISC_KERNEL, COMPUTE_KERNEL};

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -49,14 +49,14 @@ bool RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                 .source = dm_src,
                 .num_threads = 6,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 4,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen2Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {DM_KERNEL, COMPUTE_KERNEL};
@@ -70,23 +70,29 @@ bool RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
             },
             experimental::KernelSpec{
                 .unique_id = NCRISC_KERNEL,
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen1Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {BRISC_KERNEL, NCRISC_KERNEL, COMPUTE_KERNEL};

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -49,14 +49,14 @@ void RunFillUpAllBuffers(
                 .source = dm_src,
                 .num_threads = 6,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 4,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen2Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {DM_KERNEL, COMPUTE_KERNEL};
@@ -70,23 +70,29 @@ void RunFillUpAllBuffers(
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
             },
             experimental::KernelSpec{
                 .unique_id = NCRISC_KERNEL,
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen1Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {BRISC_KERNEL, NCRISC_KERNEL, COMPUTE_KERNEL};

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -47,14 +47,14 @@ void RunFillUpAllBuffers(
                 .source = dm_src,
                 .num_threads = 6,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+                .hw_config = experimental::DataMovementHardwareConfig{},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 4,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen2Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {DM_KERNEL, COMPUTE_KERNEL};
@@ -68,23 +68,29 @@ void RunFillUpAllBuffers(
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
             },
             experimental::KernelSpec{
                 .unique_id = NCRISC_KERNEL,
                 .source = dm_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
-                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
+                .hw_config =
+                    experimental::DataMovementHardwareConfig{
+                        .config_1xx =
+                            experimental::DataMovementHardwareConfig::DataMovement1XXConfig{
+                                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
             },
             experimental::KernelSpec{
                 .unique_id = COMPUTE_KERNEL,
                 .source = compute_src,
                 .num_threads = 1,
                 .compiler_options = {.defines = defines},
-                .hw_config = experimental::ComputeGen1Config{},
+                .hw_config = experimental::ComputeHardwareConfig{},
             },
         };
         wu_kernels = {BRISC_KERNEL, NCRISC_KERNEL, COMPUTE_KERNEL};

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
@@ -51,9 +51,9 @@ KernelSpec::CompilerOptions::Defines make_typecast_defines(
 // an UnpackToDest entry for the input DFB. Metal 2.0 additionally *requires* an explicit entry for a
 // consumed Float32 DFB when enable_32_bit_dest is set, where legacy silently defaulted — so supply
 // the legacy default (UnpackToSrc, which lowers to UnpackToDestMode::Default) in that case.
-ComputeUnpackModes make_unpack_modes(
+ComputeHardwareConfig::ComputeUnpackModes make_unpack_modes(
     const TypecastParams& args, const DFBSpecName& in_dfb, tt::DataFormat input_data_format) {
-    ComputeUnpackModes unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes unpack_modes;
     if (args.preserve_fp32_precision) {
         unpack_modes.emplace(in_dfb, tt::tt_metal::UnpackMode::UnpackToDest);
     } else if (args.fp32_dest_acc_en && input_data_format == tt::DataFormat::Float32) {
@@ -67,14 +67,18 @@ ComputeUnpackModes make_unpack_modes(
 //   bfp8_pack_precise -> bfp_pack_precision_mode; math_approx_mode=false -> sfpu_precision_mode.
 // dst_full_sync_en was left at its legacy default (false), which is double_buffer_dest = true (the
 // Metal 2.0 default), so it needs no explicit setting.
-ComputeGen1Config make_compute_config(const TypecastParams& args, ComputeUnpackModes unpack_modes) {
-    return ComputeGen1Config{
+ComputeHardwareConfig make_compute_config(
+    const TypecastParams& args, ComputeHardwareConfig::ComputeUnpackModes unpack_modes) {
+    return ComputeHardwareConfig{
         .fpu_math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
         .sfpu_precision_mode = tt::tt_metal::Precision::Precise,  // legacy math_approx_mode = false
-        .bfp_pack_precision_mode =
-            args.bfp8_pack_precise ? tt::tt_metal::Precision::Precise : tt::tt_metal::Precision::Approximate,
         .enable_32_bit_dest = args.fp32_dest_acc_en,
         .unpack_modes = std::move(unpack_modes),
+        .config_1xx =
+            ComputeHardwareConfig::Compute1XXConfig{
+                .bfp_pack_precision_mode =
+                    args.bfp8_pack_precise ? tt::tt_metal::Precision::Precise : tt::tt_metal::Precision::Approximate,
+            },
     };
 }
 
@@ -146,7 +150,7 @@ ttnn::device_operation::ProgramArtifacts TypecastProgramFactory::create_program_
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     const KernelSpec writer{
@@ -156,7 +160,7 @@ ttnn::device_operation::ProgramArtifacts TypecastProgramFactory::create_program_
             .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     const auto typecast_defines = make_typecast_defines(input_dtype, output_dtype);
@@ -254,8 +258,6 @@ ttnn::device_operation::ProgramArtifacts TypecastSubgridProgramFactory::create_p
     tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t single_tile_size_output = tt::tile_size(cb_data_format_output);
 
-    const auto* device = input.device();
-
     uint32_t ntiles = input.physical_volume() / tt::constants::TILE_HW;
     uint32_t ncores = sub_core_grids->num_cores();
 
@@ -310,7 +312,7 @@ ttnn::device_operation::ProgramArtifacts TypecastSubgridProgramFactory::create_p
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     const KernelSpec writer{
@@ -320,7 +322,7 @@ ttnn::device_operation::ProgramArtifacts TypecastSubgridProgramFactory::create_p
             .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     uint32_t ntiles_per_core = ntiles / ncores;

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -165,7 +165,7 @@ ttnn::device_operation::ProgramArtifacts TypecastRowMajorChunkedProgramFactory::
                 {"partial_chunk_size_bytes", input_partial_chunk_size_bytes}  // DRAM read size
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "start_row_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     const KernelSpec writer{
@@ -182,7 +182,7 @@ ttnn::device_operation::ProgramArtifacts TypecastRowMajorChunkedProgramFactory::
                 {"partial_chunk_size_bytes", output_partial_chunk_size_bytes}  // DRAM write size
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "start_row_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Create compute kernels - compute per_core_block_cnt as total chunks (full + partial) per core
@@ -190,7 +190,7 @@ ttnn::device_operation::ProgramArtifacts TypecastRowMajorChunkedProgramFactory::
 
     // Legacy set unpack_to_dest_mode[input_cb] = UnpackToDestFp32 when preserve_fp32_precision and
     // left every other CB at Default; the named equivalent is an UnpackToDest entry for the input DFB.
-    ComputeUnpackModes unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes unpack_modes;
     if (args.preserve_fp32_precision) {
         unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     } else if (args.fp32_dest_acc_en && cb_data_format_input == tt::DataFormat::Float32) {
@@ -232,14 +232,18 @@ ttnn::device_operation::ProgramArtifacts TypecastRowMajorChunkedProgramFactory::
             .compile_time_args =
                 {{"per_core_block_cnt", per_core_block_cnt},  // rows * total_chunks_per_row
                  {"per_core_block_dim", 1u}},
-            .hw_config = ComputeHardwareConfig{ComputeGen1Config{
-                .fpu_math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-                .sfpu_precision_mode = tt::tt_metal::Precision::Precise,  // legacy math_approx_mode = false
-                .bfp_pack_precision_mode =
-                    args.bfp8_pack_precise ? tt::tt_metal::Precision::Precise : tt::tt_metal::Precision::Approximate,
-                .enable_32_bit_dest = args.fp32_dest_acc_en,
-                .unpack_modes = unpack_modes,
-            }},
+            .hw_config =
+                ComputeHardwareConfig{
+                    .fpu_math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+                    .sfpu_precision_mode = tt::tt_metal::Precision::Precise,  // legacy math_approx_mode = false
+                    .enable_32_bit_dest = args.fp32_dest_acc_en,
+                    .unpack_modes = unpack_modes,
+                    .config_1xx =
+                        ComputeHardwareConfig::Compute1XXConfig{
+                            .bfp_pack_precision_mode = args.bfp8_pack_precise ? tt::tt_metal::Precision::Precise
+                                                                              : tt::tt_metal::Precision::Approximate,
+                        },
+                },
         };
     };
 

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
@@ -30,8 +30,6 @@ ttnn::device_operation::ProgramArtifacts TypecastShardedProgramFactory::create_p
     auto all_cores = shard_spec.grid;
     uint32_t ncores = shard_spec.num_cores();
 
-    const auto* device = input.device();
-
     auto out_shard_spec = output.shard_spec().value();
     TT_FATAL(
         out_shard_spec.num_cores() == ncores,
@@ -154,7 +152,7 @@ ttnn::device_operation::ProgramArtifacts TypecastShardedProgramFactory::create_p
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec::CompilerOptions::Defines unary_defines;
@@ -173,7 +171,7 @@ ttnn::device_operation::ProgramArtifacts TypecastShardedProgramFactory::create_p
 
     // Legacy set unpack_to_dest_mode[in_cb] = UnpackToDestFp32 when preserve_fp32_precision and left
     // every other CB at Default; the named equivalent is an UnpackToDest entry for the input DFB.
-    ComputeUnpackModes unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes unpack_modes;
     if (args.preserve_fp32_precision) {
         unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     } else if (args.fp32_dest_acc_en && act_df == tt::DataFormat::Float32) {
@@ -202,14 +200,18 @@ ttnn::device_operation::ProgramArtifacts TypecastShardedProgramFactory::create_p
              DFBBinding{.dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
              DFBBinding{.dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .compile_time_args = {{"per_core_block_cnt", 1u}, {"per_core_block_dim", num_tile_per_core}},
-        .hw_config = ComputeHardwareConfig{ComputeGen1Config{
-            .fpu_math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-            .sfpu_precision_mode = tt::tt_metal::Precision::Precise,  // legacy math_approx_mode = false
-            .bfp_pack_precision_mode =
-                args.bfp8_pack_precise ? tt::tt_metal::Precision::Precise : tt::tt_metal::Precision::Approximate,
-            .enable_32_bit_dest = args.fp32_dest_acc_en,
-            .unpack_modes = std::move(unpack_modes),
-        }},
+        .hw_config =
+            ComputeHardwareConfig{
+                .fpu_math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+                .sfpu_precision_mode = tt::tt_metal::Precision::Precise,  // legacy math_approx_mode = false
+                .enable_32_bit_dest = args.fp32_dest_acc_en,
+                .unpack_modes = std::move(unpack_modes),
+                .config_1xx =
+                    ComputeHardwareConfig::Compute1XXConfig{
+                        .bfp_pack_precision_mode = args.bfp8_pack_precise ? tt::tt_metal::Precision::Precise
+                                                                          : tt::tt_metal::Precision::Approximate,
+                    },
+            },
     };
 
     KernelRunArgs reader_run_args{.kernel = READER};

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -106,8 +106,7 @@ std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kerne
         compute_kernel_config.dst_full_sync_en);
 }
 
-tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
-    tt::ARCH arch, const ComputeKernelConfig& config) {
+tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(const ComputeKernelConfig& config) {
     // Translate the universal TTNN ComputeKernelConfig (legacy scalar vocabulary) into the
     // Metal 2.0 vocabulary. Two representation changes are worth calling out:
     //   - double_buffer_dest is the logical inverse of the legacy dst_full_sync_en.
@@ -115,22 +114,14 @@ tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
     const tt::tt_metal::Precision sfpu_precision_mode =
         config.math_approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise;
 
-    if (arch == tt::ARCH::QUASAR) {
-        return tt::tt_metal::experimental::ComputeGen2Config{
-            .fpu_math_fidelity = config.math_fidelity,
-            .sfpu_precision_mode = sfpu_precision_mode,
-            .enable_32_bit_dest = config.fp32_dest_acc_en,
-            .double_buffer_dest = !config.dst_full_sync_en,
-            // Per-DFB unpack_modes is left default for the program factory to set.
-        };
-    }
-    return tt::tt_metal::experimental::ComputeGen1Config{
+    return tt::tt_metal::experimental::ComputeHardwareConfig{
         .fpu_math_fidelity = config.math_fidelity,
         .sfpu_precision_mode = sfpu_precision_mode,
-        // bfp_pack_precision_mode is left default (rarely set non-default).
         .enable_32_bit_dest = config.fp32_dest_acc_en,
         .double_buffer_dest = !config.dst_full_sync_en,
         // Per-DFB unpack_modes is left default for the program factory to set.
+        // bfp_pack_precision_mode is left default (Approximate). Unused on 2xx.
+        .config_1xx = tt::tt_metal::experimental::ComputeHardwareConfig::Compute1XXConfig{},
     };
 }
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -61,17 +61,14 @@ ttnn::operations::compute_throttle_utils::ThrottleLevel get_throttle_level(
 std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kernel_config_args(
     tt::ARCH arch, const DeviceComputeKernelConfig& compute_kernel_config);
 
-// Maps the four hardware knobs (math_fidelity, math_approx_mode, fp32_dest_acc_en,
-// dst_full_sync_en) of a ComputeKernelConfig to a Metal 2.0 ComputeHardwareConfig. The knobs are
-// common to both generations; `arch` selects the matching alternative (ComputeGen2Config on Quasar,
-// else ComputeGen1Config) — the config's generation must match the target platform.
+// Maps the four hardware settings (math_fidelity, math_approx_mode, fp32_dest_acc_en,
+// dst_full_sync_en) of a ComputeKernelConfig onto a Metal 2.0 ComputeHardwareConfig. Those
+// settings are common to both generations and are written on the outer struct.
 // packer_l1_acc and throttle_level are op-side concerns, not translated.
 //
 // The result's per-DFB unpack_modes table is left default for the program factory to set.
-// bfp_pack_precision_mode is likewise left default (rarely set non-default).
 //
-tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
-    tt::ARCH arch, const ComputeKernelConfig& config);
+tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(const ComputeKernelConfig& config);
 
 uint32_t get_dest_reg_count(
     const DeviceComputeKernelConfig& compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp
@@ -4,41 +4,37 @@
 
 #pragma once
 
-#include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp>
 
 namespace ttnn {
 
 // Generation-agnostic construction of a Metal 2.0 DataMovementHardwareConfig.
 //
-// DataMovementHardwareConfig is a variant over a Gen1 (WH/BH) and a Gen2 (Quasar) config, and a kernel
-// must carry the alternative matching its target architecture. These helpers pick that alternative from
-// `arch` so architecture-agnostic host code doesn't have to branch at every kernel spec.
+// Calls the Metal reader/writer factory (which fills config_1xx pins) and layers the
+// 2xx implicit-sync opt-out on top so architecture-agnostic host code doesn't have to
+// branch at every kernel spec.
 
-// The conventional reader / writer DM placement, generation-agnostic. On Gen1 these forward to the
-// metal create_reader/writer_gen1_datamovement_config() placement; on Quasar both yield a default
-// DataMovementGen2Config.
+// The conventional reader / writer DM placement. On 1xx these use the Metal factory's
+// RISC/NOC pins; on 2xx those extras are unused and the implicit-sync flag applies.
 //
 // disable_dfb_implicit_sync_for_all opts the kernel's DFBs out of implicit-sync credit accounting so the
 // kernel's explicit reserve_back/push_back (resp. wait_front/pop_front) stays authoritative. This is a
-// Gen2 (Quasar) concept only — DM kernels doing many sub-tile ("stick") NOC transfers stall the implicit
-// credit accounting there; it is ignored on the Gen1 (WH/BH) placement, which has no such feature.
+// 2xx (Quasar) concept only — DM kernels doing many sub-tile ("stick") NOC transfers stall the implicit
+// credit accounting there; it is ignored on the 1xx (WH/BH) placement, which has no such feature.
 inline tt::tt_metal::experimental::DataMovementHardwareConfig create_reader_datamovement_config(
-    tt::ARCH arch, bool disable_dfb_implicit_sync_for_all = false) {
-    if (arch == tt::ARCH::QUASAR) {
-        return tt::tt_metal::experimental::DataMovementGen2Config{
-            .disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
-    }
-    return tt::tt_metal::experimental::CreateReaderGen1DataMovementConfig();
+    bool disable_dfb_implicit_sync_for_all = false) {
+    auto hw = tt::tt_metal::experimental::CreateReaderDataMovementConfig();
+    hw.config_2xx = tt::tt_metal::experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+        .disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
+    return hw;
 }
 
 inline tt::tt_metal::experimental::DataMovementHardwareConfig create_writer_datamovement_config(
-    tt::ARCH arch, bool disable_dfb_implicit_sync_for_all = false) {
-    if (arch == tt::ARCH::QUASAR) {
-        return tt::tt_metal::experimental::DataMovementGen2Config{
-            .disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
-    }
-    return tt::tt_metal::experimental::CreateWriterGen1DataMovementConfig();
+    bool disable_dfb_implicit_sync_for_all = false) {
+    auto hw = tt::tt_metal::experimental::CreateWriterDataMovementConfig();
+    hw.config_2xx = tt::tt_metal::experimental::DataMovementHardwareConfig::DataMovement2XXConfig{
+        .disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
+    return hw;
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
@@ -127,7 +127,7 @@ ttnn::device_operation::ProgramArtifacts BcastMultiCoreHProgramFactory::create_p
              TensorBinding{.tensor_parameter_name = INPUT_B, .accessor_name = "src1"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"src0_num_tiles", "NCHtWt", "NC", "Ht", "Wt", "nc1", "start_id", "HtWt"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -138,10 +138,10 @@ ttnn::device_operation::ProgramArtifacts BcastMultiCoreHProgramFactory::create_p
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"Ht", "Wt", "Wt_read", "Wt_skip", "NC", "HtWt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    ComputeHardwareConfig compute_hw = ComputeGen1Config{};  // legacy ComputeConfigDescriptor{} defaults
+    ComputeHardwareConfig compute_hw{};  // legacy ComputeConfigDescriptor{} defaults
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source =

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
@@ -196,7 +196,7 @@ ttnn::device_operation::ProgramArtifacts BcastMultiCoreHWProgramFactory::create_
         .tensor_bindings = reader_tensor_bindings,
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "HtWt", "base_start_id_HtWt", "curr_id_from_base", "bcast_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // Rung-1 reuse of the shared eltwise/unary writer's Metal 2.0 fork (do not edit — it already has
@@ -211,10 +211,10 @@ ttnn::device_operation::ProgramArtifacts BcastMultiCoreHWProgramFactory::create_
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = writer_tensor_bindings,
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    ComputeHardwareConfig compute_hw = ComputeGen1Config{};  // legacy ComputeConfigDescriptor{} defaults
+    ComputeHardwareConfig compute_hw{};  // legacy ComputeConfigDescriptor{} defaults
     KernelSpec compute{
         .unique_id = COMPUTE,
         // Rung-2 fork of the lent bcast_hw.cpp compute kernel (rotate_half still binds the legacy original).

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
@@ -127,7 +127,7 @@ ttnn::device_operation::ProgramArtifacts BcastMultiCoreWProgramFactory::create_p
              TensorBinding{.tensor_parameter_name = INPUT_B, .accessor_name = "src1"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"src0_num_tiles", "NCHtWt", "NC", "Ht", "Wt", "nc1", "start_id", "HtWt", "Wt_skip"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -138,10 +138,10 @@ ttnn::device_operation::ProgramArtifacts BcastMultiCoreWProgramFactory::create_p
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"Ht", "Wt", "Wt_read", "Wt_skip", "NC", "HtWt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    ComputeHardwareConfig compute_hw = ComputeGen1Config{};  // legacy ComputeConfigDescriptor{} defaults
+    ComputeHardwareConfig compute_hw{};  // legacy ComputeConfigDescriptor{} defaults
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source =

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
@@ -163,10 +163,10 @@ ttnn::device_operation::ProgramArtifacts BcastShardedHOptimisedProgramFactory::c
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_B, .accessor_name = "src1"}},
         // Legacy reader index 4 ("batch_offset") is fed tile_offset.
         .runtime_arg_schema = {.runtime_arg_names = {"Ht", "Wt", "offset", "batch_offset", "w_blk", "batch_b"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
-    ComputeHardwareConfig compute_hw = ComputeGen1Config{};  // legacy ComputeConfigDescriptor{} defaults
+    ComputeHardwareConfig compute_hw{};
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source = std::filesystem::path(

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
@@ -157,10 +157,10 @@ ttnn::device_operation::ProgramArtifacts BcastShardedHProgramFactory::create_pro
         // Legacy arg names on the reader side: the kernel reads index 4 as "NC" (fed Ht_per_core) and
         // index 5 as "batch_offset" (fed tile_offset). Names preserve the kernel-side identifiers.
         .runtime_arg_schema = {.runtime_arg_names = {"Ht", "Wt", "offset", "NC", "batch_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
-    ComputeHardwareConfig compute_hw = ComputeGen1Config{};  // legacy ComputeConfigDescriptor{} defaults
+    ComputeHardwareConfig compute_hw{};
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source =

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
@@ -181,7 +181,7 @@ ttnn::device_operation::ProgramArtifacts CloneProgramFactory::create_program_art
             .dfb_spec_name = SRC, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = rta_names},
-        .hw_config = ttnn::create_reader_datamovement_config(input.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     KernelSpec writer{
         .unique_id = WRITER,
@@ -190,7 +190,7 @@ ttnn::device_operation::ProgramArtifacts CloneProgramFactory::create_program_art
             .dfb_spec_name = writer_dfb, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = rta_names},
-        .hw_config = ttnn::create_writer_datamovement_config(input.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
     spec.kernels.push_back(reader);
     spec.kernels.push_back(writer);
@@ -199,15 +199,12 @@ ttnn::device_operation::ProgramArtifacts CloneProgramFactory::create_program_art
     // Compute KernelSpecs for dtype conversion (per core group — preserved multiplicity)
     // ---------------------------------------------------------------------
     if (convert_dtype) {
-        auto compute_hw =
-            ttnn::to_compute_hardware_config(input.device()->arch(), operation_attributes.compute_kernel_config);
+        auto compute_hw = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
         // Metal 2.0 requires an explicit unpack_modes entry when a compute kernel consumes a
         // Float32 DFB with a 32-bit dest register. Legacy ComputeConfigDescriptor left
         // unpack_to_dest_mode default (== UnpackToSrc); mirror that value faithfully.
-        if (auto* gen1 = std::get_if<ComputeGen1Config>(&compute_hw)) {
-            if (input_data_format == tt::DataFormat::Float32 && gen1->enable_32_bit_dest) {
-                gen1->unpack_modes = ComputeUnpackModes{{SRC, UnpackMode::UnpackToSrc}};
-            }
+        if (input_data_format == tt::DataFormat::Float32 && compute_hw.enable_32_bit_dest) {
+            compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{SRC, UnpackMode::UnpackToSrc}};
         }
 
         auto make_compute = [&](const KernelSpecName& unique_id, uint32_t num_tiles) {

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_default_row_major_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_default_row_major_program_factory.cpp
@@ -127,8 +127,6 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultRowMajor::c
         .data_format_metadata = output_data_format,
     };
 
-    const auto arch = device->arch();
-
     m2::KernelSpec reader{
         .unique_id = READER,
         .source = KERNEL_READER,
@@ -170,7 +168,7 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultRowMajor::c
             {
                 .runtime_arg_names = {"start_row", "num_rows_to_process"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     m2::KernelSpec writer{
@@ -200,7 +198,7 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultRowMajor::c
             {
                 .runtime_arg_names = {"start_row", "num_rows_to_process"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Runtime args: each core owns a contiguous span of logical rows.

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_default_tilized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_default_tilized_program_factory.cpp
@@ -112,8 +112,6 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultTilized::cr
     // reader-produced IN directly.
     const m2::DFBSpecName& writer_dfb = convert_df ? OUT : IN;
 
-    const auto arch = device->arch();
-
     m2::KernelSpec reader{
         .unique_id = READER,
         .source = KERNEL_READER_INTERLEAVED,
@@ -133,7 +131,7 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultTilized::cr
             {
                 .runtime_arg_names = {"num_pages", "start_id"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     m2::KernelSpec writer{
@@ -155,11 +153,11 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultTilized::cr
             {
                 .runtime_arg_names = {"num_pages", "start_id"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Compute kernel (only present when converting data format): consumes IN, produces OUT.
-    // ComputeGen1Config defaults match the legacy ComputeConfigDescriptor{} defaults; opt_level is set
+    // ComputeHardwareConfig defaults match the legacy ComputeConfigDescriptor{} defaults; opt_level is set
     // to O3 explicitly (legacy compute defaults to O3; Metal 2.0 CompilerOptions defaults to O2).
     m2::KernelSpec compute{
         .unique_id = COMPUTE,
@@ -182,7 +180,7 @@ ttnn::device_operation::ProgramArtifacts CopyDeviceOperation::DefaultTilized::cr
             {
                 .runtime_arg_names = {"per_core_tile_cnt"},
             },
-        .hw_config = m2::ComputeGen1Config{},
+        .hw_config = m2::ComputeHardwareConfig{},
     };
 
     // Runtime args: each core owns a contiguous span of tiles.

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -186,7 +186,7 @@ ttnn::device_operation::ProgramArtifacts FillPadProgramFactory::create_program_a
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"start_right", "num_right", "start_bottom", "num_bottom", "start_corner", "num_corner"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     reader_spec.compiler_options.defines = fill_defines;
 
@@ -213,7 +213,7 @@ ttnn::device_operation::ProgramArtifacts FillPadProgramFactory::create_program_a
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"start_right", "num_right", "start_bottom", "num_bottom", "start_corner", "num_corner"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
     writer_spec.compiler_options.defines = mask_defines;
 
@@ -230,7 +230,7 @@ ttnn::device_operation::ProgramArtifacts FillPadProgramFactory::create_program_a
             .dfb_spec_name = BOT_MASK, .accessor_name = "bot_mask", .endpoint_type = DFBEndpointType::CONSUMER});
     }
 
-    ComputeGen1Config compute_hw{};
+    ComputeHardwareConfig compute_hw{};
     compute_hw.enable_32_bit_dest = need_fp32_dest_acc;
     if (is_fp32) {
         // Match legacy UnpackToDestFp32 on the FP32 DFBs the compute kernel consumes.
@@ -578,7 +578,7 @@ ttnn::device_operation::ProgramArtifacts FillPadL1ShardedProgramFactory::create_
                 {{"W_tiles", W_tiles}, {"has_right_pad", key.has_right_pad}, {"elem_size", input_element_size_bytes}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"shard_H_tiles", "has_bottom_pad_core", "num_work", "local_right_col"}},
-            .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+            .hw_config = ttnn::create_reader_datamovement_config(),
         };
 
         // Writer.
@@ -606,7 +606,7 @@ ttnn::device_operation::ProgramArtifacts FillPadL1ShardedProgramFactory::create_
             .runtime_arg_schema =
                 {.runtime_arg_names =
                      {"shard_H_tiles", "has_bottom_pad_core", "num_work", "local_right_col", "has_right_pad_core"}},
-            .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+            .hw_config = ttnn::create_writer_datamovement_config(),
         };
         writer_spec.compiler_options.defines = mask_defines;
 
@@ -626,7 +626,7 @@ ttnn::device_operation::ProgramArtifacts FillPadL1ShardedProgramFactory::create_
             compute_dfb_bindings.push_back(DFBBinding{
                 .dfb_spec_name = BOT_MASK, .accessor_name = "bot_mask", .endpoint_type = DFBEndpointType::CONSUMER});
         }
-        ComputeGen1Config compute_hw{};
+        ComputeHardwareConfig compute_hw{};
         compute_hw.enable_32_bit_dest = need_fp32_dest_acc;
         if (is_fp32) {
             compute_hw.unpack_modes.insert({DATA_IN, UnpackMode::UnpackToDest});

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
@@ -88,7 +88,7 @@ ttnn::device_operation::ProgramArtifacts FillRMProgramFactory::create_program_ar
             {
                 .runtime_arg_names = {"NC", "H", "W", "fillH", "fillW", "val_hi", "val_lo"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(output.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -131,7 +131,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         .compile_time_args =
             {{"tiles_per_channel_dim", tiles_per_channel_dim}, {"tiles_per_width_dim", tiles_per_width_dim}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block_id", "num_blocks"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // Writer kernel: DFB -> DRAM.
@@ -152,7 +152,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
              {"element_size", datum_size(out_dfb_data_format)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_block_id", "num_blocks", "patch_height_offset", "output_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Compute kernel (untilize). One KernelSpec per legacy compute KernelDescriptor (main + cliff),
@@ -160,7 +160,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     // only fp32_dest_acc_en was set by the legacy op -> enable_32_bit_dest.
     const bool fp32_dest_acc_en = dfb_data_format == tt::DataFormat::Float32;
     auto make_compute_spec = [&](const KernelSpecName& id, uint32_t nblocks) {
-        ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+        ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
         // The compute kernel consumes SRC0. When SRC0 is Float32 and enable_32_bit_dest is set,
         // the validator requires an explicit unpack mode. Legacy set none (default) -> UnpackToSrc.
         if (fp32_dest_acc_en) {
@@ -383,7 +383,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .compile_time_args = common_cta,
         .runtime_arg_schema = {.runtime_arg_names = {"work_per_core", "src_index", "curr_src_row_index"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // Writer: consumes src0; when !is_l1_aligned it also uses src1 as a self-loop scratch.
@@ -403,7 +403,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = common_cta,
         .runtime_arg_schema = {.runtime_arg_names = {"work_per_core", "dst_index"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Per-core runtime args (name-first tables built from the legacy node-first loop).

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -115,7 +115,7 @@ ttnn::device_operation::ProgramArtifacts Fold::MultiCore::create_program_artifac
             {DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "src0", .endpoint_type = DFBEndpointType::PRODUCER},
              DFBBinding{.dfb_spec_name = DST0, .accessor_name = "dst0", .endpoint_type = DFBEndpointType::PRODUCER}},
         .compile_time_args = make_cta(/*is_reader=*/1),
-        .hw_config = ttnn::create_writer_datamovement_config(input.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelSpec reader_spec{
@@ -126,7 +126,7 @@ ttnn::device_operation::ProgramArtifacts Fold::MultiCore::create_program_artifac
             {DFBBinding{.dfb_spec_name = SRC0, .accessor_name = "src0", .endpoint_type = DFBEndpointType::CONSUMER},
              DFBBinding{.dfb_spec_name = DST0, .accessor_name = "dst0", .endpoint_type = DFBEndpointType::CONSUMER}},
         .compile_time_args = make_cta(/*is_reader=*/0),
-        .hw_config = ttnn::create_reader_datamovement_config(input.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.cpp
@@ -299,8 +299,6 @@ ttnn::device_operation::ProgramArtifacts IndexedFillProgramFactory::create_progr
         .data_format_metadata = dfb_data_format,
     });
 
-    const auto arch = input_a.device()->arch();
-
     // ---- Reader: single unified kernel; path selected via the `mode` compile-time arg.
     // The one source serves all four modes through `if constexpr (mode)`. Because the named
     // `args::` tokens are emitted per-kernel from the schema, and name lookup still runs on the
@@ -348,13 +346,13 @@ ttnn::device_operation::ProgramArtifacts IndexedFillProgramFactory::create_progr
                   "full_tile_w",
                   "col_page_offset",
                   "col_byte_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer: path-dependent source and bindings.
     KernelSpec writer{
         .unique_id = IF_WRITER,
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
     if (is_native || is_shard_local) {
         // Data DFB is borrowed onto the output buffer: the writer just synchronises on the DFB.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -215,7 +215,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgra
                      "start_dim_offset_c",
                      "start_dim_offset_n"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -248,7 +248,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgra
             {
                 .runtime_arg_names = {"num_sticks_per_core", "num_sticks_per_barrier", "start_page_id"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Build per-core runtime args inline (legacy path called get_runtime_args_rm()

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -298,7 +298,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactor
                      "num_local_unpadded_Y",
                      "num_local_W"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -331,7 +331,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactor
                      "dst_stick_offset",
                      "num_local_W"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = RM_MC_READER};

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -136,7 +136,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create
                      "num_local_unpadded_Y",
                      "num_local_W"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -169,7 +169,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create
                      "dst_stick_offset",
                      "num_local_W"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     uint32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -245,8 +245,6 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
     tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat dst_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    IDevice* device = a.device();
-
     // input shard spec
     auto shard_spec_unpadded = a.shard_spec().value();
     uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
@@ -368,7 +366,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
                 {"num_sticks_padded", shard_height_padded},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_cores_read"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = num_reader_varargs},
     };
 
@@ -421,7 +419,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
                      "start_dim_offset_c",
                      "start_dim_offset_n"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = SH_H_READER};

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -52,8 +52,6 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
     auto unpadded_stick_bytes = W * input_tensor.element_size();
     auto padded_stick_bytes = W_padded * input_tensor.element_size();
 
-    IDevice* device = input_tensor.device();
-
     // input shard spec
     auto input_shard_spec = input_tensor.shard_spec().value();
     uint32_t shard_height_unpadded = input_shard_spec.shape[0];
@@ -160,7 +158,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
                 {"unpadded_stick_step", unpadded_stick_step},
                 {"padded_stick_step", padded_stick_step},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -193,7 +191,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
                 {"padding_value_as_u32", padding_value_as_u32},
                 {"padding_value_num_bytes", static_cast<uint32_t>(output.element_size())},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Neither sharded kernel takes runtime args: every per-core value is pinned by the hashed

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
@@ -138,7 +138,7 @@ ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_
                 {"num_dims", num_dims},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = num_varargs},
     };
 
@@ -178,7 +178,7 @@ ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_
                 {"element_size", static_cast<uint32_t>(output.element_size())},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = num_varargs},
     };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -123,7 +123,7 @@ ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_progr
                 },
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -169,7 +169,7 @@ ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_progr
                      "num_padded_Xt",
                      "pad_value"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -93,7 +93,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreRowInv
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .compile_time_args = {{"N", N}, {"page_size", input_rm_page_size}, {"num_rows", num_rows}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_row", "end_row"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -107,7 +107,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreRowInv
         .compile_time_args = {{"N", N}, {"page_size", output_rm_page_size}, {"num_rows", num_rows}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_row", "end_row"}},
         // rank-length shape/perm/stride arrays (count = N, a CTA) → runtime varargs.
-        .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 3 * N},
     };
 
@@ -267,7 +267,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreBlocke
              {"w_block_size", w_block_size},
              {"element_size", input_tensor.element_size()}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block", "end_block"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 2 * N},
     };
 
@@ -296,16 +296,16 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreBlocke
              {"w_block_size", w_block_size},
              {"W", W}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block", "end_block"}},
-        .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 3 * N},
     };
 
     bool fp32_dest_acc_en = cb_data_format_output == tt::DataFormat::Float32 ||
                             cb_data_format_output == tt::DataFormat::Int32 ||
                             cb_data_format_output == tt::DataFormat::UInt32;
-    // Style B compute config: build ComputeGen1Config directly, matching the legacy
+    // Style B compute config: build ComputeHardwareConfig directly, matching the legacy
     // ComputeConfigDescriptor{.fp32_dest_acc_en=...} (all other fields at legacy defaults).
-    ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+    ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
     // Metal 2.0 requires an explicit unpack_modes entry for every Float32 DFB the compute
     // kernel consumes when enable_32_bit_dest = true. The compute kernel consumes SRC_CB
     // (via tilize) and TILIZE_CB (self-loop). UnpackToDest, not UnpackToSrc: SrcA/SrcB are
@@ -333,7 +333,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreBlocke
                  .dfb_spec_name = OUT_CB, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::PRODUCER}},
         .compile_time_args = {{"x_block_size", x_block_size}, {"w_block_size", w_block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_blocks"}},
-        .hw_config = ComputeHardwareConfig{std::move(compute_cfg)},
+        .hw_config = std::move(compute_cfg),
     };
 
     // ---- Varargs (core-invariant) ----

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -150,7 +150,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileIn
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .compile_time_args = {{"rank", rank}, {"page_size", input_page_size}, {"num_tiles", num_tiles}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_tile", "end_tile"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 3 * rank},
     };
 
@@ -164,7 +164,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileIn
             .dfb_spec_name = OUTPUT_CB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     Group<KernelSpec> kernels = {std::move(reader), std::move(writer)};
@@ -173,7 +173,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileIn
     if (swap_hw) {
         bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                                 cb_data_format == tt::DataFormat::UInt32;
-        ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+        ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
         // Legacy set unpack_to_dest_mode[c_0] = UnpackToDestFp32 for Float32 → UnpackMode::UnpackToDest.
         // Compute consumes SRC0 (c_0); the required-entry rule fires only for Float32.
         if (cb_data_format == tt::DataFormat::Float32) {
@@ -189,7 +189,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileIn
                  DFBBinding{
                      .dfb_spec_name = OUT16, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::PRODUCER}},
             .runtime_arg_schema = {.runtime_arg_names = {"NHtWt"}},
-            .hw_config = ComputeHardwareConfig{std::move(compute_cfg)},
+            .hw_config = std::move(compute_cfg),
         });
     }
 
@@ -442,7 +442,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileRo
              {"tile_height", tile_shape[1]},
              {"tile_width", tile_shape[0]}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer (own) ----
@@ -466,7 +466,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileRo
              {"rank", rank},
              {"h_in_dest", h_in_dest}},
         .runtime_arg_schema = {.runtime_arg_names = writer_rta_names},
-        .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 2 * rank},
     };
 
@@ -476,7 +476,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileRo
     if (swap_hw) {
         bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                                 cb_data_format == tt::DataFormat::UInt32;
-        ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+        ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
         // Legacy set unpack_to_dest_mode[c_0] = UnpackToDestFp32 for Float32 → UnpackMode::UnpackToDest.
         // Compute consumes SRC0 (c_0); the required-entry rule fires only for Float32.
         if (cb_data_format == tt::DataFormat::Float32) {
@@ -492,7 +492,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTileRo
                  DFBBinding{
                      .dfb_spec_name = OUT16, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::PRODUCER}},
             .runtime_arg_schema = {.runtime_arg_names = {"NHtWt"}},
-            .hw_config = ComputeHardwareConfig{std::move(compute_cfg)},
+            .hw_config = std::move(compute_cfg),
         });
     }
 
@@ -780,10 +780,10 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTiledG
 
     uint32_t non_x_rows = num_rows / x;
 
-    // ---- Compute config (Style B: build ComputeGen1Config directly, mirroring legacy) ----
+    // ---- Compute config (Style B: build ComputeHardwareConfig directly, mirroring legacy) ----
     bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                             cb_data_format == tt::DataFormat::UInt32;
-    ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+    ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
     // Metal 2.0 requires an explicit unpack_modes entry for each Float32 DFB the compute kernel consumes
     // when enable_32_bit_dest = true. Compute consumes SRC_CB (via tilize) and TILIZE_CB (self-loop).
     // Keep both the tilize input (c_0 = SRC_CB) and its output (c_1 = TILIZE_CB, which feeds the transpose)
@@ -847,7 +847,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTiledG
              {"misalignment", misalignment},
              {"read_alignment", read_alignment}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block", "end_block"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 2 * rank},
     };
 
@@ -864,7 +864,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTiledG
              DFBBinding{
                  .dfb_spec_name = OUT_CB, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block", "end_block"}},
-        .hw_config = ComputeHardwareConfig{std::move(compute_cfg)},
+        .hw_config = std::move(compute_cfg),
     };
 
     KernelSpec writer{
@@ -897,7 +897,7 @@ ttnn::device_operation::ProgramArtifacts PermuteDeviceOperation::MultiCoreTiledG
              {"w_blocks", w_blocks},
              {"permuted_w_dim", permuted_w_dim}},
         .runtime_arg_schema = {.runtime_arg_names = writer_rta_names},
-        .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 2 * rank},
     };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
@@ -136,7 +136,7 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryHigherDim::create_p
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"higher_dim_start", "higher_dim_end", "lower_dim_start", "lower_dim_end", "repetitions", "nop"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = READER};

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
@@ -119,7 +119,7 @@ ttnn::device_operation::ProgramArtifacts RepeatProgramFactoryLastDim::create_pro
              TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = {{"original_page_size_bytes", source_page_size_bytes}, {"num_repeats", num_repeats}},
         .runtime_arg_schema = {.runtime_arg_names = {"page_start", "page_end", "nop"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = READER};

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
@@ -211,11 +211,11 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewRMProgramFactory::create_pro
 
     ProgramSpec spec;
     spec.name = "reshape_view_rm";
-    spec.kernels.push_back(make_rm_kernel(READER, create_reader_datamovement_config(device->arch()), SRC0, SRC1));
+    spec.kernels.push_back(make_rm_kernel(READER, create_reader_datamovement_config(), SRC0, SRC1));
     spec.dataflow_buffers.push_back(make_scratch_dfb(SRC0, dfb_size0, 2));
     spec.dataflow_buffers.push_back(make_scratch_dfb(SRC1, dfb_size1, 1));
     if (can_use_dual_kernel) {
-        spec.kernels.push_back(make_rm_kernel(WRITER, create_writer_datamovement_config(device->arch()), SRC2, SRC3));
+        spec.kernels.push_back(make_rm_kernel(WRITER, create_writer_datamovement_config(), SRC2, SRC3));
         spec.dataflow_buffers.push_back(make_scratch_dfb(SRC2, dfb_size0, 2));
         spec.dataflow_buffers.push_back(make_scratch_dfb(SRC3, dfb_size1, 1));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
@@ -397,7 +397,7 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledProgramFactory::create_
                 {"Tile_size_bytes", input_tile_size_bytes},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"start_output_page_idx", "end_output_page_idx"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -425,7 +425,7 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledProgramFactory::create_
                 {"element_sz_bytes", tt::datum_size(output_dfb_data_format)},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"start_output_page", "end_output_page"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     };
 
     spec.kernels = {reader, writer};

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
@@ -159,7 +159,7 @@ ttnn::device_operation::ProgramArtifacts ScatterProgramFactory::create_program_a
                      "source_chunk_size",
                      "scatter_reduction_type"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         // Per-dimension shape extents (input dims then index dims). N = rank-1 per tensor; the
         // count varies with rank across instantiations, so these are delivered as runtime varargs.
         .advanced_options =
@@ -186,7 +186,7 @@ ttnn::device_operation::ProgramArtifacts ScatterProgramFactory::create_program_a
             {
                 .runtime_arg_names = {"start_stick_id", "sticks_for_core", "input_and_output_chunk_size"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Per-dimension shape extents are the same on every node; build once and bind per node.

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
@@ -172,7 +172,7 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
                      "source_chunk_size",
                      "scatter_reduction_type"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         // Per-dimension shape extents (input dims then index dims). N = rank-1 per tensor; the
         // count varies with rank across instantiations, so these are delivered as runtime varargs.
         .advanced_options =
@@ -199,7 +199,7 @@ ttnn::device_operation::ProgramArtifacts ScatterReduceBfloat16ProgramFactory::cr
             {
                 .runtime_arg_names = {"start_stick_id", "sticks_for_core", "input_and_output_chunk_size"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Per-dimension shape extents are the same on every node; build once and bind per node.

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -134,8 +134,11 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyLocalShardFactory<local_is
             .runtime_arg_schema =
                 {.runtime_arg_names = {"first_shard_id"},
                  .common_runtime_arg_names = {"num_shards", "shard_id_stride"}},
-            .hw_config = DataMovementHardwareConfig{DataMovementGen1Config{
-                .processor = processor, .noc = noc, .noc_mode = NOC_MODE::DM_DEDICATED_NOC}},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .config_1xx =
+                        DataMovementHardwareConfig::DataMovement1XXConfig{
+                            .processor = processor, .noc = noc, .noc_mode = NOC_MODE::DM_DEDICATED_NOC}},
         };
     };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -53,8 +53,6 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_progr
     const auto data_format = datatype_to_dataformat_converter(input.dtype());
     constexpr uint32_t num_tiles_in_dfb = 1;  // TODO: Try double buffering
 
-    auto* device = input.device();
-
     // ------------------------------------------------------------------
     // ProgramSpec (immutable)
     // ------------------------------------------------------------------
@@ -78,7 +76,7 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_progr
                 .tensor_parameter_name = TensorParamName{kCPInputTensorParam}, .accessor_name = kCPInputTensorParam}},
             .compile_time_args = compile_time_args,
             .runtime_arg_schema = {.runtime_arg_names = {"start_page", "end_page"}},
-            .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_reader_datamovement_config(),
         },
         KernelSpec{
             .unique_id = KernelSpecName{kCPWriterKernel},
@@ -92,7 +90,7 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_progr
                 .tensor_parameter_name = TensorParamName{kCPOutputTensorParam}, .accessor_name = kCPOutputTensorParam}},
             .compile_time_args = compile_time_args,
             .runtime_arg_schema = {.runtime_arg_names = {"start_page", "end_page"}},
-            .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_writer_datamovement_config(),
         },
     };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -802,10 +802,8 @@ ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_a
     // The two same-source instances raw-write disjoint output page ranges; the output shard is
     // resident and nothing drains it. Two role-free touchers over one grid -> assign 1P + 1C.
     spec.kernels = {
-        make_worker(
-            kGenReaderKernel, ttnn::create_reader_datamovement_config(device->arch()), DFBEndpointType::PRODUCER),
-        make_worker(
-            kGenWriterKernel, ttnn::create_writer_datamovement_config(device->arch()), DFBEndpointType::CONSUMER),
+        make_worker(kGenReaderKernel, ttnn::create_reader_datamovement_config(), DFBEndpointType::PRODUCER),
+        make_worker(kGenWriterKernel, ttnn::create_writer_datamovement_config(), DFBEndpointType::CONSUMER),
     };
 
     // Output sharded DFB, built on the output buffer's borrowed memory so its backing L1 address is

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
@@ -163,10 +163,8 @@ ttnn::device_operation::ProgramArtifacts ReshardSameHeightFactory<local_is_outpu
     // The two same-source instances split the sticks of each core, so both raw-touch the shard DFB.
     // Two role-free touchers over one grid -> assign 1P + 1C.
     spec.kernels = {
-        make_worker(
-            kSHReaderKernel, ttnn::create_reader_datamovement_config(device->arch()), DFBEndpointType::PRODUCER),
-        make_worker(
-            kSHWriterKernel, ttnn::create_writer_datamovement_config(device->arch()), DFBEndpointType::CONSUMER),
+        make_worker(kSHReaderKernel, ttnn::create_reader_datamovement_config(), DFBEndpointType::PRODUCER),
+        make_worker(kSHWriterKernel, ttnn::create_writer_datamovement_config(), DFBEndpointType::CONSUMER),
     };
 
     // Local sharded DFB, built on the local buffer's borrowed memory so its backing L1 address is

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -234,12 +234,12 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
     spec.kernels = {
         make_worker(
             kSWReaderKernel,
-            ttnn::create_reader_datamovement_config(device->arch()),
+            ttnn::create_reader_datamovement_config(),
             DFBEndpointType::PRODUCER,
             /*is_reader=*/1),
         make_worker(
             kSWWriterKernel,
-            ttnn::create_writer_datamovement_config(device->arch()),
+            ttnn::create_writer_datamovement_config(),
             DFBEndpointType::CONSUMER,
             /*is_reader=*/0),
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -142,7 +142,7 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
                 .endpoint_type = DFBEndpointType::PRODUCER,
             }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // Writer kernel (writes interleaved output to DRAM). Both layout variants present the same binding
@@ -159,7 +159,7 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
                 .endpoint_type = DFBEndpointType::CONSUMER,
             }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
-        .hw_config = ttnn::create_writer_datamovement_config(input.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
     if (is_tile) {
         writer.source =
@@ -209,11 +209,11 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
                  }},
             .compile_time_args = {{"per_core_tile_cnt", num_units_per_shard}},
             // Every field of the legacy ComputeConfigDescriptor{} was left at its default, and the
-            // Metal 2.0 Gen1 compute defaults match those field for field (HiFi4; math_approx_mode
-            // false = Precise SFPU; bfp8_pack_precise false = Approximate pack; fp32_dest_acc_en
-            // false; dst_full_sync_en false = double_buffer_dest true), so an all-default Gen1 config
+            // Metal 2.0 ComputeHardwareConfig defaults match those field for field (HiFi4; math_approx_mode
+            // false = Precise SFPU; bfp8_pack_precise false = Approximate pack in config_1xx; fp32_dest_acc_en
+            // false; dst_full_sync_en false = double_buffer_dest true), so an all-default ComputeHardwareConfig
             // reproduces the legacy settings exactly.
-            .hw_config = ComputeHardwareConfig{ComputeGen1Config{}},
+            .hw_config = ComputeHardwareConfig{},
         });
         work_unit_kernels.push_back(COMPUTE);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -557,7 +557,7 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactorySingleRowSingleCore::
                 {"W_index_bytes", W_index_bytes},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"core_loop_count"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -581,10 +581,10 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactorySingleRowSingleCore::
                 {"W_value_bytes", W_value_bytes},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"core_loop_count"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
-    ComputeGen1Config compute_hw_config{.enable_32_bit_dest = is_32_bit_data};
+    ComputeHardwareConfig compute_hw_config{.enable_32_bit_dest = is_32_bit_data};
     // UINT16 keys also route through the fp32 sort path (sort_value_cb_data_format
     // is Float32 for UINT16 — the reader's software conversion writes Float32 into
     // INPUT_TENSOR), so treat UINT16 the same as Float32 here: the value buffers
@@ -1292,8 +1292,6 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactoryCrossCoreDataExchange
     // -----------------------------------------------------------------------
     // Kernels
     // -----------------------------------------------------------------------
-    auto* const device = tensor_args.input_tensor.device();
-
     spec.kernels.push_back(KernelSpec{
         .unique_id = READER,
         .source = "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/"
@@ -1327,7 +1325,7 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactoryCrossCoreDataExchange
                 {"input_tensor_tile_size_bytes", input_tensor_tile_size},
                 {"index_tensor_tile_size_bytes", index_tensor_tile_size},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -1351,10 +1349,10 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactoryCrossCoreDataExchange
                 {"is_32_bit_data", static_cast<uint32_t>(is_32_bit_data)},
                 {"W_value_slice_bytes", W_value_slice_bytes},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
-    ComputeGen1Config compute_hw_config{.enable_32_bit_dest = is_32_bit_data};
+    ComputeHardwareConfig compute_hw_config{.enable_32_bit_dest = is_32_bit_data};
     if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
         // Only buffers this configuration actually binds may appear here, and an absent entry
         // means UnpackToSrc. Float32 operands are unpacked straight to Dest so the sort keeps full
@@ -1989,7 +1987,7 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactorySingleRowMultiCore::c
                   "end_core_physical_coord_y",
                   "number_of_workers",
                   "num_multicast_dests"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // The workers read their input from the value-output buffer: the coordinator has already copied
@@ -2026,7 +2024,7 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactorySingleRowMultiCore::c
         // of one per worker node.
         .runtime_arg_schema =
             {.common_runtime_arg_names = {"coordinator_core_physical_coord_x", "coordinator_core_physical_coord_y"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -2057,10 +2055,10 @@ ttnn::device_operation::ProgramArtifacts SortProgramFactorySingleRowMultiCore::c
         // See the reader above: one fixed coordinator core means one value for every worker.
         .runtime_arg_schema =
             {.common_runtime_arg_names = {"coordinator_core_physical_coord_x", "coordinator_core_physical_coord_y"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
-    ComputeGen1Config compute_hw_config{.enable_32_bit_dest = is_32_bit_data};
+    ComputeHardwareConfig compute_hw_config{.enable_32_bit_dest = is_32_bit_data};
     if (input_tensor_cb_data_format == tt::DataFormat::Float32 || is_uint16_input) {
         // Only buffers this configuration actually binds may appear here, and an absent entry
         // means UnpackToSrc. Float32 operands are unpacked straight to Dest so the sort keeps full

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -132,7 +132,7 @@ ttnn::device_operation::ProgramArtifacts SplitProgramFactory::create_program_art
                 {"y_stride", y_stride_read},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"in0_tensor_tile_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // N writers of ONE source, one per chunk. Each writer is bound to its chunk's output tensor and is
@@ -177,7 +177,7 @@ ttnn::device_operation::ProgramArtifacts SplitProgramFactory::create_program_art
                     {"y_stride", y_stride_write},
                 },
             .runtime_arg_schema = {.runtime_arg_names = {"out_tensor_tile_id"}},
-            .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_writer_datamovement_config(),
         });
 
         tensor_parameters.push_back(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
@@ -138,7 +138,7 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreDefaultFac
              {"aligned_page_size", aligned_page_size},
              {"size_of_valid_data_in_last_page_in_row", size_of_valid_data_in_last_page_in_row}},
         .runtime_arg_schema = {.runtime_arg_names = {"padded_X_size", "pad_value", "start_page_id", "n_block_reps"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     /** writer
@@ -155,21 +155,20 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreDefaultFac
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     /** compute
      */
     // Legacy ComputeConfigDescriptor set only fp32_dest_acc_en and unpack_to_dest_mode; every other
-    // field stayed at its default, which ComputeGen1Config reproduces exactly. The legacy
+    // field stayed at its default, which ComputeHardwareConfig reproduces exactly. The legacy
     // unpack_to_dest_mode vector was Default everywhere except v[c_0] = UnpackToDestFp32 when
     // fp32_llk_acc, i.e. UnpackToDest on the tilize input DFB (Default == UnpackToSrc is expressed by
     // omitting the entry). Both compute KernelSpecs get the same config, as in legacy.
-    ComputeGen1Config compute_gen1{.enable_32_bit_dest = fp32_llk_acc};
+    ComputeHardwareConfig compute_hw{.enable_32_bit_dest = fp32_llk_acc};
     if (fp32_llk_acc) {
-        compute_gen1.unpack_modes = ComputeUnpackModes{{IN, UnpackMode::UnpackToDest}};
+        compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{IN, UnpackMode::UnpackToDest}};
     }
-    ComputeHardwareConfig compute_hw{std::move(compute_gen1)};
 
     // One KernelSpec per legacy compute KernelDescriptor: the per-group block count stays a CTA, so
     // the two groups keep their distinct specialization instead of collapsing onto a runtime arg.

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_sharded_program_factory.cpp
@@ -162,7 +162,7 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreShardedFac
                   "num_padded_rows",
                   "num_batches",
                   "packed_pad_value"}},
-        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     /** writer
@@ -177,21 +177,20 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreShardedFac
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     /** compute
      */
     // Legacy ComputeConfigDescriptor set only fp32_dest_acc_en and unpack_to_dest_mode; every other
-    // field stayed at its default, which ComputeGen1Config reproduces exactly. The legacy
+    // field stayed at its default, which ComputeHardwareConfig reproduces exactly. The legacy
     // unpack_to_dest_mode vector was Default everywhere except v[c_0] = UnpackToDestFp32 when
     // fp32_llk_acc — c_0 is this factory's staging buffer, i.e. the tilize input DFB (Default ==
     // UnpackToSrc is expressed by omitting the entry).
-    ComputeGen1Config compute_gen1{.enable_32_bit_dest = fp32_llk_acc};
+    ComputeHardwareConfig compute_hw{.enable_32_bit_dest = fp32_llk_acc};
     if (fp32_llk_acc) {
-        compute_gen1.unpack_modes = ComputeUnpackModes{{STAGE, UnpackMode::UnpackToDest}};
+        compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{STAGE, UnpackMode::UnpackToDest}};
     }
-    ComputeHardwareConfig compute_hw{std::move(compute_gen1)};
 
     spec.kernels.push_back(KernelSpec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
@@ -180,7 +180,7 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingSingleCoreFactory::
                   "num_blocks_w_diff",
                   "block_row_size",
                   "block_row_leftover_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---------------------------------------------------------------------
@@ -197,22 +197,21 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingSingleCoreFactory::
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---------------------------------------------------------------------
     // Compute
     // ---------------------------------------------------------------------
     // Legacy ComputeConfigDescriptor set only fp32_dest_acc_en and unpack_to_dest_mode; every other
-    // field stayed at its default, which ComputeGen1Config reproduces exactly. The legacy
+    // field stayed at its default, which ComputeHardwareConfig reproduces exactly. The legacy
     // unpack_to_dest_mode vector was Default everywhere except v[c_0] = UnpackToDestFp32 when
     // fp32_llk_acc, i.e. UnpackToDest on the tilize input DFB (Default == UnpackToSrc is expressed by
     // omitting the entry).
-    ComputeGen1Config compute_gen1{.enable_32_bit_dest = fp32_llk_acc};
+    ComputeHardwareConfig compute_hw{.enable_32_bit_dest = fp32_llk_acc};
     if (fp32_llk_acc) {
-        compute_gen1.unpack_modes = ComputeUnpackModes{{IN, UnpackMode::UnpackToDest}};
+        compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{IN, UnpackMode::UnpackToDest}};
     }
-    ComputeHardwareConfig compute_hw{std::move(compute_gen1)};
 
     spec.kernels.push_back(KernelSpec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -98,7 +98,7 @@ ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_progr
         .compile_time_args = {{"page_size", src0_buffer->aligned_page_size()}, {"read_size", stick_size}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"N", "C", "HtWt", "batch_step", "channel_step", "num_pages", "start_id", "hw", "n"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -114,7 +114,7 @@ ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_progr
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = {{"page_size", dst_buffer->aligned_page_size()}, {"write_size", stick_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     });
 
     spec.work_units.push_back(WorkUnitSpec{

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -171,7 +171,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_pro
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks_per_core_read", "num_read_per_barrier", "start_id", "curr_c", "curr_h", "curr_n"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -186,7 +186,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_pro
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = {{"W_size_bytes", stick_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_sticks_per_core_read", "num_read_per_barrier", "start_id"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     });
 
     spec.work_units.push_back(WorkUnitSpec{

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -215,7 +215,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFacto
              {"tile_height", 1u},
              {"tile_width", 1u}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -241,7 +241,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFacto
              {"face_width", face_shape[1]}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_tile_idx", "end_tile_idx", "start_padding_tile_idx", "end_padding_tile_idx"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     };
 
     if (needs_padding) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -113,7 +113,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_
                   "ct",
                   "ctoffs",
                   "wt"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     };
     reader.compile_time_args.insert({"subtile_line_bytes", sub_tile_line_bytes});
     reader.compile_time_args.insert({"float32_dtype", dfb_data_format == tt::DataFormat::Float32 ? 1u : 0u});
@@ -147,7 +147,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     };
 
     spec.kernels.push_back(std::move(reader));

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -110,7 +110,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
             .endpoint_type = DFBEndpointType::PRODUCER,
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     };
     if (row_major) {
         reader.source =
@@ -135,7 +135,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
     // ---- writer ----
     KernelSpec writer{
         .unique_id = WRITER,
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     };
     if (row_major) {
         writer.source =
@@ -178,8 +178,8 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
 
     // Legacy built a ComputeConfigDescriptor directly (no TTNN ComputeKernelConfig feeding it),
     // setting only fp32_dest_acc_en and unpack_to_dest_mode; every other field kept its Metal
-    // default, which ComputeGen1Config reproduces.
-    ComputeGen1Config compute_hw{.enable_32_bit_dest = fp32_dest_acc_en};
+    // default, which ComputeHardwareConfig reproduces.
+    ComputeHardwareConfig compute_hw{.enable_32_bit_dest = fp32_dest_acc_en};
     if (src0_dfb_data_format == tt::DataFormat::Float32) {
         compute_hw.unpack_modes.insert({IN0, UnpackMode::UnpackToDest});
         if (row_major) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -91,7 +91,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::creat
             .endpoint_type = DFBEndpointType::PRODUCER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -104,13 +104,13 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::creat
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     });
 
     // Legacy built a ComputeConfigDescriptor directly, setting only fp32_dest_acc_en and
-    // unpack_to_dest_mode; every other field kept its Metal default, which ComputeGen1Config
+    // unpack_to_dest_mode; every other field kept its Metal default, which ComputeHardwareConfig
     // reproduces.
-    ComputeGen1Config compute_hw{.enable_32_bit_dest = fp32_dest_acc_en};
+    ComputeHardwareConfig compute_hw{.enable_32_bit_dest = fp32_dest_acc_en};
     if (src0_dfb_data_format == tt::DataFormat::Float32) {
         compute_hw.unpack_modes.insert({IN0, UnpackMode::UnpackToDest});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -40,8 +40,6 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
     constexpr const char* COMPUTE_SRC =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_metal2.cpp";
 
-    auto* device = a.device();
-
     tt::DataFormat input_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_data_format);
     tt::DataFormat output_data_format = datatype_to_dataformat_converter(output.dtype());
@@ -87,7 +85,7 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = SRC0, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -96,10 +94,10 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+    ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
     if (fp32_dest_acc_en) {
         compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -47,8 +47,6 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/"
         "untilize_variable_num_blocks_metal2.cpp";
 
-    auto* device = a.device();
-
     tt::DataFormat input_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_data_format);
     tt::DataFormat output_data_format = datatype_to_dataformat_converter(output.dtype());
@@ -122,7 +120,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
              {"num_shards", num_shards},
              {"num_cores", num_compute_cores}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     uint32_t output_element_size = output.element_size();
@@ -164,10 +162,10 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
              {"output_tensor_width", output_tensor_width},
              {"output_tensor_height", output_tensor_height}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+    ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
     if (fp32_dest_acc_en) {
         compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -111,7 +111,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
             .dfb_spec_name = SRC0, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -124,7 +124,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_core", "tile_width_size", "start_stick_id", "offset_within_stick"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;
@@ -134,7 +134,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
     // One KernelSpec per legacy compute KernelDescriptor (full + cliff), preserving the per-group
     // block-count multiplicity across disjoint WorkUnitSpecs.
     auto make_compute = [&](const KernelSpecName& id, uint32_t per_core_block_cnt) {
-        ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+        ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
         if (fp32_dest_acc_en) {
             compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -157,7 +157,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
         .unique_id = READER,
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = SRC0, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (use_block_reader) {
         reader_spec.source = std::filesystem::path{READER_BLOCK_SRC};
@@ -211,7 +211,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
                   "num_unpadded_cols_per_input_block",
                   "width_wise_output_block_start_index",
                   "num_cols_already_processed_in_first_output_block"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Compute kernel(s) — full + cliff (cliff only for interleaved input).
@@ -220,7 +220,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
         compute_defines.insert({"DST_ACCUM_MODE", "1"});
     }
     auto make_compute = [&](const KernelSpecName& id) {
-        ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+        ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
         if (fp32_dest_acc_en) {
             compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -44,8 +44,6 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
     constexpr const char* COMPUTE_SRC =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_metal2.cpp";
 
-    auto* device = a.device();
-
     tt::DataFormat input_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_data_format);
     tt::DataFormat output_data_format = datatype_to_dataformat_converter(output.dtype());
@@ -109,7 +107,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
             .dfb_spec_name = SRC0, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -122,10 +120,10 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_core", "tile_width_size", "start_stick_id", "offset_within_stick"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+    ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
     if (fp32_dest_acc_en) {
         compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -46,8 +46,6 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
     constexpr const char* COMPUTE_SRC =
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_metal2.cpp";
 
-    auto* device = a.device();
-
     const CoreCoord node{0, 0};
 
     tt::DataFormat input_data_format = datatype_to_dataformat_converter(a.dtype());
@@ -127,7 +125,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
             .dfb_spec_name = SRC0, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -143,12 +141,12 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
              {"num_blocks_per_output_column_row", num_blocks_per_column_row},
              {"num_tiles_per_output_block", num_tiles_per_block},
              {"output_single_block_width_size", output_single_block_width_size}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Compute kernel (untilize). ComputeConfig set directly: only fp32_dest_acc_en is set by the
     // legacy op -> enable_32_bit_dest; the fp32 unpack mode mirrors the legacy UnpackToDestFp32.
-    ComputeGen1Config compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
+    ComputeHardwareConfig compute_cfg{.enable_32_bit_dest = fp32_dest_acc_en};
     if (fp32_dest_acc_en) {
         compute_cfg.unpack_modes.insert({SRC0, UnpackMode::UnpackToDest});
     }

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_rm_program_factory.cpp
@@ -287,7 +287,7 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsRMProgramFactory::create_prog
                 {"last_chunk_size", last_chunk_size},
             },
         .runtime_arg_schema = {.runtime_arg_names = std::move(reader_rta_names)},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // -----------------------------------------------------------------------
@@ -320,7 +320,7 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsRMProgramFactory::create_prog
                         {"last_chunk_size", last_chunk_size},
                     },
                 .runtime_arg_schema = {.runtime_arg_names = {"num_sticks", "start_id"}},
-                .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+                .hw_config = ttnn::create_writer_datamovement_config(),
             });
         } else {
             spec.kernels.push_back(KernelSpec{
@@ -333,7 +333,7 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsRMProgramFactory::create_prog
                         TensorBinding{.tensor_parameter_name = OUTPUT_PARAM, .accessor_name = "dst"},
                     },
                 .runtime_arg_schema = {.runtime_arg_names = {"stick_size", "num_sticks", "start_id"}},
-                .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+                .hw_config = ttnn::create_writer_datamovement_config(),
             });
         }
     }

--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_tilized_indices_program_factory.cpp
@@ -220,7 +220,7 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsTilizedIndicesProgramFactory:
             },
         .runtime_arg_schema =
             {.runtime_arg_names = {"tile_offset", "face_offset", "num_rows", "curr_col", "starting_index"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // -----------------------------------------------------------------------
@@ -242,7 +242,7 @@ ttnn::device_operation::ProgramArtifacts EmbeddingsTilizedIndicesProgramFactory:
                 TensorBinding{.tensor_parameter_name = OUTPUT_PARAM, .accessor_name = "dst"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"stick_size", "num_sticks", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     spec.work_units.push_back(WorkUnitSpec{

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -419,8 +419,8 @@ RotaryEmbeddingIndexedDeviceOperation::MeshWorkloadFactory::create_at(
             TensorParameter{.unique_id = METADATA_PARAM, .spec = tensor_args.metadata->mesh_tensor().tensor_spec()});
     }
 
-    const ComputeHardwareConfig compute_hw_config =
-        ComputeGen1Config{.fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
+    const ComputeHardwareConfig compute_hw_config{
+        .fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
 
     const KernelSpec::CompilerOptions::Defines reload_define{{"RELOAD_IMPL", use_reload_impl ? "1" : "0"}};
     KernelSpec::CompilerOptions::Defines reader_defines = reload_define;
@@ -475,7 +475,7 @@ RotaryEmbeddingIndexedDeviceOperation::MeshWorkloadFactory::create_at(
              {"my_sp_coord", my_sp_coord},
              {"sp_factor", sp_factor}},
         .runtime_arg_schema = reader_schema,
-        .hw_config = create_reader_datamovement_config(mesh_device->arch())};
+        .hw_config = create_reader_datamovement_config()};
 
     // ------------------------------------------------------------------ writer + compute (reused llama)
     KernelSpec writer_spec{
@@ -492,7 +492,7 @@ RotaryEmbeddingIndexedDeviceOperation::MeshWorkloadFactory::create_at(
         .compile_time_args =
             {{"n_heads", n_heads}, {"Wt", head_dim_t}, {"Ht", seq_len_t}, {"rotary_Ht", rotary_seq_len_t}},
         .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
-        .hw_config = create_writer_datamovement_config(mesh_device->arch())};
+        .hw_config = create_writer_datamovement_config()};
 
     KernelSpec compute_spec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/apply_twiddles_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/apply_twiddles_factory.cpp
@@ -135,10 +135,10 @@ ttnn::device_operation::ProgramArtifacts ApplyTwiddlesFactory::create_program_ar
              TensorBinding{.tensor_parameter_name = AT_TW_I, .accessor_name = "tw_i"}},
         .compile_time_args = {{"n1", N1}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_row", "num_rows", "n2"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
-    KernelSpec writer = shared::make_writer(device_raw->arch(), N1, is_bf16);
+    KernelSpec writer = shared::make_writer(N1, is_bf16);
     KernelSpec compute = shared::make_compute();
 
     KernelRunArgs reader_run_args{.kernel = AT_READER};

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/apply_twiddles_shared.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/apply_twiddles_shared.hpp
@@ -132,7 +132,7 @@ inline KernelSpec::CompilerOptions::Defines reader_defines(bool is_bf16) {
 // `row_len` is the number of valid elements per row (N1 for apply_twiddles,
 // P for the xl and complex_mul variants); the writer emits exactly that many
 // so the tile's padding lanes never reach DRAM.
-inline KernelSpec make_writer(tt::ARCH arch, uint32_t row_len, bool is_bf16) {
+inline KernelSpec make_writer(uint32_t row_len, bool is_bf16) {
     Group<DFBBinding> bindings = {
         DFBBinding{.dfb_spec_name = B_R, .accessor_name = "b_r", .endpoint_type = DFBEndpointType::CONSUMER},
         DFBBinding{.dfb_spec_name = B_I, .accessor_name = "b_i", .endpoint_type = DFBEndpointType::CONSUMER},
@@ -160,7 +160,7 @@ inline KernelSpec make_writer(tt::ARCH arch, uint32_t row_len, bool is_bf16) {
              TensorBinding{.tensor_parameter_name = OUT_I, .accessor_name = "out_i"}},
         .compile_time_args = {{"n1", row_len}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_row", "num_rows"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 }
 
@@ -171,14 +171,13 @@ inline KernelSpec make_writer(tt::ARCH arch, uint32_t row_len, bool is_bf16) {
 // outright; the legacy descriptor asked for unpack-to-dest on every fp32
 // buffer, which for the consumed ones is UnpackToDest.
 inline KernelSpec make_compute() {
-    ComputeGen1Config gen1{
+    ComputeHardwareConfig compute_hw{
         .fpu_math_fidelity = MathFidelity::HiFi4,
         .enable_32_bit_dest = true,
     };
     for (const auto& id : {A_R, A_I, T_R, T_I, TMP_R, TMP_I}) {
-        gen1.unpack_modes.emplace(id, UnpackMode::UnpackToDest);
+        compute_hw.unpack_modes.emplace(id, UnpackMode::UnpackToDest);
     }
-    ComputeHardwareConfig compute_hw = std::move(gen1);
 
     return KernelSpec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/apply_twiddles_xl_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/apply_twiddles_xl_factory.cpp
@@ -146,10 +146,10 @@ ttnn::device_operation::ProgramArtifacts ApplyTwiddlesXlFactory::create_program_
              TensorBinding{.tensor_parameter_name = XL_D_I, .accessor_name = "d_i"}},
         .compile_time_args = {{"p", P}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_row", "num_rows", "big_modulus"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
-    KernelSpec writer = shared::make_writer(device_raw->arch(), P, is_bf16);
+    KernelSpec writer = shared::make_writer(P, is_bf16);
     KernelSpec compute = shared::make_compute();
 
     KernelRunArgs reader_run_args{.kernel = XL_READER};

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/batched_stockham_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/batched_stockham_factory.cpp
@@ -78,25 +78,25 @@ ttnn::device_operation::ProgramArtifacts BatchedStockhamFactory::create_program_
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/batch_fft_reader.cpp",
         .compiler_options = {.defines = reader_defines},
         .dfb_bindings = shared::reader_bindings(is_bf16, false),
-        .tensor_bindings = {
-            {.tensor_parameter_name = shared::IN_R, .accessor_name = "in_r"},
-            {.tensor_parameter_name = shared::IN_I, .accessor_name = "in_i"},
-            {.tensor_parameter_name = shared::TW_R, .accessor_name = "tw_r"},
-            {.tensor_parameter_name = shared::TW_I, .accessor_name = "tw_i"}},
+        .tensor_bindings =
+            {{.tensor_parameter_name = shared::IN_R, .accessor_name = "in_r"},
+             {.tensor_parameter_name = shared::IN_I, .accessor_name = "in_i"},
+             {.tensor_parameter_name = shared::TW_R, .accessor_name = "tw_r"},
+             {.tensor_parameter_name = shared::TW_I, .accessor_name = "tw_i"}},
         .compile_time_args = {{"sub_n", N}, {"log2_sub_n", log2u_bs(N)}, {"bit_reverse_on_load", 1u}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_tile_idx", "batch_per_core", "noc_x", "noc_y"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch())};
+        .hw_config = ttnn::create_reader_datamovement_config()};
     KernelSpec writer{
         .unique_id = shared::WRITER,
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/batch_fft_writer.cpp",
         .compiler_options = {.defines = writer_defines},
         .dfb_bindings = shared::writer_bindings(is_bf16, false),
-        .tensor_bindings = {
-            {.tensor_parameter_name = shared::OUT_R, .accessor_name = "out_r"},
-            {.tensor_parameter_name = shared::OUT_I, .accessor_name = "out_i"}},
+        .tensor_bindings =
+            {{.tensor_parameter_name = shared::OUT_R, .accessor_name = "out_r"},
+             {.tensor_parameter_name = shared::OUT_I, .accessor_name = "out_i"}},
         .compile_time_args = {{"sub_n", N}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_tile_idx", "batch_per_core"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch())};
+        .hw_config = ttnn::create_writer_datamovement_config()};
     KernelSpec compute = shared::make_compute(log2u_bs(N));
 
     KernelRunArgs reader_args{.kernel = shared::READER};

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/complex_mul_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/complex_mul_factory.cpp
@@ -111,10 +111,10 @@ ttnn::device_operation::ProgramArtifacts ComplexMulFactory::create_program_artif
              TensorBinding{.tensor_parameter_name = CM_B_I, .accessor_name = "b_i"}},
         .compile_time_args = {{"p", P}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_row", "num_rows"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
-    KernelSpec writer = shared::make_writer(device_raw->arch(), P, is_bf16);
+    KernelSpec writer = shared::make_writer(P, is_bf16);
     KernelSpec compute = shared::make_compute();
 
     KernelRunArgs reader_run_args{.kernel = CM_READER};

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/fft_radix_pass_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/fft_radix_pass_factory.cpp
@@ -121,18 +121,18 @@ ttnn::device_operation::ProgramArtifacts FftRadixPassFactory::create_program_art
         .compile_time_args = {{"sub_n", N}, {"log2_sub_n", log2u_rp(N)}, {"bit_reverse_on_load", 1u}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"base_tile_idx", "batch_per_core", "noc_x", "noc_y", "pt_modulus", "pt_stride"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch())};
+        .hw_config = ttnn::create_reader_datamovement_config()};
     KernelSpec writer{
         .unique_id = shared::WRITER,
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/radix_pass_writer.cpp",
         .compiler_options = {.defines = writer_defines},
         .dfb_bindings = shared::writer_bindings(is_bf16, apply_pt),
-        .tensor_bindings = {
-            {.tensor_parameter_name = shared::OUT_R, .accessor_name = "out_r"},
-            {.tensor_parameter_name = shared::OUT_I, .accessor_name = "out_i"}},
+        .tensor_bindings =
+            {{.tensor_parameter_name = shared::OUT_R, .accessor_name = "out_r"},
+             {.tensor_parameter_name = shared::OUT_I, .accessor_name = "out_i"}},
         .compile_time_args = {{"sub_n", N}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_tile_idx", "batch_per_core", "output_scale_bits"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch())};
+        .hw_config = ttnn::create_writer_datamovement_config()};
     KernelSpec compute = shared::make_compute(log2u_rp(N));
 
     KernelRunArgs reader_args{.kernel = shared::READER};

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/rebank_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/rebank_rm_factory.cpp
@@ -122,32 +122,29 @@ ttnn::device_operation::ProgramArtifacts RebankRmFactory::create_program_artifac
     KernelSpec reader{
         .unique_id = RB_READER,
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/rebank_rm_reader.cpp",
-        .dfb_bindings =
-            {DFBBinding{
-                .dfb_spec_name = RB_BLOCK,
-                .accessor_name = "block",
-                .endpoint_type = DFBEndpointType::PRODUCER,
-            }},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = RB_BLOCK,
+            .accessor_name = "block",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = RB_INPUT, .accessor_name = "src"}},
-        .compile_time_args =
-            {{"chunk", chunk}, {"chunks_per_row", chunks_per_row}, {"is_bf16", is_bf16_flag}},
+        .compile_time_args = {{"chunk", chunk}, {"chunks_per_row", chunks_per_row}, {"is_bf16", is_bf16_flag}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_unit", "num_units"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
         .unique_id = RB_WRITER,
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/rebank_rm_writer.cpp",
-        .dfb_bindings =
-            {DFBBinding{
-                .dfb_spec_name = RB_BLOCK,
-                .accessor_name = "block",
-                .endpoint_type = DFBEndpointType::CONSUMER,
-            }},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = RB_BLOCK,
+            .accessor_name = "block",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = RB_OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = {{"chunk", chunk}, {"is_bf16", is_bf16_flag}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_unit", "num_units"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = RB_READER};

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/rebank_rm_merge_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/rebank_rm_merge_factory.cpp
@@ -115,35 +115,30 @@ ttnn::device_operation::ProgramArtifacts RebankRmMergeFactory::create_program_ar
 
     KernelSpec reader{
         .unique_id = RM_READER,
-        .source =
-            "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/rebank_rm_merge_reader.cpp",
-        .dfb_bindings =
-            {DFBBinding{
-                .dfb_spec_name = RM_BLOCK,
-                .accessor_name = "block",
-                .endpoint_type = DFBEndpointType::PRODUCER,
-            }},
+        .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/rebank_rm_merge_reader.cpp",
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = RM_BLOCK,
+            .accessor_name = "block",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = RM_INPUT, .accessor_name = "src"}},
         .compile_time_args = {{"chunk", N1}, {"is_bf16", is_bf16_flag}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_unit", "num_units"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
         .unique_id = RM_WRITER,
-        .source =
-            "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/rebank_rm_merge_writer.cpp",
-        .dfb_bindings =
-            {DFBBinding{
-                .dfb_spec_name = RM_BLOCK,
-                .accessor_name = "block",
-                .endpoint_type = DFBEndpointType::CONSUMER,
-            }},
+        .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/rebank_rm_merge_writer.cpp",
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = RM_BLOCK,
+            .accessor_name = "block",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = RM_OUTPUT, .accessor_name = "dst"}},
-        .compile_time_args =
-            {{"chunk", N1}, {"chunks_per_merge", chunks_per_merge}, {"is_bf16", is_bf16_flag}},
+        .compile_time_args = {{"chunk", N1}, {"chunks_per_merge", chunks_per_merge}, {"is_bf16", is_bf16_flag}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_unit", "num_units"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = RM_READER};

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/stockham_program_spec.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/stockham_program_spec.hpp
@@ -137,11 +137,10 @@ inline Group<DFBBinding> writer_bindings(bool is_bf16, bool apply_post_twiddle) 
 }
 
 inline KernelSpec make_compute(uint32_t log2_sub_n) {
-    ComputeGen1Config gen1{.fpu_math_fidelity = MathFidelity::HiFi4, .enable_32_bit_dest = true};
+    ComputeHardwareConfig compute_hw{.fpu_math_fidelity = MathFidelity::HiFi4, .enable_32_bit_dest = true};
     for (const auto& name : {EVEN_R, EVEN_I, ODD_R, ODD_I, TWIDDLE_R, TWIDDLE_I, TMP_R, TMP_I, TW_ODD_R, TW_ODD_I}) {
-        gen1.unpack_modes.emplace(name, UnpackMode::UnpackToDest);
+        compute_hw.unpack_modes.emplace(name, UnpackMode::UnpackToDest);
     }
-    ComputeHardwareConfig compute_hw = std::move(gen1);
     return KernelSpec{
         .unique_id = COMPUTE,
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/compute/batch_fft_compute.cpp",

--- a/ttnn/cpp/ttnn/operations/experimental/fft/device/transpose_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fft/device/transpose_rm_factory.cpp
@@ -97,31 +97,29 @@ ttnn::device_operation::ProgramArtifacts TransposeRmFactory::create_program_arti
     KernelSpec reader{
         .unique_id = TR_READER,
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/transpose_rm_reader.cpp",
-        .dfb_bindings =
-            {DFBBinding{
-                .dfb_spec_name = TR_BLOCK,
-                .accessor_name = "block",
-                .endpoint_type = DFBEndpointType::PRODUCER,
-            }},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = TR_BLOCK,
+            .accessor_name = "block",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = TR_INPUT, .accessor_name = "src"}},
         .compile_time_args = {{"a_tiles", A_tiles}, {"c_tiles", C_tiles}, {"is_bf16", is_bf16_flag}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_unit", "num_units"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
         .unique_id = TR_WRITER,
         .source = "ttnn/cpp/ttnn/operations/experimental/fft/device/kernels/dataflow/transpose_rm_writer.cpp",
-        .dfb_bindings =
-            {DFBBinding{
-                .dfb_spec_name = TR_BLOCK,
-                .accessor_name = "block",
-                .endpoint_type = DFBEndpointType::CONSUMER,
-            }},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = TR_BLOCK,
+            .accessor_name = "block",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = TR_OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = {{"a_tiles", A_tiles}, {"c_tiles", C_tiles}, {"is_bf16", is_bf16_flag}},
         .runtime_arg_schema = {.runtime_arg_names = {"base_unit", "num_units"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device_raw->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = TR_READER};

--- a/ttnn/cpp/ttnn/operations/experimental/indexed_page_cache/device/indexed_fused_update_cache/indexed_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexed_page_cache/device/indexed_fused_update_cache/indexed_fused_update_cache_program_factory.cpp
@@ -97,7 +97,7 @@ ttnn::device_operation::ProgramArtifacts IndexedFusedUpdateCacheProgramFactory::
              {"bytes_per_element", bytes_per_element},
              {"scratch_buffer_depth", scratch_buffer_depth}},
         .runtime_arg_schema = {.runtime_arg_names = {"source_rows", "worker_start", "worker_stride"}},
-        .hw_config = ttnn::create_reader_datamovement_config(cache1.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/experimental/kda/affine_exclusive_scan/device/affine_exclusive_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/affine_exclusive_scan/device/affine_exclusive_scan_program_factory.cpp
@@ -26,7 +26,6 @@ ttnn::device_operation::ProgramArtifacts AffineExclusiveScanProgramFactory::crea
     const auto& initial_state = in.initial_state.mesh_tensor();
     const auto& output = outputs[0].mesh_tensor();
     const auto& device = a.device();
-    const auto arch = device.arch();
 
     const uint32_t key_tiles = attrs.key_dim / tt::constants::TILE_WIDTH;
     const uint32_t value_tiles = attrs.value_dim / tt::constants::TILE_WIDTH;
@@ -140,12 +139,12 @@ ttnn::device_operation::ProgramArtifacts AffineExclusiveScanProgramFactory::crea
         .compile_time_args =
             {{"Kt", key_tiles}, {"Vt", value_tiles}, {"BH", attrs.batch_heads}, {"G", groups_per_head}},
         .runtime_arg_schema = {.runtime_arg_names = {"worker_index", "group"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_common_runtime_varargs = 2 * group_heads},
     };
 
-    auto compute_hardware_config = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
-    auto& unpack_modes = tt::tt_metal::experimental::unpack_modes(compute_hardware_config);
+    auto compute_hardware_config = ttnn::to_compute_hardware_config(attrs.compute_kernel_config);
+    auto& unpack_modes = compute_hardware_config.unpack_modes;
     for (const auto& name : {local_a_dfb_name, local_b_dfb_name, from_remote_affine_dfb_name, initial_state_dfb_name}) {
         unpack_modes[name] = tt::tt_metal::UnpackMode::UnpackToSrc;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/prepare_chunk_recurrence/device/prepare_chunk_recurrence_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/prepare_chunk_recurrence/device/prepare_chunk_recurrence_program_factory.cpp
@@ -34,7 +34,6 @@ ttnn::device_operation::ProgramArtifacts PrepareChunkRecurrenceProgramFactory::c
     const auto& g = in.g.mesh_tensor();
     const auto& beta = in.beta.mesh_tensor();
     const auto& device = q.device();
-    const auto arch = device.arch();
 
     const uint32_t num_heads = attrs.num_heads;
     const uint32_t num_chunks = attrs.num_chunks;
@@ -165,7 +164,7 @@ ttnn::device_operation::ProgramArtifacts PrepareChunkRecurrenceProgramFactory::c
             },
         .compile_time_args = {{"Ct", Ct}, {"Kt", Kt}, {"Vt", Vt}},
         .runtime_arg_schema = {.runtime_arg_names = {"work_item_start", "work_item_count", "num_chunks", "num_heads"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     m2::KernelSpec writer{
@@ -195,11 +194,11 @@ ttnn::device_operation::ProgramArtifacts PrepareChunkRecurrenceProgramFactory::c
             },
         .compile_time_args = {{"Ct", Ct}, {"Kt", Kt}, {"Vt", Vt}},
         .runtime_arg_schema = {.runtime_arg_names = {"work_item_start", "work_item_count"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
-    auto& unpack_modes = m2::unpack_modes(compute_hw);
+    auto compute_hw = ttnn::to_compute_hardware_config(attrs.compute_kernel_config);
+    auto& unpack_modes = compute_hw.unpack_modes;
     unpack_modes[q_dfb] = UnpackMode::UnpackToSrc;
     unpack_modes[k_dfb] = UnpackMode::UnpackToSrc;
     unpack_modes[v_dfb] = UnpackMode::UnpackToSrc;

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -38,7 +38,6 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const auto& k = outputs[1].mesh_tensor();
     const auto& v = outputs[2].mesh_tensor();
     const auto& device = input.device();
-    const auto arch = device.arch();
 
     const uint32_t Mt = attrs.sequence / tt::constants::TILE_HEIGHT;
     const uint32_t Qt = attrs.q_width / tt::constants::TILE_WIDTH;
@@ -114,7 +113,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
             },
         .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     tt::tt_metal::experimental::KernelSpec writer{
@@ -132,7 +131,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
             },
         .compile_time_args = {{"Qt", Qt}, {"Kt", Kt}, {"Vt", Vt}, {"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     tt::tt_metal::experimental::KernelSpec compute{
@@ -160,7 +159,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
             },
         .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_count"}},
-        .hw_config = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config),
+        .hw_config = ttnn::to_compute_hardware_config(attrs.compute_kernel_config),
     };
 
     tt::tt_metal::experimental::KernelRunArgs reader_run_args{.kernel = reader_kernel_name};

--- a/ttnn/cpp/ttnn/operations/experimental/kda/recurrent_chunk_scan/device/recurrent_chunk_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/recurrent_chunk_scan/device/recurrent_chunk_scan_program_factory.cpp
@@ -65,7 +65,6 @@ ttnn::device_operation::ProgramArtifacts RecurrentChunkScanProgramFactory::creat
     const auto& final_decay_tensor = in.final_decay.mesh_tensor();
     const auto& t_inv_tensor = in.t_inv.mesh_tensor();
     const auto& device = v_beta_tensor.device();
-    const auto arch = device.arch();
 
     const uint32_t BH = attrs.batch_heads;
     const uint32_t NC = attrs.num_chunks;
@@ -184,7 +183,7 @@ ttnn::device_operation::ProgramArtifacts RecurrentChunkScanProgramFactory::creat
              {"Vt_full", Vt_full},
              {"summary_pair", static_cast<uint32_t>(summary)}},
         .runtime_arg_schema = {.runtime_arg_names = {"head", "value_block", "num_chunks"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (!summary) {
         reader.tensor_bindings.push_back(tt::tt_metal::experimental::TensorBinding{q_decay_tensor_name, "q_decay"});
@@ -217,11 +216,11 @@ ttnn::device_operation::ProgramArtifacts RecurrentChunkScanProgramFactory::creat
              {"Vt_full", Vt_full},
              {"summary_pair", static_cast<uint32_t>(summary)}},
         .runtime_arg_schema = {.runtime_arg_names = {"head", "value_block", "num_chunks"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
-    auto& unpack_modes = tt::tt_metal::experimental::unpack_modes(compute_hw);
+    auto compute_hw = ttnn::to_compute_hardware_config(attrs.compute_kernel_config);
+    auto& unpack_modes = compute_hw.unpack_modes;
     for (const auto& name :
          {state_dfb_name,
           t_inv_dfb_name,

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -28,7 +28,6 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
     const auto& output_a = outputs[0].mesh_tensor();
     const auto& output_b = outputs[1].mesh_tensor();
     const auto& device = a.device();
-    const auto arch = device.arch();
 
     const uint32_t Kt = attrs.key_dim / tt::constants::TILE_WIDTH;
     const uint32_t Vt = attrs.value_dim / tt::constants::TILE_WIDTH;
@@ -135,12 +134,12 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
             },
         .compile_time_args = {{"Kt", Kt}, {"Vt", Vt}, {"G", G}},
         .runtime_arg_schema = {.runtime_arg_names = {"worker_index", "group"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_common_runtime_varargs = 2 * group_heads},
     };
 
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
-    auto& unpack_modes = tt::tt_metal::experimental::unpack_modes(compute_hw);
+    auto compute_hw = ttnn::to_compute_hardware_config(attrs.compute_kernel_config);
+    auto& unpack_modes = compute_hw.unpack_modes;
     for (const auto& name :
          {stage_a_dfb_name, stage_b_dfb_name, remote_a_dfb_name, remote_b_dfb_name, scratch_dfb_name}) {
         unpack_modes[name] = tt::tt_metal::UnpackMode::UnpackToSrc;

--- a/ttnn/cpp/ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/device/sigmoid_gated_rms_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/device/sigmoid_gated_rms_norm_program_factory.cpp
@@ -31,7 +31,6 @@ ttnn::device_operation::ProgramArtifacts SigmoidGatedRmsNormProgramFactory::crea
     const auto& weight = in.weight.mesh_tensor();
     const auto& output = outputs[0].mesh_tensor();
     const auto& device = input.device();
-    const auto arch = device.arch();
 
     const uint32_t Mt = attrs.sequence / TILE_HEIGHT;
     const uint32_t Vt = attrs.value_dim / TILE_WIDTH;
@@ -112,7 +111,7 @@ ttnn::device_operation::ProgramArtifacts SigmoidGatedRmsNormProgramFactory::crea
             },
         .compile_time_args = {{"Vt", Vt}, {"H", attrs.num_heads}, {"Mt", Mt}, {"epsilon_bits", eps_bits}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     m2::KernelSpec writer{
@@ -124,11 +123,11 @@ ttnn::device_operation::ProgramArtifacts SigmoidGatedRmsNormProgramFactory::crea
         .tensor_bindings = {m2::TensorBinding{OUTPUT, "output"}},
         .compile_time_args = {{"Vt", Vt}, {"H", attrs.num_heads}, {"Mt", Mt}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
-    auto& unpack_modes = m2::unpack_modes(compute_hw);
+    auto compute_hw = ttnn::to_compute_hardware_config(attrs.compute_kernel_config);
+    auto& unpack_modes = compute_hw.unpack_modes;
     unpack_modes[TMP_DFB] = UnpackMode::UnpackToSrc;
     unpack_modes[STATS_DFB] = UnpackMode::UnpackToSrc;
     unpack_modes[INV_DFB] = UnpackMode::UnpackToSrc;

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -99,7 +99,7 @@ ttnn::device_operation::ProgramArtifacts PlusOneProgramFactory::create_program_a
                 {"H", H},
                 {"skip_negative_entries", operation_attributes.skip_negative_entries},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(input_mesh_tensor.device().arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (src_is_dram) {
         // Accessor path (DRAM): bind the input tensor and enable the NoC transfers.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
@@ -55,7 +55,6 @@
 #include <string>
 #include <tuple>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include <tt-metalium/allocator.hpp>
@@ -707,7 +706,7 @@ ProgramArtifacts create_no_bcast_artifacts(
     // enable_32_bit_dest is true). So set it only on compute-consumer DFBs whose format is Float32
     // (which forces fp32_dest_acc_en true). A Float32 FPU consumer must still carry an explicit entry,
     // which is UnpackToSrc. compute consumers: in0(pre_lhs), in1(pre_rhs), post_lhs, post_rhs.
-    m2::ComputeUnpackModes unpack_modes;
+    m2::ComputeHardwareConfig::ComputeUnpackModes unpack_modes;
     auto set_unpack_mode = [&](const m2::DFBSpecName& dfb, tt::DataFormat df) {
         if (df == tt::DataFormat::Float32) {
             unpack_modes.emplace(dfb, is_sfpu ? UnpackMode::UnpackToDest : UnpackMode::UnpackToSrc);
@@ -781,8 +780,7 @@ ProgramArtifacts create_no_bcast_artifacts(
                   "n_stride_b",
                   "c_stride_b",
                   "src_num_tiles_b"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     m2::Group<m2::TensorBinding> writer_tensor_bindings;
@@ -809,8 +807,7 @@ ProgramArtifacts create_no_bcast_artifacts(
         .dfb_bindings = writer_dfb_bindings,
         .tensor_bindings = writer_tensor_bindings,
         .runtime_arg_schema = {.runtime_arg_names = writer_rt_names},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // Compute: consumes pre_lhs/pre_rhs, produces out. When an operand has activations, the kernel both
@@ -854,17 +851,14 @@ ProgramArtifacts create_no_bcast_artifacts(
         compute_rt_names.push_back("atol_bits");
     }
 
-    // to_compute_hardware_config maps the common knobs and picks the arch's variant (ComputeGen1Config on
-    // Wormhole, ComputeGen2Config on Quasar); it deliberately leaves the per-DFB unpack_modes
-    // default, so set it here via std::visit — the arch-agnostic pattern main's quasar untilize factories use.
-    auto compute_hw = ttnn::to_compute_hardware_config(
-        a.device()->arch(),
-        ttnn::ComputeKernelConfig{
-            .math_fidelity = MathFidelity::HiFi4,
-            .math_approx_mode = false,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-        });
-    std::visit([&](auto& cfg) { cfg.unpack_modes = unpack_modes; }, compute_hw);
+    // to_compute_hardware_config maps the common knobs and leaves per-DFB unpack_modes default, so
+    // write the table directly on the returned ComputeHardwareConfig.
+    auto compute_hw = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+        .math_fidelity = MathFidelity::HiFi4,
+        .math_approx_mode = false,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    });
+    compute_hw.unpack_modes = unpack_modes;
 
     m2::KernelSpec compute_spec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_quasar_native_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_quasar_native_factory.cpp
@@ -803,7 +803,7 @@ ProgramArtifacts create_no_bcast_artifacts(
     // enable_32_bit_dest is true). So set it only on compute-consumer DFBs whose format is Float32
     // (which forces fp32_dest_acc_en true). A Float32 FPU consumer must still carry an explicit entry,
     // which is UnpackToSrc. compute consumers: in0(pre_lhs), in1(pre_rhs), post_lhs, post_rhs.
-    m2::ComputeUnpackModes unpack_modes;
+    m2::ComputeHardwareConfig::ComputeUnpackModes unpack_modes;
     auto set_unpack_mode = [&](const m2::DFBSpecName& dfb, tt::DataFormat df) {
         if (df == tt::DataFormat::Float32) {
             unpack_modes.emplace(dfb, is_sfpu ? UnpackMode::UnpackToDest : UnpackMode::UnpackToSrc);
@@ -877,8 +877,7 @@ ProgramArtifacts create_no_bcast_artifacts(
                   "n_stride_b",
                   "c_stride_b",
                   "src_num_tiles_b"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     m2::Group<m2::TensorBinding> writer_tensor_bindings;
@@ -905,8 +904,7 @@ ProgramArtifacts create_no_bcast_artifacts(
         .dfb_bindings = writer_dfb_bindings,
         .tensor_bindings = writer_tensor_bindings,
         .runtime_arg_schema = {.runtime_arg_names = writer_rt_names},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // Compute: consumes pre_lhs/pre_rhs, produces out. When an operand has activations, the kernel both
@@ -950,17 +948,14 @@ ProgramArtifacts create_no_bcast_artifacts(
         compute_rt_names.push_back("atol_bits");
     }
 
-    // to_compute_hardware_config maps the common knobs and picks the arch's variant (ComputeGen1Config on
-    // Wormhole, ComputeGen2Config on Quasar); it deliberately leaves the per-DFB unpack_modes
-    // default, so set it here via std::visit — the arch-agnostic pattern main's quasar untilize factories use.
-    auto compute_hw = ttnn::to_compute_hardware_config(
-        a.device()->arch(),
-        ttnn::ComputeKernelConfig{
-            .math_fidelity = MathFidelity::HiFi4,
-            .math_approx_mode = false,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-        });
-    std::visit([&](auto& cfg) { cfg.unpack_modes = unpack_modes; }, compute_hw);
+    // to_compute_hardware_config maps the common knobs and deliberately leaves the per-DFB unpack_modes
+    // default, so set it here.
+    auto compute_hw = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+        .math_fidelity = MathFidelity::HiFi4,
+        .math_approx_mode = false,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+    });
+    compute_hw.unpack_modes = unpack_modes;
 
     m2::KernelSpec compute_spec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1695,16 +1695,15 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
             .endpoint_type = m2::DFBEndpointType::CONSUMER});
     }
 
-    m2::DataMovementHardwareConfig reader_hw;
-    if (device->arch() == tt::ARCH::QUASAR) {
-        // QSR: this conv activation reader fills the ACT/ACT_ROW_MAJOR DFB via per-window "stick" sub-tile NOC
-        // reads (read_sticks()); that pattern stalls the DFB implicit-sync credit accounting (reader pinned at
-        // NRBW). Opt out so explicit reserve/push credits stay authoritative (mirrors tilize/transpose HC-sharded).
-        reader_hw = m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-    } else {
-        reader_hw =
-            m2::DataMovementGen1Config{.processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = reader_noc};
-    }
+    // Pin RISCV_1 + reader_noc for TT-1.x.x. On TT-2.x.x this conv activation reader fills ACT/ACT_ROW_MAJOR
+    // via per-window "stick" sub-tile NOC reads (read_sticks()); that pattern stalls DFB implicit-sync credit
+    // accounting (reader pinned at NRBW). Opt out so explicit reserve/push credits stay authoritative.
+    m2::DataMovementHardwareConfig reader_hw{
+        .config_1xx =
+            m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = reader_noc},
+        .config_2xx = m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true},
+    };
     m2::KernelSpec reader_kernel_spec{
         .unique_id = KERNEL_READER,
         .source = std::filesystem::path(reader_kernel),
@@ -1938,17 +1937,15 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     };
 
     // ---- writer mcast SENDER ----
-    m2::DataMovementHardwareConfig writer_sender_hw;
-    if (device->arch() == tt::ARCH::QUASAR) {
-        // The sender does explicit reserve_back/push_back on WEIGHTS/BIAS/ACT_SECOND to publish blocks to
-        // compute. On Quasar the implicit-sync ISR would ALSO bump those tile counters -> double-count ->
-        // 16-bit counter overflow -> TILE_COUNTERS fault on the compute unpack that consumes WEIGHTS. Opt out
-        // so explicit credits stay authoritative (mirrors the reader + matmul mcast fix).
-        writer_sender_hw = m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-    } else {
-        writer_sender_hw = m2::DataMovementGen1Config{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = writer_mcast_noc};
-    }
+    // Pin RISCV_0 + writer_mcast_noc for TT-1.x.x. The sender does explicit reserve_back/push_back on
+    // WEIGHTS/BIAS/ACT_SECOND; on TT-2.x.x the implicit-sync ISR would also bump those tile counters
+    // (double-count -> TILE_COUNTERS overflow). Opt out so explicit credits stay authoritative.
+    m2::DataMovementHardwareConfig writer_sender_hw{
+        .config_1xx =
+            m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = writer_mcast_noc},
+        .config_2xx = m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true},
+    };
     m2::KernelSpec writer_sender_spec{
         .unique_id = KERNEL_WRITER_SENDER,
         .source = std::filesystem::path(writer_sender_kernel),
@@ -1998,16 +1995,14 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     }
 
     // ---- writer mcast RECEIVER ----
-    m2::DataMovementHardwareConfig writer_receiver_hw;
-    if (device->arch() == tt::ARCH::QUASAR) {
-        // Same as the sender: the receiver does explicit reserve_back/push_back on WEIGHTS/BIAS/ACT_SECOND;
-        // opt out of implicit sync so those tile counters aren't double-bumped (else TILE_COUNTERS overflow
-        // on the compute unpack consuming WEIGHTS).
-        writer_receiver_hw = m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-    } else {
-        writer_receiver_hw = m2::DataMovementGen1Config{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = writer_mcast_noc};
-    }
+    // Same as the sender: pin RISCV_0 + writer_mcast_noc and opt out of DFB implicit sync so explicit
+    // reserve_back/push_back on WEIGHTS/BIAS/ACT_SECOND stay authoritative.
+    m2::DataMovementHardwareConfig writer_receiver_hw{
+        .config_1xx =
+            m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = writer_mcast_noc},
+        .config_2xx = m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true},
+    };
     m2::KernelSpec writer_receiver_spec{
         .unique_id = KERNEL_WRITER_RECEIVER,
         .source = std::filesystem::path(writer_receiver_kernel),
@@ -2179,7 +2174,7 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
         .source = std::filesystem::path(compute_kernel),
         .compiler_options = {.defines = m2::KernelSpec::CompilerOptions::Defines(compute_defines)},
         .dfb_bindings = std::move(compute_dfb_bindings),
-        .hw_config = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config),
+        .hw_config = ttnn::to_compute_hardware_config(compute_kernel_config),
     };
 
     if (is_conv_1d_depthwise_conv) {
@@ -2298,10 +2293,13 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
              {"reader_num_h_subblocks",
               act_subblock_h_ntiles * act_num_subblocks * (full_k_ntiles / act_block_w_ntiles)}},
         .hw_config =
-            (device->arch() == tt::ARCH::QUASAR)
-                ? m2::DataMovementHardwareConfig{m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true}}
-                : m2::DataMovementHardwareConfig{m2::DataMovementGen1Config{
-                      .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = writer_mcast_noc}},
+            m2::DataMovementHardwareConfig{
+                .config_1xx =
+                    m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = writer_mcast_noc},
+                .config_2xx =
+                    m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true},
+            },
     };
 
     // ---- Register kernels ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -615,21 +615,21 @@ ttnn::device_operation::ProgramArtifacts Conv2dWidthShardedProgramFactory::creat
                 {"tilized_cb_second_reader_offset", 0u},
                 {"split_reader_cb_shared", 0u},
             },
-        .hw_config = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config),
+        .hw_config = ttnn::to_compute_hardware_config(compute_kernel_config),
     };
 
     // ---- Activation reader kernel ----
     // DFB bindings: produces ACT_ROW_MAJOR + ACT (mcast), consumes ACT_TILIZED (mcast source);
     // self-loops the borrowed ACT_SHARDED (input address source) and READER_INDICES.
-    m2::DataMovementHardwareConfig act_hw;
-    if (device->arch() == tt::ARCH::QUASAR) {
-        // QSR: this width-sharded activation reader fills the ACT_ROW_MAJOR/ACT DFB via per-window "stick"
-        // sub-tile NOC reads; that pattern stalls the DFB implicit-sync credit accounting (reader pinned at
-        // NRBW). Opt out so explicit reserve/push credits stay authoritative (mirrors tilize/transpose HC-sharded).
-        act_hw = m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-    } else {
-        act_hw = m2::DataMovementGen1Config{.processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = act_noc};
-    }
+    // Pin RISCV_0 + act_noc for TT-1.x.x. On TT-2.x.x this width-sharded activation reader fills
+    // ACT_ROW_MAJOR/ACT via per-window "stick" sub-tile NOC reads; that pattern stalls DFB implicit-sync
+    // credit accounting. Opt out so explicit reserve/push credits stay authoritative.
+    m2::DataMovementHardwareConfig act_hw{
+        .config_1xx =
+            m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = act_noc},
+        .config_2xx = m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true},
+    };
     m2::KernelSpec act_kernel{
         .unique_id = KERNEL_ACT,
         .source = std::filesystem::path("ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"
@@ -726,18 +726,15 @@ ttnn::device_operation::ProgramArtifacts Conv2dWidthShardedProgramFactory::creat
         weights_tensor_bindings.push_back(m2::TensorBinding{.tensor_parameter_name = TP_BIAS, .accessor_name = "bias"});
     }
 
-    m2::DataMovementHardwareConfig weights_hw;
-    if (device->arch() == tt::ARCH::QUASAR) {
-        // This weights reader does explicit reserve_back/push_back on WEIGHTS/BIAS. Full-tile page reads avoid
-        // the sub-tile *stall* the act reader hits, but they do NOT avoid the Quasar *counter double-count*: the
-        // implicit-sync ISR bumps the same 16-bit tile counter as the explicit push -> overflow ->
-        // TILE_COUNTERS fault on the compute unpack consuming WEIGHTS. Opt out so explicit credits are
-        // authoritative.
-        weights_hw = m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-    } else {
-        weights_hw =
-            m2::DataMovementGen1Config{.processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = weights_noc};
-    }
+    // Pin RISCV_1 + weights_noc for TT-1.x.x. This weights reader does explicit reserve_back/push_back on
+    // WEIGHTS/BIAS; on TT-2.x.x the implicit-sync ISR would double-count those tile counters. Opt out so
+    // explicit credits stay authoritative.
+    m2::DataMovementHardwareConfig weights_hw{
+        .config_1xx =
+            m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = weights_noc},
+        .config_2xx = m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true},
+    };
     m2::KernelSpec weights_kernel{
         .unique_id = KERNEL_WEIGHTS,
         .source = std::filesystem::path("ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -119,7 +119,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
         .compile_time_args =
             {{"tiles_per_channel_dim", tiles_per_channel_dim}, {"tiles_per_width_dim", tiles_per_width_dim}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_block_id", "num_blocks"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer kernel (SRC1 -> DRAM) ----
@@ -142,8 +142,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
              {"element_size", datum_size(out_cb_data_format)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_block_id", "num_blocks", "patch_height_offset", "output_offset"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute kernels (untilize SRC0 -> SRC1) ----
@@ -158,12 +157,8 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
                      .dfb_spec_name = SRC1, .accessor_name = "src1", .endpoint_type = DFBEndpointType::PRODUCER}},
             .compile_time_args =
                 {{"per_core_block_cnt", per_core_block_cnt}, {"per_core_block_tile_cnt", tiles_per_channel_dim}},
-            .hw_config = ttnn::to_compute_hardware_config(
-                device->arch(),
-                ttnn::ComputeKernelConfig{
-                    .math_fidelity = MathFidelity::HiFi4,
-                    .math_approx_mode = false,
-                    .fp32_dest_acc_en = fp32_dest_acc_en}),
+            .hw_config = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+                .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en}),
         };
     };
     KernelSpec compute_main = make_compute(COMPUTE_MAIN, nblocks_per_core * tiles_per_width_dim);
@@ -376,8 +371,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .compile_time_args = std::move(reader_cta),
         .runtime_arg_schema = {.runtime_arg_names = {"src_index", "curr_src_row_index"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer kernel (SRC0 [+ SRC1 scratch] -> DRAM) ----
@@ -389,8 +383,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = std::move(writer_cta),
         .runtime_arg_schema = {.runtime_arg_names = {"dst_index"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
     // SRC0 is consumed by the writer.
     writer.dfb_bindings.push_back(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/fold_multi_core_program_factory.cpp
@@ -123,8 +123,7 @@ ttnn::device_operation::ProgramArtifacts Fold::MultiCore::create_program_artifac
         .compile_time_args = make_cta(/*is_reader=*/1),
         // Quasar: reader/writer co-write the borrowed SRC0/DST0 DFBs with sub-tile stick copies; implicit
         // sync mis-credits per NOC op and stalls (reader NARW / writer WFW). Revert to explicit credits.
-        .hw_config =
-            ttnn::create_writer_datamovement_config(input.device().arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec reader{
@@ -137,8 +136,7 @@ ttnn::device_operation::ProgramArtifacts Fold::MultiCore::create_program_artifac
                 DFBBinding{.dfb_spec_name = DST0, .accessor_name = "dst0", .endpoint_type = DFBEndpointType::CONSUMER},
             },
         .compile_time_args = make_cta(/*is_reader=*/0),
-        .hw_config =
-            ttnn::create_reader_datamovement_config(input.device().arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Assemble the spec ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
@@ -376,8 +376,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithHaloProgramFactory::create_
             .compile_time_args =
                 {{"tiles_per_row", ntiles_per_block}, {"block_size", clamped_block_size_height / TILE_HEIGHT}},
             .runtime_arg_schema = {.runtime_arg_names = {"total_blocks"}},
-            .hw_config = ttnn::to_compute_hardware_config(
-                input_tensor.device()->arch(), operation_attributes.compute_kernel_config),
+            .hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config),
         };
         kernels.push_back(std::move(compute));
     }
@@ -397,16 +396,13 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithHaloProgramFactory::create_
                                  uint32_t reader_block_start_offset,
                                  DataMovementProcessor processor,
                                  NOC noc) {
-        DataMovementHardwareConfig reader_hw;
-        if (device->arch() == tt::ARCH::QUASAR) {
-            // QSR: this reader fills/drains DFBs with many sub-tile (per-row stick) NOC reads/writes (gather
-            // scatter-writes, pad replication, partial-page DRAM config reads); that sub-tile pattern stalls the
-            // DFB implicit-sync credit accounting. Opt out so explicit push_back/pop_front stay authoritative
-            // (mirrors tilize default / transpose HC-sharded).
-            reader_hw = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
-        } else {
-            reader_hw = DataMovementGen1Config{.processor = processor, .noc = noc};
-        }
+        // Pin processor/noc for TT-1.x.x. On TT-2.x.x this reader fills/drains DFBs with many sub-tile
+        // (per-row stick) NOC reads/writes; that pattern stalls DFB implicit-sync credit accounting.
+        // Opt out so explicit push_back/pop_front stay authoritative.
+        DataMovementHardwareConfig reader_hw{
+            .config_1xx = DataMovementHardwareConfig::DataMovement1XXConfig{.processor = processor, .noc = noc},
+            .config_2xx = DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true},
+        };
         KernelSpec reader{
             .unique_id = name,
             .source = std::filesystem::path(kReaderKernelPath),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -202,8 +202,7 @@ ttnn::device_operation::ProgramArtifacts InterleavedToShardedProgramFactory::cre
     KernelSpec reader{
         .unique_id = I2S_READER,
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = I2S_INPUT, .accessor_name = "src"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
     if (is_tile) {
         reader.source =
@@ -253,8 +252,7 @@ ttnn::device_operation::ProgramArtifacts InterleavedToShardedProgramFactory::cre
     // Writer kernel.
     KernelSpec writer{
         .unique_id = I2S_WRITER,
-        .hw_config =
-            ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
     if (dst_is_dram) {
         writer.dfb_bindings = {ConsumerOf(I2S_OUTPUT_DFB, "out")};
@@ -304,7 +302,6 @@ ttnn::device_operation::ProgramArtifacts InterleavedToShardedProgramFactory::cre
             .dfb_bindings = {ConsumerOf(I2S_INPUT_DFB, "in0"), ProducerOf(I2S_OUTPUT_DFB, "out")},
             .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
             .hw_config = ttnn::to_compute_hardware_config(
-                input.device()->arch(),
                 ttnn::ComputeKernelConfig{.math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false}),
         });
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -182,8 +182,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
                      "num_output_tiles",
                      "MtNt"},
             },
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer kernel ----
@@ -205,8 +204,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
             {
                 .runtime_arg_names = {"num_pages", "start_id"},
             },
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute kernel(s) — one KernelSpec per core group, preserving the per-group tile-count CTA ----
@@ -220,7 +218,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
     KernelSpec::CompilerOptions::Defines compute_defines(mm_kernel_defines);
 
     ComputeHardwareConfig compute_hw_config =
-        ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config.value());
+        ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config.value());
 
     // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop,
     // so only set Nt for simplicity

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -5197,19 +5197,19 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 namespace m2 = tt::tt_metal::experimental;
 
 namespace CMAKE_UNIQUE_NAMESPACE {
-// Create a generation-agnostic data movement hardware config: Gen1 (WH/BH) takes the given
-// processor & NOC; Gen2 (Quasar) uses the default config, optionally opting the kernel's DFBs
-// out of implicit-sync credit accounting (disable_dfb_implicit_sync_for_all) — a Gen2-only concept
-// ignored on Gen1.
+// Pin processor/NOC in config_1xx (required on TT-1.x.x, ignored on TT-2.x.x). Engage config_2xx
+// only when disable_dfb_implicit_sync_for_all is set; unused extras are ignored at program construction.
 m2::DataMovementHardwareConfig make_datamovement_hardware_config(
-    tt::ARCH arch,
     tt::tt_metal::DataMovementProcessor processor,
     tt::tt_metal::NOC noc,
     bool disable_dfb_implicit_sync_for_all = false) {
-    if (arch == tt::ARCH::QUASAR) {
-        return m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
+    m2::DataMovementHardwareConfig config{
+        .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{.processor = processor, .noc = noc}};
+    if (disable_dfb_implicit_sync_for_all) {
+        config.config_2xx =
+            m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
     }
-    return m2::DataMovementGen1Config{.processor = processor, .noc = noc};
+    return config;
 }
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 
@@ -5808,13 +5808,11 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
         m2::SemaphoreSpec{.unique_id = RO_IN1_RECEIVER_SEM, .target_nodes = all_cores},
     };
 
-    m2::ComputeHardwareConfig compute_hw_config = ttnn::to_compute_hardware_config(
-        device->arch(),
-        ttnn::ComputeKernelConfig{
-            .math_fidelity = math_fidelity,
-            .math_approx_mode = math_approx_mode,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = false});
+    m2::ComputeHardwareConfig compute_hw_config = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+        .math_fidelity = math_fidelity,
+        .math_approx_mode = math_approx_mode,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = false});
 
     // ---- in0 sender kernel CTAs (named) ----
     auto make_in0_sender_cta = [&](uint32_t core_has_output_block_work,
@@ -5962,7 +5960,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
         // multicast that never delivers VALID, and the whole grid hangs at receiver_sem.wait(VALID).
         // Matches the working mcast_2d factory.
         .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-            device->arch(),
             tt::tt_metal::DataMovementProcessor::RISCV_1,
             in0_noc,
             /*disable_dfb_implicit_sync_for_all=*/true),
@@ -5992,7 +5989,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
             .runtime_arg_schema = {.runtime_arg_names = in0_no_work_rta_names},
             // [#47797] Pin RISCV_1 + in0_noc (see in0 sender above); block-sharded mcast geometry.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -6018,7 +6014,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
             .runtime_arg_schema = {.runtime_arg_names = in0_no_work_rta_names},
             // [#47797] Pin RISCV_1 + in0_noc (see in0 sender above); block-sharded mcast geometry.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -6056,7 +6051,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
             // [#47797] Pin RISCV_1 + in0_noc for NOC parity with the in0 sender (the receiver's
             // sender_sem.up to the sender must use the same NOC as the mcast geometry).
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -6172,7 +6166,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
             // The bare WRITER hint resolves to NOC1 here and the writes never leave the NIU
             // (npw_sent=0), hanging the final barrier.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_0,
                 in1_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -6830,13 +6823,11 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
             .unique_id = RO_IN1_RECEIVER_SEM, .target_nodes = CoreRangeSet(in1_mcast_receiver_cores_bounding_box)},
     };
 
-    m2::ComputeHardwareConfig compute_hw_config = ttnn::to_compute_hardware_config(
-        device->arch(),
-        ttnn::ComputeKernelConfig{
-            .math_fidelity = math_fidelity,
-            .math_approx_mode = math_approx_mode,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = false});
+    m2::ComputeHardwareConfig compute_hw_config = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+        .math_fidelity = math_fidelity,
+        .math_approx_mode = math_approx_mode,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = false});
 
     // The in1 sender multicasts weights/bias over a dest rectangle whose start/end are swapped based
     // on in1_noc (below). The in1 sender/receiver writer kernels MUST issue NoC ops on that same NOC,
@@ -6932,7 +6923,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
             // Pin RISCV_1 + in0_noc (not a plain READER hint -> NOC_0) so this does not collide with the
             // in1 sender writer on NOC_0. See the in0_noc comment above.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -7043,7 +7033,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
             // Pin RISCV_0 + in1_noc (legacy parity): the multicast dest rectangle was swapped for
             // in1_noc, so the mcast must issue on in1_noc or it inverts and degenerates.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_0,
                 in1_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -7125,7 +7114,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
             // Pin RISCV_0 + in1_noc (legacy parity) so the receiver's NoC ops use the same NOC as
             // the sender's multicast geometry.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_0,
                 in1_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -7205,7 +7193,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
             .source = std::filesystem::path(NOOP_DM_KERNEL_PATH),
             .dfb_bindings = std::move(noop_dm_dfb),
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_0,
                 in1_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -7218,7 +7205,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
             // the program-spec validator rejects (noc_inserted). in0_noc is the opposite NOC -> distinct.
             // Mirrors the worker-core split (in0 reader on in0_noc, in1 writer on in1_noc).
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3110,19 +3110,19 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 namespace m2 = tt::tt_metal::experimental;
 
 namespace CMAKE_UNIQUE_NAMESPACE {
-// Create a generation-agnostic data movement hardware config: Gen1 (WH/BH) takes the given
-// processor & NOC; Gen2 (Quasar) uses the default config, optionally opting the kernel's DFBs
-// out of implicit-sync credit accounting (disable_dfb_implicit_sync_for_all) — a Gen2-only concept
-// ignored on Gen1.
+// Pin processor/NOC in config_1xx (required on TT-1.x.x, ignored on TT-2.x.x). Engage config_2xx
+// only when disable_dfb_implicit_sync_for_all is set; unused extras are ignored at program construction.
 m2::DataMovementHardwareConfig make_datamovement_hardware_config(
-    tt::ARCH arch,
     tt::tt_metal::DataMovementProcessor processor,
     tt::tt_metal::NOC noc,
     bool disable_dfb_implicit_sync_for_all = false) {
-    if (arch == tt::ARCH::QUASAR) {
-        return m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
+    m2::DataMovementHardwareConfig config{
+        .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{.processor = processor, .noc = noc}};
+    if (disable_dfb_implicit_sync_for_all) {
+        config.config_2xx =
+            m2::DataMovementHardwareConfig::DataMovement2XXConfig{.disable_dfb_implicit_sync_for_all = true};
     }
-    return m2::DataMovementGen1Config{.processor = processor, .noc = noc};
+    return config;
 }
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 
@@ -3786,17 +3786,15 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
         m2::SemaphoreSpec{.unique_id = RO_IN1_RECEIVER_SEM, .target_nodes = all_cores_set},
     };
 
-    m2::ComputeHardwareConfig compute_hw_config = ttnn::to_compute_hardware_config(
-        device->arch(),
-        ttnn::ComputeKernelConfig{
-            .math_fidelity = math_fidelity,
-            .math_approx_mode = math_approx_mode,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = false});
+    m2::ComputeHardwareConfig compute_hw_config = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+        .math_fidelity = math_fidelity,
+        .math_approx_mode = math_approx_mode,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = false});
 
     // in1 reader uses the optimized reader noc; in0 the dram-write noc. (The legacy split-half
     // _other receivers ran on the opposite NOC for perf; the Metal 2.0 host API selects the NOC via
-    // the reader/writer Gen1 config, so the _other kernels are functionally identical here — see report.)
+    // the reader/writer config_1xx, so the _other kernels are functionally identical here — see report.)
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
 
@@ -3937,7 +3935,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
             // in0_noc below, so the mcast must issue on in0_noc or it inverts and only the sender's
             // own column receives in0 (degenerate 2-corner delivery -> partial-grid hang).
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -3969,7 +3966,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
             .runtime_arg_schema = {.runtime_arg_names = in0_sender_rta_names},
             // Pin RISCV_1 + in0_noc (legacy parity) to match the in0-mcast rectangle geometry.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -4010,7 +4006,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
             // Pin RISCV_1 + in0_noc (legacy parity). The m2 path computes a single in0-mcast geometry
             // on in0_noc for both the main and _other receivers, so both must use in0_noc.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_1,
                 in0_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -4136,7 +4131,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
             // Pin RISCV_0 + in1_noc (legacy parity): the in1 column-mcast dest rectangle is swapped
             // for in1_noc below, so the mcast must issue on in1_noc or it inverts and degenerates.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_0,
                 in1_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),
@@ -4217,7 +4211,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
             // on in1_noc for both the main and _other receivers, so both must use in1_noc to match
             // the sender's multicast rectangle and semaphore signaling.
             .hw_config = CMAKE_UNIQUE_NAMESPACE::make_datamovement_hardware_config(
-                device->arch(),
                 tt::tt_metal::DataMovementProcessor::RISCV_0,
                 in1_noc,
                 /*disable_dfb_implicit_sync_for_all=*/true),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -411,8 +411,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseOptimizedProgramFac
             {
                 .runtime_arg_names = {"in0_tensor_start_tile_id", "batch"},
             },
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Reader/Writer kernel (reads in1, writes output) ----
@@ -459,12 +458,11 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseOptimizedProgramFac
             {
                 .runtime_arg_names = {"in1_tensor_start_tile_id", "batch", "out_tensor_start_tile_id"},
             },
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     ComputeHardwareConfig compute_hw_config =
-        ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config.value());
+        ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config.value());
 
     // ---- Compute kernel(s) — one KernelSpec per core group, preserving the per-group block-count CTA ----
     auto make_compute = [&](const KernelSpecName& unique_id, uint32_t num_blocks_per_core_group) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
@@ -171,8 +171,7 @@ ttnn::device_operation::ProgramArtifacts MoveOverlapProgramFactory::create_progr
             {
                 m2::TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"},
             },
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // Named CTA: the stick-layout kernel needs the (unaligned) page size at compile time.
@@ -215,8 +214,7 @@ ttnn::device_operation::ProgramArtifacts MoveOverlapProgramFactory::create_progr
             {
                 m2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"},
             },
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // The stick-layout writer needs the (unaligned) page size at compile time, like its reader.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
@@ -92,13 +92,11 @@ ttnn::device_operation::ProgramArtifacts MoveShardedProgramFactory::create_progr
     spec.tensor_parameters.push_back(m2::TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()});
     spec.tensor_parameters.push_back(m2::TensorParameter{.unique_id = OUTPUT, .spec = output.tensor_spec()});
 
-    // Preserve the legacy processor/NOC selection (RISCV_1 / NOC_1) via an explicit Gen1Config.
-    m2::DataMovementHardwareConfig reader_hw;
-    if (input.device()->arch() == tt::ARCH::QUASAR) {
-        reader_hw = m2::DataMovementGen2Config{};
-    } else {
-        reader_hw = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
-    }
+    // Preserve the legacy processor/NOC selection (RISCV_1 / NOC_1). Leave config_2xx disengaged so
+    // TT-2.x.x keeps default DFB implicit sync.
+    m2::DataMovementHardwareConfig reader_hw{
+        .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1}};
     m2::KernelSpec reader{
         .unique_id = READER,
         .source =

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -222,7 +222,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgra
                   "start_dim_h",
                   "start_dim_c",
                   "start_dim_n"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (has_pad_align) {
         reader_spec.compiler_options.defines = {{"HAS_PAD_ALIGN", "1"}};
@@ -246,7 +246,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgra
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .compile_time_args = writer_cta,
         .runtime_arg_schema = {.runtime_arg_names = {"num_sticks_per_core", "num_sticks_per_barrier", "start_page_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -329,8 +329,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactor
                   "num_local_unpadded_Y",
                   "full_unpadded_X_nbytes",
                   "num_local_W"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------
@@ -356,8 +355,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactor
                   "full_padded_X_nbytes",
                   "dst_stick_offset",
                   "num_local_W"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     log_debug(tt::LogOp, "ncores: {}", ncores);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -173,8 +173,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create
                   "num_local_unpadded_Y",
                   "full_unpadded_X_nbytes",
                   "num_local_W"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------
@@ -200,8 +199,7 @@ ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create
                   "full_padded_X_nbytes",
                   "dst_stick_offset",
                   "num_local_W"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -334,8 +334,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
              {"row_major_min_bytes", row_major_min_bytes},
              {"num_sticks_padded_read", static_cast<uint32_t>(stick_size_padded / row_major_min_bytes)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_cores_read"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------
@@ -365,8 +364,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
                   "start_dim_h",
                   "start_dim_c",
                   "start_dim_n"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -147,7 +147,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
              {"W_front_pad_bytes", W_padding_front_bytes},
              {"unpadded_stick_step", unpadded_stick_step},
              {"padded_stick_step", padded_stick_step}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -162,7 +162,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
              {"padded_shard_height", shard_height_padded},
              {"padding_value_as_u32", padding_value_as_u32},
              {"padding_value_num_bytes", static_cast<uint32_t>(output.element_size())}},
-        .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Both kernels take no named runtime args (data flows via CBs/compile-time args), so

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.cpp
@@ -134,7 +134,7 @@ ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
         .compile_time_args = {{"num_dims", num_dims}, {"page_size", page_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     reader_spec.advanced_options.num_runtime_varargs = 4 * num_dims;
 
@@ -153,7 +153,7 @@ ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_
              {"pad_value", packed_pad_value},
              {"element_size", static_cast<uint32_t>(output.element_size())}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
     writer_spec.advanced_options.num_runtime_varargs = 4 * num_dims;
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
@@ -122,7 +122,7 @@ ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_progr
                 TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // -------- Writer KernelSpec (consumes SRC0, fills PAD scratch, writes output) --------
@@ -166,7 +166,7 @@ ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_progr
                   "num_padded_Yt",
                   "num_unpadded_Xt",
                   "num_padded_Xt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/padded_slice/device/padded_slice_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/padded_slice/device/padded_slice_rm_program_factory.cpp
@@ -300,8 +300,7 @@ ttnn::device_operation::ProgramArtifacts PaddedSliceRMProgramFactory::create_pro
             "num_read_per_barrier"}};
     // Per-dim geometry tail (num_output_sticks_per_dim, num_input_sticks_per_dim, id_per_dim).
     reader.advanced_options.num_runtime_varargs = 3 * num_dims;
-    reader.hw_config =
-        ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    reader.hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     // Writer: drain/commit the OUTPUT DFB (non-pad). Reuses the ported i2s sharded writer.
     KernelSpec writer{
@@ -311,8 +310,7 @@ ttnn::device_operation::ProgramArtifacts PaddedSliceRMProgramFactory::create_pro
             "writer_unary_sharded.cpp"};
     writer.dfb_bindings = {ConsumerOf(PS_OUT_DFB, "out")};
     writer.runtime_arg_schema = {.runtime_arg_names = {"num_units"}};
-    writer.hw_config =
-        ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    writer.hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     spec.kernels = {reader, writer};
     spec.work_units = {WorkUnitSpec{.name = "main", .kernels = {PS_READER, PS_WRITER}, .target_nodes = total_cores}};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -1177,8 +1177,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         // exactly the sub-tile pattern that stalls the DFB implicit-sync credit accounting (reader
         // pinned at NRBW/cb_reserve_back, compute idle). Mirror the tilize/transpose HC-sharded
         // workaround and opt out of implicit sync so explicit reserve/push credits stay authoritative.
-        .hw_config =
-            ttnn::create_reader_datamovement_config(mesh_device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     std::optional<KernelSpec> reader1;
@@ -1194,8 +1193,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
             // QSR: companion opt-out on the split/second reader (writer-face). Same sub-tile stick
             // DFB transfers as reader0; keep explicit reserve/push credits authoritative to avoid the
             // implicit-sync NWFW/NRBW stall (mirrors tilize/transpose HC-sharded).
-            .hw_config = ttnn::create_writer_datamovement_config(
-                mesh_device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         };
     }
 
@@ -1358,13 +1356,11 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         /*default_l1_acc=*/false,
         /*default_dst_full_sync_en=*/(params.is_large_kernel && return_indices) || indexes_32_bit);
 
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(
-        device_arch,
-        ttnn::ComputeKernelConfig{
-            .math_fidelity = get_math_fidelity(device_compute_kernel_config),
-            .math_approx_mode = false,
-            .fp32_dest_acc_en = get_fp32_dest_acc_en(device_compute_kernel_config),
-            .dst_full_sync_en = get_dst_full_sync_en(device_compute_kernel_config)});
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+        .math_fidelity = get_math_fidelity(device_compute_kernel_config),
+        .math_approx_mode = false,
+        .fp32_dest_acc_en = get_fp32_dest_acc_en(device_compute_kernel_config),
+        .dst_full_sync_en = get_dst_full_sync_en(device_compute_kernel_config)});
 
     KernelSpec compute{
         .unique_id = COMPUTE_KERNEL,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -147,8 +147,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
         .compile_time_args =
             {{"Ht", Ht}, {"Wt", Wt}, {"HtWt", HtWt}, {"scaler_bits", scaler_bits}, {"use_welford", 0u}},
         .runtime_arg_schema = {.runtime_arg_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -158,8 +157,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     auto make_compute = [&](const KernelSpecName& id, uint32_t compute_Wt) {
@@ -174,13 +172,11 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
                  DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}},
             .compile_time_args =
                 {{"Ht", Ht}, {"Wt", compute_Wt}, {"NC", 1u}, {"post_mul_scaler_bits", post_mul_scaler_bits}},
-            .hw_config = ttnn::to_compute_hardware_config(
-                device->arch(),
-                ttnn::ComputeKernelConfig{
-                    .math_fidelity = math_fidelity,
-                    .math_approx_mode = false,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .dst_full_sync_en = dst_full_sync_en}),
+            .hw_config = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+                .math_fidelity = math_fidelity,
+                .math_approx_mode = false,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .dst_full_sync_en = dst_full_sync_en}),
         };
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -139,8 +139,7 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .compile_time_args = {{"scaler_bits", std::bit_cast<uint32_t>(scaler)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device().arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -150,8 +149,7 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device().arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute (reduce<in, scaler, out>) ----
@@ -167,13 +165,11 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings = std::move(compute_bindings),
         .compile_time_args = {{"Ht", Ht}, {"Wt", Wt}, {"NC", NC}, {"post_mul_scaler_bits", post_mul_scaler_bits}},
-        .hw_config = ttnn::to_compute_hardware_config(
-            a.device().arch(),
-            ttnn::ComputeKernelConfig{
-                .math_fidelity = math_fidelity,
-                .math_approx_mode = false,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .dst_full_sync_en = false}),
+        .hw_config = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+            .math_fidelity = math_fidelity,
+            .math_approx_mode = false,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = false}),
     };
 
     Group<KernelSpec> kernels = {reader, writer, compute};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_metal2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_metal2_program_factory.cpp
@@ -110,8 +110,7 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewRMMetalV2ProgramFactory::cre
                   "nop"}},
         // Repages with sub-tile writes (dest_page can be < source_page; tt_memmove chunks) -> per
         // ~/implicit_sync.md rule (A), revert to explicit credits.
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     spec.kernels = {reader};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_tiled_metal2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_tiled_metal2_program_factory.cpp
@@ -142,8 +142,7 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledMetalV2ProgramFactory::
             {{"max_map_size_bytes", mapping_page_size_bytes}, {"tile_size_bytes", input_tile_size_bytes}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_output_page_idx", "end_output_page_idx"}},
         // Explicit CB credit ops (staged reads) -> disable implicit sync (Quasar tile-counter double-count).
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer kernel ----
@@ -162,8 +161,7 @@ ttnn::device_operation::ProgramArtifacts ReshapeViewTiledMetalV2ProgramFactory::
              {"max_map_entries", max_map_entries},
              {"element_sz_bytes", element_sz_bytes}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_output_page", "end_output_page"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     spec.kernels = {reader, writer};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -123,16 +123,15 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyLocalShardFactory<local_is
         };
     };
 
-    // Preserve the legacy explicit RISCV_0 / NOC RISCV_0_default placement.
-    DataMovementHardwareConfig brisc_hw;
-    if (input.device()->arch() == tt::ARCH::QUASAR) {
-        brisc_hw = DataMovementGen2Config{};
-    } else {
-        brisc_hw = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-        };
-    }
+    // Preserve the legacy explicit RISCV_0 / NOC RISCV_0_default placement. Leave config_2xx
+    // disengaged so TT-2.x.x keeps default DFB implicit sync.
+    DataMovementHardwareConfig brisc_hw{
+        .config_1xx =
+            DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+            },
+    };
     KernelSpec brisc{
         .unique_id = COPY_LOCAL_BRISC,
         .source = kernel_source,
@@ -143,16 +142,15 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyLocalShardFactory<local_is
         .hw_config = std::move(brisc_hw),
     };
 
-    // Preserve the legacy explicit RISCV_1 / NOC RISCV_1_default placement.
-    DataMovementHardwareConfig ncrisc_hw;
-    if (input.device()->arch() == tt::ARCH::QUASAR) {
-        ncrisc_hw = DataMovementGen2Config{};
-    } else {
-        ncrisc_hw = DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-        };
-    }
+    // Preserve the legacy explicit RISCV_1 / NOC RISCV_1_default placement. Leave config_2xx
+    // disengaged so TT-2.x.x keeps default DFB implicit sync.
+    DataMovementHardwareConfig ncrisc_hw{
+        .config_1xx =
+            DataMovementHardwareConfig::DataMovement1XXConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+            },
+    };
     KernelSpec ncrisc{
         .unique_id = COPY_LOCAL_NCRISC,
         .source = kernel_source,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -87,8 +87,7 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_progr
                 {"page_size", aligned_page_size},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"start_page", "end_page"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -109,8 +108,7 @@ ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_progr
                 {"page_size", aligned_page_size},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"start_page", "end_page"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // Work split: per-core page ranges.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_generic.cpp
@@ -816,11 +816,11 @@ ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_a
 
     KernelSpec k0 = make_worker(
         "reader",
-        ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         DFBEndpointType::PRODUCER);
     KernelSpec k1 = make_worker(
         "writer",
-        ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         DFBEndpointType::CONSUMER);
 
     // The borrowed DFB is only an address source (the kernel writes via get_write_ptr() + offset and

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_height.cpp
@@ -133,11 +133,11 @@ ttnn::device_operation::ProgramArtifacts ReshardSameHeightFactory<local_is_outpu
 
     KernelSpec k0 = make_worker(
         "reader",
-        ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         DFBEndpointType::PRODUCER);
     KernelSpec k1 = make_worker(
         "writer",
-        ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         DFBEndpointType::CONSUMER);
 
     DataflowBufferSpec shard_dfb{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_program_factory_same_width.cpp
@@ -205,11 +205,11 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
 
     KernelSpec k0 = make_worker(
         "reader",
-        ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         DFBEndpointType::PRODUCER);
     KernelSpec k1 = make_worker(
         "writer",
-        ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         DFBEndpointType::CONSUMER);
 
     DataflowBufferSpec shard_dfb{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -167,8 +167,7 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
     // Reader kernel: produces the resident input shard into the borrowed INPUT DFB (fake-push).
     KernelSpec reader{
         .unique_id = S2I_READER,
-        .hw_config =
-            ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
     reader.source =
         "ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/kernels/dataflow/"
@@ -180,8 +179,7 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
     KernelSpec writer{
         .unique_id = S2I_WRITER,
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = S2I_OUTPUT, .accessor_name = "dst"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
     writer.dfb_bindings = {ConsumerOf(writer_in_dfb, "out")};
     if (is_tile) {
@@ -223,7 +221,6 @@ ttnn::device_operation::ProgramArtifacts ShardedToInterleavedProgramFactory::cre
             .dfb_bindings = {ConsumerOf(S2I_INPUT_DFB, "in0"), ProducerOf(S2I_OUTPUT_DFB, "out")},
             .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
             .hw_config = ttnn::to_compute_hardware_config(
-                input.device()->arch(),
                 ttnn::ComputeKernelConfig{.math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false}),
         });
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
@@ -297,8 +297,7 @@ ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_a
                  {"start_id", "num_sticks_per_core", "num_sticks_per_core_read", "num_read_per_barrier"},
              .common_runtime_arg_names =
                  {"addr_offset", "padded_stick_size", "unpadded_stick_size", "stick_size_offset", "misalignment"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         .advanced_options = {.num_runtime_varargs = num_dims, .num_common_runtime_varargs = 2 * num_dims},
     };
 
@@ -321,8 +320,7 @@ ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_a
                   "num_read_per_barrier",
                   "start_id",
                   "page_size_override"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // --- Per-core runtime args ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_sharded.cpp
@@ -291,7 +291,7 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedProgramFactory::create_pr
              {"src_stride_bytes", src_stride_bytes},
              {"dst_stride_bytes", dst_stride_bytes},
              {"begins_bytes", begins_bytes}},
-        .hw_config = ttnn::create_reader_datamovement_config(input.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = max_varargs},
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm_stride.cpp
@@ -91,8 +91,7 @@ ttnn::device_operation::ProgramArtifacts SliceRmStrideProgramFactory::create_pro
     reader.dfb_bindings = {
         DFBBinding{.dfb_spec_name = C0, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::PRODUCER}};
     reader.tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "in"}};
-    reader.hw_config =
-        ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    reader.hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     KernelSpec writer;
     writer.unique_id = WRITER;
@@ -100,8 +99,7 @@ ttnn::device_operation::ProgramArtifacts SliceRmStrideProgramFactory::create_pro
     writer.dfb_bindings = {
         DFBBinding{.dfb_spec_name = C0, .accessor_name = "cb_in", .endpoint_type = DFBEndpointType::CONSUMER}};
     writer.tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "out"}};
-    writer.hw_config =
-        ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    writer.hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     const auto& slice_start = args.slice_start;
     const auto& slice_end = args.slice_end;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile.cpp
@@ -105,8 +105,7 @@ ttnn::device_operation::ProgramArtifacts SliceTileProgramFactory::create_program
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "in"}},
         .compile_time_args = {{"num_dims", num_dims}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         .advanced_options = {.num_runtime_varargs = num_dims, .num_common_runtime_varargs = 2 * num_dims},
     };
 
@@ -121,8 +120,7 @@ ttnn::device_operation::ProgramArtifacts SliceTileProgramFactory::create_program
             .dfb_spec_name = C0, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "out"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // --- Per-core runtime args ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -129,7 +129,7 @@ ttnn::device_operation::ProgramArtifacts SliceTileTensorArgsProgramFactory::crea
              TensorBinding{.tensor_parameter_name = END, .accessor_name = "end"}},
         .compile_time_args = {{"num_dims", num_dims}, {"tile_width", tile_width}, {"tile_height", tile_height}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = num_dims, .num_common_runtime_varargs = 3 * num_dims},
     };
 
@@ -144,7 +144,7 @@ ttnn::device_operation::ProgramArtifacts SliceTileTensorArgsProgramFactory::crea
             .dfb_spec_name = C0, .accessor_name = "cb_out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "out"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // --- Per-core runtime args ---

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
@@ -276,8 +276,7 @@ ttnn::device_operation::ProgramArtifacts SliceWriteRMShardedInputProgramFactory:
             "slice_write_reader_sharded.cpp"};
     reader.dfb_bindings = {ProducerOf(SW_IN_DFB, "in0")};
     reader.runtime_arg_schema = {.runtime_arg_names = {"num_sticks"}};
-    reader.hw_config =
-        ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    reader.hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     // Writer: drain the input DFB -> interleaved output at start_id + the padded-dim walk.
     KernelSpec writer{
@@ -299,8 +298,7 @@ ttnn::device_operation::ProgramArtifacts SliceWriteRMShardedInputProgramFactory:
             "num_sticks_per_core_read",
             "num_read_per_barrier"}};
     writer.advanced_options.num_runtime_varargs = 3 * num_dims;
-    writer.hw_config =
-        ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    writer.hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     spec.kernels = {reader, writer};
     spec.work_units = {WorkUnitSpec{.name = "main", .kernels = {SW_READER, SW_WRITER}, .target_nodes = input_cores}};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
@@ -290,8 +290,7 @@ ttnn::device_operation::ProgramArtifacts SliceWriteTiledShardedInputProgramFacto
             "slice_write_reader_sharded.cpp"};
     reader.dfb_bindings = {ProducerOf(SWT_IN_DFB, "in0")};
     reader.runtime_arg_schema = {.runtime_arg_names = {"num_sticks"}};
-    reader.hw_config =
-        ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    reader.hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     // Writer: drain the input DFB -> interleaved output, writing each TILE at start_id + the padded-tile-dim walk.
     KernelSpec writer{
@@ -313,8 +312,7 @@ ttnn::device_operation::ProgramArtifacts SliceWriteTiledShardedInputProgramFacto
             "num_sticks_per_core_read",
             "num_read_per_barrier"}};
     writer.advanced_options.num_runtime_varargs = 3 * num_dims;
-    writer.hw_config =
-        ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    writer.hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     spec.kernels = {reader, writer};
     spec.work_units = {WorkUnitSpec{.name = "main", .kernels = {SWT_READER, SWT_WRITER}, .target_nodes = input_cores}};

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -244,8 +244,7 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
                       "single_block_size_col_arg",
                       "sub_block_width_size",
                       "single_sub_block_size_row_arg"}},
-            .hw_config =
-                ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         });
 
         // Writer: consumes c_16 (out); writes output tensor.
@@ -261,14 +260,13 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
                  {"total_tiles_per_row", total_tiles_per_row}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"}},
-            .hw_config =
-                ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         });
 
         // Compute: consumes c_0 (in), produces c_16 (out).
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_config_template);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config_template);
         if (fp32_llk_acc) {
-            std::visit([&](auto& c) { c.unpack_modes.emplace(g.in, UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(g.in, UnpackMode::UnpackToDest);
         }
         spec.kernels.push_back(KernelSpec{
             .unique_id = g.compute,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_default_program_factory.cpp
@@ -115,8 +115,7 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreDefaultProgramFactory::c
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_rows", "num_tiles_per_block", "block_width_size", "num_full_blocks_in_row", "start_page_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Writer kernel (spans all_cores) --
@@ -132,16 +131,15 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreDefaultProgramFactory::c
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = MC_OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Compute kernels (preserved multiplicity: per-group CTAs) --
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_llk_acc};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_llk_acc) {
-        std::visit([&](auto& c) { c.unpack_modes.emplace(MC_INPUT_DFB, UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(MC_INPUT_DFB, UnpackMode::UnpackToDest);
     }
     const char* compute_src = "ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/compute/tilize.cpp";
     auto make_compute = [&](const KernelSpecName& id, uint32_t nblocks_per_core_arg) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -84,8 +84,7 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreShardedProgramFactory::c
             .endpoint_type = DFBEndpointType::PRODUCER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Writer kernel --
@@ -99,16 +98,15 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreShardedProgramFactory::c
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Compute kernel --
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_llk_acc};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(input.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_llk_acc) {
-        std::visit([&](auto& c) { c.unpack_modes.emplace(INPUT_DFB, UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(INPUT_DFB, UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE_KERNEL,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
@@ -81,8 +81,7 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreWidthShardedProgramFacto
             .endpoint_type = DFBEndpointType::PRODUCER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Writer kernel --
@@ -96,16 +95,15 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreWidthShardedProgramFacto
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Compute kernel --
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_llk_acc};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(input.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_llk_acc) {
-        std::visit([&](auto& c) { c.unpack_modes.emplace(WS_INPUT_DFB, UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(WS_INPUT_DFB, UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = WS_COMPUTE_KERNEL,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_single_core_program_factory.cpp
@@ -119,8 +119,7 @@ ttnn::device_operation::ProgramArtifacts TilizeSingleCoreProgramFactory::create_
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_block", "block_width_size", "num_full_blocks_in_row", "start_stick_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Writer kernel --
@@ -136,16 +135,15 @@ ttnn::device_operation::ProgramArtifacts TilizeSingleCoreProgramFactory::create_
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SC_OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // -- Compute kernel --
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_llk_acc};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_llk_acc) {
-        std::visit([&](auto& c) { c.unpack_modes.emplace(SC_INPUT_DFB, UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(SC_INPUT_DFB, UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = SC_COMPUTE_KERNEL,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
@@ -116,8 +116,7 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreDefaultFac
              {"page_size", page_size},
              {"size_of_valid_data_in_last_page_in_row", size_of_valid_data_in_last_page_in_row}},
         .runtime_arg_schema = {.runtime_arg_names = {"padded_X_size", "pad_value", "start_page_id", "n_block_reps"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer (Metal 2.0 fork) ----
@@ -130,18 +129,16 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingMultiCoreDefaultFac
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute (Metal 2.0 fork; full + cliff) ----
     auto make_compute_hw = [&]() -> ComputeHardwareConfig {
         ttnn::ComputeKernelConfig hw{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_llk_acc};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), hw);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(hw);
         if (fp32_llk_acc) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest);
         }
         return compute_hw;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/factories/tilize_with_val_padding_single_core_program_factory.cpp
@@ -160,8 +160,7 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingSingleCoreFactory::
                   "num_blocks_w_diff",
                   "block_row_size",
                   "block_row_leftover_size"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer (Metal 2.0 fork of writer_unary_interleaved_start_id) ----
@@ -174,16 +173,15 @@ ttnn::device_operation::ProgramArtifacts TilizeWithValPaddingSingleCoreFactory::
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute (Metal 2.0 fork of tilize) ----
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_llk_acc};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_llk_acc) {
-        std::visit([&](auto& c) { c.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/joint_sdpa_program_factory.cpp
@@ -406,7 +406,8 @@ ttnn::device_operation::ProgramArtifacts JointSDPADeviceOperation::JointSDPAProg
 
     KernelSpec reader{
         .unique_id = READER,
-        .source = "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/joint_reader.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/joint_reader.cpp",
         .compiler_options = {.defines = base_defines},
         .dfb_bindings =
             {
@@ -446,7 +447,7 @@ ttnn::device_operation::ProgramArtifacts JointSDPADeviceOperation::JointSDPAProg
                   "local_nh_end",
                   "local_q_start",
                   "local_q_end"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     Group<DFBBinding> writer_dfbs = {
@@ -465,7 +466,8 @@ ttnn::device_operation::ProgramArtifacts JointSDPADeviceOperation::JointSDPAProg
 
     KernelSpec writer{
         .unique_id = WRITER,
-        .source = "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp",
         .compiler_options = {.defines = writer_defines},
         .dfb_bindings = writer_dfbs,
         .tensor_bindings =
@@ -498,7 +500,7 @@ ttnn::device_operation::ProgramArtifacts JointSDPADeviceOperation::JointSDPAProg
                   "local_nh_end",
                   "local_q_start",
                   "local_q_end"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     Group<DFBBinding> compute_dfbs = {
@@ -573,7 +575,7 @@ ttnn::device_operation::ProgramArtifacts JointSDPADeviceOperation::JointSDPAProg
                   "local_nh_end",
                   "local_q_start",
                   "local_q_end"}},
-        .hw_config = ttnn::to_compute_hardware_config(device->arch(), args.compute_kernel_config),
+        .hw_config = ttnn::to_compute_hardware_config(args.compute_kernel_config),
     };
 
     // ---- Assemble the ProgramSpec ----

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -1452,14 +1452,16 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
 
     KernelSpec reader{
         .unique_id = READER,
-        .source = "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/"
+            "reader_interleaved.cpp",
         .compiler_options = {.defines = reader_defines},
         .dfb_bindings = reader_dfbs,
         .semaphore_bindings = reader_sems,
         .tensor_bindings = reader_tensors,
         .compile_time_args = reader_cta,
         .runtime_arg_schema = {.runtime_arg_names = reader_rta_names},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec::CompileTimeArgs writer_cta = {
@@ -1560,13 +1562,15 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
 
     KernelSpec writer{
         .unique_id = WRITER,
-        .source = "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/dataflow/"
+            "writer_interleaved.cpp",
         .compiler_options = {.defines = writer_defines},
         .dfb_bindings = writer_dfbs,
         .tensor_bindings = writer_tensors,
         .compile_time_args = writer_cta,
         .runtime_arg_schema = {.runtime_arg_names = writer_rta_names},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelSpec::CompileTimeArgs compute_cta = {
@@ -1678,7 +1682,7 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
         compute_defines.insert({"USE_WINDOWED_NARROWING", "1"});
     }
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
     if (fp32_dest_acc_en) {
         // qk_im / sum_A / sum_B are Float32 when enable_32_bit_dest is on; the validator requires an
         // explicit unpack_modes entry for each Float32 DFB the compute consumes. Legacy defaulted to
@@ -1687,7 +1691,7 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
         // std::get<ComputeGen1Config>: the helper above builds the config from device->arch(), so on
         // Quasar it returns the Gen2 alternative and naming Gen1 here throws std::bad_variant_access.
         // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
-        auto& dfb_unpack_modes = unpack_modes(compute_hw);
+        auto& dfb_unpack_modes = compute_hw.unpack_modes;
         dfb_unpack_modes.insert({QK_IM, tt::tt_metal::UnpackMode::UnpackToSrc});
         dfb_unpack_modes.insert({SUM_A, tt::tt_metal::UnpackMode::UnpackToSrc});
         dfb_unpack_modes.insert({SUM_B, tt::tt_metal::UnpackMode::UnpackToSrc});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -1021,12 +1021,12 @@ ttnn::device_operation::ProgramArtifacts SdpaDecodeDeviceOperation::SdpaDecodePr
         .packer_l1_acc = packer_l1_acc,
         .dst_full_sync_en = dst_full_sync_en,
     };
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), resolved_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(resolved_config);
     // unpack_modes: Metal 2.0 requires an explicit entry for each Float32-format DFB a compute kernel
     // consumes when enable_32_bit_dest is set. Legacy set no unpack_to_dest_mode (all Default = UnpackToSrc),
     // so every required entry is UnpackToSrc. The trigger is the DFB's format, not the tensor dtype.
     if (fp32_dest_acc_en) {
-        auto& modes = unpack_modes(compute_hw);
+        auto& modes = compute_hw.unpack_modes;
         auto maybe_unpack = [&](const DFBSpecName& name, tt::DataFormat df, bool bound) {
             if (bound && df == tt::DataFormat::Float32) {
                 modes.insert({name, tt::tt_metal::UnpackMode::UnpackToSrc});
@@ -1069,7 +1069,7 @@ ttnn::device_operation::ProgramArtifacts SdpaDecodeDeviceOperation::SdpaDecodePr
                   "mcast_y0",
                   "mcast_y1",
                   "num_dests"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 2 * num_output_cores},
     };
     KernelSpec writer{
@@ -1103,7 +1103,7 @@ ttnn::device_operation::ProgramArtifacts SdpaDecodeDeviceOperation::SdpaDecodePr
                   "children_per_round_3",
                   "children_per_round_4",
                   "children_per_round_5"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
         .advanced_options =
             {.num_runtime_varargs = 2 * num_cores_per_head + 2 * num_reducer_cores + 2 * num_output_cores},
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
@@ -133,8 +133,7 @@ ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_progr
             },
         .runtime_arg_schema =
             {.runtime_arg_names = {"N", "C", "HtWt", "batch_step", "channel_step", "num_pages", "start_id", "hw", "n"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // Writer KernelSpec.
@@ -158,8 +157,7 @@ ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_progr
                 {"write_size", stick_size},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     spec.kernels.push_back(std::move(reader));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -113,8 +113,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_pro
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks_per_core_read", "num_read_per_barrier", "start_id", "curr_c", "curr_h", "curr_n"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------
@@ -128,8 +127,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_pro
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .compile_time_args = {{"W_size_bytes", stick_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_sticks_per_core_read", "num_read_per_barrier", "start_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -429,8 +429,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::creat
                       "num_sticks_per_shard_core",
                       "num_cores_read",
                       "read_stick_stride"}},
-            .hw_config = ttnn::create_reader_datamovement_config(
-                input_tensor.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         };
         reader_spec.compiler_options.defines = {{"USE_SPECIAL_CASE", "1"}};
         reader_spec.advanced_options.num_runtime_varargs = max_reader_varargs;
@@ -449,8 +448,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::creat
                       "read_stick_stride",
                       "src_read_stick_offset",
                       "dst_write_stick_offset"}},
-            .hw_config = ttnn::create_writer_datamovement_config(
-                input_tensor.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         };
         writer_spec.advanced_options.num_runtime_varargs = max_writer_varargs;
 
@@ -520,8 +518,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::creat
                  {"num_cores_y", num_cores_y}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"num_sticks_per_core", "start_id", "curr_c", "curr_h", "curr_n"}},
-            .hw_config = ttnn::create_reader_datamovement_config(
-                input_tensor.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         };
         reader_spec.advanced_options.num_runtime_varargs = num_cores_x + num_cores_y;
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -173,7 +173,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFacto
                 {"tile_width", 1u},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // Writer DFB bindings (SRC_CB consumer; PAD_CB consumer when padding).
@@ -211,8 +211,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFacto
             {.runtime_arg_names = {"start_tile_idx", "end_tile_idx", "start_padding_tile_idx", "end_padding_tile_idx"}},
         // Quasar: writer drains SRC/PAD CBs with ~32B face-line (sub-tile) writes; implicit sync
         // mis-credits per NOC op and stalls. Revert to explicit credits. See ~/implicit_sync.md.
-        .hw_config = ttnn::create_writer_datamovement_config(
-            input_tensor.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     spec.kernels.push_back(std::move(reader));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -156,7 +156,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_
                   "ct",
                   "ctoffs",
                   "wt"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ------------------------------------------------------------------------
@@ -170,7 +170,7 @@ ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .compile_time_args = {{"page_size", single_tile_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_program_factory.cpp
@@ -160,8 +160,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
             // this unnecessary" cleanup removed the opt-out, but that sim fix is inert on the emulator/HW.
             // Disable implicit sync so the kernel's explicit reserve_back/push_back is the sole authority
             // (matches every other Quasar tilize/untilize/HC-transpose dataflow kernel).
-            .hw_config =
-                ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         };
 
         KernelSpec writer_spec{
@@ -189,22 +188,17 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
             // each core's output shard as zeros. The craq-sim "sub-tile fix" that motivated removing the
             // opt-out is inert on the emulator/HW. Disable implicit sync so the explicit wait_front/pop_front
             // is the sole authority (matches the HC-transpose / tilize / untilize Quasar dataflow kernels).
-            .hw_config =
-                ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+            .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         };
 
         ttnn::ComputeKernelConfig compute_cfg{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_cfg);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_cfg);
         if (src_is_float32) {
             // Keep the source CB and the tile-formatted intermediate (cb_tilize) in full Float32
             // on the unpack-to-dest path; both feed the transpose.
-            std::visit(
-                [&](auto& c) {
-                    c.unpack_modes.emplace(CB_IN0, tt::tt_metal::UnpackMode::UnpackToDest);
-                    c.unpack_modes.emplace(CB_TILIZE, tt::tt_metal::UnpackMode::UnpackToDest);
-                },
-                compute_hw);
+            compute_hw.unpack_modes.emplace(CB_IN0, tt::tt_metal::UnpackMode::UnpackToDest);
+            compute_hw.unpack_modes.emplace(CB_TILIZE, tt::tt_metal::UnpackMode::UnpackToDest);
         }
 
         KernelSpec compute_spec{
@@ -284,7 +278,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
             .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
             .runtime_arg_schema =
                 {.runtime_arg_names = {"num_tiles", "start_id", "start_ht", "start_wt", "Ht", "Wt", "HtWt"}},
-            .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_reader_datamovement_config(),
         };
 
         KernelSpec writer_spec{
@@ -297,15 +291,14 @@ ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_progr
             .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
             .compile_time_args = {{"page_size", dst_single_tile_size}},
             .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-            .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_writer_datamovement_config(),
         };
 
         ttnn::ComputeKernelConfig compute_cfg{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_cfg);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_cfg);
         if (src_is_float32) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(CB_IN0, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(CB_IN0, tt::tt_metal::UnpackMode::UnpackToDest);
         }
 
         KernelSpec compute_spec{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -122,8 +122,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::creat
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = CB_IN0, .accessor_name = "cb_in0", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles"}},
-        .hw_config = ttnn::create_reader_datamovement_config(
-            input_tensor.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer_spec{
@@ -134,16 +133,14 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::creat
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = CB_OUT0, .accessor_name = "cb_out0", .endpoint_type = DFBEndpointType::CONSUMER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config = ttnn::create_writer_datamovement_config(
-            input_tensor.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     ttnn::ComputeKernelConfig compute_cfg{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(input_tensor.device()->arch(), compute_cfg);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_cfg);
     if (src0_cb_data_format == tt::DataFormat::Float32) {
-        std::visit(
-            [&](auto& c) { c.unpack_modes.emplace(CB_IN0, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(CB_IN0, tt::tt_metal::UnpackMode::UnpackToDest);
     }
 
     KernelSpec compute_spec{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -169,21 +169,17 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
         // work around, and CB_IN is a real reader->compute handshake (reserve_back/push_back vs the
         // compute's wait_front/pop_front) that needs the credits. (The earlier disable_implicit_sync_for
         // was a workaround for the self/loopback NOC-read auto-post bug, removed with that read.)
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device()->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     ttnn::ComputeKernelConfig compute_cfg{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(input_tensor.device()->arch(), compute_cfg);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_cfg);
     if (src0_cb_data_format == tt::DataFormat::Float32) {
         // Keep both the tilize input (cb_in) and its output (cb_tilize, which feeds the transpose)
         // in full Float32 on the unpack-to-dest path; otherwise the unpacker falls back to tf32.
-        std::visit(
-            [&](auto& c) {
-                c.unpack_modes.emplace(CB_IN, tt::tt_metal::UnpackMode::UnpackToDest);
-                c.unpack_modes.emplace(CB_TILIZE, tt::tt_metal::UnpackMode::UnpackToDest);
-            },
-            compute_hw);
+        compute_hw.unpack_modes.emplace(CB_IN, tt::tt_metal::UnpackMode::UnpackToDest);
+        compute_hw.unpack_modes.emplace(CB_TILIZE, tt::tt_metal::UnpackMode::UnpackToDest);
     }
 
     // Output binding: ht<=8 -> compute self-loops the borrowed output shard directly; ht>8 -> compute
@@ -249,7 +245,7 @@ ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::cre
                  {"W_per_tile_last", W_per_tile_last},
                  {"H_size_bytes", H * output_tensor.element_size()},
                  {"l1_read_offset_bytes", ht * output_tensor.element_size() * TILE_HEIGHT}},
-            .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device()->arch()),
+            .hw_config = ttnn::create_writer_datamovement_config(),
         };
         kernels.push_back(std::move(writer_spec));
         wu_kernels.push_back(WRITER_KERNEL);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -208,8 +208,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreBlockProgramFactory::c
              {"total_tiles_per_row", total_tiles_per_row}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -235,8 +234,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreBlockProgramFactory::c
                   "single_block_size_col_arg",
                   "sub_block_width_size",
                   "single_sub_block_size_row_arg"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;
@@ -252,10 +250,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreBlockProgramFactory::c
     auto make_compute_hw = [&]() -> ComputeHardwareConfig {
         ttnn::ComputeKernelConfig cfg{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), cfg);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(cfg);
         if (fp32_dest_acc_en) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
         }
         return compute_hw;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -97,8 +97,7 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -107,8 +106,7 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;
@@ -117,10 +115,9 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
     }
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit(
-            [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -88,8 +88,7 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -98,8 +97,7 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;
@@ -108,10 +106,9 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
     }
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit(
-            [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -139,8 +139,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
              {"num_shards", num_shards},
              {"num_cores", num_compute_cores}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -165,8 +164,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
              {"output_tensor_width", output_tensor_width},
              {"output_tensor_height", output_tensor_height}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;
@@ -175,10 +173,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreNDShardInputProgramFac
     }
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit(
-            [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -112,8 +112,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
             .dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer (Metal 2.0 fork of writer_..._interleaved_parallel_columns) ----
@@ -128,8 +127,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_core", "tile_width_size", "start_stick_id", "offset_within_stick"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute (Metal 2.0 fork of untilize; full + cliff) ----
@@ -140,10 +138,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreParallelizeColumnProgr
     auto make_compute_hw = [&]() -> ComputeHardwareConfig {
         ttnn::ComputeKernelConfig hw{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), hw);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(hw);
         if (fp32_dest_acc_en) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest);
         }
         return compute_hw;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -170,8 +170,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
     reader.unique_id = READER;
     reader.dfb_bindings = {
         DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}};
-    reader.hw_config =
-        ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    reader.hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
     if (use_block_reader) {
         reader.source = kdir / "reader_unary_sharded_blocks_metal2.cpp";
         reader.tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}};
@@ -209,8 +208,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
                   "num_unpadded_cols_per_input_block",
                   "width_wise_output_block_start_index",
                   "num_cols_already_processed_in_first_output_block"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute KernelSpec(s) (common; full + optional interleaved cliff) ----
@@ -221,10 +219,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreProgramFactory::create
     auto make_compute_hw = [&]() -> ComputeHardwareConfig {
         ttnn::ComputeKernelConfig hw{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), hw);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(hw);
         if (fp32_dest_acc_en) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
         }
         return compute_hw;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -109,8 +109,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
             .dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer (Metal 2.0 fork of writer_..._interleaved_parallel_columns) ----
@@ -125,8 +124,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_sticks", "num_tiles_per_core", "tile_width_size", "start_stick_id", "offset_within_stick"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute (Metal 2.0 fork of untilize; uniform across all sub-core-grid cores) ----
@@ -136,9 +134,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeMultiCoreSubCoreGridsProgramFac
     }
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit([&](auto& c) { c.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -126,8 +126,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
             .dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_page_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer ----
@@ -145,8 +144,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
              {"num_blocks_per_output_column_row", num_blocks_per_column_row},
              {"num_tiles_per_output_block", num_tiles_per_block},
              {"output_single_block_width_size", output_single_block_width_size}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute (Metal 2.0 fork of untilize) ----
@@ -156,9 +154,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeSingleCoreProgramFactory::creat
     }
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit([&](auto& c) { c.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN, tt::tt_metal::UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -197,8 +197,7 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_program_art
              {"total_tiles_per_row", total_tiles_per_row}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -223,8 +222,7 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_program_art
                   "single_block_size_col_arg",
                   "sub_block_width_size",
                   "single_sub_block_size_row_arg"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;
@@ -240,10 +238,9 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_program_art
     auto make_compute_hw = [&]() -> ComputeHardwareConfig {
         ttnn::ComputeKernelConfig cfg{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), cfg);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(cfg);
         if (fp32_dest_acc_en) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
         }
         return compute_hw;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -118,8 +118,7 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_program_artif
              {"third_dim", third_dim},
              {"number_blocks_per_core", nblocks_per_core}},
         .runtime_arg_schema = {.runtime_arg_names = {"core_number", "tiles_per_row", "num_blocks"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer kernel ----
@@ -139,8 +138,7 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_program_artif
              {"unpadded_X_size", unpadded_row_size_bytes}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"core_number", "size_per_row_per_block", "blocks_per_core", "width_size"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute kernel (full + cliff) ----
@@ -152,10 +150,9 @@ UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_program_artif
     auto make_compute_hw = [&]() -> ComputeHardwareConfig {
         ttnn::ComputeKernelConfig cfg{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), cfg);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(cfg);
         if (fp32_dest_acc_en) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
         }
         return compute_hw;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -103,8 +103,7 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_program_artifact
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer kernel ----
@@ -122,8 +121,7 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_program_artifact
             {{"float32_dtype", static_cast<uint32_t>(float32_dtype)}, {"unpadded_X_size", unpadded_row_size_bytes}},
         .runtime_arg_schema = {.runtime_arg_names = {"padded_X_size", "start_stick_id", "n_block_reps"}},
     };
-    writer.hw_config =
-        ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true);
+    writer.hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true);
 
     // ---- Compute kernels (full + cliff) ----
     KernelSpec::CompilerOptions::Defines compute_defines;
@@ -133,10 +131,9 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_program_artifact
     auto make_compute_hw = [&]() -> ComputeHardwareConfig {
         ttnn::ComputeKernelConfig cfg{
             .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(device->arch(), cfg);
+        ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(cfg);
         if (fp32_dest_acc_en) {
-            std::visit(
-                [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+            compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
         }
         return compute_hw;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -127,8 +127,7 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_program_artifacts(
              {"num_shards", num_shards},
              {"num_cores", num_compute_cores}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------
@@ -189,8 +188,7 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_program_artifacts(
              {"output_tensor_height", output_tensor_height},
              {"tensor_rank", static_cast<uint32_t>(input.padded_shape().rank())}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(input.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
         .advanced_options =
             KernelAdvancedOptions{
                 .num_common_runtime_varargs = static_cast<uint32_t>(writer_common_runtime_args.size())},
@@ -206,10 +204,9 @@ UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_program_artifacts(
 
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(input.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit(
-            [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     }
 
     KernelSpec compute{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -153,8 +153,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreShardedPr
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ------------------------------------------------------------------------
@@ -165,8 +164,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreShardedPr
     // ------------------------------------------------------------------------
     KernelSpec writer{
         .unique_id = WRITER,
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
     if (out_sharded) {
         // Both out-sharded writers consume OUT (untilized tiles) and produce the resident OUT_SHARDED
@@ -235,10 +233,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreShardedPr
 
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit(
-            [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     }
 
     KernelSpec compute{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -139,8 +139,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingSingleCoreProgramF
             .dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config =
-            ttnn::create_reader_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Writer kernel ----
@@ -169,8 +168,7 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingSingleCoreProgramF
                   "num_blocks_w_diff",
                   "block_row_size",
                   "block_row_leftover_size"}},
-        .hw_config =
-            ttnn::create_writer_datamovement_config(a.device()->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // ---- Compute kernel ----
@@ -180,10 +178,9 @@ ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingSingleCoreProgramF
     }
     ttnn::ComputeKernelConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4, .math_approx_mode = false, .fp32_dest_acc_en = fp32_dest_acc_en};
-    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(a.device()->arch(), compute_config);
+    ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(compute_config);
     if (fp32_dest_acc_en) {
-        std::visit(
-            [&](auto& c) { c.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest); }, compute_hw);
+        compute_hw.unpack_modes.emplace(IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest);
     }
     KernelSpec compute{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -16,7 +16,6 @@
 #include "intimg_device_operation.hpp"
 
 #include <array>
-#include <variant>
 
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/buffer.hpp>
@@ -137,8 +136,6 @@ ttnn::device_operation::ProgramArtifacts IntImgDeviceOperation::ProgramFactory::
         {"cores_y", CORES_Y},
     };
 
-    const auto arch = input_tensor.device()->arch();
-
     // ---- Reader (DM). Produces START (zero-fill) and INPUT (DRAM load). Reads the input tensor via binding. ----
     m2::KernelSpec reader_spec{
         .unique_id = READER,
@@ -150,7 +147,7 @@ ttnn::device_operation::ProgramArtifacts IntImgDeviceOperation::ProgramFactory::
                  .dfb_spec_name = INPUT, .accessor_name = "input", .endpoint_type = m2::DFBEndpointType::PRODUCER}},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = T_INPUT, .accessor_name = "input"}},
         .compile_time_args = scalar_ctas,
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Compute. Consumes START/INPUT/AXIS_3_BUFFER, produces OUTPUT, self-loops ACC/CUMSUM_STAGE_0/1/2/
@@ -208,9 +205,9 @@ ttnn::device_operation::ProgramArtifacts IntImgDeviceOperation::ProgramFactory::
                  .endpoint_type = m2::DFBEndpointType::CONSUMER}},
         .compile_time_args = scalar_ctas,
     };
-    // Compute hw_config — Style B (legacy set a Metal ComputeConfig directly). Build ComputeGen1Config; carry the
+    // Compute hw_config — Style B (legacy set a Metal ComputeConfig directly). Build ComputeHardwareConfig; carry the
     // resolved legacy values (HiFi4, math_approx_mode=false -> Precise, fp32_dest_acc_en -> enable_32_bit_dest).
-    m2::ComputeGen1Config compute_cfg{
+    m2::ComputeHardwareConfig compute_cfg{
         .fpu_math_fidelity = MathFidelity::HiFi4,
         .sfpu_precision_mode = Precision::Precise,
         .enable_32_bit_dest = fp32_dest_acc_en,
@@ -219,7 +216,7 @@ ttnn::device_operation::ProgramArtifacts IntImgDeviceOperation::ProgramFactory::
     // mode default (=UnpackToSrc); replicate that for the 8 DFBs the compute kernel consumes (OUTPUT is producer-only).
     // For bf16 input enable_32_bit_dest is false and no entries are required.
     if (fp32_dest_acc_en) {
-        compute_cfg.unpack_modes = m2::ComputeUnpackModes{
+        compute_cfg.unpack_modes = m2::ComputeHardwareConfig::ComputeUnpackModes{
             {START, UnpackMode::UnpackToSrc},
             {INPUT, UnpackMode::UnpackToSrc},
             {ACC, UnpackMode::UnpackToSrc},
@@ -230,7 +227,7 @@ ttnn::device_operation::ProgramArtifacts IntImgDeviceOperation::ProgramFactory::
             {AXIS_3_BUFFER, UnpackMode::UnpackToSrc},
         };
     }
-    compute_spec.hw_config = m2::ComputeHardwareConfig{compute_cfg};
+    compute_spec.hw_config = compute_cfg;
 
     // ---- Writer (DM). Consumes OUTPUT (DRAM write), produces AXIS_3_BUFFER (cross-row readback). One output
     //      TensorBinding covers both the write and the readback (both go through the same TensorAccessor). ----
@@ -246,7 +243,7 @@ ttnn::device_operation::ProgramArtifacts IntImgDeviceOperation::ProgramFactory::
                  .endpoint_type = m2::DFBEndpointType::PRODUCER}},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = T_OUTPUT, .accessor_name = "output"}},
         .compile_time_args = scalar_ctas,
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- WorkUnit: all three kernels on the fixed 2x4 grid (placement derives DFB residency). ----

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -202,7 +202,7 @@ ttnn::device_operation::ProgramArtifacts RepeatAndInterleaveEltwiseMulProgramFac
                 .runtime_arg_names =
                     {"in1_num_blocks", "in1_start_id", "in1_num_blocks_h", "in1_num_blocks_w", "in0_num_blocks_w"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -227,7 +227,7 @@ ttnn::device_operation::ProgramArtifacts RepeatAndInterleaveEltwiseMulProgramFac
                 .runtime_arg_names =
                     {"out_num_blocks_w_per_core", "start_id", "out_num_blocks_h", "out_total_blocks_w"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     Group<DFBBinding> compute_dfb_bindings = {
@@ -279,12 +279,12 @@ ttnn::device_operation::ProgramArtifacts RepeatAndInterleaveEltwiseMulProgramFac
     };
 
     // Compute hw_config — Style B (the legacy factory set a Metal ComputeConfigDescriptor directly,
-    // with no TTNN ComputeKernelConfig behind it). Build ComputeGen1Config field by field: the three
+    // with no TTNN ComputeKernelConfig behind it). Build ComputeHardwareConfig field by field: the three
     // fields the descriptor set explicitly are carried over (math_approx_mode = false becomes
-    // sfpu_precision_mode = Precise), and the three it left alone stay at ComputeGen1Config's
+    // sfpu_precision_mode = Precise), and the three it left alone stay at ComputeHardwareConfig's
     // defaults, which coincide with the legacy descriptor's. No unpack_modes entry is required
     // because enable_32_bit_dest is false.
-    const ComputeHardwareConfig compute_hw_config = ComputeGen1Config{
+    const ComputeHardwareConfig compute_hw_config{
         .fpu_math_fidelity = operation_attributes.math_fidelity,
         .sfpu_precision_mode = Precision::Precise,
         .enable_32_bit_dest = false,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
@@ -89,8 +89,6 @@ ttnn::device_operation::ProgramArtifacts NLPConcatHeadsProgramFactory::create_pr
     const TensorParamName INPUT{"input"};
     const TensorParamName OUTPUT{"output"};
 
-    const auto arch = a.device()->arch();
-
     KernelSpec reader_spec;
     KernelSpec writer_spec;
     if (in_sharded) {
@@ -137,7 +135,7 @@ ttnn::device_operation::ProgramArtifacts NLPConcatHeadsProgramFactory::create_pr
             .compile_time_args = compile_time_args,
             .runtime_arg_schema =
                 {.runtime_arg_names = {"nheads", "start_read_offset_bytes", "start_write_offset_bytes"}},
-            .hw_config = create_reader_datamovement_config(arch),
+            .hw_config = create_reader_datamovement_config(),
         };
         writer_spec = KernelSpec{
             .unique_id = WRITER,
@@ -148,7 +146,7 @@ ttnn::device_operation::ProgramArtifacts NLPConcatHeadsProgramFactory::create_pr
             .compile_time_args = std::move(compile_time_args),
             .runtime_arg_schema =
                 {.runtime_arg_names = {"nheads", "start_read_offset_bytes", "start_write_offset_bytes"}},
-            .hw_config = create_writer_datamovement_config(arch),
+            .hw_config = create_writer_datamovement_config(),
         };
     } else {
         reader_spec = KernelSpec{
@@ -173,7 +171,7 @@ ttnn::device_operation::ProgramArtifacts NLPConcatHeadsProgramFactory::create_pr
                     {"in0_HtWt", in0_HtWt},
                 },
             .runtime_arg_schema = {.runtime_arg_names = {"num_blocks", "in0_h_dim", "in0_tensor_tile_id"}},
-            .hw_config = create_reader_datamovement_config(arch),
+            .hw_config = create_reader_datamovement_config(),
         };
         // The interleaved writer reuses the shared Metal 2.0 fork of
         // writer_unary_interleaved_start_id.cpp; its binding vocabulary (dfb::out, tensor::dst,
@@ -193,7 +191,7 @@ ttnn::device_operation::ProgramArtifacts NLPConcatHeadsProgramFactory::create_pr
                 .accessor_name = "dst",
             }},
             .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-            .hw_config = create_writer_datamovement_config(arch),
+            .hw_config = create_writer_datamovement_config(),
         };
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.cpp
@@ -204,10 +204,9 @@ ttnn::device_operation::ProgramArtifacts NLPCreateQKVHeadsDecodeInterleavedProgr
         };
     };
 
-    const auto arch = input_tensor.device()->arch();
     // phase 1 on the reader instance, phase 2 on the writer instance
-    KernelSpec reader = make_kernel(READER, READER_SCRATCH, 1, create_reader_datamovement_config(arch));
-    KernelSpec writer = make_kernel(WRITER, WRITER_SCRATCH, 2, create_writer_datamovement_config(arch));
+    KernelSpec reader = make_kernel(READER, READER_SCRATCH, 1, create_reader_datamovement_config());
+    KernelSpec writer = make_kernel(WRITER, WRITER_SCRATCH, 2, create_writer_datamovement_config());
 
     ProgramSpec spec{
         .name = "nlp_create_qkv_heads_decode_interleaved",

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
@@ -158,7 +158,6 @@ ttnn::device_operation::ProgramArtifacts NLPCreateQKVHeadsDecodeShardedProgramFa
     const std::filesystem::path kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
         "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp";
-    const auto arch = device->arch();
 
     auto make_kernel = [&](const KernelSpecName& unique_id,
                            uint32_t phases_to_read,
@@ -259,26 +258,26 @@ ttnn::device_operation::ProgramArtifacts NLPCreateQKVHeadsDecodeShardedProgramFa
         /*phases_to_read=*/1,
         /*process_qv=*/true,
         overlap_qk_coregrid,
-        create_reader_datamovement_config(arch)));
+        create_reader_datamovement_config()));
     kernels.push_back(make_kernel(
         Q_WRITER,
         /*phases_to_read=*/2,
         /*process_qv=*/true,
         overlap_qk_coregrid,
-        create_writer_datamovement_config(arch)));
+        create_writer_datamovement_config()));
     if (!overlap_qk_coregrid) {
         kernels.push_back(make_kernel(
             K_READER,
             /*phases_to_read=*/1,
             /*process_qv=*/false,
             /*process_k=*/true,
-            create_reader_datamovement_config(arch)));
+            create_reader_datamovement_config()));
         kernels.push_back(make_kernel(
             K_WRITER,
             /*phases_to_read=*/2,
             /*process_qv=*/false,
             /*process_k=*/true,
-            create_writer_datamovement_config(arch)));
+            create_writer_datamovement_config()));
     }
 
     Group<WorkUnitSpec> work_units = {WorkUnitSpec{

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.cpp
@@ -164,7 +164,6 @@ NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create_program_artifact
     const std::filesystem::path kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
         "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp";
-    const auto arch = device->arch();
 
     auto make_kernel = [&](const KernelSpecName& unique_id,
                            uint32_t phases_to_read,
@@ -268,26 +267,26 @@ NLPCreateQKVHeadsDecodeShardedSubcoregridProgramFactory::create_program_artifact
         /*phases_to_read=*/1,
         /*process_qv=*/true,
         overlap_qk_coregrid,
-        create_reader_datamovement_config(arch)));
+        create_reader_datamovement_config()));
     kernels.push_back(make_kernel(
         Q_WRITER,
         /*phases_to_read=*/2,
         /*process_qv=*/true,
         overlap_qk_coregrid,
-        create_writer_datamovement_config(arch)));
+        create_writer_datamovement_config()));
     if (!overlap_qk_coregrid) {
         kernels.push_back(make_kernel(
             K_READER,
             /*phases_to_read=*/1,
             /*process_qv=*/false,
             /*process_k=*/true,
-            create_reader_datamovement_config(arch)));
+            create_reader_datamovement_config()));
         kernels.push_back(make_kernel(
             K_WRITER,
             /*phases_to_read=*/2,
             /*process_qv=*/false,
             /*process_k=*/true,
-            create_writer_datamovement_config(arch)));
+            create_writer_datamovement_config()));
     }
 
     Group<WorkUnitSpec> work_units = {WorkUnitSpec{

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
@@ -199,8 +199,8 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCorePrefillSha
     TensorParameter output_param{.unique_id = OUTPUT_PARAM, .spec = output.tensor_spec()};
 
     // hw_config — Style B (see the interleaved factory for the rationale).
-    const ComputeHardwareConfig compute_hw_config =
-        ComputeGen1Config{.fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
+    const ComputeHardwareConfig compute_hw_config{
+        .fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
 
     // ------------------------------------------------------------------
     // Reader kernel. cos_sin_sharded / trans_mat_use_global_cb move from CTAs to preprocessor defines
@@ -250,7 +250,7 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCorePrefillSha
              {"sin_Ht", sin_seq_len_t},
              {"rotary_Ht", rotary_seq_len_t}},
         .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
-        .hw_config = create_reader_datamovement_config(device->arch())};
+        .hw_config = create_reader_datamovement_config()};
 
     // Writer / compute — identical to the interleaved factory (shared kernel sources).
     const KernelSpec::CompilerOptions::Defines reload_define{{"RELOAD_IMPL", use_reload_impl ? "1" : "0"}};
@@ -268,7 +268,7 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCorePrefillSha
         .compile_time_args =
             {{"n_heads", n_heads}, {"Wt", head_dim_t}, {"Ht", seq_len_t}, {"rotary_Ht", rotary_seq_len_t}},
         .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
-        .hw_config = create_writer_datamovement_config(device->arch())};
+        .hw_config = create_writer_datamovement_config()};
 
     KernelSpec compute_spec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
@@ -170,14 +170,14 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCore::create_p
     TensorParameter output_param{.unique_id = OUTPUT_PARAM, .spec = output.tensor_spec()};
 
     // ------------------------------------------------------------------
-    // hw_config. Style B (build ComputeGen1Config directly): the legacy ComputeConfigDescriptor set
+    // hw_config. Style B (build ComputeHardwareConfig directly): the legacy ComputeConfigDescriptor set
     // only math_fidelity + fp32_dest_acc_en, leaving the rest at descriptor defaults. Routing through
     // to_compute_hardware_config would instead translate the *resolved* math_approx_mode (default true)
     // into sfpu_precision_mode=Approximate, which the legacy descriptor discarded (Precise). All DFBs
     // are bfloat16, so no unpack_modes entry is required even when enable_32_bit_dest is true.
     // ------------------------------------------------------------------
-    const ComputeHardwareConfig compute_hw_config =
-        ComputeGen1Config{.fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
+    const ComputeHardwareConfig compute_hw_config{
+        .fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
 
     const KernelSpec::CompilerOptions::Defines reload_define{{"RELOAD_IMPL", use_reload_impl ? "1" : "0"}};
 
@@ -211,7 +211,7 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCore::create_p
              {"sin_Ht", sin_seq_len_t},
              {"rotary_Ht", rotary_seq_len_t}},
         .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
-        .hw_config = create_reader_datamovement_config(device->arch())};
+        .hw_config = create_reader_datamovement_config()};
 
     KernelSpec writer_spec{
         .unique_id = WRITER,
@@ -227,7 +227,7 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCore::create_p
         .compile_time_args =
             {{"n_heads", n_heads}, {"Wt", head_dim_t}, {"Ht", seq_len_t}, {"rotary_Ht", rotary_seq_len_t}},
         .runtime_arg_schema = {.runtime_arg_names = {"batch_start", "batch_end", "seq_t_start", "seq_t_end"}},
-        .hw_config = create_writer_datamovement_config(device->arch())};
+        .hw_config = create_writer_datamovement_config()};
 
     KernelSpec compute_spec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
@@ -134,8 +134,8 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCoreSharded::c
     TensorParameter output_param{.unique_id = OUTPUT_PARAM, .spec = output.tensor_spec()};
 
     // hw_config — Style B (see the interleaved factory for the rationale).
-    const ComputeHardwareConfig compute_hw_config =
-        ComputeGen1Config{.fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
+    const ComputeHardwareConfig compute_hw_config{
+        .fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
 
     auto self_loop = [](const DFBSpecName& dfb, const std::string& name) {
         return Group<DFBBinding>{

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_program_factory.cpp
@@ -207,12 +207,12 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaFusedQKProgramFacto
     // hw_config mirrors the legacy ComputeConfigDescriptor subset: the legacy factory resolved the
     // full TTNN compute config but copied only math_fidelity and fp32_dest_acc_en onto the
     // descriptor, leaving math_approx_mode / dst_full_sync_en at descriptor defaults. Those
-    // defaults coincide with ComputeGen1Config's (sfpu_precision_mode = Precise,
+    // defaults coincide with ComputeHardwareConfig's (sfpu_precision_mode = Precise,
     // double_buffer_dest = true), so only the two copied fields are set here. No unpack_modes
     // entries: every DFB is bfloat16 (validate() forces BFLOAT16 tensors), so the Float32
     // required-entry rule never triggers even when enable_32_bit_dest is on.
-    const ComputeHardwareConfig compute_hw_config =
-        ComputeGen1Config{.fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
+    const ComputeHardwareConfig compute_hw_config{
+        .fpu_math_fidelity = math_fidelity, .enable_32_bit_dest = fp32_dest_acc_en};
 
     auto self_loop = [](const DFBSpecName& dfb, const std::string& name) {
         return Group<DFBBinding>{

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_program_factory.cpp
@@ -118,7 +118,7 @@ ttnn::device_operation::ProgramArtifacts GeluBackwardProgramFactory::create_prog
             {
                 .runtime_arg_names = {"num_tiles", "start_id", "block_height", "block_width", "num_cores_y"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // --- Writer Kernel ---
@@ -143,15 +143,15 @@ ttnn::device_operation::ProgramArtifacts GeluBackwardProgramFactory::create_prog
             {
                 .runtime_arg_names = {"num_pages", "start_id"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // --- Compute Kernel ---
     // The legacy factory set a Metal ComputeConfigDescriptor directly rather than resolving a TTNN
-    // ComputeKernelConfig, so build the Gen1 config by hand and leave every field the op did not set
-    // at its default: ComputeGen1Config's defaults coincide with the legacy descriptor's
+    // ComputeKernelConfig, so build ComputeHardwareConfig by hand and leave every field the op did not set
+    // at its default: ComputeHardwareConfig's defaults coincide with the legacy descriptor's
     // (math_approx_mode=false -> sfpu_precision_mode=Precise, dst_full_sync_en=false ->
-    // double_buffer_dest=true, bfp8_pack_precise=false -> bfp_pack_precision_mode=Approximate).
+    // double_buffer_dest=true, bfp8_pack_precise=false -> config_1xx bfp_pack_precision_mode=Approximate).
     bool fp32_dest_acc_en = (dst_cb_data_format == DataFormat::Float32) || (dst_cb_data_format == DataFormat::Int32) ||
                             (dst_cb_data_format == DataFormat::UInt32);
 
@@ -161,7 +161,7 @@ ttnn::device_operation::ProgramArtifacts GeluBackwardProgramFactory::create_prog
     // buffer on the SrcA/B path. Reproduce that exactly by emitting UnpackToDest only where the
     // legacy request was live; an omitted entry means UnpackToSrc, which is what legacy effectively
     // used for every narrower format.
-    ComputeUnpackModes unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes unpack_modes;
     if (src0_cb_data_format == DataFormat::Float32) {
         unpack_modes[GRAD_OUTPUT_DFB] = UnpackMode::UnpackToDest;
     }
@@ -169,7 +169,7 @@ ttnn::device_operation::ProgramArtifacts GeluBackwardProgramFactory::create_prog
         unpack_modes[INPUT_DFB] = UnpackMode::UnpackToDest;
     }
 
-    ComputeGen1Config compute_hw_config{
+    ComputeHardwareConfig compute_hw_config{
         .fpu_math_fidelity = MathFidelity::HiFi4,
         .enable_32_bit_dest = fp32_dest_acc_en,
         .unpack_modes = std::move(unpack_modes),
@@ -215,7 +215,7 @@ ttnn::device_operation::ProgramArtifacts GeluBackwardProgramFactory::create_prog
             {
                 .runtime_arg_names = {"num_tiles"},
             },
-        .hw_config = ComputeHardwareConfig{std::move(compute_hw_config)},
+        .hw_config = std::move(compute_hw_config),
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_interleaved.cpp
@@ -99,8 +99,6 @@ ttnn::device_operation::ProgramArtifacts FullInterleavedProgramFactory::create_p
         .runtime_arg_names = {"fill_value", "num_pages_per_core", "start_id"},
     };
 
-    const auto arch = operation_attributes.mesh_device->arch();
-
     m2::Group<m2::KernelSpec> kernels;
     m2::Group<m2::DataflowBufferSpec> dataflow_buffers;
     m2::Group<m2::KernelSpecName> work_unit_kernels;
@@ -113,7 +111,7 @@ ttnn::device_operation::ProgramArtifacts FullInterleavedProgramFactory::create_p
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .compile_time_args = compile_time_args,
         .runtime_arg_schema = runtime_arg_schema,
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
     dataflow_buffers.push_back(make_fill_value_dfb(FILL_VALUE_WRITER));
     work_unit_kernels.push_back(WRITER);
@@ -130,7 +128,7 @@ ttnn::device_operation::ProgramArtifacts FullInterleavedProgramFactory::create_p
             .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
             .compile_time_args = compile_time_args,
             .runtime_arg_schema = runtime_arg_schema,
-            .hw_config = ttnn::create_reader_datamovement_config(arch),
+            .hw_config = ttnn::create_reader_datamovement_config(),
         });
         dataflow_buffers.push_back(make_fill_value_dfb(FILL_VALUE_READER));
         work_unit_kernels.push_back(READER);

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_nd_sharded.cpp
@@ -92,7 +92,7 @@ ttnn::device_operation::ProgramArtifacts FullNDShardedProgramFactory::create_pro
              {"num_shards", num_shards},
              {"num_cores", num_compute_cores}},
         .runtime_arg_schema = {.runtime_arg_names = {"fill_value", "start_shard_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(operation_attributes.mesh_device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     m2::KernelRunArgs writer_run_args{.kernel = WRITER};

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory_sharded.cpp
@@ -93,7 +93,7 @@ ttnn::device_operation::ProgramArtifacts FullShardedProgramFactory::create_progr
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"fill_value", "start_page_id", "num_pages_per_shard_row", "num_pages_per_shard_col"}},
-        .hw_config = ttnn::create_writer_datamovement_config(operation_attributes.mesh_device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     uint32_t shard_height_in_pages = output.buffer()->shard_spec().shape_in_pages()[0];

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
@@ -201,7 +201,7 @@ ttnn::device_operation::ProgramArtifacts FillCacheMultiCoreProgramFactory::creat
             .dfb_spec_name = SRC0_DFB, .accessor_name = "in0", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = reader_tensor_bindings,
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer (donor Metal 2.0 fork; its interface: dfb::out CONSUMER, tensor::dst, num_pages/start_id) ----
@@ -216,7 +216,7 @@ ttnn::device_operation::ProgramArtifacts FillCacheMultiCoreProgramFactory::creat
             .dfb_spec_name = SRC0_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- Per-core runtime args ----

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
@@ -309,7 +309,7 @@ ttnn::device_operation::ProgramArtifacts UpdateCacheMultiCoreProgramFactory::cre
                   "cache_start_id",
                   "input_start_id",
                   "batch_start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer ----
@@ -348,19 +348,19 @@ ttnn::device_operation::ProgramArtifacts UpdateCacheMultiCoreProgramFactory::cre
                   "Wbytes",
                   "offset",
                   "batch_read_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- Compute (one KernelSpec per core group; per-group head count stays a CTA) ----
     const auto make_compute = [&](const KernelSpecName& id, std::uint32_t num_batched_heads_per_core_group) {
-        auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
+        auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         // Metal 2.0 requires an explicit unpack_modes entry for a consumed Float32 DFB when
         // enable_32_bit_dest (== fp32_dest_acc_en) is set, where legacy silently defaulted. The legacy
         // op set no unpack_to_dest_mode at all (all Default), so mirror that as UnpackToSrc. The compute
         // kernel consumes cache (c_0), input (c_1) and interm1 (c_25); interm carries Float32 exactly
         // when fp32_dest_acc_en, cache/input only if their tensor dtype is FLOAT32.
         if (fp32_dest_acc_en) {
-            auto& um = unpack_modes(compute_hw);
+            auto& um = compute_hw.unpack_modes;
             if (cache_data_format == tt::DataFormat::Float32) {
                 um.emplace(CACHE_DFB, tt::tt_metal::UnpackMode::UnpackToSrc);
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -32,7 +32,6 @@ using tt::tt_metal::experimental::ProgramSpec;
 using tt::tt_metal::experimental::TensorBinding;
 using tt::tt_metal::experimental::TensorParameter;
 using tt::tt_metal::experimental::TensorParamName;
-using tt::tt_metal::experimental::unpack_modes;
 using tt::tt_metal::experimental::WorkUnitSpec;
 
 namespace ttnn::prim {
@@ -187,8 +186,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
                 // per kernel rather than duplicated per core.
                 .common_runtime_arg_names = {"Mt", "Kt", "Nt", "MtKt", "KtNt", "batch", "bcast_B", "MtNt"},
             },
-        .hw_config =
-            ttnn::create_reader_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_reader_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     KernelSpec writer{
@@ -213,8 +211,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
             {
                 .runtime_arg_names = {"num_pages", "start_id"},
             },
-        .hw_config =
-            ttnn::create_writer_datamovement_config(device->arch(), /*disable_dfb_implicit_sync_for_all=*/true),
+        .hw_config = ttnn::create_writer_datamovement_config(/*disable_dfb_implicit_sync_for_all=*/true),
     };
 
     // Per-node runtime args for reader and writer
@@ -261,8 +258,8 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_p
         device->arch(), num_cores, mm_kernel_defines, throttle_level);
 
     // Compute kernel(s) — one per core group with different tile counts.
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    unpack_modes(compute_hw) = {
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw.unpack_modes = {
         {IN0_DFB, tt::tt_metal::UnpackMode::UnpackToSrc},
         {IN1_DFB, tt::tt_metal::UnpackMode::UnpackToSrc},
     };

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -151,7 +151,7 @@ ttnn::device_operation::ProgramArtifacts MorehAbsPowOperation::MorehAbsPowProgra
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "input"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"input_is_dram", "decimal", "num_rows_per_core", "Wt", "tile_offset", "origin_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     m2::KernelSpec writer{
@@ -161,7 +161,7 @@ ttnn::device_operation::ProgramArtifacts MorehAbsPowOperation::MorehAbsPowProgra
             .dfb_spec_name = OUTPUT_DFB, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::CONSUMER}},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"output_is_dram", "num_rows_per_core", "Wt", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -172,7 +172,7 @@ ttnn::device_operation::ProgramArtifacts MorehAbsPowOperation::MorehAbsPowProgra
     // (false). double_buffer_dest defaults to true (== !dst_full_sync_en), matching legacy. The TTNN
     // to_compute_hardware_config helper is deliberately NOT used: it would forward the resolved
     // dst_full_sync_en, which the legacy op never applied.
-    m2::ComputeGen1Config compute_gen1{
+    m2::ComputeHardwareConfig compute_hw{
         .fpu_math_fidelity = math_fidelity,
         .sfpu_precision_mode =
             math_approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
@@ -182,14 +182,13 @@ ttnn::device_operation::ProgramArtifacts MorehAbsPowOperation::MorehAbsPowProgra
     // kernel (self-loop), so the Metal 2.0 validator requires an explicit unpack_modes entry. Legacy
     // unpack_to_dest_mode was empty (all Default) → UnpackMode::UnpackToSrc.
     if (fp32_dest_acc_en) {
-        compute_gen1.unpack_modes = {
+        compute_hw.unpack_modes = {
             {XABS_DFB, tt::tt_metal::UnpackMode::UnpackToSrc},
             {XPOW_DFB, tt::tt_metal::UnpackMode::UnpackToSrc},
             {LOGX_DFB, tt::tt_metal::UnpackMode::UnpackToSrc},
             {EXP_LXMD_DFB, tt::tt_metal::UnpackMode::UnpackToSrc},
         };
     }
-    m2::ComputeHardwareConfig compute_hw = compute_gen1;
 
     // Compute kernel. The two legacy per-core-group compute descriptors collapse to a single
     // KernelSpec: they differed only by the CTA {num_units_per_core_group_*}, which the compute

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
@@ -43,8 +43,6 @@ ttnn::device_operation::ProgramArtifacts MorehDotOperation::ProgramFactory::crea
     uint32_t mask_h = (pad_h == 0) ? (tt::constants::TILE_HEIGHT) : (pad_h);
     uint32_t mask_w = (pad_w == 0) ? (tt::constants::TILE_WIDTH) : (pad_w);
 
-    IDevice* device = input_a.device();
-
     const uint32_t in0_t = 2;   // a
     const uint32_t in1_t = 2;   // b
     const uint32_t in2_t = 1;   // scaler
@@ -101,7 +99,7 @@ ttnn::device_operation::ProgramArtifacts MorehDotOperation::ProgramFactory::crea
                 TensorBinding{.tensor_parameter_name = INPUT_B, .accessor_name = "src1"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id", "mask_h", "mask_w"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     };
 
     // ----- Writer kernel -----
@@ -117,7 +115,7 @@ ttnn::device_operation::ProgramArtifacts MorehDotOperation::ProgramFactory::crea
                 TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     };
 
     // ----- Compute kernel -----
@@ -141,8 +139,8 @@ ttnn::device_operation::ProgramArtifacts MorehDotOperation::ProgramFactory::crea
                 DFBBinding{.dfb_spec_name = IM1, .accessor_name = "im1", .endpoint_type = DFBEndpointType::CONSUMER},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"per_core_block_cnt"}},
-        // Style A: op resolves a TTNN ComputeKernelConfig; translate it to the Gen1 hardware config.
-        .hw_config = to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
+        // Style A: op resolves a TTNN ComputeKernelConfig; translate it to ComputeHardwareConfig.
+        .hw_config = to_compute_hardware_config(operation_attributes.compute_kernel_config),
     };
 
     // ----- ProgramSpec -----

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
@@ -102,7 +102,7 @@ ttnn::device_operation::ProgramArtifacts MorehDotBackwardOperation::ProgramFacto
                 TensorBinding{.tensor_parameter_name = OTHER, .accessor_name = "s2"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"has_input_grad", "has_other_grad", "num_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(output_grad.device().arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer kernel ----
@@ -135,11 +135,11 @@ ttnn::device_operation::ProgramArtifacts MorehDotBackwardOperation::ProgramFacto
             },
         .tensor_bindings = std::move(writer_tensor_bindings),
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(output_grad.device().arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- Compute kernel ----
-    // Legacy ComputeConfigDescriptor{} (all defaults) → ComputeGen1Config{} (defaults match).
+    // Legacy ComputeConfigDescriptor{} (all defaults) → ComputeHardwareConfig{} (defaults match).
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source = COMPUTE_KERNEL_PATH,
@@ -153,7 +153,7 @@ ttnn::device_operation::ProgramArtifacts MorehDotBackwardOperation::ProgramFacto
                 DFBBinding{.dfb_spec_name = OUT1, .accessor_name = "out1", .endpoint_type = DFBEndpointType::PRODUCER},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"has_input_grad", "has_other_grad", "per_core_block_cnt"}},
-        .hw_config = ComputeHardwareConfig{ComputeGen1Config{}},
+        .hw_config = ComputeHardwareConfig{},
     };
 
     // ---- Assemble the spec ----

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
@@ -187,7 +187,7 @@ ttnn::device_operation::ProgramArtifacts MorehFoldOperation::MultiCore::create_p
                   "start_id",
                   "num_units_per_core",
                   "aligned"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer kernel ----
@@ -199,7 +199,7 @@ ttnn::device_operation::ProgramArtifacts MorehFoldOperation::MultiCore::create_p
             .dfb_spec_name = OUTPUT_CB, .accessor_name = "output", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"output_cb_page_size", "start_id", "num_units_per_core"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- Runtime args per core ----

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
@@ -230,7 +230,7 @@ ttnn::device_operation::ProgramArtifacts MorehGetItemOperation::MorehGetItemRmFa
                      "num_sticks",
                      "stick_size",
                  }},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -244,7 +244,7 @@ ttnn::device_operation::ProgramArtifacts MorehGetItemOperation::MorehGetItemRmFa
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "s0"}},
         .runtime_arg_schema = {.runtime_arg_names = {"output_stick_size", "start_id", "num_sticks"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Work unit (placement) ----

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
@@ -287,7 +287,7 @@ ttnn::device_operation::ProgramArtifacts MorehGetItemOperation::MorehGetItemTili
                          "num_elements_per_alignment",
                          "num_alignment_width",
                      }},
-            .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_reader_datamovement_config(),
         });
 
         // ---- Writer kernel ----
@@ -338,7 +338,7 @@ ttnn::device_operation::ProgramArtifacts MorehGetItemOperation::MorehGetItemTili
                          "num_elements_per_alignment",
                          "num_alignment_width",
                      }},
-            .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_writer_datamovement_config(),
         });
 
         // ---- Work unit (placement) ----
@@ -644,7 +644,7 @@ ttnn::device_operation::ProgramArtifacts MorehGetItemOperation::MorehGetItemTili
                      "stick_size",
                      "element_size",
                  }},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -678,7 +678,7 @@ ttnn::device_operation::ProgramArtifacts MorehGetItemOperation::MorehGetItemTili
                      "stick_size",
                      "element_size",
                  }},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Work unit (placement) ----

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
@@ -251,7 +251,7 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
                      "origin_h",
                      "origin_w"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     Group<DFBBinding> writer_dfb_bindings{};
@@ -279,7 +279,7 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
             {
                 .runtime_arg_names = {"tile_offset", "num_channels_per_core", "num_inner_tiles", "batch"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -326,12 +326,12 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
             DFBBinding{.dfb_spec_name = DBETA, .accessor_name = "dbeta", .endpoint_type = DFBEndpointType::PRODUCER});
     }
 
-    // The descriptor factory set an all-default ComputeConfigDescriptor{}, so the Gen1 config is built
+    // The descriptor factory set an all-default ComputeConfigDescriptor{}, so ComputeHardwareConfig is built
     // directly and left at its own defaults. Routing this through the TTNN ComputeKernelConfig helper
     // would silently flip every field, because that helper's defaults favor performance while the
     // Metal struct's favor precision. With enable_32_bit_dest at its default false, the Float32
     // unpack_modes requirement does not apply, so the table stays empty.
-    const ComputeHardwareConfig compute_hw = ComputeGen1Config{};
+    const ComputeHardwareConfig compute_hw{};
 
     auto make_compute = [&](const KernelSpecName& unique_id, uint32_t num_channels_per_core) {
         return KernelSpec{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
@@ -277,7 +277,7 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
                      "origin_h",
                      "origin_w"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -293,7 +293,7 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
                 TensorBinding{.tensor_parameter_name = INPUT_GRAD, .accessor_name = "input_grad"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"tile_offset", "num_rows_per_core", "num_inner_tiles"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -345,12 +345,12 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
             .dfb_spec_name = MASK_H_W, .accessor_name = "mask_h_w", .endpoint_type = DFBEndpointType::CONSUMER});
     }
 
-    // The descriptor factory set an all-default ComputeConfigDescriptor{}, so the Gen1 config is built
+    // The descriptor factory set an all-default ComputeConfigDescriptor{}, so ComputeHardwareConfig is built
     // directly and left at its own defaults. Routing this through the TTNN ComputeKernelConfig helper
     // would silently flip every field, because that helper's defaults favor performance while the
     // Metal struct's favor precision. With enable_32_bit_dest at its default false, the Float32
     // unpack_modes requirement does not apply, so the table stays empty.
-    const ComputeHardwareConfig compute_hw = ComputeGen1Config{};
+    const ComputeHardwareConfig compute_hw{};
 
     auto make_compute = [&](const KernelSpecName& unique_id, uint32_t num_rows_per_core) {
         return KernelSpec{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
@@ -251,7 +251,7 @@ MorehLayerNormBackwardGammaBetaGradOperation::MorehLayerNormBackwardGammaBetaGra
                      "mean_rstd_height",
                      "mean_rstd_width"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     Group<DFBBinding> writer_dfb_bindings{};
@@ -276,7 +276,7 @@ MorehLayerNormBackwardGammaBetaGradOperation::MorehLayerNormBackwardGammaBetaGra
         .dfb_bindings = writer_dfb_bindings,
         .tensor_bindings = writer_tensor_bindings,
         .runtime_arg_schema = {.runtime_arg_names = {"num_cols_per_core", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -319,12 +319,12 @@ MorehLayerNormBackwardGammaBetaGradOperation::MorehLayerNormBackwardGammaBetaGra
             DFBBinding{.dfb_spec_name = DBETA, .accessor_name = "dbeta", .endpoint_type = DFBEndpointType::PRODUCER});
     }
 
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
     // Metal 2.0 requires an explicit unpack mode for every Float32 buffer a compute kernel consumes
     // while the Dest register is 32-bit; the descriptor factory set no unpack_to_dest_mode at all, so
     // every entry here reproduces that default (unpack into SrcA/B).
-    if (enable_32_bit_dest(compute_hw)) {
-        auto& modes = unpack_modes(compute_hw);
+    if (compute_hw.enable_32_bit_dest) {
+        auto& modes = compute_hw.unpack_modes;
         for (const auto& dfb : dfbs) {
             const bool consumed_by_compute =
                 std::any_of(compute_dfb_bindings.begin(), compute_dfb_bindings.end(), [&](const DFBBinding& binding) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
@@ -304,7 +304,7 @@ MorehLayerNormBackwardInputGradOperation::MorehLayerNormBackwardInputGradFactory
                      "mean_rstd_height",
                      "mean_rstd_width"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -320,7 +320,7 @@ MorehLayerNormBackwardInputGradOperation::MorehLayerNormBackwardInputGradFactory
                 TensorBinding{.tensor_parameter_name = INPUT_GRAD, .accessor_name = "input_grad"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows_per_core", "Wt", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -372,12 +372,12 @@ MorehLayerNormBackwardInputGradOperation::MorehLayerNormBackwardInputGradFactory
             .dfb_spec_name = MASK_H_W, .accessor_name = "mask_h_w", .endpoint_type = DFBEndpointType::CONSUMER});
     }
 
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
     // Metal 2.0 requires an explicit unpack mode for every Float32 buffer a compute kernel consumes
     // while the Dest register is 32-bit; the descriptor factory set no unpack_to_dest_mode at all, so
     // every entry here reproduces that default (unpack into SrcA/B).
-    if (enable_32_bit_dest(compute_hw)) {
-        auto& modes = unpack_modes(compute_hw);
+    if (compute_hw.enable_32_bit_dest) {
+        auto& modes = compute_hw.unpack_modes;
         for (const auto& dfb : dfbs) {
             const bool consumed_by_compute =
                 std::any_of(compute_dfb_bindings.begin(), compute_dfb_bindings.end(), [&](const DFBBinding& binding) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
@@ -177,7 +177,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create_program_artifacts
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"batch_num", "Wt", "Wt_per_core", "start_id", "mask_h", "mask_w", "do_mask_h", "do_mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -190,7 +190,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create_program_artifacts
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = BIAS_GRAD_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -207,7 +207,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create_program_artifacts
     // Style A: the op resolves a TTNN DeviceComputeKernelConfig, so the TTNN helper carries its
     // values across (including the math_approx_mode bool -> Precision mapping and the
     // dst_full_sync_en -> double_buffer_dest inversion).
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
 
     // Legacy carried an unpack-to-dest-mode vector indexed by buffer index, every entry left at its
     // default, except the intermed1 buffer (index 25) which it set to the fp32 unpack-to-dest mode
@@ -218,7 +218,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create_program_artifacts
     // output_grad is. The legacy default is UnpackToSrc, which is legal for any format, so
     // transcribing the whole legacy row reproduces the legacy unpack vector byte-for-byte in every
     // configuration.
-    ComputeUnpackModes dfb_unpack_modes = {
+    ComputeHardwareConfig::ComputeUnpackModes dfb_unpack_modes = {
         {IN0_DFB, UnpackMode::UnpackToSrc},
         {SCALER_DFB, UnpackMode::UnpackToSrc},
         {MASK_H_W_DFB, UnpackMode::UnpackToSrc},
@@ -228,12 +228,8 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create_program_artifacts
     if (fp32_dest_acc_en) {
         dfb_unpack_modes[INTERMED1_DFB] = UnpackMode::UnpackToDest;  // legacy: c_25 = UnpackToDestFp32
     }
-    // Assign through the generation-neutral accessor rather than std::get<ComputeGen1Config>: the
-    // helper above returns whichever alternative matches `arch`, so naming Gen1 here would throw
-    // std::bad_variant_access on Quasar. (The local is named dfb_unpack_modes so it does not shadow
-    // the accessor.)
     // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
-    unpack_modes(compute_hw) = std::move(dfb_unpack_modes);
+    compute_hw.unpack_modes = std::move(dfb_unpack_modes);
 
     // Two KernelSpecs of the same source over the two disjoint core groups, differing only in the
     // per-group compile-time count — the Metal 2.0 form of the legacy two-kernel-descriptor work

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
@@ -175,7 +175,7 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create_program_artifact
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_GRAD_TENSOR, .accessor_name = "src"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "start_id", "mask_h", "mask_w", "do_mask_h", "do_mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -188,7 +188,7 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create_program_artifact
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = BIAS_GRAD_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -255,7 +255,7 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create_program_artifact
     // Style A: the op resolves a TTNN DeviceComputeKernelConfig, so the TTNN helper carries its
     // values across (including the math_approx_mode bool -> Precision mapping and the
     // dst_full_sync_en -> double_buffer_dest inversion).
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
 
     // Legacy carried an unpack-to-dest-mode vector indexed by buffer index and left every entry at
     // its default in this factory. Metal 2.0 keys the same information by DFB name and requires an
@@ -271,7 +271,7 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create_program_artifact
     // every iteration, so unpacking it to SrcA/SrcB narrows a 32-bit partial to the source
     // registers' 19 bits — the precision fp32_dest_acc_en was asked for. Reproduced as-is anyway,
     // because a port makes no functional change; correcting it is the op owner's call.
-    ComputeUnpackModes dfb_unpack_modes = {
+    ComputeHardwareConfig::ComputeUnpackModes dfb_unpack_modes = {
         {IN0_DFB, UnpackMode::UnpackToSrc},
         {SCALER_DFB, UnpackMode::UnpackToSrc},
         {INTERMED0_DFB, UnpackMode::UnpackToSrc},
@@ -282,12 +282,8 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create_program_artifact
         // binding's condition.
         dfb_unpack_modes.emplace(MASK_H_W_DFB, UnpackMode::UnpackToSrc);
     }
-    // Assign through the generation-neutral accessor rather than std::get<ComputeGen1Config>: the
-    // helper above returns whichever alternative matches `arch`, so naming Gen1 here would throw
-    // std::bad_variant_access on Quasar. (The local is named dfb_unpack_modes so it does not shadow
-    // the accessor.)
     // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
-    unpack_modes(compute_hw) = std::move(dfb_unpack_modes);
+    compute_hw.unpack_modes = std::move(dfb_unpack_modes);
 
     spec.kernels.push_back(KernelSpec{
         .unique_id = COMPUTE,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -397,7 +397,7 @@ ttnn::device_operation::ProgramArtifacts MorehMatmulOperation::MultiCoreProgramF
         .compile_time_args = reader_compile_time_args,
         // input_stride[8], other_stride[8], output_stride[8], input_not_bcast[8], other_not_bcast[8]
         .runtime_arg_schema = {.runtime_arg_names = {"output_tile_start_idx", "num_output_tiles"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 5 * static_cast<uint32_t>(ttnn::MAX_NUM_DIMENSIONS)},
     };
 
@@ -408,7 +408,7 @@ ttnn::device_operation::ProgramArtifacts MorehMatmulOperation::MultiCoreProgramF
             .dfb_spec_name = OUT0, .accessor_name = "out0", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_output_tiles"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     log_debug(
@@ -438,19 +438,17 @@ ttnn::device_operation::ProgramArtifacts MorehMatmulOperation::MultiCoreProgramF
         // Style A: translate the resolved TTNN ComputeKernelConfig; helper handles the four knobs
         // (math_fidelity, math_approx_mode->sfpu_precision_mode, fp32_dest_acc_en->enable_32_bit_dest,
         // dst_full_sync_en->double_buffer_dest inverted) and the arch selection.
-        auto compute_hw = ttnn::to_compute_hardware_config(
-            device->arch(),
-            ttnn::ComputeKernelConfig{
-                .math_fidelity = math_fidelity,
-                .math_approx_mode = math_approx_mode,
-                .fp32_dest_acc_en = fp32_dest_acc_en,
-                .dst_full_sync_en = dst_full_sync_en});
+        auto compute_hw = ttnn::to_compute_hardware_config(ttnn::ComputeKernelConfig{
+            .math_fidelity = math_fidelity,
+            .math_approx_mode = math_approx_mode,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en});
         if (fp32_dest_acc_en) {
             // Legacy set unpack_to_dest_mode[c_24] = UnpackToDestFp32 (rest Default). Metal 2.0 requires
             // an explicit unpack_mode for every Float32 DFB consumed under enable_32_bit_dest: IM0 (c_24)
             // and IM3 (c_27) are Float32 here. IM0 -> UnpackToDest (legacy UnpackToDestFp32), IM3 ->
             // UnpackToSrc (legacy Default).
-            std::get<ComputeGen1Config>(compute_hw).unpack_modes = {
+            compute_hw.unpack_modes = {
                 {IM0, UnpackMode::UnpackToDest},
                 {IM3, UnpackMode::UnpackToSrc},
             };

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
@@ -158,7 +158,7 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanHFactory::
                 {"reduce_factor", origin_H},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -173,7 +173,7 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanHFactory::
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernels (two groups) ----
@@ -185,13 +185,13 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanHFactory::
     }
     KernelSpec::CompilerOptions::Defines compute_defines(compute_defines_map);
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    if (auto* compute_gen1 = std::get_if<ComputeGen1Config>(&compute_hw); compute_gen1 && fp32_dest_acc_en) {
-        // Legacy set unpack_to_dest_mode[CBIndex::c_24] = UnpackToDestFp32 when fp32 accumulation is
-        // on; reindexed onto the DFB name and translated to the Metal 2.0 spelling. Metal 2.0 also
-        // *requires* an explicit entry here (accum_dst is Float32 and the kernel consumes it with a
-        // 32-bit dest register).
-        compute_gen1->unpack_modes = ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToDest}};
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    // Legacy set unpack_to_dest_mode[CBIndex::c_24] = UnpackToDestFp32 when fp32 accumulation is
+    // on; reindexed onto the DFB name and translated to the Metal 2.0 spelling. Metal 2.0 also
+    // *requires* an explicit entry here (accum_dst is Float32 and the kernel consumes it with a
+    // 32-bit dest register).
+    if (fp32_dest_acc_en) {
+        compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToDest}};
     }
 
     // The compute kernel binds the mask DFB in every configuration: it constructs the buffer object

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
@@ -143,7 +143,7 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanNCFactory:
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_input_tiles", "num_output_tiles", "input_tile_stride", "start_id", "HtWt", "inner_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -157,7 +157,7 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanNCFactory:
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernels (two groups) ----
@@ -168,7 +168,7 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanNCFactory:
     // No unpack_modes entry: this factory never widens the intermediate DFB to Float32, so no DFB the
     // compute kernel consumes carries a 32-bit format. Legacy left unpack_to_dest_mode all-Default,
     // which is exactly an empty table.
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
 
     auto make_compute = [&](const KernelSpecName& unique_id, uint32_t units_per_core) {
         return KernelSpec{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
@@ -155,7 +155,7 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanWFactory::
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
         .compile_time_args = {{"scaler", packed_scaler_value}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -170,7 +170,7 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanWFactory::
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernels (two groups) ----
@@ -182,12 +182,12 @@ ttnn::device_operation::ProgramArtifacts MorehMeanOperation::MorehMeanWFactory::
     }
     KernelSpec::CompilerOptions::Defines compute_defines(compute_defines_map);
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    if (auto* compute_gen1 = std::get_if<ComputeGen1Config>(&compute_hw); compute_gen1 && fp32_dest_acc_en) {
-        // Legacy left unpack_to_dest_mode entirely Default here (unlike the H factory). Metal 2.0
-        // requires the choice to be explicit once a consumed DFB is Float32 with a 32-bit dest
-        // register, so spell out the legacy Default: UnpackToSrc. Value-preserving.
-        compute_gen1->unpack_modes = ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToSrc}};
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    // Legacy left unpack_to_dest_mode entirely Default here (unlike the H factory). Metal 2.0
+    // requires the choice to be explicit once a consumed DFB is Float32 with a 32-bit dest
+    // register, so spell out the legacy Default: UnpackToSrc. Value-preserving.
+    if (fp32_dest_acc_en) {
+        compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToSrc}};
     }
 
     // The compute kernel binds the mask DFB in every configuration: it constructs the buffer object

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -190,7 +190,7 @@ MorehMeanBackwardOperation::MorehMeanBackwardProgramFactory::create_program_arti
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_GRAD_PARAM, .accessor_name = "output_grad"}},
         .compile_time_args = {{"input_grad_rank", input_grad_rank}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_output_tiles", "start_id", "num_dim"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
         .advanced_options = {.num_runtime_varargs = 3 * input_grad_rank},
     };
 
@@ -201,7 +201,7 @@ MorehMeanBackwardOperation::MorehMeanBackwardProgramFactory::create_program_arti
             .dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_GRAD_PARAM, .accessor_name = "input_grad"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -214,7 +214,7 @@ MorehMeanBackwardOperation::MorehMeanBackwardProgramFactory::create_program_arti
     if (fp32_dest_acc_en) {
         compute_defines.insert({"FP32_DEST_ACC_EN", "1"});
     }
-    const auto compute_hw_config = to_compute_hardware_config(device->arch(), compute_kernel_config);
+    const auto compute_hw_config = to_compute_hardware_config(compute_kernel_config);
 
     auto make_compute_spec = [&](const KernelSpecName& unique_id, uint32_t num_output_tiles) {
         return KernelSpec{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
@@ -220,7 +220,7 @@ ttnn::device_operation::ProgramArtifacts MorehNllLossStep1DeviceOperation::Facto
         .compile_time_args = {{"weight_has_value", static_cast<uint32_t>(weight_has_value)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"ignore_index", "num_units_per_core", "start_id", "C", "weight_num_tile"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -239,7 +239,7 @@ ttnn::device_operation::ProgramArtifacts MorehNllLossStep1DeviceOperation::Facto
                 TensorBinding{.tensor_parameter_name = TENSOR_OUTPUT, .accessor_name = "output"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_units_per_core", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     spec.kernels.push_back(std::move(reader));

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
@@ -98,14 +98,11 @@ void bind_self_loop(Group<DFBBinding>& bindings, const DFBSpecName& dfb, std::st
 // explicitly, so where the 32-bit Dest register makes the five intermediates Float32, each gets an
 // explicit UnpackToSrc -- the same mode as before, now spelled out. All five are bound by the
 // compute kernel in every configuration, so the table needs no further conditions.
-//
-// It is reached through the unpack_modes() accessor rather than std::get<ComputeGen1Config>, which
-// would throw on a Gen2 (Quasar) target.
 ComputeHardwareConfig make_compute_hw_config(
-    tt::ARCH arch, const DeviceComputeKernelConfig& compute_kernel_config, bool fp32_dest_acc_en) {
-    auto hw_config = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+    const DeviceComputeKernelConfig& compute_kernel_config, bool fp32_dest_acc_en) {
+    auto hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
     if (fp32_dest_acc_en) {
-        unpack_modes(hw_config) = {
+        hw_config.unpack_modes = {
             {DFB_TMP_WEIGHT, UnpackMode::UnpackToSrc},
             {DFB_TMP_INPUT, UnpackMode::UnpackToSrc},
             {DFB_TMP1, UnpackMode::UnpackToSrc},
@@ -334,7 +331,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_step2_impl_2d(
         .dfb_bindings = std::move(reader_dfb_bindings),
         .tensor_bindings = std::move(reader_tensor_bindings),
         .runtime_arg_schema = {.runtime_arg_names = {"ignore_index", "num_tiles_per_core", "start_id", "N", "C"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -355,10 +352,10 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_step2_impl_2d(
                 TensorBinding{.tensor_parameter_name = TENSOR_OUTPUT, .accessor_name = "output"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    const auto compute_hw_config = make_compute_hw_config(device->arch(), compute_kernel_config, fp32_dest_acc_en);
+    const auto compute_hw_config = make_compute_hw_config(compute_kernel_config, fp32_dest_acc_en);
 
     spec.kernels.push_back(std::move(reader));
     spec.kernels.push_back(std::move(writer));
@@ -591,7 +588,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_step2_impl_3d(
         .tensor_bindings = std::move(reader_tensor_bindings),
         .runtime_arg_schema =
             {.runtime_arg_names = {"ignore_index", "num_tiles_per_core", "start_id", "C", "W", "element_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -612,10 +609,10 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_step2_impl_3d(
                 TensorBinding{.tensor_parameter_name = TENSOR_OUTPUT, .accessor_name = "output"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core", "start_id", "W", "element_size"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    const auto compute_hw_config = make_compute_hw_config(device->arch(), compute_kernel_config, fp32_dest_acc_en);
+    const auto compute_hw_config = make_compute_hw_config(compute_kernel_config, fp32_dest_acc_en);
 
     spec.kernels.push_back(std::move(reader));
     spec.kernels.push_back(std::move(writer));
@@ -873,7 +870,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_step2_impl_4d(
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"ignore_index", "num_tiles_per_core", "start_id", "C", "num_inner_tile", "weight_num_tile"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -894,10 +891,10 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_step2_impl_4d(
                 TensorBinding{.tensor_parameter_name = TENSOR_OUTPUT, .accessor_name = "output"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    const auto compute_hw_config = make_compute_hw_config(device->arch(), compute_kernel_config, fp32_dest_acc_en);
+    const auto compute_hw_config = make_compute_hw_config(compute_kernel_config, fp32_dest_acc_en);
 
     spec.kernels.push_back(std::move(reader));
     spec.kernels.push_back(std::move(writer));

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
@@ -59,7 +59,10 @@ DataflowBufferSpec make_dfb(const DFBSpecName& unique_id, uint32_t num_tiles, tt
 // its unpack mode outright; every other buffer keeps the implicit unpack-to-SrcA/B default. This op
 // asks for the default everywhere, so the explicit entries carry that same choice.
 void require_unpack_mode(
-    ComputeUnpackModes& unpack_modes, bool fp32_dest_acc_en, const DFBSpecName& dfb, tt::DataFormat data_format) {
+    ComputeHardwareConfig::ComputeUnpackModes& unpack_modes,
+    bool fp32_dest_acc_en,
+    const DFBSpecName& dfb,
+    tt::DataFormat data_format) {
     if (fp32_dest_acc_en && data_format == tt::DataFormat::Float32) {
         unpack_modes.emplace(dfb, UnpackMode::UnpackToSrc);
     }
@@ -256,7 +259,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_2d(
         .tensor_bindings = std::move(reader_tensor_bindings),
         .runtime_arg_schema =
             {.runtime_arg_names = {"ignore_index", "num_tiles_per_core", "start_id", "C", "weight_num_tile"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -275,7 +278,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_2d(
                 TensorBinding{.tensor_parameter_name = TENSOR_INPUT_GRAD, .accessor_name = "input_grad"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     Group<DFBBinding> compute_dfb_bindings{
@@ -325,7 +328,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_2d(
         });
     }
 
-    ComputeUnpackModes compute_unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes compute_unpack_modes;
     require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_OUTPUT_GRAD, data_format);
     require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_TMP_WEIGHT, fp32_dest_acc_en_data_format);
     if (divisor_has_value) {
@@ -334,8 +337,8 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_2d(
         require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_TMP2, fp32_dest_acc_en_data_format);
     }
 
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = std::move(compute_unpack_modes);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = std::move(compute_unpack_modes);
 
     auto make_compute = [&](KernelSpecName unique_id, uint32_t units_per_core_group) {
         return KernelSpec{
@@ -619,7 +622,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_3d(
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"ignore_index", "num_tiles_per_core", "start_id", "C", "num_inner_tile", "weight_num_tile"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -638,7 +641,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_3d(
                 TensorBinding{.tensor_parameter_name = TENSOR_INPUT_GRAD, .accessor_name = "input_grad"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     Group<DFBBinding> compute_dfb_bindings{
@@ -688,7 +691,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_3d(
         });
     }
 
-    ComputeUnpackModes compute_unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes compute_unpack_modes;
     require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_OUTPUT_GRAD, data_format);
     require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_TMP_WEIGHT, fp32_dest_acc_en_data_format);
     if (divisor_has_value) {
@@ -697,8 +700,8 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_3d(
         require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_TMP2, fp32_dest_acc_en_data_format);
     }
 
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = std::move(compute_unpack_modes);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = std::move(compute_unpack_modes);
 
     auto make_compute = [&](KernelSpecName unique_id, uint32_t units_per_core_group) {
         return KernelSpec{
@@ -985,7 +988,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_4d(
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"ignore_index", "num_tiles_per_core", "start_id", "C", "num_inner_tile", "weight_num_tile"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -1004,7 +1007,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_4d(
                 TensorBinding{.tensor_parameter_name = TENSOR_INPUT_GRAD, .accessor_name = "input_grad"},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     Group<DFBBinding> compute_dfb_bindings{
@@ -1054,7 +1057,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_4d(
         });
     }
 
-    ComputeUnpackModes compute_unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes compute_unpack_modes;
     require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_OUTPUT_GRAD, data_format);
     require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_TMP_WEIGHT, fp32_dest_acc_en_data_format);
     if (divisor_has_value) {
@@ -1063,8 +1066,8 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_backward_impl_4d(
         require_unpack_mode(compute_unpack_modes, fp32_dest_acc_en, DFB_TMP2, fp32_dest_acc_en_data_format);
     }
 
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = std::move(compute_unpack_modes);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = std::move(compute_unpack_modes);
 
     auto make_compute = [&](KernelSpecName unique_id, uint32_t units_per_core_group) {
         return KernelSpec{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -147,7 +147,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_unreduced_backward_impl_
             {
                 .runtime_arg_names = {"ignore_index", "num_tiles_per_core", "start_id", "Nt", "Ct"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     bind_self_loop(reader, TARGET_DFB, "target");
     bind_self_loop(reader, OUTPUT_GRAD_DFB, "output_grad");
@@ -196,7 +196,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_unreduced_backward_impl_
             {
                 .runtime_arg_names = {"num_tiles_per_core", "start_id"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     spec.tensor_parameters.push_back(TensorParameter{.unique_id = TARGET_TENSOR, .spec = target.tensor_spec()});
@@ -333,7 +333,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_unreduced_backward_impl_
             {
                 .runtime_arg_names = {"ignore_index", "num_tiles_per_core", "start_id", "Ct", "Wt"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     bind_self_loop(reader, TARGET_DFB, "target");
     bind_self_loop(reader, OUTPUT_GRAD_DFB, "output_grad");
@@ -381,7 +381,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_unreduced_backward_impl_
             {
                 .runtime_arg_names = {"num_tiles_per_core", "start_id"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     spec.tensor_parameters.push_back(TensorParameter{.unique_id = TARGET_TENSOR, .spec = target.tensor_spec()});
@@ -523,7 +523,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_unreduced_backward_impl_
             {
                 .runtime_arg_names = {"ignore_index", "num_tiles_per_core", "start_id", "num_inner_tile", "C", "Ct"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     bind_self_loop(reader, TARGET_DFB, "target");
     bind_self_loop(reader, OUTPUT_GRAD_DFB, "output_grad");
@@ -571,7 +571,7 @@ ttnn::device_operation::ProgramArtifacts moreh_nll_loss_unreduced_backward_impl_
             {
                 .runtime_arg_names = {"num_tiles_per_core", "start_id"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     spec.tensor_parameters.push_back(TensorParameter{.unique_id = TARGET_TENSOR, .spec = target_spec});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
@@ -189,7 +189,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryHOthe
             {
                 .runtime_arg_names = {"input_is_dram", "num_cols_per_core", "tile_offset", "Ht", "Wt", "origin_h"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -214,7 +214,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryHOthe
             {
                 .runtime_arg_names = {"output_is_dram", "num_cols_per_core", "tile_offset"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -237,7 +237,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryHOthe
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/"
         "moreh_norm_h_kernel.cpp";
 
-    auto compute_hw_config = ttnn::to_compute_hardware_config(arch, operation_attributes.compute_kernel_config);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
     // The legacy config set UnpackToDestMode::Default for every CB index; Default is UnpackToSrc.
     // An explicit entry is *required* for any Float32 DFB the compute kernel consumes while
     // enable_32_bit_dest (= fp32_dest_acc_en) is set. That is reachable two independent ways here:
@@ -245,7 +245,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryHOthe
     // input dtype is float32. Naming every consumed DFB covers both without a dtype-dependent branch,
     // and reproduces the legacy all-Default vector byte for byte. `output` is producer-only on
     // compute, so it takes no entry.
-    std::get<ComputeGen1Config>(compute_hw_config).unpack_modes = {
+    compute_hw_config.unpack_modes = {
         {INPUT_DFB, UnpackMode::UnpackToSrc},
         {ONE_DFB, UnpackMode::UnpackToSrc},
         {MASK_H_DFB, UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
@@ -181,7 +181,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryNCOth
                      "num_inner_tiles",
                      "num_reduced_tiles_along_dim"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -206,7 +206,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryNCOth
             {
                 .runtime_arg_names = {"output_is_dram", "num_output_tiles_per_core", "tile_offset"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -228,7 +228,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryNCOth
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/"
         "moreh_norm_nc_kernel.cpp";
 
-    auto compute_hw_config = ttnn::to_compute_hardware_config(arch, operation_attributes.compute_kernel_config);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
     // The legacy config set UnpackToDestMode::Default for every CB index; Default is UnpackToSrc.
     // An explicit entry is *required* for any Float32 DFB the compute kernel consumes while
     // enable_32_bit_dest (= fp32_dest_acc_en) is set. That is reachable two independent ways here:
@@ -236,7 +236,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryNCOth
     // input dtype is float32. Naming every consumed DFB covers both without a dtype-dependent branch,
     // and reproduces the legacy all-Default vector byte for byte. `output` is producer-only on
     // compute, so it takes no entry.
-    std::get<ComputeGen1Config>(compute_hw_config).unpack_modes = {
+    compute_hw_config.unpack_modes = {
         {INPUT_DFB, UnpackMode::UnpackToSrc},
         {ONE_DFB, UnpackMode::UnpackToSrc},
         {VAL_DFB, UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
@@ -194,7 +194,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryWOthe
             {
                 .runtime_arg_names = {"input_is_dram", "num_rows_per_core", "Wt", "tile_offset", "origin_w"},
             },
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -219,7 +219,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryWOthe
             {
                 .runtime_arg_names = {"output_is_dram", "num_rows_per_core", "Wt", "tile_offset"},
             },
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -242,7 +242,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryWOthe
         "ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/"
         "moreh_norm_w_kernel.cpp";
 
-    auto compute_hw_config = ttnn::to_compute_hardware_config(arch, operation_attributes.compute_kernel_config);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
     // The legacy config set UnpackToDestMode::Default for every CB index; Default is UnpackToSrc.
     // An explicit entry is *required* for any Float32 DFB the compute kernel consumes while
     // enable_32_bit_dest (= fp32_dest_acc_en) is set. That is reachable two independent ways here:
@@ -250,7 +250,7 @@ ttnn::device_operation::ProgramArtifacts MorehNormOperation::ProgramFactoryWOthe
     // input dtype is float32. Naming every consumed DFB covers both without a dtype-dependent branch,
     // and reproduces the legacy all-Default vector byte for byte. `output` is producer-only on
     // compute, so it takes no entry.
-    std::get<ComputeGen1Config>(compute_hw_config).unpack_modes = {
+    compute_hw_config.unpack_modes = {
         {INPUT_DFB, UnpackMode::UnpackToSrc},
         {ONE_DFB, UnpackMode::UnpackToSrc},
         {MASK_W_DFB, UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -227,7 +227,7 @@ ProgramArtifacts MorehNormBackwardOperation::MorehNormBackwardProgramFactory::cr
              m2::TensorBinding{.tensor_parameter_name = T_OUTPUT_GRAD, .accessor_name = "output_grad"}},
         .compile_time_args = {{"input_grad_rank", static_cast<uint32_t>(input_grad_rank)}},
         .runtime_arg_schema = {.runtime_arg_names = {"decimal", "num_output_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     // The three per-dimension blocks (output_grad_dim, input_grad_dim, need_bcast_dim) are read as
     // runtime varargs (count = input_grad_rank each).
@@ -240,7 +240,7 @@ ProgramArtifacts MorehNormBackwardOperation::MorehNormBackwardProgramFactory::cr
             .dfb_spec_name = DX, .accessor_name = "input_grad", .endpoint_type = m2::DFBEndpointType::CONSUMER}},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = T_INPUT_GRAD, .accessor_name = "input_grad"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_input_tiles_per_core", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -253,15 +253,15 @@ ProgramArtifacts MorehNormBackwardOperation::MorehNormBackwardProgramFactory::cr
 
     // Style B: the legacy factory builds a Metal ComputeConfigDescriptor directly, setting only
     // math_fidelity / fp32_dest_acc_en / math_approx_mode; dst_full_sync_en is left at the Metal
-    // default (false), so double_buffer_dest stays at its matching Gen1 default (true). We build a
-    // ComputeGen1Config directly to preserve that (resolved dst_full_sync_en / packer_l1_acc are
+    // default (false), so double_buffer_dest stays at its matching ComputeHardwareConfig default (true). We build a
+    // ComputeHardwareConfig directly to preserve that (resolved dst_full_sync_en / packer_l1_acc are
     // unused, matching legacy).
     // Plain copies (structured-binding names captured by value to keep the lambda portable).
     const MathFidelity cfg_math_fidelity = math_fidelity;
     const bool cfg_math_approx_mode = math_approx_mode;
     const bool cfg_fp32_dest_acc_en = fp32_dest_acc_en;
     auto make_compute_hw = [&]() {
-        m2::ComputeGen1Config cfg{
+        m2::ComputeHardwareConfig cfg{
             .fpu_math_fidelity = cfg_math_fidelity,
             .sfpu_precision_mode = cfg_math_approx_mode ? Precision::Approximate : Precision::Precise,
             .enable_32_bit_dest = cfg_fp32_dest_acc_en,
@@ -280,7 +280,7 @@ ProgramArtifacts MorehNormBackwardOperation::MorehNormBackwardProgramFactory::cr
                 }
             }
         }
-        return m2::ComputeHardwareConfig{cfg};
+        return cfg;
     };
 
     // Compute DFB bindings: consume the four reader-produced inputs, produce dx, self-loop the 8

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -121,7 +121,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxCLar
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "tile_offset", "outer_stride", "inner_size", "dim_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -132,7 +132,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxCLar
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "tile_offset", "outer_stride", "inner_size", "dim_size"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     auto outer_stride = Ht * Wt;
@@ -157,9 +157,9 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxCLar
 
     // create compute kernel
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {EXPS, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {RECIP, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -148,7 +148,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxHLar
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -158,7 +158,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxHLar
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;
@@ -176,9 +176,9 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxHLar
 
     // create compute kernel
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -147,7 +147,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxHSma
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -157,7 +157,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxHSma
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     KernelSpec::CompilerOptions::Defines compute_defines;
@@ -175,9 +175,9 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxHSma
 
     // create compute kernel
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -156,7 +156,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxWLar
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer kernel ----
@@ -167,7 +167,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxWLar
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- Compute defines ----
@@ -186,9 +186,9 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxWLar
 
     // ---- Compute hardware config (Style A) ----
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -151,7 +151,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxWSma
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer kernel ----
@@ -162,7 +162,7 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxWSma
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- Compute defines ----
@@ -183,9 +183,9 @@ ttnn::device_operation::ProgramArtifacts MorehSoftmaxOperation::MorehSoftmaxWSma
     // Legacy set unpack_to_dest_mode = all-Default (=> UnpackToSrc). Metal 2.0 requires an explicit
     // entry for every Float32 DFB a compute kernel consumes when enable_32_bit_dest is set (fp32 path).
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_metal2_common.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_metal2_common.hpp
@@ -27,7 +27,7 @@ namespace ttnn::operations::moreh::moreh_softmax_backward {
 // merge into one scope, where same-named constants would collide.
 namespace metal2 {
 
-using tt::tt_metal::experimental::ComputeUnpackModes;
+using ComputeUnpackModes = tt::tt_metal::experimental::ComputeHardwareConfig::ComputeUnpackModes;
 using tt::tt_metal::experimental::DataflowBufferSpec;
 using tt::tt_metal::experimental::DFBSpecName;
 using tt::tt_metal::experimental::KernelSpec;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -66,8 +66,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create_program
 
     KernelSpec reader_spec{
         .unique_id = READER_KERNEL,
-        .source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-                  "reader_moreh_softmax_backward_c.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
+            "reader_moreh_softmax_backward_c.cpp",
         .compiler_options = {.defines = std::move(reader_defines)},
         .dfb_bindings =
             {DFBBinding{
@@ -85,13 +86,14 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create_program
              TensorBinding{.tensor_parameter_name = OUTPUT_GRAD_TENSOR, .accessor_name = "dy"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "tile_offset", "outer_stride", "inner_size", "dim_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
         .unique_id = WRITER_KERNEL,
-        .source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-                  "writer_moreh_softmax_backward_c.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
+            "writer_moreh_softmax_backward_c.cpp",
         .dfb_bindings = {DFBBinding{
             .dfb_spec_name = DX_DFB,
             .accessor_name = "out",
@@ -100,7 +102,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create_program
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_GRAD_TENSOR, .accessor_name = "dx"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "tile_offset", "outer_stride", "inner_size", "dim_size"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     auto outer_stride = Ht * Wt;
@@ -111,8 +113,8 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create_program
     auto inner_size = outer_stride / dim_size;
 
     // create compute kernel
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device.arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = MakeUnpackModes(
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = MakeUnpackModes(
         fp32_dest_acc_en,
         {{Y_DFB, data_format},
          {DY_DFB, data_format},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -67,8 +67,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create_program
 
     KernelSpec reader_spec{
         .unique_id = READER_KERNEL,
-        .source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-                  "reader_moreh_softmax_backward_h_large.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
+            "reader_moreh_softmax_backward_h_large.cpp",
         .compiler_options = {.defines = std::move(reader_defines)},
         .dfb_bindings =
             {DFBBinding{
@@ -95,7 +96,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create_program
             {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "y"},
              TensorBinding{.tensor_parameter_name = OUTPUT_GRAD_TENSOR, .accessor_name = "dy"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Ht", "Wt", "scaler", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -108,12 +109,12 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create_program
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_GRAD_TENSOR, .accessor_name = "dx"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Ht", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // create compute kernel
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device.arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = MakeUnpackModes(
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = MakeUnpackModes(
         fp32_dest_acc_en,
         {{Y_DFB, data_format},
          {DY_DFB, data_format},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -62,8 +62,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create_program
     // create read/write kernel
     KernelSpec reader_spec{
         .unique_id = READER_KERNEL,
-        .source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-                  "reader_moreh_softmax_backward_h.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
+            "reader_moreh_softmax_backward_h.cpp",
         .dfb_bindings =
             {DFBBinding{
                  .dfb_spec_name = Y_DFB,
@@ -89,7 +90,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create_program
             {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "y"},
              TensorBinding{.tensor_parameter_name = OUTPUT_GRAD_TENSOR, .accessor_name = "dy"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Ht", "Wt", "scaler", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -102,12 +103,12 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create_program
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_GRAD_TENSOR, .accessor_name = "dx"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Ht", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // create compute kernel
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device.arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = MakeUnpackModes(
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = MakeUnpackModes(
         fp32_dest_acc_en,
         {{Y_DFB, data_format},
          {DY_DFB, data_format},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -66,8 +66,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create_program
 
     KernelSpec reader_spec{
         .unique_id = READER_KERNEL,
-        .source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-                  "reader_moreh_softmax_backward_w_large.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
+            "reader_moreh_softmax_backward_w_large.cpp",
         .compiler_options = {.defines = std::move(reader_defines)},
         .dfb_bindings =
             {DFBBinding{
@@ -94,7 +95,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create_program
             {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "y"},
              TensorBinding{.tensor_parameter_name = OUTPUT_GRAD_TENSOR, .accessor_name = "dy"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Wt", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -107,12 +108,12 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create_program
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_GRAD_TENSOR, .accessor_name = "dx"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // create compute kernel
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device.arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = MakeUnpackModes(
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = MakeUnpackModes(
         fp32_dest_acc_en,
         {{Y_DFB, data_format},
          {DY_DFB, data_format},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -61,8 +61,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create_program
     // create read/write kernel
     KernelSpec reader_spec{
         .unique_id = READER_KERNEL,
-        .source = "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
-                  "reader_moreh_softmax_backward_w.cpp",
+        .source =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/"
+            "reader_moreh_softmax_backward_w.cpp",
         .dfb_bindings =
             {DFBBinding{
                  .dfb_spec_name = Y_DFB,
@@ -88,7 +89,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create_program
             {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "y"},
              TensorBinding{.tensor_parameter_name = OUTPUT_GRAD_TENSOR, .accessor_name = "dy"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Wt", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer_spec{
@@ -101,12 +102,12 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create_program
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_GRAD_TENSOR, .accessor_name = "dx"}},
         .runtime_arg_schema = {.runtime_arg_names = {"N", "tile_offset", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device.arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // create compute kernel
-    auto compute_hw_config = ttnn::to_compute_hardware_config(device.arch(), compute_kernel_config);
-    unpack_modes(compute_hw_config) = MakeUnpackModes(
+    auto compute_hw_config = ttnn::to_compute_hardware_config(compute_kernel_config);
+    compute_hw_config.unpack_modes = MakeUnpackModes(
         fp32_dest_acc_en,
         {{Y_DFB, data_format},
          {DY_DFB, data_format},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
@@ -163,7 +163,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumHIntFactory:
                 {"Wt", Wt},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -176,7 +176,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumHIntFactory:
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -187,20 +187,18 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumHIntFactory:
         compute_defines.emplace("FP32_DEST_ACC_EN", "1");
     }
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    if (auto* compute_gen1 = std::get_if<ComputeGen1Config>(&compute_hw); compute_gen1) {
-        // This factory overrides the caller's fp32_dest_acc_en above (integer sum requires a 32-bit
-        // dest); carry the *forced* value rather than the one the attributes came in with.
-        compute_gen1->enable_32_bit_dest = fp32_dest_acc_en;
-        // Every DFB here carries the Int32 output format and the dest register is 32-bit, so the
-        // Src-vs-Dest choice is real for each one the compute kernel consumes. Issue #49936 extends
-        // the choice to Int32/UInt32, where an unspecified consumer becomes a hard error.
-        compute_gen1->unpack_modes = ComputeUnpackModes{
-            {INPUT_DFB, UnpackMode::UnpackToSrc},
-            {MASK_H_DFB, UnpackMode::UnpackToSrc},
-            {INTERMED0_DFB, UnpackMode::UnpackToSrc},
-        };
-    }
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    // This factory overrides the caller's fp32_dest_acc_en above (integer sum requires a 32-bit
+    // dest); carry the *forced* value rather than the one the attributes came in with.
+    // Every DFB here carries the Int32 output format and the dest register is 32-bit, so the
+    // Src-vs-Dest choice is real for each one the compute kernel consumes. Issue #49936 extends
+    // the choice to Int32/UInt32, where an unspecified consumer becomes a hard error.
+    compute_hw.enable_32_bit_dest = fp32_dest_acc_en;
+    compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{
+        {INPUT_DFB, UnpackMode::UnpackToSrc},
+        {MASK_H_DFB, UnpackMode::UnpackToSrc},
+        {INTERMED0_DFB, UnpackMode::UnpackToSrc},
+    };
 
     // The compute kernel binds the mask DFB in every configuration: it constructs the buffer object
     // unconditionally and gates only its FIFO calls on do_mask_h. When masking is off the reader does

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
@@ -133,7 +133,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumNCIntFactory
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_input_tiles", "num_output_tiles", "start_id", "dim", "reduce_tile_size", "inner_tile_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -146,7 +146,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumNCIntFactory
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -157,19 +157,17 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumNCIntFactory
         compute_defines.emplace("FP32_DEST_ACC_EN", "1");
     }
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    if (auto* compute_gen1 = std::get_if<ComputeGen1Config>(&compute_hw); compute_gen1) {
-        // This factory overrides the caller's fp32_dest_acc_en above (integer sum requires a 32-bit
-        // dest); carry the *forced* value rather than the one the attributes came in with.
-        compute_gen1->enable_32_bit_dest = fp32_dest_acc_en;
-        // Every DFB here carries the Int32 output format and the dest register is 32-bit, so the
-        // Src-vs-Dest choice is real for each one the compute kernel consumes. Issue #49936 extends
-        // the choice to Int32/UInt32, where an unspecified consumer becomes a hard error.
-        compute_gen1->unpack_modes = ComputeUnpackModes{
-            {INPUT_DFB, UnpackMode::UnpackToSrc},
-            {INTERMED0_DFB, UnpackMode::UnpackToSrc},
-        };
-    }
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    // This factory overrides the caller's fp32_dest_acc_en above (integer sum requires a 32-bit
+    // dest); carry the *forced* value rather than the one the attributes came in with.
+    // Every DFB here carries the Int32 output format and the dest register is 32-bit, so the
+    // Src-vs-Dest choice is real for each one the compute kernel consumes. Issue #49936 extends
+    // the choice to Int32/UInt32, where an unspecified consumer becomes a hard error.
+    compute_hw.enable_32_bit_dest = fp32_dest_acc_en;
+    compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{
+        {INPUT_DFB, UnpackMode::UnpackToSrc},
+        {INTERMED0_DFB, UnpackMode::UnpackToSrc},
+    };
 
     auto make_compute = [&](const KernelSpecName& unique_id, uint32_t units_per_core) {
         return KernelSpec{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
@@ -160,7 +160,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumWIntFactory:
         .dfb_bindings = std::move(reader_dfb_bindings),
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -173,7 +173,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumWIntFactory:
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -184,20 +184,18 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumWIntFactory:
         compute_defines.emplace("FP32_DEST_ACC_EN", "1");
     }
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    if (auto* compute_gen1 = std::get_if<ComputeGen1Config>(&compute_hw); compute_gen1) {
-        // This factory overrides the caller's fp32_dest_acc_en above (integer sum requires a 32-bit
-        // dest); carry the *forced* value rather than the one the attributes came in with.
-        compute_gen1->enable_32_bit_dest = fp32_dest_acc_en;
-        // Every DFB here carries the Int32 output format and the dest register is 32-bit, so the
-        // Src-vs-Dest choice is real for each one the compute kernel consumes. Issue #49936 extends
-        // the choice to Int32/UInt32, where an unspecified consumer becomes a hard error.
-        compute_gen1->unpack_modes = ComputeUnpackModes{
-            {INPUT_DFB, UnpackMode::UnpackToSrc},
-            {MASK_W_DFB, UnpackMode::UnpackToSrc},
-            {INTERMED0_DFB, UnpackMode::UnpackToSrc},
-        };
-    }
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    // This factory overrides the caller's fp32_dest_acc_en above (integer sum requires a 32-bit
+    // dest); carry the *forced* value rather than the one the attributes came in with.
+    // Every DFB here carries the Int32 output format and the dest register is 32-bit, so the
+    // Src-vs-Dest choice is real for each one the compute kernel consumes. Issue #49936 extends
+    // the choice to Int32/UInt32, where an unspecified consumer becomes a hard error.
+    compute_hw.enable_32_bit_dest = fp32_dest_acc_en;
+    compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{
+        {INPUT_DFB, UnpackMode::UnpackToSrc},
+        {MASK_W_DFB, UnpackMode::UnpackToSrc},
+        {INTERMED0_DFB, UnpackMode::UnpackToSrc},
+    };
 
     // The compute kernel binds the mask DFB in every configuration: it constructs the buffer object
     // unconditionally and gates only its FIFO calls on do_mask_w. When masking is off the reader does

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
@@ -178,7 +178,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumHFactory::cr
                 {"HtWt", HtWt},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -192,7 +192,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumHFactory::cr
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernels (two groups) ----
@@ -202,13 +202,13 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumHFactory::cr
     }
     KernelSpec::CompilerOptions::Defines reduce_defines(reduce_defines_map);
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    if (auto* compute_gen1 = std::get_if<ComputeGen1Config>(&compute_hw); compute_gen1 && fp32_dest_acc_en) {
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    if (fp32_dest_acc_en) {
         // Legacy set unpack_to_dest_mode[CBIndex::c_24] = UnpackToDestFp32 when fp32 accumulation is
         // on; reindexed onto the DFB name and translated to the Metal 2.0 spelling. Metal 2.0 also
         // *requires* an explicit entry here (accum_dst is Float32 and the kernel consumes it with a
         // 32-bit dest register).
-        compute_gen1->unpack_modes = ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToDest}};
+        compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToDest}};
     }
 
     // The compute kernel binds the mask DFB in every configuration: it constructs the buffer object

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
@@ -139,7 +139,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumNCFactory::c
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_input_tiles", "num_output_tiles", "start_id", "dim", "reduce_tile_size", "inner_tile_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     spec.kernels.push_back(KernelSpec{
@@ -152,7 +152,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumNCFactory::c
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "output"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -166,7 +166,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumNCFactory::c
     // No unpack_modes entry: legacy left unpack_to_dest_mode all-Default, which is exactly an empty
     // table. With the dead Float32-capable intermediate gone, every DFB this kernel consumes carries
     // the output data format, so Metal 2.0's explicit-entry requirement does not fire either.
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
 
     auto make_compute = [&](const KernelSpecName& unique_id, uint32_t units_per_core) {
         return KernelSpec{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
@@ -179,7 +179,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumWFactory::cr
         // halves of one uint32_t, which the reader splats across the scaler tile.
         .compile_time_args = {{"scaler", packed_scaler_value}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -193,7 +193,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumWFactory::cr
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernels (two groups) ----
@@ -203,13 +203,13 @@ ttnn::device_operation::ProgramArtifacts MorehSumOperation::MorehSumWFactory::cr
     }
     KernelSpec::CompilerOptions::Defines reduce_defines(reduce_defines_map);
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), compute_kernel_config);
-    if (auto* compute_gen1 = std::get_if<ComputeGen1Config>(&compute_hw); compute_gen1 && fp32_dest_acc_en) {
+    auto compute_hw = ttnn::to_compute_hardware_config(compute_kernel_config);
+    if (fp32_dest_acc_en) {
         // Legacy set unpack_to_dest_mode[CBIndex::c_24] = UnpackToDestFp32 when fp32 accumulation is
         // on; reindexed onto the DFB name and translated to the Metal 2.0 spelling. Metal 2.0 also
         // *requires* an explicit entry here (accum_dst is Float32 and the kernel consumes it with a
         // 32-bit dest register).
-        compute_gen1->unpack_modes = ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToDest}};
+        compute_hw.unpack_modes = ComputeHardwareConfig::ComputeUnpackModes{{ACCUM_DST_DFB, UnpackMode::UnpackToDest}};
     }
 
     // The compute kernel binds the mask DFB in every configuration: it constructs the buffer object

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
@@ -191,10 +191,10 @@ ttnn::device_operation::ProgramArtifacts MorehSumBackwardOperation::ProgramFacto
     //                      Compute hardware config
     ////////////////////////////////////////////////////////////////////////////
     // Style B: the legacy factory built a Metal ComputeConfigDescriptor directly from the
-    // resolved compute-kernel-config scalars. Reproduce those exact values on ComputeGen1Config,
+    // resolved compute-kernel-config scalars. Reproduce those exact values on ComputeHardwareConfig,
     // minding the two non-1:1 transforms (math_approx_mode bool->Precision; dst_full_sync_en
     // inverted into double_buffer_dest).
-    ComputeGen1Config compute_cfg{
+    ComputeHardwareConfig compute_cfg{
         .fpu_math_fidelity = math_fidelity,
         .sfpu_precision_mode = math_approx_mode ? Precision::Approximate : Precision::Precise,
         .enable_32_bit_dest = fp32_dest_acc_en,
@@ -226,7 +226,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumBackwardOperation::ProgramFacto
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_GRAD, .accessor_name = "output_grad"}},
         .compile_time_args = {{"input_grad_rank", input_grad_rank}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_output_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     // The three variable-length per-dim RTA blocks (output_grad_dim, input_grad_dim, need_bcast_dim,
     // each of length input_grad_rank) are passed as positional runtime varargs (read kernel-side via
@@ -240,7 +240,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumBackwardOperation::ProgramFacto
             .dfb_spec_name = C16_OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_GRAD, .accessor_name = "input_grad"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     auto make_compute = [&](const KernelSpecName& id, uint32_t num_output_tiles) {
@@ -258,7 +258,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumBackwardOperation::ProgramFacto
                 {{"num_output_tiles", num_output_tiles},
                  {"wt_need_bcast", need_bcast_dim[0]},
                  {"ht_need_bcast", need_bcast_dim[1]}},
-            .hw_config = ComputeHardwareConfig{compute_cfg},
+            .hw_config = compute_cfg,
         };
     };
     KernelSpec compute_1 = make_compute(COMPUTE_1, num_cols_per_core_group_1);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -285,7 +285,7 @@ ttnn::device_operation::ProgramArtifacts BatchNormOperation::BatchNormFactory::c
         .compile_time_args = {{"fill_eps_fp32", static_cast<uint32_t>(any_float32)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"eps", "start_tile_id", "num_tiles", "HtWt", "n_stride", "c_stride", "N", "C"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // WRITER KERNEL
@@ -357,14 +357,14 @@ ttnn::device_operation::ProgramArtifacts BatchNormOperation::BatchNormFactory::c
                   DataFormat::Float32)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_tile_id", "num_tiles", "HtWt", "n_stride", "c_stride", "N", "C"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // COMPUTE KERNEL
     // fp32_dest_acc_en selects the compute source and gates the unpack_modes list below, so it is
     // read directly. to_compute_hardware_config carries the four knobs it covers -- math_fidelity,
     // math_approx_mode, fp32_dest_acc_en and dst_full_sync_en -- into hw_config; packer_l1_acc and
-    // throttle_level are deliberately not translated. ComputeGen1Config has no packer_l1_acc field,
+    // throttle_level are deliberately not translated. ComputeHardwareConfig has no packer_l1_acc field,
     // so the value this op resolves for it stays unapplied, as it also was under the descriptor API.
     const bool fp32_dest_acc_en = ttnn::get_fp32_dest_acc_en(operation_attributes.compute_kernel_config);
     const bool use_sfpu_kernel = fp32_dest_acc_en || any_float32;
@@ -459,18 +459,12 @@ ttnn::device_operation::ProgramArtifacts BatchNormOperation::BatchNormFactory::c
         });
     }
 
-    auto compute_hw_config =
-        ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
     if (fp32_dest_acc_en) {
         // Re-key of the legacy unpack_to_dest_mode vector, which was indexed by CB id. Every DFB the
         // compute kernel consumes is listed; the writer-facing output is producer-only, so it gets no
         // entry. An omitted DFB keeps the UnpackToSrc default.
-        // Reach unpack_modes through the generation-neutral accessor rather than
-        // std::get<ComputeGen1Config>: the helper above returns whichever alternative matches
-        // `arch`, so naming Gen1 here would throw std::bad_variant_access on Quasar. (The local is
-        // named dfb_unpack_modes so it does not shadow the accessor.)
-        // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
-        auto& dfb_unpack_modes = unpack_modes(compute_hw_config);
+        auto& dfb_unpack_modes = compute_hw_config.unpack_modes;
         for (const auto& dfb_name :
              {INPUT_DFB, BATCH_MEAN_DFB, BATCH_VAR_DFB, EPS_DFB, DEN_DFB, WEIGHT_DFB, TEMP_1_DFB, BIAS_DFB}) {
             dfb_unpack_modes[dfb_name] = UnpackMode::UnpackToDest;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -302,7 +302,7 @@ ttnn::device_operation::ProgramArtifacts RunningStatistics::RunningStatisticsPro
         .compile_time_args = {{"fill_momentum_fp32", static_cast<uint32_t>(any_float32)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"momentum", "start_tile_id", "num_tiles", "HtWt", "n_stride", "c_stride", "N", "C"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // WRITER KERNEL
@@ -378,14 +378,14 @@ ttnn::device_operation::ProgramArtifacts RunningStatistics::RunningStatisticsPro
             {{"old_stat_is_fp32", static_cast<uint32_t>(running_stat_data_format == DataFormat::Float32)}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"start_tile_id", "num_tiles", "HtWt", "n_stride", "c_stride", "N", "C"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // COMPUTE KERNEL
     // fp32_dest_acc_en selects the compute source and gates the unpack_modes list below, so it is
     // read directly. to_compute_hardware_config carries the four knobs it covers -- math_fidelity,
     // math_approx_mode, fp32_dest_acc_en and dst_full_sync_en -- into hw_config; packer_l1_acc and
-    // throttle_level are deliberately not translated. ComputeGen1Config has no packer_l1_acc field,
+    // throttle_level are deliberately not translated. ComputeHardwareConfig has no packer_l1_acc field,
     // so the value this op resolves for it stays unapplied, as it also was under the descriptor API.
     const bool fp32_dest_acc_en = ttnn::get_fp32_dest_acc_en(operation_attributes.compute_kernel_config);
     const bool use_sfpu_kernel = fp32_dest_acc_en || any_float32;
@@ -515,18 +515,12 @@ ttnn::device_operation::ProgramArtifacts RunningStatistics::RunningStatisticsPro
         });
     }
 
-    auto compute_hw_config =
-        ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config);
+    auto compute_hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
     if (fp32_dest_acc_en) {
         // Re-key of the legacy unpack_to_dest_mode vector, which was indexed by CB id. The
         // writer-facing stat buffers are producer-only for this kernel, so they get no entry. An
         // omitted DFB keeps the UnpackToSrc default.
-        // Reach unpack_modes through the generation-neutral accessor rather than
-        // std::get<ComputeGen1Config>: the helper above returns whichever alternative matches
-        // `arch`, so naming Gen1 here would throw std::bad_variant_access on Quasar. (The local is
-        // named dfb_unpack_modes so it does not shadow the accessor.)
-        // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
-        auto& dfb_unpack_modes = unpack_modes(compute_hw_config);
+        auto& dfb_unpack_modes = compute_hw_config.unpack_modes;
         for (const auto& dfb_name :
              {BATCH_MEAN_DFB,
               BATCH_VAR_DFB,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -645,7 +645,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormMultiCoreProgramFactory::creat
         // two legacy tile readers, so the schema carries the host's own name for it rather than
         // either kernel's local reading of it.
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt", "Wt", "reader_start", "eps"}},
-        .hw_config = create_reader_datamovement_config(device->arch()),
+        .hw_config = create_reader_datamovement_config(),
     };
     if (input_is_row_major) {
         // Element size of the input tensor, for the row-major reader's address stride arithmetic.
@@ -725,7 +725,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormMultiCoreProgramFactory::creat
         // writer_start is a tile-row index for the row-major writer and a flat tile offset for
         // the tile writer, so the schema carries the host's own name for it.
         .runtime_arg_schema = {.runtime_arg_names = {"Wt", "num_tile_rows", "writer_start"}},
-        .hw_config = create_writer_datamovement_config(device->arch()),
+        .hw_config = create_writer_datamovement_config(),
     };
     if (input_is_row_major) {
         // The RM writer needs elem_size to compute per-row NOC write sizes.
@@ -753,7 +753,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormMultiCoreProgramFactory::creat
                    ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp"
                    : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp");
 
-    auto compute_hw = to_compute_hardware_config(device->arch(), compute_kernel_config);
+    auto compute_hw = to_compute_hardware_config(compute_kernel_config);
 
     m2::KernelSpec compute{
         .unique_id = COMPUTE,
@@ -893,7 +893,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormMultiCoreProgramFactory::creat
     // stay legal but become slower than they need to be. They want revisiting before this op
     // targets Gen2.
     {
-        auto& modes = m2::unpack_modes(std::get<m2::ComputeHardwareConfig>(compute.hw_config));
+        auto& modes = std::get<m2::ComputeHardwareConfig>(compute.hw_config).unpack_modes;
         std::vector<m2::DFBSpecName> unpack_to_dest;
         // Each entry is gated on the same condition as its binding: an entry naming a buffer the
         // kernel does not bind is rejected, and legacy set this one from float32_reduction alone,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -353,7 +353,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormShardedProgramFactory::create_
         .per_core_recip_lut_size = block_w,
         .reader_noc = reader_noc,
         .writer_noc = writer_noc,
-        .compute_hw = to_compute_hardware_config(device->arch(), compute_kernel_config),
+        .compute_hw = to_compute_hardware_config(compute_kernel_config),
     };
     if (operation_attributes.fused_activation.has_value()) {
         const auto& act = operation_attributes.fused_activation.value();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -1207,7 +1207,7 @@ void add_compute_defines(m2::KernelSpec& kernel, const SpecConfig& c, bool is_al
 // is the preferred mode for anything the SFPU consumes, so these assignments stay legal but become
 // slower than they need to be. They want revisiting before this op targets Gen2.
 void set_compute_unpack_modes(m2::KernelSpec& kernel, const m2::ProgramSpec& spec, const SpecConfig& c) {
-    auto& modes = m2::unpack_modes(std::get<m2::ComputeHardwareConfig>(kernel.hw_config));
+    auto& modes = std::get<m2::ComputeHardwareConfig>(kernel.hw_config).unpack_modes;
     if (c.welford_fp32_alias) {
         modes.emplace(X_WELFORD, UnpackMode::UnpackToDest);
     }
@@ -1238,10 +1238,12 @@ void add_kernel_and_work_unit_specs(
     const bool has_not_all_to_all_workers = workers.num_none_all_to_all_workers > 0;
     const bool has_inactive_cores = !core_ranges.inactive_cores.empty();
 
-    const m2::DataMovementHardwareConfig reader_hw = m2::DataMovementGen1Config{
-        .processor = DataMovementProcessor::RISCV_0, .noc = c.reader_noc, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
-    const m2::DataMovementHardwareConfig writer_hw = m2::DataMovementGen1Config{
-        .processor = DataMovementProcessor::RISCV_1, .noc = c.writer_noc, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
+    const m2::DataMovementHardwareConfig reader_hw{
+        .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = c.reader_noc, .noc_mode = NOC_MODE::DM_DEDICATED_NOC}};
+    const m2::DataMovementHardwareConfig writer_hw{
+        .config_1xx = m2::DataMovementHardwareConfig::DataMovement1XXConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = c.writer_noc, .noc_mode = NOC_MODE::DM_DEDICATED_NOC}};
 
     // The reader's trailing coordinate block is one X coordinate per multicast column followed by one
     // Y coordinate per multicast row. Its length is a compile-time property of the kernel, but the

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_distributed_metal2_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_distributed_metal2_helpers.hpp
@@ -7,9 +7,6 @@
 #include <cstdint>
 #include <string>
 #include <utility>
-#include <variant>
-
-#include <tt_stl/assert.hpp>
 
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp>
@@ -55,27 +52,13 @@ inline void bind_self_loop(m2::KernelSpec& kernel, const m2::DFBSpecName& dfb, s
 // it consumes: at that combination the choice between SrcA/B and Dest is a real precision and
 // throughput tradeoff, so there is no implicit default to fall back on. A program factory should call
 // this once per such buffer, under the same condition that binds the buffer.
-inline void unpack_via_src(m2::ComputeGen1Config& compute_config, const m2::DFBSpecName& dfb) {
+inline void unpack_via_src(m2::ComputeHardwareConfig& compute_config, const m2::DFBSpecName& dfb) {
     compute_config.unpack_modes.emplace(dfb, tt::tt_metal::UnpackMode::UnpackToSrc);
 }
 
 // Record that a buffer is unpacked straight into the Dest register, keeping full 32-bit precision.
-inline void unpack_via_dest(m2::ComputeGen1Config& compute_config, const m2::DFBSpecName& dfb) {
+inline void unpack_via_dest(m2::ComputeHardwareConfig& compute_config, const m2::DFBSpecName& dfb) {
     compute_config.unpack_modes.emplace(dfb, tt::tt_metal::UnpackMode::UnpackToDest);
-}
-
-// Resolve the Gen1 alternative of a compute hardware config so per-DFB fields can be set on it.
-//
-// A compute hardware config holds one generation's settings, and this op only ever builds the Gen1
-// (Wormhole / Blackhole) alternative: `to_compute_hardware_config` returns the Gen2 alternative on
-// Quasar, and nothing here populates the Gen2-only fields or makes the Quasar-specific choices those
-// need. Say so plainly rather than letting the std::get raise std::bad_variant_access.
-inline m2::ComputeGen1Config& gen1_compute_config(m2::ComputeHardwareConfig& config) {
-    TT_FATAL(
-        std::holds_alternative<m2::ComputeGen1Config>(config),
-        "layernorm_distributed builds Gen1 (Wormhole / Blackhole) compute configs only; this device "
-        "reports a different generation, which this op does not support yet.");
-    return std::get<m2::ComputeGen1Config>(config);
 }
 
 }  // namespace ttnn::prim::layernorm_distributed_metal2

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_program_factory.cpp
@@ -384,7 +384,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherProgramFactory::c
              {"Wt", tiles_per_core_y},
              {"reduce_factor", reduce_factor}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt", "tile_offset", "stats_tile_offset", "eps", "y_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (gamma.has_value()) {
         reader.dfb_bindings.push_back(m2::DFBBinding{
@@ -407,7 +407,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherProgramFactory::c
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = POST_OUTPUT_T, .accessor_name = "dst"}},
         .compile_time_args = {{"blk", block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     m2::KernelSpec compute{
@@ -442,7 +442,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherProgramFactory::c
              {"legacy_rsqrt", static_cast<uint32_t>(program_config.legacy_rsqrt)},
              {"dfb_length", cb_length}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt"}},
-        .hw_config = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
+        .hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config),
     };
     // Every intermediate below is private to the compute kernel: it packs into the buffer and
     // unpacks it back, so it is that buffer's only endpoint on both sides.
@@ -467,7 +467,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherProgramFactory::c
         compute.dfb_bindings.push_back(m2::DFBBinding{
             .dfb_spec_name = POST_BETA, .accessor_name = "beta", .endpoint_type = m2::DFBEndpointType::CONSUMER});
     }
-    auto& compute_gen1 = gen1_compute_config(std::get<m2::ComputeHardwareConfig>(compute.hw_config));
+    auto& compute_hw = std::get<m2::ComputeHardwareConfig>(compute.hw_config);
     // With the 32-bit Dest register enabled, every Float32 buffer the compute kernel consumes needs an
     // explicit unpack mode. In this kernel every consumed buffer is read by an FPU op (the stats row
     // reduce, mul_tiles / sub_tiles / add_tiles for the variance, and the broadcast multiplies and adds
@@ -475,34 +475,34 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherProgramFactory::c
     // for all of them. They are listed one by one on purpose: any "catch all" clever method that set
     // unpack_via_src on all of them could  accidentally include a future DFB where unpack_via_src would
     // not be appropriate.
-    if (compute_gen1.enable_32_bit_dest) {
+    if (compute_hw.enable_32_bit_dest) {
         // The intermediates all carry cb_data_format, which is Float32 exactly when the Dest register is.
-        unpack_via_src(compute_gen1, POST_VAR);
-        unpack_via_src(compute_gen1, POST_RECIP_SQRT_VAR);
+        unpack_via_src(compute_hw, POST_VAR);
+        unpack_via_src(compute_hw, POST_RECIP_SQRT_VAR);
         if (!is_rmsnorm) {
-            unpack_via_src(compute_gen1, POST_STATS_REDUCED);
-            unpack_via_src(compute_gen1, POST_MEAN_SQUARED);
-            unpack_via_src(compute_gen1, POST_X_MINUS_MEAN);
+            unpack_via_src(compute_hw, POST_STATS_REDUCED);
+            unpack_via_src(compute_hw, POST_MEAN_SQUARED);
+            unpack_via_src(compute_hw, POST_X_MINUS_MEAN);
         }
         if (uses_x_normed) {
-            unpack_via_src(compute_gen1, POST_X_NORMED);
+            unpack_via_src(compute_hw, POST_X_NORMED);
         }
         if (uses_times_gamma_out) {
-            unpack_via_src(compute_gen1, POST_TIMES_GAMMA_OUT);
+            unpack_via_src(compute_hw, POST_TIMES_GAMMA_OUT);
         }
         // The inputs carry their own tensor's dtype. The epsilon buffer is always Float16_b.
         if (in_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, POST_INPUT);
-            unpack_via_src(compute_gen1, POST_REDUCE);  // the scaler tile mirrors the input's dtype
+            unpack_via_src(compute_hw, POST_INPUT);
+            unpack_via_src(compute_hw, POST_REDUCE);  // the scaler tile mirrors the input's dtype
         }
         if (stats_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, POST_STATS);
+            unpack_via_src(compute_hw, POST_STATS);
         }
         if (gamma.has_value() && gamma_cb_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, POST_GAMMA);
+            unpack_via_src(compute_hw, POST_GAMMA);
         }
         if (beta.has_value() && beta_cb_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, POST_BETA);
+            unpack_via_src(compute_hw, POST_BETA);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_welford_program_factory.cpp
@@ -389,7 +389,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherWelfordProgramFac
              {"Wt", Wt},
              {"reduce_factor", reduce_factor}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt", "tile_offset", "stats_tile_offset", "eps", "y_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     // The shared reader always fills a reduce-scalar tile, but the Welford compute kernel derives
     // its own scaling and never reads it. The reader is then the buffer's only toucher, so it takes
@@ -416,7 +416,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherWelfordProgramFac
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = POSTWF_OUTPUT_T, .accessor_name = "dst"}},
         .compile_time_args = {{"blk", block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Welford preserves the math fidelity selection and FP32 dst-acc setting from compute_kernel_config.
@@ -451,7 +451,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherWelfordProgramFac
              {"fp32_dtype", static_cast<uint32_t>(fp32_dest_acc_en)},
              {"dfb_length", cb_length}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt"}},
-        .hw_config = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
+        .hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config),
     };
     // Every intermediate below is private to the compute kernel: it packs into the buffer and
     // unpacks it back, so it is that buffer's only endpoint on both sides.
@@ -473,7 +473,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherWelfordProgramFac
             .dfb_spec_name = POSTWF_BETA, .accessor_name = "beta", .endpoint_type = m2::DFBEndpointType::CONSUMER});
     }
 
-    auto& compute_gen1 = gen1_compute_config(std::get<m2::ComputeHardwareConfig>(compute.hw_config));
+    auto& compute_hw = std::get<m2::ComputeHardwareConfig>(compute.hw_config);
     // UnpackToDest only helps for buffers whose only consumer is an op that supports the
     // unpack-to-DEST path (copy_tile or transpose_tile in fp32 mode). For those, setting
     // the mode preserves FP32 precision by bypassing SrcA. Setting it on a buffer consumed by any
@@ -490,7 +490,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherWelfordProgramFac
     //     recombine.
     //   - rmsnorm path: consumed by reduce_tile (FPU). Must NOT enable UnpackToDest.
     if (!is_rmsnorm && fp32_dest_acc_en && stats_data_format == tt::DataFormat::Float32) {
-        unpack_via_dest(compute_gen1, POSTWF_STATS);
+        unpack_via_dest(compute_hw, POSTWF_STATS);
     }
     // The rest of the Float32 buffers this kernel consumes take the SrcA/B path, each stated
     // individually because a Float32 buffer has no implicit default once the 32-bit Dest register is
@@ -498,29 +498,29 @@ ttnn::device_operation::ProgramArtifacts LayerNormPostAllGatherWelfordProgramFac
     // var + epsilon, and the broadcast multiplies and adds of the gamma / beta chain.
     if (fp32_dest_acc_en) {
         // The intermediates all carry cb_data_format, which is Float32 exactly when the Dest register is.
-        unpack_via_src(compute_gen1, POSTWF_STATS_REDUCED);
-        unpack_via_src(compute_gen1, POSTWF_RECIP_SQRT_VAR);
-        unpack_via_src(compute_gen1, POSTWF_X_MINUS_MEAN);
+        unpack_via_src(compute_hw, POSTWF_STATS_REDUCED);
+        unpack_via_src(compute_hw, POSTWF_RECIP_SQRT_VAR);
+        unpack_via_src(compute_hw, POSTWF_X_MINUS_MEAN);
         if (uses_x_normed) {
-            unpack_via_src(compute_gen1, POSTWF_X_NORMED);
+            unpack_via_src(compute_hw, POSTWF_X_NORMED);
         }
         if (uses_times_gamma_out) {
-            unpack_via_src(compute_gen1, POSTWF_TIMES_GAMMA_OUT);
+            unpack_via_src(compute_hw, POSTWF_TIMES_GAMMA_OUT);
         }
         // The inputs carry their own tensor's dtype. The epsilon buffer is always Float16_b, and the
         // reduce-scalar buffer never reaches this kernel (the reader is its only endpoint).
         if (in_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, POSTWF_INPUT);
+            unpack_via_src(compute_hw, POSTWF_INPUT);
         }
         // A Float32 stats buffer on the layernorm path already took UnpackToDest just above.
         if (stats_data_format == tt::DataFormat::Float32 && is_rmsnorm) {
-            unpack_via_src(compute_gen1, POSTWF_STATS);
+            unpack_via_src(compute_hw, POSTWF_STATS);
         }
         if (gamma.has_value() && gamma_cb_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, POSTWF_GAMMA);
+            unpack_via_src(compute_hw, POSTWF_GAMMA);
         }
         if (beta.has_value() && beta_cb_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, POSTWF_BETA);
+            unpack_via_src(compute_hw, POSTWF_BETA);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -238,7 +238,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = PRE1D_INPUT_T, .accessor_name = "src"}},
         .compile_time_args = {{"blk", block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt", "Wt", "tile_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (fuse_pre_add) {
         reader.dfb_bindings.push_back(m2::DFBBinding{
@@ -255,10 +255,10 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = PRE1D_OUTPUT_T, .accessor_name = "dst"}},
         .compile_time_args = {{"blk", writer_block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
     m2::KernelSpec compute{
         .unique_id = PRE1D_COMPUTE,
         .source = compute_kernel_file,
@@ -289,24 +289,24 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
         compute.dfb_bindings.push_back(m2::DFBBinding{
             .dfb_spec_name = PRE1D_RESIDUAL, .accessor_name = "res", .endpoint_type = m2::DFBEndpointType::CONSUMER});
     }
-    auto& compute_gen1 = gen1_compute_config(std::get<m2::ComputeHardwareConfig>(compute.hw_config));
+    auto& compute_cfg = std::get<m2::ComputeHardwareConfig>(compute.hw_config);
     // With the 32-bit Dest register enabled, every Float32 buffer the compute kernel consumes needs an
     // explicit unpack mode. Here each one feeds an FPU op (mul_tiles for x**2, the row reduce for the
     // sums), and the FPU reads its operands out of SrcA/SrcB, so SrcA/B is the mode for all of them.
     // The intermediates are Float16_b whatever the Dest width, so only the inputs can qualify.
-    if (compute_gen1.enable_32_bit_dest) {
+    if (compute_cfg.enable_32_bit_dest) {
         auto unpack_operand = [&](const m2::DFBSpecName& dfb) {
             if (unpack_fp32_active) {
-                unpack_via_dest(compute_gen1, dfb);
+                unpack_via_dest(compute_cfg, dfb);
             } else {
-                unpack_via_src(compute_gen1, dfb);
+                unpack_via_src(compute_cfg, dfb);
             }
         };
         if (in_data_format == tt::DataFormat::Float32) {
             unpack_operand(PRE1D_INPUT);
         }
         if (scaler_cb_data_format == tt::DataFormat::Float32) {
-            unpack_via_src(compute_gen1, PRE1D_REDUCE);
+            unpack_via_src(compute_cfg, PRE1D_REDUCE);
         }
         if (cb_data_format == tt::DataFormat::Float32) {
             unpack_operand(PRE1D_X2);
@@ -569,7 +569,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"NCHt", "Wt", "tile_offset", "is_merge_core", "reduce_core_noc_x", "reduce_core_noc_y", "y"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (fuse_pre_add) {
         reader.dfb_bindings.push_back(m2::DFBBinding{
@@ -586,7 +586,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = PRE2D_OUTPUT_T, .accessor_name = "dst"}},
         .compile_time_args = {{"blk", writer_block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Two instances of the one compute source, over disjoint node sets: the merge row additionally
@@ -631,7 +631,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
                  {"blk", block_size},
                  {"num_cores_y", cores_y},
                  {"unpack_fp32_active", unpack_fp32_active ? 1u : 0u}},
-            .hw_config = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
+            .hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config),
         };
         bind_self_loop(compute, PRE2D_X2, "x2");
         if (fuse_pre_add) {
@@ -647,22 +647,22 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
                 .accessor_name = "out_final",
                 .endpoint_type = m2::DFBEndpointType::PRODUCER});
         }
-        auto& compute_gen1 = gen1_compute_config(std::get<m2::ComputeHardwareConfig>(compute.hw_config));
+        auto& compute_hw = std::get<m2::ComputeHardwareConfig>(compute.hw_config);
         // Float32 operands use UnpackToDest on the accurate SFPU path and SrcA/SrcB on the FPU path.
         // The reduce scaler and the FPU merge's zero tile are always consumed through SrcA/SrcB.
-        if (compute_gen1.enable_32_bit_dest) {
+        if (compute_hw.enable_32_bit_dest) {
             auto unpack_operand = [&](const m2::DFBSpecName& dfb) {
                 if (unpack_fp32_active) {
-                    unpack_via_dest(compute_gen1, dfb);
+                    unpack_via_dest(compute_hw, dfb);
                 } else {
-                    unpack_via_src(compute_gen1, dfb);
+                    unpack_via_src(compute_hw, dfb);
                 }
             };
             if (in_data_format == tt::DataFormat::Float32) {
                 unpack_operand(PRE2D_INPUT);
             }
             if (scaler_cb_data_format == tt::DataFormat::Float32) {
-                unpack_via_src(compute_gen1, PRE2D_REDUCE);
+                unpack_via_src(compute_hw, PRE2D_REDUCE);
             }
             if (cb_data_format == tt::DataFormat::Float32) {
                 unpack_operand(PRE2D_X2);
@@ -672,7 +672,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGather2DProgramFactory::
                 // The merge sums the column's partials on the SFPU when accurate, add_tiles
                 // otherwise; dfb::zero is only the FPU path's operand.
                 unpack_operand(PRE2D_X2_MERGE);
-                unpack_via_src(compute_gen1, PRE2D_ZERO);
+                unpack_via_src(compute_hw, PRE2D_ZERO);
             }
             if (fuse_pre_add && inb_data_format == tt::DataFormat::Float32) {
                 unpack_operand(PRE2D_RESIDUAL);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
@@ -246,7 +246,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherWelfordProgramFact
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = PREWF_INPUT_T, .accessor_name = "src"}},
         .compile_time_args = {{"blk", block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt", "Wt", "tile_offset"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
     if (fuse_pre_add) {
         reader.dfb_bindings.push_back(m2::DFBBinding{
@@ -263,7 +263,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherWelfordProgramFact
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = PREWF_OUTPUT_T, .accessor_name = "dst"}},
         .compile_time_args = {{"blk", writer_block_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Welford uses fp32 accumulation; preserve fp32_dest_acc_en from the compute config.
@@ -290,7 +290,7 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherWelfordProgramFact
              {"blk", block_size},
              {"welford_unpack_fp32_active", welford_unpack_fp32_active ? 1u : 0u}},
         .runtime_arg_schema = {.runtime_arg_names = {"NCHt"}},
-        .hw_config = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
+        .hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config),
     };
     // The reciprocal table has no FIFO traffic at all: the kernel reads it by base pointer. It is
     // that kernel's only endpoint, so it takes both roles.
@@ -303,16 +303,16 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherWelfordProgramFact
         bind_self_loop(compute, PREWF_M2_SPILL, "m2_spill");
     }
 
-    auto& compute_gen1 = gen1_compute_config(std::get<m2::ComputeHardwareConfig>(compute.hw_config));
+    auto& compute_hw = std::get<m2::ComputeHardwareConfig>(compute.hw_config);
     // When welford_unpack_fp32_active:
     //   !fuse_pre_add -> UnpackToDest on the input only (read by transpose_tile in the Welford loop).
     //   fuse_pre_add  -> UnpackToDest on the input, residual and fused buffers (copy_tile pre-add
     //   unpack + transpose_tile on the post-add result).
     if (welford_unpack_fp32_active) {
-        unpack_via_dest(compute_gen1, PREWF_INPUT);
+        unpack_via_dest(compute_hw, PREWF_INPUT);
         if (fuse_pre_add) {
-            unpack_via_dest(compute_gen1, PREWF_RESIDUAL);
-            unpack_via_dest(compute_gen1, PREWF_FUSED);
+            unpack_via_dest(compute_hw, PREWF_RESIDUAL);
+            unpack_via_dest(compute_hw, PREWF_FUSED);
         }
     }
     // The transpose scratch holds data only for the final transpose operation, so its format
@@ -320,28 +320,28 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherWelfordProgramFact
     // UnpackToDest on it too so the read-back doesn't truncate to TF32. For non-FP32 outputs the
     // final pack to the output buffer truncates anyway, so unpacking to FP32 would not be useful.
     if (out_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en) {
-        unpack_via_dest(compute_gen1, PREWF_SCRATCH);
+        unpack_via_dest(compute_hw, PREWF_SCRATCH);
     }
     // The Welford spill buffers hold the FP32 accumulator between block iterations and are reloaded
     // into DEST via copy_tile. On the SrcA/B path that round-trip truncates FP32 to TF32 on every
     // block iteration. Force UnpackToDest on them so the FP32 precision survives the spill cycle.
     if (fuse_pre_add && fp32_dest_acc_en) {
-        unpack_via_dest(compute_gen1, PREWF_MEAN_SPILL);
-        unpack_via_dest(compute_gen1, PREWF_M2_SPILL);
+        unpack_via_dest(compute_hw, PREWF_MEAN_SPILL);
+        unpack_via_dest(compute_hw, PREWF_M2_SPILL);
     }
     // The remaining Float32 buffers this kernel consumes take the SrcA/B path. Each needs saying out
     // loud, because with the 32-bit Dest register enabled a Float32 buffer has no implicit default.
     if (fp32_dest_acc_en) {
         // The reciprocal table is never unpacked at all: the kernel reads it through a base pointer.
         // SrcA/B is the inert choice for a buffer no unpacker touches.
-        unpack_via_src(compute_gen1, PREWF_RECIP);
+        unpack_via_src(compute_hw, PREWF_RECIP);
         // A narrower input leaves welford_unpack_fp32_active off, which puts the pre-add on the FPU
         // add_tiles path instead of the SFPU copy_tile one. The residual and the fused result are then
         // read through SrcA/B, even though the 32-bit Dest register still makes the fused buffer Float32.
         if (fuse_pre_add && !welford_unpack_fp32_active) {
-            unpack_via_src(compute_gen1, PREWF_FUSED);
+            unpack_via_src(compute_hw, PREWF_FUSED);
             if (inb_data_format == tt::DataFormat::Float32) {
-                unpack_via_src(compute_gen1, PREWF_RESIDUAL);
+                unpack_via_src(compute_hw, PREWF_RESIDUAL);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -377,7 +377,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
         .tensor_bindings = reader_tensor_bindings,
         .compile_time_args = reader_cta,
         .runtime_arg_schema = {.runtime_arg_names = reader_rta_names},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer kernel ----
@@ -394,7 +394,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .compile_time_args = {{"num_datum_padded", num_datum_padded}, {"tile_hw", tile_height * tile_width}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset", "blk", "mask_padded_data", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // for broadcasting in H direction we need to
@@ -458,12 +458,11 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
 
     // Compute hardware config (Style A). Legacy defaulted unpack_to_dest_mode (=> UnpackToSrc); Metal 2.0
     // requires an explicit entry for every Float32 DFB the compute consumes under enable_32_bit_dest.
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, attributes.compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(attributes.compute_kernel_config);
     if (fp32_dest_acc_en) {
-        auto& gen1 = std::get<ComputeGen1Config>(compute_hw);
         auto add_unpack = [&](const DFBSpecName& name, tt::DataFormat fmt) {
             if (fmt == tt::DataFormat::Float32) {
-                gen1.unpack_modes.insert({name, tt::tt_metal::UnpackMode::UnpackToSrc});
+                compute_hw.unpack_modes.insert({name, tt::tt_metal::UnpackMode::UnpackToSrc});
             }
         };
         add_unpack(IN0, in0_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized_sharded.cpp
@@ -292,7 +292,7 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_p
         .tensor_bindings = reader_tensor_bindings,
         .compile_time_args = reader_cta,
         .runtime_arg_schema = {.runtime_arg_names = reader_rta_names},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Compute kernel ----
@@ -341,12 +341,11 @@ SoftmaxDeviceOperation::SoftmaxShardedProgramFactoryAttentionOptimized::create_p
     }
 
     // Compute hardware config (Style A) + fp32 unpack modes for every Float32 DFB consumed.
-    auto compute_hw = ttnn::to_compute_hardware_config(arch, attributes.compute_kernel_config);
+    auto compute_hw = ttnn::to_compute_hardware_config(attributes.compute_kernel_config);
     if (fp32_dest_acc_en) {
-        auto& gen1 = std::get<ComputeGen1Config>(compute_hw);
         auto add_unpack = [&](const DFBSpecName& name, tt::DataFormat fmt) {
             if (fmt == tt::DataFormat::Float32) {
-                gen1.unpack_modes.insert({name, tt::tt_metal::UnpackMode::UnpackToSrc});
+                compute_hw.unpack_modes.insert({name, tt::tt_metal::UnpackMode::UnpackToSrc});
             }
         };
         add_unpack(IN0, in0_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_c_large.cpp
@@ -121,7 +121,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralCLarge::create_program_artif
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "tile_offset", "outer_stride", "inner_size", "dim_size"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -132,7 +132,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralCLarge::create_program_artif
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema =
             {.runtime_arg_names = {"num_tiles", "tile_offset", "outer_stride", "inner_size", "dim_size"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     auto outer_stride = Ht * Wt;
@@ -150,9 +150,9 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralCLarge::create_program_artif
     }
 
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {EXPS, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {RECIP, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
@@ -158,7 +158,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralHLarge::create_program_artif
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -168,7 +168,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralHLarge::create_program_artif
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Compute kernel
@@ -181,9 +181,9 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralHLarge::create_program_artif
     }
 
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
@@ -157,7 +157,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralHSmall::create_program_artif
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt", "mask_h"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -167,7 +167,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralHSmall::create_program_artif
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Ht", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Compute kernel
@@ -180,9 +180,9 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralHSmall::create_program_artif
     }
 
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_large.cpp
@@ -165,7 +165,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralWLarge::create_program_artif
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -175,7 +175,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralWLarge::create_program_artif
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // Compute kernels
@@ -188,9 +188,9 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralWLarge::create_program_artif
     }
 
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_small.cpp
@@ -160,7 +160,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralWSmall::create_program_artif
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"}},
         .compile_time_args = {{"is_fp32", static_cast<std::uint32_t>(input_tensor.dtype() == DataType::FLOAT32)}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt", "mask_w"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // ---- Writer kernel ----
@@ -171,7 +171,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralWSmall::create_program_artif
             .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tile_offset", "Wt"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // ---- Compute defines ----
@@ -187,9 +187,9 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryGeneralWSmall::create_program_artif
     // Legacy defaulted unpack_to_dest_mode (=> UnpackToSrc). Metal 2.0 requires an explicit entry for
     // every Float32 DFB a compute kernel consumes when enable_32_bit_dest is set (fp32 path).
     auto make_compute_hw = [&]() {
-        auto hw = ttnn::to_compute_hardware_config(arch, compute_kernel_config);
+        auto hw = ttnn::to_compute_hardware_config(compute_kernel_config);
         if (fp32_dest_acc_en) {
-            std::get<ComputeGen1Config>(hw).unpack_modes = {
+            hw.unpack_modes = {
                 {IN, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MASK, tt::tt_metal::UnpackMode::UnpackToSrc},
                 {MAX_SCALER, tt::tt_metal::UnpackMode::UnpackToSrc},

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_nearest_float_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_nearest_float_program_factory.cpp
@@ -115,7 +115,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleNearestFloatProgramFactory::cre
                 {"reciprocal_scale_w_fixed", static_cast<std::uint32_t>(reciprocal_scale_w_fixed)},
             },
         .runtime_arg_schema = {.runtime_arg_names = {"num_sticks", "start_stick_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     metal2::KernelSpec writer{
@@ -128,7 +128,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleNearestFloatProgramFactory::cre
         .tensor_bindings = {metal2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .compile_time_args = {{"aligned_stick_nbytes", aligned_output_page_size}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_sticks", "start_stick_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     metal2::ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
@@ -151,7 +151,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleMultiCoreInterleavedProgramFact
         .tensor_bindings = {metal2::TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
         .compile_time_args = std::move(reader_cta),
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_page_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // Writer compile time arguments
@@ -194,7 +194,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleMultiCoreInterleavedProgramFact
         .tensor_bindings = {metal2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"}},
         .compile_time_args = std::move(writer_cta),
         .runtime_arg_schema = {.runtime_arg_names = {"num_blocks_to_read", "start_block_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     metal2::ProgramSpec spec{
@@ -245,7 +245,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleMultiCoreInterleavedProgramFact
                         {"per_core_block_cnt", work_per_core_group_1},
                         {"per_core_block_tile_cnt", num_input_tiles_in_row},
                     },
-                .hw_config = metal2::ComputeGen1Config{},
+                .hw_config = metal2::ComputeHardwareConfig{},
             };
             spec.kernels.push_back(compute_g1);
             spec.work_units.push_back(metal2::WorkUnitSpec{
@@ -274,7 +274,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleMultiCoreInterleavedProgramFact
                         {"per_core_block_cnt", work_per_core_group_2},
                         {"per_core_block_tile_cnt", num_input_tiles_in_row},
                     },
-                .hw_config = metal2::ComputeGen1Config{},
+                .hw_config = metal2::ComputeHardwareConfig{},
             };
             spec.kernels.push_back(compute_g2);
             spec.work_units.push_back(metal2::WorkUnitSpec{

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
@@ -424,7 +424,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleMultiCoreShardedProgramFactory:
                  .accessor_name = "config",
                  .endpoint_type = metal2::DFBEndpointType::PRODUCER}},
         .compile_time_args = make_cta(/*is_reader=*/0),
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     metal2::KernelSpec reader_spec{
@@ -442,7 +442,7 @@ ttnn::device_operation::ProgramArtifacts UpsampleMultiCoreShardedProgramFactory:
                  .accessor_name = "config",
                  .endpoint_type = metal2::DFBEndpointType::CONSUMER}},
         .compile_time_args = make_cta(/*is_reader=*/1),
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     metal2::ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -142,7 +142,7 @@ ttnn::device_operation::ProgramArtifacts AccumulationProgramFactory::create_prog
     // rather than through SrcA/B. The input takes the same route whenever it is not the format the
     // FPU path handles natively. Omitting a DFB is the UnpackToSrc default; the output DFB is only
     // produced into, never consumed, so it needs no entry.
-    ComputeUnpackModes unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes unpack_modes;
     unpack_modes[ACCUM_ACC] = UnpackMode::UnpackToDest;
     if (input_dataformat != DataFormat::Float16_b) {
         unpack_modes[ACCUM_SRC] = UnpackMode::UnpackToDest;
@@ -206,7 +206,7 @@ ttnn::device_operation::ProgramArtifacts AccumulationProgramFactory::create_prog
             .accessor_name = "input",
         }},
         .runtime_arg_schema = {.runtime_arg_names = dataflow_rta_names},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -222,10 +222,10 @@ ttnn::device_operation::ProgramArtifacts AccumulationProgramFactory::create_prog
             .accessor_name = "output",
         }},
         .runtime_arg_schema = {.runtime_arg_names = dataflow_rta_names},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
-    const ComputeGen1Config compute_config{
+    const ComputeHardwareConfig compute_config{
         .fpu_math_fidelity = default_math_fidelity,
         .sfpu_precision_mode = Precision::Precise,
         .enable_32_bit_dest = true,
@@ -266,7 +266,7 @@ ttnn::device_operation::ProgramArtifacts AccumulationProgramFactory::create_prog
                  }},
             .compile_time_args = {{"default_acc_value", std::bit_cast<uint32_t>(default_acc_value)}},
             .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "tiles_per_row"}},
-            .hw_config = ComputeHardwareConfig{compute_config},
+            .hw_config = compute_config,
         };
     };
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
@@ -133,7 +133,7 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
     // the reader on RISCV_0 and the writer on RISCV_1, which is the reverse of the conventional
     // assignment, so neither matches a role default and neither can go through the
     // architecture-agnostic reader / writer helpers without changing where they run. Spelling out
-    // the Gen1 config is therefore what preserves the placement, and it pins this whole factory to
+    // config_1xx (DataMovement1XXConfig) is therefore what preserves the placement, and it pins this whole factory to
     // Gen1: a Gen2 build would need placement decisions that cannot be derived from these values.
     tt::tt_metal::NOC writer_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt::tt_metal::NOC reader_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
@@ -152,10 +152,13 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
         }},
         .compile_time_args = {{"total_tiles_per_core", total_tiles_per_core}},
         .runtime_arg_schema = {.runtime_arg_names = {"src_start_tile"}},
-        .hw_config = DataMovementHardwareConfig{DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = reader_noc,
-        }},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .config_1xx =
+                    DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                        .noc = reader_noc,
+                    }},
     };
 
     KernelSpec writer{
@@ -172,10 +175,13 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
         }},
         .compile_time_args = {{"total_tiles_per_core", total_tiles_per_core}},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_start_tile"}},
-        .hw_config = DataMovementHardwareConfig{DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = writer_noc,
-        }},
+        .hw_config =
+            DataMovementHardwareConfig{
+                .config_1xx =
+                    DataMovementHardwareConfig::DataMovement1XXConfig{
+                        .processor = DataMovementProcessor::RISCV_1,
+                        .noc = writer_noc,
+                    }},
     };
 
     KernelSpec compute{
@@ -211,10 +217,10 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
              {"tiles_per_channel", tiles_per_channel},
              {"alpha_bits", alpha_bits},
              {"beta_bits", beta_bits}},
-        // Translates the TTNN ComputeKernelConfig this op resolves into its Metal 2.0 equivalent.
-        // The helper picks the alternative matching the architecture, but that does not make the
-        // program portable: the data movement kernels above are Gen1-only, so the whole factory is.
-        .hw_config = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
+        // Translates the TTNN ComputeKernelConfig this op resolves into ComputeHardwareConfig.
+        // That does not make the program portable: the data movement kernels above are Gen1-only,
+        // so the whole factory is.
+        .hw_config = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config),
     };
 
     // Set runtime args

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
@@ -404,11 +404,14 @@ ttnn::device_operation::ProgramArtifacts ArgMaxMultiCoreProgramFactory::create_p
                 },
             // Not the reader default placement (that is NOC_0): this kernel is pinned to RISCV_1 on
             // NOC_1, reproduced field-by-field from the pre-Metal-2.0 config.
-            .hw_config = DataMovementHardwareConfig{DataMovementGen1Config{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = tt::tt_metal::NOC::NOC_1,
-                .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
-            }},
+            .hw_config =
+                DataMovementHardwareConfig{
+                    .config_1xx =
+                        DataMovementHardwareConfig::DataMovement1XXConfig{
+                            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                            .noc = tt::tt_metal::NOC::NOC_1,
+                            .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+                        }},
         };
     };
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
@@ -206,7 +206,7 @@ ttnn::device_operation::ProgramArtifacts ArgMaxSingleCoreProgramFactory::create_
                 TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"},
             },
         .compile_time_args = std::move(ctime_args),
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -486,7 +486,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
         .tensor_bindings = std::move(reader_tensor_bindings),
         .compile_time_args = std::move(reader_ct_args),
         .runtime_arg_schema = {.runtime_arg_names = std::move(reader_rta_names)},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -533,7 +533,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
         .tensor_bindings = std::move(writer_tensor_bindings),
         .compile_time_args = std::move(writer_ct_args),
         .runtime_arg_schema = {.runtime_arg_names = std::move(writer_rta_names)},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernels (one per core group) ----
@@ -543,45 +543,40 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
     // would otherwise carry the caller's math_approx_mode into sfpu_precision_mode, silently
     // changing SFPU precision. (Unlike the other three factories, this one *does* forward
     // dst_full_sync_en, so double_buffer_dest keeps the helper's inverted value.)
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config);
-    // std::visit rather than a Gen1-only get_if: to_compute_hardware_config yields a
-    // ComputeGen2Config on Quasar, and the fields set below exist on both generations. The
-    // explicit-unpack-mode requirement in particular is enforced generation-agnostically, so a
-    // Gen1-only branch would leave FP32 + 32-bit-Dest programs failing ProgramSpec validation there.
+    auto compute_hw = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
     // (Unlike the other three factories, this one forwarded dst_full_sync_en, so double_buffer_dest
     // is left at whatever the caller's config resolved to.)
-    std::visit(
-        [&](auto& compute_cfg) {
-            compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
-            if (fp32_sfpu_reduce) {
-                // Legacy: unpack_to_dest_mode[src0_cb_index] = UnpackToDestFp32 — unpacks the reduce
-                // input straight into the fp32 DEST, bypassing the SrcA tf32 truncation. The RM
-                // path's chunk accumulator (legacy c_5) gets the same treatment so partials
-                // round-trip in fp32.
-                compute_cfg.unpack_modes.emplace(IN_DFB, UnpackMode::UnpackToDest);
-                if (rm_path) {
-                    compute_cfg.unpack_modes.emplace(ACC_DFB, UnpackMode::UnpackToDest);
-                }
-            }
-            // Legacy left every other entry at Default (= UnpackToSrc). Metal 2.0 nonetheless requires an
-            // explicit mode for every Float32 buffer this kernel consumes under a 32-bit Dest register,
-            // so state the legacy value for those.
-            auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
-                if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
-                    compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
-                }
-            };
-            require_explicit_unpack_mode(IN_DFB, src0_cb_data_format);
-            require_explicit_unpack_mode(SCALER_DFB, scaler_cb_data_format);
+    {
+        auto& compute_cfg = compute_hw;
+        compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
+        if (fp32_sfpu_reduce) {
+            // Legacy: unpack_to_dest_mode[src0_cb_index] = UnpackToDestFp32 — unpacks the reduce
+            // input straight into the fp32 DEST, bypassing the SrcA tf32 truncation. The RM
+            // path's chunk accumulator (legacy c_5) gets the same treatment so partials
+            // round-trip in fp32.
+            compute_cfg.unpack_modes.emplace(IN_DFB, UnpackMode::UnpackToDest);
             if (rm_path) {
-                require_explicit_unpack_mode(RM_DFB, src0_cb_data_format);
-                require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
-            } else if (use_fpu_negate) {
-                require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
-                require_explicit_unpack_mode(INEG_DFB, dst_cb_data_format);
+                compute_cfg.unpack_modes.emplace(ACC_DFB, UnpackMode::UnpackToDest);
             }
-        },
-        compute_hw);
+        }
+        // Legacy left every other entry at Default (= UnpackToSrc). Metal 2.0 nonetheless requires an
+        // explicit mode for every Float32 buffer this kernel consumes under a 32-bit Dest register,
+        // so state the legacy value for those.
+        auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
+            if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
+                compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
+            }
+        };
+        require_explicit_unpack_mode(IN_DFB, src0_cb_data_format);
+        require_explicit_unpack_mode(SCALER_DFB, scaler_cb_data_format);
+        if (rm_path) {
+            require_explicit_unpack_mode(RM_DFB, src0_cb_data_format);
+            require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
+        } else if (use_fpu_negate) {
+            require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
+            require_explicit_unpack_mode(INEG_DFB, dst_cb_data_format);
+        }
+    }
 
     // For width-sharding, num_cols_per_core_group_1 == NC * shard_Wt. Expose (shard_Wt, NC)
     // to the compute kernel so its (nc, wt_chunk, ht, wt_in_chunk) iteration matches the

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -369,7 +369,7 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
         .tensor_bindings = std::move(reader_tensor_bindings),
         .compile_time_args = std::move(reader_ct_args),
         .runtime_arg_schema = {.runtime_arg_names = std::move(reader_rta_names)},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -411,7 +411,7 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
         .tensor_bindings = std::move(writer_tensor_bindings),
         .compile_time_args = std::move(writer_ct_args),
         .runtime_arg_schema = {.runtime_arg_names = std::move(writer_rta_names)},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernels (one per core group) ----
@@ -421,44 +421,39 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
     // Reproduce that exactly: the TTNN helper would otherwise carry the caller's math_approx_mode
     // into sfpu_precision_mode and the caller's dst_full_sync_en into double_buffer_dest, silently
     // changing precision / Dest buffering.
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config);
-    // std::visit rather than a Gen1-only get_if: to_compute_hardware_config yields a
-    // ComputeGen2Config on Quasar, and the fields set below exist on both generations. The
-    // explicit-unpack-mode requirement in particular is enforced generation-agnostically, so a
-    // Gen1-only branch would leave FP32 + 32-bit-Dest programs failing ProgramSpec validation there.
-    std::visit(
-        [&](auto& compute_cfg) {
-            compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
-            compute_cfg.double_buffer_dest = true;                 // legacy dst_full_sync_en = false
-            if (fp32_sfpu_reduce) {
-                // Legacy: unpack_to_dest_mode[src0_cb_index] = UnpackToDestFp32 — unpacks the reduce
-                // input straight into the fp32 DEST, bypassing the SrcA tf32 truncation. The RM
-                // path's chunk accumulator (legacy c_5) gets the same treatment so partials
-                // round-trip in fp32.
-                compute_cfg.unpack_modes.emplace(IN_DFB, UnpackMode::UnpackToDest);
-                if (rm_path) {
-                    compute_cfg.unpack_modes.emplace(ACC_DFB, UnpackMode::UnpackToDest);
-                }
-            }
-            // Legacy left every other entry at Default (= UnpackToSrc). Metal 2.0 nonetheless requires an
-            // explicit mode for every Float32 buffer this kernel consumes under a 32-bit Dest register,
-            // so state the legacy value for those.
-            auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
-                if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
-                    compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
-                }
-            };
-            require_explicit_unpack_mode(IN_DFB, src0_cb_data_format);
-            require_explicit_unpack_mode(SCALER_DFB, scaler_cb_data_format);
+    auto compute_hw = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
+    {
+        auto& compute_cfg = compute_hw;
+        compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
+        compute_cfg.double_buffer_dest = true;                 // legacy dst_full_sync_en = false
+        if (fp32_sfpu_reduce) {
+            // Legacy: unpack_to_dest_mode[src0_cb_index] = UnpackToDestFp32 — unpacks the reduce
+            // input straight into the fp32 DEST, bypassing the SrcA tf32 truncation. The RM
+            // path's chunk accumulator (legacy c_5) gets the same treatment so partials
+            // round-trip in fp32.
+            compute_cfg.unpack_modes.emplace(IN_DFB, UnpackMode::UnpackToDest);
             if (rm_path) {
-                require_explicit_unpack_mode(RM_DFB, src0_cb_data_format);
-                require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
-            } else if (use_fpu_negate) {
-                require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
-                require_explicit_unpack_mode(INEG_DFB, dst_cb_data_format);
+                compute_cfg.unpack_modes.emplace(ACC_DFB, UnpackMode::UnpackToDest);
             }
-        },
-        compute_hw);
+        }
+        // Legacy left every other entry at Default (= UnpackToSrc). Metal 2.0 nonetheless requires an
+        // explicit mode for every Float32 buffer this kernel consumes under a 32-bit Dest register,
+        // so state the legacy value for those.
+        auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
+            if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
+                compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
+            }
+        };
+        require_explicit_unpack_mode(IN_DFB, src0_cb_data_format);
+        require_explicit_unpack_mode(SCALER_DFB, scaler_cb_data_format);
+        if (rm_path) {
+            require_explicit_unpack_mode(RM_DFB, src0_cb_data_format);
+            require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
+        } else if (use_fpu_negate) {
+            require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
+            require_explicit_unpack_mode(INEG_DFB, dst_cb_data_format);
+        }
+    }
 
     // For RM, per-group counts are logical rows; the compute kernel expects tile-row counts.
     const uint32_t ht_per_core_group_1 =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -175,7 +175,7 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
         .compile_time_args =
             {{"scaler_bits", std::bit_cast<uint32_t>(scaler)}, {"tiles_per_batch", reader_tiles_per_batch}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(a.device().arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // ---- Writer kernel ----
@@ -192,7 +192,7 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
         }},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(a.device().arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // ---- Compute kernel ----
@@ -201,31 +201,26 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
     // at the *Metal* descriptor defaults (both false). Reproduce that exactly: the TTNN helper would
     // otherwise carry the caller's math_approx_mode into sfpu_precision_mode and the caller's
     // dst_full_sync_en into double_buffer_dest, silently changing precision / Dest buffering.
-    auto compute_hw = ttnn::to_compute_hardware_config(a.device().arch(), operation_attributes.compute_kernel_config);
-    // std::visit rather than a Gen1-only get_if: to_compute_hardware_config yields a
-    // ComputeGen2Config on Quasar, and the three fields set below exist on both generations.
-    // The explicit-unpack-mode requirement in particular is enforced generation-agnostically, so a
-    // Gen1-only branch would leave FP32 + 32-bit-Dest programs failing ProgramSpec validation there.
-    std::visit(
-        [&](auto& compute_cfg) {
-            compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
-            compute_cfg.double_buffer_dest = true;                 // legacy dst_full_sync_en = false
-            // Legacy left unpack_to_dest_mode unset (all Default = UnpackToSrc). Metal 2.0 nonetheless
-            // requires an explicit mode for every Float32 buffer this kernel consumes under a 32-bit
-            // Dest register, so state the legacy value for those.
-            auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
-                if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
-                    compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
-                }
-            };
-            require_explicit_unpack_mode(IN_DFB, src0_cb_data_format);
-            require_explicit_unpack_mode(SCALER_DFB, scaler_cb_data_format);
-            if (operation_attributes.negate) {
-                require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
-                require_explicit_unpack_mode(INEG_DFB, dst_cb_data_format);
+    auto compute_hw = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
+    {
+        auto& compute_cfg = compute_hw;
+        compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
+        compute_cfg.double_buffer_dest = true;                 // legacy dst_full_sync_en = false
+        // Legacy left unpack_to_dest_mode unset (all Default = UnpackToSrc). Metal 2.0 nonetheless
+        // requires an explicit mode for every Float32 buffer this kernel consumes under a 32-bit
+        // Dest register, so state the legacy value for those.
+        auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
+            if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
+                compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
             }
-        },
-        compute_hw);
+        };
+        require_explicit_unpack_mode(IN_DFB, src0_cb_data_format);
+        require_explicit_unpack_mode(SCALER_DFB, scaler_cb_data_format);
+        if (operation_attributes.negate) {
+            require_explicit_unpack_mode(ACC_DFB, dst_cb_data_format);
+            require_explicit_unpack_mode(INEG_DFB, dst_cb_data_format);
+        }
+    }
 
     Group<DFBBinding> compute_dfb_bindings = {
         DFBBinding{

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -364,7 +364,7 @@ WelfordReduceDeviceOperation::WelfordReduceProgramFactory::create_program_artifa
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
         .compile_time_args = std::move(reader_ct_args),
         .runtime_arg_schema = {.runtime_arg_names = std::move(reader_rta_names)},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     });
 
     // --- Writer kernel ---
@@ -440,7 +440,7 @@ WelfordReduceDeviceOperation::WelfordReduceProgramFactory::create_program_artifa
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT_TENSOR, .accessor_name = "dst"}},
         .compile_time_args = std::move(writer_ct_args),
         .runtime_arg_schema = {.runtime_arg_names = std::move(writer_rta_names)},
-        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     });
 
     // --- Compute kernels ---
@@ -498,56 +498,51 @@ WelfordReduceDeviceOperation::WelfordReduceProgramFactory::create_program_artifa
     // into sfpu_precision_mode and the caller's dst_full_sync_en into double_buffer_dest, silently
     // changing precision / Dest buffering. (DST_SYNC_FULL is still passed as a *define*, exactly as
     // legacy did.)
-    auto compute_hw = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config);
-    // std::visit rather than a Gen1-only get_if: to_compute_hardware_config yields a
-    // ComputeGen2Config on Quasar, and the fields set below exist on both generations. The
-    // explicit-unpack-mode requirement in particular is enforced generation-agnostically, so a
-    // Gen1-only branch would leave FP32 + 32-bit-Dest programs failing ProgramSpec validation there.
-    std::visit(
-        [&](auto& compute_cfg) {
-            compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
-            compute_cfg.double_buffer_dest = true;                 // legacy dst_full_sync_en = false
-            // For Float32 input with fp32_dest_acc_en, force unpack-to-dest so that
-            // the unpacker writes full fp32 to DEST instead of routing through SrcA, which would
-            // downcast to TF32, losing precision and even leading to large-mean fp32 variance
-            // silently collapsing to ~0 due to TF32 truncation wiping the bits that are different
-            // between nearby samples.
-            //
-            // Apply this to every Float32 buffer the compute kernel reads back via copy_tile /
-            // transpose_tile:
-            //   - Input: needed on all three reduction paths (H, W, HW) with FP32 input. The Welford
-            //     SFPU intake reads it directly via copy_tile/transpose_tile, so UnpackToDest
-            //     preserves the full FP32 into DEST (there is no input pre-scaling -- see post_mul_scaler).
-            //   - W-reduce only: var -- the variance tile is read back after the initial
-            //     transpose to undo it.
-            //   - HW-reduce only: combined -- the variance tile is read back after the
-            //     writer-side cross-core re-reduction.
-            if (input_cb_data_format == tt::DataFormat::Float32) {
-                compute_cfg.unpack_modes.emplace(IN_DFB, UnpackMode::UnpackToDest);
+    auto compute_hw = ttnn::to_compute_hardware_config(operation_attributes.compute_kernel_config);
+    {
+        auto& compute_cfg = compute_hw;
+        compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
+        compute_cfg.double_buffer_dest = true;                 // legacy dst_full_sync_en = false
+        // For Float32 input with fp32_dest_acc_en, force unpack-to-dest so that
+        // the unpacker writes full fp32 to DEST instead of routing through SrcA, which would
+        // downcast to TF32, losing precision and even leading to large-mean fp32 variance
+        // silently collapsing to ~0 due to TF32 truncation wiping the bits that are different
+        // between nearby samples.
+        //
+        // Apply this to every Float32 buffer the compute kernel reads back via copy_tile /
+        // transpose_tile:
+        //   - Input: needed on all three reduction paths (H, W, HW) with FP32 input. The Welford
+        //     SFPU intake reads it directly via copy_tile/transpose_tile, so UnpackToDest
+        //     preserves the full FP32 into DEST (there is no input pre-scaling -- see post_mul_scaler).
+        //   - W-reduce only: var -- the variance tile is read back after the initial
+        //     transpose to undo it.
+        //   - HW-reduce only: combined -- the variance tile is read back after the
+        //     writer-side cross-core re-reduction.
+        if (input_cb_data_format == tt::DataFormat::Float32) {
+            compute_cfg.unpack_modes.emplace(IN_DFB, UnpackMode::UnpackToDest);
+        }
+        if (reduce_w && fp32_dest_acc_en && !narrow_scratch_to_bf16) {
+            compute_cfg.unpack_modes.emplace(VAR_DFB, UnpackMode::UnpackToDest);
+        }
+        if (reduce_hw && fp32_dest_acc_en && !narrow_scratch_to_bf16) {
+            compute_cfg.unpack_modes.emplace(COMBINED_DFB, UnpackMode::UnpackToDest);
+        }
+        // Legacy left every other entry at Default (= UnpackToSrc). Metal 2.0 nonetheless requires an
+        // explicit mode for every Float32 buffer this kernel consumes under a 32-bit Dest register,
+        // so state the legacy value for those.
+        auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
+            if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
+                compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
             }
-            if (reduce_w && fp32_dest_acc_en && !narrow_scratch_to_bf16) {
-                compute_cfg.unpack_modes.emplace(VAR_DFB, UnpackMode::UnpackToDest);
-            }
-            if (reduce_hw && fp32_dest_acc_en && !narrow_scratch_to_bf16) {
-                compute_cfg.unpack_modes.emplace(COMBINED_DFB, UnpackMode::UnpackToDest);
-            }
-            // Legacy left every other entry at Default (= UnpackToSrc). Metal 2.0 nonetheless requires an
-            // explicit mode for every Float32 buffer this kernel consumes under a 32-bit Dest register,
-            // so state the legacy value for those.
-            auto require_explicit_unpack_mode = [&](const DFBSpecName& name, tt::DataFormat format) {
-                if (fp32_dest_acc_en && format == tt::DataFormat::Float32) {
-                    compute_cfg.unpack_modes.emplace(name, UnpackMode::UnpackToSrc);
-                }
-            };
-            require_explicit_unpack_mode(IN_DFB, input_cb_data_format);
-            if (reduce_w) {
-                require_explicit_unpack_mode(VAR_DFB, scratch_cb_data_format);
-            }
-            if (reduce_hw) {
-                require_explicit_unpack_mode(COMBINED_DFB, combined_cb_data_format);
-            }
-        },
-        compute_hw);
+        };
+        require_explicit_unpack_mode(IN_DFB, input_cb_data_format);
+        if (reduce_w) {
+            require_explicit_unpack_mode(VAR_DFB, scratch_cb_data_format);
+        }
+        if (reduce_hw) {
+            require_explicit_unpack_mode(COMBINED_DFB, combined_cb_data_format);
+        }
+    }
 
     auto make_compute = [&](const KernelSpecName& unique_id) {
         Group<DFBBinding> dfb_bindings = {

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
@@ -73,7 +73,7 @@ ttnn::device_operation::ProgramArtifacts ManualSeedSingleSeedToAllCoresProgramFa
         .source = kernel_path,
         .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
         .compile_time_args = {{"seed", operation_attributes.seeds.value_or(0)}},
-        .hw_config = ComputeGen1Config{},
+        .hw_config = ComputeHardwareConfig{},
     };
 
     ProgramSpec spec{
@@ -109,7 +109,7 @@ ttnn::device_operation::ProgramArtifacts ManualSeedSingleSeedSingleCoreProgramFa
         .source = kernel_path,
         .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
         .compile_time_args = {{"seed", operation_attributes.seeds.value_or(0)}},
-        .hw_config = ComputeGen1Config{},
+        .hw_config = ComputeHardwareConfig{},
     };
 
     ProgramSpec spec{
@@ -184,7 +184,7 @@ ttnn::device_operation::ProgramArtifacts ManualSeedSingleSeedSetCoresProgramFact
         }},
         .compile_time_args = {{"number_of_ids", number_of_ids}},
         .runtime_arg_schema = {.runtime_arg_names = {"core_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(operation_attributes.device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = READER};
@@ -207,7 +207,7 @@ ttnn::device_operation::ProgramArtifacts ManualSeedSingleSeedSetCoresProgramFact
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
         .compile_time_args = {{"seed", operation_attributes.seeds.value_or(0)}},
-        .hw_config = ComputeGen1Config{},
+        .hw_config = ComputeHardwareConfig{},
     };
 
     ProgramSpec spec{
@@ -312,7 +312,7 @@ ttnn::device_operation::ProgramArtifacts ManualSeedSetSeedsSetCoresProgramFactor
              }},
         .compile_time_args = {{"number_of_ids", number_of_ids}},
         .runtime_arg_schema = {.runtime_arg_names = {"core_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(operation_attributes.device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelRunArgs reader_run_args{.kernel = READER};
@@ -334,7 +334,7 @@ ttnn::device_operation::ProgramArtifacts ManualSeedSetSeedsSetCoresProgramFactor
             .accessor_name = "kernel_communication",
             .endpoint_type = DFBEndpointType::CONSUMER,
         }},
-        .hw_config = ComputeGen1Config{},
+        .hw_config = ComputeHardwareConfig{},
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -214,8 +214,6 @@ ttnn::device_operation::ProgramArtifacts MoeProgramFactory::create_program_artif
         .data_format_metadata = input_dfb_data_format,
     });
 
-    const tt::ARCH arch = input_tensor.device().arch();
-
     KernelSpec reader{
         .unique_id = MOE_READER,
         .source = "ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/reader_create_index_tensor.cpp",
@@ -249,7 +247,7 @@ ttnn::device_operation::ProgramArtifacts MoeProgramFactory::create_program_artif
                 TensorBinding{.tensor_parameter_name = MOE_TENSOR_EXPERT_MASK, .accessor_name = "expert_mask"},
             },
         .compile_time_args = {{"Ht", Ht}, {"Wt", Wt}, {"K", k}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -275,7 +273,7 @@ ttnn::device_operation::ProgramArtifacts MoeProgramFactory::create_program_artif
                 TensorBinding{.tensor_parameter_name = MOE_TENSOR_OUTPUT, .accessor_name = "output"},
             },
         .compile_time_args = {{"Ht", Ht}, {"K", k}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     Group<DFBBinding> compute_dfb_bindings{
@@ -350,7 +348,7 @@ ttnn::device_operation::ProgramArtifacts MoeProgramFactory::create_program_artif
                 {"logWt", static_cast<uint32_t>(std::log2(Wt))},
                 {"tile_width", tile_width},
             },
-        .hw_config = ComputeGen1Config{},
+        .hw_config = ComputeHardwareConfig{},
     };
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -70,7 +70,7 @@ ProgramArtifacts ProdAllDeviceOperation::ProdAllProgramFactory::create_program_a
     const bool needs_wh_fp32_workaround = fp32_dest_acc_en && arch == tt::ARCH::WORMHOLE_B0;
     const auto math_fidelity = needs_wh_fp32_workaround ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
 
-    m2::ComputeGen1Config compute_hw{
+    m2::ComputeHardwareConfig compute_hw{
         .fpu_math_fidelity = math_fidelity,
         .sfpu_precision_mode = Precision::Approximate,  // legacy math_approx_mode = true
         .enable_32_bit_dest = fp32_dest_acc_en,
@@ -93,7 +93,7 @@ ProgramArtifacts ProdAllDeviceOperation::ProdAllProgramFactory::create_program_a
             .dfb_spec_name = INPUT_DFB, .accessor_name = "in", .endpoint_type = m2::DFBEndpointType::PRODUCER}},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     m2::KernelSpec writer{
@@ -104,7 +104,7 @@ ProgramArtifacts ProdAllDeviceOperation::ProdAllProgramFactory::create_program_a
             .dfb_spec_name = OUTPUT_DFB, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::CONSUMER}},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     m2::KernelSpec compute{

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -118,7 +118,7 @@ ProgramArtifacts ProdNcDeviceOperation::ProdNcProgramFactory::create_program_art
     const bool needs_wh_fp32_workaround = fp32_dest_acc_en && arch == tt::ARCH::WORMHOLE_B0;
     const auto math_fidelity = needs_wh_fp32_workaround ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
 
-    m2::ComputeGen1Config compute_hw{
+    m2::ComputeHardwareConfig compute_hw{
         .fpu_math_fidelity = math_fidelity,
         // legacy math_approx_mode unset (default false) -> sfpu_precision_mode default (Precise)
         .enable_32_bit_dest = fp32_dest_acc_en,
@@ -144,7 +144,7 @@ ProgramArtifacts ProdNcDeviceOperation::ProdNcProgramFactory::create_program_art
         .runtime_arg_schema =
             {.runtime_arg_names =
                  {"num_input_tiles", "num_output_tiles", "input_tile_offset", "start_id", "HtWt", "CHtWt"}},
-        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     m2::KernelSpec writer{
@@ -155,7 +155,7 @@ ProgramArtifacts ProdNcDeviceOperation::ProdNcProgramFactory::create_program_art
             .dfb_spec_name = OUTPUT_DFB, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::CONSUMER}},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
-        .hw_config = ttnn::create_writer_datamovement_config(arch),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // One compute KernelSpec per legacy compute KernelDescriptor (per core group), preserving the

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -289,13 +289,13 @@ ttnn::device_operation::ProgramArtifacts SamplingProgramFactory::create_program_
              {"tile_height", tile_height},
              {"use_32bit_index", static_cast<uint32_t>(use_32bit_index)},
              {"num_users", num_users}},
-        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     // 32-bit (Int32) sort indices require fp32 dest accumulation so the top-k LLK loads/stores
     // indices in INT32 mode; the 16-bit (UInt16) path uses LO16 mode with fp32 dest acc off. Every
     // other field keeps its default, matching what the compute config defaulted to before.
-    const ComputeGen1Config compute_config{
+    const ComputeHardwareConfig compute_config{
         .enable_32_bit_dest = use_32bit_index,
     };
 
@@ -521,7 +521,7 @@ ttnn::device_operation::ProgramArtifacts SamplingProgramFactory::create_program_
                  {"num_cores", num_cores},
                  {"use_32bit_index", static_cast<uint32_t>(use_32bit_index)},
                  {"num_users", num_users}},
-            .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+            .hw_config = ttnn::create_writer_datamovement_config(),
         };
     };
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -238,7 +238,7 @@ ttnn::device_operation::ProgramArtifacts TopKDeviceOperation::TopKSingleCoreProg
                  static_cast<uint32_t>(output_ind_cb_data_format == tt::DataFormat::UInt16)},  // Index format flag
             },
         .runtime_arg_schema = {.runtime_arg_names = {"id", "work_per_core"}},
-        .hw_config = ttnn::create_reader_datamovement_config(input_tensor.device().arch()),
+        .hw_config = ttnn::create_reader_datamovement_config(),
     };
 
     KernelSpec writer{
@@ -269,7 +269,7 @@ ttnn::device_operation::ProgramArtifacts TopKDeviceOperation::TopKSingleCoreProg
                 {"total_number_of_cores", total_number_of_cores},  // Total number of cores
             },
         .runtime_arg_schema = {.runtime_arg_names = {"id", "work_per_core"}},
-        .hw_config = ttnn::create_writer_datamovement_config(input_tensor.device().arch()),
+        .hw_config = ttnn::create_writer_datamovement_config(),
     };
 
     // fp32 input: unpack the value-holding buffers straight to a 32-bit dest register so the sort's
@@ -277,7 +277,7 @@ ttnn::device_operation::ProgramArtifacts TopKDeviceOperation::TopKSingleCoreProg
     // buffer name, and an omitted entry means unpack-to-source, which is what every other buffer
     // wants. They are also the only 32-bit-float buffers the compute kernel consumes, and an
     // explicit choice is required for those whenever the dest register is 32-bit.
-    ComputeUnpackModes compute_unpack_modes;
+    ComputeHardwareConfig::ComputeUnpackModes compute_unpack_modes;
     if (is_fp32_input) {
         compute_unpack_modes = {
             {INPUT_DFB, UnpackMode::UnpackToDest},
@@ -370,7 +370,7 @@ ttnn::device_operation::ProgramArtifacts TopKDeviceOperation::TopKSingleCoreProg
         // rows), so an index survives the sort intact, and an fp32 input, so values keep full
         // precision through it. double_buffer_dest is the inverse of the legacy dst_full_sync_en flag.
         .hw_config =
-            ComputeGen1Config{
+            ComputeHardwareConfig{
                 .enable_32_bit_dest = !uint16_output || is_fp32_input,
                 .double_buffer_dest = true,
                 .unpack_modes = std::move(compute_unpack_modes),


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

`ComputeHardwareConfig` and `DataMovementHardwareConfig` were
`std::variant<Gen1, Gen2>`. Most compute fields are shared, but every
common-field read or write had to go through `std::visit` or a free
accessor.

This PR makes each hardware config a **single struct**:

- Shared fields are ordinary members.
- Generation specific fields live in a nested `*1XXConfig` / `*2XXConfig`
  and are stored in `std::optional` (default `nullopt`).

Generation-specific configs not relating to the generation the program
is being dispatched onto are ignored.

```cpp
struct ComputeHardwareConfig {
    MathFidelity fpu_math_fidelity = MathFidelity::HiFi4;
    Precision sfpu_precision_mode = Precision::Precise;
    bool enable_32_bit_dest = false;
    bool double_buffer_dest = true;
    ComputeUnpackModes unpack_modes;

    struct Compute1XXConfig {
        Precision bfp_pack_precision_mode = Precision::Approximate;
    };
    std::optional<Compute1XXConfig> gen1_specific = std::nullopt;

    struct Compute2XXConfig {};  // empty today
    std::optional<Compute2XXConfig> gen2_specific = std::nullopt;
};

struct DataMovementHardwareConfig {
    // no common fields today

    struct DataMovement1XXConfig {
        DataMovementProcessor processor;
        NOC noc;
        NOC_MODE noc_mode = NOC_MODE::DM_DEDICATED_NOC;
    };
    std::optional<DataMovement1XXConfig> gen1_specific = std::nullopt;

    struct DataMovement2XXConfig {
        Group<DFBSpecName> disable_dfb_implicit_sync_for;
        bool disable_dfb_implicit_sync_for_all = false;
    };
    std::optional<DataMovement2XXConfig> gen2_specific = std::nullopt;
};
```

### Notes for reviewers

<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

- Common field accessors are removed. e.g. https://github.com/tenstorrent/tt-metal/blob/047ec3ccf96519a54c2a83b4ec2d2efc6f7ec258/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp#L197-L203
- When building for a given generation, that generation's `genX_specific` optional may be left empty; a default-constructed generation-specific struct is used in its place. `DataMovement1XXConfig` is the one exception: a data-movement kernel built for Wormhole or Blackhole must engage `gen1_specific`, because `processor` and `noc` have no defaults.
- The Arch parameter of `to_compute_hardware_config`, `create_writer_datamovement_config` and `create_reader_datamovement_config` has been dropped as the configs is no longer arch specific.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/m2-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/m2-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/m2-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/m2-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/m2-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/m2-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/m2-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/m2-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/m2-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/m2-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/m2-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/m2-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/m2-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/m2-ref)
