### PR TITLE
neighbor-pad: skip the fabric startup barrier on persistent output

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
@@ -241,8 +241,8 @@ void kernel_main() {
                 noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), w_barrier_wait);
             }
         }
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
+    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
 
     // Corners-only optimization for 2D H writers:
     // Only W-boundary sticks (corners) go to neighbor L1; non-corner sticks go directly to DRAM.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
@@ -98,6 +98,7 @@ struct NeighborPadAsyncParams {
         "pad2_right",
         "pad2_cluster_axis",
         "pad2_num_links",
+        "using_persistent_buffers",
         "logical_h",
         "t_front_pad");
 
@@ -117,6 +118,7 @@ struct NeighborPadAsyncParams {
             this->pad2_right,
             this->pad2_cluster_axis,
             this->pad2_num_links,
+            this->using_persistent_buffers,
             this->logical_h,
             this->t_front_pad);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -178,6 +178,8 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
         outer_dim_size *= input_tensor_shape[d];
     }
 
+    const bool use_barrier_sem = !operation_attributes.using_persistent_buffers;
+
     bool is_first_device = true;
     bool is_last_device = true;
     uint32_t forward_device_offset = 0;
@@ -524,7 +526,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 h_writer_num_sticks_per_halo_dim,  // num_sticks_per_halo_dim
                 virtual_core.x,                    // neighbor_sem_noc0_x
                 virtual_core.y,                    // neighbor_sem_noc0_y
-                true,                              // use_barrier_semaphore
+                use_barrier_sem,                   // use_barrier_semaphore
                 virtual_opposite_core.x,           // barrier_sem_noc0_x
                 virtual_opposite_core.y};          // barrier_sem_noc0_y
             // Phase 2 signal targets (W fabric reader cores for 2D padding)
@@ -838,7 +840,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                     1,                               // num_sticks_per_halo_dim
                     w_virtual_core.x,                // neighbor_sem_noc0_x
                     w_virtual_core.y,                // neighbor_sem_noc0_y
-                    true,                            // use_barrier_semaphore (W-axis startup barrier)
+                    use_barrier_sem,                 // use_barrier_semaphore (W-axis startup barrier)
                     w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].x,   // barrier_sem_noc0_x (opp dir)
                     w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].y};  // barrier_sem_noc0_y
                 // No Phase 2 signal targets (W writers don't signal further)


### PR DESCRIPTION
### PR Category
Bugfix

### Summary
The program factory hardcoded use_barrier_semaphore=true, so a preallocated output still paid a mesh-wide startup barrier it cannot need. using_persistent_buffers joins the program-cache key because it now feeds a runtime arg.

barrier_sem stays live either way: 2D Phase 2 (H->W) signaling reuses the same word, so the writer must zero it unconditionally.

tests/nightly/tg/ccl/test_neighbor_pad_async.py — 122 passed, 13 skipped, 0 failed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:noblewoodall/neighbor-pad/persistent-barrier-skip-2026-08-31)