### PR TITLE
#55009: Bug fix: bound JIT executor via env and move link step to posix_spawn

### DIFF
--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -27,7 +27,23 @@
 #include <thread>
 
 namespace tt::tt_metal::detail {
-inline static const size_t EXECUTOR_NTHREADS = std::thread::hardware_concurrency() ? std::thread::hardware_concurrency() : 1;
+// Executor width defaults to every online core. On hosts running several ranks
+// (e.g. 4 MPI ranks per scaleout host), a cold-cache JIT build then spawns
+// ranks-per-host * ncores concurrent compile/link jobs, which can starve the MPI
+// runtime's liveness machinery long enough that the launcher declares a healthy
+// rank dead ("Socket closed" aborts with no culprit error; see issue #55009).
+// TT_METAL_EXECUTOR_NTHREADS bounds the pool per process for such deployments.
+inline size_t get_executor_nthreads() {
+    if (const char* env = std::getenv("TT_METAL_EXECUTOR_NTHREADS")) {
+        char* end = nullptr;
+        const unsigned long n = std::strtoul(env, &end, 10);
+        if (end != env && n >= 1) {
+            return static_cast<size_t>(n);
+        }
+    }
+    return std::thread::hardware_concurrency() ? std::thread::hardware_concurrency() : 1;
+}
+inline static const size_t EXECUTOR_NTHREADS = get_executor_nthreads();
 
 using Executor = tf::Executor;
 using ExecTask = tf::Task;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -740,15 +740,26 @@ bool JitBuildState::need_link(const string& out_dir) const {
 }
 
 void JitBuildState::link(const string& out_dir, const JitBuildSettings* settings, const string& link_objs) const {
-    string cmd{"cd " + out_dir + " && " + env_.gpp_};
+    // Links run through exec_command()/posix_spawn like compiles, not system():
+    // system() forks the full (multi-GB, many-fd) parent per link, and on hosts
+    // running several ranks a cold-cache link storm can starve the MPI runtime's
+    // liveness machinery into declaring a healthy rank dead (issue #55009). None
+    // of the link argv elements carry shell metacharacters, so tokenize_flags()
+    // splitting is sufficient; the previous "cd <out_dir> &&" becomes the
+    // working_dir argument.
+    std::vector<std::string> args = jit_build::utils::tokenize_flags(env_.gpp_);
     string lflags = this->lflags_;
     if (env_.get_rtoptions().get_build_map_enabled()) {
         lflags += "-Wl,-Map=" + out_dir + this->target_name_ + ".map ";
         lflags += "-save-temps=obj -fdump-tree-all -fdump-rtl-all ";
     }
+    auto append_tokens = [&args](const std::string& flags) {
+        auto toks = jit_build::utils::tokenize_flags(flags);
+        args.insert(args.end(), std::make_move_iterator(toks.begin()), std::make_move_iterator(toks.end()));
+    };
 
     // Append user args
-    cmd += fmt::format("-{} ", settings ? settings->get_linker_opt_level() : this->default_linker_opt_level_);
+    args.push_back(fmt::format("-{}", settings ? settings->get_linker_opt_level() : this->default_linker_opt_level_));
 
     // Elf file has dependencies other than object files:
     // 1. Linker script
@@ -757,25 +768,27 @@ void JitBuildState::link(const string& out_dir, const JitBuildSettings* settings
     if (!this->is_fw_) {
         link_deps.push_back(this->weakened_firmware_name_);
         if (!this->firmware_is_kernel_object_) {
-            cmd += "-Wl,--just-symbols=";
+            args.push_back("-Wl,--just-symbols=" + this->weakened_firmware_name_);
+        } else {
+            args.push_back(this->weakened_firmware_name_);
         }
-        cmd += this->weakened_firmware_name_ + " ";
     }
 
     // Append common args provided by the build state
-    cmd += lflags;
-    cmd += this->extra_link_objs_;
-    cmd += link_objs;
+    append_tokens(lflags);
+    append_tokens(this->extra_link_objs_);
+    append_tokens(link_objs);
     std::string elf_name = out_dir + this->target_name_ + ".elf";
     jit_build::utils::FileRenamer elf_file(elf_name);
-    cmd += "-o " + elf_file.path();
+    args.push_back("-o");
+    args.push_back(elf_file.path());
+    std::string cmd = fmt::format("cd {} && {}", out_dir, fmt::join(args, " "));
     if (env_.get_rtoptions().get_log_kernels_compilation_commands()) {
         log_info(tt::LogBuildKernels, "    g++ link cmd: {}", cmd);
     }
     jit_build::utils::FileRenamer log_file(elf_name + ".log");
     fs::remove(log_file.path());
-    bool result =
-        tt::jit_build::utils::run_command(cmd, log_file.path(), env_.get_rtoptions().get_dump_build_commands());
+    bool result = tt::jit_build::utils::exec_command(args, out_dir, log_file.path());
     report_result(this->target_name_, "link", cmd, log_file.path(), result);
     jit_build::utils::FileRenamer dephash_file(elf_name + ".dephash");
     std::ofstream hash_file(dephash_file.path());


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55009

Cold-cache JIT kernel builds on hosts running several MPI ranks intermittently kill the whole job with `Socket closed ... MPI_ERRORS_ARE_FATAL` aborts that name no culprit — no crash, no TT_THROW, nothing in dmesg — and a warm-cache rerun of the identical launch succeeds. Root cause (full analysis in the issue): the build executor is sized at `hardware_concurrency()` per rank with no override, and the link step still runs through `run_command()`/`system()`, forking the full multi-GB rank process (and its MPI socket fds) once per link. The resulting storm starves OpenMPI/PMIx liveness until the launcher declares a healthy rank dead.

Two changes:
1. **`tt_metal/common/executor.hpp`** — `TT_METAL_EXECUTOR_NTHREADS` env var bounds the executor pool per process. Default behavior unchanged (`hardware_concurrency()`).
2. **`tt_metal/jit_build/build.cpp`** — `JitBuildState::link()` now builds an argv and runs via the existing `exec_command()`/`posix_spawn` path (as compiles already do), passing `out_dir` as the spawn working directory instead of `cd <dir> &&`. The `-Wl,--just-symbols=<elf>` fusion and command logging are preserved; link argv elements carry no shell metacharacters, so `tokenize_flags()` splitting is sufficient.

Not changed: the watcher-only profiler grep at `build.cpp:832` still uses `run_command()` (needs shell globbing) — it runs once, outside the storm.

### Notes for reviewers
- Behavior deltas from `system()` → `exec_command()`: with `TT_METAL_DUMP_BUILD_COMMANDS` (verbose), the previous path echoed the command to stdout and did not redirect; the new path always redirects to the `.log` file, matching what the compile step already does.
- Untested on hardware by the author beyond authoring context (drafted from a macOS workstation); CI should exercise the link path on every build. Marked draft pending a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anatarajan/55009-jit-build-storm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anatarajan/55009-jit-build-storm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anatarajan/55009-jit-build-storm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anatarajan/55009-jit-build-storm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anatarajan/55009-jit-build-storm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anatarajan/55009-jit-build-storm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anatarajan/55009-jit-build-storm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anatarajan/55009-jit-build-storm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anatarajan/55009-jit-build-storm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anatarajan/55009-jit-build-storm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anatarajan/55009-jit-build-storm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anatarajan/55009-jit-build-storm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anatarajan/55009-jit-build-storm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anatarajan/55009-jit-build-storm)