### PR TITLE
#54910: copy_init: format-driven zero flag under a 32-bit dest

### DIFF
--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common_globals.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
@@ -28,10 +29,12 @@ namespace ckernel {
  * does not reconfigure the unpacker data types. Eltwise-unary / SFPU kernels use this same init:
  * compute_kernel_hw_startup(icb, ocb) once, then copy_init(icb).
  *
- * Numerics: the copy preserves bf16 -0.0 and denormal inputs (it keeps the Src zero-substitution flag
- * disabled), so sign-sensitive SFPU ops such as signbit / copysign read the exact value back out of DST.
- * Matmul and eltwise-binary re-establish the format-driven default themselves, so this preservation never
- * leaks into them.
+ * Numerics: with a 16-bit dest the copy preserves bf16 -0.0 and denormal inputs (it keeps the Src
+ * zero-substitution flag disabled), so sign-sensitive SFPU ops such as signbit / copysign read the exact
+ * value back out of DST. With a 32-bit dest the datacopy is an ELWADD rather than a MOVA2D, which cannot
+ * preserve either, and holding the flag there instead adds 2^-127 into the result; that case takes the
+ * format-driven default. Matmul and eltwise-binary re-establish the default themselves, so this
+ * preservation never leaks into them.
  *
  * Return value: None
  *
@@ -44,10 +47,10 @@ namespace ckernel {
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void copy_init(
-    uint32_t cbid,
-    uint32_t transpose = 0,
-    uint32_t transpose_within_16x16_face = false,
-    uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t cbid,
+    std::uint32_t transpose = 0,
+    std::uint32_t transpose_within_16x16_face = false,
+    std::uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
 #ifndef ARCH_QUASAR
     state_configure(cbid, call_line);
@@ -65,10 +68,26 @@ ALWI void copy_init(
     // datums (drop-in for the eltwise-unary short init and the plain-copy path), but flush fp8
     // (e4m3/e5m2) whose zero widens to a nonzero SrcA residual and must read back as 0. MATH-only
     // config: records no format-reconfig diff, so single-SrcA reconfig tracking is unchanged. Not on Quasar.
-    MATH((ckernel::math::_configure_copy_zero_flag_state_(get_operand_dst_format(cbid))));
+    //
+    // 16-bit dest only. That policy is written for the MOVA2D datacopy, where the flag decides whether
+    // the moved datum keeps its bit pattern. Under a 32-bit dest the datacopy is an ELWADD against a
+    // ZEROSRC'd SrcB instead, and with substitution disabled the FPU reads each zeroed SrcB datum as
+    // exp==0 plus the implied hidden bit -- 2^-127 -- which is added into every result that falls inside
+    // the adder's alignment window, corrupting the eleven smallest normal binades. Nothing is preserved
+    // by holding the flag there either: ELWADD returns +0.0 for a -0.0 input whatever the flag says. So
+    // fall back to the operand-driven default, which keeps the flush on for float operands and still
+    // disables it for the 16-bit integer operands the integer datacopy branch needs.
+    if constexpr (is_fp32_dest_acc_en) {
+        MATH((ckernel::math::_configure_default_zero_flag_state_()));
+    } else {
+        MATH((ckernel::math::_configure_copy_zero_flag_state_(get_operand_dst_format(cbid))));
+    }
 #else
-    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, UnpackToDestEn>(
-        cbid)));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          DataCopyType::A2D,
+          is_fp32_dest_acc_en,
+          BroadcastType::NONE,
+          UnpackToDestEn>(cbid)));
 #endif
 }
 
@@ -94,7 +113,7 @@ ALWI void copy_init(
  * */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index) {
+ALWI void copy_tile(std::uint32_t in_cb_id, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
 #ifndef ARCH_QUASAR
     LLK_SAN_FUNCTION();
 #endif
@@ -130,14 +149,21 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
  * */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
+ALWI void copy_block(
+    std::uint32_t in_cb_id,
+    std::uint32_t start_in_tile_index,
+    std::uint32_t start_dst_tile_index,
+    std::uint32_t ntiles) {
 #ifndef ARCH_QUASAR
     LLK_SAN_FUNCTION();
 #endif
     UNPACK((llk_unpack_A_block<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         in_cb_id, start_in_tile_index, ntiles)));
-    MATH((llk_math_eltwise_unary_datacopy_block<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, UnpackToDestEn>(
-        start_dst_tile_index, ntiles, in_cb_id)));
+    MATH((llk_math_eltwise_unary_datacopy_block<
+          DataCopyType::A2D,
+          is_fp32_dest_acc_en,
+          BroadcastType::NONE,
+          UnpackToDestEn>(start_dst_tile_index, ntiles, in_cb_id)));
 }
 
 // =====================================================================================================================
@@ -162,7 +188,7 @@ ALWI void copy_block(uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t s
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated("Renamed to copy_init(). This will be removed after 20-09-2026.")]] ALWI void copy_tile_init(
-    uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t cbid, std::uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
     copy_init<is_fp32_dest_acc_en>(cbid, 0, false, call_line);
 }
@@ -182,10 +208,10 @@ template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated("Renamed to copy_init(). This will be removed after 20-09-2026.")]] ALWI void copy_tile_to_dst_init_short(
-    uint32_t cbid,
-    uint32_t transpose = 0,
-    uint32_t transpose_within_16x16_face = false,
-    uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t cbid,
+    std::uint32_t transpose = 0,
+    std::uint32_t transpose_within_16x16_face = false,
+    std::uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
     copy_init<is_fp32_dest_acc_en>(cbid, transpose, transpose_within_16x16_face, call_line);
 }
@@ -208,7 +234,7 @@ template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated(
     "Call reconfig_data_format_srca(old, new) then copy_init(new, transpose). This will be removed after "
     "20-09-2026.")]] ALWI void
-copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0) {
+copy_tile_to_dst_init_short_with_dt(std::uint32_t old_cbid, std::uint32_t new_cbid, std::uint32_t transpose = 0) {
     LLK_SAN_FUNCTION();
     // This reconfig call checks if old operand has different data format to
     // new operand idx, otherwise no reconfig call occurs
@@ -235,7 +261,10 @@ copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32
 // clang-format on
 [[deprecated("Use copy_block(); copy_block_matmul_partials will be removed after August 15th, 2026.")]] ALWI void
 copy_block_matmul_partials(
-    uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
+    std::uint32_t in_cb_id,
+    std::uint32_t start_in_tile_index,
+    std::uint32_t start_dst_tile_index,
+    std::uint32_t ntiles) {
     copy_block(in_cb_id, start_in_tile_index, start_dst_tile_index, ntiles);
 }
 


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Fixes #54910.

`copy_init` holds the Src zero-substitution flag disabled for every dest width. That is right for a 16-bit dest, where the datacopy is a `MOVA2D` and the flag decides whether the moved datum keeps its bit pattern — bf16 `-0.0`, 16-bit integers. Under a 32-bit dest the datacopy is an `ELWADD` against a ZEROSRC'd SrcB instead (the MOVA2D fallback in `llk_math_eltwise_unary_datacopy.h`): with substitution disabled the FPU reads each zeroed SrcB datum as `exp==0` plus the implied hidden bit, i.e. `2^-127`, and adds it into every result that falls inside the adder's alignment window. That is `+2^-127` for biased exponents 1–10, a ties-away round-up at 11 and exact from 12 — the eleven smallest normal binades.

Nothing is preserved by holding the flag there either: an `ELWADD` against a zero SrcB returns `+0.0` for a `-0.0` input under round-to-nearest whichever way the flag is set. That last point is reasoned from the adder's semantics, not measured — see Not covered. So under `is_fp32_dest_acc_en` fall back to the operand-driven default, which keeps the flush on for float operands and still disables it for the 16-bit integer operands the integer datacopy branch needs.

One file. `eltwise_sfpu.cpp:27` calls `copy_init(cb_input)`, so this is the init the whole SFPU unary surface goes through, `typecast` included. The `std::uint32_t` and `<cstdint>` lines in the diff are the repo's `fix-cstdint` pre-commit hook rewriting the file once it is touched, not a deliberate edit; the semantic change is the twelve lines around the `if constexpr`.

## Correctness

All 65,536 bfloat16 patterns. Both machines run the same host build of `7db779f57c2` with only this device header changed and both JIT caches cleared between arms — the header is JIT-compiled, so no rebuild separates the arms and `JIT cache stats: 0/39 hits` confirms the recompile:

| entry point | P300 base | P300 fix | N300 base | N300 fix |
|---|---|---|---|---|
| `typecast(bf16 -> f32)` normals wrong | **2,816** / 65,024 | **0** | **2,816** | **0** |
| `multiply(bf16, 1, dtype=f32)` normals wrong | **2,816** / 65,024 | **0** | **2,816** | **0** |
| `typecast(bfp8_b -> f32)` differs from the source format | **2,816** / 65,280 | **0** | **2,816** | **0** |

The P300 fix arm was re-taken after rebuilding the host from this branch, so the library and the source agree.

Everything the preserve flag exists to protect is byte-for-byte unchanged. Same probe, all four arms, identical line for line:

| | base | fix |
|---|---|---|
| bfloat8_b zero reads back as exactly 0 | OK | OK |
| int32 datacopy bit-exact | OK | OK |
| `typecast(int32 -> f32)` exact | OK | OK |
| uint16 datacopy bit-exact | OK | OK |
| `typecast(uint16 -> f32)` exact | OK | OK |
| `typecast(f32 -> bf16)` exhaustive | 254 differ | 254 differ |
| bf16 `-0.0` observable at the host | no | no |

The 254 in the narrowing row are the subnormals, flushed identically in both arms. The `-0.0` row is a limitation of the probe, not a result: the value does not survive to the host on either arm, so this probe cannot see what the 16-bit-dest MOVA2D path does with it. What it does establish is that the fix moves nothing there.

## Tests

- `test_eltwise_typecast.py`, `test_typecast_int.py`, `test_binary_ng_typecast.py`, `test_typecast_program_cache.py`, `test_typecast_sharded.py`: **2,446 passed, 452 skipped**.
- `tests/ttnn/unit_tests/operations/eltwise/` in full: **16,220 passed, 520 skipped, 15 xfailed, 0 failed**.
- No test is added. The defect is invisible to a PCC-based check — the absolute error is below 2.4e-35 — so the assertion that catches it has to be bit-exactness over the eleven binades, which does not fit the existing eltwise test shape. Worth a follow-up if the reviewers want one.

## Not covered

- The exp-field-extreme semantics of this path are unchanged and pre-date the bug: bf16 subnormals flush to `+0`, and bf16 NaN widens to a non-NaN. Both match the binary path and are not claimed as defects here.
- **The `-0.0` argument is reasoning, not a measurement.** bf16 `-0.0` does not survive to the host on either arm, so the probe cannot show what the 32-bit-dest `ELWADD` does with it; the claim that it cannot be preserved there rests on the adder's round-to-nearest semantics. If a reviewer knows of a path where a 32-bit dest is expected to carry `-0.0` out of `copy_init`, that is the case to check.
- `uint8` and int-FPU datacopy variants keep their current behaviour.
- Quasar takes the other `#ifdef` branch and is untouched.

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `7db779f57c2` (current `main`)
* Hardware: N300 and P300
