### PR TITLE
#55043: llrt: do not throw out of device open on a half-trained ethernet link

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1139,6 +1139,19 @@ std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> Cluster::get_et
     return connected_chips;
 }
 
+std::optional<EthRouterMode> Cluster::get_eth_routing_mode_if_active(
+    ChipId chip_id, const tt::tt_metal::CoreCoord& eth_core) const {
+    const auto chip_it = this->device_eth_routing_info_.find(chip_id);
+    if (chip_it == this->device_eth_routing_info_.end()) {
+        return std::nullopt;
+    }
+    const auto core_it = chip_it->second.find(eth_core);
+    if (core_it == chip_it->second.end()) {
+        return std::nullopt;
+    }
+    return core_it->second;
+}
+
 // Ethernet cluster api
 void Cluster::initialize_ethernet_sockets() {
     TT_ASSERT(this->hal_ != nullptr, "Hal is not set. Need to call set_hal() first.");
@@ -1160,7 +1173,19 @@ void Cluster::initialize_ethernet_sockets() {
                 continue;
             }
             for (const auto& eth_core : eth_cores) {
-                if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::IDLE) {
+                const auto routing_mode = this->get_eth_routing_mode_if_active(chip_id, eth_core);
+                if (!routing_mode.has_value()) {
+                    // The descriptor reports this connection but the channel never trained, so
+                    // it has no routing info. Skip it rather than throwing out of device open.
+                    log_warning(
+                        tt::LogDevice,
+                        "Skipping ethernet socket for chip {} core {}: the cluster descriptor reports a connection "
+                        "but the channel is not active (half-trained link). Retrain the board to use it.",
+                        chip_id,
+                        eth_core.str());
+                    continue;
+                }
+                if (routing_mode == EthRouterMode::IDLE) {
                     this->ethernet_sockets_.at(chip_id).at(connected_chip_id).emplace_back(eth_core);
                     this->ethernet_sockets_.at(connected_chip_id)
                         .at(chip_id)
@@ -1317,14 +1342,20 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
 
                 const auto connected_core =
                     std::get<1>(this->get_connected_ethernet_core(std::make_tuple(chip_id, eth_core)));
-                if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
+                // Same connection-list keys as initialize_ethernet_sockets, so the same guard.
+                // A core with no entry compares unequal to both modes and the link is skipped.
+                if (this->get_eth_routing_mode_if_active(chip_id, eth_core) == EthRouterMode::FABRIC_ROUTER) {
                     // already reserved for fabric, potentially by the connected chip id
                     num_reserved_cores++;
                     continue;
                 }
 
-                if (this->device_eth_routing_info_[chip_id][eth_core] == EthRouterMode::IDLE &&
-                    this->device_eth_routing_info_.at(connected_chip_id).at(connected_core) == EthRouterMode::IDLE) {
+                // operator[] here used to default-construct a missing entry, and EthRouterMode::IDLE
+                // is 0, so an untrained link read as IDLE and could then be reserved as a fabric
+                // router. A non-inserting lookup skips it instead.
+                if (this->get_eth_routing_mode_if_active(chip_id, eth_core) == EthRouterMode::IDLE &&
+                    this->get_eth_routing_mode_if_active(connected_chip_id, connected_core) ==
+                        EthRouterMode::IDLE) {
                     this->device_eth_routing_info_[chip_id][eth_core] = EthRouterMode::FABRIC_ROUTER;
                     this->device_eth_routing_info_[connected_chip_id][connected_core] = EthRouterMode::FABRIC_ROUTER;
                     num_reserved_cores++;
@@ -1379,7 +1410,8 @@ std::vector<tt::tt_metal::CoreCoord> Cluster::get_fabric_ethernet_routers_betwee
     TT_FATAL(connected_chips.contains(dst_id), "Dst Chip {} is not connected to Src Chip {}", dst_id, src_id);
     fabric_ethernet_channels.reserve(connected_chips.at(dst_id).size());
     for (const auto& eth_core : connected_chips.at(dst_id)) {
-        if (this->device_eth_routing_info_.at(src_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
+        // connected_chips comes from the connection list, so guard as above.
+        if (this->get_eth_routing_mode_if_active(src_id, eth_core) == EthRouterMode::FABRIC_ROUTER) {
             fabric_ethernet_channels.push_back(eth_core);
         }
     }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -417,6 +417,16 @@ public:
         return this->device_eth_routing_info_.at(chip_id);
     }
 
+    // Routing mode for an ethernet core, or nullopt when the core has no entry.
+    //
+    // device_eth_routing_info_ is populated from get_active_eth_channels(), i.e. trained
+    // channels only, while get_ethernet_cores_grouped_by_connected_chips() is built from the
+    // cluster descriptor's full connection list. A half-trained link appears in the second and
+    // not the first, so indexing one with keys from the other throws. Use this instead of
+    // .at() anywhere the key comes from the connection list.
+    std::optional<EthRouterMode> get_eth_routing_mode_if_active(
+        ChipId chip_id, const tt::tt_metal::CoreCoord& eth_core) const;
+
 private:
     void detect_arch_and_target();
     void generate_cluster_descriptor();


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Fixes #55043.

`device_eth_routing_info_` is populated from `get_active_eth_channels()` — trained channels only (`tt_cluster.cpp:1234`) — while `get_ethernet_cores_grouped_by_connected_chips()` is built from the cluster descriptor's full connection list (`:1116-1140`). `initialize_ethernet_sockets()` iterates the second and indexes the first with `.at()` (`:1163`), so a link the descriptor reports as connected but whose channel never trained has no entry and throws `std::out_of_range` out of `open_device`.

Add a non-throwing lookup, `Cluster::get_eth_routing_mode_if_active()`, and use it at every site whose keys come from the connection list. The crash site names the offending chip and core in a warning and continues with the degraded fabric, as `disable_ethernet_cores_with_retrain()` already does for high-retrain cores.

**Three further sites had the same mismatch**, and one of them is quieter than the crash:

| site | before | after |
|---|---|---|
| `:1163` `initialize_ethernet_sockets` | `.at()` throws out of device open | warn, skip the link |
| `:1320` fabric-router reservation | `.at()` throws the same way | skip |
| `:1330` same loop | `operator[]` **inserts** a default, and `EthRouterMode::IDLE` is `0`, so an untrained link reads as idle and can be reserved as a fabric router | skip |
| `:1382` `get_fabric_ethernet_routers_between_src_and_dest` | `.at()` over connection-list keys | skip |

`:1369` indexes the same map but from `control_plane.get_active_ethernet_cores()` and is already guarded by `is_ethernet_link_up`, so it is left alone.

## Correctness

The trigger is a cold-boot asymmetric link. `tt-smi -r` clears it and a partial single-card reset does not recreate it, so it cannot be summoned on demand — the A/B is by **fault injection** instead. Dropping one channel from the loop that fills `device_eth_routing_info_` reproduces the descriptor's state exactly: the connection list still has the link, the routing-info map does not.

| build | injection | result |
|---|---|---|
| base `047ec3ccf96` | on | `open_device` raises **`IndexError: unordered_map::at`** |
| this branch | on | warns `Skipping ethernet socket for chip 0 core 0-2 ... half-trained link`, opens, `add` on a 32x32 bf16 tile = **2048.0** |
| this branch | off | opens with **no warning**, `add` = 2048.0 |

Both arms are full host builds of the same worktree at `047ec3ccf96`, differing only in these two files plus the injection, which was removed before committing (`grep tt_injected` returns nothing, and the committed tree was rebuilt and re-checked).

## Not covered

- Why the link came up asymmetric on cold boot. Only that the descriptor reported it — stable across three reads — and that a full `tt-smi -r` cleared it.
- Whether any downstream fabric code assumes every descriptor connection has a socket. The change skips the link, so a workload that genuinely needs it now fails later with its own error rather than at device open.
- The injection proves the guard fires and that the unguarded build throws; it does not reproduce the electrical condition itself.
- No test is added. Reaching this path in CI needs a fake cluster descriptor with an asymmetric link, which the current harness has no hook for; worth a follow-up if reviewers want one.

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `047ec3ccf96` (current `main`); first seen on `c3164c86f66`
* Hardware: 2x p300c (4 Blackhole chips), fw bundle 19.8.1, KMD 2.8.0, tt_umd 0.9.8
