### PR TITLE
[exabox] health check: attach passing logs when auto-closing a recovered ticket

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -265,6 +265,16 @@ def _clean_version(value: str | None) -> str:
     return "" if value in (None, "", "N/A") else value
 
 
+def collect_run_artifacts(artifacts_dir: Path | None, *, node: str, slurm_job_id: str) -> tuple[list[Path], list[str]]:
+    """A run's result files plus the ``[^name]`` attachment names JIRA renders
+    inline, so the failure and recovery paths attach and name the same set."""
+    result_files: list[Path] = []
+    if artifacts_dir and artifacts_dir.is_dir():
+        result_files = sorted(p for p in artifacts_dir.rglob("*") if p.is_file())
+    attachment_names = [f"{node}-{slurm_job_id}.log"] + [artifact_upload_name(p, slurm_job_id) for p in result_files]
+    return result_files, attachment_names
+
+
 # ---------------------------------------------------------------------------
 # Main orchestration
 # ---------------------------------------------------------------------------
@@ -457,12 +467,7 @@ def main() -> int:
         else:
             # Files this run will reference with [^name] so JIRA renders them
             # inline with the comment/description.
-            result_files = []
-            if artifacts_dir and artifacts_dir.is_dir():
-                result_files = sorted(p for p in artifacts_dir.rglob("*") if p.is_file())
-            attachment_names = [f"{node}-{slurm_job_id}.log"] + [
-                artifact_upload_name(p, slurm_job_id) for p in result_files
-            ]
+            result_files, attachment_names = collect_run_artifacts(artifacts_dir, node=node, slurm_job_id=slurm_job_id)
 
             existing_key = find_open_ticket_for_node(
                 node=node,
@@ -569,12 +574,9 @@ def main() -> int:
                 )
                 # Attach this passing run's artifacts so the closed ticket carries
                 # the recovery evidence (telemetry, Grafana, CSVs) next to the logs.
-                result_files = []
-                if artifacts_dir and artifacts_dir.is_dir():
-                    result_files = sorted(p for p in artifacts_dir.rglob("*") if p.is_file())
-                attachment_names = [f"{node}-{slurm_job_id}.log"] + [
-                    artifact_upload_name(p, slurm_job_id) for p in result_files
-                ]
+                result_files, attachment_names = collect_run_artifacts(
+                    artifacts_dir, node=node, slurm_job_id=slurm_job_id
+                )
                 add_comment_to_jira(
                     ticket_key=recovered_key,
                     body=(

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -39,12 +39,12 @@ from pathlib import Path
 
 from utils.diag_execution import run_diag_subprocess
 from utils.jira_client import (
-    _build_failure_body,
-    _build_recovery_body,
     add_comment_to_jira,
     artifact_upload_name,
     attach_files_to_jira,
     attach_log_to_jira,
+    build_failure_body,
+    build_recovery_body,
     create_jira_ticket,
     find_open_ticket_for_node,
     transition_jira_ticket,
@@ -477,7 +477,7 @@ def main() -> int:
                 comment_body = (
                     f"Fabric System Health Check failed again on node {node} "
                     f"(recurring failure).\n\n"
-                    + _build_failure_body(
+                    + build_failure_body(
                         node=node,
                         slurm_job_id=slurm_job_id,
                         exit_code=exit_code,
@@ -581,7 +581,7 @@ def main() -> int:
                         f"*(/) Fabric System Health Check PASSED on node {node} "
                         f"(Slurm job {slurm_job_id}); the node has recovered. "
                         f"Closing this ticket automatically.*\n\n"
-                        + _build_recovery_body(
+                        + build_recovery_body(
                             node=node,
                             slurm_job_id=slurm_job_id,
                             versions=versions,

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -578,9 +578,9 @@ def main() -> int:
                 add_comment_to_jira(
                     ticket_key=recovered_key,
                     body=(
-                        f"Fabric System Health Check passed on node {node} "
+                        f"*(/) Fabric System Health Check PASSED on node {node} "
                         f"(Slurm job {slurm_job_id}); the node has recovered. "
-                        f"Closing this ticket automatically.\n\n"
+                        f"Closing this ticket automatically.*\n\n"
                         + _build_recovery_body(
                             node=node,
                             slurm_job_id=slurm_job_id,

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from utils.diag_execution import run_diag_subprocess
 from utils.jira_client import (
     _build_failure_body,
+    _build_recovery_body,
     add_comment_to_jira,
     artifact_upload_name,
     attach_files_to_jira,
@@ -566,16 +567,50 @@ def main() -> int:
                     node,
                     recovered_key,
                 )
+                # Attach this passing run's artifacts so the closed ticket carries
+                # the recovery evidence (telemetry, Grafana, CSVs) next to the logs.
+                result_files = []
+                if artifacts_dir and artifacts_dir.is_dir():
+                    result_files = sorted(p for p in artifacts_dir.rglob("*") if p.is_file())
+                attachment_names = [f"{node}-{slurm_job_id}.log"] + [
+                    artifact_upload_name(p, slurm_job_id) for p in result_files
+                ]
                 add_comment_to_jira(
                     ticket_key=recovered_key,
                     body=(
                         f"Fabric System Health Check passed on node {node} "
                         f"(Slurm job {slurm_job_id}); the node has recovered. "
-                        f"Closing this ticket automatically."
+                        f"Closing this ticket automatically.\n\n"
+                        + _build_recovery_body(
+                            node=node,
+                            slurm_job_id=slurm_job_id,
+                            versions=versions,
+                            telemetry_summary=prom_output,
+                            test_output=full_output,
+                            attachment_names=attachment_names,
+                            restart_count=restart_count,
+                            grafana_base_url=args.grafana_base_url,
+                        )
                     ),
                     jira_base_url=args.jira_base_url,
                     jira_bearer_token=jira_bearer_token,
                 )
+                attach_log_to_jira(
+                    ticket_key=recovered_key,
+                    test_output=full_output,
+                    node=node,
+                    slurm_job_id=slurm_job_id,
+                    jira_base_url=args.jira_base_url,
+                    jira_bearer_token=jira_bearer_token,
+                )
+                if result_files:
+                    attach_files_to_jira(
+                        ticket_key=recovered_key,
+                        files=result_files,
+                        slurm_job_id=slurm_job_id,
+                        jira_base_url=args.jira_base_url,
+                        jira_bearer_token=jira_bearer_token,
+                    )
                 transition_jira_ticket(
                     ticket_key=recovered_key,
                     jira_base_url=args.jira_base_url,

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -45,7 +45,7 @@ def _attachment_section(attachment_names: list[str] | None) -> str:
     return f"\n*Attachments:*\n{links}\n"
 
 
-def _build_failure_body(
+def build_failure_body(
     *,
     node: str,
     slurm_job_id: str,
@@ -94,7 +94,7 @@ def _build_failure_body(
     )
 
 
-def _build_recovery_body(
+def build_recovery_body(
     *,
     node: str,
     slurm_job_id: str,
@@ -287,7 +287,7 @@ def create_jira_ticket(
 ) -> str | None:
     """Create a JIRA ticket for a failed health check. Returns ticket key or None."""
 
-    description = f"Fabric System Health Check failed on node {node}.\n\n" + _build_failure_body(
+    description = f"Fabric System Health Check failed on node {node}.\n\n" + build_failure_body(
         node=node,
         slurm_job_id=slurm_job_id,
         exit_code=exit_code,

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -22,6 +22,29 @@ from .grafana import telemetry_dashboard_url
 log = logging.getLogger(__name__)
 
 
+def _telemetry_section(telemetry_summary: str) -> str:
+    """The ``{noformat}`` telemetry block, shared by failure and recovery bodies."""
+    if not telemetry_summary:
+        return ""
+    return f"\n*Telemetry Metrics:*\n{{noformat}}\n{telemetry_summary}\n{{noformat}}\n"
+
+
+def _grafana_section(*, node: str, when: datetime, grafana_base_url: str) -> str:
+    """A Grafana deep link time-boxed around ``when`` (fail or pass time)."""
+    if not grafana_base_url:
+        return ""
+    url = telemetry_dashboard_url(base_url=grafana_base_url, node=node, fail_time=when)
+    return f"\n*Telemetry dashboard:* [Grafana {node}|{url}]\n"
+
+
+def _attachment_section(attachment_names: list[str] | None) -> str:
+    """Inline ``[^name]`` links so JIRA renders the attached artifacts."""
+    if not attachment_names:
+        return ""
+    links = "\n".join(f"[^{name}]" for name in attachment_names)
+    return f"\n*Attachments:*\n{links}\n"
+
+
 def _build_failure_body(
     *,
     node: str,
@@ -53,20 +76,6 @@ def _build_failure_body(
             f"*Self-heal reboot: FAILED* - node was NOT rebooted or requeued. " f"Reason: {{{{{reboot_failure}}}}}\n"
         )
 
-    telemetry_section = ""
-    if telemetry_summary:
-        telemetry_section = f"\n*Telemetry Metrics:*\n" f"{{noformat}}\n{telemetry_summary}\n{{noformat}}\n"
-
-    grafana_section = ""
-    if grafana_base_url:
-        url = telemetry_dashboard_url(base_url=grafana_base_url, node=node, fail_time=fail_time)
-        grafana_section = f"\n*Telemetry dashboard:* [Grafana {node}|{url}]\n"
-
-    attachment_section = ""
-    if attachment_names:
-        links = "\n".join(f"[^{name}]" for name in attachment_names)
-        attachment_section = f"\n*Attachments:*\n{links}\n"
-
     return (
         f"*Node:* {node}\n"
         f"*Date:* {fail_date}\n"
@@ -77,9 +86,51 @@ def _build_failure_body(
         f"*TT-SMI Version:* {versions['tt_smi']}\n"
         f"*TT-KMD Version:* {versions['tt_kmd']}\n"
         f"*Firmware Version:* {versions['fw_bundle']}\n"
-        f"{telemetry_section}"
-        f"{grafana_section}"
-        f"{attachment_section}\n"
+        f"{_telemetry_section(telemetry_summary)}"
+        f"{_grafana_section(node=node, when=fail_time, grafana_base_url=grafana_base_url)}"
+        f"{_attachment_section(attachment_names)}\n"
+        f"*Last lines of output:*\n"
+        f"{{noformat}}\n{log_tail}\n{{noformat}}"
+    )
+
+
+def _build_recovery_body(
+    *,
+    node: str,
+    slurm_job_id: str,
+    versions: dict[str, str],
+    telemetry_summary: str,
+    test_output: str,
+    attachment_names: list[str] | None = None,
+    restart_count: int = 0,
+    grafana_base_url: str = "",
+) -> str:
+    """Detail block for the auto-close comment when a node recovers.
+
+    Same telemetry / Grafana / attachment / log sections as a failure so the
+    closed ticket carries the passing evidence, framed as a PASS instead of a
+    failure.
+    """
+    pass_time = datetime.now(timezone.utc)
+    pass_date = pass_time.strftime("%Y-%m-%d %H:%M:%S UTC")
+    log_tail = test_output[-4096:]
+
+    recovery_line = ""
+    if restart_count > 0:
+        recovery_line = f"*Recovered after:* {restart_count} reboot(s)\n"
+
+    return (
+        f"*Node:* {node}\n"
+        f"*Date:* {pass_date}\n"
+        f"*Slurm Job ID:* {slurm_job_id}\n"
+        f"*Result:* PASS\n"
+        f"{recovery_line}"
+        f"*TT-SMI Version:* {versions['tt_smi']}\n"
+        f"*TT-KMD Version:* {versions['tt_kmd']}\n"
+        f"*Firmware Version:* {versions['fw_bundle']}\n"
+        f"{_telemetry_section(telemetry_summary)}"
+        f"{_grafana_section(node=node, when=pass_time, grafana_base_url=grafana_base_url)}"
+        f"{_attachment_section(attachment_names)}\n"
         f"*Last lines of output:*\n"
         f"{{noformat}}\n{log_tail}\n{{noformat}}"
     )

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -202,7 +202,7 @@ def add_comment_to_jira(
         "Content-Type": "application/json",
     }
 
-    log.info("Adding recurring-failure comment to %s ...", ticket_key)
+    log.info("Adding comment to %s ...", ticket_key)
     try:
         resp = requests.post(url, headers=headers, json={"body": body}, timeout=30)
     except requests.RequestException as exc:

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -117,7 +117,7 @@ def build_recovery_body(
 
     recovery_line = ""
     if restart_count > 0:
-        recovery_line = f"*Recovered after:* {restart_count} reboot(s)\n"
+        recovery_line = f"*Slurm requeues before recovery:* {restart_count}\n"
 
     return (
         f"*Node:* {node}\n"


### PR DESCRIPTION
### PR Category
Feature

### Summary
When the auto-close mechanism closes a node's ticket on recovery, post a final comment with the passing run's evidence (versions, telemetry, Grafana deep link, log tail) and attach the passing log + result artifacts, so the closed ticket carries the recovery proof next to the earlier failure logs.

Tested: opened an already closed ticket, reran test and got a following comment: https://tenstorrent.atlassian.net/browse/DCAMP-1536?focusedCommentId=655012

Addresses https://tenstorrent.atlassian.net/browse/DCAMP-1556

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-close-ticket-passing-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/hc-close-ticket-passing-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-close-ticket-passing-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/hc-close-ticket-passing-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/hc-close-ticket-passing-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/hc-close-ticket-passing-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/hc-close-ticket-passing-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/hc-close-ticket-passing-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/hc-close-ticket-passing-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/hc-close-ticket-passing-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/hc-close-ticket-passing-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/hc-close-ticket-passing-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/hc-close-ticket-passing-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/hc-close-ticket-passing-logs)