### PR TITLE
prefill/runners unslop

### DIFF
--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 set -euo pipefail
 
 MODEL="${1:?usage: run_multirank_pcc.sh <model-key>}"

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -1,19 +1,4 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
-#
-# Multi-galaxy disaggregated prefill cache-accuracy leg: a background N-rank runner opens the mesh, loads
-# the model, warmup-compiles and publishes the merged KV chunk table to shared NFS; a device-less producer
-# then feeds it, reads EVERY device cache the model published back over UMD (a sparse model's indexer key
-# cache as well as its KVPE cache) and PCCs each against the golden trace. The producer exits non-zero on a
-# PCC miss, but under mpirun-ulfm a lost producer daemon can still return 0 with zero caches validated, so
-# the exit code alone is not trusted: the leg is green only when a durable ok=true verdict exists for every
-# producer rank (the PCC gate near the end). Perf/timing are reported but never gate.
-#
-# Usage: run_multirank_pcc.sh <model-key>       # model-key selects a block in the case below
-#
-# Everything outside that case block is model-independent launcher plumbing (host-order derivation, table
-# poll, runner reaping, durable-verdict dump), so a new model is a case entry, not another copy.
 set -euo pipefail
 
 MODEL="${1:?usage: run_multirank_pcc.sh <model-key>}"
@@ -24,9 +9,6 @@ export PYTHONPATH="${TT_METAL_HOME}"
 MANIFEST_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests"
 MGD_DIR="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration/ci"
 
-# Shared defaults; a case block below overrides what its model needs. Each branch also names its own
-# scratch dir by swapping the summaries component out of PREFILL_SUMMARIES: that keeps the run-scoped leaf
-# and the shared-NFS root the blaze impl chose, while leaving the summaries dir itself alone.
 CHUNK_SIZE=5120
 MAX_SEQ_LEN=256000
 GOLDEN_LEN=56320
@@ -46,16 +28,9 @@ case "${MODEL}" in
     ;;
   glm52)
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/glm52_prefill_runner_kv}"
-    # LINE/LINE variant: GLM-5.2's MoE all_to_all deadlocks in warmup under the torus fabric modes on
-    # multi-galaxy pipeline prefill, so the descriptor declares no wrap and the fabric mode stays 2d.
     MGD="${MGD_DIR}/glm52_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/glm52.json"
-    # No traced prefill path for glm52 yet, so exercise the D2H layer-ack backend untraced (no
-    # PREFILL_USE_TRACE) -- the same ack backend kimi27 runs under trace.
     RUNNER_ENV="export PREFILL_LAYER_ACK_D2H=1;"
-    # Sparse DSA: TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over the
-    # 21 `full` layers), both PCC'd. The trace must be the indexer-K dump -- the adapter's default golden
-    # carries no dsa/indexer_k_layer_*, which would silently downgrade this leg to a KVPE-only check.
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}'; \
         export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k;"
     ;;
@@ -69,38 +44,22 @@ mkdir -p "${PIPELINE_DIR}"
 TTRUN_DIR="${TTRUN_DIR:-/etc/ttop}"
 TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
 
-# The runner goes through tt-run automapper, which discovers rank->mesh placement from the MGD and takes
-# the plain comma-separated host list. The producer (raw mpirun) needs a slotted host list in the SAME rank
-# order tt-run's discovery chose (parsed from the generated rankfile below) so its master co-locates with
-# runner rank 0 -- the H2D stream service is host-local /dev/shm IPC.
 RESOLVED_HOSTS=$(awk 'NF {printf "%s,", $1}' "${TTRUN_DIR}/hostfile" | sed 's/,$//')
-# tt-run Phase 1 (generate_rank_bindings) writes generated/ttrun/ under the launch cwd; keep it on shared
-# NFS so the runner pod can read rank-0 outputs.
 TTRUN_CWD="${PIPELINE_DIR}/ttrun-cwd"
 mkdir -p "${TTRUN_CWD}"
 
 MR_DIR=$(mktemp -d "${PIPELINE_DIR}/${MODEL}_prefill_ci_mr.XXXXXX")
 export TABLE_PATH="${MR_DIR}/kv_chunk_table.pb"
-# Each producer rank drops its PCC verdict here before the shutdown sentinel; mpirun drops buffered stdout
-# when the runner tears down, so this file is the only durable record of the measured per-cache PCC.
 PCC_DIR="${MR_DIR}/pcc_verdict"
-# Per-rank stdout/stderr files (mpirun --output-filename). These survive the teardown race that truncates
-# forwarded stdout, so their tails are the authoritative debug log.
 RANKLOGS="${MR_DIR}/ranklogs"
 TIMING_DIR="${MR_DIR}/timing"
 mkdir -p "${TIMING_DIR}"
 
-# The runner idles owning the multi-galaxy allocation until the producer's shutdown sentinel; on any early
-# exit (table-publish timeout, producer failure) it must be reaped or it strands the hardware until the
-# step timeout. Killing ttrun.py tears down the remote ranks with it.
 cleanup() {
   if [ -n "${RUNNER_PID:-}" ] && kill -0 "${RUNNER_PID}" 2>/dev/null; then
     kill "${RUNNER_PID}" 2>/dev/null || true
     wait "${RUNNER_PID}" 2>/dev/null || true
   fi
-  # Dump diagnostics before rm: on every exit path (success, producer failure, table timeout, step-timeout
-  # kill) the live mpirun stdout may be truncated at teardown, so the durable verdict JSON and per-rank
-  # ranklog tails are the authoritative record.
   echo "==================== per-cache PCC verdicts (PROD_RC=${PROD_RC:-<unset>}) ===================="
   for f in "${PCC_DIR}"/rank*.json; do
     [ -e "$f" ] || { echo "no PCC verdict files under ${PCC_DIR}"; break; }
@@ -117,8 +76,6 @@ cleanup() {
       --chunk-size "${CHUNK_SIZE}" --perf-window-chunks "${PERF_WINDOW_CHUNKS:-4}" \
       --summary-name "${MODEL}" \
       || echo "summary generation failed (non-fatal)"
-    # Under PREFILL_SUMMARIES rather than generated/test_logs: the blaze impl uploads that root with
-    # archive:false, which yields a direct PNG link on the job-summary page instead of a log zip to unpack.
     GANTT_DIR="${PREFILL_SUMMARIES}/plots"
     mkdir -p "${GANTT_DIR}"
     python3 -c "import matplotlib" 2>/dev/null \
@@ -134,12 +91,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# tt-run automapper: --mesh-graph-descriptor + --hosts generate the rank binding by discovery, so no static
-# binding is committed. tt-run forwards only the device vars it owns (TT_MESH_*) plus its
-# ENV_PASSTHROUGH_PREFIXES; PREFILL_* fall outside that set, so -- exactly as the producer launch below does
-# -- export them inside a per-rank bash -lc rather than relying on tt-run to carry them. Launch from
-# TTRUN_CWD so Phase 1 caches on shared NFS; RUNNER_PID stays ttrun.py's pid so cleanup()'s kill still tears
-# the remote ranks down.
 cd "${TTRUN_CWD}"
 python3 "${TTRUN_PY}" \
   --skip-executable-check \
@@ -172,13 +123,8 @@ for _ in $(seq 1 360); do
 done
 [ -f "${TABLE_PATH}" ] || { echo "KV table not published within timeout"; exit 1; }
 
-# Producer rank i must land on the host running runner rank i (host-local /dev/shm H2D descriptor), and
-# tt-run discovery -- not hostfile order -- decides that mapping, so derive the host order from the rankfile
-# --force-rediscovery just wrote. Using raw hostfile order races discovery and intermittently strands the
-# master on the wrong host -- H2DStreamService.connect then times out and TT_THROWs.
 RANKFILE=$(ls -t "${TTRUN_CWD}"/generated/ttrun/*/rankfile 2>/dev/null | head -1)
 [ -f "${RANKFILE}" ] || { echo "tt-run rankfile not found under ${TTRUN_CWD}/generated/ttrun/*/rankfile"; exit 1; }
-# rankfile lines are "rank N=hostname slots=X"; emit "N hostname", sort by rank, join as host:1.
 HOSTS=$(awk '/^rank[[:space:]]+[0-9]+=/ {n=$2; sub(/=.*/,"",n); h=$2; sub(/^[0-9]+=/,"",h); print n" "h}' "${RANKFILE}" | sort -n | awk '{printf "%s%s:1", (NR>1?",":""), $2}')
 [ -n "${HOSTS}" ] || { echo "failed to parse producer host order from ${RANKFILE}"; exit 1; }
 echo "producer host order from tt-run discovery: ${HOSTS}"
@@ -208,16 +154,10 @@ set +e
 PROD_RC=$?
 set -e
 
-# The cleanup() EXIT trap dumps the durable PCC verdicts and ranklog tails on every exit path, so no inline
-# diagnostics are needed here. On success the producer already sent the shutdown sentinel; wait for the
-# runner to finish teardown so a hung shutdown surfaces here instead of being orphaned.
 if [ "${PROD_RC}" -eq 0 ]; then
   wait "${RUNNER_PID}" || echo "runner exited non-zero after producer success (rc=$?)"
 fi
 
-# PCC gate. Read the durable per-rank verdicts before cleanup() rm's MR_DIR: require an ok=true verdict from
-# every producer rank (one per host in HOSTS). This catches the case the exit code misses -- a ULFM daemon
-# loss that returns 0 with no verdict written, or a rank that failed to validate. Perf/timing never gate.
 EXPECTED_RANKS=$(printf '%s' "${HOSTS}" | tr ',' '\n' | grep -c .)
 PCC_GATE_RC=0
 python3 - "${PCC_DIR}" "${EXPECTED_RANKS}" <<'PY' || PCC_GATE_RC=$?
@@ -247,7 +187,6 @@ if bad:
 print(f"PCC GATE PASS: {len(files)}/{expected} ranks ok, all caches >= threshold")
 PY
 
-# Green only when the producer exited clean AND every rank's PCC verdict is ok.
 if [ "${PROD_RC}" -ne 0 ]; then
   exit "${PROD_RC}"
 fi

--- a/models/demos/common/prefill/runners/ci/summarize_ci_run.py
+++ b/models/demos/common/prefill/runners/ci/summarize_ci_run.py
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
-"""Render the two end-of-run matrices for the disaggregated-prefill CI leg from the durable per-rank
-ranklogs (mpirun --output-filename), which survive the teardown race that truncates forwarded stdout:
-
-  * per-layer x per-cache PCC vs golden  -- from the producer ranks' "slot .. layer .. PCC" lines
-  * per-rank x per-chunk start/end time  -- from the runner ranks' CHUNK_START / CHUNK_COMPUTE lines
-
-Each producer rank validates only its own host's layers, so the PCC rows are the union across ranklogs.
-Runner timing is meaningful only with PREFILL_SYNC_PER_CHUNK=1 (else CHUNK_COMPUTE is never emitted). The
-measured request is the last --real-chunks chunks per rank; any earlier chunks are the discarded warmup.
-"""
 import argparse
 import os
 import re
@@ -140,7 +130,6 @@ def _cell_metrics(kept, disp):
 
 
 def _publish(lines, name):
-    """Print the perf block, and when named also drop it where the CI publish step globs for it."""
     title = f"disaggregated prefill perf -- {name or 'run'}"
     if name:
         home = os.environ.get("TT_METAL_HOME")
@@ -151,7 +140,7 @@ def _publish(lines, name):
 
             emit_summary("perf", name, title, lines)
             return
-        except Exception as exc:  # publishing is a reporting nicety; never lose the block over it
+        except Exception as exc:
             print(f"perf summary not published ({exc})")
     print(title)
     print("\n".join(lines))
@@ -199,7 +188,6 @@ def _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks):
         if sa is None or sb is None or sb <= sa:
             out.append(f"  throughput {lbl:>14} ({span}): {'-':>12}")
             continue
-        # start->start spans (d - first) inter-chunk intervals, i.e. that many chunks dispatched in dt.
         dt = sb - sa
         tokens = (d - first) * chunk_size
         out.append(f"  throughput {lbl:>14} ({span}): {tokens / dt:>12,.1f} tok/s  ({dt:.3f} s)")

--- a/models/demos/common/prefill/runners/migration.py
+++ b/models/demos/common/prefill/runners/migration.py
@@ -1,26 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-"""Model-agnostic KV-migration comms for the prefill runner.
-
-The RUNNER owns the control flow; this module provides the generic (model-free) pieces and the model
-runtime owns the table build. The split for a migration bring-up:
-
-    1. deliver_device_map_and_gather_stage_layouts(...)  # ALL RANKS: deliver local FNID->UMD map to
-                                                          #   the co-located worker + all-gather barrier
-    2. runtime.build_kv_chunk_table(kv_cache, path, ...) # RANK 0: model builds + serializes the table
-                                                          #   (via serialize_kv_chunk_table here)
-    3. publish_serialized_table_and_wait_ready(path)     # RANK 0: SetTable + wait for WORKER_READY
-
-Step 1 delivers every rank's device map (the worker keys chips on their hardware unique id and never
-gathers the map itself) and doubles as the barrier guaranteeing all maps land before rank 0 SET_TABLEs.
-Step 2 is the ONLY model-specific step: ``runtime.build_kv_chunk_table`` calls back into
-``serialize_kv_chunk_table`` with a model-supplied builder, so this module never imports a model.
-Step 3 attaches the ``MigrationLayerClient`` (SetTable on table_q, then blocks on
-RespOpcode::WorkerReady) — without WORKER_READY the runner would enter its request loop before the
-scheduler can issue migrations. The ``_migration_client`` extension lives in tt-llm-engine and is
-imported LAZILY so the runner still works standalone when migration is opted out.
-"""
 
 import glob
 import os
@@ -39,25 +19,12 @@ _DEFAULT_DEVICE_MAP_FILE = "/tmp/prefill_device_map.txt"
 
 
 class KvCacheStage(NamedTuple):
-    """One migratable device cache on THIS rank -- one per config of the model's table, in config
-    order, since caches need not share a layer-index space.
-
-    ``first_layer``/``count`` are the layers this stage OWNS, in THIS cache's index space. Every cache
-    must be allocated to its own stage, so its physical slot 0 is ``first_layer`` and it holds exactly
-    ``count`` slots per user -- the address walk assumes that.
-
-    Field names match the keys :func:`allgather_kv_stage_layout` gathers them into.
-    """
-
     base_addr: int
     first_layer: int
     count: int
 
 
 def migration_file_export_enabled() -> bool:
-    """True when PREFILL_MIGRATION_EXPORT_TO_FILE=1: drop the device map and KV chunk table on
-    the filesystem for the KV manager (tt-d-gen), instead of pushing them over the co-located
-    worker's shmem queues (no MigrationLayerClient, no SET_TABLE/WORKER_READY)."""
     return os.environ.get("PREFILL_MIGRATION_EXPORT_TO_FILE", "0") == "1"
 
 
@@ -66,15 +33,10 @@ def migration_device_map_file_path() -> str:
 
 
 def _disaggregation():
-    """KvChunkAddressTable + serializer come from ttnn.experimental.disaggregation
-    (no _migration extension needed)."""
     return ttnn.experimental.disaggregation
 
 
 def _serialize_table_to_path(table, path: str) -> None:
-    """Serialize a KvChunkAddressTable to a protobuf file for the worker's SET_TABLE. Atomic, like the
-    two device-map writers: a reader polls for this path's existence and deserializes the instant it
-    appears, so writing in place hands it a truncated protobuf whenever the poll lands mid-write."""
     tmp = f"{path}.tmp"
     _disaggregation().export_to_protobuf_file(table, tmp)
     os.replace(tmp, path)
@@ -82,7 +44,6 @@ def _serialize_table_to_path(table, path: str) -> None:
 
 def _resolve_queue_names() -> tuple[str, str, str]:
     return (
-        # Default shmem queue names. Overridable via PREFILL_MIGRATION_{CMD,TABLE,RESP}_QUEUE.
         os.environ.get("PREFILL_MIGRATION_CMD_QUEUE", "/prefill_mig_cmd_1"),
         os.environ.get("PREFILL_MIGRATION_TABLE_QUEUE", "/prefill_mig_tbl_1"),
         os.environ.get("PREFILL_MIGRATION_RESP_QUEUE", "/prefill_mig_rsp_1"),
@@ -90,8 +51,6 @@ def _resolve_queue_names() -> tuple[str, str, str]:
 
 
 def _import_migration_client():
-    """Lazily import the tt-llm-engine ``_migration_client`` extension. Raises
-    ImportError if it is not importable."""
     client_dir = os.environ.get("PREFILL_MIGRATION_CLIENT_DIR")
     if client_dir and client_dir not in sys.path:
         sys.path.insert(0, client_dir)
@@ -108,9 +67,6 @@ def _import_migration_client():
 
 
 def _attach_migration_client():
-    """Resolve queue names, import ``_migration_client``, and attach. Returns
-    (client, cmd_q, table_q, resp_q); raises RuntimeError if the endpoint's shmem
-    queues are not reachable (the orchestrator must launch migration_endpoint first)."""
     cmd_q, table_q, resp_q = _resolve_queue_names()
     mod = _import_migration_client()
     try:
@@ -125,20 +81,6 @@ def _attach_migration_client():
 
 
 def _deliver_local_device_map(device_map, rank: int, timeout_s: float = 30.0) -> None:
-    """Push THIS rank's local FNID->UMD device map to its co-located host migration worker(s).
-
-    Direct port of tt-blaze's ``_deliver_local_device_map``. The migration endpoint spawns TWO
-    internal device workers per host -- an "A" master/sender and a "B" loopback receiver -- each with
-    its OWN shmem queues named ``/ep_<pid>_{a,b}_{cmd,table,resp}`` (endpoint_orchestrator.cpp::
-    run_loopback); a subordinate rank adds a ``_r<rank>`` suffix. BOTH the A worker and the B receiver
-    need the map, so we deliver to every match.
-
-    The device map does NOT go to the outward control queues (``PREFILL_MIGRATION_*_QUEUE``, e.g.
-    ``/mig_ep1_*``) -- those are a DIFFERENT, master-only channel used for SET_TABLE/WORKER_READY. We
-    discover the worker queues by globbing ``/dev/shm/ep_*_{a,b}_cmd*`` on THIS host (POSIX shm is
-    host-local, so the glob finds exactly the worker(s) co-located with this rank), exactly like blaze
-    -- NOT the ``mig_ep*`` control name, which never matches a device-map queue.
-    """
     mod = _import_migration_client()
 
     def _discover():
@@ -148,7 +90,7 @@ def _deliver_local_device_map(device_map, rank: int, timeout_s: float = 30.0) ->
             candidates = glob.glob(f"/dev/shm/ep_*_{side}_cmd") + glob.glob(f"/dev/shm/ep_*_{side}_cmd_r*")
             candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
             for c in candidates:
-                name = "/" + os.path.basename(c)  # "/ep_<pid>_<side>_cmd[_r<rank>]"
+                name = "/" + os.path.basename(c)
                 if not os.access(c, os.R_OK | os.W_OK):
                     st = os.stat(c)
                     import pwd
@@ -198,15 +140,6 @@ def _deliver_local_device_map(device_map, rank: int, timeout_s: float = 30.0) ->
 
 
 def _enumerate_devices(mesh_device) -> list[tuple[int, int, int]]:
-    """Row-major ``(umd_chip_id, fabric_mesh_id, fabric_chip_id)`` for this rank's local mesh.
-
-    ``umd_chip_id`` is the chip's HARDWARE-STABLE 64-bit ASIC unique id, resolved from the
-    FabricNodeId via ``ttnn.cluster.get_chip_unique_id_from_fabric_node_id`` — the SAME id the
-    migration worker keys ``dram_by_umd`` on (``UmdDevice::unique_id()`` from the cluster
-    descriptor). It is NOT the process-local logical id (``get_device_id``, 0..n-1) NOR the
-    physical UMD ChipId — those don't match the worker's unique-id-keyed device map, so a
-    physical-id device map reaches WORKER_READY but fails to resolve at migrate time.
-    """
     rows, cols = mesh_device.shape[0], mesh_device.shape[1]
     out: list[tuple[int, int, int]] = []
     for r in range(rows):
@@ -219,11 +152,6 @@ def _enumerate_devices(mesh_device) -> list[tuple[int, int, int]]:
 
 
 def _build_device_map(mesh_device, mesh_shape) -> list[tuple[int, int, int]]:
-    """Single-rank device map for the migration endpoint, ordered per the
-    ``send_device_map`` binding: ``(fabric_node_mesh_id, fabric_node_chip_id,
-    umd_chip_id)``. Sanity-checks mesh size and fabric-node uniqueness so a
-    misconfigured PREFILL_SP/PREFILL_TP fails loud instead of producing a
-    half-filled device map."""
     raw = _enumerate_devices(mesh_device)
     expected = int(mesh_shape[0]) * int(mesh_shape[1])
     if len(raw) != expected:
@@ -242,9 +170,6 @@ def _build_device_map(mesh_device, mesh_shape) -> list[tuple[int, int, int]]:
 
 
 def rank_scoped_device_map_path(path: str, rank: int, num_ranks: int) -> str:
-    """Per-rank JSON device-map path: ``<stem>_r<rank><ext>`` when num_ranks > 1, else ``path``
-    unchanged. Co-located ranks (an intragalaxy pipeline) would otherwise overwrite each other's map
-    at the shared host-local path; readers glob the ``_r*`` siblings back together."""
     if num_ranks <= 1:
         return path
     stem, ext = os.path.splitext(path)
@@ -252,9 +177,6 @@ def rank_scoped_device_map_path(path: str, rank: int, num_ranks: int) -> str:
 
 
 def validate_stage_layout_contiguous(stage_layout) -> int:
-    """Check a gathered layout's layer ranges tile ``[0, total)`` contiguously (no gaps/overlaps) and
-    return that cache's layer total. ``compute_layer_split`` produces a contiguous partition, so a
-    violation means the ranks disagree on the split."""
     expected = 0
     for s in sorted(stage_layout, key=lambda s: s["first_layer"]):
         if s["first_layer"] != expected:
@@ -267,10 +189,6 @@ def validate_stage_layout_contiguous(stage_layout) -> int:
 
 
 def remove_stale_device_map_sidecars(path: str) -> None:
-    """Drop the JSON device map and its rank-scoped ``_r*`` siblings left by a prior run — a leftover
-    (e.g. from a run with more ranks) would silently merge into this run's map. Call BEFORE the
-    stage-layout all-gather: every rank writes its own fresh file only after that barrier, so
-    co-located ranks racing here can never delete a fresh one."""
     stem, ext = os.path.splitext(path)
     for stale in [path, *glob.glob(f"{stem}_r*{ext}")]:
         try:
@@ -281,10 +199,6 @@ def remove_stale_device_map_sidecars(path: str) -> None:
 
 
 def serialize_device_map(mesh_device, path: str) -> str:
-    """Write a JSON {"<mesh_id>:<chip_id>": <asic_unique_id>} device map so a device-less consumer
-    (the prefill_producer) can resolve a table's FabricNodeIds to the ASIC unique_id that
-    read_dram_umd / the migration worker key device reads on. Reuses _enumerate_devices (which calls
-    ttnn.cluster.get_chip_unique_id_from_fabric_node_id). Pairs with the mock KV chunk table."""
     import json
     import os
 
@@ -295,7 +209,6 @@ def serialize_device_map(mesh_device, path: str) -> str:
             f"[migration] device-map fabric-node collision: {len(enumerated)} chips but only "
             f"{len(device_map)} unique (mesh_id, chip_id) keys"
         )
-    # Atomic publish: write a temp file then rename, so a concurrent reader never sees partial JSON.
     tmp = f"{path}.tmp"
     with open(tmp, "w") as mp:
         json.dump(device_map, mp)
@@ -314,18 +227,7 @@ def serialize_kv_chunk_table(
     chunk_size_bytes: int,
     path: str,
 ) -> str:
-    """Model-agnostic KvChunkAddressTable serialize. Owns the generic config setup + protobuf
-    serialization; the MODEL owns the address math via the ``table_builder`` callback.
-
-    ``table_builder(config, chunk_size_bytes, num_users)`` receives the populated
-    ``KvChunkAddressTableConfig`` and returns a built ``KvChunkAddressTable`` for the model's own
-    cache layout (e.g. the deepseek/kimi block-cyclic builder). This keeps the common runner module
-    free of any model import — the model calls this from ``runtime.build_kv_chunk_table``.
-
-    Returns ``path`` on success."""
     cfg = _disaggregation().KvChunkAddressTableConfig()
-    # Initial value only: a multi-stage builder overwrites cfg.num_layers with the gathered global
-    # sum of every stage's layer count (== num_layers when a single stage owns the whole model).
     cfg.num_layers = num_layers
     cfg.max_sequence_length = max_seq_len
     cfg.num_slots = num_users
@@ -336,10 +238,6 @@ def serialize_kv_chunk_table(
 
 
 def serialize_prebuilt_kv_chunk_table(*, table, path: str) -> str:
-    """Serialize an already-built KvChunkAddressTable (single- OR multi-config) to a protobuf file for
-    the worker's SET_TABLE, log it, and return ``path``. This is the model-agnostic serialize step;
-    callers that build a multi-config table themselves (e.g. a sparse model merging its KVPE + index
-    caches) construct the table and hand it here."""
     _serialize_table_to_path(table, path)
     logger.info(
         f"[migration] KV chunk address table serialized to {path} "
@@ -349,8 +247,6 @@ def serialize_prebuilt_kv_chunk_table(*, table, path: str) -> str:
 
 
 def export_device_map_to_file(mesh_device, mesh_shape, path: str) -> str:
-    """Write this rank's local device map (``fabric_mesh_id fabric_chip_id umd_chip_id`` per line)
-    to a host-local text file, atomically (temp file + rename)."""
     device_map = _build_device_map(mesh_device, mesh_shape)
     tmp = f"{path}.tmp"
     with open(tmp, "w", encoding="utf-8") as map_file:
@@ -361,41 +257,17 @@ def export_device_map_to_file(mesh_device, mesh_shape, path: str) -> str:
 
 
 def export_device_map_file_and_gather_stage_layouts(mesh_device, stages, mesh_shape, device_map_path: str):
-    """ALL RANKS: file-export counterpart of :func:`deliver_device_map_and_gather_stage_layouts` —
-    drop the local FNID->UMD map to a host-local text file instead of pushing it to a co-located
-    worker, then join the same collective all-gather. Returns one gathered layout per stage."""
     export_device_map_to_file(mesh_device, mesh_shape, device_map_path)
     return allgather_kv_stage_layouts(mesh_device, stages, mesh_shape)
 
 
 def deliver_device_map_and_gather_stage_layouts(mesh_device, stages, mesh_shape, rank):
-    """ALL RANKS run this (the runner drives it for every rank). Deliver THIS rank's local FNID->UMD
-    device map to its co-located worker, then join the collective all-gather that merges every stage
-    into one table. Returns the gathered layouts, one per stage (the runner passes them to rank
-    0's ``runtime.build_kv_chunk_table``; non-rank-0 callers just needed to join the collective).
-
-    ``stages`` are this rank's per-cache :class:`KvCacheStage` descriptions, supplied by the model via
-    ``runtime.kv_migration_stages`` -- the engine never introspects the cache struct itself.
-
-    The delivery happens BEFORE the gather so every rank's map is in place before rank 0 SET_TABLEs;
-    the all-gather doubles as the barrier that guarantees it. The gather is an MPI collective -- EVERY
-    rank must reach it or the communicator deadlocks.
-    """
     device_map = _build_device_map(mesh_device, mesh_shape)
     _deliver_local_device_map(device_map, rank)
     return allgather_kv_stage_layouts(mesh_device, stages, mesh_shape)
 
 
 def publish_serialized_table_and_wait_ready(*, table_path: str, wait_ready_timeout_ms: int = 120_000):
-    """RANK 0 ONLY. Publish an ALREADY-serialized KV chunk table to the migration worker and block on
-    WORKER_READY (or raise on timeout). Returns the attached client.
-
-    The table is built + serialized by the model runtime (``runtime.build_kv_chunk_table`` — the model
-    owns the cache layout / block-cyclic address math), and the runner runs the all-ranks device-map
-    delivery + all-gather barrier (``deliver_device_map_and_gather_stage_layouts``) FIRST, so by the
-    time this attaches the endpoint ``MigrationLayerClient`` on the master cmd/table/resp queues and
-    SET_TABLEs, every rank's local device map has landed and the worker can reach WORKER_READY.
-    """
     client, cmd_q, table_q, resp_q = _attach_migration_client()
     logger.info(
         f"[migration] publishing table={table_path} (queues cmd={cmd_q}, table={table_q}, resp={resp_q}) "
@@ -409,22 +281,10 @@ def publish_serialized_table_and_wait_ready(*, table_path: str, wait_ready_timeo
 
 
 def _host_tag_int():
-    """Per-host stable 31-bit id (crc32 of hostname, masked to fit the signed-int32 allgather).
-
-    Ranks on the same physical host produce the SAME value; different hosts (almost certainly)
-    differ. ``allgather_int`` is the only collective primitive exposed and it carries a signed
-    32-bit int, so a hostname STRING cannot be gathered directly — we gather this tag instead and
-    rebuild a stable per-host string ``host-{tag:08x}`` on every rank (matching tt-blaze's
-    migration_table_hook convention). A host owns multiple mesh rows but a given row never spans
-    hosts, so one tag per owning rank correctly groups every FNID to its worker.
-    """
     return zlib.crc32(socket.gethostname().encode()) & 0x7FFFFFFF
 
 
 def allgather_kv_stage_layouts(mesh_device, stages, mesh_shape):
-    """COLLECTIVE (all ranks): :func:`allgather_kv_stage_layout` once per stage, in config order. EVERY
-    rank must pass the same stages in the same order -- each costs a fixed sequence of allgathers, so an
-    asymmetric list desynchronizes the communicator."""
     return [
         allgather_kv_stage_layout(mesh_device, stage.base_addr, mesh_shape, stage.first_layer, stage.count)
         for stage in stages
@@ -432,25 +292,6 @@ def allgather_kv_stage_layouts(mesh_device, stages, mesh_shape):
 
 
 def allgather_kv_stage_layout(mesh_device, kv_base_addr, mesh_shape, first_layer_idx, num_my_layers):
-    """COLLECTIVE (all ranks): all-gather each rank's pipeline-STAGE layout so one merged table can
-    span every layer across every host -- tt-blaze's layer->mesh merge strategy.
-
-    In this pipeline-parallel deployment each rank owns a contiguous LAYER range
-    ``[first_layer_idx, first_layer_idx + num_my_layers)`` and holds the KV for those layers across
-    its FULL mesh (all SP rows x TP cols). A migration worker needs ONE table covering every layer,
-    but ``mesh_device``/``kv_base_addr`` only describe THIS rank's mesh + KV base. So every rank
-    contributes, via ``allgather_int``:
-
-      * its layer range ``(first_layer_idx, num_my_layers)`` -- the analog of tt-blaze's my_layer_id
-      * KV-cache base address (64-bit, split lo/hi for the 32-bit int gather)
-      * usable DRAM bank count (harvested parts differ, so gather it rather than assume)
-      * a per-host tag (see :func:`_host_tag_int`)
-      * the ``(mesh_id, chip_id)`` of every ``(row, col)`` fabric node in its FULL mesh
-
-    EVERY rank must call this with identical ``mesh_shape`` (the per-(row,col) loop must be symmetric
-    for the collective to line up). Returns a per-rank list of stage dicts:
-    ``{rank, first_layer, count, base_addr, num_banks, host_tag, fnids[row][col]}``.
-    """
     rows = mesh_shape[0]
     cols = mesh_shape[1]
     base_addr = int(kv_base_addr)
@@ -458,16 +299,11 @@ def allgather_kv_stage_layout(mesh_device, kv_base_addr, mesh_shape, first_layer
 
     all_first = ttnn.distributed_context_allgather_int(int(first_layer_idx))
     all_count = ttnn.distributed_context_allgather_int(int(num_my_layers))
-    # allgather_int carries a SIGNED int32, but a KV base word can set bit 31 (a per-rank buffer
-    # landing >= 2 GB in a ~3.98 GB DRAM bank), overflowing the binding. c_int32 reinterprets the
-    # low 32 bits as two's-complement, keeping the raw bits; the receiver re-masks with 0xFFFFFFFF.
     all_lo = ttnn.distributed_context_allgather_int(c_int32(base_addr).value)
     all_hi = ttnn.distributed_context_allgather_int(c_int32(base_addr >> 32).value)
     all_banks = ttnn.distributed_context_allgather_int(int(num_banks))
     all_host = ttnn.distributed_context_allgather_int(_host_tag_int())
 
-    # Each rank enumerates its FULL mesh (every SP row x TP col) and gathers (mesh_id, chip_id) per
-    # coord -- unlike the layers, the whole mesh belongs to this rank's stage, so no row-splitting.
     all_mesh = [[None] * cols for _ in range(rows)]
     all_chip = [[None] * cols for _ in range(rows)]
     for r in range(rows):
@@ -499,9 +335,4 @@ def allgather_kv_stage_layout(mesh_device, kv_base_addr, mesh_shape, first_layer
 
 
 def get_num_dram_banks(mesh_device):
-    """Usable DRAM banks on this device. Full Blackhole = 8; harvested parts expose fewer (e.g. 7).
-
-    The KV cache ND-shards round-robin across these banks and the disaggregation address table replays
-    that exact striping (`curr_bank_id = (curr_bank_id + 1) % num_banks`), so both MUST derive the count
-    from the same device. dram_grid_size().x is the number of DRAM cores/banks the device exposes."""
     return mesh_device.dram_grid_size().x

--- a/models/demos/common/prefill/runners/migration_driver.py
+++ b/models/demos/common/prefill/runners/migration_driver.py
@@ -1,128 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-"""KV-migration test driver: prefills slots over H2D, then migrates their KV. Run this as a script.
-
-This is the ENTRY POINT for a migration run — the whole terminal-C side in one process. It owns
-everything migration: env/manifest/CLI config, the MigrationLayerClient attach, the optional
-cross-endpoint pairing, resolving the src->dst mapping, issuing the migrate() calls, and writing the two
-sidecar files consumers wait on.
-
-The H2D half is driven with ``prefill_producer``'s helpers — manifest, push schedule, ack drain, golden
-PCC — so the push path is defined in exactly one place. The dependency runs ONE way: ``prefill_producer``
-is the plain runner test and imports nothing from here, so a runner-only run can never pull migration in.
-Everything migration-specific lives in this file, including the optional src-KV dump for a decode-side
-consumer (``--dump-src-kv``).
-
-Contrast with ``runners.migration``, which is the RUNNER's passive setup half (publish the KV chunk
-table + device map to the migration worker and block on WORKER_READY). This module reuses that module's
-queue-name / client-import resolution but sends no SET_TABLE: by the time the producer runs, the runner
-has already driven the endpoint to WORKER_READY and released its setup client, leaving the cmd queue
-free — exactly the handoff the C++ PrefillScheduler relies on.
-
-Two topologies, selected by whether the destination endpoint id differs from our own:
-  * LOOPBACK (dest == src, the default): src and dst slots live in ONE table, routed to the endpoint's
-    internal B worker. Because both slots are in our own table, THIS module verifies the migrated KV
-    after the copy — see ``--verify-migration`` (dst == src byte compare, and/or dst vs the src's golden)
-    over the same device-less UMD path ``check_pcc`` uses for sources. The runner holds no validation of
-    its own: it publishes the table and the device map, and every read-back happens out here.
-  * CROSS-ENDPOINT P->D (dest != src): dst lives in the remote DECODE galaxy's table, an independent
-    address space. Requires the pairing/connect handshake below, and the decode side has no way to know
-    each slot's prompt length / last token, so we write a JSON handoff sidecar for it.
-
-Running it — migration must share the producer's process: it needs that run's resident-slot state, and it
-must migrate while the runner still holds the KV in device DRAM. Hence one entry point covering both, and
-the same three-terminal flow as before — terminal C just runs THIS module instead of prefill_producer::
-
-    export ENGINE=/path/to/tt-llm-engine TT_METAL_HOME=/path/to/tt-metal HOST=<this-host>
-    source $TT_METAL_HOME/python_env/bin/activate
-
-    # A) migration endpoint (leave running)
-    cd $ENGINE/disaggregation/migration
-    ./launch_migration_endpoints.sh --name_server_host $HOST \
-        --prefill_hosts $HOST --prefill_endpoint_id 1
-
-    # B) prefill runner (wait for WORKER_READY)
-    cd $TT_METAL_HOME
-    ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
-      models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml \
-      $HOST:1
-
-    # C) prefill + migrate (this module). For a runner-only run, use prefill_producer instead.
-    python3 -m models.demos.common.prefill.runners.migration_driver \
-      --manifest models/demos/common/prefill/runners/producer_manifests/<MANIFEST>.yaml
-
-Multi-host (validating EVERY rank's layers, not just rank 0's). Both read-backs here — the source golden
-PCC and the destination check — go over UMD, which reaches only the chips physically attached to the host
-the process runs on. On a pipeline runner spanning N hosts, ONE driver process therefore verifies just its
-own host's layer slice and SKIPS the rest (it says so, but a PASS is then a fraction of the model). Covering
-the model needs one process per host — which this module does NOT arrange for itself. Launching is the
-shell's job, exactly as it is for the runner (``run_pipeline_prefill.sh``); use its sibling::
-
-    # C) multi-host: host order == rank order, rank 0 first and it must be THIS host. The third argument
-    #    is the NIC and must match the runner's.
-    ./models/demos/common/prefill/runners/run_migration_driver.sh \
-      models/demos/common/prefill/runners/producer_manifests/<MANIFEST>.yaml \
-      <H0>:1,<H1>:1 [tcp_iface]
-
-Run standalone (no launcher) it is simply rank 0 of 1: one process, one host's coverage, no MPI, and the
-command at the top of this docstring is exactly right. Under a launcher (``OMPI_COMM_WORLD_SIZE`` > 1) the
-same entry point splits by rank, like ``prefill_producer``:
-  * rank 0 (the launch host): the full run — H2D feed, ack drain, MigrationLayerClient, migrate(), both
-    sidecars — plus its own host's read-backs.
-  * every other rank: a device-less VALIDATOR. No H2D connect, no migration client, no migrate; it only
-    reads its OWN host's KV back (source PCC and/or destination check) and votes.
-Coordination is three collectives over the distributed context (host-side MPI, no mesh device), so all
-ranks must see the same env — the launcher script forwards every exported PREFILL_*/MIGRATION_* var and
-each rank applies the same manifest itself. GO#1 = rank 0 broadcasts the resident-slot map once every
-LayerAck has landed (releases the source PCC); GO#2 = rank 0 broadcasts the resolved (src, dst, real_len)
-triples once wait_complete has returned (releases the destination check); DONE = an allgather of each
-rank's verdict, which both waits for every validator's reads to finish and folds the pass/fail. Any rank
-failing fails the run.
-Storage, and this is the usual way a multi-host run goes wrong: PREFILL_MIGRATION_TABLE_PATH must be on
-SHARED storage (every validator reads rank 0's table), while PREFILL_MIGRATION_DEVICE_MAP_PATH must stay
-HOST-LOCAL (each rank reads its OWN host's chips).
-
-Env. Everything below except the two PREFILL_VERIFY_MIGRATION* vars also has a typed field in the
-producer manifest's ``migration:`` block — see ``apply_manifest_env``; an explicitly exported env var
-always wins. Invoking this module IS the opt-in, so ``migration.issue`` is redundant here and a ``false``
-is warned about rather than honoured:
-  PREFILL_MIGRATION_DEST_ENDPOINT_ID  destination endpoint id for migrate() (default 1). Equal to our
-                                    OWN id => loopback; a different id => cross-endpoint P->D.
-  PREFILL_MIGRATION_SRC_ENDPOINT_ID  our OWN endpoint id, i.e. the prefill side (default 1). Only used
-                                    to decide loopback vs cross-endpoint and to pick the pairing role.
-  PREFILL_MIGRATION_PAIRS           arbitrary any-src -> any-dst mapping as "src:dst,src:dst,..." (e.g.
-                                    "0:5,1:2,3:7"). When set, migrates exactly these pairs (each src must
-                                    be a resident/prefilled slot; dst must fit the KV table; duplicate src
-                                    fans out). Also settable via ``--migrations`` (CLI wins) or the
-                                    manifest ``migration.pairs`` list. Overrides DST_SLOT_OFFSET.
-  PREFILL_MIGRATION_DST_SLOT_OFFSET  offset fallback used ONLY when PREFILL_MIGRATION_PAIRS is unset:
-                                    dst_slot = src_slot + offset (default = PREFILL_NUM_USERS, i.e. src
-                                    slots [0,N) migrate to dst slots [N,2N); the KV table needs >= 2N slots).
-  PREFILL_MIGRATION_LAYERS          "0,3" => migrate ONLY those layer rows, one migrate() per layer;
-                                    unset (default) => the whole [0, num_layers) range in one shot.
-                                    Not a per-cache selector: the engine replays the number per cache, so
-                                    layer L moves ROW L of each. A compacted DSA index cache cannot be
-                                    addressed this way, and ``_cache_plan`` drops it.
-  PREFILL_MIGRATION_HANDOFF_PATH    path of the JSON handoff for a cross-endpoint decode consumer;
-                                    unset (default) => not written at all.
-  PREFILL_MIGRATION_TIMEOUT_MS      per-migration wait_complete timeout (default 3600000).
-  PREFILL_VERIFY_MIGRATION          destination read-back mode, == --verify-migration
-                                    (off|dst-bytes|dst-golden|both; default dst-bytes, loopback only).
-                                    No typed manifest field: set it via the CLI flag, an exported env var,
-                                    or the manifest's raw ``env:`` passthrough.
-  PREFILL_VERIFY_MIGRATION_LAYERS   comma layer list to spot-check instead of the full depth. Same: CLI
-                                    flag / env / raw ``env:`` block, no typed field. Honoured by the
-                                    dst-bytes half only; the golden half always reads the full depth, and
-                                    is refused outright when PREFILL_MIGRATION_LAYERS migrated a subset
-                                    (its reader would PCC dst rows the migrate never wrote).
-  MIGRATION_DONE_FILE               path of the DONE sentinel published for an external consumer to poll
-                                    (default /tmp/migration_done.sentinel).
-  The host list is NOT env or manifest config: it is an argument to run_migration_driver.sh, which is what
-  places one process per host (see the multi-host note above).
-  Queues + client come from the runner's migration env, resolved via ``runners.migration``:
-  PREFILL_MIGRATION_{CMD,TABLE,RESP}_QUEUE and PREFILL_MIGRATION_CLIENT_DIR.
-"""
 
 import json
 import os
@@ -136,19 +14,13 @@ import ttnn
 
 
 def apply_manifest_env(manifest: dict) -> None:
-    """Map a producer manifest's typed ``migration:`` block onto the PREFILL_MIGRATION_* env vars this
-    module reads. Uses setdefault, so an explicitly exported env var (and the manifest's own verbatim
-    ``env:`` passthrough, which the producer applies first) still wins.
-
-    Called from the producer's ``_apply_manifest_env`` at import time, before anything reads the env.
-    """
     migration = manifest.get("migration") or {}
 
-    def sd(key, val):  # setdefault, stringified; skips None so an absent field leaves the default
+    def sd(key, val):
         if val is not None:
             os.environ.setdefault(key, str(val))
 
-    def sd_bool(key, val):  # YAML true/false -> the "1"/"0" the env parsing expects
+    def sd_bool(key, val):
         if val is not None:
             os.environ.setdefault(key, "1" if val else "0")
 
@@ -156,8 +28,6 @@ def apply_manifest_env(manifest: dict) -> None:
     sd("PREFILL_MIGRATION_DEST_ENDPOINT_ID", migration.get("dest_endpoint_id"))
     sd("PREFILL_MIGRATION_SRC_ENDPOINT_ID", migration.get("src_endpoint_id"))
     sd("PREFILL_MIGRATION_DST_SLOT_OFFSET", migration.get("dst_slot_offset"))
-    # Arbitrary src->dst mapping. Accept a "src:dst,src:dst" string, or a list of {src, dst} dicts /
-    # [src, dst] pairs / "src:dst" strings; all normalize to the PREFILL_MIGRATION_PAIRS env string.
     pairs = migration.get("pairs")
     if pairs is not None:
         if isinstance(pairs, str):
@@ -170,9 +40,8 @@ def apply_manifest_env(manifest: dict) -> None:
                 elif isinstance(p, (list, tuple)):
                     parts.append(f"{p[0]}:{p[1]}")
                 else:
-                    parts.append(str(p))  # already a "src:dst" string
+                    parts.append(str(p))
             sd("PREFILL_MIGRATION_PAIRS", ",".join(parts))
-    # Layer subset: accept "0,3" or [0, 3].
     layers = migration.get("layers")
     if layers is not None:
         sd("PREFILL_MIGRATION_LAYERS", layers if isinstance(layers, str) else ",".join(str(x) for x in layers))
@@ -188,27 +57,18 @@ def apply_manifest_env(manifest: dict) -> None:
 
 
 def _parse_layers(spec: str):
-    """PREFILL_MIGRATION_LAYERS / manifest ``layers`` -> a list of layer ids, or None for "all"."""
     spec = (spec or "").strip()
     return [int(x) for x in spec.split(",") if x.strip()] if spec else None
 
 
 class MigrationDriver:
-    """Issues producer-side KV migrations. Construct via ``create_driver`` (which applies the enable flag),
-    then ``attach()`` before prefill and ``run()`` after the ack drain."""
-
     def __init__(self, *, chunk_size: int, num_layers: int, default_dst_slot_offset: int):
         self.chunk_size = chunk_size
         self.num_layers = num_layers
         self.dest_endpoint_id = int(os.environ.get("PREFILL_MIGRATION_DEST_ENDPOINT_ID", "1"))
-        # Our OWN endpoint id (prefill side). dest == src => loopback (src/dst share one table);
-        # dest != src => cross-endpoint P->D (dst lives in the remote decode table). Drives which mapping
-        # invariants apply in _resolve_pairs and whether we do the pairing handshake.
         self.src_endpoint_id = int(os.environ.get("PREFILL_MIGRATION_SRC_ENDPOINT_ID", "1"))
         self.timeout_ms = int(os.environ.get("PREFILL_MIGRATION_TIMEOUT_MS", "3600000"))
         self.dst_slot_offset = int(os.environ.get("PREFILL_MIGRATION_DST_SLOT_OFFSET", str(default_dst_slot_offset)))
-        # PREFILL_MIGRATION_LAYERS="0,3" => extract only those layers (one migrate per layer) into a
-        # layer-id-indexed decode table; unset => migrate the whole [0, num_layers) range in one shot.
         self.layers = _parse_layers(os.environ.get("PREFILL_MIGRATION_LAYERS", ""))
         self.done_file = os.environ.get("MIGRATION_DONE_FILE", "/tmp/migration_done.sentinel")
         self.handoff_path = os.environ.get("PREFILL_MIGRATION_HANDOFF_PATH", "")
@@ -216,30 +76,14 @@ class MigrationDriver:
 
     @property
     def cross_endpoint(self) -> bool:
-        """True when the destination table lives in a DIFFERENT endpoint (P->D) rather than our own."""
         return self.dest_endpoint_id != self.src_endpoint_id
 
-    # ---------------------------------------------------------------- attach
-
     def attach(self) -> None:
-        """Attach the MigrationLayerClient and, when cross-endpoint, complete the pairing handshake.
-
-        Called BEFORE prefill so a missing endpoint fails fast (rather than after a long prefill), and so
-        the decode side's blocking connect_to rendezvous's promptly instead of risking a connect timeout
-        while we push chunks.
-        """
         self.client = self._attach_client()
         if self.cross_endpoint:
             self._pair_cross_endpoint()
 
     def _attach_client(self):
-        """Attach a MigrationLayerClient to the migration endpoint's queues.
-
-        Reuses ``runners.migration``'s queue-name / client-import resolution (PREFILL_MIGRATION_{CMD,TABLE,
-        RESP}_QUEUE + PREFILL_MIGRATION_CLIENT_DIR). Does NOT send SET_TABLE / device map / wait_ready: the
-        runner already drove the endpoint to WORKER_READY (migration.publish_table_and_wait_ready) and
-        released its setup client, leaving the cmd queue free for us. Returns the client (do NOT call
-        shutdown() on it: the endpoint's lifetime is owned by the launcher, not the producer)."""
         from models.demos.common.prefill.runners.migration import _import_migration_client, _resolve_queue_names
 
         cmd_q, table_q, resp_q = _resolve_queue_names()
@@ -248,11 +92,6 @@ class MigrationDriver:
         return client
 
     def _pair_cross_endpoint(self) -> None:
-        """Pair this prefill endpoint with the decode endpoint (P->D only).
-
-        Without this, both endpoints self-loopback and migrate() aborts "No remote table found for
-        destination". Convention matches the decode side + smoke test: lower id = PUBLISHER (accepts),
-        higher = CONNECTOR (initiates); both sides derive ONE service_name from the id pair."""
         publisher = min(self.src_endpoint_id, self.dest_endpoint_id)
         connector = max(self.src_endpoint_id, self.dest_endpoint_id)
         service_name = f"pd-migration-ep{publisher}-ep{connector}"
@@ -264,58 +103,22 @@ class MigrationDriver:
         self.client.connect_to(remote_endpoint_id=self.dest_endpoint_id, role=role, service_name=service_name)
         logger.success(f"[migration_driver] cross-endpoint pairing established with remote_ep={self.dest_endpoint_id}")
 
-    # ------------------------------------------------------------------- run
-
     def run(self, stats, *, num_slots: int = None, slot_traces: dict = None, pools_by_trace: dict = None) -> list:
-        """Resolve the mapping, migrate every pair, then publish the sidecars. Returns the resolved
-        ``(src_slot, dst_slot, real_len)`` triples.
-
-        Must run while the runner is alive (before any SHUTDOWN sentinel): the endpoint reads source KV
-        from device DRAM. ``stats`` is the producer's RunStats — only ``stats.resident`` (slot_id ->
-        ``_SlotFill``) is read. ``num_slots`` is the KV table's slot count when known, used
-        only to bounds-check loopback destinations. ``slot_traces`` / ``pools_by_trace`` are the producer's
-        per-slot prompt maps, needed only to write the cross-endpoint handoff.
-
-        Validating the copy is the caller's job, not this method's: ``main()`` feeds the returned triples
-        to ``_verify_migrated_slots`` once wait_complete has landed.
-        """
         if self.client is None:
             raise RuntimeError("[migration_driver] run() called before attach()")
         triples = self._resolve_pairs(stats, num_slots=num_slots)
         self._issue(triples)
-        # Cross-endpoint P->D: write the decode-side JSON handoff BEFORE the DONE sentinel, so a consumer
-        # that wakes on DONE always finds a complete handoff.
         self._write_handoff(triples, slot_traces, pools_by_trace)
         self._write_done_sentinel(triples)
         return triples
 
     def _resolve_pairs(self, stats, *, num_slots: int = None) -> list:
-        """Resolve the concrete ``(src_slot, dst_slot, real_len)`` migrations to perform, ONE list shared by
-        both the migrate step and the DONE sentinel so the two can never drift apart.
-
-        Two ways to describe the mapping:
-          * Explicit — PREFILL_MIGRATION_PAIRS="src:dst,src:dst,..." (a manifest ``migration.pairs`` list or
-            the ``--migrations`` CLI flag both feed this env var). Drives ARBITRARY any-src -> any-dst
-            migrations; each src must be a resident slot (it has KV to migrate) and dst must fit the table.
-            Duplicate src is allowed (fan-out: migrate one slot to several dsts).
-          * Offset (fallback, no explicit pairs) — every resident src slot -> src + dst_slot_offset.
-
-        ``real_len`` is the SRC slot's resident non-pad token count as recorded at push time (the last
-        ``actual_end`` the producer sent), matching the KV the runner wrote; slots with no data are
-        skipped. It is read rather than re-derived from chunk counts because a multi-turn slot resumed at
-        a non-zero prefix, so ``chunks_pushed * chunk_size`` describes only its latest turn. If
-        ``num_slots`` is known (from the KV table), dst is bounds-checked so a too-large dst fails here
-        with a clear message instead of a cryptic device-side error at migrate time."""
-
         def real_len_of(src: int) -> int:
             return stats.resident[src].real_len
 
         def check_dst(src: int, dst: int) -> None:
             if dst < 0:
                 raise ValueError(f"migration dst slot {dst} (src {src}) is negative")
-            # The bound below is the PREFILL table's slot count -- only meaningful for loopback (dst lives in
-            # this same table). Cross-endpoint dst lives in the DECODE table, whose size the producer doesn't
-            # know, so skip it there (a too-large dst still fails clearly device-side at migrate time).
             if not self.cross_endpoint and num_slots is not None and dst >= num_slots:
                 raise ValueError(
                     f"migration dst slot {dst} (src {src}) is out of range: the KV table has {num_slots} "
@@ -324,7 +127,7 @@ class MigrationDriver:
 
         spec = os.environ.get("PREFILL_MIGRATION_PAIRS", "").strip()
         triples = []
-        if spec:  # explicit arbitrary mapping
+        if spec:
             for tok in spec.split(","):
                 tok = tok.strip()
                 if not tok:
@@ -344,7 +147,7 @@ class MigrationDriver:
                     continue
                 check_dst(src, dst)
                 triples.append((src, dst, real_len))
-        else:  # no explicit mapping: uniform dst = src + offset over every resident slot
+        else:
             for src in sorted(stats.resident):
                 real_len = real_len_of(src)
                 if real_len <= 0:
@@ -353,13 +156,6 @@ class MigrationDriver:
                 check_dst(src, dst)
                 triples.append((src, dst, real_len))
 
-        # Reject mappings that sequential single-shot migration cannot execute correctly. Each migrate() reads
-        # its SRC slot from device DRAM at migrate time and there is no staging buffer, so:
-        #   * a dst that is ALSO a src (overlap) -> an earlier migration overwrites a slot a later pair still
-        #     reads (swaps 0:1,1:0, chains 0:1,1:2), migrating wrong KV;
-        #   * a duplicate dst -> only the last write survives, yet the DONE sentinel asks the runner to validate
-        #     EVERY pair.
-        # Disjoint src/dst sets — the intended case, e.g. 0:3,1:2 or src [0,N) -> dst [N,2N) — are unaffected.
         srcs = [s for (s, _, _) in triples]
         dsts = [d for (_, d, _) in triples]
         dup_dsts = sorted({d for d in dsts if dsts.count(d) > 1})
@@ -368,9 +164,6 @@ class MigrationDriver:
                 f"migration has duplicate dst slot(s) {dup_dsts}: multiple pairs target the same slot, so only "
                 f"the last survives while every pair would be validated. Give each migration a distinct dst."
             )
-        # src/dst overlap corrupts KV ONLY in loopback, where src and dst share one table so an earlier
-        # migration can overwrite a slot a later pair still reads. Cross-endpoint src (this prefill table) and
-        # dst (the decode table) are independent address spaces, so src N -> dst N is the normal case there.
         overlap = sorted(set(srcs) & set(dsts))
         if overlap and not self.cross_endpoint:
             raise ValueError(
@@ -382,20 +175,6 @@ class MigrationDriver:
         return triples
 
     def _issue(self, triples: list) -> int:
-        """Migrate each resolved ``(src_slot, dst_slot, real_len)`` triple's KV, blocking on completion.
-
-        ``self.layers`` selects which layer rows move:
-          * None (default): one single-shot migrate() over the whole ``[0, num_layers)`` layer range per
-            pair -- correct when the dest table is contiguous 0..N (loopback, or a full decode).
-          * A list (PREFILL_MIGRATION_LAYERS, e.g. [0, 3]): one migrate() PER listed layer, range
-            ``[L, L+1)``. Because migrate()'s layer range is symmetric (src row == dst row), this EXTRACTS
-            specific layers from the full contiguous SOURCE table (row i = layer i) into the SAME rows of a
-            layer-id-indexed dest -- the cross-endpoint P->D case where a reduced decode holds only {0,3}.
-            The list MUST match the decode side's gathered layer ids.
-
-        (The C++ PrefillScheduler streams per-layer migrations into a burst as each layer-ack lands,
-        overlapping prefill; the Python client binds no burst API, so this runs after the ack drain
-        instead.) Returns the number of pairs migrated."""
         layer_ranges = [(int(l), int(l) + 1) for l in self.layers] if self.layers else [(0, self.num_layers)]
         if self.layers:
             logger.info(f"[migration_driver] migrating layer subset {self.layers} (one migrate per layer)")
@@ -419,7 +198,7 @@ class MigrationDriver:
                     pos_start=0,
                     pos_end_exclusive=real_len,
                 )
-                self.client.wait_complete(token, self.timeout_ms)  # self-polls when no poll thread is running
+                self.client.wait_complete(token, self.timeout_ms)
             logger.success(
                 f"[migration_driver] MIGRATE slot {src_slot} -> {dst_slot} complete "
                 f"({len(layer_ranges)} layer range(s))"
@@ -429,19 +208,6 @@ class MigrationDriver:
         return migrated
 
     def _write_handoff(self, triples: list, slot_traces: dict, pools_by_trace: dict) -> None:
-        """Write the JSON handoff the DECODE-side consumer reads (blaze run_decode_from_migrated): one entry
-        per migrated pair as ``{"slots": [{dst_slot, prompt_len, last_prompt_token}, ...]}``. ``first_token``
-        is intentionally omitted -- the decode side derives it from the migrated KV.
-
-        This exists for CROSS-ENDPOINT P->D: unlike loopback (where this module verifies the destination
-        itself and needs no prompt metadata), the destination galaxy has no way to know each slot's prompt
-        length / last token, so it cannot pick the decode start position without this sidecar. ``real_len``
-        (element 2 of each triple) is exactly the resident prompt length that was migrated, and the src slot's
-        last prompt token is ``pool[real_len - 1]`` of the trace the producer already loaded.
-
-        Gated on ``PREFILL_MIGRATION_HANDOFF_PATH``: unset => write nothing, which is what a loopback run
-        wants since its destination is verified here rather than consumed by a decode side. Written
-        atomically (tmp + os.replace) so the decode side never reads a partial file."""
         if not self.handoff_path:
             return
         if slot_traces is None or pools_by_trace is None:
@@ -454,7 +220,6 @@ class MigrationDriver:
             pool = pools_by_trace[slot_traces[src]]
             last_tok = int(pool[real_len - 1]) if 1 <= real_len <= len(pool) else int(pool[-1])
             slots.append({"dst_slot": int(dst), "prompt_len": int(real_len), "last_prompt_token": last_tok})
-        # Safelist the configured directory and confirm both joined paths stay inside it before opening.
         base_dir = os.path.abspath(os.path.dirname(self.handoff_path) or ".")
         name = os.path.basename(self.handoff_path)
         handoff_path = os.path.abspath(os.path.join(base_dir, name))
@@ -472,16 +237,10 @@ class MigrationDriver:
             )
         with open(tmp, "w") as f:
             json.dump({"slots": slots}, f)
-        os.replace(tmp, handoff_path)  # atomic: the decode side never reads a half-written handoff
+        os.replace(tmp, handoff_path)
         logger.success(f"[migration_driver] wrote handoff {handoff_path} ({len(slots)} slot(s)): {slots}")
 
     def _write_done_sentinel(self, triples: list) -> list:
-        """Write the migration DONE sentinel — one ``src dst`` line per migrated pair — for an external
-        consumer to poll. This is the SAME handshake the llm-engine scheduler/driver used
-        (prefill_scheduler_driver wrote this file after migrating). It reports which pairs were COPIED, not
-        that they were verified: the destination read-back happens back in ``main()``, after this. Takes the
-        SAME triples list ``_issue`` consumed, so the sentinel matches exactly what was migrated. Returns
-        the (src, dst) pairs written."""
         if not triples:
             raise ValueError(
                 "migration is enabled but the mapping resolved to zero pairs, so there is no DONE sentinel "
@@ -492,7 +251,6 @@ class MigrationDriver:
                 "(PREFILL_PRODUCER_ISSUE_MIGRATION=0 / migration.issue: false)."
             )
         pairs = [(src, dst) for (src, dst, _) in triples]
-        # Safelist the configured directory and confirm the joined path stays inside it before opening.
         base_dir = os.path.abspath(os.path.dirname(self.done_file) or ".")
         done_path = os.path.abspath(os.path.join(base_dir, os.path.basename(self.done_file)))
         if not done_path.startswith(base_dir + os.sep):
@@ -513,26 +271,10 @@ class MigrationDriver:
 
 
 def _cache_plan(table, migrated_layers) -> list:
-    """One entry per cache (config id): ``rows`` {global_layer: row on that cache's axis} or None to
-    leave the cache alone, ``head_dim`` (None => not decodable), ``kind`` (which cache this is),
-    ``unaddressed`` (layers a subset migrate could not reach), ``why`` for the log.
-
-    Layers do not all carry the same caches, and a cache that skips layers may be COMPACTED: GLM-5.2's
-    index cache is keyed by full-indexer rank, so global layer 6 is row 3. Axis, in order: the adapter's
-    ``cache_layer_rows(config_id, num_layers)`` / ``cache_head_dim(config_id)`` hooks (what a new model
-    implements), else identity when the cache holds every layer, else the full-indexer rank convention,
-    else None -- a short cache is ambiguous and a guessed row reads another layer's bytes.
-
-    Non-identity rows are filtered out under PREFILL_MIGRATION_LAYERS: migrate() sends ONE layer number
-    for the whole table and the engine replays it per config (``DcnSenderBackend::migrate_slot``), so a
-    subset addresses ROW L of every cache. Arbitrary M-of-N needs a config field in ``MigrateSpec``.
-
-    Publishing on the LAYER axis makes row == layer identity, so nothing is filtered out for it.
-    """
     from models.demos.common.prefill.runners import prefill_producer as producer
 
     num_layers = int(producer.NUM_LAYERS)
-    n_model_configs = producer._num_model_configs(table)  # decimal-named only; a drafter's dflash_* are not caches here
+    n_model_configs = producer._num_model_configs(table)
     adapter = producer.ADAPTER
     rows_hook = getattr(adapter, "cache_layer_rows", None)
     head_dim_hook = getattr(adapter, "cache_head_dim", None)
@@ -541,14 +283,14 @@ def _cache_plan(table, migrated_layers) -> list:
     full_layers = None
     if table.num_configs() > 1:
         try:
-            full_layers = producer._full_indexer_layer_indices(num_layers)  # None when every layer owns one
-        except Exception as e:  # a non-DSA model has no indexer_types map to read
+            full_layers = producer._full_indexer_layer_indices(num_layers)
+        except Exception as e:
             logger.debug(f"[migration_driver] no full-indexer layer map available ({e}); DSA convention off")
 
     plan = []
     for cfg_id in range(table.num_configs()):
         cfg = table.config() if cfg_id == 0 else table.config(cfg_id)
-        is_index = cfg_id == 1 and n_model_configs > 1  # config 1 is the index cache iff the MODEL published two
+        is_index = cfg_id == 1 and n_model_configs > 1
         n_rows = int(cfg.num_layers)
         rows, why = None, ""
         if rows_hook is not None:
@@ -565,17 +307,14 @@ def _cache_plan(table, migrated_layers) -> list:
                 f"a prefix cache looks like a compacted one from here"
             )
 
-        # Decode width: the dump needs it, the byte check does not.
         head_dim = head_dim_hook(cfg_id) if head_dim_hook is not None else None
         if head_dim is None and cfg_id == 0 and hasattr(mc, "KV_LORA_RANK") and hasattr(mc, "QK_ROPE_HEAD_DIM"):
             head_dim = mc.KV_LORA_RANK + mc.QK_ROPE_HEAD_DIM
         if head_dim is None and is_index:
             head_dim = getattr(mc, "INDEX_HEAD_DIM", None)
 
-        # Keep the rows a subset migrate did land on (row == layer) rather than dropping the whole cache.
         unaddressed = []
         if rows is not None and migrated_layers:
-            # Reported against what the migrate ASKED for; the rest is filtered either way, not missing coverage.
             unaddressed = sorted(l for l, r in rows.items() if l != r and l in set(migrated_layers))
             rows = {l: r for l, r in rows.items() if l == r} or None
             if unaddressed:
@@ -594,13 +333,11 @@ def _cache_plan(table, migrated_layers) -> list:
 
 
 def _log_cache_plan(plan, tag: str) -> None:
-    """One line per cache: what was covered, and why anything was dropped."""
     for entry in plan:
         cfg_id, rows = entry["config_id"], entry["rows"]
         if rows is None:
             logger.warning(f"[migration_driver] {tag}: cache config {cfg_id} SKIPPED -- {entry['why']}")
         else:
-            # Partial coverage warns: a filtered cache still reports a layer count, so a count alone misleads.
             log = logger.warning if entry["unaddressed"] else logger.info
             log(
                 f"[migration_driver] {tag}: cache config {cfg_id} carries {len(rows)} layer(s) "
@@ -609,27 +346,6 @@ def _log_cache_plan(plan, tag: str) -> None:
 
 
 def _dump_src_kv(dump_dir: str, table, stats, slot_traces: dict, layers) -> None:
-    """Save each source slot's KV to ``<dump_dir>/src_slot<N>.pt`` for a decode-side consumer to PCC its
-    received copy against (blaze's ``--migration-validate-src-kv-pt``). That check tests the TRANSFER
-    rather than the model: comparing decode's destination to the exact bytes prefill held beats comparing
-    it to a golden trace, which would also fold in any model error.
-
-    One per-layer list per cache, all indexed BY GLOBAL LAYER whatever axis the cache itself uses::
-
-        {"ref_cache_lists": {config_id: [tensor | None] * num_layers},  # every cache dumped
-         "ref_kvpe_list": [...], "ref_index_k_list": [...]}             # aliases for configs 0 and 1
-
-    ``_cache_plan`` picks the caches; one needs a known axis, a known decode width, and rows the migrate
-    addressed. A dropped index cache leaves decode checking KVPE alone, so skips are logged loudly.
-
-    Read device-lessly over UMD via the runner's published table -- the same path the producer's PCC uses,
-    reusing its table lookup and cache decode. Rows outside ``layers`` stay None: they are never read, and
-    a full 78-layer slot would be ~10 GB. Values are stored in the DEVICE rope frame exactly as read, with
-    no re-interleave, because that is the frame decode compares in.
-
-    MLA layouts only -- ``_decode_kv_chunk`` covers the 576-wide MLA formats and the DSA index chunk,
-    not the M3 triple cache.
-    """
     import torch
 
     from models.demos.common.prefill.runners import prefill_producer as producer
@@ -652,10 +368,9 @@ def _dump_src_kv(dump_dir: str, table, stats, slot_traces: dict, layers) -> None
     base_dir = os.path.abspath(os.path.expanduser(dump_dir))
     os.makedirs(base_dir, exist_ok=True)
 
-    # Which caches are writable: a per-run decision, not per-slot.
     plan = _cache_plan(table, layers)
     _log_cache_plan(plan, "src-KV dump")
-    dumpable = []  # (config_id, {global layer: row}, head_dim)
+    dumpable = []
     for entry in plan:
         cfg_id, rows = entry["config_id"], entry["rows"]
         if rows is None:
@@ -685,36 +400,32 @@ def _dump_src_kv(dump_dir: str, table, stats, slot_traces: dict, layers) -> None
         real_len = res.real_len
         if real_len <= 0:
             continue
-        read_len = ((real_len + tokens_per_block - 1) // tokens_per_block) * tokens_per_block  # round to a block
+        read_len = ((real_len + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 
-        refs = {}  # config_id -> per-GLOBAL-layer list
+        refs = {}
         for cfg_id, selected, head_dim in dumpable:
             per_layer = [None] * producer.NUM_LAYERS
             for layer, row in sorted(selected.items()):
-                # A layer-axis cache is SPARSE: an unwritten row reads back 0 bytes, so leave it None.
                 if table.lookup(row, 0, slot_id, cfg_id).size_bytes == 0:
                     continue
                 decoded_rows = []
                 for pos in range(0, read_len, tokens_per_block):
-                    loc = table.lookup(row, pos, slot_id, cfg_id)  # keyed on this cache's own axis
+                    loc = table.lookup(row, pos, slot_id, cfg_id)
                     unique_id = producer._resolve_unique_id(
                         table.get_device_group(loc.device_group_index).fabric_node_ids, device_map
                     )
                     raw = ttnn.experimental.disaggregation.read_dram_umd(unique_id, loc.noc_addr, loc.size_bytes)
-                    # Dispatch is by raw byte size, so MLA and index chunks both land right.
                     decoded_rows.append(producer._decode_kv_chunk(raw, head_dim))
-                device_kv = torch.cat(decoded_rows, dim=0)[:real_len]  # natural order (the table un-rotates)
-                per_layer[layer] = device_kv.unsqueeze(0).unsqueeze(0)  # stored by global layer
+                device_kv = torch.cat(decoded_rows, dim=0)[:real_len]
+                per_layer[layer] = device_kv.unsqueeze(0).unsqueeze(0)
             refs[cfg_id] = per_layer
 
-        # dump_dir is the safelisted base; only the derived basename varies. Confirm the join stays inside
-        # it before writing.
         out = os.path.abspath(os.path.join(base_dir, f"src_slot{int(slot_id)}.pt"))
         if not out.startswith(base_dir + os.sep):
             raise ValueError(f"src-KV dump path {out!r} escapes its base directory {base_dir!r}")
         blob = {"ref_cache_lists": refs, "ref_kvpe_list": refs[0]}
         if 1 in refs:
-            blob["ref_index_k_list"] = refs[1]  # back-compat alias for the DSA index cache
+            blob["ref_index_k_list"] = refs[1]
         torch.save(blob, out)
         counts = ", ".join(f"cfg{c}={sum(t is not None for t in lst)}" for c, lst in sorted(refs.items()))
         logger.success(
@@ -726,42 +437,10 @@ def _dump_src_kv(dump_dir: str, table, stats, slot_traces: dict, layers) -> None
 def _verify_dst_vs_src_bytes(
     table, device_map: dict, triples: list, layers, *, migrated_layers=None, max_report: int = 10
 ) -> bool:
-    """Golden-free DESTINATION check: assert every migrated dst slot holds byte-identical KV to its src
-    slot, over every config / layer / position the migrate covered. Returns True on full agreement.
-
-    This asks the dst==src question the runner's retired ``validate_migrations_pairwise`` used to ask, but
-    over the device-less UMD path instead of the runner's in-memory cache — so it runs in the driver
-    process, needs no per-model layout branch, and leaves the runner a pure serving loop.
-
-    Byte equality rather than PCC: migration is a byte copy, so the correct dst is bit-identical. That
-    removes the whole reason the old runner-side version needed a 0.99 threshold and an all-zero
-    short-circuit (a decoded all-zero pad tail or a dense layer's index_k has undefined correlation), and
-    it catches corruption in regions where correlation is undefined. Nothing is decoded here, so the check
-    is also model-agnostic — no per-layout branch, unlike ``prefill_producer._read_slot_kv_and_check_pcc``.
-
-    CROSS-TALK between concurrent pairs (pair A's copy landing in pair B's destination) is detectable here
-    ONLY when the source slots hold DIFFERENT data. With the default single-prompt schedule every slot
-    pushes the same trace, so all sources are byte-identical and a mis-routed copy is indistinguishable
-    from a correct one. Set PREFILL_PRODUCER_SLOT_TRACES="dirA,dirB,..." to give each slot its own prompt
-    if that is a property you want this gate to cover. (The same limitation applies to the golden mode —
-    it is a property of identical sources, not of the comparison.)
-
-    Scope limits, all logged rather than silently absorbed:
-      * ``layers`` (``--verify-migration-layers``) picks which rows are read -- a pure cost knob.
-        ``migrated_layers`` (PREFILL_MIGRATION_LAYERS) feeds ``_cache_plan``, which drops any cache a
-        by-global-layer subset could not address; every cache it keeps is checked.
-      * Only whole chunks inside [0, real_len) are compared. A real_len that is not a multiple of the
-        config's chunk_n_tokens leaves a trailing partial chunk unchecked, since whether the engine
-        copies it whole is its business, not this gate's.
-      * A layer whose chips are not in this host's device map is SKIPPED, not failed (multi-host: each
-        driver process only sees its co-located galaxy). The skip count is reported so a "PASSED" line
-        cannot be mistaken for whole-model coverage.
-    """
     from models.demos.common.prefill.runners import prefill_producer as producer
 
     plan = _cache_plan(table, migrated_layers)
     _log_cache_plan(plan, "verify bytes")
-    # (config_id, [(global layer, row)]) per readable cache, limited to the sampled layers.
     checkable = []
     for entry in plan:
         rows = entry["rows"]
@@ -782,7 +461,7 @@ def _verify_dst_vs_src_bytes(
         for cfg_id, picked in checkable:
             tcfg = table.config() if cfg_id == 0 else table.config(cfg_id)
             stride = int(tcfg.chunk_n_tokens)
-            n_full = (real_len // stride) * stride  # whole chunks only; see the docstring
+            n_full = (real_len // stride) * stride
             tail_tokens += real_len - n_full
             logger.info(
                 f"[migration_driver] verify bytes: slot {src} -> {dst} config {cfg_id}: "
@@ -802,7 +481,6 @@ def _verify_dst_vs_src_bytes(
                             table.get_device_group(dst_loc.device_group_index).fabric_node_ids, device_map
                         )
                     except KeyError:
-                        # Not this host's chips — the same skip prefill_producer's own read-back makes.
                         skipped += 1
                         continue
                     read_umd = ttnn.experimental.disaggregation.read_dram_umd
@@ -814,7 +492,7 @@ def _verify_dst_vs_src_bytes(
                         if len(failures) < max_report:
                             failures.append((src, dst, cfg_id, layer, pos))
                         elif len(failures) == max_report:
-                            failures.append(None)  # sentinel: "and more"
+                            failures.append(None)
                 if mismatches_in_layer:
                     logger.error(
                         f"[migration_driver] verify bytes: slot {src} -> {dst} config {cfg_id} layer {layer}: "
@@ -851,29 +529,6 @@ def _verify_dst_vs_src_bytes(
 
 
 def _verify_dst_vs_golden(table, device_map: dict, triples: list, slot_traces: dict, threshold: float) -> bool:
-    """Golden-anchored DESTINATION check: PCC each migrated dst slot against the SRC slot's golden trace.
-    Returns True when every pair meets ``threshold``.
-
-    This is the device-less counterpart of the "AFTER" half of the runner's retired
-    ``validate_migration_kv``. It reuses ``prefill_producer._read_slot_kv_and_check_pcc``
-    unchanged — that reader is already parameterised by
-    slot id, so passing ``dst`` reads the destination, and passing ``slot_traces[src]`` compares it to
-    what the source was supposed to contain. A correct migration makes dst PCC to golden exactly as src
-    does, which is the pair of numbers the old ``[kv-migrate-validate] BEFORE/AFTER`` lines reported
-    (``_verify_resident_slots`` in main() is still the BEFORE half).
-
-    Stronger than the byte compare in one way — it proves the copy carries MODEL-CORRECT data rather than
-    merely the same bytes the source held, so it also re-confirms prefill itself at the destination — and
-    weaker in others: it decodes through the per-model layout branch (so a new cache layout needs code),
-    it needs the golden trace on disk, and its PCC is undefined over the all-zero pad tail. Run ``both``
-    when you want the transport and the model correctness reported separately.
-
-    FULL DEPTH, ALWAYS. ``_read_slot_kv_and_check_pcc`` takes a slot and a trace, not a layer list: it
-    walks every layer of the model and reports each of its caches' min. There is no layer subset to pass, which is why
-    the caller (``_verify_migrated_slots``) decides whether this check may run at all rather than passing
-    one down — see the gate there. Unlike ``_verify_dst_vs_src_bytes``, this cannot honour
-    PREFILL_VERIFY_MIGRATION_LAYERS, and it must not run against a partially migrated destination.
-    """
     from models.demos.common.prefill.runners import prefill_producer as producer
 
     min_pcc, failures, checked = 1.0, [], 0
@@ -890,8 +545,6 @@ def _verify_dst_vs_golden(table, device_map: dict, triples: list, slot_traces: d
             failures.append((src, dst, float("nan")))
             continue
         checked += 1
-        # The reader reports one min per MODEL cache (a sparse model migrates its index cache too); gate on
-        # the weakest and print the breakdown so a regression names the cache that moved wrong.
         pcc = min(slot_mins.values())
         min_pcc = min(min_pcc, pcc)
         per_cache = "".join(f" {cache}_pcc={value:.6f}" for cache, value in slot_mins.items())
@@ -916,25 +569,6 @@ def _verify_dst_vs_golden(table, device_map: dict, triples: list, slot_traces: d
 def _verify_migrated_slots(
     mode: str, *, table, triples, slot_traces, layers, migrated_layers, threshold, cross_endpoint
 ) -> bool:
-    """Run the requested destination check(s) after the migrate. Returns True when everything requested
-    passed (and True for ``off``, which asserts nothing).
-
-    Skips entirely when cross-endpoint: the dst slot lives in the DECODE galaxy's table, an independent
-    address space this driver's table cannot address. Looking up ``dst`` in OUR table would silently read
-    our own slot ``dst`` — an unwritten slot, or worse, another pair's source — and report a confident
-    wrong answer. Loopback is the only topology where the destination is locally readable.
-
-    TWO layer lists arrive here, and conflating them is a bug:
-      * ``migrated_layers`` (PREFILL_MIGRATION_LAYERS) — which rows the migrate actually COPIED. A subset
-        means every other row of each dst slot was never written, so it constrains what is even
-        MEANINGFUL to read at the destination.
-      * ``layers`` (``--verify-migration-layers``, defaulting to ``migrated_layers``) — which rows this
-        run should bother reading. A pure cost knob: a subset makes a PASS a sample.
-    ``dst-bytes`` honours both: ``layers`` picks its rows, ``migrated_layers`` tells ``_cache_plan``
-    which caches the migrate could address. ``dst-golden`` can honour neither — its reader walks
-    the full depth — so the gate below runs it only when the whole model was migrated, and says so
-    otherwise instead of PCCing rows that hold nothing.
-    """
     if mode == "off":
         logger.info("[migration_driver] destination verification is OFF; this run proves TRANSPORT only.")
         return True
@@ -964,11 +598,6 @@ def _verify_migrated_slots(
         ok = _verify_dst_vs_src_bytes(table, device_map, triples, layers, migrated_layers=migrated_layers) and ok
     if mode in ("dst-golden", "both"):
         if migrated_layers:
-            # PARTIAL MIGRATION + golden check: refuse, don't guess. The golden reader walks every layer
-            # of the model, but only `migrated_layers` were copied, so it would PCC the dst slot's
-            # UNWRITTEN rows against golden and fail a perfectly correct migration. Skipping quietly would
-            # be worse than failing: `both` would then report a PASS that never looked at the destination
-            # the way the caller asked. dst-bytes is the mode that does honour a subset.
             logger.error(
                 f"[migration_driver] --verify-migration={mode} cannot run its GOLDEN half: "
                 f"PREFILL_MIGRATION_LAYERS migrated only layer(s) {sorted(set(migrated_layers))}, so every "
@@ -981,8 +610,6 @@ def _verify_migrated_slots(
             ok = False
         else:
             if layers:
-                # Everything was migrated, so the full-depth golden read is CORRECT here — just not the
-                # cheap sample that was asked for. Say so rather than silently spending the reads.
                 logger.warning(
                     f"[migration_driver] --verify-migration-layers {sorted(set(layers))} applies to the "
                     "dst-bytes half only; the golden half reads the FULL depth (its reader takes no layer "
@@ -992,33 +619,7 @@ def _verify_migrated_slots(
     return ok
 
 
-# ---------------------------------------------------------------------------
-# Multi-rank coordination (device-less; GO/DONE over MPI collectives, not files)
-#
-# One driver process per pipeline host under an MPI launcher. Rank 0 is the master (feeds H2D, owns the
-# LayerAck channel and the MigrationLayerClient, issues every migrate() and writes both sidecars); every
-# other rank is a device-less validator that reads only its OWN host's chips. The reason the split exists
-# at all is that read_dram_umd is host-local: rank 0 physically cannot read another galaxy's DRAM, so a
-# single-process driver can only ever verify its own layer slice.
-#
-# The barriers reuse prefill_producer's collectives verbatim (_mr_config / _mr_bcast_resident /
-# _mr_allgather_verdict) and add ONE of their own, _mr_bcast_triples, because the destination check needs
-# something the producer never had: the mapping rank 0 actually migrated. Ordering is fixed and identical
-# on every rank — resident bcast (GO#1), triples bcast (GO#2), verdict allgather (DONE) — since these are
-# built out of allgather_int, and a rank issuing a different NUMBER of allgathers desynchronizes the run.
-# ---------------------------------------------------------------------------
-
-
 def _mr_bcast_triples(rank: int, triples: list) -> list:
-    """Broadcast rank 0's resolved ``(src_slot, dst_slot, real_len)`` triples to every rank, built from
-    allgather_int the same way ``prefill_producer._mr_bcast_resident`` is (element [0] of each allgather is
-    rank 0's contribution; ttnn exposes no native broadcast). Non-master ranks pass ``[]`` and receive the
-    list.
-
-    Doubles as GO#2: a validator blocks in the first allgather until the master arrives, which happens only
-    after every migrate()'s wait_complete has returned — i.e. exactly when the destination slots hold data.
-    Broadcasting the triples rather than re-resolving them per rank means the validators check what was
-    MIGRATED, not what a second evaluation of the env/manifest thinks should have been."""
     items = list(triples) if rank == 0 else []
     n = ttnn.distributed_context_allgather_int(len(items) if rank == 0 else 0)[0]
     out = []
@@ -1032,24 +633,11 @@ def _mr_bcast_triples(rank: int, triples: list) -> list:
 
 
 def _run_validator(rank: int, world_size: int, args) -> None:
-    """Non-master path: no H2D feed, no migration client, no migrate() — read-back only.
-
-    Waits for the master's GO#1 (the resident-slot broadcast, which the master only reaches after draining
-    every LayerAck, so all layers are written), PCCs this host's local layers of every source slot, then
-    waits for GO#2 (the migrated triples) and runs the same destination check the master runs, again over
-    this host's layers only. Joins the verdict allgather either way — including on failure — so the master
-    can never hang waiting for a rank that gave up early. Exits non-zero when this rank's checks failed.
-
-    Both read-backs filter by the local device map: a layer whose chips are not this host's resolves to no
-    unique_id and is skipped. With one process per host the union across ranks covers the whole model,
-    which is the entire point of running multi-rank."""
     from models.demos.common.prefill.runners import prefill_producer as producer
 
     cfg = producer._config_from_env()
     producer._require_shared_table_path(world_size)
     timeout_s = int(os.environ.get("PREFILL_H2D_CONNECT_TIMEOUT", "60"))
-    # Constructed for its env-derived fields only (layers / cross_endpoint) — a validator never attaches a
-    # client and never migrates. The same env on every rank makes these identical to the master's.
     driver = MigrationDriver(
         chunk_size=producer.CHUNK_SIZE,
         num_layers=producer.NUM_LAYERS,
@@ -1061,8 +649,6 @@ def _run_validator(rank: int, world_size: int, args) -> None:
         f"src_pcc={cfg.verify} dst_verify={args.verify_migration}"
     )
 
-    # GO#1 before the table read: the master broadcasts only after draining every LayerAck, which also
-    # means rank 0 finished publishing this run's table, so a read after GO cannot observe a stale one.
     resident = producer._mr_bcast_resident(rank, {})
     logger.info(f"[migration_driver] validator rank={rank}: GO received, {len(resident)} resident slot(s)")
 
@@ -1073,13 +659,9 @@ def _run_validator(rank: int, world_size: int, args) -> None:
         kv_table = None
 
     stats = producer.RunStats(resident=resident, total_pushes=0, push_ms=[], completed=0, wall_s=0.0)
-    # Env-derived, so this is the same slot -> golden mapping the master pushed against. Resolved only for
-    # the checks that actually need a golden: a dst-bytes-only validator compares device bytes to device
-    # bytes, and requiring the trace to be mounted on every host would fail the rank for nothing.
     needs_traces = cfg.verify or args.verify_migration in ("dst-golden", "both")
     slot_traces = producer._resolve_slot_prompts(cfg)[0] if needs_traces else {}
 
-    # Source PCC (was prefill correct on THIS host's layers?), the same gate the master runs on its own.
     verify_ok = True
     if cfg.verify:
         if kv_table is None:
@@ -1092,7 +674,6 @@ def _run_validator(rank: int, world_size: int, args) -> None:
                 logger.error(f"[migration_driver] validator rank={rank}: KV read/PCC failed: {type(e).__name__}: {e}")
                 verify_ok = False
 
-    # GO#2: the migrated mapping. Blocks until the master's last wait_complete has returned.
     triples = _mr_bcast_triples(rank, [])
     logger.info(f"[migration_driver] validator rank={rank}: {len(triples)} migrated pair(s) received")
 
@@ -1112,20 +693,13 @@ def _run_validator(rank: int, world_size: int, args) -> None:
         migration_ok = False
 
     ok = verify_ok and migration_ok
-    producer._mr_allgather_verdict(ok)  # DONE barrier + verdict fold (the master reads the result)
+    producer._mr_allgather_verdict(ok)
     logger.info(f"[migration_driver] validator rank={rank}: DONE src_pcc_ok={verify_ok} dst_verify_ok={migration_ok}")
     if not ok:
         sys.exit(1)
 
 
 def main() -> None:
-    """Prefill a set of slots over H2D, then migrate their KV — the whole terminal-C side of a migration
-    run in one process.
-
-    The H2D half is driven with ``prefill_producer``'s helpers (manifest, schedule, ack drain, golden PCC);
-    the migration half is this module. The dependency runs THIS way on purpose: prefill_producer is the
-    plain runner test and knows nothing about migration, so a runner-only run can never drag migration in.
-    """
     import argparse
 
     from models.demos.common.prefill.runners import prefill_producer as producer
@@ -1183,23 +757,12 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # Manifest order matters: the producer applies `env:` first (so a raw PREFILL_* key wins) plus its own
-    # typed blocks, and hands back the parsed document; we then apply `migration:` from it. setdefault
-    # throughout, so an exported env var still beats both.
     manifest = producer._apply_manifest_env(args.manifest) if args.manifest else {}
     apply_manifest_env(manifest)
     if args.migrations is not None:
-        os.environ["PREFILL_MIGRATION_PAIRS"] = args.migrations  # CLI beats manifest + env
+        os.environ["PREFILL_MIGRATION_PAIRS"] = args.migrations
     producer._load_env_config()
 
-    # Rank split. Under an MPI launcher every non-zero rank is a read-back-only validator for its OWN
-    # host's layers; standalone this is (0, 1) and nothing below changes. Done AFTER the manifest lands in
-    # the env so every rank derives the same config from the same source.
-    #
-    # The log line matters: _mr_config() calls MPI_Init, which BLOCKS until every rank has joined, and a
-    # network misconfiguration (ranks placed on different NICs -- see run_migration_driver.sh's tcp_iface
-    # argument) makes that block forever. Announcing it turns an otherwise silent hang into a visible
-    # "waiting for N ranks".
     if int(os.environ.get("OMPI_COMM_WORLD_SIZE", "1")) > 1:
         logger.info(
             f"[migration_driver] joining the distributed context "
@@ -1211,19 +774,14 @@ def main() -> None:
         return
 
     cfg = producer._config_from_env()
-    # Validators read the table the runner published under this path from their own hosts, so on
-    # multi-rank it has to be shared storage. Checked on every rank (same env => same verdict), so a
-    # rejection exits all of them symmetrically instead of half-opening a barrier.
     producer._require_shared_table_path(world_size)
-    # Invoking THIS module is the opt-in, so migration.issue is redundant here. Warn rather than silently
-    # honour a `false` that would turn the whole invocation into a no-op.
     if os.environ.get("PREFILL_PRODUCER_ISSUE_MIGRATION", "1") == "0":
         logger.warning(
             "[migration_driver] the manifest sets migration.issue: false, which is ignored when this module "
             "is the entry point — invoking it IS the opt-in. Run prefill_producer for a no-migration run."
         )
     driver = MigrationDriver(
-        chunk_size=producer.CHUNK_SIZE,  # module attrs, read AFTER _load_env_config() rebinds them
+        chunk_size=producer.CHUNK_SIZE,
         num_layers=producer.NUM_LAYERS,
         default_dst_slot_offset=cfg.num_users,
     )
@@ -1238,15 +796,9 @@ def main() -> None:
     payload_bytes = service.payload_size_bytes()
     logger.info(f"[migration_driver] attached; payload={payload_bytes}B")
 
-    # Unconditional, unlike prefill_producer.main() which skips the table read when check_pcc is off: here
-    # the table has a SECOND consumer, --verify-migration's destination read-back, which is on by default
-    # and independent of check_pcc. Gating this on cfg.verify would make the default verify silently
-    # unavailable ("needs the KV chunk table, which never appeared") on any check_pcc: false manifest.
     kv_table = producer._read_kv_chunk_table(timeout_s)
     ack_channel = producer._connect_layer_ack_channel(timeout_s)
 
-    # Attach + pair BEFORE pushing: a missing endpoint fails in seconds instead of after a multi-minute
-    # prefill, and a cross-endpoint pairing rendezvous's while the decode side is still blocked on it.
     driver.attach()
 
     slot_traces, slot_lengths, pools_by_trace = producer._resolve_slot_prompts(cfg)
@@ -1273,15 +825,9 @@ def main() -> None:
     )
     producer._drain_layer_acks(ack_channel, producer.NUM_LAYERS * stats.total_pushes)
 
-    # Multi-rank GO#1: every layer of every chunk is now written across every stage's DRAM, so release the
-    # validators to PCC their own hosts' layers. Broadcast BEFORE this rank's own read-back so the reads
-    # overlap across hosts. The drain above is unconditional here (unlike prefill_producer, which gates it
-    # on check_pcc), so this guarantee holds even with check_pcc off.
     if world_size > 1:
         producer._mr_bcast_resident(mr_rank, stats.resident)
 
-    # Golden PCC + the src-KV dump run BEFORE migrating, so both land before the DONE sentinel a consumer
-    # may be waiting on. Migration only READS the source slots, so the order is equivalent.
     verify_ok = True
     if cfg.verify and kv_table is not None:
         try:
@@ -1297,8 +843,6 @@ def main() -> None:
         if kv_table is None:
             logger.error("[migration_driver] --dump-src-kv needs the KV chunk table, which never appeared.")
         else:
-            # Rank 0 only: every rank would write the SAME src_slot<N>.pt with a different layer subset and
-            # clobber the others. The dump therefore carries this host's layers alone on a multi-rank run.
             if world_size > 1:
                 logger.warning(
                     f"[migration_driver] --dump-src-kv runs on rank 0 only, so {args.dump_src_kv} will hold "
@@ -1307,9 +851,6 @@ def main() -> None:
                 )
             _dump_src_kv(args.dump_src_kv, kv_table, stats, slot_traces, driver.layers)
 
-    # Migrate. Wrapped so a failure here still reaches GO#2 below with an empty mapping: a validator parked
-    # in that broadcast would otherwise hang forever on a master that died. Every rank then verifies zero
-    # pairs, votes False, and the run exits non-zero together.
     triples = []
     migrate_ok = True
     try:
@@ -1323,16 +864,9 @@ def main() -> None:
         logger.exception(f"[migration_driver] migration failed: {type(e).__name__}: {e}")
         migrate_ok = False
 
-    # Multi-rank GO#2: wait_complete has returned for every pair, so the destination slots hold data.
-    # Release the validators with the mapping that was actually migrated.
     if world_size > 1:
         _mr_bcast_triples(mr_rank, triples)
 
-    # Destination read-back. Runs AFTER driver.run() because the dst slot only holds anything once the
-    # migrate's wait_complete has returned, and BEFORE the shutdown sentinel below because the UMD reads
-    # need the mesh alive. Note this lands after run() published the DONE sentinel: harmless for loopback
-    # (nothing polls it) but it does mean the sentinel means "copied", not "verified" — a cross-endpoint
-    # consumer waking on it gets no verdict from here, which is why the cross-endpoint case is skipped.
     verify_layers = _parse_layers(args.verify_migration_layers) or driver.layers
     if verify_layers and args.verify_migration != "off":
         logger.warning(
@@ -1351,15 +885,10 @@ def main() -> None:
             cross_endpoint=driver.cross_endpoint,
         )
     except Exception as e:
-        # Same reason as the migrate above: reach the verdict allgather rather than stranding a validator.
         logger.exception(f"[migration_driver] destination verify raised {type(e).__name__}: {e}")
         migration_ok = False
     migration_ok = migration_ok and migrate_ok
 
-    # Multi-rank DONE: the verdict allgather is also the barrier that holds this rank until every validator
-    # has finished reading, so the shutdown sentinel below cannot tear the mesh/DRAM down under one. Fold
-    # every rank's verdict — this rank's own is contributed as element [0] — so a failure anywhere fails
-    # the run, and each rank covers a different slice of the model.
     local_ok = migration_ok and not (cfg.verify and not verify_ok)
     all_ranks_ok = local_ok
     if world_size > 1:
@@ -1368,7 +897,6 @@ def main() -> None:
             logger.info(f"[migration_driver] rank={r}: ok={v}")
         all_ranks_ok = all(verdicts)
 
-    # Optional graceful shutdown: sent LAST, because the UMD read-backs above need the mesh/DRAM alive.
     if os.environ.get("PREFILL_SEND_SHUTDOWN", "0") == "1":
         sentinel = struct.pack("<iii", -1, -1, -1)
         payload = producer._chunk_to_host_array([1] * producer.CHUNK_SIZE)
@@ -1378,10 +906,6 @@ def main() -> None:
     else:
         logger.info("[migration_driver] exiting (the runner keeps its sync-op loop running).")
 
-    # Both gates feed the exit code: the source PCC (was prefill correct?) and the destination read-back
-    # (did the copy land correctly?). A silent success on either would make the run green while unverified.
-    # Multi-rank, they are folded across ranks first — each rank only ever saw its own host's layers, so
-    # only the fold covers the model.
     if cfg.verify and not verify_ok:
         logger.error("[migration_driver] FAILED: source KV PCC did not pass on rank 0.")
     if not migrate_ok:

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -2,86 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-"""Parametrized H2D producer for the prefill runner.
-
-It behaves like a small inference scheduler: it drives N concurrent user "slots", each running a
-request made of token chunks, and pushes those chunks to the runner over the H2D socket. The order
-and timing of the pushes is described entirely by a flat `ProducerConfig` — the producer has no notion
-of named "scenarios" or "modes". Scenarios (single-user, round-robin, random stress, ...) live in the
-test suite as ProducerConfig data (see tests/test_producer_runner_e2e.py); this engine just runs one.
-
-After pushing, it drains the runner's per-layer LayerAcks and, if asked, reads the resulting KV cache
-back and PCC-checks it against the golden trace. The KV read (read_dram_umd over a bare UMD cluster)
-and raw cache decode are BOTH device-less on purpose: touching a real ttnn device here would take the
-CHIP_IN_USE lock the runner already holds, and deadlock.
-
-`run_schedule()` takes injectable seams (push_fn / now_fn / sleep_fn / rng) so the scheduling logic
-can be unit-tested with no device and reproduced deterministically.
-
-Config — a YAML manifest (like the runner's PREFILL_MANIFEST) or PREFILL_* env vars. Point at a
-  manifest with ``--manifest <path>`` (or PREFILL_PRODUCER_MANIFEST); main() applies it via setdefault
-  (importing this module applies nothing), so any exported PREFILL_* env var still wins. Typed blocks map to the
-  env vars documented below; a verbatim ``env:`` block passes any raw PREFILL_* key through (and wins
-  over the typed blocks). See producer_manifests/prefill_producer_manifest.example.yaml. Schema:
-    model:     {variant, num_layers, max_seq_len, chunk_size}
-    transport: {sp, tp, h2d_service_id, connect_timeout_s}
-    workload:  {num_users, chunks, max_requests, duration_s, interleave, p_gap, p_burst, gap_ms,
-                mid_end_prob, seed, check_pcc, trace_dir, slot_prompts}
-    env:       {ANY_PREFILL_KEY: value}   # escape hatch for anything unmodeled
-  Any other top-level block is ignored here and returned by _apply_manifest_env() for another entry point
-  to apply — that is how runners/migration_driver.py picks up ``migration:``.
-
-Multi-rank: launched under an MPI launcher (OMPI_COMM_WORLD_SIZE > 1, one process per pipeline host)
-the same entry point splits by rank — rank 0 is the master (feeds H2D, owns the LayerAck channel) and
-every other rank is a device-less validator that only reads its own host's KV back and PCCs it. The
-roles coordinate over MPI collectives, not files (see the "Multi-rank coordination" section below).
-Standalone (no launcher) it is just the master. Multi-rank requires PREFILL_PRODUCER_CHECK_PCC=1.
-
-Env — schedule knobs (flat; the defaults describe a 1-user, 11-chunk, in-order run):
-  PREFILL_NUM_USERS              concurrent cache slots (default 1)
-  PREFILL_PRODUCER_CHUNKS        chunks per request: "N" fixed, or "min,max" random (default "11")
-  PREFILL_PRODUCER_MAX_REQUESTS  total requests across all slots before stopping (default 1)
-  PREFILL_PRODUCER_DURATION_S    wall-clock bound (default "inf" = stop on request count)
-  PREFILL_PRODUCER_P_GAP         per-step probability of an idle gap (default 0.0)
-  PREFILL_PRODUCER_P_BURST       per-step probability of a 2-3 chunk burst (default 0.0)
-  PREFILL_PRODUCER_GAP_MS        "min,max" idle-gap milliseconds (default "200,2000")
-  PREFILL_PRODUCER_MID_END_PROB  probability a request ends mid-chunk (default 0.0)
-  PREFILL_PRODUCER_INTERLEAVE    slot order: "random" (default) | "round_robin"
-  PREFILL_PRODUCER_SEED          RNG seed (default 1234)
-  PREFILL_PRODUCER_CHECK_PCC     "1" to read KV back and PCC vs golden per slot (default 0)
-  PREFILL_PRODUCER_SLOT_TRACES   per-slot prompts: "dirA,dirB,..." assigns trace i to slot i (cycling by
-                                 slot % count if fewer than num_users). Each slot pushes tokens from — and
-                                 is PCC'd against — its OWN trace, and its depth is derived from that
-                                 prompt's real length (so PREFILL_PRODUCER_CHUNKS/MID_END are ignored per
-                                 slot). Unset (default) => one shared PREFILL_TRACE_DIR + the synthetic
-                                 schedule for all slots.
-  PREFILL_DFLASH_GOLDEN_KV_DIR   dir with the DFlash drafter's golden context K/V (k_cache/v_cache
-                                 .safetensors); set it to ALSO PCC the drafter caches the table carries.
-  PREFILL_DFLASH_PCC             per-(layer, head) bar for that drafter check (default 0.88). Both feed
-                                 dflash_kv_table_pcc_check in deepseek_v3_d_p/tt/dflash_prefill/
-                                 dflash_kv_validation.py; unset golden => the drafter half is skipped.
-  PREFILL_SEND_SHUTDOWN          "1" to close the stream with an all -1 sentinel so the runner exits
-                                 gracefully after the run (sent after the KV read; default 0). PR #48718.
-Scope — this module drives the RUNNER and nothing else: push, ack-drain, optional golden PCC. It issues no
-  KV migration and imports nothing that does. To prefill AND migrate, run runners/migration_driver.py: it
-  reuses the helpers here and adds the migration steps. The dependency runs that way only, never back into
-  this module, so a runner-only run can never pull migration in.
-Env — transport (must match the runner): PREFILL_SP / PREFILL_TP / PREFILL_CHUNK_SIZE /
-  PREFILL_MAX_SEQ_LEN / PREFILL_NUM_LAYERS / PREFILL_H2D_SERVICE_ID / PREFILL_H2D_CONNECT_TIMEOUT.
-
-Usage:
-    # From a manifest (env still overrides individual knobs):
-    python -m models.demos.common.prefill.runners.prefill_producer \
-      --manifest models/demos/common/prefill/runners/producer_manifests/prefill_producer_manifest.example.yaml
-    # 1 user, full depth, with PCC:
-    PREFILL_PRODUCER_CHUNKS=11 PREFILL_PRODUCER_CHECK_PCC=1 \
-      python -m models.demos.common.prefill.runners.prefill_producer
-    # 8-user random stress + PCC:
-    PREFILL_NUM_USERS=8 PREFILL_PRODUCER_CHUNKS=1,4 PREFILL_PRODUCER_MAX_REQUESTS=200 \
-      PREFILL_PRODUCER_P_GAP=0.2 PREFILL_PRODUCER_P_BURST=0.3 PREFILL_PRODUCER_MID_END_PROB=0.33 \
-      PREFILL_PRODUCER_CHECK_PCC=1 \
-      python -m models.demos.common.prefill.runners.prefill_producer
-"""
 
 import argparse
 import json
@@ -103,38 +23,22 @@ from models.demos.common.prefill.runners.runner_utils import load_trace_token_id
 
 
 def _apply_manifest_env(manifest_path: str) -> dict:
-    """Populate the PREFILL_* env from a YAML producer manifest and RETURN the parsed manifest (setdefault
-    => an explicitly exported env var still wins). Mirrors the runner's _apply_manifest_env: a verbatim
-    ``env:`` passthrough (applied FIRST, so a raw PREFILL_* key wins over the typed mapping) plus typed
-    ``model`` / ``transport`` / ``workload`` blocks mapped to the same env vars _load_env_config() and
-    _config_from_env() read.
-
-    Blocks this module does not model are left untouched and reachable via the return value, so another
-    entry point can apply its own. That is how the migration driver picks up ``migration:`` — this module
-    stays unaware of it.
-
-    Called ONLY from main(), and necessarily before those two reads — see the call site. Deliberately not
-    invoked at import: this is the one function here that mutates os.environ, and a plain
-    ``import prefill_producer`` must not silently apply a manifest just because the env names one."""
     import yaml
 
     with open(manifest_path) as f:
         manifest = yaml.safe_load(f) or {}
 
-    def sd(key, val):  # setdefault, stringified; skips None so an absent field leaves the default
+    def sd(key, val):
         if val is not None:
             os.environ.setdefault(key, str(val))
 
-    def sd_bool(key, val):  # YAML true/false -> the "1"/"0" the env parsing expects
+    def sd_bool(key, val):
         if val is not None:
             os.environ.setdefault(key, "1" if val else "0")
 
-    # 1) verbatim escape hatch first — a raw PREFILL_* key wins over the typed blocks (setdefault:
-    #    first write wins; a shell-exported env var pre-empts both).
     for key, val in (manifest.get("env") or {}).items():
         sd(key, val)
 
-    # 2) typed blocks -> PREFILL_* env.
     model = manifest.get("model") or {}
     sd("PREFILL_MODEL", model.get("variant"))
     sd("PREFILL_NUM_LAYERS", model.get("num_layers"))
@@ -160,10 +64,10 @@ def _apply_manifest_env(manifest_path: str) -> dict:
     sd("PREFILL_PRODUCER_SEED", workload.get("seed"))
     sd_bool("PREFILL_PRODUCER_CHECK_PCC", workload.get("check_pcc"))
     sd("PREFILL_TRACE_DIR", workload.get("trace_dir"))
-    slot_prompts = workload.get("slot_prompts")  # per-slot prompt trace dirs; index = slot_id
+    slot_prompts = workload.get("slot_prompts")
     if slot_prompts is not None:
         sd("PREFILL_PRODUCER_SLOT_TRACES", slot_prompts if isinstance(slot_prompts, str) else ",".join(slot_prompts))
-    gap_ms = workload.get("gap_ms")  # accept a "lo,hi" string or a [lo, hi] list
+    gap_ms = workload.get("gap_ms")
     if gap_ms is not None:
         sd("PREFILL_PRODUCER_GAP_MS", gap_ms if isinstance(gap_ms, str) else ",".join(str(x) for x in gap_ms))
 
@@ -171,24 +75,15 @@ def _apply_manifest_env(manifest_path: str) -> dict:
     return manifest
 
 
-# PrefillMetadata on the wire: 3 x uint32 = [slot_id, actual_start, actual_end].
 METADATA_SIZE_BYTES = 12
 
 
 def _load_env_config() -> None:
-    """(Re)bind the transport/model constants below from the CURRENT environment.
-
-    Called once at import so a plain ``import prefill_producer`` still yields usable constants, and again
-    from ``main()`` right after the manifest is applied — the manifest only reaches the env at that point,
-    so the import-time values would otherwise be pre-manifest defaults. Importing this module never
-    MUTATES the environment; only ``main()`` does, via _apply_manifest_env."""
     global SP_AXIS, TP_AXIS, GLOBAL_MESH_SHAPE, CHUNK_SIZE, MAX_SEQ_LEN, NUM_LAYERS, ADAPTER
     SP_AXIS = int(os.environ.get("PREFILL_SP", 8))
     TP_AXIS = int(os.environ.get("PREFILL_TP", 4))
     GLOBAL_MESH_SHAPE = (SP_AXIS, TP_AXIS)
     CHUNK_SIZE = int(os.environ.get("PREFILL_CHUNK_SIZE", 5 * 1024))
-    # Same 11-chunk default as the runner: a larger default here would clamp requests to a depth the
-    # runner's cache can't hold, and the runner asserts on the overrunning chunk.
     MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", CHUNK_SIZE * 11))
     NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", 61))
     ADAPTER = get_adapter(os.environ.get("PREFILL_MODEL", DEFAULT_MODEL))
@@ -198,14 +93,10 @@ _load_env_config()
 
 
 def _pack_metadata(slot_id: int, actual_start: int, actual_end: int) -> bytes:
-    """Pack one chunk's PrefillMetadata (3 little-endian uint32s)."""
     return struct.pack("<III", slot_id, actual_start, actual_end)
 
 
 def _chunk_to_host_array(chunk_token_ids):
-    """One chunk's tokens as the un-sharded [SP, 1, chunk_local] uint32 buffer the H2D service expects.
-    Block-cyclic / chip-major layout, matching the runner's prepare_prefill_input_tensor; the connected
-    service resplits it across SP coordinates, so this process needs no MeshDevice."""
     sp = GLOBAL_MESH_SHAPE[0]
     chunk_local = CHUNK_SIZE // sp
     return (
@@ -217,23 +108,10 @@ def _chunk_to_host_array(chunk_token_ids):
     )
 
 
-# ---------------------------------------------------------------------------
-# Device-less helpers: read the KV table / device map, attach the LayerAck channel, decode cache data.
-# All device-less on purpose — none may touch a real ttnn device (that would take the CHIP_IN_USE
-# lock the runner holds and deadlock).
-# ---------------------------------------------------------------------------
-
-
-# Per-host filesystems: a table written under one of these by rank 0 is invisible to validators on
-# other hosts, which resolve the same path against their OWN local mount.
 _PER_HOST_FS_PREFIXES = ("/tmp", "/dev/shm", "/run", "/var/tmp")
 
 
 def _require_shared_table_path(world_size: int) -> None:
-    """Every validator reads the same serialized table rank 0 writes, so multi-rank requires it on
-    shared storage. Reject the per-host default early and symmetrically — same env + world_size on
-    every rank means all ranks exit together, never half-opening a coordination barrier — instead of
-    letting a remote validator silently read a missing/stale file."""
     if world_size <= 1:
         return
     table_path = os.path.abspath(os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb"))
@@ -247,9 +125,6 @@ def _require_shared_table_path(world_size: int) -> None:
 
 
 def _read_kv_chunk_table(timeout_s: int):
-    """Poll for and deserialize the KV chunk address table the runner published to
-    PREFILL_MIGRATION_TABLE_PATH. Fully device-less (import_from_protobuf_file rebuilds it from the
-    protobuf alone). Returns the table, or None if it never appears (the producer can still push)."""
     table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
     deadline = time.perf_counter() + timeout_s
     while not os.path.exists(table_path):
@@ -274,15 +149,6 @@ def _read_kv_chunk_table(timeout_s: int):
 
 
 def _read_device_map(timeout_s: int) -> dict:
-    """Poll for and read the runner's fabric_node -> ASIC-unique_id sidecar, so read_dram_umd can pick
-    chips by unique_id without touching the ControlPlane. Returns {(mesh_id, chip_id): unique_id}.
-
-    The runner's two publishers do not share an encoding -- the shmem path writes JSON keyed
-    "<mesh>:<chip>", the file-export path writes "<mesh> <chip> <umd>" lines -- so accept either.
-
-    A multi-rank runner writes one rank-scoped file per co-located rank (``<stem>_r<rank>.json``), so
-    all matches on this host are merged. Clear stale ``_r*`` siblings between runs whose topology
-    changed -- a leftover file would merge in."""
     import glob as _glob
     import json
 
@@ -327,9 +193,6 @@ def _read_device_map(timeout_s: int) -> dict:
 
 
 def _connect_layer_ack_channel(timeout_s: int):
-    """Attach (consumer side) to the runner's per-layer LayerAck channel
-    (/tt_prefill_layer_acks_<service_id>). Returns the channel, or None if it isn't available (only the
-    single-rank runner creates it)."""
     service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
     shm_name = f"/tt_prefill_layer_acks_{service_id}"
     try:
@@ -342,8 +205,6 @@ def _connect_layer_ack_channel(timeout_s: int):
 
 
 def _drain_layer_acks(ack_channel, expected: int, timeout_s: float = 600.0) -> int:
-    """Block until `expected` per-layer acks (NUM_LAYERS per chunk) have been drained, or timeout.
-    Returns the count actually drained."""
     if ack_channel is None:
         return 0
     drained = 0
@@ -365,39 +226,26 @@ def _drain_layer_acks(ack_channel, expected: int, timeout_s: float = 600.0) -> i
 
 
 def _decode_bfp8_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
-    """Decode a [32, head_dim] bfp8_b tile chunk (raw device bytes) to a float32 [32, head_dim] tensor,
-    in pure numpy (no ttnn tensor ops, so it never inits the device context / takes the CHIP_IN_USE
-    lock). Validated bit-exact against ttnn._ttnn.bfp_utils.unpack_bfp8.
-
-    Layout per 1088-byte tile: 64 exponent bytes (one per (face, row)) then 1024 mantissa bytes
-    ((face, row, col)); value = (-1)^sign * (mantissa & 0x7F) * 2^(exponent - 133). Face f = fr*2 + fc
-    maps to tile rows fr*16 + r and cols fc*16 + c; tiles lie along the head_dim (column) axis.
-    """
     TILE = 32
     n_tiles = head_dim // TILE
     raw_u8 = np.frombuffer(raw, dtype=np.uint8).reshape(n_tiles, 1088)
 
-    exponents = raw_u8[:, :64].astype(np.int32).reshape(n_tiles, 4, 16)  # (tile, face, row)
-    mantissas = raw_u8[:, 64:].reshape(n_tiles, 4, 16, 16)  # (tile, face, row, col)
+    exponents = raw_u8[:, :64].astype(np.int32).reshape(n_tiles, 4, 16)
+    mantissas = raw_u8[:, 64:].reshape(n_tiles, 4, 16, 16)
     signs = (mantissas >> 7).astype(np.int32)
     magnitude = (mantissas & 0x7F).astype(np.float32)
     scale = np.exp2((exponents - 133).astype(np.float32))[..., None]
-    values = np.where(signs > 0, -(magnitude * scale), magnitude * scale)  # (tile, face, row, col)
+    values = np.where(signs > 0, -(magnitude * scale), magnitude * scale)
 
-    # face (fr, fc) -> tile rows fr*16+r, cols fc*16+c
     by_face = values.reshape(n_tiles, 2, 2, 16, 16).transpose(0, 1, 3, 2, 4).reshape(n_tiles, TILE, TILE)
-    decoded = by_face.transpose(1, 0, 2).reshape(TILE, n_tiles * TILE)  # tile t -> columns [t*32 : (t+1)*32]
+    decoded = by_face.transpose(1, 0, 2).reshape(TILE, n_tiles * TILE)
     return torch.from_numpy(np.ascontiguousarray(decoded))
 
 
 def _decode_bf16_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
-    """Decode a ``[32, head_dim]`` bf16 TILE chunk (raw device bytes) to float32, device-less. Same face/
-    tile de-swizzle as ``_decode_bfp8_chunk`` but bf16 has no exponent block: each 2048-byte tile is 1024
-    bf16 values (uint16 -> float32 via a 16-bit left shift, which is exact). NOTE: not validated against a
-    ttnn unpack the way the bf8 path is."""
     TILE = 32
     n_tiles = head_dim // TILE
-    u16 = np.frombuffer(raw, dtype="<u2").reshape(n_tiles, 4, 16, 16)  # (tile, face, row, col)
+    u16 = np.frombuffer(raw, dtype="<u2").reshape(n_tiles, 4, 16, 16)
     f32 = (u16.astype(np.uint32) << 16).view(np.float32)
     by_face = f32.reshape(n_tiles, 2, 2, 16, 16).transpose(0, 1, 3, 2, 4).reshape(n_tiles, TILE, TILE)
     decoded = by_face.transpose(1, 0, 2).reshape(TILE, n_tiles * TILE)
@@ -405,7 +253,6 @@ def _decode_bf16_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
 
 
 def _decode_row_major_chunk(raw: bytes, head_dim: int, dtype: torch.dtype) -> torch.Tensor:
-    """Decode 32 native row pages, dropping any physical row padding."""
     element_size = torch.empty((), dtype=dtype).element_size()
     if len(raw) % _KV_CHUNK_TOKENS != 0:
         raise ValueError(f"row-major KV chunk has {len(raw)} bytes, not a multiple of {_KV_CHUNK_TOKENS} rows")
@@ -431,7 +278,6 @@ _SCALED_FP8_ROW_BYTES = _SCALED_FP8_ROPE_OFFSET + _SCALED_FP8_ROPE_DIM * 2
 
 
 def _decode_scaled_fp8_kv_rows(rows: torch.Tensor, head_dim: int) -> torch.Tensor:
-    """Reconstruct ``[scaled latent | RoPE]`` from packed mixed-format row bytes."""
     if head_dim != _SCALED_FP8_LATENT_DIM + _SCALED_FP8_ROPE_DIM:
         raise ValueError(f"packed scaled-FP8 KV requires head_dim 576, got {head_dim}")
 
@@ -454,12 +300,6 @@ def _decode_scaled_fp8_kv_rows(rows: torch.Tensor, head_dim: int) -> torch.Tenso
 
 
 def _decode_kv_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
-    """Decode one raw 32-token MLA KV chunk by its table-reported physical byte size.
-
-    The deployed 576-wide formats have distinct physical row sizes: tiled bfp8_b, raw row-major
-    fp8_e4m3, packed scaled FP8, and row-major bfloat16. The packed format is reconstructed from its
-    512 E4M3 latent bytes, four FP32 scales, and 64 BF16 RoPE values. Row padding is discarded.
-    """
     if head_dim % 32 == 0 and len(raw) == (head_dim // 32) * _BFP8_TILE_BYTES:
         return _decode_bfp8_chunk(raw, head_dim)
 
@@ -479,8 +319,6 @@ def _decode_kv_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
 
 
 def _resolve_unique_id(fabric_node_ids, device_map: dict) -> int:
-    """ASIC unique_id for any replica fabric node present in the device map (replicas hold identical KV,
-    and add_device_group sorts the ids so index 0 is not a fixed chip). Raises if none are mapped."""
     for node in fabric_node_ids:
         key = (int(node.mesh_id), int(node.chip_id))
         if key in device_map:
@@ -489,37 +327,27 @@ def _resolve_unique_id(fabric_node_ids, device_map: dict) -> int:
     raise KeyError(f"no fabric node {tried} in device map ({len(device_map)} chips; single-rank/one-galaxy only)")
 
 
-# ---------------------------------------------------------------------------
-# Config + scheduler engine (mode-unaware; run_schedule touches no device/ttnn, so it is unit-testable)
-# ---------------------------------------------------------------------------
-
-
 @dataclass
 class ProducerConfig:
-    """A flat description of a push schedule. A "scenario" is just a set of these values."""
-
-    num_users: int  # number of concurrent cache slots (users)
-    chunks_min: int  # per-request chunk count is rng.randint(chunks_min, chunks_max)
+    num_users: int
+    chunks_min: int
     chunks_max: int
-    max_requests: int  # total requests across all slots before stopping
-    duration_s: float  # wall-clock bound (inf => stop on request count only)
-    p_gap: float  # per-step probability of an idle gap
-    p_burst: float  # per-step probability of a 2-3 chunk burst to one slot
-    gap_ms: tuple  # (min, max) idle-gap milliseconds
-    mid_chunk_end_prob: float  # probability a request ends mid-chunk (exercises the actual_end clamp)
+    max_requests: int
+    duration_s: float
+    p_gap: float
+    p_burst: float
+    gap_ms: tuple
+    mid_chunk_end_prob: float
     seed: int
-    verify: bool  # read KV back and PCC each resident slot vs golden
+    verify: bool
     pcc_threshold: float
-    interleave: str = "random"  # slot order: "random" | "round_robin" (fair alternation)
-    slot_lengths: dict = None  # per-slot real token count (from per-slot prompts); overrides the random
-    # chunk draw + mid_chunk_end when set (each slot pushes exactly its prompt). None => synthetic depth.
-    multi_turn_prob: float = 0.0  # P(a recycled slot resumes its conversation at the 32-aligned cached
-    # prefix instead of restarting at 0). 0.0 => every recycle is a fresh request (pre-multi-turn behaviour).
+    interleave: str = "random"
+    slot_lengths: dict = None
+    multi_turn_prob: float = 0.0
 
 
 def _config_from_env() -> ProducerConfig:
-    """Build a ProducerConfig from the flat PREFILL_PRODUCER_* env vars (every knob independent)."""
-    max_chunks = MAX_SEQ_LEN // CHUNK_SIZE  # a request can't exceed the per-user cache
+    max_chunks = MAX_SEQ_LEN // CHUNK_SIZE
     chunk_bounds = [int(x) for x in os.environ.get("PREFILL_PRODUCER_CHUNKS", "11").split(",")]
     chunks_max = min(chunk_bounds[-1], max_chunks)
     chunks_min = min(chunk_bounds[0], chunks_max)
@@ -548,18 +376,14 @@ def _config_from_env() -> ProducerConfig:
 
 
 class _Slot:
-    """One cache-user slot holding one in-flight request. `next_chunk` advances per push; `actual_isl` is
-    the conversation's real (non-pad) token count. `prefix_len` is the 32-aligned absolute cache offset
-    this turn resumes at (0 for a fresh conversation); every length here is absolute, not turn-relative."""
-
     def __init__(self, slot_id: int):
         self.slot_id = slot_id
         self.req_id = -1
         self.target_chunks = 0
         self.next_chunk = 0
         self.actual_isl = 0
-        self.prefix_len = 0  # absolute, 32-aligned; where this turn starts writing
-        self.turn_idx = 0  # 0 = first turn of the conversation resident in this slot
+        self.prefix_len = 0
+        self.turn_idx = 0
 
     @property
     def done(self) -> bool:
@@ -567,32 +391,18 @@ class _Slot:
 
 
 class _SlotFill(NamedTuple):
-    """How much of one slot's KV cache the prefill filled: `real_len`, the absolute non-pad extent
-    [0, real_len) the runner actually wrote (the last `actual_end` pushed). Recorded, not re-derived from
-    chunk counts -- a multi-turn slot resumes at a non-zero prefix, so chunks_pushed * CHUNK_SIZE would
-    describe only its latest turn. Shared producer/migration_driver contract."""
-
     real_len: int
 
 
 def _new_request(
     slot: _Slot, req_id: int, cfg: ProducerConfig, rng: random.Random, *, prefix_len: int = 0, turn_idx: int = 0
 ) -> None:
-    """(Re)assign a request to `slot`, starting at chunk 0 of a turn that writes from `prefix_len`.
-
-    Per-slot-prompt mode (cfg.slot_lengths set): the slot pushes exactly its assigned prompt (depth
-    ceil(real_len / CHUNK_SIZE)); the random chunk draw + mid_chunk_end are bypassed. Otherwise a random
-    chunk count, optionally ending mid-chunk. A resumed turn (prefix_len > 0) clamps its depth draw to the
-    capacity still left under the per-user cache; at prefix_len == 0 that clamp is already chunks_max, so
-    the rng sequence is unchanged."""
     slot.req_id = req_id
     slot.next_chunk = 0
     slot.prefix_len = prefix_len
     slot.turn_idx = turn_idx
     if cfg.slot_lengths is not None and slot.slot_id in cfg.slot_lengths:
         real_len = cfg.slot_lengths[slot.slot_id]
-        # real_len is relative to the turn; actual_isl is absolute, so a resumed turn ends at
-        # prefix_len + real_len. If that no longer fits the per-user cache, restart the conversation.
         if prefix_len + real_len > MAX_SEQ_LEN:
             prefix_len = slot.prefix_len = 0
             slot.turn_idx = 0
@@ -612,7 +422,7 @@ def _new_request(
 
 @dataclass
 class RunStats:
-    resident: dict  # slot_id -> _SlotFill (what is physically in that slot's KV cache)
+    resident: dict
     total_pushes: int
     push_ms: list
     completed: int
@@ -620,19 +430,10 @@ class RunStats:
 
 
 def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, sleep_fn=time.sleep, rng=None):
-    """Execute the push schedule described by `cfg`.
-
-    Device-free: `push_fn(slot_id, chunk_idx, actual_start, actual_end) -> elapsed_ms` does and times the
-    push; now_fn/sleep_fn/rng are injectable so tests run instantly and deterministically. Records each
-    slot's resident request as a `_SlotFill` at push time, and returns RunStats. A recycled slot restarts
-    at chunk 0 unless `cfg.multi_turn_prob` continues the conversation from its aligned-down length; either
-    way `_SlotFill.real_len` is the slot's absolute non-pad extent.
-    """
     rng = rng if rng is not None else random.Random(cfg.seed)
     slots = [_Slot(i) for i in range(cfg.num_users)]
     resident: dict = {}
 
-    # Give every slot an initial request; `next_req_id` counts total requests (initial + recycled).
     next_req_id = 0
     for slot in slots:
         _new_request(slot, next_req_id, cfg, rng)
@@ -641,7 +442,7 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
     push_ms: list = []
     total_pushes = 0
     completed = 0
-    round_robin_cursor = -1  # only used when cfg.interleave == "round_robin"
+    round_robin_cursor = -1
     start = now_fn()
 
     def send_chunk(slot: _Slot) -> None:
@@ -652,14 +453,10 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
         push_ms.append(push_fn(slot.slot_id, chunk_idx, actual_start, actual_end))
         total_pushes += 1
         slot.next_chunk += 1
-        resident[slot.slot_id] = _SlotFill(real_len=actual_end)  # what's now resident in this slot
+        resident[slot.slot_id] = _SlotFill(real_len=actual_end)
         if slot.done:
             completed += 1
-            if next_req_id < cfg.max_requests:  # recycle the slot
-                # Multi-turn: resume at the aligned prefix already cached. Align DOWN to 32
-                # (update_padded_kv_cache asserts kv_actual_global % 32 == 0); the <=31 tail tokens are
-                # replayed by this turn's first chunk (PCC-idempotent). Guarded so the default path draws
-                # no extra rng value and the schedule stays bit-identical.
+            if next_req_id < cfg.max_requests:
                 prefix = (slot.actual_isl // _KV_CHUNK_TOKENS) * _KV_CHUNK_TOKENS
                 if (
                     cfg.multi_turn_prob > 0
@@ -676,14 +473,12 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
         if not active_slots:
             break
 
-        # One random draw classifies the step: [0, p_gap) gap, [p_gap, p_gap+p_burst) burst, else single.
         roll = rng.random()
         if roll < cfg.p_gap:
             sleep_fn(rng.uniform(*cfg.gap_ms) / 1000.0)
             continue
 
         if cfg.interleave == "round_robin":
-            # Advance the cursor to the next non-done slot (active_slots is non-empty, so this finds one).
             for _ in range(len(slots)):
                 round_robin_cursor = (round_robin_cursor + 1) % len(slots)
                 if not slots[round_robin_cursor].done:
@@ -692,7 +487,7 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
         else:
             slot = rng.choice(active_slots)
 
-        if roll < cfg.p_gap + cfg.p_burst:  # burst: 2-3 chunks to this slot
+        if roll < cfg.p_gap + cfg.p_burst:
             for _ in range(rng.randint(2, 3)):
                 if slot.done:
                     break
@@ -705,25 +500,7 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
     )
 
 
-# ---------------------------------------------------------------------------
-# Per-slot KV read-back + PCC (device-less: read_dram_umd over UMD + host cache decode)
-# ---------------------------------------------------------------------------
-
-
 def _read_slot_kv_and_check_pcc(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
-    """Read slot `slot_id`'s KV over [0, real_len) via the published table and PCC-check it against the
-    golden trace. Dispatches on the model: MLA (single merged kvpe config), M3 (multi-config triple
-    cache), or GPT-OSS (multi-config K/V heads, no index_k). Returns ``{cache name: min PCC across that
-    cache's layers}`` — one entry per MODEL cache actually validated, so the caller can gate on the min
-    while still reporting each cache separately. A cache with no golden to compare against is ABSENT from
-    the mapping rather than present at 1.0.
-
-    The reader is NOT adapter-pluggable — a new model whose cache is neither of those layouts needs
-    a branch here (and its own decode), not just an adapter.
-
-    The MODEL's own caches only. Under DFlash the drafter's context caches ride in the same table under
-    further `dflash_*` configs, checked as a sibling gate from _verify_resident_slots (see
-    dflash_kv_table_pcc_check in the deepseek dflash_prefill module)."""
     golden_cap = int(os.environ.get("PREFILL_PCC_GOLDEN_LEN", "0"))
     if golden_cap:
         real_len = min(real_len, golden_cap)
@@ -735,19 +512,14 @@ def _read_slot_kv_and_check_pcc(table, device_map: dict, slot_id: int, real_len:
 
 
 def _config_names(table) -> list:
-    """Every config's name, indexed by config id."""
     return [table.config_name(i) for i in range(table.num_configs())]
 
 
 def _num_model_configs(table) -> int:
-    """Configs describing the MODEL's own caches (KVPE + any index cache), i.e. the decimal-named ones. The
-    drafter's `dflash_*` are excluded, so `num_configs() > 1` can't read a dense+DFlash table as sparse."""
     return sum(1 for name in _config_names(table) if name.isdigit())
 
 
 def _read_kv_slice(table, device_map, config_id, layer, slot_id, read_len, head_dim, decode):
-    """Read one config's KV chunks over [0, read_len) for (layer, slot) via the address table and return
-    the decoded ``[read_len, head_dim]`` tensor in natural token order."""
     from models.demos.minimax_m3.tt.attention.kv_cache import NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
 
     rows = []
@@ -760,9 +532,6 @@ def _read_kv_slice(table, device_map, config_id, layer, slot_id, read_len, head_
 
 
 def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
-    """GPT-OSS multi-config read-back: reconstruct per-head K/V from the 2N-config table and PCC vs the
-    GQA golden (no index_k). Config layout: k_h0..N-1 = 0..N-1, v_h0..N-1 = N..2N-1. Returns the per-cache
-    minima keyed by cache name."""
     from pathlib import Path
 
     from safetensors import safe_open
@@ -786,7 +555,6 @@ def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, r
     mins = {"k": 1.0, "v": 1.0}
     checked = 0
     for layer in range(NUM_LAYERS):
-        # Skip layers owned by another host's stage (their chips are not in this host's device map).
         loc0 = table.lookup(layer, 0, slot_id, 0)
         try:
             _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
@@ -822,16 +590,12 @@ def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, r
         f"[producer] slot {slot_id} GPT-OSS KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} (min {min_pcc:.6f})"
     )
-    # Zero resolved layers would return the 1.0 inits as a perfect pass — fail loudly instead.
     if checked == 0:
         raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
     return mins
 
 
 def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
-    """M3 multi-config read-back: reconstruct per-head K/V + index_k from the 9-config table and PCC vs the
-    separate_k_v golden. Config layout matches the builder: k_h0..N-1 = 0..N-1, v_h0..N-1 = N..2N-1,
-    index_k = 2N. Returns the per-cache minima keyed by cache name."""
     from pathlib import Path
 
     from safetensors import safe_open
@@ -842,8 +606,7 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
 
     mc = ADAPTER.model_config
     n_kv, head_dim, rotary_dim = mc.NUM_KEY_VALUE_HEADS, mc.HEAD_DIM, mc.ROTARY_DIM
-    perm = _hf_to_meta_rotary_perm(head_dim, rotary_dim)  # golden HF -> device Meta rotary swizzle
-    # index_k dtype from its config's chunk size (bf8 vs bf16) -> the right decoder.
+    perm = _hf_to_meta_rotary_perm(head_dim, rotary_dim)
     ik_cfg = 2 * n_kv
     ik_bf16 = table.config(ik_cfg).chunk_size_bytes == (head_dim // 32) * 2048
     ik_decode = _decode_bf16_chunk if ik_bf16 else _decode_bfp8_chunk
@@ -856,7 +619,6 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
     checked = 0
     ik_checked = 0
     for layer in range(NUM_LAYERS):
-        # Skip layers owned by another host's stage (their chips are not in this host's device map).
         loc0 = table.lookup(layer, 0, slot_id, 0)
         try:
             _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
@@ -869,9 +631,7 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
                 for h in range(n_kv)
             ],
             dim=0,
-        )[
-            :, :real_len
-        ]  # [n_kv, real_len, head_dim]
+        )[:, :real_len]
         dev_v = torch.stack(
             [
                 _read_kv_slice(table, device_map, n_kv + h, layer, slot_id, read_len, head_dim, _decode_bfp8_chunk)
@@ -882,7 +642,7 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
 
         with safe_open(str(kv_dir / f"layer_{layer}.safetensors"), framework="pt") as h:
             keys = set(h.keys())
-            g_k = h.get_tensor(f"key_cache_layer_{layer}").float()[0, :, :real_len, :][..., perm]  # HF -> Meta
+            g_k = h.get_tensor(f"key_cache_layer_{layer}").float()[0, :, :real_len, :][..., perm]
             g_v = h.get_tensor(f"value_cache_layer_{layer}").float()[0, :, :real_len, :]
             has_ik = f"index_k_cache_layer_{layer}" in keys
             g_ik = (
@@ -906,43 +666,23 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
         f"[producer] slot {slot_id} M3 KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} index_k={mins['index_k']:.5f} (min {min_pcc:.6f})"
     )
-    # Zero resolved layers would return the 1.0 inits as a perfect pass — fail loudly instead.
     if checked == 0:
         raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
-    # Only some traces carry an index_k golden. Its min is still the 1.0 init when none did, so drop the
-    # key rather than reporting an unmeasured cache as perfect.
     if not ik_checked:
         del mins["index_k"]
     return mins
 
 
 def _full_indexer_layer_indices(num_layers: int):
-    """Global layer indices that own a lightning indexer, over layers [0, num_layers).
-
-    GLM-5.2 reuses one ``full`` layer's top-k across the ``shared`` layers that follow, so only full
-    layers write the index cache and config 1 of the merged table is COMPACTED to that count: its layer
-    axis is the full-indexer RANK, not the global layer index. The golden trace's
-    ``dsa/indexer_k_layer_N`` is numbered by GLOBAL layer, so rank -> global has to be mapped before
-    loading it (GLM-5.2 full layers are {0, 1, 2, 6, 10, ... 74}, so rank 3 is global layer 6).
-
-    Returns None when the model has no ``indexer_types`` map (GLM-5.1 / v3.2: every layer is a full
-    indexer owner, so rank == global index and no mapping is needed).
-    """
     from models.demos.deepseek_v3_d_p.tt.mla.indexer import indexer_layer_is_reused
 
-    hf_config = ADAPTER.load_hf_config()  # host-only attribute config; no device, no weights
+    hf_config = ADAPTER.load_hf_config()
     if not getattr(hf_config, "indexer_types", None):
         return None
     return [layer for layer in range(num_layers) if not indexer_layer_is_reused(hf_config, layer)]
 
 
 def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
-    """Read slot `slot_id`'s KV over [0, real_len) via the table and validate it. Config 0 (the KVPE
-    cache) is PCC'd vs the golden trace. For a sparse/DSA model the merged table also carries config 1
-    (the index-key cache), which is PCC'd vs the golden indexer key. Returns ``{"kvpe": min}`` plus
-    ``"index": min`` when the index cache was validated — omitted, not defaulted to 1.0, when the model is
-    dense or the trace carries no indexer-key golden (warned, not fatal — see below). Raises on an
-    index-cache READ failure."""
     from models.demos.deepseek_v3_d_p.tt.mla.indexer import normalized_hadamard_matrix
     from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import (
         _load_golden_index_k,
@@ -952,36 +692,31 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
     from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     from tests.ttnn.utils_for_testing import comp_pcc
 
-    KV_LORA = ADAPTER.model_config.KV_LORA_RANK  # "nope" part: device_kv[:, :KV_LORA]
-    HEAD_DIM = KV_LORA + ADAPTER.model_config.QK_ROPE_HEAD_DIM  # + rope "pe" part: device_kv[:, KV_LORA:]
+    KV_LORA = ADAPTER.model_config.KV_LORA_RANK
+    HEAD_DIM = KV_LORA + ADAPTER.model_config.QK_ROPE_HEAD_DIM
     tokens_per_block = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
-    read_len = ((real_len + tokens_per_block - 1) // tokens_per_block) * tokens_per_block  # round up to a block
+    read_len = ((real_len + tokens_per_block - 1) // tokens_per_block) * tokens_per_block
 
     min_pcc = 1.0
     checked = 0
     for layer in range(NUM_LAYERS):
-        # A merged multi-rank table spans every host's layers, but this producer's device map holds only
-        # its co-located host's chips, so a layer owned by another rank resolves to no local unique_id.
-        # Skip it: each rank validates exactly the layers physically resident on its own machine.
         loc0 = table.lookup(layer, 0, slot_id)
         try:
             _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
         except KeyError:
             continue
 
-        # Read this layer's KV block by block over UMD, decode its physical cache format, and concat.
         decoded_rows = []
         for pos in range(0, read_len, tokens_per_block):
             loc = table.lookup(layer, pos, slot_id)
             unique_id = _resolve_unique_id(table.get_device_group(loc.device_group_index).fabric_node_ids, device_map)
             raw = ttnn.experimental.disaggregation.read_dram_umd(unique_id, loc.noc_addr, loc.size_bytes)
             decoded_rows.append(_decode_kv_chunk(raw, HEAD_DIM))
-        device_kv = torch.cat(decoded_rows, dim=0)[:real_len]  # natural order (table un-rotates block-cyclic)
+        device_kv = torch.cat(decoded_rows, dim=0)[:real_len]
 
         golden = _load_golden_kv_post(trace_dir, layer, real_len)
         _, pcc_nope = comp_pcc(golden[:, :KV_LORA], device_kv[:, :KV_LORA])
 
-        # The rope "pe" columns are stored interleaved in HF layout; re-interleave the golden to Meta layout.
         golden_pe = golden[:, KV_LORA:]
         pe_dim = golden_pe.shape[-1]
         golden_pe = torch.stack([golden_pe[:, : pe_dim // 2], golden_pe[:, pe_dim // 2 :]], dim=-1).reshape(-1, pe_dim)
@@ -995,23 +730,9 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
         f"[producer] slot {slot_id} KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
         f"{min_pcc:.6f}"
     )
-    # No local layer resolved to this rank's device map — min_pcc is still its 1.0 init, which would
-    # masquerade as a perfect pass. A rank that was asked to verify but owns no layers of this slot is a
-    # misconfiguration (wrong device map / stage split), so fail loudly instead of returning 1.0.
     if checked == 0:
         raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
 
-    # config 1: index cache (sparse/DSA only). Validated the SAME way as config 0 — read block-by-block
-    # via the table, decode, and PCC vs the golden indexer key. Config 1 holds all layers on GLM-5.1 and
-    # only the full-indexer layers on GLM-5.2, so iterate its OWN layer count, not NUM_LAYERS. The index
-    # cache is bf8 TILE. Its Hadamard transform is undone before comparing against the natural-basis
-    # golden, which is already in the device rope frame (no re-interleave, unlike pe).
-    #
-    # A trace can carry the KVPE golden but no indexer-key golden (some vllm dumps store only
-    # dsa/dsa_topk_indices_layer_*). There is then nothing to PCC config 1 against, so warn and return the
-    # config-0 PCC rather than failing the slot: the KVPE result is still a valid check.
-    # `_num_model_configs`, not `num_configs()`: under DFlash the same table also carries the drafter's
-    # `dflash_*` configs, and config 1 is only the index cache when the MODEL published two caches.
     mins = {"kvpe": min_pcc}
     if _num_model_configs(table) > 1:
         if not index_golden_present(trace_dir):
@@ -1024,7 +745,6 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
         index_head_dim = ADAPTER.model_config.INDEX_HEAD_DIM
         index_hadamard = normalized_hadamard_matrix(index_head_dim).float()
         n_index_layers = table.config(1).num_layers
-        # Config 1 is published on the GLOBAL LAYER axis, same numbering as the golden: rows == full-indexer layer ids.
         full_layers = _full_indexer_layer_indices(NUM_LAYERS)
         index_rows = list(range(n_index_layers)) if full_layers is None else full_layers
         assert full_layers is None or max(full_layers) < n_index_layers, (
@@ -1035,8 +755,7 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
         min_index = 1.0
         checked_index = 0
         for layer in index_rows:
-            # Same host-local filter as config 0: skip an index layer owned by another rank.
-            loc0 = table.lookup(layer, 0, slot_id, 1)  # config 1 = index cache
+            loc0 = table.lookup(layer, 0, slot_id, 1)
             try:
                 _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
             except KeyError:
@@ -1044,20 +763,15 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
 
             decoded_rows = []
             for pos in range(0, read_len, tokens_per_block):
-                loc = table.lookup(layer, pos, slot_id, 1)  # config 1 = index cache, keyed by global layer
+                loc = table.lookup(layer, pos, slot_id, 1)
                 unique_id = _resolve_unique_id(
                     table.get_device_group(loc.device_group_index).fabric_node_ids, device_map
                 )
                 raw = ttnn.experimental.disaggregation.read_dram_umd(unique_id, loc.noc_addr, loc.size_bytes)
-                # Same byte-size-driven dispatch as config 0; a 128-wide bfp8 index chunk is
-                # (128/32) x 1088 = 4352 B, which lands on the bfp8 tile branch.
                 decoded_rows.append(_decode_kv_chunk(raw, index_head_dim))
             dev_ik = torch.cat(decoded_rows, dim=0)[:real_len]
 
             golden_ik = _load_golden_index_k(trace_dir, layer, real_len)
-            # Sparse prefill stores index keys in the decode indexer's orthonormal Hadamard basis.
-            # The trace golden is captured before that transform, so apply the symmetric,
-            # self-inverse H matrix once more to compare both tensors in the natural basis.
             dev_ik = (dev_ik.float() @ index_hadamard).to(torch.bfloat16)
             _, pcc_index = comp_pcc(golden_ik, dev_ik)
             min_index = min(min_index, pcc_index)
@@ -1076,14 +790,6 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
 def _write_pcc_verdict(
     rank: int, ok: bool, min_pcc: float, checked: int, threshold: float, per_cache: dict | None = None
 ) -> None:
-    """Persist this rank's PCC verdict to PREFILL_PCC_SUMMARY_DIR (opt-in). The verdict is logged to
-    stdout just before the shutdown sentinel, and mpirun drops its buffered output forwarding when the
-    runner tears down in response — so under a launcher the numbers never reach the captured log. A file
-    on shared storage is read back by the harness independently of that teardown.
-
-    `min_pcc` is the gated number: the min over every validated cache. `per_cache` breaks it down by cache
-    (a sparse model's KVPE vs index cache), so a durable verdict distinguishes which cache set the bar and
-    shows that the others were checked at all — a cache missing from it was NOT validated."""
     summary_dir = os.environ.get("PREFILL_PCC_SUMMARY_DIR")
     if not summary_dir:
         return
@@ -1101,13 +807,6 @@ def _write_pcc_verdict(
 
 
 def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_traces: dict, rank: int = 0) -> bool:
-    """PCC-check every slot that holds resident trace-derived KV, each against ITS OWN golden trace
-    (slot_traces[slot_id]). Returns True only if at least one slot was checked and all met the threshold.
-
-    Two independent gates per slot, both of which must pass: the model's own caches vs the trace, and --
-    when the table carries the DFlash drafter's configs -- the drafter's context K/V at its own bar (see
-    dflash_kv_table_pcc_check). The drafter half is silent when not measured (no marker field, no success
-    line), so a non-DFlash run's output is unchanged."""
     device_map = _read_device_map(int(os.environ.get("PREFILL_H2D_CONNECT_TIMEOUT", "60")))
     if not device_map:
         logger.error("[producer] no device map available; skipping KV read/PCC.")
@@ -1115,9 +814,6 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
         return False
 
     dflash_threshold = float(os.environ.get("PREFILL_DFLASH_PCC", "0.88"))
-    # Under DFlash the table also carries the drafter's context caches (extra dflash_* configs); PCC them
-    # via the deepseek gate. The import + read closure are built only when those configs are present, so a
-    # non-DFlash run neither imports the deepseek module nor measures anything.
     check_dflash = any(name.startswith("dflash_") for name in _config_names(kv_table))
     if check_dflash:
         from models.demos.deepseek_v3_d_p.tt.dflash_prefill.dflash_kv_validation import dflash_kv_table_pcc_check
@@ -1128,8 +824,8 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
             )
 
     min_pcc_overall = 1.0
-    per_cache = {}  # cache name -> min over slots; a cache never validated stays absent
-    min_dflash_overall = None  # stays None unless a drafter slice is actually measured
+    per_cache = {}
+    min_dflash_overall = None
     checked = 0
     failures = []
     dflash_failures = []
@@ -1140,29 +836,25 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
         slot_mins = _read_slot_kv_and_check_pcc(kv_table, device_map, slot_id, real_len, slot_traces[slot_id])
         for cache, value in slot_mins.items():
             per_cache[cache] = value if cache not in per_cache else min(per_cache[cache], value)
-        pcc = min(slot_mins.values())  # the gate is the weakest cache
+        pcc = min(slot_mins.values())
         min_pcc_overall = min(min_pcc_overall, pcc)
         checked += 1
         if pcc < threshold:
             failures.append((slot_id, real_len, pcc))
         if check_dflash:
-            # None when no golden is configured (the drafter golden is prompt-specific, so opt-in).
             dflash_pcc = dflash_kv_table_pcc_check(
                 kv_table,
                 slot_id,
                 real_len,
                 read_config_slice=read_dflash_slice,
                 threshold=dflash_threshold,
-                rope_convention="interleaved",  # the only convention this branch's drafter implements
+                rope_convention="interleaved",
             )
             if dflash_pcc is not None:
                 min_dflash_overall = dflash_pcc if min_dflash_overall is None else min(min_dflash_overall, dflash_pcc)
                 if dflash_pcc < dflash_threshold:
                     dflash_failures.append((slot_id, real_len, dflash_pcc))
 
-    # The drafter field appears ONLY when it was measured: on every non-DFlash run the marker line is exactly
-    # what it was before this gate existed. Keep `min_pcc=` last-but-one so a `min_pcc=([\d.]+)` reader is
-    # unaffected either way.
     dflash_field = "" if min_dflash_overall is None else f" min_dflash_pcc={min_dflash_overall:.6f}"
     per_cache_field = "".join(f" {cache}_pcc={value:.6f}" for cache, value in per_cache.items())
     print(
@@ -1193,20 +885,13 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
     return True
 
 
-# ---------------------------------------------------------------------------
-# Entry point
-# ---------------------------------------------------------------------------
-
-
 def _percentile(sorted_values: list, p: float) -> float:
-    """p-th percentile (p in 0..1) of an already-sorted list; 0.0 if empty."""
     if not sorted_values:
         return 0.0
     return sorted_values[min(len(sorted_values) - 1, int(p * len(sorted_values)))]
 
 
 def _load_token_pool(trace_dir, num_tokens: int) -> list:
-    """A token pool a request replays from chunk 0, padded up to `num_tokens` if the trace is shorter."""
     pool = load_trace_token_ids(trace_dir, num_tokens)
     if len(pool) < num_tokens:
         pool = pool + [1] * (num_tokens - len(pool))
@@ -1214,20 +899,6 @@ def _load_token_pool(trace_dir, num_tokens: int) -> list:
 
 
 def _resolve_slot_prompts(cfg: ProducerConfig):
-    """Resolve each slot's prompt (tokens + golden trace) and load the token pool(s).
-
-    Returns ``(slot_traces, slot_lengths, pools_by_trace)``:
-      * slot_traces: {slot_id -> resolved trace Path}. Both the tokens pushed AND the golden PCC'd for a
-        slot come from its trace, so per-slot traces == per-slot prompts + per-slot goldens.
-      * slot_lengths: {slot_id -> real token count} in per-slot-prompt mode, else None (see _new_request).
-      * pools_by_trace: {trace Path -> token pool}, deduped so a trace shared by N slots loads once.
-
-    Single-prompt (default): no PREFILL_PRODUCER_SLOT_TRACES => every slot uses PREFILL_TRACE_DIR (or the
-    adapter default), the synthetic schedule drives depth (slot_lengths=None), one pool sized to chunks_max.
-
-    Multi-prompt: PREFILL_PRODUCER_SLOT_TRACES="dirA,dirB,..." assigns trace i to slot i (cycling by
-    ``slot % len`` if fewer entries than users, so "dirA,dirB" alternates across 8 users). Each slot then
-    pushes exactly its prompt: depth = ceil(real_len/CHUNK_SIZE), clamped to the per-user cache."""
     default = os.environ.get("PREFILL_TRACE_DIR", ADAPTER.prefill_trace_default)
     spec = os.environ.get("PREFILL_PRODUCER_SLOT_TRACES", "").strip()
     if spec and cfg.multi_turn_prob > 0:
@@ -1242,8 +913,6 @@ def _resolve_slot_prompts(cfg: ProducerConfig):
     if not spec:
         trace = resolve_trace_dir(default)
         slot_traces = {s: trace for s in range(cfg.num_users)}
-        # A resumed turn slices the pool from its prefix onward, so multi-turn needs a pool covering the
-        # whole per-user cache, not just one request's depth (else push_chunk's payload-size assert fires).
         pool_tokens = MAX_SEQ_LEN if cfg.multi_turn_prob > 0 else cfg.chunks_max * CHUNK_SIZE
         return slot_traces, None, {trace: _load_token_pool(trace, pool_tokens)}
 
@@ -1278,27 +947,7 @@ def _resolve_slot_prompts(cfg: ProducerConfig):
     return slot_traces, slot_lengths, pools_by_trace
 
 
-# Multi-rank coordination (device-less; GO/DONE over MPI collectives, not sync files)
-#
-# Only the barriers are MPI — the merged KV table and the device map are still delivered as files the
-# producer polls; the collectives just replace the old NFS GO/DONE sentinels.
-#
-# One producer runs per host under an MPI launcher (mpirun-ulfm), mirroring the pipeline runner's
-# ranks. rank 0 is the master (co-located with the runner's first rank): it alone feeds tokens over
-# H2D and owns the aggregated LayerAck channel. Every rank reads its OWN host's KV back and PCCs only
-# the layers resident on its machine (the merged table + a host-local device map filter to the local
-# layers automatically). Coordination is two collectives over the distributed context (host-side MPI,
-# NO mesh device): the master broadcasts the resident-slot map once every layer of every chunk has
-# acked — this releases the validators (GO) — then an allgather of each rank's PCC ok-flag both waits
-# for every validator's read-back to finish (DONE) and folds the verdicts, so the master holds the
-# runner's shutdown sentinel until the mesh/DRAM is safe to tear down.
-# ---------------------------------------------------------------------------
-
-
 def _mr_config():
-    """(rank, world_size). Under an MPI launcher (OMPI_COMM_WORLD_SIZE > 1) initialize the distributed
-    context and take rank/size from it. Standalone (the single-rank de-risk, no mpirun) skips MPI
-    entirely: 0 / 1, no coordination. rank 0 is the master; every other rank is a validator."""
     if int(os.environ.get("OMPI_COMM_WORLD_SIZE", "1")) <= 1:
         return (0, 1)
     if not ttnn.distributed_context_is_initialized():
@@ -1309,12 +958,6 @@ def _mr_config():
 
 
 def _mr_bcast_resident(rank: int, resident: dict) -> dict:
-    """Broadcast the master's resident-slot map (slot_id -> _SlotFill) to every rank via allgather_int:
-    element [0] of each allgather is rank 0's contribution, giving a broadcast from the only value-carrying
-    collective ttnn exposes (no native broadcast/scatter). Doubles as the GO barrier: a validator blocks in
-    the first allgather until the master arrives (only after it has drained every LayerAck). Non-master ranks
-    pass {} and receive the map. All ranks must issue the same number of allgathers in the same order, so the
-    slot count is broadcast first, then each slot's (slot_id, real_len)."""
     items = sorted(resident.items()) if rank == 0 else []
     n = ttnn.distributed_context_allgather_int(len(items) if rank == 0 else 0)[0]
     out: dict = {}
@@ -1327,20 +970,11 @@ def _mr_bcast_resident(rank: int, resident: dict) -> dict:
 
 
 def _mr_allgather_verdict(ok: bool) -> list:
-    """Collective: every rank contributes its PCC ok-flag and receives all of them. Doubles as the DONE
-    barrier — the master cannot proceed to the shutdown sentinel until every validator has reached here
-    (i.e. finished its read-back)."""
     return [bool(v) for v in ttnn.distributed_context_allgather_int(1 if ok else 0)]
 
 
 def _run_validator(rank: int, world_size: int) -> None:
-    """Non-master path: no H2D feed. Read the merged table, wait for the master's GO (the resident-map
-    broadcast), PCC this host's local layers, then join the verdict allgather (the master reads the
-    result). Exits non-zero on PCC failure."""
     cfg = _config_from_env()
-    # A validator's whole job is read-back PCC, and the GO barrier's "every layer is written" guarantee
-    # comes from the master draining LayerAcks — which it only does when verify is on. Both ranks see the
-    # same env, so this exits on every rank symmetrically (before any collective) — no half-open barrier.
     if not cfg.verify:
         logger.error("[producer] multi-rank requires PREFILL_PRODUCER_CHECK_PCC=1 (validators only verify).")
         sys.exit(1)
@@ -1348,10 +982,6 @@ def _run_validator(rank: int, world_size: int) -> None:
     timeout_s = int(os.environ.get("PREFILL_H2D_CONNECT_TIMEOUT", "60"))
     logger.info(f"[producer] validator rank={rank}/{world_size}: read-back only (no H2D feed)")
 
-    # GO before the table read: the master broadcasts the resident map only after draining every
-    # LayerAck, which also means rank 0 finished publishing this run's table. Reading after GO can't
-    # observe a stale prior-run table, and a read failure here still reaches the verdict allgather
-    # (ok=False) — the master already cleared GO, so it can't hang.
     resident = _mr_bcast_resident(rank, {})
     logger.info(f"[producer] validator rank={rank}: GO received, {len(resident)} resident slots")
 
@@ -1368,24 +998,19 @@ def _run_validator(rank: int, world_size: int) -> None:
         ok = False
     else:
         try:
-            # Rebuild the SAME config-derived slot->trace map the master builds (both ranks see identical
-            # env + the shared trace dir), so the validator PCCs its host's layers against the same goldens.
-            # Purely config-derived (no push/device state), so it's safe to resolve here on the read-back path.
             slot_traces, _slot_lengths, _pools = _resolve_slot_prompts(cfg)
             ok = _verify_resident_slots(kv_table, stats, cfg.pcc_threshold, slot_traces, rank=rank)
         except Exception as e:
             logger.error(f"[producer] validator KV read/PCC failed: {type(e).__name__}: {e}")
             ok = False
 
-    _mr_allgather_verdict(ok)  # DONE barrier + verdict fold
+    _mr_allgather_verdict(ok)
     logger.info(f"[producer] validator rank={rank}: DONE ok={ok}")
     if not ok:
         sys.exit(1)
 
 
 def main() -> None:
-    # argparse is the SINGLE place argv is read: --manifest defaults to PREFILL_PRODUCER_MANIFEST, so one
-    # parse covers both sources and unknown args still error out.
     parser = argparse.ArgumentParser(
         prog="prefill_producer",
         description="H2D producer for the prefill runner. Config comes from a YAML manifest "
@@ -1400,9 +1025,6 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # Apply the manifest HERE, not at import: importing this module must never mutate os.environ. Order
-    # matters — the manifest lands in the env first, then _load_env_config() re-reads the module constants
-    # (bound to pre-manifest defaults at import) and _config_from_env() reads the schedule knobs.
     if args.manifest:
         _apply_manifest_env(args.manifest)
     _load_env_config()
@@ -1413,9 +1035,6 @@ def main() -> None:
         return
 
     cfg = _config_from_env()
-    # See _run_validator: multi-rank coordination only holds together when every rank verifies (the GO
-    # barrier depends on the master draining LayerAcks, which is gated on verify). Assert it on the
-    # master too — same env on every rank means this exits symmetrically, never half-opening a barrier.
     if world_size > 1 and not cfg.verify:
         logger.error("[producer] multi-rank requires PREFILL_PRODUCER_CHECK_PCC=1 (all ranks verify).")
         sys.exit(1)
@@ -1432,15 +1051,8 @@ def main() -> None:
     payload_bytes = service.payload_size_bytes()
     logger.info(f"[producer] attached; payload={payload_bytes}B")
 
-    # Read the KV table BEFORE pushing (the runner publishes it at setup). Only the read-back needs it,
-    # and a runner that publishes no table (no migration, no PREFILL_MOCK_MIGRATION) would otherwise cost
-    # a full connect timeout of dead air before the first push.
     kv_table = _read_kv_chunk_table(timeout_s) if cfg.verify else None
-    # The LayerAck channel is a shared counter and try_consume_all() REMOVES completions. Draining it
-    # serves ONLY the golden-trace KV read-back below
 
-    # If we're not performing golden trace PCC-validation, then don't consume these and allow loopback
-    # migration test in prefill_runner.py to consume acks and perform the testing of loopback migration
     ack_channel = _connect_layer_ack_channel(timeout_s) if cfg.verify else None
     if cfg.verify and ack_channel is None:
         logger.error(
@@ -1455,10 +1067,8 @@ def main() -> None:
             "channel (pure token feeder; the runner's migration self-test owns it)"
         )
 
-    # Per-slot prompts: each slot pushes tokens from (and is PCC'd against) its own trace. With no
-    # PREFILL_PRODUCER_SLOT_TRACES every slot shares one trace (PREFILL_TRACE_DIR / the adapter default).
     slot_traces, slot_lengths, pools_by_trace = _resolve_slot_prompts(cfg)
-    cfg.slot_lengths = slot_lengths  # None => synthetic schedule depth; else depth per prompt length
+    cfg.slot_lengths = slot_lengths
 
     def push_chunk(slot_id: int, chunk_idx: int, actual_start: int, actual_end: int) -> float:
         pool = pools_by_trace[slot_traces[slot_id]]
@@ -1493,18 +1103,11 @@ def main() -> None:
         f"p99={_percentile(sorted_ms, 0.99):.1f}"
     )
 
-    # Wait for the runner's per-layer LayerAcks: NUM_LAYERS per chunk, for every chunk pushed. With a
-    # pipeline runner (num_ranks>1) the branch's LayerCompletionRouter funnels every rank's completions
-    # into this master channel, so this waits for ALL ranks' layers, not just the first stage's.
     _drain_layer_acks(ack_channel, NUM_LAYERS * stats.total_pushes)
 
-    # Multi-rank: all layers of all chunks are now written across every stage's DRAM. Release the
-    # validators (they PCC their own host's layers) by broadcasting the resident-slot map. Do it BEFORE
-    # the master's own read-back so the reads overlap across hosts; the broadcast is the GO barrier.
     if world_size > 1:
         _mr_bcast_resident(mr_rank, stats.resident)
 
-    # Opt-in: read the generated KV back per resident slot and PCC-check vs the golden trace.
     verify_ok = True
     if cfg.verify and kv_table is not None:
         try:
@@ -1516,32 +1119,24 @@ def main() -> None:
         logger.error("[producer] PREFILL_PRODUCER_CHECK_PCC=1 but no KV chunk table available; skipping PCC.")
         verify_ok = False
 
-    # Multi-rank: the verdict allgather is the DONE barrier — it can't return until every validator has
-    # finished its read-back, so the shutdown sentinel below won't tear the mesh/DRAM down while one is
-    # still reading. Fold every rank's verdict (including this master's own, contributed as element [0]).
     if world_size > 1:
         verdicts = _mr_allgather_verdict(verify_ok)
         for r, v in enumerate(verdicts):
             logger.info(f"[producer] rank={r}: ok={v}")
         verify_ok = all(verdicts)
 
-    # Optional graceful shutdown (PR #48718): close the stream with an all -1 PrefillMetadata sentinel so
-    # the runner breaks its request loop and tears down cleanly instead of blocking to SIGKILL. Sent LAST,
-    # after the KV read, because read_dram_umd needs the mesh/DRAM alive (the runner is idle until now).
     if os.environ.get("PREFILL_SEND_SHUTDOWN", "0") == "1":
         sentinel = struct.pack("<iii", -1, -1, -1)
         assert len(sentinel) == METADATA_SIZE_BYTES
-        sentinel_payload = _chunk_to_host_array([1] * CHUNK_SIZE)  # contents ignored by the runner; size must match
+        sentinel_payload = _chunk_to_host_array([1] * CHUNK_SIZE)
         assert sentinel_payload.nbytes == payload_bytes
         logger.info("[producer] sending SHUTDOWN sentinel (metadata=-1,-1,-1)")
         service.forward_to_tensor_bytes(sentinel_payload, metadata=sentinel)
-        service.barrier()  # drain the sentinel before releasing the descriptor
+        service.barrier()
         logger.info("[producer] exiting; SHUTDOWN sentinel sent — runner will drain and shut down.")
     else:
         logger.info("[producer] exiting (the runner keeps its sync-op loop running).")
 
-    # Non-zero exit on PCC failure so a CI / scripted run can gate on the exit code (after the sentinel,
-    # so the runner is still told to drain even when verification failed).
     if cfg.verify and not verify_ok:
         sys.exit(1)
 

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -2,32 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-"""Disaggregated prefill runner — one entry point driving an N-rank serving pipeline.
-
-Model-agnostic: the model is selected by PREFILL_MODEL and driven through a PrefillModelAdapter
-(see ../adapter.py and ADDING_A_PREFILL_MODEL.md). This driver wires rank topology, input,
-transport, and the per-chunk schedule; the adapter supplies how to build the model, allocate the KV
-cache, run a chunk, and describe the cache's layout as a KV-chunk address table.
-
-The model is split across N ranks under tt-run: each rank owns a contiguous layer slice and builds
-the same TtPrefillRuntime (first_layer_idx / is_first_rank / is_last_rank). With >1 rank the cross-rank
-hidden state moves device-to-device over fabric sockets (connected MGD + FABRIC_2D); N=1 is the
-single-galaxy case (no transport). Ranks run decoupled (no per-chunk barrier; one warm-up barrier
-after compile).
-
-Serving is request-driven: rank 0's tokens + per-iter PrefillMetadata arrive over the H2D socket from
-an external producer (prefill_producer.py / the scheduler); the loop is UNBOUNDED. KV-chunk-table
-migration and per-layer LayerAck run at any rank count: every rank joins the all-gather that merges
-the chunk table and rank 0 publishes it, and pipeline layer completions are routed to the master
-rank, which re-emits them into the same ack channel the scheduler connects to in the single-rank case
-(only PREFILL_MOCK_MIGRATION stays single-rank). Shutdown is graceful: the producer/scheduler closes
-the stream with an all -1 PrefillMetadata sentinel that each rank forwards downstream and then exits
-on; a rank blocked in the recv can only be released by a transfer (the recv device op has no timeout),
-so SIGTERM/SIGKILL remains the hard fallback if no sentinel arrives.
-
-The model class is the single source of truth — this driver wires rank topology, input, transport,
-and the per-chunk schedule; it does not reimplement embed / layers / forward.
-"""
 
 import json
 import os
@@ -53,17 +27,8 @@ from models.demos.common.prefill.runners.runner_utils import (
     open_mesh_device,
 )
 
-# NOTE: the layer_completion classes (the standalone `_layer_completion` extension)
-# are imported lazily at point-of-use — its .so is built only under WITH_PYTHON_BINDINGS and may be
-# absent in a packaged/wheel build, so a top-level import would hard-fail the runner for everyone
-# (including single-rank runs that never touch layer completion).
-
 
 def _apply_manifest_env():
-    """If PREFILL_MANIFEST is set, load the shared run.json and populate the env vars
-    the runner reads. setdefault => an explicitly exported env var still wins over the
-    manifest. Must be invoked before the module-level env reads below (e.g.
-    PREFILL_MAX_SEQ_LEN) so the values take effect."""
     manifest_path = os.environ.get("PREFILL_MANIFEST")
     if not manifest_path:
         return
@@ -75,41 +40,20 @@ def _apply_manifest_env():
         if val is not None:
             os.environ.setdefault(key, str(val))
 
-    # Generic model/run config: a flat PREFILL_* map applied verbatim (setdefault). This lets a
-    # rank-binding stay topology-only (rank_bindings + mesh_graph_desc) and point at a per-model
-    # manifest for all model config — PREFILL_MODEL, fabric mode, chunk count, etc.
     for key, val in manifest.get("env", {}).items():
         sd(key, val)
 
 
-# Populate env from the manifest BEFORE the module-level env reads below.
 _apply_manifest_env()
 
-# Both socket transports (H2D input on rank 0, D2D between ranks) share a 1x1 push/sync worker grid and
-# the same 3-word PrefillMetadata (slot_id, actual_start, actual_end). The 1x1 grid is the cheapest
-# footprint with no penalty: a grid sweep showed compute + handoff gap flat from 1x1 to 4x4 (the
-# per-chunk overhead is the persistent service's fabric/NoC presence, not the push workers).
 SYNC_WORKER_CORES = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
 METADATA_SIZE_BYTES = 12
 
-# The packed [1,1,1,3] uint32 message the sockets carry is `metadata_msg` everywhere; the model's
-# `metadata` is the per-element triple of [1,1,1,1] operands the device ops take. There is no device-side
-# conversion between them, so a name that blurs the two hides a required host round trip.
 
-# LayerAck D2H FIFO. Records are METADATA_SIZE_BYTES (12 B) each; 4 KB is a PCIe-aligned
-# one-page buffer with generous headroom for in-flight records.
 LAYER_ACK_FIFO_SIZE_BYTES = int(os.environ.get("PREFILL_LAYER_ACK_FIFO_BYTES", 4 * 1024))
 
-# End-of-stream sentinel: the producer/scheduler closes the request stream with one final push whose
-# PrefillMetadata words are all -1 (0xFFFFFFFF on the wire). -1 is out of range for slot_id and both KV
-# positions, so it can't collide with a real chunk. On receipt a rank forwards it to the next rank
-# (unblocking that rank's recv) and breaks its loop, so an N-rank pipeline drains and exits gracefully
-# instead of every rank blocking in its recv until SIGKILL. Shared wire convention with the scheduler;
-# see ADDING_A_PREFILL_MODEL.md.
 SHUTDOWN_METADATA_WORD = -1
 
-# H2D socket service (request mode, rank 0 input): one worker core copies each pushed chunk into a fresh
-# tensor; the producer packs the PrefillMetadata alongside each push.
 H2D_MAPPER_CONFIG = ttnn.MeshMapperConfig(placements=[ttnn.PlacementShard(0), ttnn.PlacementReplicate()])
 
 D2D_FIFO_SIZE_BYTES = int(os.environ.get("PREFILL_PP_D2D_FIFO_BYTES", 256))
@@ -117,9 +61,6 @@ D2D_FIFO_SIZE_BYTES = int(os.environ.get("PREFILL_PP_D2D_FIFO_BYTES", 256))
 ADAPTER = get_adapter(os.environ.get("PREFILL_MODEL", DEFAULT_MODEL))
 MODEL_CFG = ADAPTER.model_config
 
-# D2D socket transport (>1 rank): one sender/receiver pair per rank boundary carries the hidden state
-# over inter-galaxy fabric, sharded seq across SP rows. The emb (TP) axis follows the adapter's residual
-# layout (see pipeline_activation_emb_tp_sharded) so the receiver backing needs no reshard.
 D2D_MAPPER_CONFIG = ttnn.MeshMapperConfig(
     placements=[
         ttnn.PlacementShard(2),
@@ -132,39 +73,19 @@ _tp = int(os.environ.get("PREFILL_TP", 4))
 GLOBAL_MESH_SHAPE = (_sp, _tp)
 NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", 61))
 CHUNK_SIZE = int(os.environ.get("PREFILL_CHUNK_SIZE", 5 * 1024))
-# Per-user KV cache length. In request mode the external producer decides the chunk count, so this is
-# the one cache-sizing knob; a chunk must not push a slot past it. Default holds 11 chunks.
 MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", CHUNK_SIZE * 11))
 NUM_USERS = int(os.environ.get("PREFILL_NUM_USERS", 2))
 CAPACITY_FACTOR = int(os.environ.get("PREFILL_CAPACITY_FACTOR", 8))
 _gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", ADAPTER.default_gate_mode)
-# When on (default), the last transformer layer runs kv-only: it fills the KV cache for migration and
-# skips its Q/SDPA/wo, FFN/MoE, final norm, and LM head. In a pipeline only the last rank applies it.
 KV_ONLY_LAST_LAYER = os.environ.get("PREFILL_KV_ONLY_LAST_LAYER", "1") == "1"
-# Build the DFlash drafter context-KV cache during this prefill. Three gates, ALL required: the selected
-# model declares the capability (ADAPTER.supports_dflash — only Kimi K2.6/K2.7), the run explicitly opts in
-# (PREFILL_DFLASH=1), and a drafter checkpoint is provided (DFLASH_HF_MODEL, resolved by the runtime). The
-# capability gate keeps a non-dflash model from ever building a Kimi drafter; the explicit PREFILL_DFLASH
-# switch keeps it off unless asked for, even when a checkpoint happens to be on disk.
 DFLASH_ENABLED = (
     ADAPTER.supports_dflash and os.environ.get("PREFILL_DFLASH", "0") == "1" and bool(os.environ.get("DFLASH_HF_MODEL"))
 )
-# Measurement-only: synchronize the device after each chunk's forward and log the isolated per-rank
-# compute (CHUNK_COMPUTE). Off in production — the sync serializes dispatch and kills pipeline overlap.
 SYNC_PER_CHUNK = os.environ.get("PREFILL_SYNC_PER_CHUNK", "0") == "1"
 TIMING_DIR = os.environ.get("PREFILL_TIMING_DIR", "")
-# Some models (e.g. Kimi: single expert group, device gate) route the MoE routing all-gather's global
-# semaphores to L1_SMALL so they don't pin the main-L1 floor and clash with the next layer's MLA static
-# CBs, which needs the mesh opened with an L1_SMALL region. The adapter owns both knobs.
 _L1_SMALL_SIZE = ADAPTER.l1_small_size
-# Capture each rank's per-chunk forward as a (segmented) ttnn trace and replay it every chunk instead of
-# re-dispatching op-by-op. Needs the mesh opened with a trace region; the segmented capture (sub-device
-# swaps + per-layer acks) is handled by SubDeviceTraceController inside the runtime.
 USE_TRACE = os.environ.get("PREFILL_USE_TRACE", "0") == "1"
 _TRACE_REGION_SIZE = int(os.environ.get("PREFILL_TRACE_REGION_SIZE", 256 * 1024 * 1024)) if USE_TRACE else 0
-# DFlash is not trace-compatible: the drafter tap / pack-unpack / KV finalize run outside the runtime's
-# captured per-chunk segment, so a replayed trace would silently skip them. Fail loudly rather than
-# produce meaningless drafter KV. (Per offline discussion — keep DFlash on the eager per-op path.)
 assert not (DFLASH_ENABLED and USE_TRACE), (
     "PREFILL_DFLASH=1 is incompatible with PREFILL_USE_TRACE=1: the DFlash drafter path is not "
     "trace-captured. Run DFlash with PREFILL_USE_TRACE=0."
@@ -180,50 +101,17 @@ def _handle_sigterm(signum, frame):
     _shutdown = True
 
 
-# ---------------------------------------------------------------------------
-# Layer-completion routing (pipeline / num_ranks > 1)
-# ---------------------------------------------------------------------------
-
-# When the completion ring is full, spin waiting for the router to drain rather than
-# dropping/failing immediately. Bounded so a genuinely stalled router still surfaces.
 LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S = float(os.environ.get("PREFILL_LAYER_COMPLETION_PUSH_TIMEOUT_S", 30.0))
 LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S = 10.0
-LAYER_COMPLETION_PUSH_SPIN_SLEEP_S = 0.001  # tiny yield so the spin doesn't peg a core
+LAYER_COMPLETION_PUSH_SPIN_SLEEP_S = 0.001
 
 
 def build_layer_completion_sink(producer, *, source_rank, num_layers):
-    """Build the per-layer completion sink the runtime fires once per layer.
-
-    Computes a globally-dense ordering key and pushes a full completion
-    into `producer` (a ttnn._experimental.layer_completion.LayerCompletionQueue). The
-    master router re-emits completions strictly in ascending `seq`.
-
-    seq = request_id * num_layers + layer_idx — dense across all (request,
-    layer) pairs. For pipelined prefill each rank owns a disjoint set of
-    global layer indices per request, so the union of every rank's seqs
-    tiles [0, num_requests*num_layers) with no gaps or collisions.
-
-    The runtime calls the returned sink as `sink(layer_idx, request_id)`,
-    binding the current chunk's request_id per prefill() call — so this
-    builder needs no request-id accessor and reads no shared mutable state.
-
-    Args:
-        producer: connected LayerCompletionQueue (the host-local ring).
-        source_rank: this rank's world rank (diagnostic in the payload).
-        num_layers: total GLOBAL layers (the seq stride per request), NOT this rank's slice.
-    """
-
     def on_layer_complete(layer_idx: int, request_id: int) -> None:
-        # Hot path: fired once per layer inside model.forward. Push directly (no per-call closure)
-        # and return on the common success; only the rare full-ring case falls into the spin below.
         seq = request_id * num_layers + layer_idx
         if producer.try_push(seq=seq, source_rank=source_rank, layer_idx=layer_idx, request_id=request_id):
             return
 
-        # Ring is sized well above in-flight depth; a full ring means the router
-        # thread is momentarily behind. Spin (don't drop) for up to PUSH_SPIN_TIMEOUT_S
-        # waiting for it to drain; log on entry, every PUSH_SPIN_LOG_EVERY_S while waiting,
-        # and on exit. Only surface an error if it never catches up.
         start = time.monotonic()
         next_log = start + LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S
         logger.warning(
@@ -235,9 +123,6 @@ def build_layer_completion_sink(producer, *, source_rank, num_layers):
                 logger.info(f"[layer-completion] ring drained after {time.monotonic() - start:.1f}s; pushed seq={seq}")
                 return
             if _shutdown:
-                # Operator asked to stop (SIGTERM/SIGINT). Abort the spin immediately instead of
-                # ignoring the signal for up to the full timeout; teardown runs via run_request_loop's
-                # finally. Raising (vs. silently dropping) keeps the failure visible.
                 raise RuntimeError(f"layer-completion ring full (seq={seq}); shutdown requested while spinning")
             now = time.monotonic()
             if now - start >= LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S:
@@ -254,20 +139,12 @@ def build_layer_completion_sink(producer, *, source_rank, num_layers):
     return on_layer_complete
 
 
-# ---------------------------------------------------------------------------
-# Loop
-# ---------------------------------------------------------------------------
-
-
 def _decode_metadata(metadata_msg) -> dict:
-    """Read the packed [1,1,1,3] metadata device tensor to host: {slot_id, actual_start, actual_end}."""
     m = ttnn.to_torch(ttnn.get_device_tensors(metadata_msg)[0]).view(torch.int32).flatten()
     return {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
 
 
 def _is_shutdown_sentinel(meta: dict) -> bool:
-    """True for the all -1 end-of-stream sentinel (see SHUTDOWN_METADATA_WORD); false for every real
-    chunk, whose slot_id and KV positions are non-negative and in range."""
     return (
         meta["slot_id"] == SHUTDOWN_METADATA_WORD
         and meta["actual_start"] == SHUTDOWN_METADATA_WORD
@@ -276,12 +153,6 @@ def _is_shutdown_sentinel(meta: dict) -> bool:
 
 
 def _socket_next(h2d_service) -> tuple:
-    """Block on the next producer push: returns (tt_tokens, meta, metadata_msg). The device metadata
-    tensor is returned (not discarded) so it can be propagated into the model's per-layer ack send.
-    Used only by the unbounded request loop (rank 0 input).
-
-    The metadata is always read to host: the scalars are tiny and the read is what lets the loop see the
-    in-band shutdown sentinel, which is the runner's graceful teardown path under trace and eager alike."""
     tt_tokens, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         h2d_service, metadata_size_bytes=METADATA_SIZE_BYTES
     )
@@ -289,21 +160,9 @@ def _socket_next(h2d_service) -> tuple:
 
 
 def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_size: int, hidden_size: int):
-    """Stand up this rank's persistent D2D endpoints for the pipeline: an inbound receiver from rank-1
-    (every rank but the first) and an outbound sender to rank+1 (every rank but the last). Returns
-    (inbound_receiver_or_None, outbound_sender_or_None).
-
-    Setup order is inbound-then-outbound on every rank. create_sender/create_receiver rendezvous
-    point-to-point between the two boundary ranks (no world barrier), and each MeshSocket ctor blocks
-    until its peer's matching ctor. Doing inbound first chains the bring-up: rank 0's sender unblocks
-    rank 1's receiver, which frees rank 1 to build its sender for rank 2's receiver, and so on — no
-    deadlock. Both sides pass the identical worker-core grid and global spec."""
     global_spec = activation_global_spec(chunk_size, hidden_size)
 
     def _common():
-        # Fresh mapper per call: create_sender/create_receiver take the mapper by std::unique_ptr and
-        # MOVE it, so a middle rank (builds BOTH a receiver and a sender) must not reuse one — the
-        # second create would get a consumed/null mapper and fail overload resolution.
         return dict(
             global_spec=global_spec,
             mapper=ttnn.create_mesh_mapper(mesh_device, D2D_MAPPER_CONFIG),
@@ -312,7 +171,6 @@ def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_s
             receiver_worker_cores=SYNC_WORKER_CORES,
             metadata_size_bytes=METADATA_SIZE_BYTES,
             share_fabric_links=True,
-            # The service asserts L1-only (d2d_stream_service.cpp:260).
             socket_buffer_type=ttnn.BufferType.L1,
         )
 
@@ -336,9 +194,6 @@ def build_d2d_pipeline_endpoints(mesh_device, rank: int, num_ranks: int, chunk_s
 
 
 def _d2d_recv(inbound) -> tuple:
-    """Drain the next chunk that landed in the inbound receiver backing into a fresh device tensor. The
-    returned tensor already has the embedding-output sharding, so it feeds runtime.prefill with no
-    reshard. Pairs with the upstream rank's _d2d_send."""
     t0 = time.perf_counter()
     act, metadata_msg = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
         inbound, metadata_size_bytes=METADATA_SIZE_BYTES
@@ -352,17 +207,6 @@ def _d2d_recv(inbound) -> tuple:
 def _d2d_send(
     outbound, activation: ttnn.Tensor, rank: int, meta: Optional[dict], *, deallocate: bool = True, metadata_msg=None
 ) -> None:
-    """Push this rank's output hidden state + metadata to the downstream rank's receiver, then free it.
-    The model already emits the activation in the sender backing's spec, and outbound_socket_service_sync
-    TT_FATALs on any spec mismatch, so no host-side relayout is needed.
-
-    metadata_msg (traced path): the packed device tensor received on this rank is forwarded downstream
-    verbatim — it is already the [1,1,1,3] uint32 replicated form the op expects, so no host rebuild
-    runs (meta may be None). When metadata_msg is None (eager path) the tensor is rebuilt from meta.
-
-    deallocate=False when the activation is the traced path's persistent _trace_output buffer: the socket
-    sync copies it into the sender backing on the CQ (before the next replay, which reuses the same buffer,
-    is enqueued), so it must NOT be freed — the next chunk's replay writes into it in place."""
     t0 = time.perf_counter()
 
     if metadata_msg is not None:
@@ -370,7 +214,6 @@ def _d2d_send(
     else:
         backing = outbound.get_backing_tensor()
         words = [meta["slot_id"], meta["actual_start"], meta["actual_end"]]
-        # The outbound op ships metadata as a replicated device tensor (3 uint32 words), not a Python list.
         md_tensor = ttnn.from_torch(
             torch.tensor(words, dtype=torch.int32).reshape(1, 1, 1, -1),
             dtype=ttnn.uint32,
@@ -390,11 +233,6 @@ def _d2d_send(
 
 
 def _forward_shutdown(d2d_out, rank: int, hidden_size: int) -> None:
-    """Forward the shutdown sentinel to the downstream rank so it unblocks in its own recv, then release
-    the outbound link so the transfer ships (mirroring _compute_and_send's tail). The activation content
-    is irrelevant — the downstream discards it once it sees the sentinel — but outbound_socket_service_sync
-    requires the input's per-shard spec to equal the sender backing's, so build the dummy exactly like a
-    real activation: the [1, 1, CHUNK_SIZE, hidden_size] bf16 TILE spec sharded by D2D_MAPPER_CONFIG."""
     dev = d2d_out.get_backing_tensor().device()
     dummy = ttnn.from_torch(
         torch.zeros(1, 1, CHUNK_SIZE, hidden_size),
@@ -409,15 +247,12 @@ def _forward_shutdown(d2d_out, rank: int, hidden_size: int) -> None:
         "actual_start": SHUTDOWN_METADATA_WORD,
         "actual_end": SHUTDOWN_METADATA_WORD,
     }
-    _d2d_send(d2d_out, dummy, rank, sentinel)  # ships + frees the dummy
+    _d2d_send(d2d_out, dummy, rank, sentinel)
     d2d_out.release_fabric_links()
     logger.info(f"[pp rank {rank}] forwarded SHUTDOWN sentinel to rank {rank + 1}")
 
 
 def _lease_reclaim(d2d_in, d2d_out) -> None:
-    """Before a chunk: reclaim this rank's fabric links (the previous-iter D2D transfer has drained),
-    then grant the inbound receiver so this chunk's activation drains into its backing. No-op without
-    D2D (single rank). The outbound grant happens AFTER the push, in _compute_and_send."""
     if d2d_in is not None:
         d2d_in.wait_for_fabric_links()
     if d2d_out is not None:
@@ -427,8 +262,6 @@ def _lease_reclaim(d2d_in, d2d_out) -> None:
 
 
 def _record_chunk_timing(rank: int, c: int, compute_start: float, compute_ms: float) -> None:
-    """Append one chunk's timing to this rank's CSV via a single O_APPEND write (per-rank file => lone
-    writer, atomic even on NFS). Telemetry must never take down the run, so any write error is swallowed."""
     if not TIMING_DIR:
         return
     try:
@@ -444,11 +277,6 @@ def _record_chunk_timing(rank: int, c: int, compute_start: float, compute_ms: fl
 def _compute_and_send(
     runtime, kv_caches, rank: int, c: int, inp, meta: Optional[dict], d2d_out, d2h_service=None, metadata_msg=None
 ) -> float:
-    """Run one chunk: prefill into the engine-owned kv_caches, forward the output downstream (non-last
-    rank) and grant the outbound sender so it ships over fabric. Returns the compute-start epoch
-    (NTP-comparable). CHUNK_START is logged BEFORE the forward, with this chunk's metadata, so the
-    slot/KV-range is visible per rank even if prefill_chunk hangs. The trailing metadata is kept after
-    compute_start so the c=/compute_start= fields stay parseable (plot_pipeline_trace.py)."""
     if SYNC_PER_CHUNK:
         ttnn.synchronize_device(runtime.mesh_device)
     t_start = time.time()
@@ -466,19 +294,11 @@ def _compute_and_send(
         metadata_msg=metadata_msg,
     )
     if SYNC_PER_CHUNK:
-        # Block on device completion so the delta is this rank's forward alone, not the downstream-start
-        # proxy. Serializes dispatch (no overlap) — measurement runs only.
         ttnn.synchronize_device(runtime.mesh_device)
         compute_ms = (time.perf_counter() - t_perf) * 1000.0
         logger.info(f"[pp rank {rank}] CHUNK_COMPUTE c={c} compute_ms={compute_ms:.3f}")
         _record_chunk_timing(rank, c, t_start, compute_ms)
     if not runtime.config.is_last_rank:
-        # Traced: `out` is the runtime's persistent _trace_output (the next replay overwrites it in place),
-        # so the send copies it into the socket backing but must not free it. Forward the runtime's
-        # persistent metadata, NOT the raw received metadata_msg: that raw tensor is a fresh socket output
-        # the replay's writes can land on, so it can arrive corrupted downstream (per-shard-inconsistent),
-        # tripping the D2H ack's cross-socket identity check. The persistent buffer survives replay. Eager:
-        # `out` is fresh — free it, rebuild md from meta.
         forward_md = None
         if runtime.config.use_trace:
             persistent_md = getattr(runtime, "trace_metadata_msg", None)
@@ -490,21 +310,16 @@ def _compute_and_send(
             meta,
             deallocate=not runtime.config.use_trace,
             metadata_msg=forward_md,
-        )  # grant below ships it
+        )
     if d2d_out is not None:
         d2d_out.release_fabric_links()
     return t_start
 
 
 def _drain_and_log_e2e(runtime, rank: int, d2d_out, first_compute_start, n_done: int, t0: float) -> None:
-    """Per-rank teardown: drain the last outbound D2D forward, one synchronize so the e2e clock reflects
-    device completion, then log E2E_CLOCK (first prefill start + last compute end, NTP-comparable epochs)
-    and the chunk count. No teardown barrier across ranks."""
     if d2d_out is not None:
         d2d_out.wait_for_fabric_links()
     ttnn.synchronize_device(runtime.mesh_device)
-    # first_compute_start is None if the loop exited before any chunk was computed (e.g. an immediate
-    # shutdown sentinel, or SIGINT during the initial socket wait) — guard the float format.
     fcs = f"{first_compute_start:.6f}" if first_compute_start is not None else "n/a"
     logger.info(f"[pp rank {rank}] E2E_CLOCK first_compute_start={fcs} last_compute_end={time.time():.6f}")
     logger.info(f"[pp rank {rank}] processed {n_done} chunks in {(time.perf_counter() - t0) * 1000.0:.2f} ms")
@@ -522,16 +337,6 @@ def run_request_loop(
     d2d_out=None,
     d2h_service=None,
 ) -> None:
-    """Production serving loop — UNBOUNDED. rank 0 reads each chunk from the H2D socket (the external
-    producer decides the count); downstream ranks read from D2D. Runs until the producer/scheduler
-    closes the stream with the all -1 shutdown sentinel (each rank forwards it and exits gracefully) or,
-    as a hard fallback, until SIGTERM/SIGKILL. No fixed chunk bound, no trace input, no PCC, no
-    migration — the runner serves; migration is issued from outside (migration_driver.py).
-
-    The per-chunk metadata is read to host on every chunk (traced and eager alike): the scalars are tiny
-    and the read is what lets the loop see the in-band shutdown sentinel and drain gracefully. Trace
-    replay still consumes the metadata on-device from the persistent buffer; this host read is only the
-    small sentinel/logging copy alongside it."""
     cfg = runtime.config
     if cfg.is_first_rank and h2d_service is None:
         raise ValueError("request mode requires the H2D service on the first rank for input")
@@ -545,12 +350,10 @@ def run_request_loop(
     while not _shutdown:
         _lease_reclaim(d2d_in, d2d_out)
         if cfg.is_first_rank:
-            inp, meta, metadata_msg = _socket_next(h2d_service)  # slot/start/end from producer
+            inp, meta, metadata_msg = _socket_next(h2d_service)
         else:
             inp, meta, metadata_msg = _d2d_recv(d2d_in)
         if _is_shutdown_sentinel(meta):
-            # End of stream: drop the throwaway payload + its metadata tensor, hand the sentinel to the
-            # next rank so it too unblocks and exits, then fall through to the graceful drain below.
             logger.info(f"[pp rank {rank}] SHUTDOWN sentinel received after {c} chunks; exiting request loop")
             ttnn.deallocate(inp)
             ttnn.deallocate(metadata_msg)
@@ -566,15 +369,7 @@ def run_request_loop(
     _drain_and_log_e2e(runtime, rank, d2d_out, first, c, t0)
 
 
-# ---------------------------------------------------------------------------
-# Entry point
-# ---------------------------------------------------------------------------
-
-
 def _print_config() -> None:
-    """Print every env var the runner (and its downstream model/runner_utils) reads at startup so each
-    rank's config is visible in logs. Values shown are the resolved effective values, not just what was
-    set in the environment."""
     rows = [
         ("PREFILL_MODEL", ADAPTER.name),
         ("PREFILL_HF_MODEL", os.environ.get("PREFILL_HF_MODEL", ADAPTER.hf_model_default)),
@@ -621,18 +416,6 @@ def _print_config() -> None:
 
 
 def _assert_ranks_agree_on_config(rank: int, num_ranks: int) -> None:
-    """Fail fast when the ranks of a pipeline did not resolve the SAME model/shape config.
-
-    Every PREFILL_* knob is read from this process's environment, and tt-run only guarantees
-    per-rank delivery for what a rank binding puts in `global_env` (it auto-propagates just the
-    TT_/ARCH_/WH_/TTNN_/DEEPSEEK_/MESH_ prefixes, and an `-x FOO` in --mpi-args lands in mpirun's
-    FIRST application context -> rank 0 only). So exporting PREFILL_MANIFEST in the launching shell
-    sets rank 0 and silently leaves every other rank on adapter.py's DEFAULT_MODEL -- a DIFFERENT,
-    perfectly valid model, whose weight cache is equally "complete". Nothing errors: the pipeline
-    just runs one model's layers into another's, and only the downstream ranks' KV fails PCC.
-
-    A one-int allgather of a config fingerprint turns that into an immediate, named failure.
-    """
     if num_ranks <= 1:
         return
     import zlib
@@ -670,8 +453,6 @@ def main() -> None:
 
     _print_config()
 
-    # tt-run launches the MPI ranks but does not stand up the distributed context;
-    # do it here before reading rank/size (idempotent across re-entry).
     if not ttnn.distributed_context_is_initialized():
         ttnn.init_distributed_context()
     rank = int(ttnn.distributed_context_get_rank())
@@ -705,14 +486,9 @@ def main() -> None:
         chunk_size=CHUNK_SIZE,
         num_users=NUM_USERS,
         capacity_factor=CAPACITY_FACTOR,
-        num_links=2 if is_blackhole() else 1,  # Blackhole trains 2 fabric routing planes, others 1
+        num_links=2 if is_blackhole() else 1,
         gate_mode_name=_gate_mode_name,
-        # Chunked prefill never samples (the populated KV cache is the output), so the final stage is
-        # headless: its last layer runs KV-only and no norm/LM-head is built. Only the last rank does
-        # this (single-rank inherits it); PREFILL_KV_ONLY_LAST_LAYER can force it off.
         kv_only_last_layer=is_last_rank and KV_ONLY_LAST_LAYER,
-        # NOT gated on is_last_rank: every rank builds its owned fc slices; the runtime derives the
-        # last-rank KV tail from is_last_rank.
         dflash_enabled=DFLASH_ENABLED,
         weight_cache_path=ADAPTER.weight_cache_path(GLOBAL_MESH_SHAPE),
         sparse_kv_cache_format=ADAPTER.default_sparse_kv_cache_format,
@@ -721,20 +497,11 @@ def main() -> None:
     )
 
     runtime = ADAPTER.build_runtime(mesh_device=mesh_device, hf_config=hf_config, params=params)
-    # The engine owns the KV cache(s): allocate them once (the adapter defines the layout) as an opaque
-    # KvCaches, hand that container to every runtime call, and let it free with the mesh at shutdown. The
-    # runner stays model-agnostic — it never unpacks the container; the (model-specific) runtime pulls out
-    # the primary cache and any secondary cache (e.g. a sparse/DSA model's index cache) it needs, and folds
-    # both into the merged migration table (see build_kv_chunk_table).
     kv_caches = ADAPTER.allocate_kv_cache(mesh_device=mesh_device, hf_config=hf_config, params=params)
     runtime.compile(kv_caches)
 
     _serve_request(runtime, kv_caches, mesh_device, hf_config, rank, num_ranks, is_first_rank)
 
-    # Release captured traces + the sub-device managers that own them BEFORE closing the mesh: the
-    # trace buffers live inside the MoE-overlap SubDeviceManagers, so closing with both registered
-    # frees them in the wrong order and segfaults in BankManager::deallocate_buffer (see
-    # TtPrefillRuntime.release_trace). Optional hook — models without it are unaffected.
     _release_trace = getattr(runtime, "release_trace", None)
     if _release_trace is not None:
         _release_trace()
@@ -745,24 +512,11 @@ def main() -> None:
 
 
 def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ranks: int, is_first_rank: bool) -> None:
-    """Production serving: token chunks + PrefillMetadata arrive over the H2D socket from an external
-    producer (prefill_producer.py / the scheduler); unbounded (runs to SIGTERM), num_ranks 1..N over D2D.
-
-    Migration (KV-chunk-table publish) runs for any rank count: every rank all-gathers its stage into
-    the merged table and rank 0 builds + publishes it. Per-layer completions feed the scheduler channel
-    directly single-rank, or route through a per-host LayerCompletionRouter to the master for
-    num_ranks>1. Shutdown for num_ranks>1 is rough: downstream ranks block in D2D recv when rank 0
-    stops, so they exit on teardown / SIGKILL."""
     single_rank = num_ranks == 1
-    # DFlash packs the drafter's FC partial alongside the hidden (concat on the feature dim), so the D2D
-    # activation is 2H wide when enabled; the non-dflash path (every other model) stays H.
     d2d_activation_width = hf_config.hidden_size * (2 if DFLASH_ENABLED else 1)
 
-    ttnn.distributed_context_barrier()  # warm-up: all ranks finish compile before chunks flow
+    ttnn.distributed_context_barrier()
 
-    # H2D input service lives on the first rank only (downstream ranks read from D2D). compile() leaves
-    # a custom sub-device manager loaded; the service's init program validates its cores against the
-    # default whole-chip sub-device, so revert first.
     h2d_service = None
     if is_first_rank:
         mesh_device.clear_loaded_sub_device_manager()
@@ -781,80 +535,39 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             f"drive it with prefill_producer.py / the scheduler."
         )
 
-    # D2D pipeline transport for num_ranks>1.
     d2d_in = d2d_out = None
     if num_ranks > 1:
         mesh_device.clear_loaded_sub_device_manager()
         d2d_in, d2d_out = build_d2d_pipeline_endpoints(mesh_device, rank, num_ranks, CHUNK_SIZE, d2d_activation_width)
-        # The chained D2D socket rendezvous finishes at staggered times per rank. Without this barrier
-        # a rank can reach the loop's first fabric-link lease while an upstream/downstream rank is still
-        # in rendezvous, deadlocking the lease handshake before any chunk flows.
         ttnn.distributed_context_barrier()
 
-    # Per-layer LayerAck -> scheduler-driven migration. Two wirings by topology:
-    #   * single-rank: the runtime owns the scheduler's counter channel and inject()s it
-    #     directly (the original path).
-    #   * pipeline (num_ranks > 1): each rank owns only a layer slice, so it cannot inject
-    #     the scheduler channel directly. Every rank pushes full {seq, source_rank, layer_idx,
-    #     request_id} completions into a host-local LayerCompletionQueue; a per-host
-    #     LayerCompletionRouter forwards them to the master rank, which re-emits them in
-    #     global seq order into the SAME counter channel the scheduler connects to. See
-    #     build_layer_completion_sink() and ttnn._ttnn.layer_completion.
     service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
     ack_shm_name = f"/tt_prefill_layer_acks_{service_id}"
     master_rank = int(os.environ.get("PREFILL_MASTER_RANK", "0"))
     ack_channel = None
     router = None
-    # Single-rank D2H layer-ack: the per-layer ack is emitted by a device op into this D2H FIFO and a
-    # host reader thread (LayerAckService) bumps `ack_channel`, instead of the model calling back into
-    # host code mid-forward. Set up further down, next to the ack_channel it feeds.
     d2h_service = None
     layer_ack_service = None
     producer = None
-    # The single-rank LayerAck channel is the scheduler's per-layer signal (it drives migration).
-    # Opt-in: creating it unconditionally makes two concurrent single-rank runs sharing a service_id
-    # collide on the same /dev/shm segment. Defaults on when migration is enabled (its only consumer);
-    # set PREFILL_ENABLE_LAYER_ACK=1 to force it on without full migration.
     enable_layer_ack = (
         os.environ.get("PREFILL_ENABLE_LAYER_ACK", os.environ.get("PREFILL_ENABLE_MIGRATION", "0")) == "1"
     )
 
     def _unlink_stale_shm(name: str) -> None:
-        # A prior run that didn't tear down cleanly leaves the segment behind (shm_open O_EXCL fails).
         path = f"/dev/shm/{name.lstrip('/')}"
         if os.path.exists(path):
             logger.warning(f"[migration] removing stale shm {path} from a prior run")
             os.remove(path)
 
-    # Migration KV-chunk-table publish: runs for ANY rank count. The runner owns the control flow;
-    # every rank joins the cross-host all-gather (barrier) that merges the table, then ONLY the first
-    # rank asks its model runtime to build the merged table and sends it to the worker (mirroring
-    # tt-blaze where all ranks all-gather but only mesh 0 builds + sends). Previously single-rank only.
-    # The runner never migrates; it only publishes. Rank 0 holds the client here for the process's
-    # lifetime because dropping the reference destroys it and the worker loses the table it gated on.
     migration_endpoint = None
-    # Mock integration: publish the KV chunk table + device map for an external reader
-    # (prefill_producer.py's PREFILL_PRODUCER_CHECK_PCC) with NO migration worker. It must open this
-    # block ON ITS OWN — gating it behind _migration_enabled made it unreachable, since
-    # PREFILL_ENABLE_MIGRATION additionally drives the publish-and-block-on-WORKER_READY path below.
     _mock_migration = os.environ.get("PREFILL_MOCK_MIGRATION", "0") == "1"
     _migration_enabled = os.environ.get("PREFILL_ENABLE_MIGRATION", "0") == "1"
     _file_export = migration_file_export_enabled()
 
-    # Mock integration (prefill_producer.py's PREFILL_PRODUCER_CHECK_PCC): publish the KV chunk table +
-    # device map for an external device-less reader, with NO migration worker. Deliberately OUTSIDE the
-    # _migration_enabled block below: that block's first step is
-    # deliver_device_map_and_gather_stage_layouts(), which imports the _migration_client .so and joins a
-    # cross-rank all-gather. Mock has neither a client nor peers, so routing it through there raises
-    # ImportError(_migration_client) — which is exactly what happens if you only make the old in-block
-    # `elif PREFILL_MOCK_MIGRATION` reachable. Both writes here are local (build table + serialize map).
     if _mock_migration and not _migration_enabled:
         _mock_table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
         _mock_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
         runtime.build_kv_chunk_table(kv_caches, path=_mock_table_path)
-        # fabric_node -> ASIC unique_id, so the producer can resolve chips for read_dram_umd without
-        # touching the ControlPlane. Stale rank-scoped siblings from a prior multi-rank run would
-        # merge into the reader's map, so drop them first.
         remove_stale_device_map_sidecars(_mock_map_path)
         serialize_device_map(mesh_device, _mock_map_path)
         logger.info(
@@ -863,15 +576,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         )
 
     if _migration_enabled:
-        # Migration bring-up, split by ownership before the request loop opens (the worker gates on
-        # SetTable + AssignDevMap, so this must finish first):
-        #   * ALL RANKS deliver their local device map + join the all-gather barrier (COLLECTIVE —
-        #     every rank must call it or the communicator deadlocks).
-        #   * The model RUNTIME builds + serializes the model-specific KV chunk table and returns its
-        #     path (runtime.build_kv_chunk_table — the model owns the cache layout / address math).
-        #   * RANK 0 ONLY publishes that serialized table to the worker and blocks on WORKER_READY.
-        # With PREFILL_MIGRATION_EXPORT_TO_FILE=1 the device map goes to a host-local text file
-        # and the table stays on disk instead; no worker handshake.
         from models.demos.common.prefill.runners.migration import (
             KvCacheStage,
             allgather_kv_stage_layouts,
@@ -882,21 +586,12 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             rank_scoped_device_map_path,
         )
 
-        # This rank's pipeline stage owns layers [first_layer_idx, first_layer_idx + num_my_layers).
-        # The layer-aware merge gathers each rank's range so the table spans all stages; pass this
-        # rank's range -- via the adapter's boundaries, so it is the split the MODEL was built with in
-        # main(). Without them a cross-layer-reuse model (GLM-5.2 snaps 39/39 to 38/40) describes a
-        # partition its KV cache does not hold, mismapping every layer of the second stage.
         first_layer_idx, num_my_layers = compute_layer_split(
             NUM_LAYERS, num_ranks, ADAPTER.layer_split_boundaries(NUM_LAYERS)
         )[rank]
         table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
         wait_ready_ms = int(os.environ.get("PREFILL_MIGRATION_WAIT_READY_MS", "120000"))
 
-        # Only rank 0 writes the merged table, but every rank (and every co-located producer) reads it
-        # back. Multi-host therefore requires shared storage; the per-host default is invisible to the
-        # other hosts. Reject it here — rank-invariant (same env + num_ranks), so all ranks raise
-        # together before the stage-layout all-gather below rather than deadlocking the survivors.
         if num_ranks > 1:
             _abs_table = os.path.abspath(table_path)
             if any(_abs_table == p or _abs_table.startswith(p + "/") for p in ("/tmp", "/dev/shm", "/run", "/var/tmp")):
@@ -906,29 +601,15 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                     "it at shared/NFS storage (e.g. /data/...)."
                 )
 
-        # Drop a stale table from a prior run before rank 0 rebuilds it, so a reader can never
-        # deserialize last run's table (same rationale as the DONE sentinel above).
         if is_first_rank and os.path.exists(table_path):
             logger.warning(f"[migration] removing stale KV chunk table {table_path} from a prior run")
             os.remove(table_path)
 
-        # Same rationale for the JSON device-map sidecars: a leftover rank-scoped file from a run with
-        # a different rank count would silently merge into this run's map. Must stay BEFORE the
-        # all-gather barrier below — every rank writes its fresh map only after it.
         if not _file_export:
             remove_stale_device_map_sidecars(
                 os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
             )
 
-        # ALL RANKS join the stage-layout all-gather (collective barrier; rank 0 needs the merged
-        # layout to build the table). Real migration also delivers this rank's local FNID->UMD map to
-        # its co-located worker first; mock has no worker (the producer reads a serialized JSON map),
-        # so it joins the gather directly and never imports the worker client extension.
-        #
-        # Ask the runtime to describe its migratable caches -- the engine must not introspect the opaque
-        # KvCaches struct, whose shape is per-model. One stage per config of the model's table, since a
-        # layout carries one cache's DRAM base and one layer-index space. A runtime predating
-        # `kv_migration_stages` exposes only the single-cache base address.
         _multi_cache_runtime = hasattr(runtime, "kv_migration_stages")
         if _multi_cache_runtime:
             kv_stages = runtime.kv_migration_stages(kv_caches, first_layer_idx, num_my_layers)
@@ -950,26 +631,9 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         else:
             stage_layouts = deliver_device_map_and_gather_stage_layouts(mesh_device, kv_stages, GLOBAL_MESH_SHAPE, rank)
 
-        # A runtime predating `kv_migration_stages` describes ONE cache and takes the singular
-        # `stage_layout=` -- its single gathered layout. Keep calling it that way: its single-rank guard
-        # counts stages in that layout, and handing it the outer per-cache list would count caches (always
-        # 1) and silently stop rejecting multi-rank migration.
         _layout_kwarg = {"stage_layouts": stage_layouts} if _multi_cache_runtime else {"stage_layout": stage_layouts[0]}
 
         if _mock_migration:
-            # Mock integration (prefill_producer.py): the SAME merged table the real publish builds, but
-            # serialized to disk for a device-less producer to read back via
-            # ttnn.experimental.disaggregation.import_from_protobuf_file — WITHOUT the migration_endpoint
-            # worker (no MigrationLayerClient, no WORKER_READY). Checked before is_first_rank so rank 0
-            # also takes this path instead of blocking on a worker that isn't running.
-            #
-            # EVERY rank serializes its OWN local fabric_node -> ASIC unique_id device map so each
-            # co-located producer can resolve only its host's chips for read_dram_umd (the multi-rank
-            # merged table carries every host's fnids; a producer merges the local maps and skips
-            # layers owned by another host). Rank-scoped filename for num_ranks > 1 — co-located ranks
-            # would otherwise overwrite each other at the shared host-local path; the table path MUST
-            # be on shared storage (only rank 0 writes it, but every host's reader resolves the same
-            # path) — enforced above for num_ranks > 1.
             device_map_path = rank_scoped_device_map_path(
                 os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json"),
                 rank,
@@ -977,8 +641,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             )
             serialize_device_map(mesh_device, device_map_path)
             if is_first_rank:
-                # RANK 0 builds the merged table spanning every gathered stage — identical to the real
-                # publish call below, minus the worker handshake.
                 table_path = runtime.build_kv_chunk_table(
                     kv_caches,
                     table_path,
@@ -989,7 +651,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                 logger.info(f"[mock-migration] merged KV chunk table -> {table_path} (no migration worker)")
             logger.info(f"[mock-migration] rank {rank}: local device map -> {device_map_path}")
         elif _file_export:
-            # The files on disk are the handoff: no SET_TABLE, no WORKER_READY.
             if is_first_rank:
                 table_path = runtime.build_kv_chunk_table(
                     kv_caches,
@@ -1001,13 +662,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                 logger.info(f"[migration] merged KV chunk table -> {table_path} (file export; no worker handshake)")
             logger.info(f"[migration] rank {rank}: exported local device map -> {migration_device_map_file_path()}")
         else:
-            # EVERY rank serializes its own local fabric_node -> ASIC unique_id map, exactly as the
-            # mock path above does. The real path used to skip this, which silently disabled every
-            # device-less reader downstream: migration_driver's destination verification
-            # (--verify-migration, both dst-bytes and dst-golden) and prefill_producer's source-KV
-            # PCC each resolve chips through this file, log "device map ... not found", and FAIL —
-            # so a real migration run could never verify what it copied. Host-local by design;
-            # rank-scoped filename for num_ranks > 1 so co-located ranks don't overwrite each other.
             device_map_path = rank_scoped_device_map_path(
                 os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json"),
                 rank,
@@ -1017,8 +671,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             logger.info(f"[migration] rank {rank}: local device map -> {device_map_path}")
 
             if is_first_rank:
-                # RANK 0: model runtime builds + serializes the merged table (spanning all gathered
-                # stages), then publish the serialized path + block on WORKER_READY.
                 table_path = runtime.build_kv_chunk_table(
                     kv_caches,
                     table_path,
@@ -1037,21 +689,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                 )
 
     elif os.environ.get("PREFILL_MOCK_MIGRATION", "0") == "1":
-        # Mock integration (prefill_producer.py): serialize the KV chunk table so an external
-        # producer can read it back via ttnn.experimental.disaggregation.import_from_protobuf_file
-        # and locate each chunk — WITHOUT the migration_endpoint worker (no MigrationLayerClient,
-        # no WORKER_READY). One galaxy => one complete table spanning all NUM_LAYERS / NUM_USERS
-        # (both caches, merged, for a sparse model).
-        # Sibling of `if _migration_enabled:` ON PURPOSE -- the mock path is what runs when migration
-        # is OFF. One level deeper it was an elif of `if is_first_rank:`, so reaching it needed
-        # _migration_enabled AND a non-first rank: unreachable in single-rank, and the runner then
-        # entered the request loop having never published the table/device map its consumer waits on.
-        # Single-rank only, and loudly so. Dedenting it out of `if _migration_enabled:` also took it
-        # out of the pre-#48826 `if single_rank:` wrapper, so with num_ranks>1 every rank would build
-        # a table covering only ITS layer slice and publish over the same paths -- and co-located
-        # ranks would race serialize_device_map's `<path>.tmp` -> os.replace as well. Only the real
-        # migration path merges stages (deliver_device_map_and_gather_stage_layouts), and that needs
-        # the worker. Same guard #48826 removed for PREFILL_ENABLE_MIGRATION, kept for the mock path.
         if not single_rank:
             raise ValueError(
                 f"PREFILL_MOCK_MIGRATION=1 is unsupported for num_ranks={num_ranks} (each rank would "
@@ -1060,8 +697,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             )
         table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
         runtime.build_kv_chunk_table(kv_caches, path=table_path)
-        # Also publish the fabric_node -> ASIC unique_id device map so the producer can resolve chips
-        # for its device-less UMD read (read_dram_umd) without touching the ControlPlane.
         device_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
         serialize_device_map(mesh_device, device_map_path)
         logger.info(
@@ -1069,34 +704,17 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             f"(no migration worker); prefill_producer can import them"
         )
 
-    # D2H layer-ack backend: the device sends one per-layer ack record over a metadata-only D2H socket
-    # (outbound_socket_service_sync in each block) and a LayerAckService reader thread derives a
-    # globally-dense seq per record and pushes it into the router-owned ring. This feeds the SAME
-    # LayerCompletionRouter the multi-rank host-callback path uses, so it is multi-host compatible: it
-    # works on any rank count (single-rank => world_size=1 router, local ring + counter channel, no MPI).
     use_d2h = os.environ.get("PREFILL_LAYER_ACK_D2H", "0") == "1"
-    # The router path covers: (a) any multi-rank run (each rank owns only a layer slice, so it can't
-    # inject the scheduler channel directly and must route to the master), and (b) the D2H backend on
-    # any rank count (its LayerAckService is a pure producer into the ring). The single-rank non-D2H
-    # path keeps the original direct-inject wiring.
     use_router = (not single_rank) or (use_d2h and enable_layer_ack)
 
     if use_router:
-        # Imported here (not at module top) so single-rank / no-extension builds never need the
-        # standalone _layer_completion .so (built only with WITH_PYTHON_BINDINGS).
         from ttnn._experimental.layer_completion import LayerCompletionQueue, LayerCompletionRouter
 
-        # Each rank's router OWNS its own ring, so the name must be per-rank — append _{rank} even to
-        # the env override (a single literal would make colocated ranks unlink each other's live ring
-        # and collide on O_EXCL create).
         ring_base = os.environ.get("PREFILL_LAYER_COMPLETION_RING", "/tt_prefill_layer_completion_ring")
         ring_shm_name = f"{ring_base}_{rank}"
         _unlink_stale_shm(ring_shm_name)
         if rank == master_rank:
             _unlink_stale_shm(ack_shm_name)
-        # The router owns the host-local ring (and, on the master, the scheduler counter channel,
-        # which it inject()s in order). Subordinate ranks MPI-forward completions to the master.
-        # Constructed BEFORE the ring source below: the router creates the ring, the source connects.
         router = LayerCompletionRouter(
             rank=rank,
             world_size=num_ranks,
@@ -1106,17 +724,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             teardown_timeout_ms=30000,
         )
         if use_d2h:
-            # Device-record source. The reader thread reconstructs (chunk, global-layer) from a per-rank
-            # record counter — valid because each rank emits exactly its layer-slice count (num_my_layers)
-            # of records per chunk, in layer order. d2h_service is threaded into the request loop so
-            # prefill_chunk drives the device-side send on every rank.
-            #
-            # MUST pass the adapter's split boundaries: seq = chunk * NUM_LAYERS + first_layer_idx + k, so
-            # first_layer_idx/num_my_layers have to be the split the MODEL was actually built with (main(),
-            # which snaps the even split onto ADAPTER.layer_split_boundaries). For a dense model boundaries
-            # are None and this equals the even split; for a DSA/cross-layer-reuse model (GLM) the snapped
-            # split differs, and an unsnapped one here would hand the router overlapping/gapped seqs, which
-            # its reorder buffer cannot sequence — it would stall head-of-line instead of failing loudly.
             first_layer_idx, num_my_layers = compute_layer_split(
                 NUM_LAYERS, num_ranks, ADAPTER.layer_split_boundaries(NUM_LAYERS)
             )[rank]
@@ -1136,19 +743,11 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                 local_layers=num_my_layers,
             )
             if runtime.config.use_trace:
-                # Traced: the ack op is recorded inside the capture, so register the service up front and
-                # defer the reader — it starts after the capture's warm records are drained below, or the
-                # scheduler would see a phantom chunk's acks and migrate a slot that was never filled.
                 runtime.set_d2h_ack_service(d2h_service)
             else:
-                layer_ack_service.start()  # connects to the router-owned ring (created above)
+                layer_ack_service.start()
             source_desc = "D2H device records"
         else:
-            # Host-callback source: the runtime fires on_layer_complete(layer_idx, request_id) per layer
-            # and the sink pushes into the ring (no device D2H). seq stride is the GLOBAL layer total
-            # (NUM_LAYERS), NOT this rank's slice; layer_idx arriving at the sink is already global; the
-            # chunk index is bound per prefill() call as request_id (passed by _compute_and_send), so the
-            # sink reads no shared mutable state.
             producer = LayerCompletionQueue.connect(ring_shm_name, connect_timeout_ms=30000)
             runtime.set_layer_completion_sink(
                 build_layer_completion_sink(
@@ -1164,8 +763,6 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             + (f"(owns scheduler channel {ack_shm_name})" if rank == master_rank else "(subordinate -> master)")
         )
     elif single_rank and enable_layer_ack:
-        # Single-rank non-D2H direct path: the runtime owns + inject()s the scheduler counter channel
-        # directly (on_layer_complete fires per layer inside the model). Works traced or untraced.
         _unlink_stale_shm(ack_shm_name)
         ack_channel = ttnn.InterProcessCounterChannel(ack_shm_name)
         runtime.set_layer_ack_channel(ack_channel)
@@ -1173,16 +770,8 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     elif single_rank:
         logger.info("[migration] LayerAck channel disabled (set PREFILL_ENABLE_LAYER_ACK=1 to enable)")
 
-    # Capture the trace (use_trace) after the D2D endpoints AND the per-layer completion wiring
-    # (LayerAck channel / layer-completion sink) are set up, but before the request loop: the capture
-    # must split at each completion point, and doing it here keeps the one-time cost out of the loop.
-    # No-op if already captured. See TtPrefillRuntime.capture_trace().
     if getattr(runtime, "capture_trace", None) and runtime.config.use_trace:
         runtime.capture_trace(kv_caches)
-        # D2H ack under trace: the capture's warm forward compiles the ack programs by running them, so
-        # num_layers real records already sit in the FIFO. Drain them before the reader starts, or the
-        # scheduler sees a phantom chunk's worth of layer acks and migrates a slot that was never filled.
-        # The host-callback source has no reader to defer and writes no D2H records, so it skips this.
         if use_d2h and layer_ack_service is not None:
             n_warm = getattr(runtime, "warmup_ack_count", lambda: 0)()
             for _ in range(n_warm):
@@ -1206,17 +795,8 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             d2h_service=d2h_service,
         )
     finally:
-        # Always tear down — the request loop can raise (e.g. the layer-completion sink's ring-full
-        # spin timing out on a stalled router); without this, producer/router/ack segments + the
-        # router listener thread leak, and a downstream peer blocked in D2D recv deadlocks the pipeline.
-        # Release services while the mesh + command queues are still alive (their dtors free a command
-        # queue and service-core L1; running after close_mesh_device aborts with cq_id-out-of-range).
         import gc
 
-        # Stop the D2H LayerAckService reader thread first (D2H backend only): it reads the D2H
-        # service's sockets and pushes into the router-owned ring, so it must be joined before the
-        # D2H service is dropped AND before router.stop() drains the ring (so the last records land).
-        # No-op under the host-callback / direct-inject backends (layer_ack_service stays None).
         if layer_ack_service is not None:
             layer_ack_service.stop()
             layer_ack_service = None
@@ -1225,16 +805,13 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         if producer is not None:
             producer.shutdown()
         if router is not None:
-            router.stop()  # joins the listener; the master's final ring-drain + inject happens HERE
+            router.stop()
         if ack_channel is not None:
-            ack_channel.shutdown()  # munmap + shm_unlink
+            ack_channel.shutdown()
             ack_channel = None
 
 
 if __name__ == "__main__":
-    # Best-effort: some galaxies ship a small RLIMIT_NPROC soft limit that starves the runner's threads, so
-    # raise it to the hard limit. Guarded — get/setrlimit can raise OSError/ValueError when the limit is
-    # immutable or the process lacks permission, and that must not crash the runner before main().
     try:
         import resource
 

--- a/models/demos/common/prefill/runners/producer_manifests/prefill_producer_manifest.example.yaml
+++ b/models/demos/common/prefill/runners/producer_manifests/prefill_producer_manifest.example.yaml
@@ -1,110 +1,38 @@
-# prefill_producer — FULL REFERENCE manifest: every supported flag, its PREFILL_* env var, and default.
-#
-# Drive with:
-#   python -m models.demos.common.prefill.runners.prefill_producer \
-#     --manifest models/demos/common/prefill/runners/producer_manifests/prefill_producer_manifest.example.yaml
-#
-# Precedence (lowest -> highest): typed block below  <  a raw key in the `env:` block  <  a PREFILL_* var
-# exported in the shell  <  a CLI flag (--migrations). The manifest is applied via setdefault, so anything
-# you export still wins. Every field is OPTIONAL — omit it to take the default shown. Fields marked
-# [MATCH RUNNER] MUST equal the runner's values (wire layout / ack counts / IPC paths won't line up else).
-# This file sets everything explicitly for documentation; a real manifest only needs the few you change.
-#
-# MODEL-AGNOSTIC: every value below is the documented DEFAULT, not a tuned config for any one model. Set
-# the `model:` block (and the trace paths) to whatever you are actually running.
-
-# ---------------------------------------------------------------------------
 model:
-  variant: deepseek_v3_d_p  # PREFILL_MODEL           (default: deepseek_v3_d_p) registry key in adapter.py
-  num_layers: 61            # PREFILL_NUM_LAYERS      (default: 61)    [MATCH RUNNER] per-layer ack count
-  max_seq_len: 56320        # PREFILL_MAX_SEQ_LEN     (default: 56320) [MATCH RUNNER] per-user cache tokens
-  chunk_size: 5120          # PREFILL_CHUNK_SIZE      (default: 5120)  [MATCH RUNNER] tokens per push
+  variant: deepseek_v3_d_p
+  num_layers: 61
+  max_seq_len: 56320
+  chunk_size: 5120
 
-# ---------------------------------------------------------------------------
 transport:
-  sp: 8                     # PREFILL_SP              (default: 8)  [MATCH RUNNER] mesh rows (seq-parallel)
-  tp: 4                     # PREFILL_TP              (default: 4)  [MATCH RUNNER] mesh cols (tensor-parallel)
-  h2d_service_id: ds_prefill # PREFILL_H2D_SERVICE_ID (default: ds_prefill) [MATCH RUNNER] H2D socket name
-  connect_timeout_s: 60     # PREFILL_H2D_CONNECT_TIMEOUT (default: 60) attach/table/devmap poll timeout
+  sp: 8
+  tp: 4
+  h2d_service_id: ds_prefill
+  connect_timeout_s: 60
 
-# ---------------------------------------------------------------------------
 workload:
-  num_users: 2              # PREFILL_NUM_USERS            (default: 1)   concurrent src cache slots [0,N)
-  chunks: "11"              # PREFILL_PRODUCER_CHUNKS      (default: "11") "N" fixed, or "min,max" random
-  max_requests: 2           # PREFILL_PRODUCER_MAX_REQUESTS (default: 1)  total requests before stopping
-  duration_s: "inf"         # PREFILL_PRODUCER_DURATION_S  (default: inf) wall-clock bound
-  interleave: round_robin   # PREFILL_PRODUCER_INTERLEAVE  (default: random) "random" | "round_robin"
-  check_pcc: false          # PREFILL_PRODUCER_CHECK_PCC   (default: false) producer-side per-slot read-back PCC
+  num_users: 2
+  chunks: "11"
+  max_requests: 2
+  duration_s: "inf"
+  interleave: round_robin
+  check_pcc: false
   trace_dir: /path/to/golden/traces/prompt_a
-                            # PREFILL_TRACE_DIR (default: the adapter's prefill_trace_default) shared prompt
-  # slot_prompts -> PREFILL_PRODUCER_SLOT_TRACES (default: unset => single shared trace_dir on every slot).
-  # Per-slot prompt (tokens + golden), index = slot_id; depth derived from each prompt's real length.
-  # Overrides trace_dir + chunks for those slots. Cycles by slot % count if fewer entries than num_users.
-  # slot_prompts:
-  #   - /path/to/golden/traces/prompt_a  # slot 0
-  #   - /path/to/golden/traces/prompt_b  # slot 1
 
-# ---------------------------------------------------------------------------
-# Real KV migration issued BY the producer (opt-in). Needs a live migration_endpoint the runner already
-# drove to WORKER_READY. migration_driver migrates, writes the DONE sentinel, and — in loopback — reads the
-# destination slots back itself (--verify-migration, see the env: block below). The runner validates
-# nothing: it publishes the KV-chunk table + device map, and every read-back happens in this process.
 migration:
-  issue: false              # PREFILL_PRODUCER_ISSUE_MIGRATION (default: false) attach client + migrate
-  # NO host list here. Multi-host is a LAUNCH concern, so it is an argument to the launcher script, not a
-  # manifest field:
-  #     ./models/demos/common/prefill/runners/run_migration_driver.sh <this file> "$HOSTSP" [tcp_iface]
-  # That places one driver process per host, rank 0 first and on the host you launch from; rank 0 runs the
-  # whole thing while the others are read-back-only validators, and the per-rank verdicts are allgathered.
-  # It exists because read_dram_umd is HOST-LOCAL — one process can only read the chips in its own machine,
-  # so on an N-host pipeline runner it verifies 1/N of the layers and skips the rest. Needed only when the
-  # RUNNER spans more than one host; a 1-galaxy run can invoke the module directly.
-  # Multi-host also requires table_path on SHARED storage and device_map_path HOST-LOCAL (see both below).
-  dest_endpoint_id: 1       # PREFILL_MIGRATION_DEST_ENDPOINT_ID (default: 1) own id => loopback; other => x-ep
-  dst_slot_offset: 2        # PREFILL_MIGRATION_DST_SLOT_OFFSET (default: num_users) dst = src + offset
-  # pairs -> PREFILL_MIGRATION_PAIRS (default: unset => use dst_slot_offset). Arbitrary any-src -> any-dst;
-  # overrides dst_slot_offset. Each src must be resident; each dst < the RUNNER's slot count. Also --migrations.
-  # pairs:
-  #   - {src: 0, dst: 3}
-  #   - {src: 1, dst: 2}
-  timeout_ms: 3600000       # PREFILL_MIGRATION_TIMEOUT_MS (default: 3600000) per-migration wait_complete ms
-  done_file: /tmp/migration_done.sentinel   # MIGRATION_DONE_FILE (default: /tmp/migration_done.sentinel)
+  issue: false
+  dest_endpoint_id: 1
+  dst_slot_offset: 2
+  timeout_ms: 3600000
+  done_file: /tmp/migration_done.sentinel
   client_dir: /path/to/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python
-                            # PREFILL_MIGRATION_CLIENT_DIR (default: unset) dir holding _migration_client*.so
-  cmd_queue: /mig_ep1_cmd   # PREFILL_MIGRATION_CMD_QUEUE   (default: /prefill_mig_cmd_1) [MATCH ENDPOINT]
-  table_queue: /mig_ep1_table # PREFILL_MIGRATION_TABLE_QUEUE (default: /prefill_mig_tbl_1) [MATCH ENDPOINT]
-  resp_queue: /mig_ep1_resp # PREFILL_MIGRATION_RESP_QUEUE  (default: /prefill_mig_rsp_1) [MATCH ENDPOINT]
-  table_path: /tmp/prefill_kv_chunk_table.pb    # PREFILL_MIGRATION_TABLE_PATH [MATCH RUNNER] KV addr table
-                            # On a multi-host run this MUST be on SHARED storage:
-                            # rank 0 writes it and every validator reads it from its own host. The driver
-                            # exits with an error if it points at /tmp, /dev/shm, /run or /var/tmp.
-  device_map_path: /tmp/prefill_kv_device_map.json # PREFILL_MIGRATION_DEVICE_MAP_PATH [MATCH RUNNER] (check_pcc)
-                            # The OPPOSITE of the table: keep it HOST-LOCAL. Every runner rank serializes
-                            # its OWN host's fnid -> unique_id map under this name, which is what makes each
-                            # driver rank resolve exactly its own host's layers. On shared storage the ranks
-                            # race serialize_device_map's `<path>.tmp` -> os.replace and one dies with
-                            # FileNotFoundError while the survivor leaves the wrong host's map.
+  cmd_queue: /mig_ep1_cmd
+  table_queue: /mig_ep1_table
+  resp_queue: /mig_ep1_resp
+  table_path: /tmp/prefill_kv_chunk_table.pb
+  device_map_path: /tmp/prefill_kv_device_map.json
 
-# ---------------------------------------------------------------------------
-# Escape hatch: any raw PREFILL_* key (wins over the typed blocks). Also the home for flags with no typed
-# field of their own:
 env:
-  PREFILL_SEND_SHUTDOWN: "0"            # (default: 0) "1" => close the stream with an all -1 sentinel so the
-                                        # runner drains + tears down after the run. Sent LAST, after both the
-                                        # KV read-back and --verify-migration, so it never pulls the mesh out
-                                        # from under a UMD read. Leave "0" only if shutdown is external —
-                                        # otherwise the runner's unbounded loop sits in recv until SIGTERM.
-  PREFILL_STANDALONE_CHUNKED_PCC: "0.93" # (default: 0.93) producer-side check_pcc pass/fail threshold. Also the
-                                        # threshold for --verify-migration dst-golden.
-  # migration_driver only, and deliberately NOT typed fields in the `migration:` block above — set them here,
-  # export them, or pass --verify-migration / --verify-migration-layers.
-  PREFILL_VERIFY_MIGRATION: "dst-bytes" # (default: dst-bytes) destination read-back after the migrate, LOOPBACK
-                                        # only: off | dst-bytes (dst == src, golden-free, model-agnostic) |
-                                        # dst-golden (dst PCC'd vs the src's golden) | both. Feeds the exit code.
-  # PREFILL_VERIFY_MIGRATION_LAYERS: "0,30,60"  # (default: every migrated layer) spot-check subset. dst-bytes
-                                        # reads BOTH slots, so a full-depth pair is expensive; a subset makes a
-                                        # PASS a sample, not a proof, and restricts the check to config 0.
-  # The MPI NIC is not env config either: it is run_migration_driver.sh's 3rd argument (default
-  # ens5f0np0, the same default run_pipeline_prefill.sh uses). It MUST match the interface the RUNNER was
-  # launched with -- these hosts are multi-homed (docker0 carries the SAME address everywhere), and a
-  # mismatch hangs MPI_Init with every rank silent after "applied manifest".
+  PREFILL_SEND_SHUTDOWN: "0"
+  PREFILL_STANDALONE_CHUNKED_PCC: "0.93"
+  PREFILL_VERIFY_MIGRATION: "dst-bytes"

--- a/models/demos/common/prefill/runners/producer_manifests/producer_manifest_arbitrary_migration.yaml
+++ b/models/demos/common/prefill/runners/producer_manifests/producer_manifest_arbitrary_migration.yaml
@@ -1,31 +1,3 @@
-# Producer manifest: arbitrary any-src -> any-dst KV migration.
-#
-# Migrates via an explicit `migration.pairs` mapping (0->3, 1->2) instead of the uniform src+offset;
-# equivalent CLI: --migrations "0:3,1:2". src and dst sets must be disjoint (overlaps and duplicate
-# destinations are rejected).
-#
-# Requires (a) a running migration_endpoint (launch_migration_endpoints.sh, prefill_endpoint_id 1) and
-# (b) a single-rank REQUEST-mode runner with migration enabled. Start from
-# topology_configuration/pipeline_prefill_request_1rank.yaml and add to its global_env:
-#   PREFILL_NUM_USERS: "4"            # dst slots 2,3 must exist in the table
-#   PREFILL_ENABLE_MIGRATION: "1"     # publish the KV table + reach WORKER_READY
-#   PREFILL_MIGRATION_CMD_QUEUE / _TABLE_QUEUE / _RESP_QUEUE / _TABLE_PATH / _CLIENT_DIR  # match below
-#   PREFILL_MANIFEST + PREFILL_NUM_LAYERS                                    # your model
-# Run it with migration_driver, NOT prefill_producer — the latter ignores `migration:` entirely, so
-# `pairs:` below would never take effect:
-#   python -m models.demos.common.prefill.runners.migration_driver \
-#     --manifest models/demos/common/prefill/runners/producer_manifests/producer_manifest_arbitrary_migration.yaml
-# Every verdict is logged there — the runner validates nothing. Sources come from check_pcc below,
-# destinations from --verify-migration (default dst-bytes).
-#
-# MODEL-AGNOSTIC: this file describes the migration SCENARIO only, so it works with any prefill model.
-# The model + wire layout are deliberately NOT set here; they must match the runner you launched. Supply
-# them either by exporting PREFILL_MODEL / PREFILL_NUM_LAYERS / PREFILL_MAX_SEQ_LEN / PREFILL_CHUNK_SIZE,
-# or by adding a `model:` block (see prefill_producer_manifest.example.yaml for the full schema), e.g.
-#   model: {variant: <adapter key>, num_layers: <MATCH RUNNER>, max_seq_len: ..., chunk_size: ...}
-# Left unset they fall back to the adapter defaults, which will NOT match a runner of a different depth
-# — the per-layer ack count is num_layers * chunks, so a mismatch hangs the ack drain.
-
 transport:
   sp: 8
   tp: 4
@@ -33,16 +5,16 @@ transport:
   connect_timeout_s: 60
 
 workload:
-  num_users: 2            # src slots 0,1 (the runner's table has 4 slots, so dst 2,3 are free)
+  num_users: 2
   chunks: "11"
-  max_requests: 2         # one resident request per slot (no recycling)
+  max_requests: 2
   interleave: round_robin
-  check_pcc: true         # SOURCE-slot golden PCC; --verify-migration covers the destinations
+  check_pcc: true
 
 migration:
-  issue: true             # attach the Python MigrationLayerClient and migrate
-  dest_endpoint_id: 1     # loopback: the endpoint's own id
-  pairs:                  # ARBITRARY any-src -> any-dst (overrides dst_slot_offset)
+  issue: true
+  dest_endpoint_id: 1
+  pairs:
     - {src: 0, dst: 3}
     - {src: 1, dst: 2}
   timeout_ms: 3600000

--- a/models/demos/common/prefill/runners/producer_manifests/producer_manifest_migration_api_validation.yaml
+++ b/models/demos/common/prefill/runners/producer_manifests/producer_manifest_migration_api_validation.yaml
@@ -1,31 +1,3 @@
-# Producer manifest: Python migration API.
-#
-# `issue: true` attaches a MigrationLayerClient and calls migrate() + wait_complete() per resident slot,
-# then writes the DONE sentinel. Uniform mapping here (dst = src + 2); set `pairs:` instead for an
-# arbitrary mapping.
-#
-# Requires (a) a running migration_endpoint (prefill_endpoint_id 1) and (b) a single-rank REQUEST-mode
-# runner with migration enabled. Start from
-# topology_configuration/pipeline_prefill_request_1rank.yaml and add to its global_env:
-#   PREFILL_NUM_USERS: "4"            # dst slots 2,3 must exist in the table
-#   PREFILL_ENABLE_MIGRATION: "1"     # publish the KV table + reach WORKER_READY
-#   PREFILL_MIGRATION_CMD_QUEUE / _TABLE_QUEUE / _RESP_QUEUE / _TABLE_PATH / _CLIENT_DIR  # match below
-#   PREFILL_MANIFEST + PREFILL_NUM_LAYERS                                    # your model
-# Run it with migration_driver, NOT prefill_producer — the latter ignores `migration:` entirely, so the
-# scenario this file describes would never be exercised:
-#   python -m models.demos.common.prefill.runners.migration_driver \
-#     --manifest models/demos/common/prefill/runners/producer_manifests/producer_manifest_migration_api_validation.yaml
-# Every verdict is logged there — the runner validates nothing. Sources come from check_pcc below,
-# destinations from --verify-migration (default dst-bytes).
-#
-# MODEL-AGNOSTIC: this file describes the migration SCENARIO only, so it works with any prefill model.
-# The model + wire layout are deliberately NOT set here; they must match the runner you launched. Supply
-# them either by exporting PREFILL_MODEL / PREFILL_NUM_LAYERS / PREFILL_MAX_SEQ_LEN / PREFILL_CHUNK_SIZE,
-# or by adding a `model:` block (see prefill_producer_manifest.example.yaml for the full schema), e.g.
-#   model: {variant: <adapter key>, num_layers: <MATCH RUNNER>, max_seq_len: ..., chunk_size: ...}
-# Left unset they fall back to the adapter defaults, which will NOT match a runner of a different depth
-# — the per-layer ack count is num_layers * chunks, so a mismatch hangs the ack drain.
-
 transport:
   sp: 8
   tp: 4
@@ -33,16 +5,16 @@ transport:
   connect_timeout_s: 60
 
 workload:
-  num_users: 2            # src slots 0,1 -> dst 2,3
+  num_users: 2
   chunks: "11"
   max_requests: 2
   interleave: round_robin
-  check_pcc: true         # SOURCE-slot golden PCC; --verify-migration covers the destinations
+  check_pcc: true
 
 migration:
-  issue: true             # <-- the Python Migration API: MigrationLayerClient.migrate()/wait_complete()
+  issue: true
   dest_endpoint_id: 1
-  dst_slot_offset: 2      # uniform: dst = src + 2  (0->2, 1->3)
+  dst_slot_offset: 2
   timeout_ms: 3600000
   done_file: /tmp/migration_done.sentinel
   client_dir: /path/to/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python

--- a/models/demos/common/prefill/runners/producer_manifests/producer_manifest_multiprompt.yaml
+++ b/models/demos/common/prefill/runners/producer_manifests/producer_manifest_multiprompt.yaml
@@ -1,33 +1,3 @@
-# Producer manifest: multi-prompt single-stage KV validation.
-#
-# Assigns a prompt (tokens + golden) per slot via `slot_prompts` and PCCs each slot's KV against its own
-# golden (check_pcc); per-slot depth is derived from each prompt's real length. Single stage (1 rank /
-# 1 galaxy), no migration endpoint needed.
-#
-# Needs a single-rank REQUEST-mode runner that publishes the KV table for the producer's device-less
-# read-back. Start from topology_configuration/pipeline_prefill_request_1rank.yaml and add to its
-# global_env:
-#   PREFILL_MOCK_MIGRATION: "1"       # serialize the KV table + device map; no migration_endpoint needed
-#   PREFILL_NUM_USERS: "2"            # one slot per prompt below
-#   PREFILL_MANIFEST + PREFILL_NUM_LAYERS                                    # your model
-# The runner stays open across producer runs, so you can re-run this manifest against the same runner.
-# Run:
-#   python -m models.demos.common.prefill.runners.prefill_producer \
-#     --manifest models/demos/common/prefill/runners/producer_manifests/producer_manifest_multiprompt.yaml
-# Expect: [producer] KV cache PCC PASSED.
-#
-# For a SPARSE/DSA model the table also carries an index config. A trace that ships the indexer-key golden
-# (dsa/indexer_k_layer_*) has its index cache PCC'd alongside the KVPE cache; one that ships only
-# dsa/dsa_topk_indices_layer_* is validated on the KVPE cache alone (warned, not fatal).
-#
-# MODEL-AGNOSTIC: this file describes the multi-prompt SCENARIO only. The model + wire layout are NOT set
-# here; they must match the runner you launched. Supply them by exporting PREFILL_MODEL /
-# PREFILL_NUM_LAYERS / PREFILL_MAX_SEQ_LEN / PREFILL_CHUNK_SIZE, or add a `model:` block (see
-# prefill_producer_manifest.example.yaml), e.g.
-#   model: {variant: <adapter key>, num_layers: <MATCH RUNNER>, max_seq_len: ..., chunk_size: ...}
-# Left unset they fall back to the adapter defaults, which will NOT match a runner of a different depth
-# — the per-layer ack count is num_layers * chunks, so a mismatch hangs the ack drain.
-
 transport:
   sp: 8
   tp: 4
@@ -36,18 +6,15 @@ transport:
 
 workload:
   num_users: 2
-  max_requests: 2         # one resident request per slot (no recycling)
+  max_requests: 2
   interleave: round_robin
-  check_pcc: true         # producer-side per-slot read-back PCC — this IS the validation gate
-  # One pre-tokenized golden trace dir (tokens + golden) per slot; index = slot id. Prompts are inherently
-  # model-specific — point these at traces for the PREFILL_MODEL you are running. Use DISTINCT traces for a
-  # true multi-prompt run; repeating one trace only exercises the plumbing.
+  check_pcc: true
   slot_prompts:
-    - /path/to/golden/traces/prompt_a  # slot 0
-    - /path/to/golden/traces/prompt_b  # slot 1
+    - /path/to/golden/traces/prompt_a
+    - /path/to/golden/traces/prompt_b
 
 migration:
-  issue: false            # single-stage multi-prompt validation; no real migration
+  issue: false
 
 env:
   PREFILL_MIGRATION_TABLE_PATH: /tmp/prefill_kv_chunk_table.pb

--- a/models/demos/common/prefill/runners/run_migration_driver.sh
+++ b/models/demos/common/prefill/runners/run_migration_driver.sh
@@ -1,42 +1,4 @@
 #!/usr/bin/env bash
-# Launcher for the KV-migration driver — one driver process per pipeline host.
-#
-# Sibling of run_pipeline_prefill.sh, and for the same reason: launch concerns (host list, MPI transport,
-# env forwarding) live in shell, not in the Python they launch. The driver module itself never spawns
-# anything; it only splits by rank once MPI has placed it.
-#
-# WHY ONE PROCESS PER HOST: both of the driver's read-backs — the source golden PCC and the destination
-# --verify-migration — go over read_dram_umd, which reaches only the chips in the machine it runs on. One
-# process on an N-host pipeline runner therefore verifies 1/N of the layers and silently skips the rest.
-# With a process per host, each rank reads its own galaxy and the per-rank verdicts are allgathered, so the
-# union covers the whole model. Rank 0 additionally does the whole run: H2D feed, ack drain, migrate, both
-# sidecar files.
-#
-# Usage:
-#   run_migration_driver.sh <producer_manifest.yaml> [host_list] [tcp_iface] [extra driver args...]
-#
-#   <producer_manifest.yaml>  path (relative to TT_METAL_HOME or absolute) to the producer manifest.
-#   [host_list]               mpirun --host value, in RANK ORDER. Rank 0 comes first and MUST be this host:
-#                             it alone attaches the H2D service and the /mig_ep*_ queues, which exist only
-#                             where the runner's rank 0 runs. Use the SAME list you passed to
-#                             run_pipeline_prefill.sh. Omit it (or pass a single host) to run one process,
-#                             covering this host's layers only — correct for a 1-galaxy runner.
-#   [tcp_iface]               NIC for MPI TCP. Default: ens5f0np0. MUST match what the runner was launched
-#                             with (run_pipeline_prefill.sh's 3rd argument): these hosts are multi-homed
-#                             and docker0 carries the SAME address on every one, so an unpinned OpenMPI
-#                             advertises on one NIC and connects on another and MPI_Init never completes —
-#                             every rank logs "applied manifest" and then goes silent.
-#   [extra driver args...]    Anything else is passed through to the module verbatim, on every rank, e.g.
-#                             --verify-migration both --verify-migration-layers 0,30,60
-#
-# Examples:
-#   # 2 galaxies, full coverage
-#   ./run_migration_driver.sh \
-#     models/demos/common/prefill/runners/producer_manifests/producer_manifest_ds_2galaxy_loopback.yaml \
-#     bh-glx-110-c04u02:1,bh-glx-110-c04u08:1
-#
-#   # single galaxy — no MPI at all
-#   ./run_migration_driver.sh models/demos/common/prefill/runners/producer_manifests/<manifest>.yaml
 set -euo pipefail
 
 MANIFEST="${1:?usage: run_migration_driver.sh <producer_manifest.yaml> [host_list] [tcp_iface] [args...]}"
@@ -46,8 +8,6 @@ HOST_LIST="${1:-}"
 TCP_IFACE="${1:-ens5f0np0}"
 [ $# -gt 0 ] && shift
 
-# TT_METAL_HOME = the tt-metal tree this script lives in
-# (models/demos/common/prefill/runners -> 5 levels up). Matches run_pipeline_prefill.sh.
 TT_METAL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
 export TT_METAL_HOME PYTHONPATH="${PYTHONPATH:-$TT_METAL_HOME}"
 [ -z "${VIRTUAL_ENV:-}" ] && [ -f "$TT_METAL_HOME/python_env/bin/activate" ] && source "$TT_METAL_HOME/python_env/bin/activate"
@@ -56,19 +16,14 @@ cd "$TT_METAL_HOME"
 MODULE="models.demos.common.prefill.runners.migration_driver"
 NUM_HOSTS=$(printf '%s' "$HOST_LIST" | tr ',' '\n' | grep -c . || true)
 
-# One host (or none): no MPI. The driver runs standalone, rank 0 of 1, and verifies this host's layers.
 if [ "$NUM_HOSTS" -le 1 ]; then
   echo "[run_migration_driver] single process (host_list='${HOST_LIST}'); verifying THIS host's layers only."
   exec python3 -m "$MODULE" --manifest "$MANIFEST" "$@"
 fi
 
-# mpirun-ulfm is what tt-run prefers; fall back to plain mpirun.
 LAUNCHER="$(command -v mpirun-ulfm || command -v mpirun || true)"
 [ -n "$LAUNCHER" ] || { echo "[run_migration_driver] no mpirun-ulfm or mpirun on PATH" >&2; exit 1; }
 
-# ttrun only auto-propagates TT_*/ARCH_*/... , so PATH/PYTHONPATH must be named or a peer rank resolves a
-# bare python3 with no ttnn. Every exported PREFILL_*/MIGRATION_* goes too: the ranks coordinate over MPI
-# collectives and must agree on the config, so a knob that reached only rank 0 would desynchronize them.
 FWD=(-x PATH -x LD_LIBRARY_PATH -x PYTHONPATH -x TT_METAL_HOME)
 [ -n "${TT_METAL_CACHE:-}" ] && FWD+=(-x TT_METAL_CACHE)
 [ -n "${VIRTUAL_ENV:-}" ] && FWD+=(-x VIRTUAL_ENV)
@@ -80,9 +35,6 @@ done < <(compgen -e | grep -E '^(PREFILL_|MIGRATION_)' | sort)
 echo "[run_migration_driver] $NUM_HOSTS host(s): $HOST_LIST (rank 0 = ${HOST_LIST%%,*}, must be $(hostname))"
 echo "[run_migration_driver] tcp interface: $TCP_IFACE — must match the runner's"
 
-# --mca btl self,tcp --mca btl_tcp_if_include <iface>: the same transport arguments ttrun gives the runner
-# (see default_multihost_mpi_args in ttnn/ttnn/distributed/ttrun.py). Both jobs span the same hosts, so
-# they have to agree on the network.
 exec "$LAUNCHER" \
   --host "$HOST_LIST" \
   --map-by slot \

--- a/models/demos/common/prefill/runners/run_pipeline_prefill.sh
+++ b/models/demos/common/prefill/runners/run_pipeline_prefill.sh
@@ -1,74 +1,21 @@
 #!/usr/bin/env bash
-# Thin launcher for the pipeline-parallel prefill runner under tt-run.
-#
-# All real config (mesh, layer split, chunk count, transport, PCC, PREFILL_* env) lives in the
-# rank-binding YAML's global_env — ttrun does NOT auto-propagate PREFILL_* from the shell, so
-# per-run knobs belong there, not here. This script only captures the launch boilerplate: env
-# exports, the host list / TCP interface, the activation-handoff dir cleanup, and the ttrun call.
-#
-# Usage:
-#   run_pipeline_prefill.sh <rank_binding.yaml> [host_list] [tcp_iface]
-#
-#   <rank_binding.yaml>  path (relative to TT_METAL_HOME or absolute) to the tt-run rank binding.
-#   [host_list]          mpirun --host value. Default: bh-glx-d03u02:1,bh-glx-d03u08:1 (2 galaxies).
-#                        For a single-rank/one-galaxy binding pass e.g. bh-glx-d03u02:1.
-#   [tcp_iface]          NIC for MPI TCP. Default: ens5f0np0 (the 10.32.24.x cluster net here).
-#
-# This launcher is model-agnostic (it only execs the common prefill_runner entry point). The
-# rank-binding YAMLs + mesh-graph descriptors are topology config (model-agnostic; the model is
-# selected by the binding's PREFILL_MANIFEST) and live at
-# models/demos/common/prefill/runners/topology_configuration/. Pass your binding as $1.
-#
-# Examples (drive each with prefill_producer.py on the launch host). The request_* bindings are
-# model-agnostic and carry no PREFILL_MANIFEST, so they run the default model; set PREFILL_MANIFEST in
-# the binding's global_env to select another (e.g. deepseek_v3_d_p/.../manifests/kimi26.json for Kimi-2.6):
-#   # 2-galaxy D2D pipeline (connected MGD, FABRIC_2D):
-#   ./run_pipeline_prefill.sh models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank.yaml bh-glx-d07u02:1,bh-glx-d07u08:1
-#
-#   # 4-galaxy D2D pipeline (ring-chain host order — see the 4-galaxy connected MGD):
-#   ./run_pipeline_prefill.sh models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank.yaml bh-glx-d07u02:1,bh-glx-d07u08:1,bh-glx-d08u08:1,bh-glx-d08u02:1
-#
-#   # single-galaxy 1-rank full-model de-risk:
-#   ./run_pipeline_prefill.sh models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml bh-glx-d07u02:1
 set -euo pipefail
 
 RANK_BINDING="${1:?usage: run_pipeline_prefill.sh <rank_binding.yaml> [host_list] [tcp_iface]}"
 HOST_LIST="${2:-bh-glx-d03u02:1,bh-glx-d03u08:1}"
 TCP_IFACE="${3:-ens5f0np0}"
 
-# TT_METAL_HOME = the tt-metal tree this script lives in
-# (models/demos/common/prefill/runners -> 5 levels up).
 TT_METAL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
 export TT_METAL_HOME PYTHONPATH="$TT_METAL_HOME"
-# ttrun.py runs on THIS (launch) host and must use the venv interpreter (loguru etc.); peer ranks get
-# it via -x PATH below. Activate here so callers don't have to remember to source the venv first.
 [ -z "${VIRTUAL_ENV:-}" ] && [ -f "$TT_METAL_HOME/python_env/bin/activate" ] && source "$TT_METAL_HOME/python_env/bin/activate"
-# Per-host LOCAL JIT cache. A shared (NFS) TT_METAL_CACHE makes both hosts write the same generated
-# kernel files (defines_generated.h, ...) concurrently on a cold cache -> "Stale file handle" compile
-# failures. /tmp is per-host, so each rank compiles into its own dir. ttrun auto-propagates TT_* vars.
 export TT_METAL_CACHE="${PP_TT_METAL_CACHE:-/tmp/tt-metal-cache-pp}"
 cd "$TT_METAL_HOME"
 
-# Optional shell-selected model, SINGLE-HOST ONLY: forward PREFILL_MANIFEST / PREFILL_MODEL when set, so
-# a GENERIC binding (one that does not set the model in its global_env) can run any model without a
-# per-model binding, e.g.
-#   PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json \
-#     ./run_pipeline_prefill.sh <generic_binding.yaml> <host_list>
-# Use this with a binding that leaves the model unset; don't also set it in that binding's global_env.
-# Multi-host: -x reaches only the launch-host rank, so remote ranks silently take the default model and
-# disagree on the chunk plan — put PREFILL_MANIFEST (ABSOLUTE path) in the binding's global_env instead.
 FWD_ENV=""
 [ -n "${PREFILL_MANIFEST:-}" ] && FWD_ENV="${FWD_ENV} -x PREFILL_MANIFEST"
 [ -n "${PREFILL_MODEL:-}" ] && FWD_ENV="${FWD_ENV} -x PREFILL_MODEL"
-# The KV-PCC read-back gate needs the runner to publish its chunk table; forward the flag when set so a
-# single-host accuracy run can enable it from the shell (multi-host: same -x caveat as the model above).
 [ -n "${PREFILL_MOCK_MIGRATION:-}" ] && FWD_ENV="${FWD_ENV} -x PREFILL_MOCK_MIGRATION"
 
-# -x PATH/LD_LIBRARY_PATH: ttrun only forwards TT_*/ARCH_*/... prefixed vars, not PATH, so peer ranks
-# would otherwise resolve a bare `python3` to the system interpreter (no ttnn). Forwarding the launch
-# host's PATH works only because every host's venv sits at the identical clone path.
-# `--` terminates ttrun's own option parsing: ttrun's -m short flag (--mesh-graph-descriptor) otherwise
-# swallows the target's `python3 -m <module>` and trips the mesh-graph/rank-binding mutual-exclusion check.
 exec python3 ttnn/ttnn/distributed/ttrun.py \
   --tcp-interface "$TCP_IFACE" \
   --rank-binding "$RANK_BINDING" \

--- a/models/demos/common/prefill/runners/runner_utils.py
+++ b/models/demos/common/prefill/runners/runner_utils.py
@@ -1,18 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-"""Model-agnostic utilities for the prefill runner.
-
-Only metal-native helpers live here — pure ttnn, no upward dependencies
-on blaze (`_migration`, `_mpi_test_helpers`) and no dependency on any specific
-model package. Migration-coupled diagnostics live in blaze at
-`disaggregation/migration/python/prefill_runner_util.py`.
-
-Per-model plumbing (which model to build, where its weights/config/trace live,
-how to allocate its KV cache, how to call chunked prefill) lives behind the
-PrefillModelAdapter (../adapter.py), NOT here. Model-specific KV diagnostics /
-PCC live in the model package's own runner_utils.
-"""
 
 import os
 from pathlib import Path
@@ -23,34 +11,14 @@ import ttnn
 
 
 def _create_fabric_router_config(max_payload_size):
-    """FabricRouterConfig with a custom max payload size. Inlined here (a 3-line
-    ttnn wrapper) so this common module needs no model-package import."""
     config = ttnn._ttnn.fabric.FabricRouterConfig()
     config.max_packet_payload_size_bytes = max_payload_size
     return config
 
 
-# ---------------------------------------------------------------------------
-# Device / H2D-service setup
-# ---------------------------------------------------------------------------
 def open_mesh_device(
     mesh_shape: tuple, model_cfg: type, l1_small_size: int = 0, trace_region_size: int = 0
 ) -> ttnn.MeshDevice:
-    """Configure fabric and open the mesh device.
-
-    Default fabric is 1D for sp<=8, else 2D. PREFILL_FABRIC_MODE overrides this: the D2D-socket
-    pipeline needs 2D even at sp=8 because a MeshSocket routes over 2D fabric, and set_fabric_config
-    is one global config for the whole run. Accepted modes: 1d, 2d, 1d_ring, 2d_torus_x,
-    2d_torus_y, 2d_torus_xy. A torus mode physically wraps the named axis (x = cols = tp_axis,
-    y = rows = sp_axis) into a ring and MUST match the mesh-graph descriptor's dim_types (a Ring
-    collective on an axis the fabric does not wrap hangs). The per-axis CCL topology is derived from
-    the opened fabric via tt_ccl.per_axis_topology().
-
-    `l1_small_size` > 0 carves an L1_SMALL region (needed when an op routes its
-    semaphores there, e.g. the Kimi MoE routing all-gather with use_l1_small_for_semaphores).
-
-    `trace_region_size` > 0 reserves device DRAM for ttnn trace capture — needed when the runtime
-    replays a captured forward (TtPrefillRuntime use_trace). 0 = no trace region (default)."""
     sp = mesh_shape[0]
     fabric_mode = os.environ.get("PREFILL_FABRIC_MODE", "").strip().lower()
     fabric_mode_map = {
@@ -88,9 +56,6 @@ def open_mesh_device(
 
 
 def make_global_spec(mesh_shape: tuple, chunk_size: int) -> ttnn.TensorSpec:
-    """Per-push input spec used by `build_h2d_service` to set the service's
-    global tensor shape (the producer matches it on the host side). One push carries one
-    chunk_size-token chunk. Shape `(sp_factor, 1, chunk_size // sp_factor)` uint32 ROW_MAJOR DRAM."""
     sp_factor = mesh_shape[0]
     isl_per_chip = chunk_size // sp_factor
     return ttnn.TensorSpec(
@@ -110,32 +75,18 @@ def build_h2d_service(
     worker_cores: ttnn.CoreRange,
     metadata_size_bytes: int,
 ) -> ttnn.H2DStreamService:
-    """Construct an H2DStreamService whose per-shard backing tensor matches
-    what `prepare_prefill_input_tensor` would have produced. Each push carries one chunk_size-token
-    chunk (chunked prefill streams one chunk per push), not the full sequence.
-
-    Per-shard target: `(1, 1, chunk_size // sp_factor)` uint32 ROW_MAJOR DRAM.
-    Achieved by setting global_spec.shape = `(sp_factor, 1, chunk_size // sp_factor)` and
-    mapping `[Shard(0), Replicate]` on a `(sp, tp)` mesh — first axis of the
-    tensor is sharded across mesh rows (sp), nothing else is split.
-    """
     sp_factor, tp_factor = mesh_shape
     assert chunk_size % sp_factor == 0, f"chunk_size={chunk_size} must be divisible by sp_factor={sp_factor}"
     isl_per_chip = chunk_size // sp_factor
-    per_chip_bytes = isl_per_chip * 4  # uint32
+    per_chip_bytes = isl_per_chip * 4
 
     global_spec = make_global_spec(mesh_shape, chunk_size)
     mapper = ttnn.create_mesh_mapper(mesh_device, mapper_config)
-    # worker_cores set so the service-core kernel multicasts a data-ready inc
-    # after each transfer; inbound_socket_service_sync() waits on that on-device, which
-    # avoids the host-side barrier() round-trip per iteration.
-    # metadata_size_bytes set so the producer can ship per-iter control bytes
-    # (slot_id, actual_start, actual_end) inline with the token push.
     service = ttnn.H2DStreamService(
         mesh_device=mesh_device,
         global_spec=global_spec,
-        fifo_size_bytes=8 * per_chip_bytes,  # 8 in-flight pages of headroom (0 would auto-size)
-        max_socket_page_size_bytes=per_chip_bytes,  # cap socket page at one tensor page (0 = auto/coalesced)
+        fifo_size_bytes=8 * per_chip_bytes,
+        max_socket_page_size_bytes=per_chip_bytes,
         mapper=mapper,
         worker_cores=worker_cores,
         metadata_size_bytes=metadata_size_bytes,
@@ -148,9 +99,6 @@ def build_h2d_service(
 
 
 def activation_global_spec(chunk_size: int, hidden_size: int) -> ttnn.TensorSpec:
-    """Global spec of the inter-rank hidden state carried over the D2D pipeline socket:
-    [1, 1, chunk_size, hidden_size] bf16 TILE DRAM. The caller's mesh mapper shards it (seq across SP
-    rows, emb across TP cols) to match the embedding output layout the downstream model consumes."""
     return ttnn.TensorSpec(
         shape=ttnn.Shape([1, 1, chunk_size, hidden_size]),
         dtype=ttnn.bfloat16,
@@ -160,9 +108,6 @@ def activation_global_spec(chunk_size: int, hidden_size: int) -> ttnn.TensorSpec
 
 
 def resolve_trace_dir(path) -> Path:
-    """Resolve a trace dir to the one holding metadata.json. vllm traces nest metadata.json + kv_cache
-    under a single run-hash subdir, so if `path` itself has no metadata.json, descend into the sole
-    subdir that does."""
     path = Path(path)
     if (path / "metadata.json").exists():
         return path
@@ -173,7 +118,6 @@ def resolve_trace_dir(path) -> Path:
 
 
 def load_trace_token_ids(trace_dir, total_len=None) -> list:
-    """Input token_ids from a resolved trace's metadata.json (optionally truncated to total_len)."""
     import json
 
     with open(Path(trace_dir) / "metadata.json") as f:
@@ -182,15 +126,7 @@ def load_trace_token_ids(trace_dir, total_len=None) -> list:
     return tids[:total_len] if total_len is not None else tids
 
 
-# ---------------------------------------------------------------------------
-# Layer assignment
-# ---------------------------------------------------------------------------
-
-
 def _snap_counts_to_starts(counts, valid_starts, num_layers):
-    """Nudge an even split's interior rank boundaries onto the nearest valid start (preserving
-    sum == num_layers), for models that constrain where a rank may begin (layer_split_boundaries).
-    Nearest by |distance| then lower index; each boundary is used at most once and stays increasing."""
     valid = sorted(valid_starts)
     boundaries, s = [], 0
     for c in counts[:-1]:
@@ -215,13 +151,6 @@ def _snap_counts_to_starts(counts, valid_starts, num_layers):
 
 
 def compute_layer_split(num_layers: int, num_ranks: int, valid_starts=None) -> list[tuple[int, int]]:
-    """Contiguous (first_layer_idx, count) per rank. PREFILL_PP_LAYER_COUNTS, a
-    comma-separated count list summing to num_layers, overrides the default even
-    split (remainder handed to the earlier ranks).
-
-    ``valid_starts`` (from the adapter's ``layer_split_boundaries``): layer indices at which a rank may
-    begin. None => unconstrained. When set, the default even split is auto-snapped onto valid
-    boundaries, and any split (explicit or snapped) whose rank starts fall off them is rejected early."""
     override = os.environ.get("PREFILL_PP_LAYER_COUNTS")
     if override:
         counts = [int(x) for x in override.split(",")]

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
@@ -1,18 +1,3 @@
-# Connected 2-galaxy mesh graph descriptor for D2D-socket pipeline prefill: ONE fabric link between
-# the two galaxies so the D2D MeshSocket has a path: stage 0 (mesh 0) -> stage 1 (mesh 1).
-#
-# Structure adapted from the decode superpod MGD
-# (models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_mesh_graph_descriptor_superpod.textproto),
-# which chains 64 4x2 meshes 0<->1<->...<->63 with count:8 RELAXED links and NO pinnings (pure
-# discovery) on these same machines. We keep that connection format but use the prefill 8x4
-# full-galaxy geometry — one mesh per galaxy, one inter-galaxy link. d07u02<->d07u08 are directly
-# cabled (UMD topology: 4 matched remote chips), so discovery maps mesh 0 -> first --host, mesh 1 ->
-# second, and binds the inter-galaxy link.
-#
-# dim_types [RING, RING]: each galaxy is an XY torus (rows/SP and cols/TP both wrap). This MUST be
-# paired with PREFILL_FABRIC_MODE=2d_torus_xy in the rank binding — a mismatch between the descriptor
-# wrap and the fabric mode hangs at fabric bring-up. Requires the 2d_torus_* modes from #48711.
-
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
@@ -27,8 +12,6 @@ graph_descriptors {
   instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
   instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
 
-  # Inter-galaxy fabric link (the D2D pipeline hop). count:8 matches the decode superpod's
-  # per-galaxy-boundary link on this hardware.
   connections {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto
@@ -1,15 +1,3 @@
-# CONNECTED 4-galaxy mesh graph descriptor for the D2D-socket pipeline prefill, FABRIC_2D variant.
-#
-# Four 8x4 BH-galaxy meshes chained mesh 0 <-> 1 <-> 2 <-> 3 by inter-galaxy fabric links, one per
-# pipeline boundary (rank r sends to rank r+1).
-#
-# Host order matters: discovery maps mesh 0 -> first --host, mesh 1 -> second, etc., and the chained
-# connections require consecutive hosts to be physically cabled. List the --host slots in the order
-# the galaxies are cabled in the superpod chain.
-#
-# dim_types [LINE, LINE]: no row/column wrap, so this pairs with PREFILL_FABRIC_MODE=2d. GLM-5.2's MoE
-# all_to_all deadlocks in warmup under the torus modes on multi-galaxy pipeline prefill, which is why
-# the wrap is dropped here rather than declared and left unused.
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto
@@ -1,18 +1,3 @@
-# CONNECTED 4-galaxy mesh graph descriptor for the D2D-socket pipeline prefill.
-#
-# Four 8x4 BH-galaxy meshes chained mesh 0 <-> 1 <-> 2 <-> 3 by inter-galaxy fabric links, one per
-# pipeline boundary (rank r sends to rank r+1). Mirrors the decode superpod MGD's connection format
-# (consecutive mesh_ids, count:8 RELAXED, discovery / no pinnings) but with the prefill 8x4 geometry.
-#
-# Host order matters: discovery maps mesh 0 -> first --host, mesh 1 -> second, etc., and the chained
-# connections require consecutive hosts to be physically cabled. List the --host slots in the order
-# the galaxies are cabled in the superpod chain (verify with the UMD topology tool if a boundary's
-# fabric fails to train).
-#
-# dim_types [RING, RING]: each galaxy is an XY torus (rows/SP and cols/TP both wrap). This MUST be
-# paired with PREFILL_FABRIC_MODE=2d_torus_xy in the rank binding — a mismatch between the descriptor
-# wrap and the fabric mode hangs at fabric bring-up. Requires the 2d_torus_* modes from #48711.
-
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_8galaxy_connected_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_8galaxy_connected_mesh_graph_descriptor.textproto
@@ -1,13 +1,3 @@
-# CONNECTED 8-galaxy mesh graph descriptor for the D2D-socket pipeline prefill.
-#
-# Eight 8x4 BH-galaxy meshes chained mesh 0 <-> 1 <-> ... <-> 7 by inter-galaxy fabric links, one per
-# pipeline boundary (rank r sends to rank r+1). Same connection format as the 4-galaxy MGD, extended
-# to eight consecutive mesh_ids.
-#
-# Host order matters: discovery maps mesh 0 -> first --host, mesh 1 -> second, etc., and the chained
-# connections require consecutive hosts to be physically cabled as a single 8-hop path. List the
-# --host slots in that cabling order (verify with the UMD topology tool if a boundary fails to train).
-
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
@@ -43,8 +33,6 @@ graph_descriptors {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
     channels { count: 8 policy: RELAXED }
   }
-  # mesh 3<->4 is the inter-rack boundary (glx-120: c07u20<->c08u20), physically a single reciprocated
-  # link. count:8 with RELAXED trains over whatever links exist, so the D2D socket forms over the 1 link.
   connections {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml
@@ -1,10 +1,7 @@
-# REQUEST mode (unbounded, H2D-driven), 1 rank. rank0 builds the
-# H2D service + waits; drive it with prefill_producer.py on this host. Cache sized to 11 chunks.
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
 mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
 global_env:
-  # XY sub-torus (both axes wrap); matches the [RING,RING] descriptor above. Needs #48711's 2d_torus_* modes.
   PREFILL_FABRIC_MODE: "2d_torus_xy"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank_d2h_ack.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank_d2h_ack.yaml
@@ -1,7 +1,3 @@
-# REQUEST mode (unbounded, H2D-driven), 1 rank — D2H LAYER-ACK TEST variant of
-# pipeline_prefill_request_1rank.yaml. Exercises the D2H device-record -> LayerAckService ->
-# router-ring path (world_size=1: local ring + counter channel, no MPI). Drive with
-# prefill_producer.py on THIS host; its _drain_layer_acks reports N/(chunks*NUM_LAYERS).
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
 mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
@@ -11,9 +7,5 @@ global_env:
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
 
-  # D2H layer-ack path. Single-rank needs BOTH of these (the use_router gate:
-  # use_router = (not single_rank) or (use_d2h and enable_layer_ack)).
-  # The producer's _drain_layer_acks is the verdict, and the only consumer this channel can have:
-  # the cursor is a destructive read, so a second reader would split the count.
   PREFILL_LAYER_ACK_D2H: "1"
   PREFILL_ENABLE_LAYER_ACK: "1"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank.yaml
@@ -1,9 +1,3 @@
-# REQUEST mode (unbounded, H2D-driven), 2-rank D2D pipeline.
-# rank0 (d07u02) builds the H2D service; downstream rank1 reads via D2D. Migration/LayerAck work at this
-# rank count too (every rank all-gathers the KV table, rank0 publishes it). Cache sized to 11 chunks.
-# Shutdown: the producer's all -1 sentinel (PREFILL_SEND_SHUTDOWN=1); SIGKILL is the fallback.
-# Non-default model: add PREFILL_MANIFEST (absolute path) to global_env below — shell-forwarded env
-# reaches only the launch-host rank.
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
@@ -15,8 +9,6 @@ global_env:
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
 
   PREFILL_ENABLE_MIGRATION: "0"
-  # Worker shmem queue names -- must match the running migration_endpoint
-  # Set PREFILL_MIGRATION_CLIENT_DIR to the dir containing the migration_client.so file
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
   PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
   PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank_d2h_ack.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank_d2h_ack.yaml
@@ -1,9 +1,3 @@
-# REQUEST mode (unbounded, H2D-driven), 2-rank D2D pipeline — D2H LAYER-ACK TEST variant of
-# pipeline_prefill_request_2rank.yaml. Both ranks emit per-layer D2H records; each rank's
-# LayerAckService pushes into its router ring; rank 1 (subordinate) MPI-forwards to rank 0
-# (master), which reorders + injects the scheduler counter channel. Drive with prefill_producer.py
-# on RANK 0's host (owns the H2D service + master router + counter channel); its _drain_layer_acks
-# reports N/(chunks*NUM_LAYERS).
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
@@ -15,14 +9,8 @@ global_env:
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
 
   PREFILL_ENABLE_MIGRATION: "0"
-  # Worker shmem queue names -- must match the running migration_endpoint
-  # Set PREFILL_MIGRATION_CLIENT_DIR to the dir containing the migration_client.so file
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
   PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
   PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"
 
-  # D2H layer-ack path. Multi-rank always builds the router; this only switches the completion
-  # source to device records (vs the host on_layer_complete callback). The producer's
-  # _drain_layer_acks is the verdict, and the only consumer this channel can have: the cursor is a
-  # destructive read, so a second reader would split the count.
   PREFILL_LAYER_ACK_D2H: "1"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank.yaml
@@ -1,9 +1,3 @@
-# REQUEST mode (unbounded, H2D-driven), 4-rank D2D pipeline.
-# rank0 builds the H2D service; downstream ranks read via D2D. Migration/LayerAck work at this rank count
-# too (every rank all-gathers the KV table, rank0 publishes it). Shutdown: the producer's all -1 sentinel
-# (PREFILL_SEND_SHUTDOWN=1); SIGKILL is the fallback. Host order is the ring chain (see the 4-galaxy MGD).
-# Non-default model: add PREFILL_MANIFEST (absolute path) to global_env below — shell-forwarded env
-# reaches only the launch-host rank.
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
@@ -17,8 +11,6 @@ global_env:
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
 
   PREFILL_ENABLE_MIGRATION: "0"
-  # Worker shmem queue names -- must match the running migration_endpoint
-  # Set PREFILL_MIGRATION_CLIENT_DIR to the dir containing the migration_client.so file
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
   PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
   PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank_d2h_ack.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank_d2h_ack.yaml
@@ -1,9 +1,3 @@
-# REQUEST mode (unbounded, H2D-driven), 4-rank D2D pipeline — D2H LAYER-ACK TEST variant of
-# pipeline_prefill_request_4rank.yaml. All ranks emit per-layer D2H records; each rank's
-# LayerAckService pushes into its router ring; subordinate ranks (1..3) MPI-forward to rank 0
-# (master), which reorders + injects the scheduler counter channel. Drive with prefill_producer.py
-# on RANK 0's host; its _drain_layer_acks reports N/(chunks*NUM_LAYERS). Host order is the ring
-# chain (see the 4-galaxy MGD).
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
@@ -17,14 +11,8 @@ global_env:
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
 
   PREFILL_ENABLE_MIGRATION: "0"
-  # Worker shmem queue names -- must match the running migration_endpoint
-  # Set PREFILL_MIGRATION_CLIENT_DIR to the dir containing the migration_client.so file
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
   PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
   PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"
 
-  # D2H layer-ack path. Multi-rank always builds the router; this only switches the completion
-  # source to device records (vs the host on_layer_complete callback). The producer's
-  # _drain_layer_acks is the verdict, and the only consumer this channel can have: the cursor is a
-  # destructive read, so a second reader would split the count.
   PREFILL_LAYER_ACK_D2H: "1"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_8rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_8rank.yaml
@@ -1,12 +1,3 @@
-# REQUEST mode (unbounded, H2D-driven), 8-rank D2D pipeline.
-# rank0 builds the H2D service; downstream ranks read via D2D. Migration/LayerAck work at this rank count
-# too (every rank all-gathers the KV table, rank0 publishes it). Shutdown: the producer's all -1 sentinel
-# (PREFILL_SEND_SHUTDOWN=1); SIGKILL is the fallback.
-# Host order is the physical cabling chain (mesh 0 -> first --host, ... mesh 7 -> last). Proven chain on
-# glx-120 (the mesh 3<->4 boundary is the single-link inter-rack bridge c07u20<->c08u20, which trains fine):
-#   bh-glx-120-c07u02:1,c07u08:1,c07u14:1,c07u20:1,c08u20:1,c08u14:1,c08u08:1,c08u02:1
-# Non-default model: add PREFILL_MANIFEST (absolute path) to global_env below — shell-forwarded env
-# reaches only the launch-host rank.
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
@@ -24,8 +15,6 @@ global_env:
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
 
   PREFILL_ENABLE_MIGRATION: "0"
-  # Worker shmem queue names -- must match the running migration_endpoint
-  # Set PREFILL_MIGRATION_CLIENT_DIR to the dir containing the migration_client.so file
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
   PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
   PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml
@@ -1,10 +1,3 @@
-# 2-stage intra-galaxy pipeline prefill: one 8x4 galaxy carved into 2 Z-connected [4,4] sub-meshes; the
-# hidden state hops stage->stage over the Z-link MeshSocket. Request mode — rank 0 serves an external
-# prefill_producer. Model selected by PREFILL_MANIFEST.
-#
-# TT_VISIBLE_DEVICES: two 2x4 slices per mesh (mesh0 = {0,1}, mesh1 = {2,3}), ordered by the
-# Generate2x4SliceToPCIeDeviceMapping discovery gtest into a contiguous 4x4; other splits fail topology_mapper.
-
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "28,29,24,25,0,4,5,1,31,26,27,30,6,7,2,3"}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "18,22,23,19,14,15,10,11,20,16,17,21,9,8,13,12"}}
@@ -18,7 +11,5 @@ global_env:
   PREFILL_NUM_LAYERS: "60"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
-  # Only 12B of metadata transits the queue, so reducing its size has no effect on transfer speed
-  # Keeping it default (64KB) clashes with the MoE FFN L1 allocation
   PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml
@@ -1,8 +1,3 @@
-# 4-stage intra-galaxy pipeline prefill: one 8x4 galaxy carved into 4 Z-connected [2,4] sub-meshes; the
-# hidden state hops stage->stage over the Z-link MeshSocket. Request mode — rank 0 serves an external
-# prefill_producer. Model selected by PREFILL_MANIFEST.
-# Tray pins from test_physical_discovery (QUAD rank->tray {0:1,1:3,2:4,3:2}).
-
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"}}
@@ -18,7 +13,5 @@ global_env:
   PREFILL_NUM_LAYERS: "60"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
-  # Only 12B of metadata transits the queue, so reducing its size has no effect on transfer speed
-  # Keeping it default (64KB) clashes with the MoE FFN L1 allocation
   PREFILL_PP_D2D_FIFO_BYTES: "32768"
   LOGURU_LEVEL: "INFO"


### PR DESCRIPTION
who reads comments anyway?

Blaze Models Prefill tests  https://github.com/tenstorrent/tt-metal/actions/runs/33505940975 

(Blackhole) e2e tests    https://github.com/tenstorrent/tt-metal/actions/runs/33505943867

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill_runner_unslop)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill_runner_unslop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill_runner_unslop)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill_runner_unslop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill_runner_unslop)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill_runner_unslop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill_runner_unslop)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill_runner_unslop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill_runner_unslop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill_runner_unslop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill_runner_unslop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill_runner_unslop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill_runner_unslop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill_runner_unslop)
