### PR TITLE
[Bug fix] Fix ttnn.sort duplicating indices for tied values

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -999,25 +999,15 @@ def test_sort_row_major_multi_core_correctness(descending, device):
 @pytest.mark.parametrize("descending", [False, True])
 def test_sort_tied_values_indices_are_a_permutation(descending, device):
     """
-    Regression test for #54767: cross-core index duplication on tied values.
+    Test for cross-core index duplication on tied values.
 
     Every value is equal, so a compare-exchange network must leave the row
-    untouched and return the identity permutation. The CrossCoreDataExchange
-    factory used to merge a split tile pair redundantly on both cores, each
-    keeping one half; because a tie makes topk_merge a no-op, both cores kept
-    the same physical tile and one tile's indices were duplicated over the
-    other's. Gather-based checks cannot see this — the values are tied, so a
-    duplicated index still gathers the right value — so assert injectivity.
+    untouched and return the identity permutation.
 
     Wt = 128 is the smallest width past the single-core threshold. On any grid
     with >= 64 compute cores (every standard Wormhole and Blackhole part) the
     CrossCore capacity is at least 2 * cores >= 128 tiles, so this width always
-    selects the CrossCoreDataExchange factory that carried the bug; on smaller
-    grids it falls to the DRAM multi-core factory, whose tie behaviour this
-    then checks instead. Deriving Wt from the grid size does not do this: a
-    grid whose core count is not a power of two can only take the CrossCore
-    route at widths just above 64 tiles, so e.g. on 140 cores next_pow2(2 *
-    cores) = 512 lands on the multi-core factory while Wt = 128 is CrossCore.
+    selects the CrossCoreDataExchange factory.
     """
     wt = 128
     n = wt * TILE_WIDTH

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -994,3 +994,36 @@ def test_sort_row_major_multi_core_correctness(descending, device):
 
     ttnn_gathered = torch.gather(input_t, -1, ttnn.to_torch(ttnn_indices).to(torch.int64))
     assert_equal(torch_values, ttnn_gathered)
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_sort_tied_values_indices_are_a_permutation(descending, device):
+    """
+    Regression test for #54767: cross-core index duplication on tied values.
+
+    Every value is equal, so a compare-exchange network must leave the row
+    untouched and return the identity permutation. The CrossCoreDataExchange
+    factory used to merge a split tile pair redundantly on both cores, each
+    keeping one half; because a tie makes topk_merge a no-op, both cores kept
+    the same physical tile and one tile's indices were duplicated over the
+    other's. Gather-based checks cannot see this — the values are tied, so a
+    duplicated index still gathers the right value — so assert injectivity.
+
+    Wt is taken just past the single-core threshold so the cross-core path is
+    exercised on any grid, and the shape stays small enough to be cheap.
+    """
+    grid = device.compute_with_storage_grid_size()
+    wt = _next_pow2(grid.x * grid.y * 2)
+    n = wt * TILE_WIDTH
+
+    input_tensor = torch.zeros((1, n), dtype=torch.float32)
+    ttnn_input = ttnn.from_torch(input_tensor, ttnn.float32, layout=ttnn.Layout.TILE, device=device)
+
+    _, ttnn_indices = ttnn.sort(ttnn_input, dim=-1, descending=descending)
+
+    indices = ttnn.to_torch(ttnn_indices).reshape(-1).to(torch.int64)
+    assert (
+        indices.min() >= 0 and indices.max() < n
+    ), f"indices out of range [0, {n}): min={int(indices.min())}, max={int(indices.max())}"
+    unique_count = indices.unique().numel()
+    assert unique_count == n, f"{n - unique_count} duplicated indices"

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -1009,11 +1009,17 @@ def test_sort_tied_values_indices_are_a_permutation(descending, device):
     other's. Gather-based checks cannot see this — the values are tied, so a
     duplicated index still gathers the right value — so assert injectivity.
 
-    Wt is taken just past the single-core threshold so the cross-core path is
-    exercised on any grid, and the shape stays small enough to be cheap.
+    Wt = 128 is the smallest width past the single-core threshold. On any grid
+    with >= 64 compute cores (every standard Wormhole and Blackhole part) the
+    CrossCore capacity is at least 2 * cores >= 128 tiles, so this width always
+    selects the CrossCoreDataExchange factory that carried the bug; on smaller
+    grids it falls to the DRAM multi-core factory, whose tie behaviour this
+    then checks instead. Deriving Wt from the grid size does not do this: a
+    grid whose core count is not a power of two can only take the CrossCore
+    route at widths just above 64 tiles, so e.g. on 140 cores next_pow2(2 *
+    cores) = 512 lands on the multi-core factory while Wt = 128 is CrossCore.
     """
-    grid = device.compute_with_storage_grid_size()
-    wt = _next_pow2(grid.x * grid.y * 2)
+    wt = 128
     n = wt * TILE_WIDTH
 
     input_tensor = torch.zeros((1, n), dtype=torch.float32)

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
@@ -230,21 +230,42 @@ void kernel_main() {
                         }
 
                         // Process received tiles from other core
+                        //
+                        // Both cores of the pair run this same merge on the same two tiles and each
+                        // keeps one half of the result, so the two runs must agree on which half is
+                        // which. topk_merge only swaps DEST[0]/DEST[1] when the values are strictly
+                        // out of order, so for tied values the halves are told apart purely by which
+                        // DEST slot each tile was loaded into. Loading "local" into DEST[0] would
+                        // make that slot mean tile i on one core and tile j on the other: on a tie
+                        // neither core swaps, the opposite `select_lower` values then select the
+                        // same physical tile on both, and that tile's indices are duplicated while
+                        // the partner's are lost (#54767).
+                        //
+                        // Ordering the slots by global tile id instead makes both cores build an
+                        // identical DEST, so a tie leaves each core holding a different tile. For
+                        // distinct values this is a no-op: a compare-exchange leaves min in DEST[0]
+                        // and max in DEST[1] whichever slot each operand arrived in.
+                        const bool local_tile_is_low = i < j;
+                        const uint32_t local_value_dest = local_tile_is_low ? input_dest_start : input_dest_end;
+                        const uint32_t local_index_dest = local_tile_is_low ? index_dest_start : index_dest_end;
+                        const uint32_t peer_value_dest = local_tile_is_low ? input_dest_end : input_dest_start;
+                        const uint32_t peer_index_dest = local_tile_is_low ? index_dest_end : index_dest_start;
+
                         tile_regs_acquire();
 
                         // Prepare local index tiles for sorting with new tiles
                         copy_tile_to_dst_init_with_cb_update(dfb::index_tensor_transposed, global_old_cb);
-                        copy_tile(dfb::index_tensor_transposed, tile_id, index_dest_start);
+                        copy_tile(dfb::index_tensor_transposed, tile_id, local_index_dest);
 
                         // Prepare local value tiles for sorting with new tiles
                         copy_tile_to_dst_init_with_cb_update(dfb::input_tensor_transposed, global_old_cb);
-                        copy_tile(dfb::input_tensor_transposed, tile_id, input_dest_start);
+                        copy_tile(dfb::input_tensor_transposed, tile_id, local_value_dest);
 
                         index_tensor_peer_dfb.wait_front(one_tile);
 
                         // Load new index tile for sorting
                         copy_tile_to_dst_init_with_cb_update(dfb::index_tensor_peer, global_old_cb);
-                        copy_tile(dfb::index_tensor_peer, FIRST_TILE, index_dest_end);
+                        copy_tile(dfb::index_tensor_peer, FIRST_TILE, peer_index_dest);
 
                         index_tensor_peer_dfb.pop_front(one_tile);
 
@@ -253,7 +274,7 @@ void kernel_main() {
 
                         // Load new value tile for sorting
                         copy_tile_to_dst_init_with_cb_update(dfb::value_tensor_peer, global_old_cb);
-                        copy_tile(dfb::value_tensor_peer, FIRST_TILE, input_dest_end);
+                        copy_tile(dfb::value_tensor_peer, FIRST_TILE, peer_value_dest);
 
                         value_tensor_peer_dfb.pop_front(one_tile);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
@@ -231,20 +231,16 @@ void kernel_main() {
 
                         // Process received tiles from other core
                         //
-                        // Both cores of the pair run this same merge on the same two tiles and each
+                        // Both cores of the pair run same merge on the same two tiles and each
                         // keeps one half of the result, so the two runs must agree on which half is
                         // which. topk_merge only swaps DEST[0]/DEST[1] when the values are strictly
                         // out of order, so for tied values the halves are told apart purely by which
-                        // DEST slot each tile was loaded into. Loading "local" into DEST[0] would
-                        // make that slot mean tile i on one core and tile j on the other: on a tie
-                        // neither core swaps, the opposite `select_lower` values then select the
-                        // same physical tile on both, and that tile's indices are duplicated while
-                        // the partner's are lost (#54767).
+                        // DEST slot each tile was loaded into.
                         //
-                        // Ordering the slots by global tile id instead makes both cores build an
-                        // identical DEST, so a tie leaves each core holding a different tile. For
-                        // distinct values this is a no-op: a compare-exchange leaves min in DEST[0]
-                        // and max in DEST[1] whichever slot each operand arrived in.
+                        // Ordering the slots by global tile id makes both cores build an identical DEST,
+                        // so a tie leaves each core holding a different tile. For distinct values this is
+                        // a no-op: a compare-exchange leaves min in DEST[0] and max in DEST[1] whichever
+                        // slot each operand arrived in.
                         const bool local_tile_is_low = i < j;
                         const uint32_t local_value_dest = local_tile_is_low ? input_dest_start : input_dest_end;
                         const uint32_t local_index_dest = local_tile_is_low ? index_dest_start : index_dest_end;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #54767
Closes #54686

`test_sort_fp32_wide_index_correctness[descending=False]` fails deterministically on WH with duplicated indices.

Root cause: in `sort_cross_core_data_exchange.cpp`, a bitonic tile pair that straddles two cores is merged redundantly on both cores, each keeping one half of the comparator result:

```cpp
copy_tile(index_tensor_transposed, tile_id,   index_dest_start);  // DEST[0]/[2] = LOCAL tile
copy_tile(value_tensor_peer,      FIRST_TILE, input_dest_end);    // DEST[1]/[3] = PEER tile
ckernel::topk_merge(0, m_iter, 32);            // DEST[0]=min, DEST[1]=max
const uint32_t select_lower = dir ^ (i < j);   // opposite on the two cores
```

Both cores load their own tile into `DEST[0]`, so that slot means tile `i` on one core and tile `j` on the other. On a tie neither core swaps — and since `select_lower` is opposite on the two cores, both keep the same physical tile. That tile's indices are duplicated over the pair and the partner's are lost.

**Fix** — order the DEST slots by global tile id instead of local/peer, so both cores build an identical DEST and a tie leaves each core holding a different tile. For distinct values this is a no-op: a compare-exchange leaves min in `DEST[0]` and max in `DEST[1]` whichever slot each operand arrived in, which is why only tied inputs were ever affected.

**Why it looked WH-only** — the CrossCore factory selection depends on the core grid, not on the architecture. `select_program_factory` picks the hybrid factory when

```
Wt <= total_cores * min(128, max(Wt / total_cores, 2))   // get_number_of_tiles_per_core, USE_AS_MANY_CORES
```

The repro pads to `Wt = 8192`. On a 64-core Wormhole grid it lands on `CrossCoreDataExchange`. No Blackhole grid divides 8192 evenly — so there the same tensor falls through to `SingleRowMultiCore`, which does not have this issue.

The CrossCore path is equally broken on Blackhole. The regression test added here has `Wt = 128`, the smallest power-of-two width above the single-core threshold, where capacity is `2 * total_cores` on any grid of >= 64 cores — so it exercises `CrossCoreDataExchange` on Wormhole and Blackhole. Verified on an 11x10 (110-core) Blackhole: 4032 of 4096 indices duplicated before the fix, clean after.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fix-sort-crosscore-tied-index-duplication)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fix-sort-crosscore-tied-index-duplication)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fix-sort-crosscore-tied-index-duplication)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fix-sort-crosscore-tied-index-duplication)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fix-sort-crosscore-tied-index-duplication)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fix-sort-crosscore-tied-index-duplication)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fix-sort-crosscore-tied-index-duplication)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fix-sort-crosscore-tied-index-duplication)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fix-sort-crosscore-tied-index-duplication)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fix-sort-crosscore-tied-index-duplication)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fix-sort-crosscore-tied-index-duplication)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fix-sort-crosscore-tied-index-duplication)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fix-sort-crosscore-tied-index-duplication)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fix-sort-crosscore-tied-index-duplication)
