### PR TITLE
[stable] Cherry-pick #50550: auto-skip HF weight load on warm ttnn cache

### DIFF
--- a/models/common/weight_cache.py
+++ b/models/common/weight_cache.py
@@ -1,0 +1,426 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared, ModelArgs-agnostic warm ttnn weight-cache helpers (generalizes PR #50550 / #48531
+to forked model loaders — issue #45400 follow-up).
+
+On a warm cache, a model can be built from its on-disk ``.tensorbin`` files without the
+expensive host-side HF ``from_pretrained`` load (the load that OOMs/hangs during prefill,
+#48509): ``ttnn.as_tensor(torch_weight, cache_file_name=...)`` loads the cached tensor and
+ignores ``torch_weight`` on a cache hit (see ttnn/operations/core.py). So most weights only
+need a dataless placeholder (``torch.empty`` of the right shape/dtype) to satisfy the modules'
+host-side reshape ops before ``as_tensor``.
+
+Some forks (e.g. gemma4) additionally consume a *small* set of weights on the host — token
+embeddings used via ``F.embedding``, per-layer scalars read via ``.item()``, etc. Those must be
+real. ``mark_weight_cache_complete`` persists exactly those tensors to a sidecar at cold-build
+time (write-access run), and ``build_cached_state_dict`` serves them real on later warm runs
+while placeholdering the rest — a HYBRID state_dict. The host subset is a tiny fraction of the
+weight bytes, so the full from_pretrained (and its OOM) is still avoided.
+"""
+
+import collections.abc
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import torch
+from loguru import logger
+
+WEIGHT_CACHE_MARKER = ".weights_complete"
+HOST_WEIGHTS_SIDECAR = ".host_weights.pt"
+# Bump when the set/naming/layout of cached weights, or this marker schema, changes such that an
+# existing cache would not satisfy a new build. A marker written by an older format is rejected,
+# so the run cold-loads and regenerates rather than building from an incompatible cache.
+#   v2: model/n_layers/mesh_shape validation + a {key: [shape, dtype]} manifest.
+#   v3: canonical mesh_shape encoding shared with ModelArgs (the two writers previously encoded it
+#       differently and each rejected the other's marker), a `components` field so a text-only seed
+#       cannot certify a cache for a build that also needs the vision tower, and `cache_files` --
+#       the recursive list of .tensorbin files the completed build actually produced, verified
+#       per-file on read. That last one is load-bearing: ttnn.as_tensor PERSISTS whatever tensor it
+#       is handed on a cache miss, so a marker that outlives some of its tensorbins would otherwise
+#       dump placeholders to disk as real cache entries -- silent, permanent corruption. Verifying
+#       the recorded file set turns every such case back into a plain cold load. Also `build_variant`
+#       -- the build options (prefetcher, precision) that change an as_tensor cache FILENAME, matched
+#       exactly, because a different variant needs different files rather than fewer.
+WEIGHT_CACHE_FORMAT_VERSION = 3
+
+DEFAULT_FORCE_ENV = "TT_TRANSFORMERS_FORCE_MODEL_LOAD"
+
+
+def _variant_digest(build_variant):
+    """Stable short digest of a build_variant dict ("none" for None)."""
+    if build_variant is None:
+        return "none"
+    return hashlib.sha1(json.dumps(build_variant, sort_keys=True, default=str).encode()).hexdigest()[:12]
+
+
+def _variant_unverifiable(build_variant):
+    return bool(build_variant) and bool(build_variant.get("unverifiable"))
+
+
+def marker_path(cache_path, build_variant=None):
+    """The marker file for one (cache dir, build variant).
+
+    The variant digest is part of the FILENAME, not just a field compared inside one shared
+    marker. A cache dir legitimately serves several build variants (the Llama CI job runs
+    eval-32 with and without the DRAM prefetcher against the same instruct cache), and a single
+    marker matched exactly would make each variant's seed evict the other's on every run -- both
+    then cold-load forever with nothing going red. One marker per variant lets them coexist.
+    (#45400 review, finding B3)"""
+    return Path(cache_path) / f"{WEIGHT_CACHE_MARKER}.{_variant_digest(build_variant)}"
+
+
+def _dtype_from_str(s):
+    return getattr(torch, s.rsplit(".", 1)[-1])
+
+
+def normalize_mesh_shape(mesh_shape):
+    """Canonical marker encoding for a mesh shape.
+
+    ``ttnn.MeshShape`` stringifies as ``MeshShape([1, 8])`` while callers that pass a plain tuple
+    stringify as ``(1, 8)``. Both writers must agree or each rejects the other's marker and the
+    model cold-loads forever (gemma3 inherits ModelArgs but its demos call this module). Normalize
+    everything to a plain tuple-of-ints string."""
+    try:
+        return str(tuple(int(d) for d in mesh_shape))
+    except TypeError:
+        return str(mesh_shape)
+
+
+def _normalize_components(components):
+    """Canonical component list. ``None`` means "the whole model as this loader builds it" and is
+    encoded as a single implicit component so old-style callers stay self-consistent."""
+    if components is None:
+        return ["all"]
+    if isinstance(components, str):
+        return [components]
+    return sorted(str(c) for c in components)
+
+
+def list_cache_files(cache_path):
+    """Every ``.tensorbin`` under ``cache_path``, recursively, as sorted relative POSIX paths.
+
+    Recursive because forked loaders nest per-layer weights in subdirectories (qwen36
+    ``layers.{n}/``, gemma4 ``layer_{i}/``); a top-level ``glob`` would call a cache complete when
+    only the root-level ``output.weight`` survived an interrupted seed."""
+    cache_path = Path(cache_path)
+    return sorted(p.relative_to(cache_path).as_posix() for p in cache_path.rglob("*.tensorbin"))
+
+
+# One-entry cache so the completeness gate's validation load is reused by
+# build_cached_state_dict instead of torch.load-ing the same multi-GB file twice per warm run
+# (gemma-4-31b's embedding alone is ~2.8 GB). Keyed on (path, mtime, size) so a republished
+# sidecar is never served stale; the builder consumes the entry so the tensors are not pinned
+# past the build. (#45400 review, finding R1)
+_SIDECAR_CACHE = {}
+
+
+def load_host_sidecar(cache_path, *, consume=False):
+    """Load the host-weights sidecar, or None if absent/unreadable.
+
+    ``consume=True`` drops the memoized entry after returning it (the caller takes ownership)."""
+    sidecar = Path(cache_path) / HOST_WEIGHTS_SIDECAR
+    if not sidecar.is_file():
+        return None
+    try:
+        st = sidecar.stat()
+        key = (str(sidecar), st.st_mtime_ns, st.st_size)
+        host = _SIDECAR_CACHE.get(key)
+        if host is None:
+            host = torch.load(sidecar, map_location="cpu", weights_only=True)
+            _SIDECAR_CACHE.clear()
+            _SIDECAR_CACHE[key] = host
+        if consume:
+            _SIDECAR_CACHE.pop(key, None)
+        return host
+    except Exception:
+        return None
+
+
+def weight_cache_is_complete(
+    cache_path,
+    *,
+    model_name,
+    n_layers,
+    mesh_shape,
+    components=None,
+    build_variant=None,
+    force_env=DEFAULT_FORCE_ENV,
+):
+    """True when the on-disk ttnn weight cache at ``cache_path`` was fully built by a previous run
+    for this exact build, and every tensorbin that build produced is still present.
+
+    ``components`` names the model parts this build will construct (e.g. ``"text"`` vs
+    ``"text+vision"``); a marker written by a narrower build does not satisfy a wider one, because
+    the wider build needs tensorbins the narrower one never wrote. ``force_env=...=1`` forces a
+    cold load."""
+    if force_env and os.getenv(force_env) == "1":
+        return False
+    # A variant we could not compute is a variant we cannot verify: accepting it could hand a
+    # placeholder to a build whose cache-filename set we did not check, and as_tensor would
+    # persist that placeholder to disk. Fail closed, loudly. (#45400 review, finding R3)
+    if _variant_unverifiable(build_variant):
+        logger.warning(
+            f"Warm-cache check for {cache_path}: build_variant could not be computed "
+            f"({build_variant.get('error', 'unknown error')}); forcing a cold load."
+        )
+        return False
+    cache_path = Path(cache_path)
+    marker = marker_path(cache_path, build_variant)
+    if not marker.is_file():
+        return False
+    try:
+        meta = json.loads(marker.read_text())
+    except (ValueError, OSError):
+        return False
+    if meta.get("format_version") != WEIGHT_CACHE_FORMAT_VERSION:
+        return False
+    if meta.get("model_name") != model_name or meta.get("n_layers") != n_layers:
+        return False
+    if meta.get("mesh_shape") != normalize_mesh_shape(mesh_shape):
+        return False
+    # The recorded build must cover every component this build needs. Superset is fine (a
+    # text+vision seed wrote the text tensorbins too, so it satisfies a text-only build); a subset
+    # is not (a text-only seed never wrote the vision tower's tensorbins, and accepting it would
+    # make as_tensor dump placeholders for them).
+    if not set(_normalize_components(components)).issubset(set(meta.get("components") or [])):
+        return False
+    # Build options that change an as_tensor cache FILENAME (prefetcher, precision) must match
+    # exactly. A superset rule is wrong here: a different variant does not need fewer files, it
+    # needs DIFFERENT ones, and any it is missing would be regenerated from the placeholder.
+    if meta.get("build_variant") != build_variant:
+        return False
+    if not meta.get("weights"):
+        return False
+    # Every tensorbin the completed build produced must still be on disk. Any missing file would
+    # otherwise be regenerated by as_tensor FROM THE PLACEHOLDER we are about to hand it, writing
+    # garbage into the cache permanently. Missing file => cold load, which rebuilds it correctly.
+    recorded = meta.get("cache_files")
+    if not recorded:
+        return False
+    present = set(list_cache_files(cache_path))
+    if not all(f in present for f in recorded):
+        return False
+    # If host weights were captured, the sidecar must be present AND loadable. A torn/corrupt
+    # sidecar (interrupted or racing seed) must fall back to a cold load -- the way a torn marker
+    # already does via the except above -- rather than pass this gate and then crash torch.load on
+    # every subsequent run, bricking the cache dir. Checked LAST so the load it performs is
+    # memoized only when the gate is about to pass, for build_cached_state_dict to consume.
+    # (#45400 review)
+    if meta.get("host_weights") and load_host_sidecar(cache_path) is None:
+        return False
+    return True
+
+
+def mark_weight_cache_complete(
+    cache_path,
+    state_dict,
+    *,
+    model_name,
+    n_layers,
+    mesh_shape,
+    components=None,
+    build_variant=None,
+    is_moe=False,
+    is_host_weight=None,
+):
+    """Record that the ttnn weight cache at ``cache_path`` is fully built.
+
+    Writes a ``.weights_complete`` marker holding a ``{key: [shape, dtype]}`` manifest of every
+    weight plus the recursive list of ``.tensorbin`` files this build produced (verified per-file
+    on read). If ``is_host_weight(key)`` is provided, the (real) tensors it matches are also saved
+    to a ``.host_weights.pt`` sidecar so a later warm run can serve them for real (hybrid).
+
+    Call this only AFTER the model has been constructed, so the tensorbins exist to be recorded."""
+    if _variant_unverifiable(build_variant):
+        # Never certify a cache under an identity we could not compute -- a later run computing
+        # the same error string would otherwise warm-match it. (#45400 review, finding R3)
+        logger.warning(
+            f"Not marking weight cache complete at {cache_path}: build_variant could not be "
+            f"computed ({build_variant.get('error', 'unknown error')})."
+        )
+        return
+    cache_path = Path(cache_path)
+    marker = marker_path(cache_path, build_variant)
+    weights = {}
+    host = {}
+    for k, v in state_dict.items():
+        shape = getattr(v, "shape", None)
+        dt = getattr(v, "dtype", None)
+        if shape is None or dt is None:
+            continue  # skip non-tensor entries
+        weights[k] = [list(shape), str(dt)]
+        if is_host_weight is not None and is_host_weight(k):
+            host[k] = v
+    try:
+        cache_path.mkdir(parents=True, exist_ok=True)
+        cache_files = list_cache_files(cache_path)
+        if not cache_files:
+            logger.warning(f"Not marking weight cache complete: no .tensorbin files under {cache_path}")
+            return
+        # Write both the sidecar and the marker atomically (temp file + os.replace, atomic on
+        # POSIX). Two jobs can seed the same (model, dtype, mesh) dir on one host concurrently, and
+        # an interrupted write must never leave a torn file that a later run picks up: a half-written
+        # sidecar would otherwise pass the is_file() gate and crash torch.load on every subsequent
+        # run. The temp name is pid-unique so two concurrent seeders cannot write the SAME temp
+        # inode -- with a fixed name, B could publish the file while A was still writing into it.
+        # Sidecar first, then marker, so the completeness gate only appears once its sidecar is
+        # fully in place. (#45400 review)
+        uniq = os.getpid()
+        if host:
+            sidecar = cache_path / HOST_WEIGHTS_SIDECAR
+            sidecar_tmp = sidecar.with_suffix(sidecar.suffix + f".tmp.{uniq}")
+            torch.save(host, sidecar_tmp)
+            os.replace(sidecar_tmp, sidecar)
+        marker_body = json.dumps(
+            {
+                "format_version": WEIGHT_CACHE_FORMAT_VERSION,
+                "model_name": model_name,
+                "n_layers": n_layers,
+                "mesh_shape": normalize_mesh_shape(mesh_shape),
+                "components": _normalize_components(components),
+                "build_variant": build_variant,
+                "cache_files": cache_files,
+                "is_moe": bool(is_moe),
+                "host_weights": sorted(host.keys()),
+                "weights": weights,
+            }
+        )
+        marker_tmp = marker.with_suffix(marker.suffix + f".tmp.{uniq}")
+        marker_tmp.write_text(marker_body)
+        os.replace(marker_tmp, marker)
+        logger.info(f"Marked ttnn weight cache complete: {marker} ({len(weights)} weights, {len(host)} host-loaded)")
+    except Exception as e:
+        # Deliberately broad: this function only RECORDS completion -- failing to record must
+        # never kill a build that already succeeded. The concrete case: on a read-only
+        # /mnt/MLPerf, torch.save of the host sidecar raises RuntimeError from torch's C++
+        # serializer (inline_container.cc "Read-only file system"), not OSError, and the narrow
+        # except crashed every read-only cold run of the sidecar models (gemma4/gemma3) right
+        # after a successful build. (#45400 review, finding R5; seen on Gemma-4-E2B bh_p150,
+        # run 32511945147)
+        logger.warning(f"Could not write weight-cache completion marker {marker}: {e}")
+
+
+class CachedStateDict(collections.abc.MutableMapping):
+    """A stand-in ``state_dict`` for warm-cache builds.
+
+    Serves the real tensor for keys captured in the host-weights sidecar; for every other key it
+    returns a fresh dataless ``torch.empty`` of the manifest shape/dtype (which ``ttnn.as_tensor``
+    discards on the guaranteed cache hit). Mutable (some loaders ``setdefault`` missing KV-shared
+    weights) and truthy (some loaders gate real-weight loading on ``if state_dict:``)."""
+
+    # Explicit marker that this is a warm-cache stand-in, NOT real weights. Callers that must tell
+    # "warm-cache placeholder" apart from "real weights" MUST branch on this attribute, never on
+    # truthiness: this mapping is truthy (non-zero __len__) but tt_transformers' _PlaceholderStateDict
+    # is falsy (__bool__ -> False), so a truthiness test silently means opposite things for the two.
+    # If tt_transformers is ever collapsed onto this class (a listed follow-up), the attribute keeps
+    # `if is_placeholder(...)` reload sites (e.g. test_model_prefill) correct. (#45400 review)
+    is_placeholder = True
+
+    def __init__(self, manifest, host):
+        self._manifest = manifest  # key -> (shape, dtype_str)
+        self._host = dict(host or {})  # key -> real torch.Tensor
+        self._overrides = {}  # keys set by the caller at build time
+        self._deleted = set()
+
+    def __getitem__(self, key):
+        if key in self._deleted:
+            raise KeyError(key)
+        if key in self._overrides:
+            return self._overrides[key]
+        if key in self._host:
+            return self._host[key]
+        spec = self._manifest.get(key)
+        if spec is None:
+            raise KeyError(key)
+        shape, dt = spec
+        return torch.empty(tuple(shape), dtype=_dtype_from_str(dt))
+
+    def __setitem__(self, key, value):
+        self._deleted.discard(key)
+        self._overrides[key] = value
+
+    def __delitem__(self, key):
+        if key not in self:
+            raise KeyError(key)
+        self._overrides.pop(key, None)
+        if key in self._host or key in self._manifest:
+            self._deleted.add(key)
+
+    def __iter__(self):
+        seen = set()
+        for k in list(self._overrides) + list(self._host) + list(self._manifest):
+            if k in self._deleted or k in seen:
+                continue
+            seen.add(k)
+            yield k
+
+    def __len__(self):
+        return sum(1 for _ in self)
+
+    # Mapping's default __contains__/get/items route through __getitem__, which allocates a
+    # full-size torch.empty for EVERY key touched -- including multi-GB ones like lm_head.weight.
+    # substate() (models/tt_dit/utils/substate.py) iterates .items() and filters by prefix, so a
+    # 62-layer gemma4 build would allocate the entire model once per layer just to discard it.
+    # Answer membership from the key sets, and make items() lazy so only matching keys materialize.
+    def __contains__(self, key):
+        if key in self._deleted:
+            return False
+        return key in self._overrides or key in self._host or key in self._manifest
+
+    def keys(self):
+        return list(self)
+
+    def items(self):
+        for k in self:
+            yield k, self[k]
+
+    def get(self, key, default=None):
+        if key not in self:
+            return default
+        return self[key]
+
+
+def build_cached_state_dict(cache_path, host=None, args=None, build_variant=None):
+    """Build the warm-cache stand-in ``state_dict`` from the marker manifest + host sidecar.
+
+    ``host`` may be a sidecar dict already loaded by ``weight_cache_is_complete``'s validation, to
+    avoid a second multi-GB ``torch.load`` of the same file on every warm run (gemma-4-31b's
+    embedding alone is ~2.8 GB).
+
+    ``args`` (a ModelArgs-like) has ``is_mixture_of_experts`` restored from the marker. That flag is
+    normally set as a side effect of ``load_state_dict`` (by sniffing for ``.experts.`` keys), which
+    the warm path skips -- so without this a MoE checkpoint would build a dense decoder and die on a
+    missing ``feed_forward.w1.weight``. (#45400 review)"""
+    cache_path = Path(cache_path)
+    meta = json.loads(marker_path(cache_path, build_variant).read_text())
+    manifest = meta["weights"]
+    if args is not None and hasattr(args, "__dict__"):
+        args.is_mixture_of_experts = bool(meta.get("is_moe", False))
+        # fuse_qkv / fuse_mlp are normally sniffed from the checkpoint keys inside load_state_dict,
+        # which the warm path skips -- leaving them at their __init__ defaults and silently changing
+        # how the decoder is built. The manifest holds the same key set, so derive them identically.
+        keys = manifest.keys()
+        args.fuse_qkv = any("qkv" in k for k in keys)
+        args.fuse_mlp = any("gate_up" in k for k in keys)
+        if args.is_mixture_of_experts:
+            args.moe = True
+            expert_indices = [int(k[-11]) + 1 for k in keys if "block_sparse_moe.experts" in k]
+            if expert_indices:
+                args.num_experts = max(expert_indices)
+            elif hasattr(args, "num_local_experts"):
+                args.num_experts = args.num_local_experts
+    if host is None and meta.get("host_weights"):
+        # consume=True: reuse the load the completeness gate just performed and release the
+        # memoized entry, so the sidecar is read from NAS once per warm run, not twice. (R1)
+        host = load_host_sidecar(cache_path, consume=True)
+    host = host or {}
+    logger.info(
+        f"Warm ttnn weight cache: built state_dict for {len(manifest)} weights "
+        f"({len(host)} real host weights, no full HF load)."
+    )
+    return CachedStateDict(manifest, host)

--- a/models/demos/blackhole/qwen36/tt/common.py
+++ b/models/demos/blackhole/qwen36/tt/common.py
@@ -43,8 +43,17 @@ def create_tt_model(
         args.n_layers = n_layers
         args.attention_type_list = args.attention_type_list[:n_layers]
 
+    # NOTE: the warm-ttnn-cache HF-load skip is DISABLED for qwen3.6.
+    # Its Gated-DeltaNet loader consumes conv weights on the host without a cache_file_name --
+    # gdn/weights.py::load_conv_weight does ttnn.from_torch(state_dict[name], ...) for q/k/v_conv in
+    # every DeltaNet layer, and gdn/tp.py derives taps the same way -- so a dataless placeholder
+    # feeds those layers garbage while the HF load is skipped. This is the same failure that made
+    # the vision demo emit token soup, on the text path. Re-enabling needs those conv weights either
+    # cache-backed or captured to the sidecar via an is_host_weight predicate. (#45400 review)
+    cache_path = args.weight_cache_path()
     logger.info("Loading + remapping weights via Qwen36ModelArgs.load_state_dict()...")
     state_dict = args.load_state_dict()
-    cache_path = args.weight_cache_path()
+
     model = Qwen36Model(mesh_device, args, state_dict, tensor_cache_path=cache_path)
+
     return args, model, state_dict

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -525,7 +525,13 @@ class Qwen36Model:
 
     @classmethod
     def from_pretrained(
-        cls, device, max_batch_size=1, max_seq_len=2048, n_layers=None, layer_indices=None, hf_model=None
+        cls,
+        device,
+        max_batch_size=1,
+        max_seq_len=2048,
+        n_layers=None,
+        layer_indices=None,
+        hf_model=None,
     ):
         # HF_MODEL env var (hub or local path) is canonical; hf_model sets it for back-compat.
         if hf_model is not None:
@@ -553,11 +559,19 @@ class Qwen36Model:
             args.n_layers = n_layers
             args.attention_type_list = args.attention_type_list[:n_layers]
 
+        # NOTE: the warm-ttnn-cache HF-load skip is DISABLED for qwen3.6.
+        # Its Gated-DeltaNet loader consumes conv weights on the host without a cache_file_name --
+        # gdn/weights.py::load_conv_weight does ttnn.from_torch(state_dict[name], ...) for q/k/v_conv in
+        # every DeltaNet layer, and gdn/tp.py derives taps the same way -- so a dataless placeholder
+        # feeds those layers garbage while the HF load is skipped. This is the same failure that made
+        # the vision demo emit token soup, on the text path. Re-enabling needs those conv weights either
+        # cache-backed or captured to the sidecar via an is_host_weight predicate. (#45400 review)
+        cache_path = args.weight_cache_path()
         logger.info("Loading + remapping weights via Qwen36ModelArgs.load_state_dict()...")
         state_dict = args.load_state_dict()
 
-        cache_path = args.weight_cache_path()
-        return cls(device, args, state_dict, tensor_cache_path=cache_path)
+        model = cls(device, args, state_dict, tensor_cache_path=cache_path)
+        return model
 
     def prefill_tp(self, token_ids, valid_len=None, vision_tokens=None):
         """Tensor-parallel full-model prefill (num_devices>1). Stateless: runs the

--- a/models/demos/gemma4/tt/common.py
+++ b/models/demos/gemma4/tt/common.py
@@ -12,13 +12,34 @@ Usage:
 
 import os
 
+from loguru import logger
+
 import ttnn
+from models.common.weight_cache import build_cached_state_dict, mark_weight_cache_complete, weight_cache_is_complete
 from models.demos.gemma4.config import MeshConfig, ModeConfig
 from models.demos.gemma4.tt.assistant.model import Gemma4AssistantModel
 from models.demos.gemma4.tt.ccl import CCLManager
 from models.demos.gemma4.tt.model import Gemma4Model
 from models.demos.gemma4.tt.model_config import Gemma4AssistantArgs, Gemma4ModelArgs
 from models.demos.gemma4.tt.precision import Gemma4Precision
+
+# Weights gemma4 consumes on the HOST (not just via ttnn.as_tensor) and that therefore must be
+# loaded for real even on a warm cache (see #45400 follow-up analysis of models/demos/gemma4/tt):
+#  - token embedding: F.embedding(tokens, _embed_weight_cpu)      (model.py:1218/1238/1421)
+#  - per-layer-input embed/proj/norm (E2B/E4B):                    (model.py:615-635)
+#  - per-layer learned scalar read via .item():                   (layer.py:122-123)
+# Everything else flows through ttnn.as_tensor(cache_file_name=...) and is placeholder-safe.
+_GEMMA4_HOST_WEIGHT_SUFFIXES = (
+    "embed_tokens.weight",
+    "embed_tokens_per_layer.weight",
+    "per_layer_model_projection.weight",
+    "per_layer_projection_norm.weight",
+    ".layer_scalar",
+)
+
+
+def _gemma4_is_host_weight(key):
+    return any(key.endswith(s) for s in _GEMMA4_HOST_WEIGHT_SUFFIXES)
 
 
 def create_tt_model(
@@ -74,16 +95,42 @@ def create_tt_model(
     else:
         ccl_manager = None
 
+    # Warm ttnn cache => skip the full HF weight load and build from .tensorbin. Hybrid: the few
+    # host-consumed weights (token embedding, per-layer scalars/PLI) are served real from the
+    # sidecar, the rest as dataless placeholders. Generalizes PR #50550 to gemma4 (#45400).
+    cache_dir = model_args.weight_cache_path(dtype)
+    # Resolved early so it can key the cache identity: gemma4 embeds each module's dtype in its
+    # tensorbin FILENAME (attention/experts/shared_mlp/router *_{dtype} suffixes), so an edit to
+    # precision_overrides.json changes which files a build needs. Without the precision in the
+    # variant, a marker seeded under the old overrides would certify a warm build whose files do
+    # not exist -- and as_tensor would persist placeholders for them. (#45400 review, finding B2)
+    _worker_mesh = tuple(mesh_device.shape) if hasattr(mesh_device, "shape") else (1, 1)
+    _precision_for_variant = Gemma4Precision.load(model_path, _worker_mesh)
+    cache_identity = dict(
+        model_name=os.path.basename(str(model_path).rstrip("/")) or "gemma4",
+        n_layers=model_args.num_hidden_layers,
+        mesh_shape=_worker_mesh,
+        build_variant={
+            "precision": {k: str(v) for k, v in sorted(_precision_for_variant._overrides.items())},
+        },
+    )
+    loaded_real_weights = False
     if state_dict is None:
-        state_dict = Gemma4ModelArgs.load_state_dict(model_path, dummy_weights=False)
+        if num_layers is None and weight_cache_is_complete(cache_dir, **cache_identity):
+            logger.info("Warm ttnn weight cache detected -- skipping HF state_dict load (gemma4 hybrid).")
+            state_dict = build_cached_state_dict(
+                cache_dir, args=model_args, build_variant=cache_identity["build_variant"]
+            )
+        else:
+            state_dict = Gemma4ModelArgs.load_state_dict(model_path, dummy_weights=False)
+            loaded_real_weights = bool(state_dict)
 
-    tensor_cache_path = str(model_args.weight_cache_path(dtype))
+    tensor_cache_path = str(cache_dir)
 
     # Resolve per-module dtype overrides from precision_overrides.json. The
     # mesh shape is the worker grid (rows x cols); a 1x1 mesh on a multi-device
     # system still gets the 1x1 entry.
-    mesh_shape = tuple(mesh_device.shape) if hasattr(mesh_device, "shape") else (1, 1)
-    precision = Gemma4Precision.load(model_path, mesh_shape)
+    precision = _precision_for_variant
 
     model = Gemma4Model(
         mesh_device=mesh_device,
@@ -101,6 +148,11 @@ def create_tt_model(
         precision=precision,
         bounded_sliding_kv_cache=bounded_sliding_kv_cache,
     )
+
+    # After a full cold build, record completion (+ capture host-consumed weights to the sidecar)
+    # so future runs can skip the HF load.
+    if loaded_real_weights and num_layers is None:
+        mark_weight_cache_complete(cache_dir, state_dict, is_host_weight=_gemma4_is_host_weight, **cache_identity)
 
     return model_args, model, model.tt_kv_cache, state_dict
 

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1,32 +1,29 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
-from loguru import logger
-from datetime import datetime
 import hashlib
-import requests
 import json
 import math
-import torch
-import pytest
 import os
-import ttnn
+from datetime import datetime
+from pathlib import Path
 
+import pytest
+import requests
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.common.weight_cache import build_cached_state_dict, mark_weight_cache_complete, weight_cache_is_complete
 from models.demos.llama3_70b_galaxy.tt.generator import Generator, SamplingParams
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations
-from models.tt_transformers.tt.common import (
-    preprocess_inputs_prefill,
-    PagedAttentionConfig,
-)
-from models.perf.benchmarking_utils import BenchmarkProfiler, BenchmarkData
-from models.common.utility_functions import (
-    comp_pcc,
-)
 from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
 from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):
@@ -214,7 +211,34 @@ def create_tt_model(
     # When running running prefill-only profile, run just 1 layer
     tt_model_args.n_layers = num_layers if not prefill_profile else 1
 
-    state_dict = tt_model_args.load_state_dict()
+    # Warm ttnn cache => build from .tensorbin, skip the HF from_pretrained load. Pure placeholder:
+    # this galaxy demo embeds tokens on-device (HostEmbedding is tests-only), so the state_dict
+    # feeds only the TtTransformer -- no host-weight hybrid needed. (#45400)
+    cache_dir = tt_model_args.weight_cache_path(dtype)
+    cache_identity = dict(
+        model_name=tt_model_args.model_name,
+        n_layers=tt_model_args.n_layers,
+        mesh_shape=tuple(mesh_device.shape),
+        # The galaxy loader picks prefetcher-vs-DRAM cache FILENAMES off use_prefetcher
+        # (llama_attention.py wqkv_sharded_2d_prefetcher / _dram), and the optimizations level
+        # sets per-tensor dtypes that are baked into filenames. Key the marker on both so a cache
+        # seeded under one configuration is not certified for another. (#45400 review, finding B2)
+        build_variant={
+            "use_prefetcher": bool(getattr(tt_model_args, "use_prefetcher", False)),
+            "optimizations": repr(getattr(tt_model_args, "optimizations", None)),
+        },
+    )
+    loaded_real_weights = False
+    if (
+        not prefill_profile
+        and not getattr(tt_model_args, "dummy_weights", False)
+        and weight_cache_is_complete(cache_dir, **cache_identity)
+    ):
+        logger.info("Warm ttnn weight cache detected -- skipping HF state_dict load.")
+        state_dict = build_cached_state_dict(cache_dir, build_variant=cache_identity["build_variant"])
+    else:
+        state_dict = tt_model_args.load_state_dict()
+        loaded_real_weights = bool(state_dict) and not getattr(tt_model_args, "dummy_weights", False)
     page_table = None
     paged_attention_config = None
     tt_kv_cache = None
@@ -245,6 +269,9 @@ def create_tt_model(
 
     if use_paged_kv_cache:
         tt_kv_cache = [l.attention.layer_past for l in model.layers]
+
+    if loaded_real_weights and not prefill_profile:
+        mark_weight_cache_complete(cache_dir, state_dict, **cache_identity)
 
     return tt_model_args, model, page_table, [tt_kv_cache]
 

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -1,36 +1,31 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from loguru import logger
-from datetime import datetime
 import json
 import math
-import torch
-import pytest
 import os
-import ttnn
+from datetime import datetime
 
+import pytest
+import torch
+from loguru import logger
+from transformers import AutoTokenizer
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.llama3_70b_galaxy.demo.demo_common import load_inputs_advanced
 from models.demos.llama3_70b_galaxy.tt.generator import Generator, SamplingParams
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations
-from models.tt_transformers.tt.common import (
-    preprocess_inputs_prefill,
-    PagedAttentionConfig,
-)
-from models.perf.benchmarking_utils import BenchmarkProfiler, BenchmarkData
-from models.common.utility_functions import (
-    comp_pcc,
-)
-from models.demos.utils.device_sku import get_current_device_sku_name
-from models.demos.utils.llm_demo_utils import verify_perf, verify_accuracy
-from models.demos.utils.model_targets import resolve_perf_targets, resolve_accuracy_targets
-from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 
 # Qwen-specific imports
 from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
 from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import DECODE_FABRIC_CONFIG as _FABRIC_CONFIG
-from transformers import AutoTokenizer
-from models.demos.llama3_70b_galaxy.demo.demo_common import load_inputs_advanced
-
+from models.demos.utils.device_sku import get_current_device_sku_name
+from models.demos.utils.llm_demo_utils import verify_accuracy, verify_perf
+from models.demos.utils.model_targets import resolve_accuracy_targets, resolve_perf_targets
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
 
 # Use common functions from demo_common.py
 # load_and_cache_context and load_inputs are now imported from demo_common
@@ -141,6 +136,13 @@ def create_tt_qwen_model(
     # When running running prefill-only profile, run just 1 layer
     tt_model_args.n_layers = num_layers if not prefill_profile else 1
 
+    # NOTE: the warm-ttnn-cache HF-load skip is intentionally DISABLED for qwen3-32b-galaxy.
+    # Qwen attention builds its q_norm/k_norm RMSNorms without a weight_cache_path
+    # (llama_attention.py), so those norms are materialized straight from the state_dict with
+    # cache_file_name=None -- i.e. NOT loaded from a .tensorbin. A dataless placeholder would feed
+    # uninitialized (garbage) q_norm/k_norm weights and corrupt accuracy while still passing.
+    # Load the real weights until those norms are cache-backed or captured in a host sidecar.
+    # (llama3.3-70b-galaxy has no q_norm/k_norm and keeps the skip.) (#45400)
     state_dict = tt_model_args.load_state_dict()
     page_table = None
     paged_attention_config = None

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -16,6 +16,7 @@ from loguru import logger
 import ttnn
 from models.common.sampling import SamplingParams
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
+from models.common.weight_cache import build_cached_state_dict, mark_weight_cache_complete, weight_cache_is_complete
 from models.demos.multimodal.gemma3.tt.gemma_e2e_model import TtGemmaModel
 from models.demos.multimodal.gemma3.tt.gemma_multimodal_generator import GemmaMultimodalGenerator as Generator
 from models.demos.utils.device_sku import get_current_device_sku_name
@@ -70,7 +71,7 @@ def create_tt_model(
     dummy_weights: bool = False,
     enable_program_trace: bool = False,
 ):
-    from models.demos.multimodal.gemma3.tt.model_config import ModelArgs
+    from models.demos.multimodal.gemma3.tt.model_config import ModelArgs, is_gemma3_host_weight
     from models.tt_transformers.tt.model import Transformer
 
     tt_model_args = ModelArgs(
@@ -116,9 +117,37 @@ def create_tt_model(
                 # Turn off fp32_dest_acc_en to not trigger L1 OOM
                 tt_model_args._force_sdpa_prefill_hifi4_fp16()
 
-    # Avoid loading state_dict for every DP model
-    if not state_dict:
-        state_dict = tt_model_args.load_state_dict()
+    # Warm ttnn cache => skip the HF from_pretrained host load and build from .tensorbin. Text and
+    # vision share one cache dir and gemma3's load_state_dict returns the full multimodal dict, so
+    # both paths use the shared hybrid helper with the SAME host-weight set (the text Transformer
+    # consumes none of the 5 vision host keys, but they must be captured to the sidecar for the
+    # vision path). None=decide, placeholder=skip/DP-reuse, populated=reuse.
+    #
+    # components="text": this build constructs ONLY the text Transformer, so it only writes the
+    # text tensorbins. The marker records that, and vision_demo (components="text+vision") will not
+    # accept it -- otherwise the vision tower would be built from placeholders and as_tensor would
+    # dump them to disk as real cache entries. (#45400 review)
+    cache_dir = tt_model_args.weight_cache_path(dtype)
+    cache_identity = dict(
+        model_name=tt_model_args.model_name,
+        n_layers=tt_model_args.n_layers,
+        mesh_shape=tuple(tt_model_args.mesh_device.shape),
+        components=["text"],
+        # gemma3 inherits the tt_transformers ModelArgs, so its cache filenames move with the
+        # same knobs (precision config, prefetcher, batch, rope mode). Key the marker on them the
+        # same way create_tt_model does. (#45400 review, finding B2)
+        build_variant=tt_model_args._weight_cache_build_variant(),
+    )
+    loaded_real_weights = False
+    if state_dict is None:
+        if not tt_model_args.dummy_weights and weight_cache_is_complete(cache_dir, **cache_identity):
+            logger.info("Warm ttnn weight cache detected -- building state_dict from cache (no HF load).")
+            state_dict = build_cached_state_dict(
+                cache_dir, args=tt_model_args, build_variant=cache_identity["build_variant"]
+            )
+        else:
+            state_dict = tt_model_args.load_state_dict()
+            loaded_real_weights = bool(state_dict) and not tt_model_args.dummy_weights
 
     model = Transformer(
         args=tt_model_args,
@@ -130,6 +159,9 @@ def create_tt_model(
     )
 
     tt_kv_cache = [l.attention.layer_past for l in model.layers] if paged_attention_config else None
+
+    if loaded_real_weights and num_layers is None:
+        mark_weight_cache_complete(cache_dir, state_dict, is_host_weight=is_gemma3_host_weight, **cache_identity)
 
     return tt_model_args, model, tt_kv_cache, state_dict
 

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -12,6 +12,7 @@ from PIL import Image as PIL_Image
 from pydantic import BaseModel
 
 from models.common.llama_models import sample_top_p
+from models.common.weight_cache import build_cached_state_dict, mark_weight_cache_complete, weight_cache_is_complete
 from models.tt_transformers.tt.common import ImageMedia, InterleavedTextMedia, Role
 from models.tt_transformers.tt.generator import create_submeshes
 
@@ -69,7 +70,7 @@ def create_multimodal_model(
     enable_program_trace: bool = False,
 ):
     from models.demos.multimodal.gemma3.tt.gemma_e2e_model import TtGemmaModel
-    from models.demos.multimodal.gemma3.tt.model_config import ModelArgs
+    from models.demos.multimodal.gemma3.tt.model_config import ModelArgs, is_gemma3_host_weight
 
     # limit length or we'll run out of space
     tt_model_args = ModelArgs(
@@ -91,18 +92,49 @@ def create_multimodal_model(
         dtype = ttnn.bfloat8_b
         logger.info(f"Setting dtype to bfloat8_b for 90B model on T3K to fit model in memory")
 
+    # Warm ttnn cache => build from .tensorbin (hybrid): the 5 vision weights gemma3 loads without
+    # a cache_file_name (patch-embed conv, siglip position embed, the two projector weights) are
+    # served real from the sidecar; the rest are dataless placeholders. The build uses bfloat8_b,
+    # so the cache identity must too. Shares the cache dir + host-weight set with the text path.
+    # components="text+vision": this build also constructs the siglip tower and projector, whose
+    # tensorbins a text-only seed never wrote. Recording it means a text-seeded marker is rejected
+    # here and we cold-load instead of building the vision tower from placeholders. (#45400 review)
+    cache_dtype = ttnn.bfloat8_b
+    cache_dir = tt_model_args.weight_cache_path(cache_dtype)
+    cache_identity = dict(
+        model_name=tt_model_args.model_name,
+        n_layers=tt_model_args.n_layers,
+        mesh_shape=tuple(tt_model_args.mesh_device.shape),
+        components=["text", "vision"],
+        # gemma3 inherits the tt_transformers ModelArgs, so its cache filenames move with the
+        # same knobs (precision config, prefetcher, batch, rope mode). Key the marker on them the
+        # same way create_tt_model does. (#45400 review, finding B2)
+        build_variant=tt_model_args._weight_cache_build_variant(),
+    )
+    loaded_real_weights = False
     if checkpoint is None:
-        checkpoint = tt_model_args.load_state_dict()
+        if not tt_model_args.dummy_weights and weight_cache_is_complete(cache_dir, **cache_identity):
+            logger.info("Warm ttnn weight cache detected -- building hybrid vision state_dict (no HF load).")
+            checkpoint = build_cached_state_dict(
+                cache_dir, args=tt_model_args, build_variant=cache_identity["build_variant"]
+            )
+        else:
+            checkpoint = tt_model_args.load_state_dict()
+            loaded_real_weights = bool(checkpoint) and not tt_model_args.dummy_weights
 
     model = TtGemmaModel(
         mesh_device=mesh_device,
         state_dict=checkpoint,
-        weight_cache_path=tt_model_args.weight_cache_path(ttnn.bfloat8_b),
-        dtype=ttnn.bfloat8_b,
+        weight_cache_path=tt_model_args.weight_cache_path(cache_dtype),
+        dtype=cache_dtype,
         args=tt_model_args,
         use_paged_kv_cache=use_paged_kv_cache,
         paged_attention_config=paged_attention_config,
     )
+
+    if loaded_real_weights and num_layers is None:
+        mark_weight_cache_complete(cache_dir, checkpoint, is_host_weight=is_gemma3_host_weight, **cache_identity)
+
     return tt_model_args, model, checkpoint
 
 

--- a/models/demos/multimodal/gemma3/tt/model_config.py
+++ b/models/demos/multimodal/gemma3/tt/model_config.py
@@ -38,6 +38,24 @@ _GEMMA3_SDPA_DECODE_K_CHUNK_DEFAULT = 256
 _GEMMA3_SDPA_DECODE_K_CHUNK_PROGRAM_TRACE = 32
 
 
+# Vision weights gemma3 materializes to device WITHOUT a .tensorbin cache_file_name (patch-embed
+# conv, siglip position embedding, the two multi_modal_projector weights) -- a warm run would feed
+# them uninitialized garbage, so they must be served real from the host sidecar even on a warm
+# cache. Everything else flows through cached ttnn.as_tensor and is placeholder-safe. Enumerated
+# from the gemma3 vision stack (#45400 follow-up). Text path consumes none of these.
+GEMMA3_HOST_WEIGHT_SUFFIXES = (
+    "patch_embedding._linear.weight",
+    "patch_embedding._linear.bias",
+    "position_embedding.positional_embedding",
+    "mm_input_projection_weight",
+    "mm_soft_emb_norm.weight",
+)
+
+
+def is_gemma3_host_weight(key):
+    return any(key.endswith(s) for s in GEMMA3_HOST_WEIGHT_SUFFIXES)
+
+
 class ModelArgs(TTModelArgs):
     OP_KEYS = (
         # Embedding

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -80,6 +80,14 @@ def create_tt_model(
         optimizations=optimizations,
         max_seq_len=max_seq_len,
     )
+    # NOTE: no warm-ttnn-cache skip here -- this fork always loads the real weights.
+    # The skip was gated on text_only, but every caller builds the vision tower, so the branch was
+    # unreachable and the model never actually saved anything. Enabling it needs the multimodal
+    # weight set identified first: the "a placeholder is safe because the vision path uses a
+    # separate live HF reference" reasoning was disproved on qwen36, where the same comment held and
+    # vision_demo.py still generated token soup from a dataless state_dict (CI run 31503881448) --
+    # the multimodal splice reads weights the placeholder cannot supply. Until the equivalent weight
+    # here is found and sidecarred (as gemma3-vision does), cold-load. (#45400 review)
     state_dict = tt_model_args.load_state_dict()
 
     paged_attention_config = (

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -63,6 +63,14 @@ def create_tt_model(
         optimizations=optimizations,
         max_seq_len=max_seq_len,
     )
+    # NOTE: no warm-ttnn-cache skip here -- this fork always loads the real weights.
+    # The skip was gated on text_only, but every caller builds the vision tower, so the branch was
+    # unreachable and the model never actually saved anything. Enabling it needs the multimodal
+    # weight set identified first: the "a placeholder is safe because the vision path uses a
+    # separate live HF reference" reasoning was disproved on qwen36, where the same comment held and
+    # vision_demo.py still generated token soup from a dataless state_dict (CI run 31503881448) --
+    # the multimodal splice reads weights the placeholder cannot supply. Until the equivalent weight
+    # here is found and sidecarred (as gemma3-vision does), cold-load. (#45400 review)
     state_dict = tt_model_args.load_state_dict()
 
     paged_attention_config = (

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1051,6 +1051,11 @@ def test_demo_text(
     # This loop will rotate the prompts between the users for each batch, to simulate users sending different requests
     # If batch_size=1, the same prompt is repeated for each batch
 
+    # Time the model build. On a cold cache this includes the host HF weight load; on a warm
+    # ttnn cache that load is skipped (see create_tt_model / weight_cache_is_complete), so the
+    # cold-vs-warm delta of this segment is the host time saved per run. Flows through
+    # create_benchmark_data into the models-ci dashboard.
+    profiler.start("load_weights")
     (
         model_args,
         model,
@@ -1074,6 +1079,8 @@ def test_demo_text(
         use_prefetcher=use_prefetcher,
         use_hf_rope=use_hf_rope,
     )
+    profiler.end("load_weights")
+    logger.info(f"Model build (load_weights) took {profiler.get_duration('load_weights'):.2f}s")
 
     global_batch_size = batch_size * local_data_parallel
     input_prompts = select_local_data_parallel_items(input_prompts, batch_size, data_parallel, local_submesh_indices)
@@ -1562,6 +1569,18 @@ def test_demo_text(
         # Instead of running warmup iterations, the demo profiles the initial compile iteration
         bench_n_warmup_iter = {"inference_prefill": 0, "inference_decode": 1}
         benchmark_data = create_benchmark_data(profiler, measurements, bench_n_warmup_iter, targets)
+
+        # Model-build time (cold = incl. host HF weight load; warm ttnn cache = load skipped).
+        # The cold-vs-warm delta of this KPI is the host time saved by the warm-cache skip (#45400).
+        benchmark_data.add_measurement(
+            profiler,
+            0,
+            "load_weights",
+            "time(s)",
+            profiler.get_duration("load_weights"),
+            step_warm_up_num_iterations=None,
+            target=None,
+        )
 
         if not token_accuracy:
             # Save the decode performance of every iteration for plotting in superset

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -186,6 +186,12 @@ def create_multimodal_model(
         dtype = ttnn.bfloat8_b
         logger.info("Setting dtype to bfloat8_b for 90B model on T3K to fit model in memory")
 
+    # NOTE: the warm-ttnn-cache HF-load skip is intentionally NOT applied to this multimodal path.
+    # The vision tower consumes several weights on the *host* (materialized without a
+    # `cache_file_name`), so a dataless placeholder silently feeds garbage and collapses accuracy
+    # (90B-Vision warm run: BERTScore F1 0.21 vs 0.55). Getting the win here needs a host-weight
+    # hybrid like the gemma3-vision path — tracked as a follow-up (#45400). checkpoint is None =>
+    # load here; {} => explicit/DP-reuse skip; populated => reuse.
     if checkpoint is None:
         checkpoint = tt_model_args.load_state_dict()
 
@@ -207,6 +213,7 @@ def create_multimodal_model(
             configuration=tt_model_args,
             use_paged_kv_cache=use_paged_kv_cache,
         )
+
     return tt_model_args, model, checkpoint
 
 

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -200,6 +200,15 @@ def test_model_inference(
     # Load reference model
     if run_ref_pt:
         logger.info("Loading reference model...")
+        # On a warm ttnn cache, create_tt_model defers the HF load and returns a dataless
+        # placeholder state_dict. The host reference embedding below still needs the REAL weights,
+        # so reload them here when the state_dict is a warm-cache placeholder (either flavor) or
+        # genuinely empty. Branch on is_placeholder, NOT truthiness: tt_transformers'
+        # _PlaceholderStateDict is falsy but the shared CachedStateDict is truthy, so `if not
+        # state_dict` alone would silently stop reloading -- and build this torch reference from
+        # torch.empty garbage -- if the loaders are ever collapsed onto the shared class. (#45400)
+        if getattr(state_dict, "is_placeholder", False) or not state_dict:
+            state_dict = model_args.load_state_dict()
         state_dict_prefix = model_args.get_state_dict_prefix("", None)
         reference_model = model_args.reference_transformer(load_checkpoint=True)
         # Embedding on host

--- a/models/tt_transformers/tests/test_warm_cache_marker.py
+++ b/models/tt_transformers/tests/test_warm_cache_marker.py
@@ -1,0 +1,437 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Lightweight (CPU-only, no device, no model download) tests for the warm ttnn weight-cache
+detector generalized into tt_transformers (issue #45400, generalizes GPT-OSS PR #48531).
+
+These exercise the *real* ModelArgs.weight_cache_is_complete / mark_weight_cache_complete /
+placeholder_state_dict logic by binding the unbound methods to a tiny stub whose
+weight_cache_path points at a tmp dir -- so we validate marker round-trip, the shape/dtype
+manifest, staleness rejection, the force-load override, the .tensorbin belt-and-suspenders
+check, and the dataless placeholder state_dict without constructing a full ModelArgs.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from models.tt_transformers.tt.model_config import ModelArgs
+
+DTYPE = "bfp8"  # opaque here: the stub's weight_cache_path ignores it; marker stores str(dtype)
+
+SAMPLE_SD = {
+    "tok_embeddings.weight": torch.zeros(4, 8, dtype=torch.bfloat16),
+    "layers.0.attention.wo.weight": torch.zeros(8, 8, dtype=torch.float32),
+}
+
+
+class _FakeArgs:
+    """Minimal stand-in exposing exactly what the marker methods touch, with the real methods
+    bound so the production logic is under test."""
+
+    WEIGHT_CACHE_MARKER = ModelArgs.WEIGHT_CACHE_MARKER
+    WEIGHT_CACHE_FORMAT_VERSION = ModelArgs.WEIGHT_CACHE_FORMAT_VERSION
+    _weight_cache_identity = ModelArgs._weight_cache_identity
+    # Bound too: _weight_cache_identity calls it on self, so leaving it out made every gate call
+    # raise AttributeError -- and nothing ran this file to notice. (#45400 review, finding B1)
+    _weight_cache_build_variant = ModelArgs._weight_cache_build_variant
+    weight_cache_is_complete = ModelArgs.weight_cache_is_complete
+    mark_weight_cache_complete = ModelArgs.mark_weight_cache_complete
+    placeholder_state_dict = ModelArgs.placeholder_state_dict
+
+    def __init__(self, cache_dir, model_name="Test-Model-8B", n_layers=32, mesh_shape=(1, 8)):
+        self._cache_dir = Path(cache_dir)
+        self.model_name = model_name
+        self.n_layers = n_layers
+        self.dummy_weights = False
+        self.is_mixture_of_experts = False
+        self.mesh_device = SimpleNamespace(shape=mesh_shape)
+        # Everything _weight_cache_build_variant reads. get_tensor_dtype deliberately lives on
+        # self.optimizations (a DecodersPrecision in production), NOT on the args object: the
+        # variant helper shipped calling self.get_tensor_dtype and threw AttributeError on every
+        # model, and a stub that put the method on the args would have kept agreeing with that
+        # bug. Mirror the production shape so the stub can only pass against correct code.
+        self.prefetcher = None
+        self.max_batch_size = 1
+        self.use_fused_all_gather_matmul = False
+        self.use_hf_rope = False
+        self.optimizations = SimpleNamespace(
+            get_tensor_dtype=lambda decoder_id, tensor, prefetcher=False: "DataType.BFLOAT8_B"
+        )
+
+    def weight_cache_path(self, dtype):
+        return self._cache_dir
+
+
+def _touch_tensorbin(cache_dir):
+    (Path(cache_dir) / "some.weight.tensorbin").write_bytes(b"\x00")
+
+
+@pytest.fixture(autouse=True)
+def _clear_force_env(monkeypatch):
+    monkeypatch.delenv("TT_TRANSFORMERS_FORCE_MODEL_LOAD", raising=False)
+
+
+def test_cold_cache_is_incomplete(tmp_path):
+    args = _FakeArgs(tmp_path)
+    assert args.weight_cache_is_complete(DTYPE) is False
+
+
+def test_mark_then_complete_roundtrip(tmp_path):
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)  # a real build writes tensor files alongside the marker
+    args.mark_weight_cache_complete(DTYPE, SAMPLE_SD)
+    assert args.weight_cache_is_complete(DTYPE) is True
+
+    # Marker payload includes the shape/dtype manifest.
+    meta = json.loads(marker_path(tmp_path, args._weight_cache_build_variant()).read_text())
+    assert meta["model_name"] == "Test-Model-8B"
+    assert meta["n_layers"] == 32
+    assert meta["mesh_shape"] == "(1, 8)"
+    assert meta["format_version"] == ModelArgs.WEIGHT_CACHE_FORMAT_VERSION
+    assert meta["weights"]["tok_embeddings.weight"] == [[4, 8], "torch.bfloat16"]
+
+
+def test_marker_without_manifest_is_incomplete(tmp_path):
+    # A marker with no weight manifest (e.g. an old v1-style write) can't back a warm build.
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)
+    args.mark_weight_cache_complete(DTYPE)  # no state_dict -> weights == {}
+    assert args.weight_cache_is_complete(DTYPE) is False
+
+
+def test_marker_without_tensorbin_is_incomplete(tmp_path):
+    args = _FakeArgs(tmp_path)
+    args.mark_weight_cache_complete(DTYPE, SAMPLE_SD)
+    # No .tensorbin present -> belt-and-suspenders check fails.
+    assert args.weight_cache_is_complete(DTYPE) is False
+
+
+def test_force_env_disables_skip(tmp_path, monkeypatch):
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)
+    args.mark_weight_cache_complete(DTYPE, SAMPLE_SD)
+    assert args.weight_cache_is_complete(DTYPE) is True  # warm...
+    monkeypatch.setenv("TT_TRANSFORMERS_FORCE_MODEL_LOAD", "1")
+    assert args.weight_cache_is_complete(DTYPE) is False  # ...but forced to cold-load
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param({"format_version": 999}, id="stale-format"),
+        pytest.param({"model_name": "Other-Model"}, id="wrong-model"),
+        pytest.param({"n_layers": 1}, id="partial-build"),
+        pytest.param({"mesh_shape": "(2, 4)"}, id="wrong-mesh"),
+        pytest.param({"weights": {}}, id="empty-manifest"),
+    ],
+)
+def test_stale_marker_rejected(tmp_path, mutate):
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)
+    args.mark_weight_cache_complete(DTYPE, SAMPLE_SD)
+    marker = marker_path(tmp_path, args._weight_cache_build_variant())
+    meta = json.loads(marker.read_text())
+    meta.update(mutate)
+    marker.write_text(json.dumps(meta))
+    assert args.weight_cache_is_complete(DTYPE) is False
+
+
+def test_corrupt_marker_is_incomplete(tmp_path):
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)
+    marker_path(tmp_path, args._weight_cache_build_variant()).write_text("{ not json")
+    assert args.weight_cache_is_complete(DTYPE) is False
+
+
+def test_placeholder_state_dict_is_dataless_and_falsy(tmp_path):
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)
+    args.mark_weight_cache_complete(DTYPE, SAMPLE_SD)
+
+    sd = args.placeholder_state_dict(DTYPE)
+    # Falsy so reference-building callers (`if not state_dict`) load real weights instead.
+    assert not sd
+    assert len(sd) == 2
+    assert set(sd.keys()) == set(SAMPLE_SD.keys())
+    # Reconstructs correct shape/dtype without any real data.
+    emb = sd["tok_embeddings.weight"]
+    assert tuple(emb.shape) == (4, 8)
+    assert emb.dtype == torch.bfloat16
+    assert sd["layers.0.attention.wo.weight"].dtype == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# models/common/weight_cache.py -- the shared helper used by the forked loaders.
+# The tests above bind the tt_transformers ModelArgs methods; these cover the shared
+# module's own behaviour: sidecar capture/rejection, per-file completeness, component
+# matching, atomic publish, and the CachedStateDict contract. (#45400 review)
+# ---------------------------------------------------------------------------
+
+from models.common.weight_cache import (  # noqa: E402
+    HOST_WEIGHTS_SIDECAR,
+    WEIGHT_CACHE_MARKER,
+    CachedStateDict,
+    build_cached_state_dict,
+    mark_weight_cache_complete,
+    marker_path,
+    normalize_mesh_shape,
+    weight_cache_is_complete,
+)
+
+SHARED_ID = dict(model_name="unit/test-model", n_layers=2, mesh_shape=(1, 8))
+
+
+def _seed(tmp_path, *, components=None, is_host_weight=None, sd=None):
+    """Write a tensorbin then mark the cache complete, mimicking a real cold build."""
+    _touch_tensorbin(tmp_path)
+    mark_weight_cache_complete(
+        tmp_path, sd if sd is not None else SAMPLE_SD, components=components, is_host_weight=is_host_weight, **SHARED_ID
+    )
+
+
+def test_shared_marker_roundtrip(tmp_path):
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is False
+    _seed(tmp_path)
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is True
+
+
+def test_shared_marker_rejects_missing_tensorbin(tmp_path):
+    """A recorded tensorbin that later disappears must force a cold load -- otherwise as_tensor
+    regenerates it from the placeholder and writes garbage into the cache permanently."""
+    _seed(tmp_path)
+    for f in tmp_path.glob("*.tensorbin"):
+        f.unlink()
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is False
+
+
+def test_shared_marker_finds_tensorbins_in_subdirs(tmp_path):
+    """Forked loaders nest per-layer weights (qwen36 layers.N/, gemma4 layer_N/)."""
+    sub = tmp_path / "layers.0"
+    sub.mkdir()
+    (sub / "wq_dtype_BFLOAT8_B_layout_TILE.tensorbin").write_bytes(b"x")
+    mark_weight_cache_complete(tmp_path, SAMPLE_SD, **SHARED_ID)
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is True
+    (sub / "wq_dtype_BFLOAT8_B_layout_TILE.tensorbin").unlink()
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is False
+
+
+def test_components_subset_matching(tmp_path):
+    """A text-only seed must not certify a build that also needs the vision tower; the reverse
+    (vision seed satisfying a text-only build) is fine."""
+    _seed(tmp_path, components=["text"])
+    assert weight_cache_is_complete(tmp_path, components=["text"], **SHARED_ID) is True
+    assert weight_cache_is_complete(tmp_path, components=["text", "vision"], **SHARED_ID) is False
+
+    _seed(tmp_path, components=["text", "vision"])
+    assert weight_cache_is_complete(tmp_path, components=["text"], **SHARED_ID) is True
+
+
+def test_sidecar_capture_and_corruption_rejected(tmp_path):
+    _seed(tmp_path, is_host_weight=lambda k: k == "tok_embeddings.weight")
+    assert (tmp_path / HOST_WEIGHTS_SIDECAR).is_file()
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is True
+
+    sd = build_cached_state_dict(tmp_path)
+    # The captured host weight is served REAL; everything else is a dataless placeholder.
+    assert torch.equal(sd["tok_embeddings.weight"], SAMPLE_SD["tok_embeddings.weight"])
+
+    # A torn sidecar must degrade to a cold load, not crash every later run.
+    (tmp_path / HOST_WEIGHTS_SIDECAR).write_bytes(b"not a torch file")
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is False
+
+
+def test_no_temp_files_left_behind(tmp_path):
+    _seed(tmp_path, is_host_weight=lambda k: k == "tok_embeddings.weight")
+    assert not list(tmp_path.glob("*.tmp*")), "atomic publish must not leave temp files"
+
+
+def test_mesh_shape_encoding_is_writer_agnostic(tmp_path):
+    """Both marker writers must encode the mesh identically or each rejects the other's marker."""
+
+    class _MeshShape:
+        def __init__(self, dims):
+            self._dims = dims
+
+        def __iter__(self):
+            return iter(self._dims)
+
+        def __str__(self):
+            return f"MeshShape({list(self._dims)})"
+
+    assert normalize_mesh_shape(_MeshShape((1, 8))) == normalize_mesh_shape((1, 8))
+    _seed(tmp_path)
+    identity = dict(SHARED_ID, mesh_shape=_MeshShape((1, 8)))
+    assert weight_cache_is_complete(tmp_path, **identity) is True
+
+
+def test_cached_state_dict_contract():
+    manifest = {k: [list(v.shape), str(v.dtype)] for k, v in SAMPLE_SD.items()}
+    real = SAMPLE_SD["tok_embeddings.weight"]
+    sd = CachedStateDict(manifest, {"tok_embeddings.weight": real})
+
+    # Truthy and flagged (the tt_transformers placeholder is falsy -- callers must branch on the
+    # attribute, not truthiness).
+    assert sd
+    assert sd.is_placeholder is True
+
+    # Membership must not materialize a tensor.
+    assert "layers.0.attention.wo.weight" in sd
+    assert "nope" not in sd
+    assert sd.get("nope") is None
+
+    # Mutable: loaders setdefault KV-shared weights.
+    sd["extra"] = torch.zeros(2)
+    assert "extra" in sd
+    del sd["extra"]
+    assert "extra" not in sd
+
+    del sd["tok_embeddings.weight"]
+    assert "tok_embeddings.weight" not in sd
+    try:
+        sd["tok_embeddings.weight"]
+        raise AssertionError("a deleted key must raise KeyError, even when the sidecar still has it")
+    except KeyError:
+        pass
+
+
+def test_build_variant_must_match_exactly(tmp_path):
+    """Build options that change an as_tensor cache FILENAME (prefetcher, precision) are matched
+    exactly, not as a superset: a different variant needs DIFFERENT files, and any it is missing
+    would be regenerated from the placeholder rather than cold-loaded."""
+    perf = {"prefetcher": False, "precision": "aaaaaaaaaaaa"}
+    _touch_tensorbin(tmp_path)
+    mark_weight_cache_complete(tmp_path, SAMPLE_SD, build_variant=perf, **SHARED_ID)
+
+    assert weight_cache_is_complete(tmp_path, build_variant=perf, **SHARED_ID) is True
+    # different precision config
+    assert (
+        weight_cache_is_complete(tmp_path, build_variant={"prefetcher": False, "precision": "bbbb"}, **SHARED_ID)
+        is False
+    )
+    # prefetcher flips the dtypes and adds ring-matmul splits
+    assert (
+        weight_cache_is_complete(tmp_path, build_variant={"prefetcher": True, "precision": "aaaaaaaaaaaa"}, **SHARED_ID)
+        is False
+    )
+    # a caller that records no variant must not be satisfied by one that did
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is False
+
+
+# ---------------------------------------------------------------------------
+# Review-fix coverage (#45400 findings B3 / R1 / R3).
+# ---------------------------------------------------------------------------
+
+import models.common.weight_cache as _wc  # noqa: E402
+
+
+def test_variant_markers_coexist(tmp_path):
+    """One marker file PER build variant: two variants sharing a cache dir must not evict each
+    other's marker. The live case is the Llama CI job running eval-32 with and without the DRAM
+    prefetcher against one instruct cache -- a single exactly-matched marker made each leg's seed
+    clobber the other's, so both cold-loaded forever with nothing going red. (finding B3)"""
+    no_pf = {"prefetcher": False, "precision": "aaaaaaaaaaaa"}
+    with_pf = {"prefetcher": True, "precision": "aaaaaaaaaaaa"}
+    _touch_tensorbin(tmp_path)
+    mark_weight_cache_complete(tmp_path, SAMPLE_SD, build_variant=no_pf, **SHARED_ID)
+    mark_weight_cache_complete(tmp_path, SAMPLE_SD, build_variant=with_pf, **SHARED_ID)
+
+    # Both warm at once -- the second seed did not evict the first.
+    assert weight_cache_is_complete(tmp_path, build_variant=no_pf, **SHARED_ID) is True
+    assert weight_cache_is_complete(tmp_path, build_variant=with_pf, **SHARED_ID) is True
+    assert marker_path(tmp_path, no_pf) != marker_path(tmp_path, with_pf)
+    # A variant nobody seeded stays cold.
+    assert (
+        weight_cache_is_complete(tmp_path, build_variant={"prefetcher": False, "precision": "b"}, **SHARED_ID) is False
+    )
+    # And each variant's builder reads its own manifest.
+    sd = build_cached_state_dict(tmp_path, build_variant=with_pf)
+    assert set(sd.keys()) == set(SAMPLE_SD.keys())
+
+
+def test_unverifiable_variant_fails_closed(tmp_path):
+    """A build variant that could not be computed must never certify or match a cache: the gate
+    returns False and mark refuses to write, so the run cold-loads instead of risking a
+    placeholder persist under an unchecked filename set. (finding R3)"""
+    bad = {"unverifiable": True, "error": "RuntimeError: boom"}
+    _touch_tensorbin(tmp_path)
+    mark_weight_cache_complete(tmp_path, SAMPLE_SD, build_variant=bad, **SHARED_ID)
+    assert not list(tmp_path.glob(f"{WEIGHT_CACHE_MARKER}*")), "unverifiable variant must not write a marker"
+    # Even with a marker forged at the matching path, the gate rejects the request side.
+    mark_weight_cache_complete(tmp_path, SAMPLE_SD, **SHARED_ID)  # legit .none marker
+    assert weight_cache_is_complete(tmp_path, build_variant=bad, **SHARED_ID) is False
+
+
+def test_modelargs_variant_error_disables_skip(tmp_path):
+    """ModelArgs path: if computing the precision signature raises, the sentinel flows through
+    identity -> gate -> False (cold load), and marking is refused -- instead of the old behaviour
+    of collapsing to a match-anything 'unknown'. (finding R3)"""
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)
+
+    def _boom(decoder_id, tensor, prefetcher=False):
+        raise RuntimeError("precision config unavailable")
+
+    args.optimizations = SimpleNamespace(get_tensor_dtype=_boom)
+    variant = args._weight_cache_build_variant()
+    assert variant.get("unverifiable") is True
+    args.mark_weight_cache_complete(DTYPE, SAMPLE_SD)
+    assert not list(Path(tmp_path).glob(f"{WEIGHT_CACHE_MARKER}*"))
+    assert args.weight_cache_is_complete(DTYPE) is False
+
+
+def test_hf_rope_is_part_of_the_variant(tmp_path):
+    """load_state_dict permutes QKV differently per rope mode under the SAME cache filenames, so a
+    marker seeded in one mode must not certify the other. (finding R2)"""
+    args = _FakeArgs(tmp_path)
+    _touch_tensorbin(tmp_path)
+    args.mark_weight_cache_complete(DTYPE, SAMPLE_SD)
+    assert args.weight_cache_is_complete(DTYPE) is True
+    args.use_hf_rope = True
+    assert args.weight_cache_is_complete(DTYPE) is False
+
+
+def test_sidecar_loaded_once_per_warm_run(tmp_path, monkeypatch):
+    """The completeness gate's validation load must be reused by build_cached_state_dict, not
+    repeated -- the sidecar can be multi-GB on NAS. The builder consumes the memoized entry so the
+    tensors are not pinned afterwards. (finding R1)"""
+    _seed(tmp_path, is_host_weight=lambda k: k == "tok_embeddings.weight")
+
+    real_load = torch.load
+    calls = []
+
+    def counting_load(*a, **k):
+        calls.append(a[0] if a else k.get("f"))
+        return real_load(*a, **k)
+
+    monkeypatch.setattr(torch, "load", counting_load)
+    _wc._SIDECAR_CACHE.clear()
+
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is True
+    sd = build_cached_state_dict(tmp_path)
+    assert torch.equal(sd["tok_embeddings.weight"], SAMPLE_SD["tok_embeddings.weight"])
+    assert len(calls) == 1, f"sidecar torch.load'ed {len(calls)}x per warm run, expected 1"
+    assert not _wc._SIDECAR_CACHE, "builder must consume the memoized sidecar entry"
+
+
+def test_mark_survives_non_oserror_write_failure(tmp_path, monkeypatch):
+    """mark_weight_cache_complete only records completion; a failure to record must warn, not
+    raise. torch.save on a read-only mount raises RuntimeError from the C++ serializer (not
+    OSError), which crashed every read-only cold run of the sidecar models right after a
+    successful build. (finding R5, Gemma-4-E2B bh_p150, run 32511945147)"""
+    _touch_tensorbin(tmp_path)
+
+    def _ro_save(*a, **k):
+        raise RuntimeError(
+            "[enforce fail at inline_container.cc:747] . open file failed with strerror: Read-only file system"
+        )
+
+    monkeypatch.setattr(torch, "save", _ro_save)
+    # Must not raise, and must not publish a marker that claims a sidecar it could not write.
+    mark_weight_cache_complete(tmp_path, SAMPLE_SD, is_host_weight=lambda k: k == "tok_embeddings.weight", **SHARED_ID)
+    assert weight_cache_is_complete(tmp_path, **SHARED_ID) is False

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -925,9 +925,25 @@ def create_tt_model(
     if prefetcher is not None:
         prefetcher.num_layers = tt_model_args.n_layers
 
-    # Avoid loading state_dict for every DP model
-    if not state_dict:
-        state_dict = tt_model_args.load_state_dict()
+    # Decide whether the HF weights are still needed on host. When the ttnn weight cache for
+    # this build was already fully built on a previous run, ttnn.as_tensor loads every weight from
+    # disk and the state_dict is never read -- so skip the expensive from_pretrained host load
+    # entirely (the load that OOMs/hangs in prefill, #48509). Generalizes GPT-OSS PR #48531 (whose
+    # --skip-model-load pytest flag is gpt_oss-only; nothing equivalent exists for these models).
+    #
+    # state_dict is None  -> decide here (warm cache => placeholder, else cold load).
+    # state_dict falsy/{}  -> caller already decided to skip (e.g. a prior DP submesh); build as-is.
+    # state_dict populated -> reuse across DP models (avoid reloading for every submesh).
+    loaded_real_weights = False
+    if state_dict is None:
+        if not tt_model_args.dummy_weights and tt_model_args.weight_cache_is_complete(dtype):
+            logger.info("Warm ttnn weight cache detected -- skipping HF state_dict load.")
+            # Dataless placeholder: every weight is loaded from its .tensorbin by ttnn.as_tensor;
+            # the placeholder only satisfies the host-side reshape ops (see placeholder_state_dict).
+            state_dict = tt_model_args.placeholder_state_dict(dtype)
+        else:
+            state_dict = tt_model_args.load_state_dict()
+            loaded_real_weights = bool(state_dict) and not tt_model_args.dummy_weights
 
     model = Transformer(
         args=tt_model_args,
@@ -938,6 +954,12 @@ def create_tt_model(
         paged_attention_config=paged_attention_config,
         prefetcher=prefetcher,
     )
+
+    # If this run populated the cache from a cold host load, record completion so future runs
+    # can skip the load. Only for full-model builds (a num_layers override produces a partial
+    # cache that must not satisfy the completeness check).
+    if loaded_real_weights and num_layers is None:
+        tt_model_args.mark_weight_cache_complete(dtype, state_dict)
 
     tt_kv_cache = [l.attention.layer_past for l in model.layers] if paged_attention_config else None
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import inspect
 import json
 import math
@@ -16,6 +17,11 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import hf_cache_to_legacy, is_blackhole, is_wormhole_b0, nearest_32
+from models.common.weight_cache import WEIGHT_CACHE_FORMAT_VERSION as _WC_FORMAT_VERSION
+from models.common.weight_cache import WEIGHT_CACHE_MARKER as _WC_MARKER
+from models.common.weight_cache import mark_weight_cache_complete as _mark_weight_cache_complete
+from models.common.weight_cache import marker_path as _wc_marker_path
+from models.common.weight_cache import weight_cache_is_complete as _weight_cache_is_complete
 from models.tt_transformers.tt.common import (
     Mode,
     calculate_hidden_dim,
@@ -1338,11 +1344,13 @@ class ModelArgs:
                 k=self.dim // self.cluster_shape[0],
                 n=self.hidden_dim // self.cluster_shape[1],
                 grid_size=self.mlp1_3_grid(seq_len),
-                per_core_N=math.ceil(
-                    (self.hidden_dim // self.cluster_shape[1]) / (ttnn.TILE_SIZE * self.dram_shard_grid_width)
-                )
-                if not self.is_galaxy
-                else None,
+                per_core_N=(
+                    math.ceil(
+                        (self.hidden_dim // self.cluster_shape[1]) / (ttnn.TILE_SIZE * self.dram_shard_grid_width)
+                    )
+                    if not self.is_galaxy
+                    else None
+                ),
             )
 
     @lru_cache(maxsize=None)
@@ -1398,9 +1406,11 @@ class ModelArgs:
                     k=self.hidden_dim // (self.cluster_shape[1] if self.is_galaxy else 1),
                     n=self.dim,
                     grid_size=self.mlp2_grid(seq_len),
-                    per_core_N=math.ceil(self.dim / (ttnn.TILE_SIZE * self.dram_shard_grid_width))
-                    if not self.is_galaxy
-                    else None,
+                    per_core_N=(
+                        math.ceil(self.dim / (ttnn.TILE_SIZE * self.dram_shard_grid_width))
+                        if not self.is_galaxy
+                        else None
+                    ),
                 )
         else:
             raise ValueError(f"Invalid mode: {mode}")
@@ -1560,21 +1570,29 @@ class ModelArgs:
         q_chunk = (
             256
             if seq_len >= 2048 and (chunk_start_idx is None or chunk_start_idx == 0)
-            else 64
-            if seq_len < 2048 and (chunk_start_idx is None or chunk_start_idx == 0)
-            else min(256, chunk_start_idx & -chunk_start_idx)
-            if seq_len >= 2048
-            else min(64, chunk_start_idx & -chunk_start_idx)
+            else (
+                64
+                if seq_len < 2048 and (chunk_start_idx is None or chunk_start_idx == 0)
+                else (
+                    min(256, chunk_start_idx & -chunk_start_idx)
+                    if seq_len >= 2048
+                    else min(64, chunk_start_idx & -chunk_start_idx)
+                )
+            )
         )
         # Workaround for https://github.com/tenstorrent/tt-metal/issues/35225:
         k_chunk = (
             256
             if seq_len >= 2048 and (chunk_start_idx is None or chunk_start_idx == 0)
-            else 64
-            if seq_len < 2048 and (chunk_start_idx is None or chunk_start_idx == 0)
-            else min(256, chunk_start_idx & -chunk_start_idx)
-            if seq_len >= 2048
-            else min(64, chunk_start_idx & -chunk_start_idx)
+            else (
+                64
+                if seq_len < 2048 and (chunk_start_idx is None or chunk_start_idx == 0)
+                else (
+                    min(256, chunk_start_idx & -chunk_start_idx)
+                    if seq_len >= 2048
+                    else min(64, chunk_start_idx & -chunk_start_idx)
+                )
+            )
         )
         return ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=(8, 8),
@@ -2034,9 +2052,9 @@ class ModelArgs:
                 grid_size=self.find_prefill_grid(self.prefill_rows, k_dim // ttnn.TILE_SIZE),
                 in0_block_w=1 if self.is_galaxy else None,
                 fuse_batch=seq_len <= 1024,
-                per_core_N=math.ceil(n_dim / (ttnn.TILE_SIZE * self.dram_shard_grid_width))
-                if dram_sharded_wo
-                else None,
+                per_core_N=(
+                    math.ceil(n_dim / (ttnn.TILE_SIZE * self.dram_shard_grid_width)) if dram_sharded_wo else None
+                ),
             )
         else:
             raise ValueError(f"Invalid mode: {mode}")
@@ -3124,6 +3142,161 @@ class ModelArgs:
                 self.model_cache_path / {ttnn.bfloat16: "tensor_cache_bf16", ttnn.bfloat8_b: "tensor_cache_bfp8"}[dtype]
             )
 
+    # Name of the marker file dropped into a weight-cache directory once every weight for that
+    # (model, dtype, mesh shape) has been materialized to disk. Generalizes the GPT-OSS
+    # warm-cache detector (#48531) to every tt_transformers e2e model.
+    # Marker filename and schema version both come from models/common/weight_cache.py -- this
+    # class must not define its own, or the two writers diverge (they previously shared a filename
+    # and version number while encoding mesh_shape incompatibly). See that module for the version
+    # history and what each field guarantees.
+    WEIGHT_CACHE_MARKER = _WC_MARKER
+    WEIGHT_CACHE_FORMAT_VERSION = _WC_FORMAT_VERSION
+
+    def _weight_cache_build_variant(self):
+        """A signature of the build options that change an ``as_tensor`` cache *filename*.
+
+        The cache name is ``{name}_dtype_{dtype}_layout_{layout}.tensorbin``, so anything that moves
+        a weight to a different dtype -- or adds weights outright -- produces a different file set.
+        Two knobs do that here: the DRAM prefetcher (pins every layer to decoder 0's dtype and adds
+        the ring-matmul splits in lm_head) and the precision/optimizations config (per-decoder,
+        per-tensor-group dtypes). Recording them means a cache seeded under one variant is not
+        accepted for a build that needs a different one -- which matters because a filename this
+        build needs but the seed never wrote would otherwise be regenerated by as_tensor FROM the
+        placeholder. (#45400 review)"""
+        try:
+            # get_tensor_dtype lives on the DecodersPrecision held in self.optimizations, NOT on
+            # ModelArgs. The original self.get_tensor_dtype(...) raised AttributeError on every
+            # model -- unnoticed because the old except collapsed it to the match-anything
+            # "unknown", and no hardware run executed this method until the 0ec5959bade sweep,
+            # where the fail-closed sentinel surfaced it on the first cold build. (#45400 review)
+            dtypes = [
+                str(self.optimizations.get_tensor_dtype(decoder_id, group, prefetcher=bool(self.prefetcher)))
+                for decoder_id in range(self.n_layers)
+                for group in TensorGroup
+            ]
+            precision = hashlib.sha1("|".join(dtypes).encode()).hexdigest()[:12]
+        except Exception as e:
+            # A variant we cannot compute is a variant we cannot verify. Do NOT collapse to a
+            # match-anything constant (that silently reopened the placeholder-persistence hole for
+            # every precision variant); return an unverifiable sentinel that the completeness gate
+            # rejects and mark_weight_cache_complete refuses to write, so the build cold-loads --
+            # slow but correct -- and the log says why. (#45400 review, finding R3)
+            logger.warning(f"Could not compute the weight-cache build variant ({e!r}); warm-cache skip disabled.")
+            return {"unverifiable": True, "error": f"{type(e).__name__}: {e}"}
+        return {
+            "prefetcher": bool(self.prefetcher),
+            "precision": precision,
+            # attention.py caches wqkv_bias_decode_sharded_{batch_size}, so batch is in a filename.
+            "batch": int(getattr(self, "max_batch_size", 0) or 0),
+            # attention.py picks cache_name("wo_width_sharded_2d") vs cache_name("wo") off this.
+            "fused_ag": bool(getattr(self, "use_fused_all_gather_matmul", False)),
+            # load_state_dict permutes QKV differently per rope mode, so the SAME cache filename
+            # carries different content across modes. The Llama CI job runs both modes against one
+            # cache dir; keeping the mode in the variant stops a marker seeded under one mode from
+            # certifying the other. (#45400 review, finding R2)
+            "hf_rope": bool(getattr(self, "use_hf_rope", False)),
+        }
+
+    def _weight_cache_identity(self, components=None):
+        """Marker identity for this build. `components` names the parts being constructed, so a
+        text-only seed cannot certify a cache for a build that also needs the vision tower."""
+        return dict(
+            model_name=self.model_name,
+            n_layers=self.n_layers,
+            mesh_shape=tuple(self.mesh_device.shape),
+            components=components,
+            build_variant=self._weight_cache_build_variant(),
+        )
+
+    def weight_cache_is_complete(self, dtype, components=None):
+        """True when the on-disk ttnn weight cache for this (model, dtype, mesh shape, components)
+        was fully built by a previous run and every tensorbin that build produced is still present.
+
+        When True, ttnn.as_tensor loads every weight from its cached .tensorbin and the HF
+        state_dict is never read, so the caller can skip the expensive from_pretrained host
+        load entirely (the load that OOMs/hangs during prefill, #48509). Set
+        TT_TRANSFORMERS_FORCE_MODEL_LOAD=1 to force a fresh load (e.g. to regenerate the cache).
+
+        Delegates to models/common/weight_cache.py so there is a SINGLE marker reader/writer: the
+        two used to encode mesh_shape differently while sharing one filename and format_version,
+        so a model reachable from both (gemma3 inherits this class but its demos call the shared
+        helper) had each side reject the other's marker and cold-load forever. (#45400 review)"""
+        return _weight_cache_is_complete(self.weight_cache_path(dtype), **self._weight_cache_identity(components))
+
+    def mark_weight_cache_complete(self, dtype, state_dict=None, components=None):
+        """Record that the ttnn weight cache for this (model, dtype, mesh shape, components) was
+        fully built, so subsequent runs can skip the HF state_dict load.
+
+        state_dict (the real, just-loaded weights) is captured as a {key: [shape, dtype]} manifest
+        so a later warm run can reconstruct a dataless placeholder without touching HF. Must be
+        called AFTER the model is constructed, so the tensorbins exist to be recorded."""
+        if state_dict is None:
+            return
+        _mark_weight_cache_complete(
+            self.weight_cache_path(dtype),
+            state_dict,
+            is_moe=bool(getattr(self, "is_mixture_of_experts", False)),
+            **self._weight_cache_identity(components),
+        )
+
+    def placeholder_state_dict(self, dtype):
+        """Warm-cache build: return a lazy, dataless stand-in for the HF state_dict.
+
+        Every weight is served as an uninitialized CPU torch.empty of the shape/dtype recorded
+        in the marker manifest -- no from_pretrained, no weight bytes read from disk, so the
+        prefill host-OOM (#48509) is avoided. ttnn.as_tensor(cache_file_name=...) ignores this
+        placeholder on a cache hit (ttnn/operations/core.py) and loads the real weight from its
+        .tensorbin; the placeholder exists only to satisfy the host-side reshape ops
+        (permute/chunk/cat/transpose) the modules run before calling as_tensor. Guarded by
+        weight_cache_is_complete, so every as_tensor is guaranteed to hit and discard it.
+
+        The mapping is falsy (__bool__ -> False) so reference-building callers that test
+        `if not state_dict` (e.g. test_model_prefill) load real weights explicitly, while
+        modules that index it during construction still work."""
+        import collections.abc
+
+        marker = _wc_marker_path(self.weight_cache_path(dtype), self._weight_cache_build_variant())
+        meta = json.loads(marker.read_text())
+        manifest = meta["weights"]
+        self.is_mixture_of_experts = bool(meta.get("is_moe", False))
+        # Same reasoning as build_cached_state_dict: these are set by load_state_dict from the
+        # checkpoint keys, which the warm path never reads. The manifest has the same keys.
+        self.fuse_qkv = any("qkv" in k for k in manifest)
+        self.fuse_mlp = any("gate_up" in k for k in manifest)
+        if self.is_mixture_of_experts:
+            self.moe = True
+            expert_indices = [int(k[-11]) + 1 for k in manifest if "block_sparse_moe.experts" in k]
+            self.num_experts = max(expert_indices) if expert_indices else self.num_local_experts
+
+        dtype_cache = {}
+
+        def _to_dtype(s):
+            if s not in dtype_cache:
+                dtype_cache[s] = getattr(torch, s.rsplit(".", 1)[-1])
+            return dtype_cache[s]
+
+        class _PlaceholderStateDict(collections.abc.Mapping):
+            is_placeholder = True
+
+            def __init__(self, spec):
+                self._spec = spec  # key -> (shape, dtype_str)
+
+            def __bool__(self):
+                return False
+
+            def __getitem__(self, key):
+                shape, dt = self._spec[key]
+                return torch.empty(tuple(shape), dtype=_to_dtype(dt))
+
+            def __iter__(self):
+                return iter(self._spec)
+
+            def __len__(self):
+                return len(self._spec)
+
+        logger.info(f"Warm ttnn weight cache: built placeholder state_dict for {len(manifest)} weights (no HF load).")
+        return _PlaceholderStateDict(manifest)
+
     def get_model_config(self):
         return self.model_config
 
@@ -3192,7 +3365,7 @@ class ModelArgs:
                 self.CKPT_DIR,
                 torch_dtype="auto",
                 trust_remote_code=self.trust_remote_code_hf,
-                local_files_only=os.getenv("CI") == "true"
+                local_files_only=os.getenv("CI") == "true",
                 # Note that the default setting is torch.dtype.float32, but model weights are
                 # may come in any dtype. If the model's weights are in torch.dtype.bfloat16, this would result in 2x memory usage from an
                 # unnecessary cast.

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -17,6 +17,10 @@
   cmd: |
     unset TT_METAL_WATCHER  # blocked by #50886
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
+    # CPU-only (<10s, no device, no weights): guards the warm-weight-cache marker semantics
+    # (variant-qualified markers, fail-closed unverifiable variants, sidecar single-load) that
+    # every tt_transformers e2e leg depends on. See #45400.
+    pytest --timeout 120 models/tt_transformers/tests/test_warm_cache_marker.py
     pytest --timeout 300 models/tt_transformers/tests/test_embedding.py
     pytest --timeout 300 models/tt_transformers/tests/test_rms_norm.py
     pytest --timeout 600 models/tt_transformers/tests/test_mlp.py


### PR DESCRIPTION
Cherry-pick of #50550 (`5c73430ac16`) onto `stable`. Clean pick, zero conflicts.

> **This is not the fix for the Llama 3.1-8B release-pipeline timeout.** An earlier revision of this description claimed it was. That was wrong — see "What this does not fix" below. This PR stands only on the smaller merits described here.

## What this does

`stable` branched from `main` at `99ba95dc2446` (2026-08-18) and so lacks #50550, the warm-ttnn-weight-cache skip. Without it, all four pytest invocations in the Llama 3.1-8B e2e leg do a full 291-tensor HF safetensors load instead of reusing the cache.

Measured on `tt-metal-ci-vm-303`, tier-1 e2e, `bh_p150`, same commit both sides:

| | plain `stable` | `stable` + this PR |
|---|---|---|
| cold HF loads | 4 | 0 |
| warm cache hits | 0 | 4 |
| step total | 5m38s | 5m16s |

Runs: [33515162442](https://github.com/tenstorrent/tt-metal/actions/runs/33515162442) (control, plain `stable`) and [33511409702](https://github.com/tenstorrent/tt-metal/actions/runs/33511409702) (this cherry-pick).

So the real benefit is about **22 seconds** on this leg, plus bringing `stable` in line with how `main` loads weights. Modest, but the pick is clean and the code is already proven on `main`.

## What this does not fix

The `Llama 3.1-8B e2e tests [bh_p150]` timeout in `Package and release` on `stable` has a different cause: on `stable`, `release-build-test-publish.yaml` wires `release-demo-tests` to `build-artifact-tracy`, so the demo tests run against the **Tracy/profiler-instrumented build**, which is roughly 2x slower.

| run | branch | build | prefill compile | decode | result |
|---|---|---|---|---|---|
| [33137983804](https://github.com/tenstorrent/tt-metal/actions/runs/33137983804) | stable | profiler | 152.9s | 113ms | timeout |
| [33345537907](https://github.com/tenstorrent/tt-metal/actions/runs/33345537907) | stable | profiler | 156.8s | 108ms | timeout |
| [33456206351](https://github.com/tenstorrent/tt-metal/actions/runs/33456206351) | main | plain | 73.2s | 55.8ms | pass |
| [33515162442](https://github.com/tenstorrent/tt-metal/actions/runs/33515162442) | stable | plain | 74.2s | 54.3ms | pass |

The split is entirely by build, not by branch — plain `stable` on a non-profiler build passes comfortably.

`main` already fixed this in `8f340f92af1` (#53509), which collapsed the dual tracy/release builds into a single `build-artifact` and pointed `release-demo-tests` at it. `stable` still has both `build-artifact-tracy` and `build-artifact-release` and feeds the tracy one to the tests. The targeted fix for `stable` is to repoint those three `release-demo-tests` inputs at `build-artifact-release`. That will be a separate PR.