### PR TITLE
minimal_matmul: reconfig data formats before op inits

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -20,9 +20,12 @@
 // uint32_t) signature and is in scope here via `using namespace ckernel`. See tt-metal#50386.
 void copy_and_pack_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
     CircularBuffer cb_out(out_cb);
-    copy_init(in_cb);
+    // Data formats must be reconfigured before the op init: llk_unpack_A_init asserts that the
+    // unpacker is already configured for in_cb (see #55052), and the preceding matmul left it
+    // configured for its own operands.
     reconfig_data_format_srca(in_cb);
     pack_reconfig_data_format(out_cb);
+    copy_init(in_cb);
     uint32_t fused_act_dst_id = 0;
 
     uint32_t tile_id = 0;
@@ -111,9 +114,9 @@ void swiglu_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_
  */
 void add_bias_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
     CircularBuffer cb_out(out_cb);
-    add_bcast_rows_init(in_cb, bias_cb);
     reconfig_data_format(in_cb, bias_cb);
     pack_reconfig_data_format(out_cb);
+    add_bcast_rows_init(in_cb, bias_cb);
     uint32_t fused_act_dst_id = 0;
 
     uint32_t tile_id = 0;
@@ -162,9 +165,9 @@ void add_bias_and_addcmul_block(
     // Read from intermediate_cb and write back to intermediate_cb
     // ============================================
 
-    add_bcast_rows_init(intermediate_cb, bias_cb);
     reconfig_data_format(intermediate_cb, bias_cb);
     pack_reconfig_data_format(intermediate_cb);
+    add_bcast_rows_init(intermediate_cb, bias_cb);
 
     // Wait for ALL input data ONCE at the beginning
     cb_bias.wait_front(N_block_tiles);
@@ -210,6 +213,8 @@ void add_bias_and_addcmul_block(
         // === BROADCAST: single row, wait/pop once ===
         cb_ternary_b.wait_front(N_block_tiles);
 
+        reconfig_data_format(intermediate_cb, ternary_b_cb);
+        pack_reconfig_data_format(intermediate_cb);
 #ifndef TERNARY_B_IS_FLOAT32
         mul_bcast_rows_init(intermediate_cb, ternary_b_cb);
 #else
@@ -222,8 +227,6 @@ void add_bias_and_addcmul_block(
 #endif  // TERNARY_B_IS_FLOAT32
 
         binop_with_scalar_tile_init();
-        reconfig_data_format(intermediate_cb, ternary_b_cb);
-        pack_reconfig_data_format(intermediate_cb);
 
         tile_id = 0;
         for (uint32_t m = 0; m < M_block_tiles; m++) {
@@ -239,6 +242,7 @@ void add_bias_and_addcmul_block(
                 unary_bcast_init<BroadcastType::ROW>(ternary_b_cb);
                 unary_bcast<BroadcastType::ROW>(ternary_b_cb, n, TERNARY_B_DST_ID);
 
+                reconfig_data_format_srca(intermediate_cb);
                 copy_init(intermediate_cb);
                 copy_tile(intermediate_cb, tile_id, DST_ID);
 
@@ -259,12 +263,12 @@ void add_bias_and_addcmul_block(
         cb_ternary_b.pop_front(N_block_tiles);
     } else {
         // === NO BROADCAST: row-by-row, wait/pop per M row ===
+        reconfig_data_format(intermediate_cb, ternary_b_cb);
+        pack_reconfig_data_format(intermediate_cb);
 #ifndef TERNARY_B_IS_FLOAT32
         mul_init(intermediate_cb, ternary_b_cb);
 #endif
         binop_with_scalar_tile_init();
-        reconfig_data_format(intermediate_cb, ternary_b_cb);
-        pack_reconfig_data_format(intermediate_cb);
 
         tile_id = 0;
         for (uint32_t m = 0; m < M_block_tiles; m++) {
@@ -276,9 +280,11 @@ void add_bias_and_addcmul_block(
                 mul_tiles(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
 #else
                 constexpr uint32_t TERNARY_B_DST_ID = 1;
+                reconfig_data_format_srca(ternary_b_cb);
                 copy_init(ternary_b_cb);
                 copy_tile(ternary_b_cb, n, TERNARY_B_DST_ID);
 
+                reconfig_data_format_srca(intermediate_cb);
                 copy_init(intermediate_cb);
                 copy_tile(intermediate_cb, tile_id, DST_ID);
 
@@ -306,9 +312,9 @@ void add_bias_and_addcmul_block(
 
     cb_intermediate.wait_front(out_block_num_tiles);
 
-    add_init(intermediate_cb, ternary_a_cb);
     reconfig_data_format(intermediate_cb, ternary_a_cb);
     pack_reconfig_data_format(out_cb);
+    add_init(intermediate_cb, ternary_a_cb);
 
     tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
@@ -467,6 +473,10 @@ void kernel_main() {
             current_N_block_tiles = n_tile_end - n_tile;
             current_subblock_w = std::min(current_N_block_tiles, subblock_w);
 
+            // Reconfig before init: on all but the first block the unpackers are still
+            // configured for the previous output stage's operands (see #55052).
+            reconfig_data_format(in1_cb, in0_cb);
+            pack_reconfig_data_format(intermediate_cb);
             matmul_block_init(
                 in0_cb,
                 in1_cb,
@@ -474,8 +484,6 @@ void kernel_main() {
                 current_subblock_w /*ct_dim*/,
                 current_subblock_h /*rt_dim*/,
                 K_block_tiles /*kt_dim*/);
-            reconfig_data_format(in1_cb, in0_cb);
-            pack_reconfig_data_format(intermediate_cb);
             // Accumulation buffer
             cb_intermediate.reserve_back(out_block_num_tiles);
             for (uint32_t k_block = 0; k_block < K_num_blocks; k_block++) {


### PR DESCRIPTION
### Ticket
Fixes #55052
Related: #40867 (same root cause, reported earlier on the llama70b_galaxy path)

### Problem description
With `TT_METAL_LLK_ASSERTS=1`, `minimal_matmul` trips
`is_unpacker_A_configured_correctly` inside `llk_unpack_A_init` (via `copy_init`
in `copy_and_pack_block`) and hangs the device:

```
MESH_DEVICE=N150 pytest models/experimental/llama32_1b_quasar/tests/graph_ops/test_minimal_matmul.py
```

### What's changed
The compute kernel called op inits (`copy_init`, `matmul_block_init`,
`add_bcast_rows_init`, `mul_init`, `add_init`) **before** `reconfig_data_format*`.
The LLK init APIs assert that the unpacker is already configured for the operand's
data formats, because `_llk_unpack_*_init_` does not program formats itself — only
`hw_configure`/reconfig do. After the matmul stage leaves srcA configured for
`in1_cb` (BFP8_B in the failing test), `copy_init(intermediate_cb)` fails the
format check. This matches the assert author's guidance in #40867 that the fix
belongs in the kernel.

- Reordered reconfig-before-init at every init site in `compute.cpp`. This is a
  pure ordering change for these sites: no unpack occurred between the init and
  the old reconfig location, so numerics are unchanged.
- Added missing `reconfig_data_format_srca` in the `TERNARY_B_IS_FLOAT32`
  per-tile paths, where `copy_init` ran against a stale unpacker format.

### Checklist
Verified on n150 (Wormhole B0), all with `TT_METAL_LLK_ASSERTS=1 TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS=1 TT_METAL_ENV=dev`:
- [x] Repro from the issue reproduced on unmodified main (assert callstack identical on all cores, captured with `tools/triage/dump_lightweight_asserts.py`), passes with this change: `2 passed`
- [x] `tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py -k "not perf_table and not performance"`: `162 passed`
- [x] `tests/ttnn/nightly/unit_tests/operations/experimental/test_dit_minimal_matmul_addcmul_fused.py`: `15 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/55052-minimal-matmul-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/55052-minimal-matmul-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cglagovich/55052-minimal-matmul-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cglagovich/55052-minimal-matmul-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/55052-minimal-matmul-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/55052-minimal-matmul-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cglagovich/55052-minimal-matmul-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cglagovich/55052-minimal-matmul-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/55052-minimal-matmul-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/55052-minimal-matmul-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/55052-minimal-matmul-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/55052-minimal-matmul-llk-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/55052-minimal-matmul-llk-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/55052-minimal-matmul-llk-assert)