### PR TITLE
[stable] Run release demo tests against the non-tracy build

### DIFF
--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -94,7 +94,10 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       build-wheel: true
       tracy: true
-      wheel-ref: ${{ format('refs/tags/{0}', inputs.tag-version) }}
+      # Dry-run does not create or move the version tag, so build from github.sha.
+      # A real release tags that SHA first, then builds the wheel from the tag.
+      # Equivalent to the guard main carries on its single build-artifact job (#53509).
+      wheel-ref: ${{ inputs.dry-run && github.sha || format('refs/tags/{0}', inputs.tag-version) }}
       fetch-depth: 0
       skip-tt-train: false
       enable-lto: false
@@ -114,7 +117,10 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       build-wheel: true
       tracy: false
-      wheel-ref: ${{ format('refs/tags/{0}', inputs.tag-version) }}
+      # Dry-run does not create or move the version tag, so build from github.sha.
+      # A real release tags that SHA first, then builds the wheel from the tag.
+      # Equivalent to the guard main carries on its single build-artifact job (#53509).
+      wheel-ref: ${{ inputs.dry-run && github.sha || format('refs/tags/{0}', inputs.tag-version) }}
       fetch-depth: 0
       skip-tt-train: false
       enable-lto: false

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -140,14 +140,18 @@ jobs:
           fi
 
   release-demo-tests:
-    needs: [check-harbor, build-artifact-tracy, determine-test-skus]
+    needs: [check-harbor, build-artifact-release, determine-test-skus]
     if: ${{ inputs.tag-version != '' }}
     secrets: inherit
     uses: ./.github/workflows/release-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact-tracy.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact-tracy.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact-tracy.outputs.wheel-artifact-name }}
+      # Model demo tests run against the NON-tracy build. The tracy/profiler build
+      # is roughly 2x slower end to end (prefill compile 153s vs 74s, decode 113ms
+      # vs 54ms on Llama 3.1-8B / bh_p150), which blows the per-test timeout budget
+      # these tests are calibrated against. main made the same switch in #53509.
+      docker-image: ${{ needs.build-artifact-release.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-release.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-release.outputs.wheel-artifact-name }}
       enabled-skus: ${{ needs.determine-test-skus.outputs.enabled-skus }}
       mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
       tier: "1"


### PR DESCRIPTION
> This description uses ASD-STE100 Simplified Technical English.

## 1. Validation

| run | function | status |
|---|---|---|
| [33522458606](https://github.com/tenstorrent/tt-metal/actions/runs/33522458606) | `Package and release`, `dry-run: true`, on this branch. Runs `release-demo-tests`. | all 12 legs pass |
| [33518727717](https://github.com/tenstorrent/tt-metal/actions/runs/33518727717) | Tier-1 e2e, `llama3.1-8b` and `bh_p150`, on this branch. | pass, 5 min 50 s |

Run 33522458606 tests this change. The two legs that fail on `stable` now pass, with the same 11 minute limit:

| leg | runner | step time | test times |
|---|---|---|---|
| 22.04 `Llama 3.1-8B e2e tests [bh_p150]` | vm-302 | 5 min 32 s | 170.2 / 53.2 / 23.7 / 56.4 s |
| 24.04 `Llama 3.1-8B e2e tests [bh_p150]` | vm-304 | 5 min 58 s | 189.3 / 53.5 / 24.1 / 61.4 s |

The runner `vm-304` is the same runner that failed this job on `stable` on 2026-08-31. The job log shows the artifact `TTMetal_build_any_24.04_..._libstdcpp_Release_d4162ddd894..._33522458606`. The name has no `profiler` part. Thus the leg used the standard build.

All 12 legs pass, on the two platforms. This includes the 4 models on `bh_quietbox_2`: Gemma-4-26B-A4B, Gemma-4-31B, GPT-OSS 120B, and TT-DiT Flux.1 dev. No leg gave the message `much better than expected, update target`.

Run 33518727717 shows only that the branch is correct. The tier-1 pipeline does not use `release-build-test-publish.yaml`, and it already used the standard build.

## 2. Problem

The job `Llama 3.1-8B e2e tests [bh_p150]` fails in `Package and release` runs on `stable`. Examples: [33137983804](https://github.com/tenstorrent/tt-metal/actions/runs/33137983804) and [33345537907](https://github.com/tenstorrent/tt-metal/actions/runs/33345537907).

The job does not stop. The log timestamps show only seconds between the lines. The step time limit of 11 minutes stops the job.

## 3. Cause

The job `release-demo-tests` uses the outputs of `build-artifact-tracy`. Thus all model demo tests use the Tracy profiler build. This build is approximately 2 times slower than the standard build. The time limits in `tests/pipeline_reorg/models_e2e_tests.yaml` agree with the standard build.

The results divide by build type. The branch and the runner do not change the results.

| run | branch | build | prefill compile | decode | result |
|---|---|---|---|---|---|
| [33137983804](https://github.com/tenstorrent/tt-metal/actions/runs/33137983804) | stable | profiler | 152.9s | 113ms | timeout |
| [33345537907](https://github.com/tenstorrent/tt-metal/actions/runs/33345537907) | stable | profiler | 156.8s | 108ms | timeout |
| [33456206351](https://github.com/tenstorrent/tt-metal/actions/runs/33456206351) | main | standard | 73.2s | 55.8ms | pass |
| [33515162442](https://github.com/tenstorrent/tt-metal/actions/runs/33515162442) | stable | standard | 74.2s | 54.3ms | pass, 5 min 38 s |

Run 33515162442 is the reference run. It uses plain `stable` with no changes to the source, and the same commit `bc4c4df7cb` as the runs that fail. It passed the same 11 minute limit.

The two runs that fail used two different runners, `vm-307` and `vm-304`. The runner `vm-304` passes with the standard build. Thus the runner is not the cause.

## 4. Change

**Commit 1** sets the three inputs of `release-demo-tests` to `build-artifact-release`. This build job is already on this branch. It differs from `build-artifact-tracy` only by `tracy: false`.

**Commit 2** sets `wheel-ref` to `github.sha` when `dry-run` is true. The two wheel builds used `wheel-ref: refs/tags/<tag-version>`. A dry run does not make the tag. Thus the wheel build got the source code of a different tag, or the checkout failed. Commit 2 is necessary to test commit 1 before a merge. A real release makes the tag on the same commit first, and thus does not change.

The branch `main` has both changes. They came to `main` in `8f340f92af1` (#53509). That commit also combined the two build jobs and moved some deepseek and wan tests. Thus you cannot cherry-pick it. This PR uses the same expressions on the two build jobs that are on this branch.

The job `build-artifact-tracy` continues to run, because `check-rtl-sim-status` lists it in `needs`. That dependency controls only the sequence. You can remove the tracy build later.

## 5. Effect on other tests

The change moves 8 test legs to the standard build:

| test | SKU |
|---|---|
| Llama 3.1-8B e2e | wh_n150, bh_p150 |
| Whisper e2e | wh_n150, bh_p150 |
| Gemma-4-26B-A4B e2e | bh_quietbox_2 |
| Gemma-4-31B e2e | bh_quietbox_2 |
| GPT-OSS 120B e2e | bh_quietbox_2 |
| TT-DiT Flux.1 dev e2e | bh_quietbox_2 |

No `cmd` block of these tests uses tracy, the profiler, or `TT_METAL_DEVICE_PROFILER`. The file `release-demo-tests-impl.yaml` has no step that needs the profiler. Thus no leg loses a function.

The effect on the time of each leg is not the same for all legs. Llama 3.1-8B and Whisper are quicker with the standard build. Gemma-4-31B took 11 min 13 s in run 33522458606, and 9 min 16 s with the profiler build in run 33137983804. Those two runs used two different hosts, `qb2-120-p06t03` and `qb2-120-p06t02`, and each gives one sample. Thus this difference can be host variation. All legs stay inside their time limits.

The input `docker-image` does not change in operation. The value `dev-docker-image` depends on the platform and the dockerfile, and not on `tracy`. All other jobs already use `build-artifact-release`.

## 6. Performance data is also incorrect

Llama 3.1-8B is the only leg that is more than its time limit. But the profiler build also makes all 8 legs record incorrect performance data. Whisper `bh_p150` gives these results, with the same test and the same targets:

| build | branch | decode_t/s | target 530, tolerance 0.2 |
|---|---|---|---|
| profiler | stable | 240.33 | drift |
| standard | stable | 385.75 | drift |
| standard | main | no drift message | in the band |

The targets in `models/model_targets.yaml` agree with the standard build. The job still passes, because the check in the test gives only a warning. The file `release-demo-tests-impl.yaml` sends this data to the SFTP benchmark store.

Three points for the review:

- This PR corrects the profiler part of the error. Whisper improves by a factor of approximately 1.6.
- **This PR does not remove all of the drift.** Whisper on `stable` with the standard build is still below the target. The branch `main` with the same build is in the band. Thus `stable` has a second performance difference. That difference is not in the scope of this PR.
- The benchmark data will show a sudden increase for these models. The new values are more correct, but the Whisper values stay below the target.

The function `validate_perf_targets.py` uses a symmetric tolerance band. The measurements move up. Thus they move toward the band, and not through it. Run 33522458606 shows the result for each leg.

## 7. Draft status

Run 33522458606 is complete and all 12 legs pass. This PR is ready for review.

This PR replaces #55070. That PR proposed a cherry-pick of #50550. That diagnosis was incorrect. PR #50550 gives approximately 22 seconds on this leg, and does not correct the timeout.
