### PR TITLE
docs: scope AGENTS.md hardware note to the cloud-agent runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,12 +86,18 @@ rather than burning the session on it.
 
 Do not claim you ran anything you did not run.
 
-## Things you cannot verify here
+## Things you cannot verify on the cloud-agent runner
 
-The runner has no Tenstorrent accelerator attached, so anything requiring real
-silicon — device tests, performance measurements, hardware-dependent
-behaviour — cannot be checked in your environment. Compilation and host-side
-unit tests are in scope; on-device results are not.
+This section describes the internal cloud-agent runner from "Your
+environment" above — it is not a claim about every environment a tt-metal
+checkout might run in. If you are a different agent and your machine has a
+real Tenstorrent accelerator attached, this does not apply to you: verify
+against the actual device instead of assuming it is unavailable.
+
+On the cloud-agent runner specifically: there is no Tenstorrent accelerator
+attached, so anything requiring real silicon — device tests, performance
+measurements, hardware-dependent behaviour — cannot be checked. Compilation
+and host-side unit tests are in scope; on-device results are not.
 
 If a change's correctness depends on device behaviour, say so.
 


### PR DESCRIPTION
## Summary
- The "Things you cannot verify here" section stated flatly that no Tenstorrent accelerator is attached, which reads as a blanket claim about every environment a tt-metal checkout runs in.
- In practice this is only true of the internal cloud-agent runner described earlier in the file. Other agents (internal devs, external customers) running on machines with real Tenstorrent hardware attached were being told, incorrectly, that they can't verify on-device behaviour.
- Reworded the section to explicitly scope the claim to the cloud-agent runner and point agents on real hardware to verify directly instead.

Raised on behalf of a concern flagged by Mark O'Connor:
> The AGENTS.md in tt-metal main is actively hostile to most agentic use cases internal and external [...] This is not true on all the places I run agents on a tt-metal checkout! [...] This is gonna be actively bad for our devs as well as for external customers.

## Test plan
- [x] Docs-only change, no build required per the file's own guidance.
- [ ] Confirm with Mark that the new wording resolves the concern.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=docs/scope-agents-md-hardware-note)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:docs/scope-agents-md-hardware-note)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=docs/scope-agents-md-hardware-note)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:docs/scope-agents-md-hardware-note)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=docs/scope-agents-md-hardware-note)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:docs/scope-agents-md-hardware-note)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=docs/scope-agents-md-hardware-note)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:docs/scope-agents-md-hardware-note)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=docs/scope-agents-md-hardware-note)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:docs/scope-agents-md-hardware-note)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=docs/scope-agents-md-hardware-note)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:docs/scope-agents-md-hardware-note)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=docs/scope-agents-md-hardware-note)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:docs/scope-agents-md-hardware-note)