### PR TITLE
[Bug fix] Outline Wormhole zero-flag LLK assertions

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -103,6 +103,16 @@ inline LLK_ZEROFLAG_DEFAULT_ATTR void _configure_default_zero_flag_state_()
     _apply_src_zero_flag_(value);
 }
 
+// Keep the execute-time invariant check out of templated hot paths. Inlining this
+// predicate into every binary/matmul specialization causes substantial TRISC
+// code growth when LLK assertions are enabled.
+inline __attribute__((noinline, cold)) void _assert_default_zero_flag_state_()
+{
+    LLK_ASSERT(
+        src_zero_flag_hw == (requires_disabled_src_zero_flag(src_zero_flag_srca_fmt, src_zero_flag_srcb_fmt) ? 1u : 0u),
+        "Src zero-substitution flag does not hold the operand-driven default");
+}
+
 // Data-movement ops keep the flag set so values pass through faithfully (bf16 -0.0, 16b/32b ints).
 inline void _configure_preserve_zero_flag_state_()
 {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -678,13 +678,7 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void _llk_math_eltwise_binary_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc = false)
 {
-    // Zero-flag leak guard. ELWADD/ELWMUL/ELWSUB honor ALU_ACC_CTRL_Zero_Flag_disabled_src; a prior
-    // copy_init/datacopy op leaking PRESERVE here changes denormal Src results. eltwise_binary_init
-    // must have re-established the format-driven DEFAULT (fires only under LLK asserts).
-    LLK_ASSERT(
-        math::src_zero_flag_hw == (requires_disabled_src_zero_flag(math::src_zero_flag_srca_fmt, math::src_zero_flag_srcb_fmt) ? 1u : 0u),
-        "eltwise_binary: Src zero-substitution flag is not in DEFAULT state — a prior op (copy_init/datacopy) leaked "
-        "PRESERVE into ELWADD/ELWMUL/ELWSUB without a format-changing reconfig; denormal Src results will differ");
+    math::_assert_default_zero_flag_state_();
 
     if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::NONE)
     {
@@ -852,11 +846,7 @@ inline void _llk_math_eltwise_binary_init_(std::uint32_t srca_reuse_count = 4)
  */
 inline void _llk_math_eltwise_binary_(std::uint32_t dst_index)
 {
-    // Zero-flag leak guard — see the TensorShape overload above.
-    LLK_ASSERT(
-        math::src_zero_flag_hw == (requires_disabled_src_zero_flag(math::src_zero_flag_srca_fmt, math::src_zero_flag_srcb_fmt) ? 1u : 0u),
-        "eltwise_binary (SDPA): Src zero-substitution flag is not in DEFAULT state — a prior op leaked "
-        "PRESERVE into ELWADD/ELWMUL/ELWSUB without a format-changing reconfig; denormal Src results will differ");
+    math::_assert_default_zero_flag_state_();
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -850,16 +850,7 @@ inline void _llk_math_matmul_(std::uint32_t dst_index, const std::uint32_t ct_di
 {
     llk::san::operation_check<llk::san::Operation::Matmul>(math_fidelity, THROTTLE_LEVEL, ct_dim, rt_dim);
 
-    // Zero-flag leak guard. MVMUL reads ALU_ACC_CTRL_Zero_Flag_disabled_src, which for
-    // denormal Src operands changes the result (flush vs keep — measured on WH n150 / BH p150b). Matmul is
-    // a "runs-in-DEFAULT" op: it never sets the flag itself and relies on hw_configure / a format-changing
-    // reconfig having established the format-driven DEFAULT. If a prior copy_init/datacopy op left the flag in
-    // PRESERVE and no format-changing reconfig ran before this matmul, MVMUL silently
-    // keeps denormals. This assert catches exactly that leak (fires only under LLK asserts).
-    LLK_ASSERT(
-        math::src_zero_flag_hw == (requires_disabled_src_zero_flag(math::src_zero_flag_srca_fmt, math::src_zero_flag_srcb_fmt) ? 1u : 0u),
-        "matmul: Src zero-substitution flag does not hold the operand-driven value — a prior op (copy_init/datacopy) left "
-        "a keep flag before MVMUL without a format-changing reconfig; denormal Src results will differ");
+    math::_assert_default_zero_flag_state_();
 
     const bool reuse_a           = ct_dim >= rt_dim;
     const std::uint32_t t_dim    = reuse_a ? rt_dim : ct_dim;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #54880.

PR #49924 added execute-time zero-flag invariant checks to the Wormhole eltwise-binary and matmul LLKs. Those checks were written directly inside heavily templated, inline execute functions. With LLK assertions enabled, every instantiated specialization received its own copy of the predicate and failure branch.

For the convolution configuration reported in #54880, that duplicated code pushes the TRISC1 kernel across a code-generation/layout cliff. The zero-flag predicates themselves are true, but the resulting kernel hangs and eventually reports the unrelated TensorShape coverage assertion. The reported shape is the valid 32x32 shape (`0x02021010`, or `{16, 16, 2, 2}`) and is already present in the coverage table.

This change moves the common invariant check into a single `noinline`, `cold` helper and has the binary and matmul execute paths call it. This preserves the diagnostic check and all functional zero-flag behavior while avoiding duplicated assertion code in templated hot paths.

### Root-cause evidence

The issue was bisected to `b7b79a806eddae2c34ce48933678eae16aeb2b47`, from PR #49924. Its parent, `ec70e9f7b448a81b41c3717f51c37c916aad209b`, passes the exact reproducer.

The changes in that PR were partitioned and tested independently:

- The Conv `copy_init` migrations are dormant for the failing configuration: `reload_partials` is false because `packer_l1_acc && fuse_bias`, and TILE output disables the untilize path.
- The TensorShape is valid and covered.
- With both inline execute guards present, the exact reproducer hangs.
- Removing only the eltwise-binary execute guard passes.
- Restoring the binary guard and removing only the matmul execute guard also passes.
- Preserving both checks through one shared out-of-line helper passes.

This demonstrates that neither assertion condition is the problem. The failure depends on their combined inline code-generation footprint.

TRISC1 ELF comparison for the exact convolution kernel:

| Variant | `.text` | `_start` | Result |
|---|---:|---:|---|
| Both checks inline | 2812 bytes | 2764 bytes | Hang / false downstream assertion |
| Binary check removed | 2460 bytes | 2412 bytes | Pass |
| Matmul check removed | 2532 bytes | 2484 bytes | Pass |
| Shared out-of-line helper, both checks retained | 2248 bytes | 2156 bytes | Pass |

The shared helper is 44 bytes.



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-54880-outline-zero-flag-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-54880-outline-zero-flag-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-54880-outline-zero-flag-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-54880-outline-zero-flag-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-54880-outline-zero-flag-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-54880-outline-zero-flag-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-54880-outline-zero-flag-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-54880-outline-zero-flag-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-54880-outline-zero-flag-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-54880-outline-zero-flag-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-54880-outline-zero-flag-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-54880-outline-zero-flag-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-54880-outline-zero-flag-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-54880-outline-zero-flag-assert)