### PR TITLE
[Test Escalation] Reassign test owner_id per 2026-09-01 escalation (#55019)

### DIFF
--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -734,7 +734,7 @@
     bh_quietbox_2:
       timeout: 12
       tier: 3
-  owner_id: U08GEGWHQJF # Adam Roberge
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 
 - name: Mixtral-8x7B e2e tests

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -262,7 +262,7 @@
     wh_llmbox:
       timeout: 20
       tier: 3
-  owner_id: U08GEGWHQJF # Adam Roberge
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 
 - name: ViT unit tests


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Applies the test-ownership reassignments from the test escalation issue:
**#55019** — `[2026-09-01] Test Escalation Assignment`

Closes #55019

Adam Roberge's `owner_id` (`U08GEGWHQJF`) is no longer a valid test owner. Both affected tests are reassigned to the `models` team lead, Miguel Tairum Cruz (`U03PUAKE719`), per `.github/TESTOWNERS`. Only the `owner_id` lines are touched — no other YAML content, ordering, or formatting was changed.

## Affected owners

| Owner | GitHub handle | Slack ID | Tests |
|---|---|---|---|
| Miguel Tairum Cruz | @mtairum | `U03PUAKE719` | **2** |

## Files changed

- `tests/pipeline_reorg/models_e2e_tests.yaml` — Mistral-Small-3.1-24B e2e tests
- `tests/pipeline_reorg/models_unit_tests.yaml` — Mistral-Small-3.1-24B vision unit tests

### Notes for reviewers

@mtairum — before approving, please confirm these two tests should be attributed to you (they were reassigned per `.github/TESTOWNERS` since Adam Roberge is no longer a valid owner).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=test-escalation/2026-09-01-mistral-small-24b-55019)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:test-escalation/2026-09-01-mistral-small-24b-55019)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=test-escalation/2026-09-01-mistral-small-24b-55019)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:test-escalation/2026-09-01-mistral-small-24b-55019)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=test-escalation/2026-09-01-mistral-small-24b-55019)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:test-escalation/2026-09-01-mistral-small-24b-55019)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=test-escalation/2026-09-01-mistral-small-24b-55019)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:test-escalation/2026-09-01-mistral-small-24b-55019)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=test-escalation/2026-09-01-mistral-small-24b-55019)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:test-escalation/2026-09-01-mistral-small-24b-55019)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=test-escalation/2026-09-01-mistral-small-24b-55019)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:test-escalation/2026-09-01-mistral-small-24b-55019)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=test-escalation/2026-09-01-mistral-small-24b-55019)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:test-escalation/2026-09-01-mistral-small-24b-55019)