### PR TITLE
up the timing budget to get tests passing on release tests

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -339,7 +339,7 @@ models:
     wh_n150: 28
     wh_galaxy_perf: 215
     bh_p150: 27
-    bh_quietbox_2: 255
+    bh_quietbox_2: 260
     bh_galaxy: 78
     bh_sc1: 140
     bh_sc4: 120

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -1312,7 +1312,8 @@
     # 2x2 and the 2x4 family skip on a Galaxy by device count; ring_bh_4x8 now skips on the
     # fabric payload guard in conftest.py. wh_4x8 at 480p is still excluded: it misses its
     # encoder tolerance (0.105-0.111 measured against 0.1), which is a separate question.
-    pytest --timeout 2700 models/tt_dit/tests/models/wan2_2/test_performance_wan.py \
+    # TODO: Remove these filters on wh_4x8. they shouldn't be here.
+    pytest --timeout 3000 models/tt_dit/tests/models/wan2_2/test_performance_wan.py \
       -k "resolution_480p and t2v and not wh_4x8" || fail=1
     pytest --timeout 1500 models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py \
       -k "4x8sp1tp0nl4_ring_is_fsdp1 and resolution_720p" || fail=1
@@ -1323,7 +1324,7 @@
   model_family: Wan
   skus:
     bh_quietbox_2:
-      timeout: 50
+      timeout: 55
       tier: 1
       release_ready: true
     wh_galaxy_perf:


### PR DESCRIPTION
This pull request makes minor adjustments to model time budgets and test timeouts to better reflect current performance and improve test reliability. The main changes are slight increases to time allocations for the `bh_quietbox_2` model and related tests, as well as a clarification comment in the test configuration.

**Time budget and timeout adjustments:**

* Increased the time budget for the `bh_quietbox_2` model from 255 to 260 in `.github/time_budget.yaml` to accommodate recent performance observations.
* Increased the test timeout for the `bh_quietbox_2` model from 50 to 55 in `tests/pipeline_reorg/models_e2e_tests.yaml` to reduce test flakiness.
* Increased the pytest timeout for the `test_performance_wan.py` test from 2700 to 3000 seconds and added a TODO comment about removing unnecessary filters on `wh_4x8` in `tests/pipeline_reorg/models_e2e_tests.yaml`.

to address failure here: https://github.com/tenstorrent/tt-metal/actions/runs/33456206351/job/99868052581

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jameslee/up_wan_bh_qb2_timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jameslee/up_wan_bh_qb2_timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jameslee/up_wan_bh_qb2_timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jameslee/up_wan_bh_qb2_timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jameslee/up_wan_bh_qb2_timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jameslee/up_wan_bh_qb2_timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jameslee/up_wan_bh_qb2_timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jameslee/up_wan_bh_qb2_timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jameslee/up_wan_bh_qb2_timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jameslee/up_wan_bh_qb2_timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jameslee/up_wan_bh_qb2_timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jameslee/up_wan_bh_qb2_timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jameslee/up_wan_bh_qb2_timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jameslee/up_wan_bh_qb2_timeouts)