### PR TITLE
[skip ci] ci: add continue-on-error to phoenix-actions/test-reporting in basic.yaml

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -167,6 +167,12 @@ jobs:
         # Because of https://github.com/tenstorrent/tt-metal/issues/19413, only run for our repo
         # for now. No forks!
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        # The merge queue uses an ephemeral temporary SHA. phoenix-actions creates a check run
+        # against github.sha, but between create() and update() the merge queue can discard that
+        # commit → 404 Not Found. The action is also unmaintained (last commit May 2024) so this
+        # will never be fixed upstream. continue-on-error prevents this from blocking the gate.
+        # Proper fix (replace with mikepenz/action-junit-report): #41519
+        continue-on-error: true
         uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
         with:
           name: ${{ inputs.product }} ${{ matrix.test-group.sku }} basic tests (${{ github.workflow }}, attempt ${{ github.run_attempt }})


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Adds `continue-on-error: true` to the `Test Report` step in `.github/workflows/basic.yaml`, matching the fix already applied in `smoke.yaml`.

`phoenix-actions/test-reporting` is unmaintained (last commit May 2024) and can fail the whole job for reasons unrelated to whether the tests themselves passed:
- In the merge queue, it creates a check run against the ephemeral SHA, which can be discarded between `create()` and `update()`, causing a 404.
- It also hits GitHub API rate limits (installation-level), as seen here: https://github.com/tenstorrent/tt-metal/actions/runs/33537023336/job/99958389168 — the actual test run succeeded, but the job was marked `failure` solely because this reporting step failed.

Relates to #41519, which tracks the proper long-term fix (swap to `mikepenz/action-junit-report`).

### Notes for reviewers
Purely additive `continue-on-error: true` + explanatory comment, copied verbatim from the existing precedent in `smoke.yaml`. No behavior change to test execution or reporting when things succeed — this only stops reporting failures from blocking the job/merge gate.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/test-report-non-blocking)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/test-report-non-blocking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/test-report-non-blocking)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/test-report-non-blocking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/test-report-non-blocking)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/test-report-non-blocking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/test-report-non-blocking)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/test-report-non-blocking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/test-report-non-blocking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/test-report-non-blocking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/test-report-non-blocking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/test-report-non-blocking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/test-report-non-blocking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/test-report-non-blocking)