### PR TITLE
#53943: Reduce register pressure for clreg -1.0f loss

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -257,7 +257,7 @@ inline void calculate_cosine() {
 
     sfpi::vFloat C2, C1, C0;
     float C3;  // Cannot keep this in a register in 7.73.0, which
-               // removes -1,0f constant. After sfpi 7.73.0
+               // removes -1.0f constant. After sfpi 7.73.0
                // lands we'll have vConstFloatPrgm3 to hold this value
 
     if constexpr (is_fp32_dest_acc_en) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -286,7 +286,7 @@ inline void calculate_cosine() {
 
         // At this point, the mantissa bits of j contain the rounded integer.
         // Store for later; the LSB tracks quadrant parity for sign selection.
-        // // #55065: sfpi::round should offer no int debiasing
+        // #55065: sfpi::round should offer no int debiasing
         sfpi::vInt q = sfpi::as<sfpi::vInt>(j);
 
         j = j - rounding_bias;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -255,7 +255,10 @@ inline void calculate_cosine() {
     const float P0 = -0x1.92p+0f;   // representable as bf16
     const float P1 = -0x1.fbp-12f;  // representable as fp16
 
-    sfpi::vFloat C3, C2, C1, C0;
+    sfpi::vFloat C2, C1, C0;
+    float C3;  // Cannot keep this in a register in 7.73.0, which
+               // removes -1,0f constant. After sfpi 7.73.0
+               // lands we'll have vConstFloatPrgm3 to hold this value
 
     if constexpr (is_fp32_dest_acc_en) {
         // Constants for sin(a) = a + a^3 (C0 + a^2 (C1 + a^2 (C2 + a^2 C3))) on [0, PI/2].
@@ -269,35 +272,28 @@ inline void calculate_cosine() {
         C0 = -0x1.5554a4p-3f;
     }
 
-    const float ROUNDING_BIAS = 12582912.0f;
-    const float NEG_ROUNDING_BIAS = -12582912.0f;
-
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
-        // Force v * (1/PI) + 0.5 to compile as a single SFPMAD sequence for consistent instruction scheduling.
-        sfpi::vFloat half = sfpi::sFloat16b(0.5f);
-        sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
-        sfpi::vFloat neg_one = -1.0f;
-
         // Start from j = v * (1 / PI) + 0.5; after bias-round and 2*j - 1, j is an odd quadrant index.
-        // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest.
-        sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi.get(), half.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
+        sfpi::vFloat j = v * inv_pi + 0.5f;
 
-        // sfpi::vFloat rounding_bias;
-        // rounding_bias = sfpi::sFloat16b(0x1.8p23f);
-        // j = __builtin_rvtt_sfpmad(v.get(), one, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
-
-        j = j + ROUNDING_BIAS;
+        // rounding_bias shifts mantissa bits to perform round-to-nearest.
+        // #55065: sfpi::round should offer no int debiasing
+        sfpi::vFloat rounding_bias = 12582912.0f;
+        j = j + rounding_bias;
 
         // At this point, the mantissa bits of j contain the rounded integer.
         // Store for later; the LSB tracks quadrant parity for sign selection.
+        // // #55065: sfpi::round should offer no int debiasing
         sfpi::vInt q = sfpi::as<sfpi::vInt>(j);
 
-        j = j + NEG_ROUNDING_BIAS;
+        j = j - rounding_bias;
 
-        sfpi::vFloat two = sfpi::sFloat16b(2.0f);
-        j = __builtin_rvtt_sfpmad(j.get(), two.get(), neg_one.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        // #55060: Compiler optimizes to imul/iadd
+        j = __builtin_rvtt_sfpmad(
+            j.get(), sfpi::vFloat(2.0f).get(), sfpi::vFloat(-1.0f).get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
         // Four-stage Cody-Waite reduction; a = v + j * -PI / 2.
         // P0 representable as bf16; generates a single SFPLOADI, filling NOP slot from previous SFPADDI.


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
This is a second attempt at reducing register pressure on quasar when const lreg -1.0f goes away.
Unlike previously, continue direct use of sfpmad builtin -- that's a separate compiler issue.
1) Migrate the 1.0f constant generation to the sfpmad location.
2) the 4-coefficient case also ran out of register, so synthesize C3 at the point of use.

with these changes the update compiler doesn't break this code.

The constant synthesis increases loadi use in the loop, but the changes to the `rounding_bias` reduces the number of them, so I think it's a wash.  After the compiler lands, we'll have `vConstFloatPrgm3` becomes a thing, and we can hold C3 in that.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/cosine-before)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/cosine-before)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/cosine-before)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/cosine-before)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/cosine-before)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/cosine-before)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/cosine-before)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/cosine-before)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/cosine-before)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/cosine-before)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/cosine-before)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/cosine-before)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/cosine-before)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/cosine-before)