### PR TITLE
compute API: move selected SFPU functions out of the monolith compute_kernel_api.h

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -9,6 +9,7 @@
 #include "../metadata/metadata.hpp"
 #ifdef TRISC_MATH
 #include "experimental/llk_sfpu/ckernel_sfpu_sampling.h"
+#include "api/compute/sfpu_reduce.h"
 #endif
 
 #if defined(COMPILE_FOR_TRISC)

--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -7,9 +7,14 @@
 #include "kernel_utils.hpp"
 #include "api/numeric/bfloat16.h"
 #include "../metadata/metadata.hpp"
+// sfpu_reduce()/sfpu_reduce_init() are called from trisc_fused_softmax_top_p_sampling_block()
+// without a MATH() wrapper, so every TRISC parses those calls and needs the declarations --
+// not just the math TRISC.
+#if defined(COMPILE_FOR_TRISC)
+#include "api/compute/sfpu_reduce.h"
+#endif
 #ifdef TRISC_MATH
 #include "experimental/llk_sfpu/ckernel_sfpu_sampling.h"
-#include "api/compute/sfpu_reduce.h"
 #endif
 
 #if defined(COMPILE_FOR_TRISC)

--- a/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/kernels/compute/frobenius_normalize_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/kernels/compute/frobenius_normalize_compute.cpp
@@ -22,6 +22,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/recip.h"
 #include "api/compute/eltwise_unary/sqrt.h"
+#include "api/compute/sfpu_reduce.h"
 #include "api/compute/tile_move_copy.h"
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
 

--- a/tt_metal/hw/inc/api/compute/add_top_row.h
+++ b/tt_metal/hw/inc/api/compute/add_top_row.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#ifndef ARCH_QUASAR
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_add_top_row.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs element-wise add_top_row operation between the top rows of two tiles in DST register.
+ * Takes the top row of tile at dst_tile_0 and adds it with the top row of tile at dst_tile_1,
+ * storing the result in the top row of tile at dst_tile_out.
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Only 32x32 tile dimensions are supported.
+ * All tile indices must reference valid tiles within the DST register.
+ *
+ * | Argument        | Description                                                              | Type      | Valid Range                                           | Required |
+ * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
+ * | dst_tile_0      | The index of the first tile in DST register                              | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | dst_tile_1      | The index of the second tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | dst_tile_out    | The index of the output tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | format          | The data format for the add_top_row operation                            | DataFormat| Float32, Int32, UInt32                                | True     |
+ */
+// clang-format on
+template <DataFormat format>
+ALWI void sfpu_add_top_row(uint32_t dst_tile_0, uint32_t dst_tile_1, uint32_t dst_tile_out) {
+    static_assert(
+        format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32,
+        "Unsupported data format. Supported formats: Float32, Int32, UInt32");
+
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_add_top_row,
+        (format),
+        dst_tile_0,
+        dst_tile_1,
+        dst_tile_out,
+        VectorMode::RC_custom)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void sfpu_add_top_row_init() { MATH((SFPU_BINARY_INIT_FN_NO_ARGS(add_top_row, sfpu::init_add_top_row))); }
+
+}  // namespace ckernel
+
+#endif  // !ARCH_QUASAR

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -26,8 +26,6 @@
 #ifndef ARCH_QUASAR
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #include "llk_math_eltwise_binary_sfpu_macros.h"
-#include "ckernel_sfpu_add_top_row.h"
-#include "ckernel_sfpu_max_pool_indices.h"
 #include "llk_math_binary_api.h"
 #include "llk_math_reduce_api.h"
 // SFPU op kernels invoked directly via the unary macros below. The macros
@@ -49,7 +47,6 @@
 #include "ckernel_sfpu_expm1.h"
 #include "ckernel_sfpu_topk.h"
 #include "ckernel_sfpu_unary_max_min.h"
-#include "ckernel_sfpu_reduce.h"
 #include "ckernel_sfpu_alt_complex_rotate90.h"
 #else
 #include "ckernel_sfpu_sigmoid.h"
@@ -840,165 +837,6 @@ ALWI void topk_uint16_prepare_value_tile_for_pack(uint32_t idst) {
 }
 
 #ifndef ARCH_QUASAR  // BH/WH-only ops below
-
-// clang-format off
-/**
- * Performs MaxPool with indices algorithm on the data tile and index tile
- * that are pre-loaded in DST register. The DST register buffer must be in
- * acquired state via *acquire_dst* call. This call is blocking and is only
- * available on the compute engine.
- *
- * | Argument        | Description                                                                 | Type       | Valid Range                                           | Required |
- * |-----------------|-----------------------------------------------------------------------------|------------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register containing the data to be reduced     | uint32_t   | Must be less than the size of the DST register buffer | True     |
- * | idst_idx        | The index of the tile in DST register containing the indices of the data    | uint32_t   | Must be less than the size of the DST register buffer | True     |
- * | chunk           | The index of the intra-kernel "chunk" of data for large kernel accumulation | uint32_t   | 0 to UINT_MAX                                         | False    |
- * | num_rows        | The number of rows to use for the MaxPool operation                         | uint32_t   | <= 32, but note either 9 or 32 rows will be reduced   | False    |
- * | layout          | The data layout of the data in DST                                          | DataLayout | TILE or ROW_MAJOR                                     | False    |
- * | accumulate      | Whether to accumulate results for large kernels                             | bool       | true, false                                           | False    |
- * | ITERATIONS      | The number of iterations to perform (unused)                                | int        | 1 to 8                                                | False    |
- */
-// clang-format on
-template <
-    int num_rows = 9,
-    ckernel::DataLayout layout = ckernel::DataLayout::TILE,
-    bool accumulate = false,
-    int ITERATIONS = 8, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void max_reduce_with_indices(uint32_t idst, uint32_t idst_idx, uint32_t chunk = 0) {
-    static_assert(num_rows <= 32, "num_rows must be <= 32");
-    MATH((SFPU_BINARY_CALL(
-        DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
-        calculate_max_pool_with_indices,
-        (true /* APPROXIMATE */, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout, accumulate),
-        idst,
-        idst_idx,
-        0 /* DST out unused, but required for _llk_math_eltwise_binary_sfpu_params_ */,
-        VectorMode::RC,
-        chunk)));
-}
-
-/**
- * Please refer to documentation for any_init.
- */
-template <ckernel::DataLayout layout = ckernel::DataLayout::TILE>
-ALWI void max_reduce_with_indices_init() {
-    MATH((SFPU_BINARY_INIT_FN(
-        max_pool_with_indices, sfpu::init_max_pool_with_indices, (true /* APPROXIMATE */, layout))));
-}
-
-// clang-format off
-/**
- * Performs reduce operation (sum, average, max, min) on a 32x32 tile for column reduction and multiple tiles for row reduction, placing output values into the first row.
- * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only
- * available on the compute engine.
- *
- * Only 32x32 tile dimensions are supported
- *  - This kernel is optimized for 32x32 tile dimensions and uses VectorMode::RC_custom for customized reduction
- *  - Column reduction (REDUCE_COL) is supported for all pool types; row reduction (REDUCE_ROW) is supported for SUM, MAX and MIN only.
- *  - REDUCE_COL operates on a single tile only (ct_dim = 1, rt_dim = 1).
- *  - REDUCE_ROW supports multiple tiles: ct_dim and rt_dim specify the tile block dimensions to reduce over.
- *
- * | Argument        | Description                                                                     | Type      | Valid Range
- * |-----------------|---------------------------------------------------------------------------------|-----------|-------------------------------------------------------
- * | pool_type       | The type of reduction operation                                                 | PoolType  | SUM, AVG, MAX, MIN
- * | format          | The data format for the reduction operation                                     | DataFormat| Float32, Int32, UInt32, UInt16, Float16_b
- * | reduce_dim      | The reduction dimension                                                         | ReduceDim | REDUCE_COL or REDUCE_ROW (REDUCE_ROW only for SUM, MAX and MIN)
- * | idst            | The index of the tile in DST register containing the data to be reduced         | uint32_t  | Must be less than the size of the DST register buffer
- * | ct_dim          | Tile dimension along columns (runtime); must be 1 when reduce_dim is REDUCE_COL | uint32_t  | >= 1; default 1
- * | rt_dim          | Tile dimension along rows (runtime); must be 1 when reduce_dim is REDUCE_COL    | uint32_t  | >= 1; default 1
- */
-// clang-format on
-template <PoolType pool_type, DataFormat format, ReduceDim reduce_dim = ReduceDim::REDUCE_COL, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void sfpu_reduce(uint32_t idst, uint32_t ct_dim = 1, uint32_t rt_dim = 1) {
-    static_assert(
-        reduce_dim == ReduceDim::REDUCE_COL ||
-            (reduce_dim == ReduceDim::REDUCE_ROW &&
-             (pool_type == PoolType::SUM || pool_type == PoolType::MAX || pool_type == PoolType::MIN)),
-        "Only column reduction (REDUCE_COL) is supported for all pool types; row reduction (REDUCE_ROW) is only "
-        "supported for SUM, MAX and MIN");
-    static_assert(
-        format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32 ||
-            format == DataFormat::UInt16 || format == DataFormat::Float16_b,
-        "Unsupported data format. Supported formats: Float32, Int32, UInt32, UInt16, Float16_b");
-    static_assert(
-        pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||
-            pool_type == PoolType::MIN,
-        "Unsupported pool type. Supported pool types: SUM, AVG, MAX, MIN");
-
-    // This kernel is optimized for 32x32 tiles and uses RC_custom vector mode for custom reduction
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
-        calculate_reduce,
-        (pool_type, reduce_dim, format, is_fp32_dest_acc_en),
-        idst,
-        VectorMode::RC_custom,
-        ct_dim,
-        rt_dim));
-}
-
-/**
- * @brief Initialization for SFPU reduce kernel.
- *        Must be called before sfpu_reduce() to set up the necessary configurations for reduction operations.
- *        The same init is used for both REDUCE_COL and REDUCE_ROW; it does not take tile dimensions.
- * @tparam pool_type The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
- * @tparam format The data format, currently supported: (Float32, Int32, UInt32, UInt16, Float16_b)
- */
-template <PoolType pool_type, DataFormat format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void sfpu_reduce_init() {
-    static_assert(
-        pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||
-            pool_type == PoolType::MIN,
-        "Unsupported pool type. Supported pool types: SUM, AVG, MAX, MIN");
-    static_assert(
-        format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32 ||
-            format == DataFormat::UInt16 || format == DataFormat::Float16_b,
-        "Unsupported data format. Supported formats: Float32, Int32, UInt32, UInt16, Float16_b");
-
-    MATH(SFPU_UNARY_INIT_FN_ARGS(reduce, sfpu::init_reduce, (pool_type, format, is_fp32_dest_acc_en), 1 /* block_ct_dim */));
-}
-
-// clang-format off
-/**
- * Performs element-wise add_top_row operation between the top rows of two tiles in DST register.
- * Takes the top row of tile at dst_tile_0 and adds it with the top row of tile at dst_tile_1,
- * storing the result in the top row of tile at dst_tile_out.
- * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only
- * available on the compute engine.
- *
- * Only 32x32 tile dimensions are supported.
- * All tile indices must reference valid tiles within the DST register.
- *
- * | Argument        | Description                                                              | Type      | Valid Range                                           | Required |
- * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
- * | dst_tile_0      | The index of the first tile in DST register                              | uint32_t  | Must be less than the size of the DST register buffer | True     |
- * | dst_tile_1      | The index of the second tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
- * | dst_tile_out    | The index of the output tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
- * | format          | The data format for the add_top_row operation                            | DataFormat| Float32, Int32, UInt32                                | True     |
- */
-// clang-format on
-template <DataFormat format>
-ALWI void sfpu_add_top_row(uint32_t dst_tile_0, uint32_t dst_tile_1, uint32_t dst_tile_out) {
-    static_assert(
-        format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32,
-        "Unsupported data format. Supported formats: Float32, Int32, UInt32");
-
-    MATH((SFPU_BINARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_add_top_row,
-        (format),
-        dst_tile_0,
-        dst_tile_1,
-        dst_tile_out,
-        VectorMode::RC_custom)));
-}
-
-/**
- * Please refer to documentation for any_init.
- */
-ALWI void sfpu_add_top_row_init() { MATH((SFPU_BINARY_INIT_FN_NO_ARGS(add_top_row, sfpu::init_add_top_row))); }
 
 /**
  * Pauses the cores so that the debug interface can be used to inspect the value of the registers.

--- a/tt_metal/hw/inc/api/compute/max_pool_indices.h
+++ b/tt_metal/hw/inc/api/compute/max_pool_indices.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#ifndef ARCH_QUASAR
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_max_pool_indices.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs MaxPool with indices algorithm on the data tile and index tile
+ * that are pre-loaded in DST register. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * | Argument        | Description                                                                 | Type       | Valid Range                                           | Required |
+ * |-----------------|-----------------------------------------------------------------------------|------------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register containing the data to be reduced     | uint32_t   | Must be less than the size of the DST register buffer | True     |
+ * | idst_idx        | The index of the tile in DST register containing the indices of the data    | uint32_t   | Must be less than the size of the DST register buffer | True     |
+ * | chunk           | The index of the intra-kernel "chunk" of data for large kernel accumulation | uint32_t   | 0 to UINT_MAX                                         | False    |
+ * | num_rows        | The number of rows to use for the MaxPool operation                         | uint32_t   | <= 32, but note either 9 or 32 rows will be reduced   | False    |
+ * | layout          | The data layout of the data in DST                                          | DataLayout | TILE or ROW_MAJOR                                     | False    |
+ * | accumulate      | Whether to accumulate results for large kernels                             | bool       | true, false                                           | False    |
+ * | ITERATIONS      | The number of iterations to perform (unused)                                | int        | 1 to 8                                                | False    |
+ */
+// clang-format on
+template <
+    int num_rows = 9,
+    ckernel::DataLayout layout = ckernel::DataLayout::TILE,
+    bool accumulate = false,
+    int ITERATIONS = 8,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+ALWI void max_reduce_with_indices(uint32_t idst, uint32_t idst_idx, uint32_t chunk = 0) {
+    static_assert(num_rows <= 32, "num_rows must be <= 32");
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        calculate_max_pool_with_indices,
+        (true /* APPROXIMATE */, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout, accumulate),
+        idst,
+        idst_idx,
+        0 /* DST out unused, but required for _llk_math_eltwise_binary_sfpu_params_ */,
+        VectorMode::RC,
+        chunk)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+template <ckernel::DataLayout layout = ckernel::DataLayout::TILE>
+ALWI void max_reduce_with_indices_init() {
+    MATH((SFPU_BINARY_INIT_FN(
+        max_pool_with_indices, sfpu::init_max_pool_with_indices, (true /* APPROXIMATE */, layout))));
+}
+
+}  // namespace ckernel
+
+#endif  // !ARCH_QUASAR

--- a/tt_metal/hw/inc/api/compute/sfpu_reduce.h
+++ b/tt_metal/hw/inc/api/compute/sfpu_reduce.h
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#ifndef ARCH_QUASAR
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_reduce.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs reduce operation (sum, average, max, min) on a 32x32 tile for column reduction and multiple tiles for row reduction, placing output values into the first row.
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Only 32x32 tile dimensions are supported
+ *  - This kernel is optimized for 32x32 tile dimensions and uses VectorMode::RC_custom for customized reduction
+ *  - Column reduction (REDUCE_COL) is supported for all pool types; row reduction (REDUCE_ROW) is supported for SUM, MAX and MIN only.
+ *  - REDUCE_COL operates on a single tile only (ct_dim = 1, rt_dim = 1).
+ *  - REDUCE_ROW supports multiple tiles: ct_dim and rt_dim specify the tile block dimensions to reduce over.
+ *
+ * | Argument        | Description                                                                     | Type      | Valid Range
+ * |-----------------|---------------------------------------------------------------------------------|-----------|-------------------------------------------------------
+ * | pool_type       | The type of reduction operation                                                 | PoolType  | SUM, AVG, MAX, MIN
+ * | format          | The data format for the reduction operation                                     | DataFormat| Float32, Int32, UInt32, UInt16, Float16_b
+ * | reduce_dim      | The reduction dimension                                                         | ReduceDim | REDUCE_COL or REDUCE_ROW (REDUCE_ROW only for SUM, MAX and MIN)
+ * | idst            | The index of the tile in DST register containing the data to be reduced         | uint32_t  | Must be less than the size of the DST register buffer
+ * | ct_dim          | Tile dimension along columns (runtime); must be 1 when reduce_dim is REDUCE_COL | uint32_t  | >= 1; default 1
+ * | rt_dim          | Tile dimension along rows (runtime); must be 1 when reduce_dim is REDUCE_COL    | uint32_t  | >= 1; default 1
+ */
+// clang-format on
+template <
+    PoolType pool_type,
+    DataFormat format,
+    ReduceDim reduce_dim = ReduceDim::REDUCE_COL,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+ALWI void sfpu_reduce(uint32_t idst, uint32_t ct_dim = 1, uint32_t rt_dim = 1) {
+    static_assert(
+        reduce_dim == ReduceDim::REDUCE_COL ||
+            (reduce_dim == ReduceDim::REDUCE_ROW &&
+             (pool_type == PoolType::SUM || pool_type == PoolType::MAX || pool_type == PoolType::MIN)),
+        "Only column reduction (REDUCE_COL) is supported for all pool types; row reduction (REDUCE_ROW) is only "
+        "supported for SUM, MAX and MIN");
+    static_assert(
+        format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32 ||
+            format == DataFormat::UInt16 || format == DataFormat::Float16_b,
+        "Unsupported data format. Supported formats: Float32, Int32, UInt32, UInt16, Float16_b");
+    static_assert(
+        pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||
+            pool_type == PoolType::MIN,
+        "Unsupported pool type. Supported pool types: SUM, AVG, MAX, MIN");
+
+    // This kernel is optimized for 32x32 tiles and uses RC_custom vector mode for custom reduction
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        calculate_reduce,
+        (pool_type, reduce_dim, format, is_fp32_dest_acc_en),
+        idst,
+        VectorMode::RC_custom,
+        ct_dim,
+        rt_dim));
+}
+
+/**
+ * @brief Initialization for SFPU reduce kernel.
+ *        Must be called before sfpu_reduce() to set up the necessary configurations for reduction operations.
+ *        The same init is used for both REDUCE_COL and REDUCE_ROW; it does not take tile dimensions.
+ * @tparam pool_type The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
+ * @tparam format The data format, currently supported: (Float32, Int32, UInt32, UInt16, Float16_b)
+ */
+template <PoolType pool_type, DataFormat format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+ALWI void sfpu_reduce_init() {
+    static_assert(
+        pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||
+            pool_type == PoolType::MIN,
+        "Unsupported pool type. Supported pool types: SUM, AVG, MAX, MIN");
+    static_assert(
+        format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32 ||
+            format == DataFormat::UInt16 || format == DataFormat::Float16_b,
+        "Unsupported data format. Supported formats: Float32, Int32, UInt32, UInt16, Float16_b");
+
+    MATH(SFPU_UNARY_INIT_FN_ARGS(
+        reduce, sfpu::init_reduce, (pool_type, format, is_fp32_dest_acc_en), 1 /* block_ct_dim */));
+}
+
+}  // namespace ckernel
+
+#endif  // !ARCH_QUASAR

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -32,6 +32,7 @@ set(HW_JIT_API_HEADERS
     inc/api/scratchpad.h
     inc/api/compute/compute_kernel_api.h
     inc/api/compute/add_int_sfpu.h
+    inc/api/compute/add_top_row.h
     inc/api/compute/atan2.h
     inc/api/compute/bcast.h
     inc/api/compute/binary_bitwise_sfpu.h
@@ -125,6 +126,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/logsigmoid.h
     inc/api/compute/mask.h
     inc/api/compute/matmul.h
+    inc/api/compute/max_pool_indices.h
     inc/api/compute/mul_int_sfpu.h
     inc/api/compute/pack.h
     inc/api/compute/pack_untilize.h
@@ -139,6 +141,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/sentinel/sentinel_core.h
     inc/api/compute/sentinel/testing_spy.h
     inc/api/compute/situ_glu.h
+    inc/api/compute/sfpu_reduce.h
     inc/api/compute/softmax.h
     inc/api/compute/src_order.h
     inc/api/compute/sub_int_sfpu.h

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -140,8 +140,8 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/sentinel/compute_kernel_sentinel.h
     inc/api/compute/sentinel/sentinel_core.h
     inc/api/compute/sentinel/testing_spy.h
-    inc/api/compute/situ_glu.h
     inc/api/compute/sfpu_reduce.h
+    inc/api/compute/situ_glu.h
     inc/api/compute/softmax.h
     inc/api/compute/src_order.h
     inc/api/compute/sub_int_sfpu.h

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -9,6 +9,7 @@
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/binary_max_min.h"
 #include "api/compute/compute_kernel_api.h"
+#include "api/compute/sfpu_reduce.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/typecast.h"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_mpwi.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/tilize.h"
 #include "api/compute/compute_kernel_api.h"
+#include "api/compute/max_pool_indices.h"
 #include "api/compute/pack.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/tile_move_copy.h"

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/tilize.h"
 #include "api/compute/compute_kernel_api.h"
+#include "api/compute/max_pool_indices.h"
 #include "api/compute/pack.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/tile_move_copy.h"


### PR DESCRIPTION
## PR Category

Optimization (kernel JIT compile time)

## Summary

Follow-up to the`ckernel_sfpu_topk.h` compilation time optimization in #53557 

`tt_metal/hw/inc/api/compute/compute_kernel_api.h` unconditionally includes 19 SFPU op headers under `#ifdef TRISC_MATH`. Every math TRISC TU that reaches the monolith parses all of them, whether or not the kernel uses those ops.

This PR moves the three largest headers that almost nothing uses into per-op headers, following the existing convention (`cumsum.h`, `softmax.h`, …):

| header | size | consumers | new header |
|---|---|---|---|
| `ckernel_sfpu_reduce.h` | 119.3 KB | 1 | `api/compute/sfpu_reduce.h` |
| `ckernel_sfpu_max_pool_indices.h` | 21.4 KB | 2 | `api/compute/max_pool_indices.h` |
| `ckernel_sfpu_add_top_row.h` | 3.5 KB | **0** | `api/compute/add_top_row.h` |

144 KB removed from the always-parsed path, for five added `#include` lines.

## Measured impact

Blackhole p150b, real cached kernel files:

| math-TRISC TU | main | this branch | delta |
|---|---|---|---|
| non-consumer kernel TU, full 144 KB | 783.9 ms | 739.1 ms | **−44.8 ms** (−5.7%) |
| `compute_mpwi` (real consumer) | 824.3 ms | 785.5 ms | −38.8 ms (−4.7%) |
| same TU on **unpack** TRISC (control) | 561.2 ms | 561.1 ms | −0.1 ms |

Notes on extrapolating this:

- The saving applies only to TUs that compute_kernel_api.h — roughly 235 of ~533 compute-kernel roots. 
- Per-Sanity-job saving is order 10–30 s

## What is deliberately NOT in this PR

**The remaining ~77 KB of eltwise-unary SFPU ops** (`log`, `unary_power`, `tanh`, `unary_max_min`, `expm1`, `exp2`, `signbit`, `sigmoid`, `silu`, `abs`, `sign`, `heaviside`, `tiled_prod`, `square`, `alt_complex_rotate90`).

These cannot be extracted the same way. They are reached through the generic eltwise-unary kernel, whose includes are driven by the `SFPU_OP_*_INCLUDE` define mechanism, which would need to updated too.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwroszTT/sfpu-header-narrowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwroszTT/sfpu-header-narrowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwroszTT/sfpu-header-narrowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwroszTT/sfpu-header-narrowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwroszTT/sfpu-header-narrowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwroszTT/sfpu-header-narrowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwroszTT/sfpu-header-narrowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwroszTT/sfpu-header-narrowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwroszTT/sfpu-header-narrowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwroszTT/sfpu-header-narrowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwroszTT/sfpu-header-narrowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwroszTT/sfpu-header-narrowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwroszTT/sfpu-header-narrowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwroszTT/sfpu-header-narrowing)
