### PR TITLE
[Feature] Add resource binding lookup for Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4177,6 +4177,64 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentPrUsageExampleJITSmoke) {
+    // Kernel shape from the PR description: always-present `normal`, optional `bias` via
+    // get_token_if_present + std::optional. Compiles the same source with and without `bias` bound.
+    constexpr const char* kSource = R"(
+#include <optional>
+void kernel_main() {
+    DataflowBuffer dfb_normal(dfb::normal);
+
+    constexpr const DFBBindingToken* bias_token = dfb::get_token_if_present<"bias">();
+    std::optional<DataflowBuffer> dfb_bias;
+#pragma GCC diagnostic push
+// This is needed to avoid compiler warning the address will not/ always be null.
+#pragma GCC diagnostic ignored "-Waddress"
+    if constexpr (bias_token != nullptr) {
+        dfb_bias.emplace(*bias_token);
+    }
+
+    dfb_normal.push_back(1);
+    if constexpr (bias_token != nullptr) {
+        dfb_bias->push_back(1);
+    }
+#pragma GCC diagnostic pop
+}
+)";
+
+    auto compile_variant = [&](bool with_bias) {
+        NodeCoord node{0, 0};
+
+        auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+        dm_kernel.source = KernelSpec::SourceCode{kSource};
+        auto compute_kernel = MakeMinimalGen1ComputeKernel("compute_kernel");
+
+        auto normal = MakeMinimalDFB("normal");
+        normal.data_format_metadata = tt::DataFormat::Float16_b;
+        dm_kernel.dfb_bindings.push_back(ProducerOf(DFBSpecName{"normal"}, "normal"));
+        compute_kernel.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"normal"}, "normal"));
+
+        ProgramSpec spec;
+        spec.name = with_bias ? "pr_usage_bias_present" : "pr_usage_bias_absent";
+        spec.dataflow_buffers = {normal};
+        if (with_bias) {
+            auto bias = MakeMinimalDFB("bias");
+            bias.data_format_metadata = tt::DataFormat::Float16_b;
+            spec.dataflow_buffers.push_back(bias);
+            dm_kernel.dfb_bindings.push_back(ProducerOf(DFBSpecName{"bias"}, "bias"));
+            compute_kernel.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"bias"}, "bias"));
+        }
+        spec.kernels = {dm_kernel, compute_kernel};
+        spec.work_units = {MakeMinimalWorkUnit("work_unit", node, {"dm_kernel", "compute_kernel"})};
+
+        Program program = MakeProgramFromSpec(*mesh_device_, spec);
+        EXPECT_NO_THROW(program.impl().compile(mesh_device_.get())) << "with_bias=" << with_bias;
+    };
+
+    compile_variant(/*with_bias=*/false);
+    compile_variant(/*with_bias=*/true);
+}
+
 TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsScratchpadJITSmoke) {
     NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -395,22 +395,15 @@ TEST_F(ProgramSpecTestQuasar, CPU_InvalidLocalAccessorNameFails) {
                 ::testing::HasSubstr("DFB accessor_name '" + bad_name + "' must be a valid C++ identifier")))
             << "Expected rejection for name: '" << bad_name << "'";
     }
-}
 
-TEST_F(ProgramSpecTestQuasar, CPU_TooLongLocalAccessorNameFails) {
-    // An accessor_name longer than MAX_ACCESSOR_NAME_LENGTH cannot be passed to the kernel-side
-    // by-name binding lookup, so a valid-but-too-long identifier must fail at Program construction
-    // rather than as a kernel JIT static_assert.
+    // A valid-but-too-long identifier cannot be passed to the kernel-side by-name binding lookup,
+    // so it must fail at Program construction rather than as a kernel JIT static_assert.
     const std::string too_long(MAX_ACCESSOR_NAME_LENGTH + 1, 'a');
-    NodeCoord node{0, 0};
-
     ProgramSpec spec;
     spec.name = "test_program";
-
     auto kernel = MakeMinimalGen2DMKernel("kernel");
     auto dfb = MakeMinimalDFB("dfb");
     kernel.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, too_long));
-
     spec.kernels = {kernel};
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
@@ -1521,8 +1514,9 @@ TEST_F(ProgramSpecTestQuasar, CPU_DuplicateScratchpadAccessorNameFails) {
 
 TEST_F(ProgramSpecTestQuasar, CPU_InvalidScratchpadAccessorNameFails) {
     // The accessor_name becomes a C++ identifier in the generated kernel_bindings header, so it must
-    // be a valid C++ identifier. (Mirrors InvalidLocalAccessorNameFails / the semaphore-accessor
-    // equivalent; here we just spot-check a couple of clearly-invalid names.)
+    // be a valid C++ identifier and fit in MAX_ACCESSOR_NAME_LENGTH. (Mirrors
+    // InvalidLocalAccessorNameFails / the semaphore-accessor equivalent; here we just spot-check a
+    // couple of clearly-invalid names plus the too-long case.)
     const std::vector<std::string> invalid_names = {
         "1bad",       // leading digit
         "has space",  // whitespace
@@ -1539,9 +1533,7 @@ TEST_F(ProgramSpecTestQuasar, CPU_InvalidScratchpadAccessorNameFails) {
             ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("must be a valid C++ identifier")))
             << "Expected rejection for scratchpad accessor_name: '" << bad_name << "'";
     }
-}
 
-TEST_F(ProgramSpecTestQuasar, CPU_TooLongScratchpadAccessorNameFails) {
     const std::string too_long(MAX_ACCESSOR_NAME_LENGTH + 1, 'a');
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch_0"}, .size_per_node = 1024}};
@@ -3923,9 +3915,9 @@ TEST_F(ProgramSpecTestGen1, CPU_DuplicateTensorAccessorNameWithinKernelFails) {
 }
 
 TEST_F(ProgramSpecTestGen1, CPU_InvalidTensorAccessorNameFails) {
-    // Smoke-tests the IsValidCppIdentifier check on tensor accessor names. The check is the
-    // same one DFB / Semaphore use; one bad name here is sufficient (full coverage lives in
-    // the DFB version of this test).
+    // Smoke-tests the IsValidCppIdentifier / length checks on tensor accessor names. The checks
+    // are the same ones DFB / Semaphore use; one bad name of each kind here is sufficient
+    // (full identifier coverage lives in the DFB version of this test).
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor")};
@@ -3935,10 +3927,8 @@ TEST_F(ProgramSpecTestGen1, CPU_InvalidTensorAccessorNameFails) {
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("tensor accessor_name 'has-dash' must be a valid C++ identifier")));
-}
 
-TEST_F(ProgramSpecTestGen1, CPU_TooLongTensorAccessorNameFails) {
-    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor")};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", std::string(MAX_ACCESSOR_NAME_LENGTH + 1, 'a'));
 
@@ -4026,35 +4016,8 @@ static_assert(tensor::get_token_if_present<"not_a_tensor">() == nullptr);
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentReturnsNullptrWhenNoBindingsJITSmoke) {
-    // The lookup is emitted even when a kernel has no bindings of a given kind, so a kernel can
-    // probe for an optional resource without the host having to inject a dummy token. This is the
-    // empty-namespace path (no DFB / tensor / scratchpad bindings at all); the
-    // present-plus-absent case is covered by the per-category JIT smokes above.
-    NodeCoord node{0, 0};
-
-    ProgramSpec spec;
-    spec.name = "binding_lookup_empty";
-
-    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
-    dm_kernel.source = KernelSpec::SourceCode{R"(
-void kernel_main() {
-    static_assert(dfb::get_token_if_present<"missing">() == nullptr);
-    static_assert(tensor::get_token_if_present<"missing">() == nullptr);
-    static_assert(scratch::get_token_if_present<"missing">() == nullptr);
-}
-)"};
-
-    spec.kernels = {dm_kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
-
-    Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
-}
-
 TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentReturnsNullptrWhenNoBindingsComputeJITSmoke) {
-    // Same empty-namespace lookups as the DM smoke above, on a compute kernel with no bindings.
-    // Covers the TRISC compile of kernel_bindings_generated.h's unconditional token-header includes.
+    // The DM counterpart is CPU_GetTokenIfPresentConstructsWhenNoBindingsJITSmoke.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -4063,6 +4026,9 @@ TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentReturnsNullptrWhenNoBindingsCom
     auto compute = MakeMinimalGen1ComputeKernel("compute");
     compute.source = KernelSpec::SourceCode{R"(
 #include "api/tensor/local_tensor_accessor.h"
+// Codegen omits these when the kernel has no DFB / scratchpad bindings.
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 
 void kernel_main() {
     static_assert(dfb::get_token_if_present<"missing">() == nullptr);
@@ -4093,9 +4059,7 @@ void kernel_main() {
 }
 
 TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsWhenNoBindingsJITSmoke) {
-    // Same empty ProgramSpec as the nullptr static_assert smoke above, but with the
-    // `if (const auto* token = get_token_if_present<...>())` shape so each absent lookup's
-    // false branch still type-checks constructing the resource from *token.
+    // The compute counterpart is CPU_GetTokenIfPresentReturnsNullptrWhenNoBindingsComputeJITSmoke.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -4104,6 +4068,9 @@ TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsWhenNoBindingsJITSmok
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 #include "api/tensor/local_tensor_accessor.h"
+// Codegen omits these when the kernel has no DFB / scratchpad bindings.
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/scratchpad.h"
 
 void kernel_main() {
     static_assert(dfb::get_token_if_present<"missing">() == nullptr);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4191,20 +4191,17 @@ TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentPrUsageExampleJITSmoke) {
 void kernel_main() {
     DataflowBuffer dfb_normal(dfb::normal);
 
-    constexpr const DFBBindingToken* bias_token = dfb::get_token_if_present<"bias">();
+    const DFBBindingToken* bias_token = dfb::get_token_if_present<"bias">();
+
     std::optional<DataflowBuffer> dfb_bias;
-#pragma GCC diagnostic push
-// This is needed to avoid compiler warning the address will not/ always be null.
-#pragma GCC diagnostic ignored "-Waddress"
-    if constexpr (bias_token != nullptr) {
+    if (bias_token != nullptr) {
         dfb_bias.emplace(*bias_token);
     }
 
     dfb_normal.push_back(1);
-    if constexpr (bias_token != nullptr) {
+    if (dfb_bias) {
         dfb_bias->push_back(1);
     }
-#pragma GCC diagnostic pop
 }
 )";
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4013,8 +4013,8 @@ void kernel_main() {
     (void)noc_addr;
 }
 
-static_assert(tensor::get_binding_if_present<"input_tensor">() == &tensor::input_tensor);
-static_assert(tensor::get_binding_if_present<"not_a_tensor">() == nullptr);
+static_assert(tensor::get_token_if_present<"input_tensor">() == &tensor::input_tensor);
+static_assert(tensor::get_token_if_present<"not_a_tensor">() == nullptr);
 )"};
 
     spec.kernels = {dm_kernel};
@@ -4026,7 +4026,7 @@ static_assert(tensor::get_binding_if_present<"not_a_tensor">() == nullptr);
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_GetBindingIfPresentReturnsNullptrWhenNoBindingsJITSmoke) {
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentReturnsNullptrWhenNoBindingsJITSmoke) {
     // The lookup is emitted even when a kernel has no bindings of a given kind, so a kernel can
     // probe for an optional resource without the host having to inject a dummy token. This is the
     // empty-namespace path (no DFB / tensor / scratchpad / semaphore bindings at all); the
@@ -4039,15 +4039,484 @@ TEST_F(ProgramSpecTestGen1, CPU_GetBindingIfPresentReturnsNullptrWhenNoBindingsJ
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
-    static_assert(dfb::get_binding_if_present<"missing">() == nullptr);
-    static_assert(tensor::get_binding_if_present<"missing">() == nullptr);
-    static_assert(scratch::get_binding_if_present<"missing">() == nullptr);
-    static_assert(sem::get_binding_if_present<"missing">() == nullptr);
+    static_assert(dfb::get_token_if_present<"missing">() == nullptr);
+    static_assert(tensor::get_token_if_present<"missing">() == nullptr);
+    static_assert(scratch::get_token_if_present<"missing">() == nullptr);
+    static_assert(sem::get_token_if_present<"missing">() == nullptr);
 }
 )"};
 
     spec.kernels = {dm_kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentReturnsNullptrWhenNoBindingsComputeJITSmoke) {
+    // Same empty-namespace lookups as the DM smoke above, on a compute kernel with no bindings.
+    // Covers the TRISC compile of kernel_bindings_generated.h's unconditional token-header includes.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "binding_lookup_empty_compute";
+
+    auto compute = MakeMinimalGen1ComputeKernel("compute");
+    compute.source = KernelSpec::SourceCode{R"(
+#include "api/tensor/local_tensor_accessor.h"
+
+void kernel_main() {
+    static_assert(dfb::get_token_if_present<"missing">() == nullptr);
+    if (const auto* token = dfb::get_token_if_present<"missing">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(tensor::get_token_if_present<"missing">() == nullptr);
+    if (const auto* token = tensor::get_token_if_present<"missing">()) {
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)local_accessor;
+    }
+
+    static_assert(scratch::get_token_if_present<"missing">() == nullptr);
+    if (const auto* token = scratch::get_token_if_present<"missing">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(sem::get_token_if_present<"missing">() == nullptr);
+}
+)"};
+
+    spec.kernels = {compute};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsWhenNoBindingsJITSmoke) {
+    // Same empty ProgramSpec as the nullptr static_assert smoke above, but with the
+    // `if (const auto* token = get_token_if_present<...>())` shape so each absent lookup's
+    // false branch still type-checks constructing the resource from *token.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "binding_lookup_empty_constructs";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/local_tensor_accessor.h"
+
+void kernel_main() {
+    static_assert(dfb::get_token_if_present<"missing">() == nullptr);
+    if (const auto* token = dfb::get_token_if_present<"missing">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(tensor::get_token_if_present<"missing">() == nullptr);
+    if (const auto* token = tensor::get_token_if_present<"missing">()) {
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+
+    static_assert(scratch::get_token_if_present<"missing">() == nullptr);
+    if (const auto* token = scratch::get_token_if_present<"missing">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(sem::get_token_if_present<"missing">() == nullptr);
+    if (const auto* token = sem::get_token_if_present<"missing">()) {
+        Semaphore s(*token);
+        (void)s;
+    }
+}
+)"};
+
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+// ============================================================================
+// get_token_if_present: construct the resource from a present token, and keep
+// an optional nullptr path compiling (same if (const auto* token = ...) shape)
+// ============================================================================
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsDataflowBufferJITSmoke) {
+    // dfb_present is bound; dfb_absent is not. Both lookups use the same `if (const auto* token = ...)`
+    // shape so the absent path still type-checks DataflowBuffer(*token) in the false branch.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.kernels[0].dfb_bindings[0].accessor_name = "dfb_present";
+    spec.kernels[1].dfb_bindings[0].accessor_name = "dfb_present";
+
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    static_assert(dfb::get_token_if_present<"dfb_present">() == &dfb::dfb_present);
+    if (const auto* token = dfb::get_token_if_present<"dfb_present">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(dfb::get_token_if_present<"dfb_absent">() == nullptr);
+    if (const auto* token = dfb::get_token_if_present<"dfb_absent">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+}
+)"};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsScratchpadJITSmoke) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "binding_lookup_constructs_scratch";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    static_assert(scratch::get_token_if_present<"scratch_present">() == &scratch::scratch_present);
+    if (const auto* token = scratch::get_token_if_present<"scratch_present">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(scratch::get_token_if_present<"scratch_absent">() == nullptr);
+    if (const auto* token = scratch::get_token_if_present<"scratch_absent">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+}
+)"};
+    dm_kernel.scratchpad_bindings.push_back(KernelSpec::ScratchpadBinding{
+        .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch_present"});
+
+    spec.kernels = {dm_kernel};
+    spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch"}, .size_per_node = 1024}};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsTensorAccessorJITSmoke) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "binding_lookup_constructs_tensor";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+#include "api/tensor/local_tensor_accessor.h"
+
+void kernel_main() {
+    static_assert(tensor::get_token_if_present<"tensor_present">() == &tensor::tensor_present);
+    if (const auto* token = tensor::get_token_if_present<"tensor_present">()) {
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+
+    static_assert(tensor::get_token_if_present<"tensor_absent">() == nullptr);
+    if (const auto* token = tensor::get_token_if_present<"tensor_absent">()) {
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+}
+)"};
+
+    spec.kernels = {dm_kernel};
+    spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor", tt::tt_metal::BufferType::L1)};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "tensor_present");
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsSemaphoreJITSmoke) {
+    // sem_present is bound; sem_absent is not. Semaphore is constructed from the looked-up id (*token).
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    SemaphoreSpec sem;
+    sem.unique_id = SemaphoreSpecName{"sem_0"};
+    sem.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem};
+    spec.kernels[0].semaphore_bindings = {
+        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_0"}, .accessor_name = "sem_present"}};
+
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+#include "api/dataflow/noc_semaphore.h"
+void kernel_main() {
+    static_assert(sem::get_token_if_present<"sem_present">() == &sem::sem_present);
+    if (const auto* token = sem::get_token_if_present<"sem_present">()) {
+        Semaphore s(*token);
+        (void)s;
+    }
+
+    static_assert(sem::get_token_if_present<"sem_absent">() == nullptr);
+    if (const auto* token = sem::get_token_if_present<"sem_absent">()) {
+        Semaphore s(*token);
+        (void)s;
+    }
+}
+)"};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentDisambiguatesMultipleBindingsJITSmoke) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    auto dfb_b = MakeMinimalDFB("dfb_1");
+    dfb_b.data_format_metadata = tt::DataFormat::Float16_b;
+    spec.dataflow_buffers.push_back(dfb_b);
+    spec.kernels[0].dfb_bindings[0].accessor_name = "dfb_a";
+    spec.kernels[0].dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb_1"}, "dfb_b"));
+    spec.kernels[1].dfb_bindings[0].accessor_name = "dfb_a";
+    spec.kernels[1].dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_1"}, "dfb_b"));
+
+    spec.tensor_parameters = {
+        MakeMinimalTensorParameter("t0", tt::tt_metal::BufferType::L1),
+        MakeMinimalTensorParameter("t1", tt::tt_metal::BufferType::L1),
+    };
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "tensor_a");
+    BindTensorParameterToKernel(spec.kernels[0], "t1", "tensor_b");
+
+    spec.scratchpads = {
+        ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch_0"}, .size_per_node = 1024},
+        ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch_1"}, .size_per_node = 1024},
+    };
+    spec.kernels[0].scratchpad_bindings = {
+        KernelSpec::ScratchpadBinding{
+            .scratchpad_spec_name = ScratchpadSpecName{"scratch_0"}, .accessor_name = "scratch_a"},
+        KernelSpec::ScratchpadBinding{
+            .scratchpad_spec_name = ScratchpadSpecName{"scratch_1"}, .accessor_name = "scratch_b"},
+    };
+
+    SemaphoreSpec sem_0;
+    sem_0.unique_id = SemaphoreSpecName{"sem_0"};
+    sem_0.target_nodes = NodeCoord{0, 0};
+    SemaphoreSpec sem_1;
+    sem_1.unique_id = SemaphoreSpecName{"sem_1"};
+    sem_1.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem_0, sem_1};
+    spec.kernels[0].semaphore_bindings = {
+        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_0"}, .accessor_name = "sem_a"},
+        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_1"}, .accessor_name = "sem_b"},
+    };
+
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/local_tensor_accessor.h"
+
+void kernel_main() {
+    static_assert(dfb::get_token_if_present<"dfb_a">() == &dfb::dfb_a);
+    if (const auto* token = dfb::get_token_if_present<"dfb_a">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(dfb::get_token_if_present<"dfb_b">() == &dfb::dfb_b);
+    if (const auto* token = dfb::get_token_if_present<"dfb_b">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(tensor::get_token_if_present<"tensor_a">() == &tensor::tensor_a);
+    if (const auto* token = tensor::get_token_if_present<"tensor_a">()) {
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+
+    static_assert(tensor::get_token_if_present<"tensor_b">() == &tensor::tensor_b);
+    if (const auto* token = tensor::get_token_if_present<"tensor_b">()) {
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+
+    static_assert(scratch::get_token_if_present<"scratch_a">() == &scratch::scratch_a);
+    if (const auto* token = scratch::get_token_if_present<"scratch_a">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(scratch::get_token_if_present<"scratch_b">() == &scratch::scratch_b);
+    if (const auto* token = scratch::get_token_if_present<"scratch_b">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(sem::get_token_if_present<"sem_a">() == &sem::sem_a);
+    if (const auto* token = sem::get_token_if_present<"sem_a">()) {
+        Semaphore s(*token);
+        (void)s;
+    }
+
+    static_assert(sem::get_token_if_present<"sem_b">() == &sem::sem_b);
+    if (const auto* token = sem::get_token_if_present<"sem_b">()) {
+        Semaphore s(*token);
+        (void)s;
+    }
+}
+)"};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstantExpressionBigSmoke) {
+    // Same bindings as CPU_GetTokenIfPresentDisambiguatesMultipleBindingsJITSmoke.
+    // Present names use `if constexpr (get_token_if_present<"x">() == &ns::x)` — converting the
+    // pointer to bool is -Werror=address because it is the address of a constexpr object.
+    // Absent names use `if constexpr (constexpr const auto* token = get_token_if_present<"missing">())`.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    auto dfb_b = MakeMinimalDFB("dfb_1");
+    dfb_b.data_format_metadata = tt::DataFormat::Float16_b;
+    spec.dataflow_buffers.push_back(dfb_b);
+    spec.kernels[0].dfb_bindings[0].accessor_name = "dfb_a";
+    spec.kernels[0].dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb_1"}, "dfb_b"));
+    spec.kernels[1].dfb_bindings[0].accessor_name = "dfb_a";
+    spec.kernels[1].dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_1"}, "dfb_b"));
+
+    spec.tensor_parameters = {
+        MakeMinimalTensorParameter("t0", tt::tt_metal::BufferType::L1),
+        MakeMinimalTensorParameter("t1", tt::tt_metal::BufferType::L1),
+    };
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "tensor_a");
+    BindTensorParameterToKernel(spec.kernels[0], "t1", "tensor_b");
+
+    spec.scratchpads = {
+        ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch_0"}, .size_per_node = 1024},
+        ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch_1"}, .size_per_node = 1024},
+    };
+    spec.kernels[0].scratchpad_bindings = {
+        KernelSpec::ScratchpadBinding{
+            .scratchpad_spec_name = ScratchpadSpecName{"scratch_0"}, .accessor_name = "scratch_a"},
+        KernelSpec::ScratchpadBinding{
+            .scratchpad_spec_name = ScratchpadSpecName{"scratch_1"}, .accessor_name = "scratch_b"},
+    };
+
+    SemaphoreSpec sem_0;
+    sem_0.unique_id = SemaphoreSpecName{"sem_0"};
+    sem_0.target_nodes = NodeCoord{0, 0};
+    SemaphoreSpec sem_1;
+    sem_1.unique_id = SemaphoreSpecName{"sem_1"};
+    sem_1.target_nodes = NodeCoord{0, 0};
+    spec.semaphores = {sem_0, sem_1};
+    spec.kernels[0].semaphore_bindings = {
+        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_0"}, .accessor_name = "sem_a"},
+        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_1"}, .accessor_name = "sem_b"},
+    };
+
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/local_tensor_accessor.h"
+
+void kernel_main() {
+    static_assert(dfb::get_token_if_present<"dfb_a">() == &dfb::dfb_a);
+    if constexpr (dfb::get_token_if_present<"dfb_a">() == &dfb::dfb_a) {
+        constexpr const auto* token = dfb::get_token_if_present<"dfb_a">();
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+    static_assert(dfb::get_token_if_present<"dfb_absent">() == nullptr);
+    if constexpr (constexpr const auto* token = dfb::get_token_if_present<"dfb_absent">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(dfb::get_token_if_present<"dfb_b">() == &dfb::dfb_b);
+    if constexpr (dfb::get_token_if_present<"dfb_b">() == &dfb::dfb_b) {
+        constexpr const auto* token = dfb::get_token_if_present<"dfb_b">();
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(tensor::get_token_if_present<"tensor_a">() == &tensor::tensor_a);
+    if constexpr (tensor::get_token_if_present<"tensor_a">() == &tensor::tensor_a) {
+        constexpr const auto* token = tensor::get_token_if_present<"tensor_a">();
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+    static_assert(tensor::get_token_if_present<"tensor_absent">() == nullptr);
+    if constexpr (constexpr const auto* token = tensor::get_token_if_present<"tensor_absent">()) {
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+
+    static_assert(tensor::get_token_if_present<"tensor_b">() == &tensor::tensor_b);
+    if constexpr (tensor::get_token_if_present<"tensor_b">() == &tensor::tensor_b) {
+        constexpr const auto* token = tensor::get_token_if_present<"tensor_b">();
+        TensorAccessor accessor(*token);
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)accessor;
+        (void)local_accessor;
+    }
+
+    static_assert(scratch::get_token_if_present<"scratch_a">() == &scratch::scratch_a);
+    if constexpr (scratch::get_token_if_present<"scratch_a">() == &scratch::scratch_a) {
+        constexpr const auto* token = scratch::get_token_if_present<"scratch_a">();
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+    static_assert(scratch::get_token_if_present<"scratch_absent">() == nullptr);
+    if constexpr (constexpr const auto* token = scratch::get_token_if_present<"scratch_absent">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(scratch::get_token_if_present<"scratch_b">() == &scratch::scratch_b);
+    if constexpr (scratch::get_token_if_present<"scratch_b">() == &scratch::scratch_b) {
+        constexpr const auto* token = scratch::get_token_if_present<"scratch_b">();
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(sem::get_token_if_present<"sem_a">() == &sem::sem_a);
+    if constexpr (sem::get_token_if_present<"sem_a">() == &sem::sem_a) {
+        constexpr const auto* token = sem::get_token_if_present<"sem_a">();
+        Semaphore s(*token);
+        (void)s;
+    }
+    static_assert(sem::get_token_if_present<"sem_absent">() == nullptr);
+    if constexpr (constexpr const auto* token = sem::get_token_if_present<"sem_absent">()) {
+        Semaphore s(*token);
+        (void)s;
+    }
+
+    static_assert(sem::get_token_if_present<"sem_b">() == &sem::sem_b);
+    if constexpr (sem::get_token_if_present<"sem_b">() == &sem::sem_b) {
+        constexpr const auto* token = sem::get_token_if_present<"sem_b">();
+        Semaphore s(*token);
+        (void)s;
+    }
+}
+)"};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
@@ -4372,8 +4841,8 @@ void kernel_main() {
     (void)base;
 }
 
-static_assert(scratch::get_binding_if_present<"scratch">() == &scratch::scratch);
-static_assert(scratch::get_binding_if_present<"not_a_scratch">() == nullptr);
+static_assert(scratch::get_token_if_present<"scratch">() == &scratch::scratch);
+static_assert(scratch::get_token_if_present<"not_a_scratch">() == nullptr);
 )"};
     dm_kernel.scratchpad_bindings.push_back(KernelSpec::ScratchpadBinding{
         .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch"});
@@ -4404,8 +4873,8 @@ void kernel_main() {
     (void)base;
 }
 
-static_assert(scratch::get_binding_if_present<"scratch">() == &scratch::scratch);
-static_assert(scratch::get_binding_if_present<"not_a_scratch">() == nullptr);
+static_assert(scratch::get_token_if_present<"scratch">() == &scratch::scratch);
+static_assert(scratch::get_token_if_present<"not_a_scratch">() == nullptr);
 )"};
 
     spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch"}, .size_per_node = 1024}};
@@ -4438,8 +4907,8 @@ void kernel_main() {
     (void)sink;
 }
 
-static_assert(scratch::get_binding_if_present<"scratch">() == &scratch::scratch);
-static_assert(scratch::get_binding_if_present<"not_a_scratch">() == nullptr);
+static_assert(scratch::get_token_if_present<"scratch">() == &scratch::scratch);
+static_assert(scratch::get_token_if_present<"not_a_scratch">() == nullptr);
 )"};
     dm_kernel.scratchpad_bindings.push_back(KernelSpec::ScratchpadBinding{
         .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch"});
@@ -4483,8 +4952,8 @@ TT_KERNEL void compute_entry(uint32_t input_offset, uint32_t num_tiles) {  // RT
     (void)sink;
 }
 
-static_assert(dfb::get_binding_if_present<"out_dfb">() == &dfb::out_dfb);
-static_assert(dfb::get_binding_if_present<"not_a_dfb">() == nullptr);
+static_assert(dfb::get_token_if_present<"out_dfb">() == &dfb::out_dfb);
+static_assert(dfb::get_token_if_present<"not_a_dfb">() == nullptr);
 )";
 
 TEST_F(ProgramSpecTestGen1, CPU_TtKernelComputeShimCompiles) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4026,6 +4026,33 @@ static_assert(tensor::get_binding_if_present<"not_a_tensor">() == nullptr);
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
+TEST_F(ProgramSpecTestGen1, CPU_GetBindingIfPresentReturnsNullptrWhenNoBindingsJITSmoke) {
+    // The lookup is emitted even when a kernel has no bindings of a given kind, so a kernel can
+    // probe for an optional resource without the host having to inject a dummy token. This is the
+    // empty-namespace path (no DFB / tensor / scratchpad / semaphore bindings at all); the
+    // present-plus-absent case is covered by the per-category JIT smokes above.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "binding_lookup_empty";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    static_assert(dfb::get_binding_if_present<"missing">() == nullptr);
+    static_assert(tensor::get_binding_if_present<"missing">() == nullptr);
+    static_assert(scratch::get_binding_if_present<"missing">() == nullptr);
+    static_assert(sem::get_binding_if_present<"missing">() == nullptr);
+}
+)"};
+
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
 // ============================================================================
 // TensorBindingSequence: validation + JIT smoke (compile-only, no hardware loop)
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4029,7 +4029,7 @@ static_assert(tensor::get_token_if_present<"not_a_tensor">() == nullptr);
 TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentReturnsNullptrWhenNoBindingsJITSmoke) {
     // The lookup is emitted even when a kernel has no bindings of a given kind, so a kernel can
     // probe for an optional resource without the host having to inject a dummy token. This is the
-    // empty-namespace path (no DFB / tensor / scratchpad / semaphore bindings at all); the
+    // empty-namespace path (no DFB / tensor / scratchpad bindings at all); the
     // present-plus-absent case is covered by the per-category JIT smokes above.
     NodeCoord node{0, 0};
 
@@ -4042,7 +4042,6 @@ void kernel_main() {
     static_assert(dfb::get_token_if_present<"missing">() == nullptr);
     static_assert(tensor::get_token_if_present<"missing">() == nullptr);
     static_assert(scratch::get_token_if_present<"missing">() == nullptr);
-    static_assert(sem::get_token_if_present<"missing">() == nullptr);
 }
 )"};
 
@@ -4083,8 +4082,6 @@ void kernel_main() {
         Scratchpad<int32_t> pad(*token);
         (void)pad;
     }
-
-    static_assert(sem::get_token_if_present<"missing">() == nullptr);
 }
 )"};
 
@@ -4106,7 +4103,6 @@ TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsWhenNoBindingsJITSmok
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
-#include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/local_tensor_accessor.h"
 
 void kernel_main() {
@@ -4128,12 +4124,6 @@ void kernel_main() {
     if (const auto* token = scratch::get_token_if_present<"missing">()) {
         Scratchpad<int32_t> pad(*token);
         (void)pad;
-    }
-
-    static_assert(sem::get_token_if_present<"missing">() == nullptr);
-    if (const auto* token = sem::get_token_if_present<"missing">()) {
-        Semaphore s(*token);
-        (void)s;
     }
 }
 )"};
@@ -4306,38 +4296,6 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsSemaphoreJITSmoke) {
-    // sem_present is bound; sem_absent is not. Semaphore is constructed from the looked-up id (*token).
-    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
-
-    SemaphoreSpec sem;
-    sem.unique_id = SemaphoreSpecName{"sem_0"};
-    sem.target_nodes = NodeCoord{0, 0};
-    spec.semaphores = {sem};
-    spec.kernels[0].semaphore_bindings = {
-        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_0"}, .accessor_name = "sem_present"}};
-
-    spec.kernels[0].source = KernelSpec::SourceCode{R"(
-#include "api/dataflow/noc_semaphore.h"
-void kernel_main() {
-    static_assert(sem::get_token_if_present<"sem_present">() == &sem::sem_present);
-    if (const auto* token = sem::get_token_if_present<"sem_present">()) {
-        Semaphore s(*token);
-        (void)s;
-    }
-
-    static_assert(sem::get_token_if_present<"sem_absent">() == nullptr);
-    if (const auto* token = sem::get_token_if_present<"sem_absent">()) {
-        Semaphore s(*token);
-        (void)s;
-    }
-}
-)"};
-
-    Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
-}
-
 TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentDisambiguatesMultipleBindingsJITSmoke) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -4367,20 +4325,7 @@ TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentDisambiguatesMultipleBindingsJI
             .scratchpad_spec_name = ScratchpadSpecName{"scratch_1"}, .accessor_name = "scratch_b"},
     };
 
-    SemaphoreSpec sem_0;
-    sem_0.unique_id = SemaphoreSpecName{"sem_0"};
-    sem_0.target_nodes = NodeCoord{0, 0};
-    SemaphoreSpec sem_1;
-    sem_1.unique_id = SemaphoreSpecName{"sem_1"};
-    sem_1.target_nodes = NodeCoord{0, 0};
-    spec.semaphores = {sem_0, sem_1};
-    spec.kernels[0].semaphore_bindings = {
-        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_0"}, .accessor_name = "sem_a"},
-        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_1"}, .accessor_name = "sem_b"},
-    };
-
     spec.kernels[0].source = KernelSpec::SourceCode{R"(
-#include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/local_tensor_accessor.h"
 
 void kernel_main() {
@@ -4423,18 +4368,6 @@ void kernel_main() {
         Scratchpad<int32_t> pad(*token);
         (void)pad;
     }
-
-    static_assert(sem::get_token_if_present<"sem_a">() == &sem::sem_a);
-    if (const auto* token = sem::get_token_if_present<"sem_a">()) {
-        Semaphore s(*token);
-        (void)s;
-    }
-
-    static_assert(sem::get_token_if_present<"sem_b">() == &sem::sem_b);
-    if (const auto* token = sem::get_token_if_present<"sem_b">()) {
-        Semaphore s(*token);
-        (void)s;
-    }
 }
 )"};
 
@@ -4475,20 +4408,7 @@ TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstantExpressionBigSmoke) {
             .scratchpad_spec_name = ScratchpadSpecName{"scratch_1"}, .accessor_name = "scratch_b"},
     };
 
-    SemaphoreSpec sem_0;
-    sem_0.unique_id = SemaphoreSpecName{"sem_0"};
-    sem_0.target_nodes = NodeCoord{0, 0};
-    SemaphoreSpec sem_1;
-    sem_1.unique_id = SemaphoreSpecName{"sem_1"};
-    sem_1.target_nodes = NodeCoord{0, 0};
-    spec.semaphores = {sem_0, sem_1};
-    spec.kernels[0].semaphore_bindings = {
-        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_0"}, .accessor_name = "sem_a"},
-        SemaphoreBinding{.semaphore_spec_name = SemaphoreSpecName{"sem_1"}, .accessor_name = "sem_b"},
-    };
-
     spec.kernels[0].source = KernelSpec::SourceCode{R"(
-#include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/local_tensor_accessor.h"
 
 void kernel_main() {
@@ -4553,25 +4473,6 @@ void kernel_main() {
         constexpr const auto* token = scratch::get_token_if_present<"scratch_b">();
         Scratchpad<int32_t> pad(*token);
         (void)pad;
-    }
-
-    static_assert(sem::get_token_if_present<"sem_a">() == &sem::sem_a);
-    if constexpr (sem::get_token_if_present<"sem_a">() == &sem::sem_a) {
-        constexpr const auto* token = sem::get_token_if_present<"sem_a">();
-        Semaphore s(*token);
-        (void)s;
-    }
-    static_assert(sem::get_token_if_present<"sem_absent">() == nullptr);
-    if constexpr (constexpr const auto* token = sem::get_token_if_present<"sem_absent">()) {
-        Semaphore s(*token);
-        (void)s;
-    }
-
-    static_assert(sem::get_token_if_present<"sem_b">() == &sem::sem_b);
-    if constexpr (sem::get_token_if_present<"sem_b">() == &sem::sem_b) {
-        constexpr const auto* token = sem::get_token_if_present<"sem_b">();
-        Semaphore s(*token);
-        (void)s;
     }
 }
 )"};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3966,6 +3966,9 @@ void kernel_main() {
     auto noc_addr = accessor.get_noc_addr(0);
     (void)noc_addr;
 }
+
+static_assert(tensor::get_binding_if_present<"input_tensor">() == &tensor::input_tensor);
+static_assert(tensor::get_binding_if_present<"not_a_tensor">() == nullptr);
 )"};
 
     spec.kernels = {dm_kernel};
@@ -4295,6 +4298,9 @@ void kernel_main() {
     volatile uint32_t base = pad.get_base_address();
     (void)base;
 }
+
+static_assert(scratch::get_binding_if_present<"scratch">() == &scratch::scratch);
+static_assert(scratch::get_binding_if_present<"not_a_scratch">() == nullptr);
 )"};
     dm_kernel.scratchpad_bindings.push_back(KernelSpec::ScratchpadBinding{
         .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch"});
@@ -4324,6 +4330,9 @@ void kernel_main() {
     volatile uint32_t base = pad.get_base_address();
     (void)base;
 }
+
+static_assert(scratch::get_binding_if_present<"scratch">() == &scratch::scratch);
+static_assert(scratch::get_binding_if_present<"not_a_scratch">() == nullptr);
 )"};
 
     spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch"}, .size_per_node = 1024}};
@@ -4355,6 +4364,9 @@ void kernel_main() {
     volatile int32_t sink = acc;  // keep the loop live so the range-for is actually instantiated
     (void)sink;
 }
+
+static_assert(scratch::get_binding_if_present<"scratch">() == &scratch::scratch);
+static_assert(scratch::get_binding_if_present<"not_a_scratch">() == nullptr);
 )"};
     dm_kernel.scratchpad_bindings.push_back(KernelSpec::ScratchpadBinding{
         .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch"});
@@ -4397,6 +4409,9 @@ TT_KERNEL void compute_entry(uint32_t input_offset, uint32_t num_tiles) {  // RT
     volatile uint32_t sink = magic ^ entry_size ^ input_offset;
     (void)sink;
 }
+
+static_assert(dfb::get_binding_if_present<"out_dfb">() == &dfb::out_dfb);
+static_assert(dfb::get_binding_if_present<"not_a_dfb">() == nullptr);
 )";
 
 TEST_F(ProgramSpecTestGen1, CPU_TtKernelComputeShimCompiles) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4134,9 +4134,58 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
+TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstructsDataflowBufferComputeJITSmoke) {
+    // Compute-kernel counterpart of CPU_GetTokenIfPresentConstructsDataflowBufferJITSmoke.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
+    spec.kernels[0].dfb_bindings[0].accessor_name = "dfb_present";
+    spec.kernels[1].dfb_bindings[0].accessor_name = "dfb_present";
+
+    spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch"}, .size_per_node = 1024}};
+    spec.kernels[1].scratchpad_bindings.push_back(KernelSpec::ScratchpadBinding{
+        .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch"});
+
+    spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor", tt::tt_metal::BufferType::L1)};
+    BindTensorParameterToKernel(spec.kernels[1], "input_tensor", "tensor_present");
+
+    spec.kernels[1].source = KernelSpec::SourceCode{R"(
+#include "api/tensor/local_tensor_accessor.h"
+
+void kernel_main() {
+    static_assert(dfb::get_token_if_present<"dfb_present">() == &dfb::dfb_present);
+    if (const auto* token = dfb::get_token_if_present<"dfb_present">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(dfb::get_token_if_present<"dfb_absent">() == nullptr);
+    if (const auto* token = dfb::get_token_if_present<"dfb_absent">()) {
+        DataflowBuffer buf(*token);
+        (void)buf;
+    }
+
+    static_assert(scratch::get_token_if_present<"scratch">() == &scratch::scratch);
+    if (const auto* token = scratch::get_token_if_present<"scratch">()) {
+        Scratchpad<int32_t> pad(*token);
+        (void)pad;
+    }
+
+    static_assert(tensor::get_token_if_present<"tensor_present">() == &tensor::tensor_present);
+    if (const auto* token = tensor::get_token_if_present<"tensor_present">()) {
+        LocalTensorAccessor<uint32_t> local_accessor(*token);
+        (void)local_accessor;
+    }
+}
+)"};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
 TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentPrUsageExampleJITSmoke) {
     // Kernel shape from the PR description: always-present `normal`, optional `bias` via
-    // get_token_if_present + std::optional. Compiles the same source with and without `bias` bound.
+    // get_token_if_present + std::optional. Compiles the same source on DM and compute, with
+    // and without `bias` bound.
     constexpr const char* kSource = R"(
 #include <optional>
 void kernel_main() {
@@ -4165,6 +4214,7 @@ void kernel_main() {
         auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
         dm_kernel.source = KernelSpec::SourceCode{kSource};
         auto compute_kernel = MakeMinimalGen1ComputeKernel("compute_kernel");
+        compute_kernel.source = KernelSpec::SourceCode{kSource};
 
         auto normal = MakeMinimalDFB("normal");
         normal.data_format_metadata = tt::DataFormat::Float16_b;
@@ -4344,9 +4394,10 @@ void kernel_main() {
 
 TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstantExpressionBigSmoke) {
     // Same bindings as CPU_GetTokenIfPresentDisambiguatesMultipleBindingsJITSmoke.
-    // Present names use `if constexpr (get_token_if_present<"x">() == &ns::x)` — converting the
-    // pointer to bool is -Werror=address because it is the address of a constexpr object.
-    // Absent names use `if constexpr (constexpr const auto* token = get_token_if_present<"missing">())`.
+    // Present and absent names use the same
+    // `if constexpr (constexpr const auto* token = get_token_if_present<"x">())` shape.
+    // Converting a present token pointer to bool is -Werror=address (address of a constexpr
+    // object), so the kernel suppresses -Waddress around those conditions.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     auto dfb_b = MakeMinimalDFB("dfb_1");
@@ -4379,9 +4430,11 @@ TEST_F(ProgramSpecTestGen1, CPU_GetTokenIfPresentConstantExpressionBigSmoke) {
 #include "api/tensor/local_tensor_accessor.h"
 
 void kernel_main() {
+#pragma GCC diagnostic push
+// Present tokens are addresses of constexpr objects; converting them to bool is -Werror=address.
+#pragma GCC diagnostic ignored "-Waddress"
     static_assert(dfb::get_token_if_present<"dfb_a">() == &dfb::dfb_a);
-    if constexpr (dfb::get_token_if_present<"dfb_a">() == &dfb::dfb_a) {
-        constexpr const auto* token = dfb::get_token_if_present<"dfb_a">();
+    if constexpr (constexpr const auto* token = dfb::get_token_if_present<"dfb_a">()) {
         DataflowBuffer buf(*token);
         (void)buf;
     }
@@ -4392,15 +4445,13 @@ void kernel_main() {
     }
 
     static_assert(dfb::get_token_if_present<"dfb_b">() == &dfb::dfb_b);
-    if constexpr (dfb::get_token_if_present<"dfb_b">() == &dfb::dfb_b) {
-        constexpr const auto* token = dfb::get_token_if_present<"dfb_b">();
+    if constexpr (constexpr const auto* token = dfb::get_token_if_present<"dfb_b">()) {
         DataflowBuffer buf(*token);
         (void)buf;
     }
 
     static_assert(tensor::get_token_if_present<"tensor_a">() == &tensor::tensor_a);
-    if constexpr (tensor::get_token_if_present<"tensor_a">() == &tensor::tensor_a) {
-        constexpr const auto* token = tensor::get_token_if_present<"tensor_a">();
+    if constexpr (constexpr const auto* token = tensor::get_token_if_present<"tensor_a">()) {
         TensorAccessor accessor(*token);
         LocalTensorAccessor<uint32_t> local_accessor(*token);
         (void)accessor;
@@ -4415,8 +4466,7 @@ void kernel_main() {
     }
 
     static_assert(tensor::get_token_if_present<"tensor_b">() == &tensor::tensor_b);
-    if constexpr (tensor::get_token_if_present<"tensor_b">() == &tensor::tensor_b) {
-        constexpr const auto* token = tensor::get_token_if_present<"tensor_b">();
+    if constexpr (constexpr const auto* token = tensor::get_token_if_present<"tensor_b">()) {
         TensorAccessor accessor(*token);
         LocalTensorAccessor<uint32_t> local_accessor(*token);
         (void)accessor;
@@ -4424,8 +4474,7 @@ void kernel_main() {
     }
 
     static_assert(scratch::get_token_if_present<"scratch_a">() == &scratch::scratch_a);
-    if constexpr (scratch::get_token_if_present<"scratch_a">() == &scratch::scratch_a) {
-        constexpr const auto* token = scratch::get_token_if_present<"scratch_a">();
+    if constexpr (constexpr const auto* token = scratch::get_token_if_present<"scratch_a">()) {
         Scratchpad<int32_t> pad(*token);
         (void)pad;
     }
@@ -4436,11 +4485,11 @@ void kernel_main() {
     }
 
     static_assert(scratch::get_token_if_present<"scratch_b">() == &scratch::scratch_b);
-    if constexpr (scratch::get_token_if_present<"scratch_b">() == &scratch::scratch_b) {
-        constexpr const auto* token = scratch::get_token_if_present<"scratch_b">();
+    if constexpr (constexpr const auto* token = scratch::get_token_if_present<"scratch_b">()) {
         Scratchpad<int32_t> pad(*token);
         (void)pad;
     }
+#pragma GCC diagnostic pop
 }
 )"};
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -397,6 +397,30 @@ TEST_F(ProgramSpecTestQuasar, CPU_InvalidLocalAccessorNameFails) {
     }
 }
 
+TEST_F(ProgramSpecTestQuasar, CPU_TooLongLocalAccessorNameFails) {
+    // An accessor_name longer than MAX_ACCESSOR_NAME_LENGTH cannot be passed to the kernel-side
+    // by-name binding lookup, so a valid-but-too-long identifier must fail at Program construction
+    // rather than as a kernel JIT static_assert.
+    const std::string too_long(MAX_ACCESSOR_NAME_LENGTH + 1, 'a');
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto kernel = MakeMinimalGen2DMKernel("kernel");
+    auto dfb = MakeMinimalDFB("dfb");
+    kernel.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, too_long));
+
+    spec.kernels = {kernel};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("must be at most " + std::to_string(MAX_ACCESSOR_NAME_LENGTH) + " characters")));
+}
+
 TEST_F(ProgramSpecTestQuasar, CPU_KernelReferencesUnknownDFBFails) {
     NodeCoord node{0, 0};
 
@@ -1515,6 +1539,18 @@ TEST_F(ProgramSpecTestQuasar, CPU_InvalidScratchpadAccessorNameFails) {
             ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("must be a valid C++ identifier")))
             << "Expected rejection for scratchpad accessor_name: '" << bad_name << "'";
     }
+}
+
+TEST_F(ProgramSpecTestQuasar, CPU_TooLongScratchpadAccessorNameFails) {
+    const std::string too_long(MAX_ACCESSOR_NAME_LENGTH + 1, 'a');
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch_0"}, .size_per_node = 1024}};
+    spec.kernels[0].scratchpad_bindings = {KernelSpec::ScratchpadBinding{
+        .scratchpad_spec_name = ScratchpadSpecName{"scratch_0"}, .accessor_name = too_long}};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("must be at most")));
 }
 
 TEST_F(ProgramSpecTestQuasar, CPU_MultipleScratchpadsEachBoundToOwnKernelSucceeds) {
@@ -3899,6 +3935,16 @@ TEST_F(ProgramSpecTestGen1, CPU_InvalidTensorAccessorNameFails) {
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("tensor accessor_name 'has-dash' must be a valid C++ identifier")));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TooLongTensorAccessorNameFails) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor")};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", std::string(MAX_ACCESSOR_NAME_LENGTH + 1, 'a'));
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("must be at most")));
 }
 
 TEST_F(ProgramSpecTestGen1, CPU_AccessorNamesAcrossCategoriesAreSeparateNamespaces) {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <string>
@@ -67,6 +68,11 @@ namespace tt::tt_metal::experimental {
 
 // A name identifying a KernelSpec within a ProgramSpec.
 using KernelSpecName = ttsl::StrongType<std::string, struct KernelSpecNameTag>;
+
+// Maximum length of a resource binding's accessor_name (DFB, semaphore, scratchpad, tensor).
+//
+// MAINTAINER: This constant is in sync with MAX_TEMPLATE_STRING_LEN on device side.
+inline constexpr std::size_t MAX_ACCESSOR_NAME_LENGTH = 64;
 
 //------------------------------------------------
 // KernelSpec

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -67,6 +67,12 @@ public:
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
 
+    // Construct from the "binding not present" token.
+    // Meant to be used with `get_token_if_present` to make the token-not-exist branch compile.
+    // This will never be run in runtime & NullTensorBindingToken is not constructible.
+    [[nodiscard]] explicit LocalTensorAccessor(const tensor_accessor::NullTensorBindingToken&) noexcept :
+        LocalTensorAccessor(uint32_t{0}) {}
+
     // Legacy constructor: from a raw node-local L1 base address (a byte address).
     // (Typically a legacy Buffer's address passed into the kernel as a CRTA.)
     [[nodiscard]] explicit LocalTensorAccessor(uint32_t bank_base_address) noexcept :

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -28,6 +28,20 @@ T get_arg_val(int arg_idx);
 
 namespace tensor_accessor {
 
+// DSpec of an accessor built from an absent tensor binding (see NullTensorBindingToken).
+//
+// This is a dummy DSpec only meant to allow instantiation of a TensorAccessor from a NullTensorBindingToken.
+// The details of these fields should not be accessed at runtime.
+using NullDSpec = DistributionSpec<
+    /* RankCT */ 1,
+    /* NumBanksCT */ 1,
+    /* TensorShapeWrapper */ ArrayStaticWrapperU32<1>,
+    /* ShardShapeWrapper */ ArrayStaticWrapperU32<1>,
+    /* BankCoordsWrapper */ ArrayStaticWrapperU16<0>,
+    /* IsInterleaved */ false,
+    /* IsDram */ false,
+    /* IsShardContiguous */ false>;
+
 // This helper gets proper additional offset from interleaved_addr_gen::get_bank_offset +
 //      Adds proper xy coordinates for NOC address
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
@@ -104,6 +118,12 @@ public:
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
+
+    // Construct from the "binding not present" token.
+    // Meant to be used with `get_token_if_present` to make the token-not-exist branch compile.
+    // Will not attempt to read any CTAs.
+    // This will never be run in runtime & NullTensorBindingToken is not constructible.
+    explicit TensorAccessor(const tensor_accessor::NullTensorBindingToken&) : TensorAccessor(size_t{0}, uint32_t{0}) {}
 
     constexpr const auto& dspec() const {
         if constexpr (DSpec::is_static) {
@@ -562,6 +582,8 @@ TensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>
         /* IsDram */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_dram,
         /* IsShardContiguous */
         TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_shard_contiguous>>;
+
+TensorAccessor(const tensor_accessor::NullTensorBindingToken&) -> TensorAccessor<tensor_accessor::NullDSpec>;
 
 template <std::size_t CTA_OFFSET, std::size_t CRTA_OFFSET>
 TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t, uint32_t)

--- a/tt_metal/hw/inc/api/tensor/tensor_binding_token.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_binding_token.h
@@ -46,4 +46,30 @@ struct TensorBindingToken {
     static constexpr uint32_t addr_crta_offset = ADDR_CRTA_OFFSET;  // in bytes
 };
 
+// NullTensorBindingToken: the "this name is not bound" result of a binding lookup.
+//
+// tensor::get_token_if_present<"name">() returns a pointer to the named TensorBindingToken when
+// the host bound that name, and a null NullTensorBindingToken pointer when it did not. That lets a
+// kernel written against an optional binding compile either way:
+//
+//   if (const auto* token = tensor::get_token_if_present<"maybe">()) {
+//       TensorAccessor accessor(*token);   // instantiated, but only reached when "maybe" is bound
+//       ...
+//   }
+//
+// Both branches are type-checked even though the guard is a compile-time constant, so the absent
+// case still has to name a constructible accessor. It cannot reuse TensorBindingToken with dummy
+// offsets: that constructor always reads a compile-time arg at CTA_OFFSET, which fails outright in
+// a kernel with no (or differently laid out) tensor CTAs. This distinct type selects overloads that
+// read nothing; see NullDSpec in tensor_accessor.h.
+//
+// NullTensorBindingToken is not meant to be constructed, only used as a type for the null pointer.
+struct NullTensorBindingToken {
+    NullTensorBindingToken() = delete;
+    NullTensorBindingToken(const NullTensorBindingToken&) = delete;
+    NullTensorBindingToken(NullTensorBindingToken&&) = delete;
+    NullTensorBindingToken& operator=(const NullTensorBindingToken&) = delete;
+    NullTensorBindingToken& operator=(NullTensorBindingToken&&) = delete;
+};
+
 }  // namespace tensor_accessor

--- a/tt_metal/hw/inc/internal/template_string.h
+++ b/tt_metal/hw/inc/internal/template_string.h
@@ -8,8 +8,13 @@
 
 namespace internal {
 
-// This should go away when we upgrade to C++20 in-favor of CTAD
-inline constexpr size_t MAX_TEMPLATE_STRING_LEN = 63;
+// Maximum number of characters this type can hold, excluding the terminating NUL.
+//
+// This restriction is aribtary to support use of TemplateString type as a non-type template parameter without CTAD.
+// This should go away when we upgrade to C++20.
+//
+// MAINTAINER: This constant must be kept in sync with MAX_ACCESSOR_NAME_LENGTH in kernel_spec.hpp on host.
+inline constexpr size_t MAX_TEMPLATE_STRING_LEN = 65;  // 64 + NUL
 
 /**
  * Represents a null terminated string meant to be used as a non-type template parameter.
@@ -30,14 +35,14 @@ inline constexpr size_t MAX_TEMPLATE_STRING_LEN = 63;
  */
 struct TemplateString {
     // invariant: always null-terminated
-    char value[MAX_TEMPLATE_STRING_LEN + 1] = {};
+    char value[MAX_TEMPLATE_STRING_LEN] = {};
+    // Size of the string including the terminating NUL.
     std::size_t length;
 
     template <std::size_t N>
     constexpr TemplateString(const char (&str)[N]) : length(N) {
         static_assert(
-            N <= MAX_TEMPLATE_STRING_LEN,
-            "Template String must be instantiated with a string that's shorter than MAX_TEMPLATE_STRING_LEN");
+            N <= MAX_TEMPLATE_STRING_LEN, "TemplateString content must be at most MAX_TEMPLATE_STRING_LEN characters");
         for (size_t i = 0; i < N; ++i) {
             value[i] = str[i];
         }

--- a/tt_metal/hw/inc/internal/template_string.h
+++ b/tt_metal/hw/inc/internal/template_string.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+
+namespace internal {
+
+// This should go away when we upgrade to C++20 in-favor of CTAD
+inline constexpr size_t MAX_TEMPLATE_STRING_LEN = 63;
+
+/**
+ * Represents a null terminated string meant to be used as a non-type template parameter.
+ *
+ * Example usage:
+ * ```cpp
+ * template <TemplateString name>
+ * int foo() {
+ *   if (name == "something") {
+ *     return 1;
+ *   }
+ *   return 0;
+ * }
+ *
+ * static_assert(foo<TemplateString("something")>() == 1);
+ * static_assert(foo<TemplateString("something else")>() == 0);
+ * ```
+ */
+struct TemplateString {
+    // invariant: always null-terminated
+    char value[MAX_TEMPLATE_STRING_LEN + 1] = {};
+    std::size_t length;
+
+    template <std::size_t N>
+    constexpr TemplateString(const char (&str)[N]) : length(N) {
+        static_assert(
+            N <= MAX_TEMPLATE_STRING_LEN,
+            "Template String must be instantiated with a string that's shorter than MAX_TEMPLATE_STRING_LEN");
+        for (size_t i = 0; i < N; ++i) {
+            value[i] = str[i];
+        }
+    }
+
+    constexpr bool operator==(const TemplateString& other) const {
+        if (length != other.length) {
+            return false;
+        }
+        for (size_t i = 0; i < length; ++i) {
+            if (value[i] != other.value[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    constexpr bool operator!=(const TemplateString& other) const { return !(*this == other); }
+};
+
+static_assert(TemplateString("something") == TemplateString("something"));
+static_assert(TemplateString("something") != TemplateString("something else"));
+
+}  // namespace internal

--- a/tt_metal/hw/inc/internal/template_string.h
+++ b/tt_metal/hw/inc/internal/template_string.h
@@ -8,13 +8,13 @@
 
 namespace internal {
 
-// Maximum number of characters this type can hold, including the terminating NUL.
+// Maximum number of characters this type can hold, excluding the terminating NUL.
 //
 // This restriction is aribtary to support use of TemplateString type as a non-type template parameter without CTAD.
 // This should go away when we upgrade to C++20.
 //
 // MAINTAINER: This constant must be kept in sync with MAX_ACCESSOR_NAME_LENGTH in kernel_spec.hpp on host.
-inline constexpr size_t MAX_TEMPLATE_STRING_LEN = 65;  // 64 + NUL
+inline constexpr size_t MAX_TEMPLATE_STRING_LEN = 64;
 
 /**
  * Represents a null terminated string meant to be used as a non-type template parameter.
@@ -35,14 +35,15 @@ inline constexpr size_t MAX_TEMPLATE_STRING_LEN = 65;  // 64 + NUL
  */
 struct TemplateString {
     // invariant: always null-terminated
-    char value[MAX_TEMPLATE_STRING_LEN] = {};
+    char value[MAX_TEMPLATE_STRING_LEN + 1] = {};
     // Size of the string including the terminating NUL.
     std::size_t length;
 
     template <std::size_t N>
     constexpr TemplateString(const char (&str)[N]) : length(N) {
         static_assert(
-            N <= MAX_TEMPLATE_STRING_LEN, "TemplateString content must be at most MAX_TEMPLATE_STRING_LEN characters");
+            N <= MAX_TEMPLATE_STRING_LEN + 1,
+            "TemplateString content must be at most MAX_TEMPLATE_STRING_LEN characters");
         for (size_t i = 0; i < N; ++i) {
             value[i] = str[i];
         }

--- a/tt_metal/hw/inc/internal/template_string.h
+++ b/tt_metal/hw/inc/internal/template_string.h
@@ -8,7 +8,7 @@
 
 namespace internal {
 
-// Maximum number of characters this type can hold, excluding the terminating NUL.
+// Maximum number of characters this type can hold, including the terminating NUL.
 //
 // This restriction is aribtary to support use of TemplateString type as a non-type template parameter without CTAD.
 // This should go away when we upgrade to C++20.

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -186,6 +186,7 @@ set(HW_JIT_API_HEADERS
     inc/internal/firmware_common.h
     inc/internal/mod_div_lib.h
     inc/internal/risc_attribs.h
+    inc/internal/template_string.h
     inc/internal/tensix_functions.h
     inc/internal/vptr_uint.h
     inc/internal/dataflow/dataflow_api_addrgen.h

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -247,6 +247,18 @@ bool IsValidCppIdentifier(std::string_view s) {
     return !kCppKeywords.contains(s);
 }
 
+template <typename KernelId>
+void ValidateAccessorNameLength(const KernelId& kernel_id, std::string_view kind, std::string_view name) {
+    TT_FATAL(
+        name.size() <= MAX_ACCESSOR_NAME_LENGTH,
+        "Kernel '{}' {} accessor_name '{}' is {} characters; an accessor_name must be at most {} characters",
+        kernel_id,
+        kind,
+        name,
+        name.size(),
+        MAX_ACCESSOR_NAME_LENGTH);
+}
+
 // ============================================================================
 // Step 1: Spec Collection & Validation
 // ============================================================================
@@ -326,6 +338,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                     "Kernel '{}' DFB accessor_name '{}' must be a valid C++ identifier",
                     kernel.unique_id,
                     dfb_binding.accessor_name);
+                ValidateAccessorNameLength(kernel.unique_id, "DFB", dfb_binding.accessor_name);
             } else {
                 TT_FATAL(
                     info.dfb_spec_name == dfb_binding.dfb_spec_name,
@@ -429,6 +442,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' semaphore accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            ValidateAccessorNameLength(kernel.unique_id, "semaphore", binding.accessor_name);
             TT_FATAL(
                 collected.semaphore_by_name.contains(binding.semaphore_spec_name),
                 "Kernel '{}' references unknown semaphore '{}'",
@@ -469,6 +483,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' scratchpad accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            ValidateAccessorNameLength(kernel.unique_id, "scratchpad", binding.accessor_name);
             TT_FATAL(
                 collected.scratchpad_by_name.contains(binding.scratchpad_spec_name),
                 "Kernel '{}' references unknown scratchpad '{}'",
@@ -524,6 +539,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' tensor accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            ValidateAccessorNameLength(kernel.unique_id, "tensor", binding.accessor_name);
             TT_FATAL(
                 collected.tensor_parameter_by_name.contains(binding.tensor_parameter_name),
                 "Kernel '{}' references unknown TensorParameter '{}'",

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -218,6 +218,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         tensor_binding_sequence_entries.empty()) {
         content << "// No bindings for this kernel.\n";
     } else {
+        content << "#include \"internal/template_string.h\"\n";
         if (!dfb_entries.empty()) {
             content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
         }
@@ -264,6 +265,20 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
                     content << "constexpr DFBBindingToken " << name << "{" << id << "};\n";
                 }
             }
+
+            content << "template <::internal::TemplateString name>\n"
+                    << "constexpr const DFBBindingToken* get_binding_if_present() {\n";
+            const char* if_kw = "    if constexpr";
+            for (const auto& entry : dfb_entries) {
+                content << if_kw << " (name == \"" << entry.first << "\") {\n"
+                        << "        return &" << entry.first << ";\n";
+                if_kw = "    } else if constexpr";
+            }
+            content << "    } else {\n"
+                    << "        return nullptr;\n"
+                    << "    }\n";
+            content << "}\n";
+
             content << "}  // namespace dfb\n";
         }
 
@@ -327,7 +342,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             }
         }
 
-        if (!ta_entries.empty() || !tensor_binding_sequence_entries.empty()) {
+        if (!ta_entries.empty()) {
             // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
             // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
             // its implicit base-address CRTA.
@@ -343,10 +358,27 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
                         << "u, " << entry.addr_crta_offset << "u>;\n";
                 content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
             }
+
+            // return type is auto as individual binding tokens have different template parameters.
+            content << "template <::internal::TemplateString name>\n"
+                    << "constexpr auto get_binding_if_present() {\n";
+            const char* if_kw = "    if constexpr";
+            for (const auto& entry : ta_entries) {
+                content << if_kw << " (name == \"" << entry.name << "\") {\n"
+                        << "        return &" << entry.name << ";\n";
+                if_kw = "    } else if constexpr";
+            }
+            content << "    } else {\n"
+                    << "        return nullptr;\n"
+                    << "    }\n";
+
+            content << "}\n";
+
             for (const auto& sequence : tensor_binding_sequence_entries) {
                 content << fmt::format(
                     "constexpr auto {} = std::make_tuple({});\n", sequence.name, fmt::join(sequence.members, ", "));
             }
+
             content << "}  // namespace tensor\n";
         }
 
@@ -362,6 +394,20 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
                 content << "constexpr ScratchpadBindingToken " << entry.name << "{" << entry.addr_crta_word << "u, "
                         << entry.size_bytes << "u};\n";
             }
+
+            content << "template <::internal::TemplateString name>\n"
+                    << "constexpr const ScratchpadBindingToken* get_binding_if_present() {\n";
+            const char* if_kw = "    if constexpr";
+            for (const auto& entry : scratch_entries) {
+                content << if_kw << " (name == \"" << entry.name << "\") {\n"
+                        << "        return &" << entry.name << ";\n";
+                if_kw = "    } else if constexpr";
+            }
+            content << "    } else {\n"
+                    << "        return nullptr;\n"
+                    << "    }\n";
+            content << "}\n";
+
             content << "}  // namespace scratch\n";
         }
     }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -270,11 +270,14 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n";
 
-    // Binding-token headers are included even when a kernel has no bindings of that kind.
-    // get_token_if_present() is always emitted, and its absent path names the token type as
-    // the return type, so those types must be in scope for any Metal 2.0 kernel.
+    // Emit Includes:
+    // Support get_token_if_present() helper.
     content << "#include \"internal/template_string.h\"\n";
-    content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+
+    if (!dfb_entries.empty()) {
+        content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+    }
+
     if (!sem_entries.empty()) {
         // Defines SemaphoreBindingToken and SemScope. Header-only and dependency-free,
         // so it is safe on compute builds too.
@@ -287,12 +290,29 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         content << "#include \"api/dataflow/dataflow_api.h\"\n";
         content << "#endif\n";
     }
+
+    // This is included unconditionally for the `get_token_if_present()` helper, as it needs to see the full templated
+    // definition of TensorBindingToken.
     content << "#include \"api/tensor/tensor_binding_token.h\"\n";
-    content << "#include \"api/scratchpad.h\"\n";
+
+    if (!scratch_entries.empty()) {
+        content << "#include \"api/scratchpad.h\"\n";
+    }
+
     if (!tensor_binding_sequence_entries.empty()) {
         content << "#include <tuple>\n";
     }
     content << "\n";
+
+    // get_token_if_present() is always emitted. When this kernel has no DFB / scratchpad bindings,
+    // the headers that define those token types are omitted, but the empty getter still returns
+    // const BindingTokenType*{nullptr} and needs those types in scope.
+    if (dfb_entries.empty()) {
+        content << "struct DFBBindingToken;\n";
+    }
+    if (scratch_entries.empty()) {
+        content << "struct ScratchpadBindingToken;\n";
+    }
 
     // Emit DFB bindings
     content << "namespace dfb {\n";

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -275,9 +275,11 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     // the return type, so those types must be in scope for any Metal 2.0 kernel.
     content << "#include \"internal/template_string.h\"\n";
     content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
-    // Defines SemaphoreBindingToken and SemScope. Header-only and dependency-free,
-    // so it is safe on compute builds too.
-    content << "#include \"api/dataflow/semaphore_binding_token.h\"\n";
+    if (!sem_entries.empty()) {
+        // Defines SemaphoreBindingToken and SemScope. Header-only and dependency-free,
+        // so it is safe on compute builds too.
+        content << "#include \"api/dataflow/semaphore_binding_token.h\"\n";
+    }
     if (has_cached_sem) {
         // Include for the entry/exit stubs' bodies (get_semaphore + the MEM_ defines),
         // guarded exactly like those bodies (the pool is DM-only).
@@ -313,10 +315,6 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
 
     // Emit Semaphore bindings
     tt::tt_metal::emit_semaphore_binding_tokens(content, sem_entries);
-    content << "namespace sem {\n";
-    emit_programmatic_binding_token_getter(
-        content, sem_entries, "::SemaphoreBindingToken<0u, ::SemScope::LOCAL_NONATOMIC>");
-    content << "}  // namespace sem\n";
     if (has_cached_sem) {
         // Cached-pool entry/exit stubs. A cached semaphore's pool row must be seeded
         // with its init value once per program, by exactly one hart, before anyone

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -8,7 +8,6 @@
 #include "data_format.hpp"
 #include <algorithm>
 #include <cstdint>
-#include <span>
 #include <tt_backend_api_types.hpp>
 #include <cstddef>
 #include <cstring>
@@ -125,43 +124,54 @@ bool write_named_ct_arg_map_header(const string& out_dir, const JitBuildSettings
 }
 
 /**
- * Emit get_binding_if_present() helper for a given binding type.
+ * Emit get_token_if_present() helper for a given binding type.
  *
- * get_binding_if_present() is a helper function on the device side that performs lookup of the resource binding token
+ * get_token_if_present() is a helper function on the device side that performs lookup of the resource binding token
  * by name. The function returns a pointer to the binding token if found, otherwise nullptr.
  *
  * This is used by kernels to check if a binding is present when kernel is meant to be reusable across different
  * programs.
  */
 template <typename Entry>
-void emit_programatic_binding_token_getter(ostream& content, const vector<Entry>& entries) {
+void emit_programmatic_binding_token_getter(
+    ostream& content, const vector<Entry>& entries, string_view null_binding_type) {
     // Function header
     content << "template <::internal::TemplateString name>\n"
-            // Using auto to avoid pulling in includes when no bindings are emitted.
-            << "constexpr auto get_binding_if_present() {\n";
+            // Using auto here as the tokens could be templated differently depending on the name.
+            << "constexpr auto get_token_if_present() {\n";
+
+    // 4 space left pad.
+    string padding(4, ' ');
 
     // If statements for each entry, switching between `if constexpr` and `else if constexpr`
-    const char* if_kw = "    if constexpr";
+    const char* if_kw = "if constexpr";
     for (const auto& entry : entries) {
-        // Emits equivlanet to:
+        // Emits equivalent to:
         // if constexpr (name == "entry_name") {
         //     return &entry_name;
         // }
-        content << if_kw << " (name == \"" << entry.name << "\") {\n"
-                << "        return &" << entry.name << ";\n";
+        content << padding << if_kw << " (name == \"" << entry.name << "\") {\n"
+                << padding << padding << "return &" << entry.name << ";\n";
 
-        if_kw = "    } else if constexpr";
+        if_kw = "} else if constexpr";
     }
 
     // Emit "cannot find binding" case
+    //
+    // equivalent to:
+    // using null_token_ptr_t = const <null_binding_type>*;
+    // return null_token_ptr_t{nullptr};
     if (entries.empty()) {
-        content << "   return nullptr;\n";
+        content << padding << "using null_token_ptr_t = const " << null_binding_type << "*;\n"
+                << padding << "return null_token_ptr_t{nullptr};\n";
     } else {
-        content << "    } else {\n"
-                << "        return nullptr;\n"
-                << "    }\n";
+        content << padding << "} else {\n"
+                << padding << padding << "using null_token_ptr_t = const " << null_binding_type << "*;\n"
+                << padding << padding << "return null_token_ptr_t{nullptr};\n"
+                << padding << "}\n";
     }
 
+    // Function close
     content << "}\n";
 }
 
@@ -260,15 +270,14 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n";
 
+    // Binding-token headers are included even when a kernel has no bindings of that kind.
+    // get_token_if_present() is always emitted, and its absent path names the token type as
+    // the return type, so those types must be in scope for any Metal 2.0 kernel.
     content << "#include \"internal/template_string.h\"\n";
-    if (!dfb_entries.empty()) {
-        content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
-    }
-    if (!sem_entries.empty()) {
-        // Defines SemaphoreBindingToken and SemScope. Header-only and dependency-free,
-        // so it is safe on compute builds too.
-        content << "#include \"api/dataflow/semaphore_binding_token.h\"\n";
-    }
+    content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+    // Defines SemaphoreBindingToken and SemScope. Header-only and dependency-free,
+    // so it is safe on compute builds too.
+    content << "#include \"api/dataflow/semaphore_binding_token.h\"\n";
     if (has_cached_sem) {
         // Include for the entry/exit stubs' bodies (get_semaphore + the MEM_ defines),
         // guarded exactly like those bodies (the pool is DM-only).
@@ -276,18 +285,10 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         content << "#include \"api/dataflow/dataflow_api.h\"\n";
         content << "#endif\n";
     }
-    if (!ta_entries.empty()) {
-        // This header defines TensorBindingToken, a type which can be used
-        // to construct a TensorAccessor or LocalTensorAccessor.
-        content << "#include \"api/tensor/tensor_binding_token.h\"\n";
-    }
+    content << "#include \"api/tensor/tensor_binding_token.h\"\n";
+    content << "#include \"api/scratchpad.h\"\n";
     if (!tensor_binding_sequence_entries.empty()) {
         content << "#include <tuple>\n";
-    }
-    if (!scratch_entries.empty()) {
-        // The full Scratchpad type (NOC-free, so it compiles on both data-movement and
-        // compute/TRISC builds), which also pulls in the ScratchpadBindingToken type.
-        content << "#include \"api/scratchpad.h\"\n";
     }
     content << "\n";
 
@@ -307,13 +308,14 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             content << "constexpr DFBBindingToken " << entry.name << "{" << entry.id << "};\n";
         }
     }
-    emit_programatic_binding_token_getter(content, dfb_entries);
+    emit_programmatic_binding_token_getter(content, dfb_entries, "DFBBindingToken");
     content << "}  // namespace dfb\n";
 
     // Emit Semaphore bindings
     tt::tt_metal::emit_semaphore_binding_tokens(content, sem_entries);
     content << "namespace sem {\n";
-    emit_programatic_binding_token_getter(content, sem_entries);
+    emit_programmatic_binding_token_getter(
+        content, sem_entries, "::SemaphoreBindingToken<0u, ::SemScope::LOCAL_NONATOMIC>");
     content << "}  // namespace sem\n";
     if (has_cached_sem) {
         // Cached-pool entry/exit stubs. A cached semaphore's pool row must be seeded
@@ -388,7 +390,9 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
     }
 
-    emit_programatic_binding_token_getter(content, ta_entries);
+    // Unlike other binding token types, TensorBindingToken has meaningful template parameters associated with it.
+    // Thus, a dedicated type is needed to represent the absence of a binding.
+    emit_programmatic_binding_token_getter(content, ta_entries, "::tensor_accessor::NullTensorBindingToken");
 
     // Emit TensorBindingToken sequences
     for (const auto& sequence : tensor_binding_sequence_entries) {
@@ -412,7 +416,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
                 << entry.size_bytes << "u};\n";
     }
 
-    emit_programatic_binding_token_getter(content, scratch_entries);
+    emit_programmatic_binding_token_getter(content, scratch_entries, "ScratchpadBindingToken");
 
     content << "}  // namespace scratch\n";
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -8,13 +8,13 @@
 #include "data_format.hpp"
 #include <algorithm>
 #include <cstdint>
+#include <span>
 #include <tt_backend_api_types.hpp>
 #include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <functional>
 #include <iterator>
-#include <tuple>
 // Blaze-only experimental named args (removal tracked by issue #50953): <map>/<set> below
 #include <map>
 #include <set>
@@ -124,6 +124,47 @@ bool write_named_ct_arg_map_header(const string& out_dir, const JitBuildSettings
     return true;
 }
 
+/**
+ * Emit get_binding_if_present() helper for a given binding type.
+ *
+ * get_binding_if_present() is a helper function on the device side that performs lookup of the resource binding token
+ * by name. The function returns a pointer to the binding token if found, otherwise nullptr.
+ *
+ * This is used by kernels to check if a binding is present when kernel is meant to be reusable across different
+ * programs.
+ */
+template <typename Entry>
+void emit_programatic_binding_token_getter(ostream& content, const vector<Entry>& entries) {
+    // Function header
+    content << "template <::internal::TemplateString name>\n"
+            // Using auto to avoid pulling in includes when no bindings are emitted.
+            << "constexpr auto get_binding_if_present() {\n";
+
+    // If statements for each entry, switching between `if constexpr` and `else if constexpr`
+    const char* if_kw = "    if constexpr";
+    for (const auto& entry : entries) {
+        // Emits equivlanet to:
+        // if constexpr (name == "entry_name") {
+        //     return &entry_name;
+        // }
+        content << if_kw << " (name == \"" << entry.name << "\") {\n"
+                << "        return &" << entry.name << ";\n";
+
+        if_kw = "    } else if constexpr";
+    }
+
+    // Emit "cannot find binding" case
+    if (entries.empty()) {
+        content << "   return nullptr;\n";
+    } else {
+        content << "    } else {\n"
+                << "        return nullptr;\n"
+                << "    }\n";
+    }
+
+    content << "}\n";
+}
+
 // METAL 2.0 only:
 // This is only invoked for Metal 2.0 kernels created via the new ProgramSpec host APIs.
 // Legacy kernels (created via CreateKernel) do not get kernel_bindings_generated.h.
@@ -133,14 +174,18 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     // Get the DFB bindings from the settings callback
     // Sort them to ensure the file output is deterministic for the JIT build cache
     // (aka the on-disk per-object dephash cache)
-    vector<tuple<string, uint16_t, bool, uint8_t>> dfb_entries;
+    struct DfbEntry {
+        string name;
+        uint16_t id;
+        bool is_relay;
+        uint8_t prefetcher_pipe_id;
+    };
+    vector<DfbEntry> dfb_entries;
     settings.process_dataflow_buffer_binding_handles(
         [&dfb_entries](const string& name, uint16_t id, bool is_relay, uint8_t prefetcher_pipe_id) {
-            dfb_entries.emplace_back(name, id, is_relay, prefetcher_pipe_id);
+            dfb_entries.push_back({name, id, is_relay, prefetcher_pipe_id});
         });
-    sort(dfb_entries.begin(), dfb_entries.end(), [](const auto& a, const auto& b) {
-        return std::get<0>(a) < std::get<0>(b);
-    });
+    sort(dfb_entries.begin(), dfb_entries.end(), [](const auto& a, const auto& b) { return a.name < b.name; });
 
     // Get the semaphore bindings from the settings callback
     // Sort them to ensure the file output is deterministic, as explained above
@@ -214,203 +259,163 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     ostringstream content;
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n";
-    if (dfb_entries.empty() && sem_entries.empty() && ta_entries.empty() && scratch_entries.empty() &&
-        tensor_binding_sequence_entries.empty()) {
-        content << "// No bindings for this kernel.\n";
-    } else {
-        content << "#include \"internal/template_string.h\"\n";
-        if (!dfb_entries.empty()) {
-            content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
-        }
-        if (!sem_entries.empty()) {
-            // Defines SemaphoreBindingToken and SemScope. Header-only and dependency-free,
-            // so it is safe on compute builds too.
-            content << "#include \"api/dataflow/semaphore_binding_token.h\"\n";
-        }
-        if (has_cached_sem) {
-            // Include for the entry/exit stubs' bodies (get_semaphore + the MEM_ defines),
-            // guarded exactly like those bodies (the pool is DM-only).
-            content << "#if defined(ARCH_QUASAR) && !defined(COMPILE_FOR_TRISC)\n";
-            content << "#include \"api/dataflow/dataflow_api.h\"\n";
-            content << "#endif\n";
-        }
-        if (!ta_entries.empty()) {
-            // This header defines TensorBindingToken, a type which can be used
-            // to construct a TensorAccessor or LocalTensorAccessor.
-            content << "#include \"api/tensor/tensor_binding_token.h\"\n";
-        }
-        if (!tensor_binding_sequence_entries.empty()) {
-            content << "#include <tuple>\n";
-        }
-        if (!scratch_entries.empty()) {
-            // The full Scratchpad type (NOC-free, so it compiles on both data-movement and
-            // compute/TRISC builds), which also pulls in the ScratchpadBindingToken type.
-            content << "#include \"api/scratchpad.h\"\n";
-        }
-        content << "\n";
 
-        if (!dfb_entries.empty()) {
-            content << "namespace dfb {\n";
-            for (const auto& [name, id, is_relay, prefetcher_pipe_id] : dfb_entries) {
-                if (is_relay) {
-                    // PrefetcherPipe relays bake the persistent slot into the token so the TRISC
-                    // constructor can O(1)-align to the durable checkpoint; CrossNode relays
-                    // use the single-arg form (NO_PREFETCHER_PIPE default, no align needed).
-                    content << "constexpr RelayDFBBindingToken " << name << "{" << id;
-                    if (prefetcher_pipe_id != 0xFF) {
-                        content << ", " << static_cast<uint32_t>(prefetcher_pipe_id);
-                    }
-                    content << "};\n";
-                } else {
-                    content << "constexpr DFBBindingToken " << name << "{" << id << "};\n";
-                }
+    content << "#include \"internal/template_string.h\"\n";
+    if (!dfb_entries.empty()) {
+        content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+    }
+    if (!sem_entries.empty()) {
+        // Defines SemaphoreBindingToken and SemScope. Header-only and dependency-free,
+        // so it is safe on compute builds too.
+        content << "#include \"api/dataflow/semaphore_binding_token.h\"\n";
+    }
+    if (has_cached_sem) {
+        // Include for the entry/exit stubs' bodies (get_semaphore + the MEM_ defines),
+        // guarded exactly like those bodies (the pool is DM-only).
+        content << "#if defined(ARCH_QUASAR) && !defined(COMPILE_FOR_TRISC)\n";
+        content << "#include \"api/dataflow/dataflow_api.h\"\n";
+        content << "#endif\n";
+    }
+    if (!ta_entries.empty()) {
+        // This header defines TensorBindingToken, a type which can be used
+        // to construct a TensorAccessor or LocalTensorAccessor.
+        content << "#include \"api/tensor/tensor_binding_token.h\"\n";
+    }
+    if (!tensor_binding_sequence_entries.empty()) {
+        content << "#include <tuple>\n";
+    }
+    if (!scratch_entries.empty()) {
+        // The full Scratchpad type (NOC-free, so it compiles on both data-movement and
+        // compute/TRISC builds), which also pulls in the ScratchpadBindingToken type.
+        content << "#include \"api/scratchpad.h\"\n";
+    }
+    content << "\n";
+
+    // Emit DFB bindings
+    content << "namespace dfb {\n";
+    for (const auto& entry : dfb_entries) {
+        if (entry.is_relay) {
+            // PrefetcherPipe relays bake the persistent slot into the token so the TRISC
+            // constructor can O(1)-align to the durable checkpoint; CrossNode relays
+            // use the single-arg form (NO_PREFETCHER_PIPE default, no align needed).
+            content << "constexpr RelayDFBBindingToken " << entry.name << "{" << entry.id;
+            if (entry.prefetcher_pipe_id != 0xFF) {
+                content << ", " << static_cast<uint32_t>(entry.prefetcher_pipe_id);
             }
-
-            content << "template <::internal::TemplateString name>\n"
-                    << "constexpr const DFBBindingToken* get_binding_if_present() {\n";
-            const char* if_kw = "    if constexpr";
-            for (const auto& entry : dfb_entries) {
-                content << if_kw << " (name == \"" << entry.first << "\") {\n"
-                        << "        return &" << entry.first << ";\n";
-                if_kw = "    } else if constexpr";
-            }
-            content << "    } else {\n"
-                    << "        return nullptr;\n"
-                    << "    }\n";
-            content << "}\n";
-
-            content << "}  // namespace dfb\n";
-        }
-
-        if (!sem_entries.empty()) {
-            tt::tt_metal::emit_semaphore_binding_tokens(content, sem_entries);
-            if (has_cached_sem) {
-                // Cached-pool entry/exit stubs. A cached semaphore's pool row must be seeded
-                // with its init value once per program, by exactly one hart, before anyone
-                // touches it, and is left clean for the next program. Each 8B row is [0] = the
-                // counter, [1] = a bookkeeping word: entered[15:0], exited[30:16], seeded[31]
-                // On entry, each binder hart increments `entered`; whoever got there first
-                // copies the init value from the ring into the pool counter and sets `seeded`;
-                // everyone else waits for that bit. On exit, each hart increments `exited`;
-                // the last one zeroes the bookkeeping word so the next program starts fresh.
-                // Any number of local kernels/threads works.
-                content << "#define TT_DM_CACHED_SEM_STUBS 1\n";
-                content << "namespace sem_internal {\n";
-                content << "inline void init_dm_local_cached() {\n";
-                content << "#if defined(ARCH_QUASAR) && !defined(COMPILE_FOR_TRISC)\n";
-                for (const auto& entry : sem_entries) {
-                    if (entry.scope != SemScope::DM_LOCAL_CACHED) {
-                        continue;
-                    }
-                    content << "    {\n";
-                    content << "        auto* row = reinterpret_cast<uint32_t*>("
-                            << "static_cast<uintptr_t>(MEM_DM_CACHED_SEM_BASE) + " << entry.id
-                            << "u * MEM_DM_CACHED_SEM_ROW);\n";
-                    content << "        if ((__atomic_fetch_add(row + 1, 1u, __ATOMIC_ACQ_REL) & 0xFFFFu) == 0u) {\n";
-                    content << "            row[0] = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>("
-                            << "::get_semaphore(" << entry.id << "u) + MEM_L1_UNCACHED_BASE);\n";
-                    content << "            __atomic_fetch_or(row + 1, 0x80000000u, __ATOMIC_RELEASE);\n";
-                    content << "        } else {\n";
-                    content
-                        << "            while ((__atomic_load_n(row + 1, __ATOMIC_ACQUIRE) & 0x80000000u) == 0u) {\n";
-                    content << "            }\n";
-                    content << "        }\n";
-                    content << "    }\n";
-                }
-                content << "#endif\n";
-                content << "}\n";
-                content << "inline void finish_dm_local_cached() {\n";
-                content << "#if defined(ARCH_QUASAR) && !defined(COMPILE_FOR_TRISC)\n";
-                for (const auto& entry : sem_entries) {
-                    if (entry.scope != SemScope::DM_LOCAL_CACHED) {
-                        continue;
-                    }
-                    content << "    {\n";
-                    content << "        auto* row = reinterpret_cast<uint32_t*>("
-                            << "static_cast<uintptr_t>(MEM_DM_CACHED_SEM_BASE) + " << entry.id
-                            << "u * MEM_DM_CACHED_SEM_ROW);\n";
-                    content << "        if (((__atomic_fetch_add(row + 1, 0x10000u, __ATOMIC_ACQ_REL) >> 16) & "
-                               "0x7FFFu) == "
-                            << entry.total_binder_harts << "u - 1u) {\n";
-                    content << "            __atomic_store_n(row + 1, 0u, __ATOMIC_RELEASE);\n";
-                    content << "        }\n";
-                    content << "    }\n";
-                }
-                content << "#endif\n";
-                content << "}\n";
-                content << "}  // namespace sem_internal\n";
-            }
-        }
-
-        if (!ta_entries.empty()) {
-            // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
-            // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
-            // its implicit base-address CRTA.
-            // The kernel-side TensorAccessor (or LocalTensorAccessor) constructor unpacks both pieces.
-            //
-            // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
-            // template with extra metadata in the future without touching kernel source.
-            //
-            // Tensor binding sequences are constexpr std::tuple of those member tokens (members order).
-            content << "namespace tensor {\n";
-            for (const auto& entry : ta_entries) {
-                content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset
-                        << "u, " << entry.addr_crta_offset << "u>;\n";
-                content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
-            }
-
-            // return type is auto as individual binding tokens have different template parameters.
-            content << "template <::internal::TemplateString name>\n"
-                    << "constexpr auto get_binding_if_present() {\n";
-            const char* if_kw = "    if constexpr";
-            for (const auto& entry : ta_entries) {
-                content << if_kw << " (name == \"" << entry.name << "\") {\n"
-                        << "        return &" << entry.name << ";\n";
-                if_kw = "    } else if constexpr";
-            }
-            content << "    } else {\n"
-                    << "        return nullptr;\n"
-                    << "    }\n";
-
-            content << "}\n";
-
-            for (const auto& sequence : tensor_binding_sequence_entries) {
-                content << fmt::format(
-                    "constexpr auto {} = std::make_tuple({});\n", sequence.name, fmt::join(sequence.members, ", "));
-            }
-
-            content << "}  // namespace tensor\n";
-        }
-
-        if (!scratch_entries.empty()) {
-            // ScratchpadBindingToken scratchpad_accessor_name{ADDR_CRTA_WORD, SIZE_BYTES}
-            // Carries the word index of the scratchpad's (framework-allocated) base-address CRTA
-            // and the scratchpad's compile-time per-node size.
-            // The kernel-side Scratchpad(token) constructor unpacks both.
-            // The token's members are opaque, so the framework can extend it later without touching
-            // kernel source.
-            content << "namespace scratch {\n";
-            for (const auto& entry : scratch_entries) {
-                content << "constexpr ScratchpadBindingToken " << entry.name << "{" << entry.addr_crta_word << "u, "
-                        << entry.size_bytes << "u};\n";
-            }
-
-            content << "template <::internal::TemplateString name>\n"
-                    << "constexpr const ScratchpadBindingToken* get_binding_if_present() {\n";
-            const char* if_kw = "    if constexpr";
-            for (const auto& entry : scratch_entries) {
-                content << if_kw << " (name == \"" << entry.name << "\") {\n"
-                        << "        return &" << entry.name << ";\n";
-                if_kw = "    } else if constexpr";
-            }
-            content << "    } else {\n"
-                    << "        return nullptr;\n"
-                    << "    }\n";
-            content << "}\n";
-
-            content << "}  // namespace scratch\n";
+            content << "};\n";
+        } else {
+            content << "constexpr DFBBindingToken " << entry.name << "{" << entry.id << "};\n";
         }
     }
+    emit_programatic_binding_token_getter(content, dfb_entries);
+    content << "}  // namespace dfb\n";
+
+    // Emit Semaphore bindings
+    tt::tt_metal::emit_semaphore_binding_tokens(content, sem_entries);
+    content << "namespace sem {\n";
+    emit_programatic_binding_token_getter(content, sem_entries);
+    content << "}  // namespace sem\n";
+    if (has_cached_sem) {
+        // Cached-pool entry/exit stubs. A cached semaphore's pool row must be seeded
+        // with its init value once per program, by exactly one hart, before anyone
+        // touches it, and is left clean for the next program. Each 8B row is [0] = the
+        // counter, [1] = a bookkeeping word: entered[15:0], exited[30:16], seeded[31]
+        // On entry, each binder hart increments `entered`; whoever got there first
+        // copies the init value from the ring into the pool counter and sets `seeded`;
+        // everyone else waits for that bit. On exit, each hart increments `exited`;
+        // the last one zeroes the bookkeeping word so the next program starts fresh.
+        // Any number of local kernels/threads works.
+        content << "#define TT_DM_CACHED_SEM_STUBS 1\n";
+        content << "namespace sem_internal {\n";
+        content << "inline void init_dm_local_cached() {\n";
+        content << "#if defined(ARCH_QUASAR) && !defined(COMPILE_FOR_TRISC)\n";
+        for (const auto& entry : sem_entries) {
+            if (entry.scope != SemScope::DM_LOCAL_CACHED) {
+                continue;
+            }
+            content << "    {\n";
+            content << "        auto* row = reinterpret_cast<uint32_t*>("
+                    << "static_cast<uintptr_t>(MEM_DM_CACHED_SEM_BASE) + " << entry.id
+                    << "u * MEM_DM_CACHED_SEM_ROW);\n";
+            content << "        if ((__atomic_fetch_add(row + 1, 1u, __ATOMIC_ACQ_REL) & 0xFFFFu) == 0u) {\n";
+            content << "            row[0] = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>("
+                    << "::get_semaphore(" << entry.id << "u) + MEM_L1_UNCACHED_BASE);\n";
+            content << "            __atomic_fetch_or(row + 1, 0x80000000u, __ATOMIC_RELEASE);\n";
+            content << "        } else {\n";
+            content << "            while ((__atomic_load_n(row + 1, __ATOMIC_ACQUIRE) & 0x80000000u) == 0u) {\n";
+            content << "            }\n";
+            content << "        }\n";
+            content << "    }\n";
+        }
+        content << "#endif\n";
+        content << "}\n";
+        content << "inline void finish_dm_local_cached() {\n";
+        content << "#if defined(ARCH_QUASAR) && !defined(COMPILE_FOR_TRISC)\n";
+        for (const auto& entry : sem_entries) {
+            if (entry.scope != SemScope::DM_LOCAL_CACHED) {
+                continue;
+            }
+            content << "    {\n";
+            content << "        auto* row = reinterpret_cast<uint32_t*>("
+                    << "static_cast<uintptr_t>(MEM_DM_CACHED_SEM_BASE) + " << entry.id
+                    << "u * MEM_DM_CACHED_SEM_ROW);\n";
+            content << "        if (((__atomic_fetch_add(row + 1, 0x10000u, __ATOMIC_ACQ_REL) >> 16) & "
+                       "0x7FFFu) == "
+                    << entry.total_binder_harts << "u - 1u) {\n";
+            content << "            __atomic_store_n(row + 1, 0u, __ATOMIC_RELEASE);\n";
+            content << "        }\n";
+            content << "    }\n";
+        }
+        content << "#endif\n";
+        content << "}\n";
+        content << "}  // namespace sem_internal\n";
+    }
+
+    // Emit Tensor bindings
+    content << "namespace tensor {\n";
+    // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
+    // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
+    // its implicit base-address CRTA.
+    // The kernel-side TensorAccessor (or LocalTensorAccessor) constructor unpacks both pieces.
+    //
+    // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
+    // template with extra metadata in the future without touching kernel source.
+    //
+    // Tensor binding sequences are constexpr std::tuple of those member tokens (members order).
+    for (const auto& entry : ta_entries) {
+        content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset << "u, "
+                << entry.addr_crta_offset << "u>;\n";
+        content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
+    }
+
+    emit_programatic_binding_token_getter(content, ta_entries);
+
+    // Emit TensorBindingToken sequences
+    for (const auto& sequence : tensor_binding_sequence_entries) {
+        content << fmt::format(
+            "constexpr auto {} = std::make_tuple({});\n", sequence.name, fmt::join(sequence.members, ", "));
+    }
+
+    content << "}  // namespace tensor\n";
+
+    // Emit Scratchpad bindings
+    content << "namespace scratch {\n";
+
+    // ScratchpadBindingToken scratchpad_accessor_name{ADDR_CRTA_WORD, SIZE_BYTES}
+    // Carries the word index of the scratchpad's (framework-allocated) base-address CRTA
+    // and the scratchpad's compile-time per-node size.
+    // The kernel-side Scratchpad(token) constructor unpacks both.
+    // The token's members are opaque, so the framework can extend it later without touching
+    // kernel source.
+    for (const auto& entry : scratch_entries) {
+        content << "constexpr ScratchpadBindingToken " << entry.name << "{" << entry.addr_crta_word << "u, "
+                << entry.size_bytes << "u};\n";
+    }
+
+    emit_programatic_binding_token_getter(content, scratch_entries);
+
+    content << "}  // namespace scratch\n";
+
     write_file(path, content.str());
 }
 


### PR DESCRIPTION
## PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

## Summary
For background of the "why" of this feature (and alternative approaches considered), see https://github.com/tenstorrent/tt-metal/issues/55114.

**Goal**: Allow Metal 2.0 kernels to _safely_ interact with conditionally-bound `Program` resources (`DataflowBuffer`s, `TensorAccessor`s, etc), and to do so using `if constexpr` expressions rather than preprocessor `ifdef`s. 

In the legacy Metal API, the following syntax was legal:

```
CircularBuffer my_cb(cb_index::cb0); // whether or not cb0 is declared in the host code

// Idea: The op correct sets my_cond_CTA to "false" if the cb0 resource was never allocated:
if constexpr my_cond_CTA {
   my_cb.push_back(my_data);
}

// But... if cb0 is unallocated, the following results in undefined behavior. 
// No checks (static or runtime) will catch it:
my_cb.push_back(my_other_data); //oops
``` 

This PR adds a device-side programatic lookup API for Metal 2.0 resource bindings. This enables the desired kernel syntax, while retaining safety checks.

**Solution**: The PR adds the following helper functions. Each one returns:
 - a pointer to the named resource token, if one exists, OR
 - nullptr

```cpp
namespace dfb {
  template<char* binding_name>
  constexpr const DFBBindingToken* get_token_if_present();
};

namespace tensor {
  template<char* binding_name>
  constexpr const auto * get_token_if_present()  /* -> TensorBindingToken<...> */;
};

namespace scratchpad {
  template<char* binding_name>
  constexpr const ScratchpadBindingToken* get_token_if_present();
};
```
------

## Usage example

Previous to this PR, the only way to handle conditionally bound resources in a Metal 2.0 kernel was via `#ifdef`s:
```cpp
// Normal is always present as a resource
DataflowBuffer dfb_normal(dfb::normal);

// Bias is an optional resource and is currently guarded by pre-processor directive
#ifdef BIAS_EXIST
DataflowBuffer dfb_bias(dfb::bias);
#endif

dfb_normal./* ... */;

#ifdef BIAS_EXIST
dfb_bias./* ... */;
#endif
```

After this PR, the kernel code can get the resource programmatically:
```cpp
// The binding's presence is the condition (matching CTA not required)
const DFBBindingToken* bias_token = dfb::get_token_if_present<"bias">();

std::optional<DataflowBuffer> dfb_bias;
if (bias_token != nullptr) {
    dfb_bias.emplace(*bias_token);
}

// ... later ...
if(dfb_bias) {
    dfb_bias->push_back(/* ... */);
}
```

### Notes for reviewers
Note that the original Metal 2.0 `#ifdef` solution reduces the kernel binary size versus programming retrieval. It should be preferredin any situation where the kernel binary size impacts performance.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/optional_token_getter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/optional_token_getter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/optional_token_getter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/optional_token_getter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/optional_token_getter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/optional_token_getter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/optional_token_getter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/optional_token_getter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/optional_token_getter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/optional_token_getter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/optional_token_getter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/optional_token_getter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/optional_token_getter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/optional_token_getter)