### PR TITLE
[Feature] Support zeroing APIs under V1 NOC APIs

### DIFF
--- a/tt_metal/hw/inc/api/core_local_mem.h
+++ b/tt_metal/hw/inc/api/core_local_mem.h
@@ -199,12 +199,10 @@ struct noc_traits_t<CoreLocalMem<T, AddressType>> {
 
 template <typename T, typename AddressType>
 inline constexpr bool noc_zero_l1_endpoint_v<CoreLocalMem<T, AddressType>> = true;
-#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
+#ifdef ARCH_QUASAR
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#elif !defined(ARCH_QUASAR)
+#else
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
-#if !defined(ARCH_QUASAR) || !defined(NOC_API_V1)
 #include "internal/noc_zero_dram.inl"
-#endif
 #endif  // !defined(COMPILE_FOR_TRISC)

--- a/tt_metal/hw/inc/api/dataflow/circular_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/circular_buffer.h
@@ -258,13 +258,11 @@ private:
 template <>
 inline constexpr bool noc_zero_l1_endpoint_v<CircularBuffer> = true;
 
-#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
+#ifdef ARCH_QUASAR
 #include "internal/tt-2xx/noc_zero_l1.inl"
 #else
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
-#if !defined(ARCH_QUASAR) || !defined(NOC_API_V1)
 #include "internal/noc_zero_dram.inl"
-#endif
 
 #endif  // !COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -488,19 +488,17 @@ inline constexpr bool noc_zero_l1_endpoint_v<DataflowBuffer> = true;
 #endif
 
 // Arch-specific _impl bodies for DataflowBuffer member functions
-#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
+#ifdef ARCH_QUASAR
 #include "internal/tt-2xx/dataflow_buffer.inl"
 #else
 #include "internal/tt-1xx/dataflow_buffer.inl"
 #endif
 
 #ifndef COMPILE_FOR_TRISC
-#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
+#ifdef ARCH_QUASAR
 #include "internal/tt-2xx/noc_zero_l1.inl"
 #else
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
-#if !defined(ARCH_QUASAR) || !defined(NOC_API_V1)
 #include "internal/noc_zero_dram.inl"
-#endif
 #endif

--- a/tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl
@@ -4,14 +4,22 @@
 
 #pragma once
 
-// Single iDMA zero-device transaction with the full cmdbuf sequence
-// spelled out, plus the matching write_zeros_l1_barrier (iDMA ack spin).
-// No cache invalidate is needed here: zeroed buffers are assumed not resident
+// Quasar L1 zeroing and its barrier, in two flavours picked by the NOC API version:
+//
+//   NOC_API_V2 : single iDMA zero-device transaction with the full cmdbuf sequence spelled out,
+//                plus the matching write_zeros_l1_barrier (iDMA ack spin).
+//   NOC_API_V1 : naive RISC store loop through the uncached L1 alias; the barrier is just a fence.
+//                For NOC_API_V1 compatibility only, not intended for production use.
+//
+// No cache invalidate is needed in either path: zeroed buffers are assumed not resident
 // in the DM core's cache. Access to a buffer should be bracketed by lock/unlock
 // (unlock will be responsible for cache eviction). Zeroing a locked buffer
 // should be flagged by the NOC transaction debug tool -- see TODO below.
 
+
+#if defined(NOC_API_V2)
 #include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
+#endif
 #include "internal/tt-2xx/quasar/noc_nonblocking_api.h"
 #include "internal/debug/noc_zero_guard.h"
 
@@ -28,6 +36,7 @@ inline void Noc::async_write_zeros(const Dst& dst, uint32_t size_bytes, const ds
     const uint32_t local_addr = static_cast<uint32_t>(get_dst_ptr<AddressType::LOCAL_L1>(dst, args));
     DEBUG_SANITIZE_L1_ADDR(local_addr, size_bytes);
 
+#if defined(NOC_API_V2)
     // Engage the Quasar iDMA zero device (Overlay Spec §4.12). The zero mode is
     // a HW overlay on top of the iDMA copy path: same MISC.idma_en + MISC.write_trans
     // setup as iDMA copy, but with AXI_OPT_1.src_protocol = 4 and decouple_aw = 1. The
@@ -73,12 +82,34 @@ inline void Noc::async_write_zeros(const Dst& dst, uint32_t size_bytes, const ds
     // wired up here yet: the RECORD_NOC_EVENT_WITH_ADDR machinery is currently only enabled for
     // COMPILE_FOR_NCRISC/BRISC, not Quasar's COMPILE_FOR_DM.
 
+#else
+    // The iDMA zeroing machine bypasses the cache and writes directly to TL1. Use the uncached address
+    // range to match that behavior.
+    uintptr_t addr = static_cast<uintptr_t>(local_addr) + MEM_L1_UNCACHED_BASE;
+
+    // Byte head to reach 8B alignment, 8B body, byte tail. Quasar L1 takes byte-granular stores, so
+    // the caller needs no alignment -- same contract as the v2 iDMA path.
+    uint32_t remaining = size_bytes;
+    for (; remaining > 0 && (addr & (sizeof(uint64_t) - 1)) != 0; ++addr, --remaining) {
+        *reinterpret_cast<volatile uint8_t*>(addr) = 0;
+    }
+    for (; remaining >= sizeof(uint64_t); addr += sizeof(uint64_t), remaining -= sizeof(uint64_t)) {
+        *reinterpret_cast<volatile uint64_t*>(addr) = 0;
+    }
+    for (; remaining > 0; ++addr, --remaining) {
+        *reinterpret_cast<volatile uint8_t*>(addr) = 0;
+    }
+#endif
+
     // WATCHER: mark cmd buffer 0 borrowed for zeroing; write_zeros_l1_barrier() clears it. Lets
     // watcher builds catch any NoC write issued before the barrier (the zero->barrier->reuse rule).
+    // Under v1 no cmd buffer is borrowed and there is no such hazard, but the guard is armed all
+    // the same so the rule is enforced identically and kernels stay portable between versions.
     NOC_ZERO_MODE_ENTER();
 }
 
 inline void Noc::write_zeros_l1_barrier() const {
+#if defined(NOC_API_V2)
     // TODO: this barrier should record a NOC-debug event so the tool can flag a missing
     // write_zeros_l1_barrier (use-before-flush), the way read/write barriers do.
     while (!overlay::idma_acked_cmdbuf_0()) {
@@ -94,5 +125,8 @@ inline void Noc::write_zeros_l1_barrier() const {
     // TODO: Quasar has architecture different enough that we may want to get out of using
     // noc_nonblocking_api. Refactor this when we move away from it.
     init_wr_cmd_buf(noc_local_xy());
+#else
+    __asm__ __volatile__("fence" ::: "memory");
+#endif
     NOC_ZERO_MODE_EXIT();  // cmd buffer 0 restored; NoC writes are safe again
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl
@@ -16,8 +16,7 @@
 // (unlock will be responsible for cache eviction). Zeroing a locked buffer
 // should be flagged by the NOC transaction debug tool -- see TODO below.
 
-
-#if defined(NOC_API_V2)
+#if !defined(NOC_API_V1)
 #include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
 #endif
 #include "internal/tt-2xx/quasar/noc_nonblocking_api.h"
@@ -36,7 +35,7 @@ inline void Noc::async_write_zeros(const Dst& dst, uint32_t size_bytes, const ds
     const uint32_t local_addr = static_cast<uint32_t>(get_dst_ptr<AddressType::LOCAL_L1>(dst, args));
     DEBUG_SANITIZE_L1_ADDR(local_addr, size_bytes);
 
-#if defined(NOC_API_V2)
+#if !defined(NOC_API_V1)
     // Engage the Quasar iDMA zero device (Overlay Spec §4.12). The zero mode is
     // a HW overlay on top of the iDMA copy path: same MISC.idma_en + MISC.write_trans
     // setup as iDMA copy, but with AXI_OPT_1.src_protocol = 4 and decouple_aw = 1. The
@@ -109,7 +108,7 @@ inline void Noc::async_write_zeros(const Dst& dst, uint32_t size_bytes, const ds
 }
 
 inline void Noc::write_zeros_l1_barrier() const {
-#if defined(NOC_API_V2)
+#if !defined(NOC_API_V1)
     // TODO: this barrier should record a NOC-debug event so the tool can flag a missing
     // write_zeros_l1_barrier (use-before-flush), the way read/write barriers do.
     while (!overlay::idma_acked_cmdbuf_0()) {


### PR DESCRIPTION
### PR Category
Feature

### Summary
Currently the zeroing API uses the iDMA engine and NOC command buffers, which only works with NOC_API_V2. `tt-sim` won't support the v2 NOC API for quite some time, so this PR adds a v1 NOC API compatible implementation to remove the block. The implementation is a naive store loop, with the barrier reduced to a fence. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/zero-noc-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/zero-noc-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/zero-noc-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/zero-noc-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/zero-noc-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/zero-noc-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/zero-noc-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/zero-noc-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/zero-noc-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/zero-noc-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/zero-noc-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/zero-noc-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/zero-noc-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/zero-noc-v1)