### PR TITLE
[LLK][Bug fix] Drain the math pipeline in the Dest->Src bank waits (WH + BH); pipeline the dummy publications

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
@@ -117,8 +117,7 @@ inline void _configure_preserve_zero_flag_state_()
 inline void _configure_copy_zero_flag_state_(const std::uint32_t src_dst_format)
 {
     const std::uint32_t fmt = src_dst_format & 0x1F;
-    const bool flush_fp8 =
-        (fmt == static_cast<std::uint32_t>(DataFormat::Fp8_e4m3)) || (fmt == static_cast<std::uint32_t>(DataFormat::Lf8));
+    const bool flush_fp8    = (fmt == static_cast<std::uint32_t>(DataFormat::Fp8_e4m3)) || (fmt == static_cast<std::uint32_t>(DataFormat::Lf8));
     _configure_src_zero_flag_(!flush_fp8);
 }
 
@@ -178,7 +177,7 @@ inline void move_d2a_row_broadcast_fixed_face(const std::uint8_t addrmod)
 {
     // MOVD2A does not auto-wait for SrcA[MatrixUnit.SrcABank].AllowedClient == MatrixUnit, so gate on SRCA_VLD
     // before the row moves (mirrors move_d2b_fixed_face's SRCB_VLD wait). See llk_math_transpose_dest.h. tt-llk#1664.
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
     // // Seems to make things 200 clocks slower. Really shouldn't though.
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, addrmod, p_movd2a::MOV_1_ROW, 0);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 1, addrmod, p_movd2a::MOV_1_ROW, 0);
@@ -209,11 +208,11 @@ inline void wait_bank_valid()
 {
     if constexpr (SrcReg == Srcs::SrcA)
     {
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
     }
     else
     {
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD);
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_custom_mm_reuse_dest_srcb.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_custom_mm_reuse_dest_srcb.h
@@ -139,7 +139,7 @@ inline void _llk_math_custom_mm_reuse_dest_srcb_(
         "custom_mm_reuse_dest_srcb: in0 tile height must be 1, 2, 4 or 8");
 
     const std::uint32_t dest_buffer_base = get_dest_buffer_base();
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD | p_stall::WAIT_SFPU);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     for (std::uint32_t i = 0; i < kt_dim; i++)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_face_compressed_mm.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_face_compressed_mm.h
@@ -460,7 +460,7 @@ inline void _llk_math_face_compressed_mm_(
         // Merge each face's split partial into its accumulation.
         constexpr std::int16_t partial = _llk_math_face_compressed_mm_split_acc_partial_rows_;
 
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD | p_stall::SRCB_VLD); // wait for both operands
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD | p_stall::SRCB_VLD); // wait for both operands
         // Move both partials into SrcB, face 0 at row 0 and face 1 at row 8.
         // ADDR_MOD_0 advances dest by one face between the two, and ADDR_MOD_2 resets it afterwards.
         TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_0, p_movd2b::MOV_4_ROWS, partial);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_generalized_moe_gate_transpose_dest_single_face.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_generalized_moe_gate_transpose_dest_single_face.h
@@ -218,7 +218,7 @@ inline void _llk_math_generalized_moe_gate_copy4rows_()
 {
     static_assert(!(is_32bit || is_fp32_dest_acc_en), "32-bit / fp32 dest accum not supported");
     math::reset_counters(p_setrwc::SET_ABD_F);
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
     ckernel_template::run();
 }
 
@@ -234,7 +234,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi_(
 {
     static_assert(!(is_32bit || is_fp32_dest_acc_en), "32-bit and fp32 dest accum enable are not supported for single face transpose");
     math::reset_counters(p_setrwc::SET_ABD_F);
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
     ckernel_template::run();
 }
 
@@ -245,7 +245,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step0_()
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -262,7 +262,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step1_()
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -279,7 +279,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step2_()
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     ckernel_template::run();
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
@@ -73,8 +73,8 @@ inline void rmsnorm_bcast_scalar_reuse_dest_as_src()
 {
     TTI_STALLWAIT(
         p_stall::STALL_MATH,
-        p_stall::WAIT_SFPU | p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy
-                                                 // data_valid, so we want to wait on that
+        p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy
+                                                                 // data_valid, so we want to wait on that
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_1_ROW, 0);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_sdpa_bcast_col_srca_srcb_reuse.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_sdpa_bcast_col_srca_srcb_reuse.h
@@ -69,8 +69,8 @@ inline void _llk_math_sdpa_bcast_col_srca_srcb_reuse_preamble_(std::uint32_t isr
 {
     TTI_STALLWAIT(
         p_stall::STALL_MATH,
-        p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy
-                                                                     // data_valid, so we want to wait on that
+        p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCA_VLD | p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy
+                                                                                     // data_valid, so we want to wait on that
     std::uint32_t src_index = isrc + get_dest_buffer_base();
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, src_index);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_sdpa_bcast_col_srcb_reuse.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_sdpa_bcast_col_srcb_reuse.h
@@ -64,8 +64,8 @@ inline void _llk_math_sdpa_bcast_col_srcb_reuse_preamble_()
 {
     TTI_STALLWAIT(
         p_stall::STALL_MATH,
-        p_stall::WAIT_SFPU | p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy
-                                                 // data_valid, so we want to wait on that
+        p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy
+                                                                 // data_valid, so we want to wait on that
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(0);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_sdpa_custom_mm_reuse_dest_srcb.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_sdpa_custom_mm_reuse_dest_srcb.h
@@ -122,7 +122,7 @@ inline void _llk_math_sdpa_custom_mm_reuse_dest_srcb_(
     static_assert(input_granularity >= 1, "input_granularity must be >= 1");
     constexpr std::uint32_t SFPU_FPU = ckernel::semaphore::UNPACK_MATH_DONE;
     std::uint32_t dest_buffer_base   = get_dest_buffer_base();
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
     for (std::uint32_t i = 0; i < kt_dim; i++)
     {
         TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, src_index + i * 8 * 2 + dest_buffer_base);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_rmsnorm.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_rmsnorm.h
@@ -51,12 +51,12 @@ inline void _llk_unpack_A_rmsnorm_mop_config_(
         1); // ch0/ch1 z_inc
     static constexpr std::uint32_t unpack_srca_to_dest_transpose_of_faces =
         TT_OP_UNPACR(SrcA, 0b00010010, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch1_z+=1, ch0_z+=2
-    static constexpr std::uint32_t unpack_srca_set_dvalid = TT_OP_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    static constexpr std::uint32_t unpack_srca_set_dvalid = TT_OP_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
     static constexpr std::uint32_t unpack_srcb =
         TT_OP_UNPACR(SrcB, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr std::uint32_t unpack_srcb_inc_z_0 =
         TT_OP_UNPACR(SrcB, 0b0 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    static constexpr std::uint32_t unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    static constexpr std::uint32_t unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
     static constexpr std::uint32_t srca_set_z_1           = TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001); // set srcA ch0_z = 1
     static constexpr std::uint32_t srcb_set_z_2           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 2, 0b0001); // set srcB ch0_z = 2
     static constexpr std::uint32_t srcb_clear_z           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0001); // set srcB ch0_z = 0

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_sdpa.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_sdpa.h
@@ -83,12 +83,15 @@ inline void _llk_unpack_A_sdpa_init_(
 inline void _llk_unpack_A_sdpa_set_srcb_dummy_valid_()
 {
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK);
-    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    // Stall_Clr_Cntrl=1 so the publication waits on the bank it clears.
+    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
 }
 
 inline void _llk_unpack_A_sdpa_set_srca_srcb_dummy_valid_()
 {
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK);
-    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    // Stall_Clr_Cntrl=1 on each: per-instruction, so the SrcB publication flipping the
+    // unpacker's bank pointer cannot leave the SrcA publication relying on a stale gate.
+    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -176,7 +176,7 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
     // for SrcA[MatrixUnit.SrcABank].AllowedClient == SrcClient::MatrixUnit.
     // Wait condition SRCB_VLD is required as MOVD2B doesn't automatically wait
     // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit.
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
 
     // Both paths run a MOVD2B/MOVB2D/MOVA2D transpose sequence that flushes any datum with a zero low
     // byte (e.g. bf16 0x4400 = 768.0) when the Src zero-substitution flag is at the operand DEFAULT,

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -373,8 +373,13 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 inline void _llk_unpack_set_srcb_dummy_valid_()
 {
     TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK);
-    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    // Stall_Clr_Cntrl=1: each publication waits on Unpackers[i].SrcBank -- the bank it
+    // actually clears -- rather than MatrixUnit.Src?Bank, a different bank once
+    // double-buffering reaches steady state. Carried by the instruction itself, so it
+    // cannot go stale the way a separate preceding stall can once SET_DVALID flips the
+    // bank pointer. Wormhole uses a preceding stall only because it has no such operand.
+    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -173,7 +173,7 @@ inline void move_d2a_row_broadcast_fixed_face(const std::uint8_t addrmod)
 {
     // MOVD2A does not auto-wait for SrcA[MatrixUnit.SrcABank].AllowedClient == MatrixUnit, so gate on SRCA_VLD
     // before the row moves (mirrors move_d2b_fixed_face's SRCB_VLD wait). See llk_math_transpose_dest.h. tt-llk#1664.
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
     // // Seems to make things 200 clocks slower. Really shouldn't though.
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, addrmod, p_movd2a::MOV_1_ROW, 0);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 1, addrmod, p_movd2a::MOV_1_ROW, 0);
@@ -204,11 +204,11 @@ inline void wait_bank_valid()
 {
     if constexpr (SrcReg == Srcs::SrcA)
     {
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
     }
     else
     {
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD);
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_generalized_moe_gate_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_generalized_moe_gate_eltwise_binary.h
@@ -103,8 +103,8 @@ inline void generalized_moe_gate_eltwise_binary_configure_mop(const std::uint32_
         lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, 5);
         TTI_STALLWAIT(
             p_stall::STALL_MATH,
-            p_stall::WAIT_SFPU | p_stall::SRCA_VLD); // MOVD2A for a whole face assumes unpacker will set a dummy
-                                                     // data_valid, so we want to wait on that
+            p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCA_VLD); // MOVD2A for a whole face assumes unpacker will set a dummy
+                                                                     // data_valid, so we want to wait on that
         TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0);
         TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 4, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 4);
         TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 8, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 8);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_generalized_moe_gate_transpose_dest_single_face.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_generalized_moe_gate_transpose_dest_single_face.h
@@ -218,7 +218,7 @@ inline void _llk_math_generalized_moe_gate_copy4rows_()
 {
     static_assert(!(is_32bit || is_fp32_dest_acc_en), "32-bit / fp32 dest accum not supported");
     math::reset_counters(p_setrwc::SET_ABD_F);
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
     ckernel_template::run();
 }
 
@@ -234,7 +234,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi_(
 {
     static_assert(!(is_32bit || is_fp32_dest_acc_en), "32-bit and fp32 dest accum enable are not supported for single face transpose");
     math::reset_counters(p_setrwc::SET_ABD_F);
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
     ckernel_template::run();
 }
 
@@ -245,7 +245,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step0_()
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -262,7 +262,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step1_()
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -279,7 +279,7 @@ inline void _llk_math_generalized_moe_gate_transpose_dest_single_face_step2_()
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     ckernel_template::run();
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -175,7 +175,7 @@ inline void _llk_math_transpose_dest_(const std::uint32_t dst_index)
     // for SrcA[MatrixUnit.SrcABank].AllowedClient == SrcClient::MatrixUnit.
     // Wait condition SRCB_VLD is required as MOVD2B doesn't automatically wait
     // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit.
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
 
     // Both paths run a MOVD2B/MOVB2D/MOVA2D transpose sequence that flushes any datum with a zero low
     // byte (e.g. bf16 0x4400 = 768.0) when the Src zero-substitution flag is at the operand DEFAULT,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -162,7 +162,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_() {
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -180,7 +180,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_() {
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -198,7 +198,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_() {
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     ckernel_template::run();
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
@@ -47,8 +47,9 @@ inline void deepseek_moe_gate_eltwise_binary_reuse_dest_as_src() {
     if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA) {
         TTI_STALLWAIT(
             p_stall::STALL_MATH,
-            p_stall::WAIT_SFPU | p_stall::SRCA_VLD);  // MOVD2A for a whole face assumes unpacker will set a dummy
-                                                      // data_valid, so we want to wait on that
+            p_stall::WAIT_SFPU | p_stall::MATH |
+                p_stall::SRCA_VLD);  // MOVD2A for a whole face assumes unpacker will set a dummy
+                                     // data_valid, so we want to wait on that
         TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0);
         TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 4, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 4);
         TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 8, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 8);
@@ -56,8 +57,9 @@ inline void deepseek_moe_gate_eltwise_binary_reuse_dest_as_src() {
     } else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB) {
         TTI_STALLWAIT(
             p_stall::STALL_MATH,
-            p_stall::WAIT_SFPU | p_stall::SRCB_VLD);  // MOVD2B for a whole face assumes unpacker will set a dummy
-                                                      // data_valid, so we want to wait on that
+            p_stall::WAIT_SFPU | p_stall::MATH |
+                p_stall::SRCB_VLD);  // MOVD2B for a whole face assumes unpacker will set a dummy
+                                     // data_valid, so we want to wait on that
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -151,7 +151,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_() {
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -169,7 +169,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_() {
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     // Run the 16-bit single-face transpose MOP
     ckernel_template::run();
@@ -187,7 +187,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_() {
     math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Wait for SFPU and SrcB to be available
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::MATH | p_stall::SRCB_VLD);
 
     ckernel_template::run();
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The `Dest`→`Src` reuse handshake has **two sides**, and fixing one does not fix the other. This PR fixes **both**, at every site not already owned by another PR.

Fixes #55106

### (a) Math side — the FPU-pipeline drain (33 sites, 16 files)

`MOVD2A`/`MOVD2B` *write* a Src bank, so the Wait Gate's automatic `AllowedClient` wait — which covers only Matrix Unit instructions that *read* Src — does not apply. `MOVD2A.md`/`MOVD2B.md` say so and direct software to `STALLWAIT`.

But a `STALLWAIT` selecting only the bank-valid condition is still wrong: it indexes `MatrixUnit.Src?Bank` **live**, and that pointer advances in the *epilogue* of the preceding Matrix Unit instruction (`ELWMUL.md`'s `if (FlipSrcA)` block; likewise `SETRWC` with `CLR_*`). With a flipping op in flight it tests the **pre-flip** bank, passes vacuously, and the move then writes the **post-flip** bank the unpacker owns. Selecting `p_stall::MATH` drains the pipe first.

Symptom is a **silent wrong value, never a hang** — every Src *reader* auto-waits — so "no hangs observed" is not evidence of safety.

### (b) Unpack side — the pipelined bank wait (7 publications, 3 Blackhole files)

**This half is a throughput change, not a correctness fix.** Please read it as such — and note the title says "pipeline", not "tighten": the bit *relaxes* the wait.

The publications changed here are Blackhole's combined form — one `UNPACR_NOP` carrying both `Set_Dvalid` and `Unpack_Pop=UNP_ZEROSRC` — so each does clear `Unpackers[i].SrcBank` (that is the `ZEROSRC` half; a *bare* `SET_DVALID` clears nothing and performs no wait of its own). With `Stall_Clr_Cntrl=0` the instruction *waits* on `MatrixUnit.Src?Bank`. That wait names a bank the instruction does not modify, and it is **stronger than necessary**: under the bank-pointer lockstep invariant `MatrixUnit.Src?Bank` is back with the unpackers only when *no* bank is outstanding, so the default form implies the own-bank condition and then some.

**It is nonetheless safe today.** With two banks and a one-for-one fill/consume cycle the pointers cannot reach the harmful arrangement: the Matrix Unit pointer only advances at the instant it hands a bank back, which lands it on the bank the unpacker is holding. Getting the unpacker onto a busy bank while the Matrix pointer sits on a free one would need the unpacker to run two hand-overs ahead, which two banks prevent. So the old form **over-waits rather than under-waits** — it loses the overlap the second bank exists to provide, but does not corrupt.

Setting `Stall_Clr_Cntrl=1` makes the instruction wait on exactly the bank it clears, matching Blackhole's `dest_reuse_dummy_unpack()` from #52256 — whose own comment gives the same rationale: *"so unpack can prepare the next bank while math consumes the current bank."* The bit changes **only the wait**; the bank cleared is `UnpackBank` either way.

#52256's commit message is explicit that this is a mode, not a fix, and it is worth quoting in full because it settles how (a) and (b) relate:

> It also sets `Stall_Clr_Cntrl=1` on destination-reuse dummy unpacks. This is the preferred Blackhole operating mode: it gates the dummy operation using the unpacker-selected bank and allows unpack to prepare the next bank while math consumes the current one. **It is complementary to, rather than a replacement for, the explicit math-pipeline drain.**

**One constraint this PR does not hit, but that any future site must.** The bit is only valid when the publication clears a *single* bank. With a both-banks clear (`Bank_Clr_Ctrl=1`) the own-bank wait covers only the bank being prepared, so clearing both can overwrite one the Matrix Unit still owns — a both-banks clear is correct **only** with the default drained wait. All 7 publications changed here have `Bank_Clr_Ctrl=0`, and the three in-tree both-banks sites (`llk_unpack_AB_compressed_custom_mm.h`, `llk_unpack_AB_custom_mm.h`, `llk_unpack_AB_face_compressed_mm.h`) are untouched and correctly keep the default wait. #55123 adds a checker flag for the unsafe pairing so this cannot regress silently.

| File | Publications |
|---|---|
| `llk_unpack_common.h` `_llk_unpack_set_srcb_dummy_valid_` | 2 — its Wormhole twin already waits correctly, via a preceding `STALLWAIT` on `SRCA_CLR｜SRCB_CLR` |
| `llk_unpack_A_sdpa.h` | 3, across 2 functions |
| `llk_unpack_A_rmsnorm.h` | 2 `static constexpr` MOP constants |

**Reviewer risk to weigh.** The change removes an incidental coupling: the old wait forced the unpacker to wait for the FPU, so unpack could not run ahead. Letting it run ahead is the point, but anything that silently relied on that coupling would now be exposed — and the failure would surface downstream, not at the changed instruction. **`llk_unpack_A_sdpa.h` and `llk_unpack_A_rmsnorm.h` have no test coverage in `unit_tests_llk`;** only `llk_unpack_common.h` is exercised, by the three transpose tests. If you would rather this half landed separately, say so and I will split it.

### (c) The join

Fixing (a) lengthens the math-thread wait and shifts inter-thread timing; (b) lets the unpack side run ahead again. They touch the same handshake from opposite ends, which is why they are reviewed together — but (a) is the bug fix and (b) is the throughput mode. (b) is never a substitute for (a).

### Scope — everything owned elsewhere is excluded

| Site | Owner |
|---|---|
| WH `cmath_common.h` `move_d2a/d2b_fixed_face` | open #54731 |
| BH MoE eltwise-binary + the ttnn BH deepseek copy | open #53690 |
| BH `cmath_common.h` `move_d2a/d2b_fixed_face` | merged #52256 |
| WH+BH `llk_unpack_mul_reduce_scalar.h` | open #54683 |

Also excluded as a different hazard: `compressed_custom_mm` (the wait gates a `SETRWC`/matmul replay), `sdpa_custom_mm` (`MOVB2D` *reads* SrcB), `topk_xl` (`STALL_CFG` around SFPU config), and all of Quasar, whose `STALLWAIT` encoding differs and whose bank model needs a Quasar owner.

**Investigated and deliberately not changed:** `llk_math_hadamard.h`'s `MOVD2B` has a `MATH`-only stall and no `SRCB_VLD`, but nothing flips SrcB before it (the `CLR_AB` releases come *after*, at the next matmul block) and its `MATH` drain guards a different, documented hazard — `MVMUL` writes dst on the FPU pipe while `MOVD2B` reads it on the MOV pipe.

Two of the 33 math-side sites (`move_d2a_row_broadcast_fixed_face`, `wait_bank_valid<>`) have no callers today; they are pre-broken templates, fixed so the defect does not ship the moment something calls them.

### Testing

Blackhole p100a, `unit_tests_llk` over transpose / MoE-gate / rmsnorm / sdpa / custom-mm / binary / reduce:

| | Result |
|---|---|
| branch without the producer commit | 100 ran, 86 passed, 14 skipped, **0 failed** |
| with it | identical |

The math-side change is a mask constant and cannot alter recorded replay lengths. The unpack-side change **is** behavioural — it alters which bank the instruction waits on — which is why the A/B baseline was run.

**The Wormhole sites were not executed** — no Wormhole silicon on this box. They need a WH run before merge.

Like #53655/#53690 this is an inspection- and ISA-grounded fix for a latent class: the defect only produces a wrong value when a bank flip is in flight at the wait, which no current test forces, so there is no fail-without/pass-with reproducer to add.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-dest-reuse-math-drain-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-dest-reuse-math-drain-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-dest-reuse-math-drain-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-dest-reuse-math-drain-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-dest-reuse-math-drain-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-dest-reuse-math-drain-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-dest-reuse-math-drain-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-dest-reuse-math-drain-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-dest-reuse-math-drain-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-dest-reuse-math-drain-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-dest-reuse-math-drain-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-dest-reuse-math-drain-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-dest-reuse-math-drain-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-dest-reuse-math-drain-sweep)