### PR TITLE
Synchronize mid-kernel FP32 dest-acc switches across Unpack/Math/Pack

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -35,7 +35,7 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
  * Programs ALU_ACC_CTRL and PCK_DEST_RD_CTRL after Unpack and Pack have drained.
  *
  * @param enable True to enable FP32 dest accumulation, false to disable.
- * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ * @note Must be called together with llk_unpack_wait_fp32_dest_acc and llk_pack_wait_fp32_dest_acc.
  */
 inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::MathThreadId>(enable); }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -11,6 +11,7 @@
 #include "api/debug/waypoint.h"
 #include "llk_assert.h"
 #include "llk_defs.h"
+#include "llk_fp32_dest_acc.h"
 #include "llk_math_common.h"
 #include "llk_operands.h"
 
@@ -28,7 +29,15 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
         unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
-inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_acc_(enable); }
+/**
+ * Math-thread half of a mid-kernel FP32 dest-acc reconfiguration.
+ *
+ * Programs ALU_ACC_CTRL and PCK_DEST_RD_CTRL after Unpack and Pack have drained.
+ *
+ * @param enable True to enable FP32 dest accumulation, false to disable.
+ * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ */
+inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::MathThreadId>(enable); }
 
 inline void llk_math_reconfig_remap(const bool remap_enable) { _llk_math_reconfig_remap_(remap_enable); }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_globals.h"
 #include "llk_assert.h"
+#include "llk_fp32_dest_acc.h"
 #include "llk_outputs.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
@@ -16,11 +17,13 @@
  *************************************************************************/
 
 /**
- * Enable or disable FP32 accumulation in the packer destination register.
+ * Pack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
  *
- * @param enable When true, the packer treats the destination register as FP32 accumulated.
+ * @param enable When true, dest-acc is programmed for 32-bit destination reads. MATH owns the CFG
+ *               writes, including PCK_DEST_RD_CTRL.
+ * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_math_set_fp32_dest_acc.
  */
-inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
+inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::PackThreadId>(enable); }
 
 /**
  * Configure the packer hardware for the given output operand.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
@@ -19,11 +19,12 @@
 /**
  * Pack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
  *
- * @param enable When true, dest-acc is programmed for 32-bit destination reads. MATH owns the CFG
- *               writes, including PCK_DEST_RD_CTRL.
- * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_math_set_fp32_dest_acc.
+ * Drains the packer FIFO, waits for MATH to program dest-acc CFG (including PCK_DEST_RD_CTRL),
+ * then STALLWAITs.
+ *
+ * @note Must be called together with llk_unpack_wait_fp32_dest_acc and llk_math_set_fp32_dest_acc.
  */
-inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::PackThreadId>(enable); }
+inline void llk_pack_wait_fp32_dest_acc() { _llk_set_fp32_dest_acc_<ThreadId::PackThreadId>(); }
 
 /**
  * Configure the packer hardware for the given output operand.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -15,6 +15,7 @@
 #include "llk_operands.h"
 #include "llk_param_structs.h"
 #include "llk_assert.h"
+#include "llk_fp32_dest_acc.h"
 #include "llk_unpack_common.h"
 
 /*************************************************************************
@@ -77,6 +78,16 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
     llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
+}
+
+/**
+ * Unpack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
+ *
+ * @param enable True to enable FP32 dest accumulation, false to disable.
+ * @note Must be called together with llk_math_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ */
+inline void llk_unpack_set_fp32_dest_acc(bool enable) {
+    _llk_set_fp32_dest_acc_<ThreadId::UnpackThreadId>(enable);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -83,12 +83,11 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
 /**
  * Unpack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
  *
- * @param enable True to enable FP32 dest accumulation, false to disable.
- * @note Must be called together with llk_math_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ * Drains the unpacker FIFO, waits for MATH to program dest-acc CFG, then STALLWAITs.
+ *
+ * @note Must be called together with llk_math_set_fp32_dest_acc and llk_pack_wait_fp32_dest_acc.
  */
-inline void llk_unpack_set_fp32_dest_acc(bool enable) {
-    _llk_set_fp32_dest_acc_<ThreadId::UnpackThreadId>(enable);
-}
+inline void llk_unpack_wait_fp32_dest_acc() { _llk_set_fp32_dest_acc_<ThreadId::UnpackThreadId>(); }
 
 /**
  * Determine whether the unpacker must be reconfigured when switching operands, i.e. whether the

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -10,6 +10,7 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_defs.h"
+#include "llk_fp32_dest_acc.h"
 #include "llk_math_common.h"
 #include "llk_operands.h"
 #include "api/debug/waypoint.h"
@@ -28,7 +29,15 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
         unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
-inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_acc_(enable); }
+/**
+ * Math-thread half of a mid-kernel FP32 dest-acc reconfiguration.
+ *
+ * Programs ALU_ACC_CTRL and PCK_DEST_RD_CTRL after Unpack and Pack have drained.
+ *
+ * @param enable True to enable FP32 dest accumulation, false to disable.
+ * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ */
+inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::MathThreadId>(enable); }
 
 inline void llk_math_reconfig_remap(const bool /*remap_enable*/) {}
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -35,7 +35,7 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
  * Programs ALU_ACC_CTRL and PCK_DEST_RD_CTRL after Unpack and Pack have drained.
  *
  * @param enable True to enable FP32 dest accumulation, false to disable.
- * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ * @note Must be called together with llk_unpack_wait_fp32_dest_acc and llk_pack_wait_fp32_dest_acc.
  */
 inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::MathThreadId>(enable); }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
@@ -7,6 +7,7 @@
 #include "ckernel_globals.h"
 #include "internal/circular_buffer_interface.h"
 #include "llk_assert.h"
+#include "llk_fp32_dest_acc.h"
 #include "llk_outputs.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
@@ -16,11 +17,13 @@
  *************************************************************************/
 
 /**
- * Enable or disable FP32 accumulation in the packer destination register.
+ * Pack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
  *
- * @param enable When true, the packer treats the destination register as FP32 accumulated.
+ * @param enable When true, dest-acc is programmed for 32-bit destination reads. MATH owns the CFG
+ *               writes, including PCK_DEST_RD_CTRL.
+ * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_math_set_fp32_dest_acc.
  */
-inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
+inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::PackThreadId>(enable); }
 
 /**
  * Configure the packer hardware for the given output operand.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
@@ -19,11 +19,12 @@
 /**
  * Pack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
  *
- * @param enable When true, dest-acc is programmed for 32-bit destination reads. MATH owns the CFG
- *               writes, including PCK_DEST_RD_CTRL.
- * @note Must be called together with llk_unpack_set_fp32_dest_acc and llk_math_set_fp32_dest_acc.
+ * Drains the packer FIFO, waits for MATH to program dest-acc CFG (including PCK_DEST_RD_CTRL),
+ * then STALLWAITs.
+ *
+ * @note Must be called together with llk_unpack_wait_fp32_dest_acc and llk_math_set_fp32_dest_acc.
  */
-inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_set_fp32_dest_acc_<ThreadId::PackThreadId>(enable); }
+inline void llk_pack_wait_fp32_dest_acc() { _llk_set_fp32_dest_acc_<ThreadId::PackThreadId>(); }
 
 /**
  * Configure the packer hardware for the given output operand.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -14,6 +14,7 @@
 #include "llk_operands.h"
 #include "llk_param_structs.h"
 #include "llk_assert.h"
+#include "llk_fp32_dest_acc.h"
 #include "llk_unpack_common.h"
 #include "api/debug/waypoint.h"
 
@@ -77,6 +78,16 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
     llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
+}
+
+/**
+ * Unpack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
+ *
+ * @param enable True to enable FP32 dest accumulation, false to disable.
+ * @note Must be called together with llk_math_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ */
+inline void llk_unpack_set_fp32_dest_acc(bool enable) {
+    _llk_set_fp32_dest_acc_<ThreadId::UnpackThreadId>(enable);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -83,12 +83,11 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
 /**
  * Unpack-thread half of a mid-kernel FP32 dest-acc reconfiguration.
  *
- * @param enable True to enable FP32 dest accumulation, false to disable.
- * @note Must be called together with llk_math_set_fp32_dest_acc and llk_pack_set_fp32_dest_acc.
+ * Drains the unpacker FIFO, waits for MATH to program dest-acc CFG, then STALLWAITs.
+ *
+ * @note Must be called together with llk_math_set_fp32_dest_acc and llk_pack_wait_fp32_dest_acc.
  */
-inline void llk_unpack_set_fp32_dest_acc(bool enable) {
-    _llk_set_fp32_dest_acc_<ThreadId::UnpackThreadId>(enable);
-}
+inline void llk_unpack_wait_fp32_dest_acc() { _llk_set_fp32_dest_acc_<ThreadId::UnpackThreadId>(); }
 
 /**
  * Determine whether the unpacker must be reconfigured when switching operands, i.e. whether the

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -13,7 +13,12 @@
 #endif
 
 #ifdef TRISC_MATH
+#include "llk_math_common_api.h"
 #include "llk_math_eltwise_unary_sfpu_init.h"
+#endif
+
+#ifdef TRISC_PACK
+#include "llk_pack_common_api.h"
 #endif
 
 namespace ckernel {
@@ -103,8 +108,10 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) { compute_kerne
  *
  * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
  * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data)
- * for 32-bit destination reads. This is a lightweight, standalone
- * reconfiguration that is safe to call mid-kernel without re-running
+ * for 32-bit destination reads. UNPACK/PACK tensix_sync then notify MATH
+ * and wait; MATH writes dest-acc CFG and releases them. Every thread
+ * STALLWAITs on TRISC_CFG, blocking unpacker / packer / FPU / SFPU until
+ * those writes are visible. Safe to call mid-kernel without re-running
  * compute_kernel_hw_startup.
  *
  * Must be paired with disable_fp32_dest_acc() when switching back to
@@ -117,6 +124,7 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) { compute_kerne
 // clang-format on
 #ifndef ARCH_QUASAR
 ALWI void enable_fp32_dest_acc() {
+    UNPACK((llk_unpack_set_fp32_dest_acc(true)));
     MATH((llk_math_set_fp32_dest_acc(true)));
     PACK((llk_pack_set_fp32_dest_acc(true)));
 }
@@ -129,8 +137,10 @@ ALWI void enable_fp32_dest_acc() {
  *
  * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
  * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data)
- * to disable 32-bit destination reads. This is a lightweight, standalone
- * reconfiguration that is safe to call mid-kernel without re-running
+ * to disable 32-bit destination reads. UNPACK/PACK tensix_sync then notify
+ * MATH and wait; MATH writes dest-acc CFG and releases them. Every thread
+ * STALLWAITs on TRISC_CFG, blocking unpacker / packer / FPU / SFPU until
+ * those writes are visible. Safe to call mid-kernel without re-running
  * compute_kernel_hw_startup.
  *
  * Only available on Wormhole and Blackhole. Not supported on Quasar (compile error)
@@ -140,6 +150,7 @@ ALWI void enable_fp32_dest_acc() {
 // clang-format on
 #ifndef ARCH_QUASAR
 ALWI void disable_fp32_dest_acc() {
+    UNPACK((llk_unpack_set_fp32_dest_acc(false)));
     MATH((llk_math_set_fp32_dest_acc(false)));
     PACK((llk_pack_set_fp32_dest_acc(false)));
 }

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -124,9 +124,9 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) { compute_kerne
 // clang-format on
 #ifndef ARCH_QUASAR
 ALWI void enable_fp32_dest_acc() {
-    UNPACK((llk_unpack_set_fp32_dest_acc(true)));
+    UNPACK((llk_unpack_wait_fp32_dest_acc()));
     MATH((llk_math_set_fp32_dest_acc(true)));
-    PACK((llk_pack_set_fp32_dest_acc(true)));
+    PACK((llk_pack_wait_fp32_dest_acc()));
 }
 #endif
 
@@ -150,9 +150,9 @@ ALWI void enable_fp32_dest_acc() {
 // clang-format on
 #ifndef ARCH_QUASAR
 ALWI void disable_fp32_dest_acc() {
-    UNPACK((llk_unpack_set_fp32_dest_acc(false)));
+    UNPACK((llk_unpack_wait_fp32_dest_acc()));
     MATH((llk_math_set_fp32_dest_acc(false)));
-    PACK((llk_pack_set_fp32_dest_acc(false)));
+    PACK((llk_pack_wait_fp32_dest_acc()));
 }
 #endif
 

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -114,6 +114,9 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) { compute_kerne
  * those writes are visible. Safe to call mid-kernel without re-running
  * compute_kernel_hw_startup.
  *
+ * All three TRISC threads must call this together. TRISC mailboxes must not
+ * be in use.
+ *
  * Must be paired with disable_fp32_dest_acc() when switching back to
  * BF16 accumulation mode within the same kernel.
  *
@@ -142,6 +145,9 @@ ALWI void enable_fp32_dest_acc() {
  * STALLWAITs on TRISC_CFG, blocking unpacker / packer / FPU / SFPU until
  * those writes are visible. Safe to call mid-kernel without re-running
  * compute_kernel_hw_startup.
+ *
+ * All three TRISC threads must call this together. TRISC mailboxes must not
+ * be in use.
  *
  * Only available on Wormhole and Blackhole. Not supported on Quasar (compile error)
  *

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_fp32_dest_acc.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_fp32_dest_acc.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
+
+using namespace ckernel;
+
+/**
+ * @brief Coordinate a mid-kernel FP32 dest-acc reconfiguration across Unpack, Math, and Pack.
+ *
+ * Dest-acc CFG is MATH-owned. tensix_sync drains each thread's Tensix FIFO (including FPU / SFPU /
+ * packer); the mailbox then holds RISC so no new work is issued until MATH has written dest-acc:
+ *   1. UNPACK/PACK tensix_sync, signal MATH, and wait.
+ *   2. MATH tensix_syncs, waits for both, programs ALU_ACC_CTRL and PCK_DEST_RD_CTRL, and releases
+ *      UNPACK/PACK.
+ *   3. Every thread STALLWAITs on TRISC_CFG, blocking unpacker / packer / FPU / SFPU until those
+ *      writes are visible.
+ *
+ * @tparam thread_id: TRISC thread compiling this specialization, values = <UnpackThreadId/MathThreadId/PackThreadId>
+ * @param enable: True to enable FP32 dest accumulation, false to disable.
+ * @note All three TRISC threads must call their specialization together. Not supported on Quasar.
+ */
+template <ThreadId thread_id>
+inline void _llk_set_fp32_dest_acc_([[maybe_unused]] bool enable)
+{
+    static_assert(IS_TRISC_THREAD<thread_id>, "_llk_set_fp32_dest_acc_ requires a TRISC thread");
+
+    constexpr std::uint32_t dest_acc_stall = p_stall::STALL_UNPACK | p_stall::STALL_PACK | p_stall::STALL_MATH | p_stall::STALL_SFPU;
+
+    tensix_sync();
+
+    if constexpr (thread_id == ThreadId::UnpackThreadId || thread_id == ThreadId::PackThreadId)
+    {
+        mailbox_write(ThreadId::MathThreadId, 1);
+        const std::uint32_t config_issued = mailbox_read(ThreadId::MathThreadId);
+        (void)config_issued;
+        TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
+    }
+    else
+    {
+        const std::uint32_t unpack_here = mailbox_read(ThreadId::UnpackThreadId);
+        const std::uint32_t pack_here   = mailbox_read(ThreadId::PackThreadId);
+        (void)unpack_here;
+        (void)pack_here;
+
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);
+        cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
+        TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
+
+        mailbox_write(ThreadId::UnpackThreadId, 1);
+        mailbox_write(ThreadId::PackThreadId, 1);
+    }
+}

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_fp32_dest_acc.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_fp32_dest_acc.h
@@ -25,11 +25,11 @@ using namespace ckernel;
  *      writes are visible.
  *
  * @tparam thread_id: TRISC thread compiling this specialization, values = <UnpackThreadId/MathThreadId/PackThreadId>
- * @param enable: True to enable FP32 dest accumulation, false to disable.
+ * @param enable: MATH only. True to enable FP32 dest accumulation, false to disable.
  * @note All three TRISC threads must call their specialization together. Not supported on Quasar.
  */
 template <ThreadId thread_id>
-inline void _llk_set_fp32_dest_acc_([[maybe_unused]] bool enable)
+inline void _llk_set_fp32_dest_acc_(bool enable = false)
 {
     static_assert(IS_TRISC_THREAD<thread_id>, "_llk_set_fp32_dest_acc_ requires a TRISC thread");
 
@@ -40,16 +40,13 @@ inline void _llk_set_fp32_dest_acc_([[maybe_unused]] bool enable)
     if constexpr (thread_id == ThreadId::UnpackThreadId || thread_id == ThreadId::PackThreadId)
     {
         mailbox_write(ThreadId::MathThreadId, 1);
-        const std::uint32_t config_issued = mailbox_read(ThreadId::MathThreadId);
-        (void)config_issued;
+        mailbox_read(ThreadId::MathThreadId);
         TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
     }
     else
     {
-        const std::uint32_t unpack_here = mailbox_read(ThreadId::UnpackThreadId);
-        const std::uint32_t pack_here   = mailbox_read(ThreadId::PackThreadId);
-        (void)unpack_here;
-        (void)pack_here;
+        mailbox_read(ThreadId::UnpackThreadId);
+        mailbox_read(ThreadId::PackThreadId);
 
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_fp32_dest_acc.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_fp32_dest_acc.h
@@ -10,8 +10,16 @@
 #include "ckernel_defs.h"
 #include "ckernel_instr_params.h"
 #include "ckernel_ops.h"
+#include "llk_assert.h"
 
 using namespace ckernel;
+
+namespace fp32_dest_acc
+{
+constexpr std::uint32_t UNPACK_READY = 0x46504101; // 'FPA' | 0x01
+constexpr std::uint32_t PACK_READY   = 0x46504102; // 'FPA' | 0x02
+constexpr std::uint32_t MATH_DONE    = 0x46504110; // 'FPA' | 0x10
+} // namespace fp32_dest_acc
 
 /**
  * @brief Coordinate a mid-kernel FP32 dest-acc reconfiguration across Unpack, Math, and Pack.
@@ -37,23 +45,33 @@ inline void _llk_set_fp32_dest_acc_(bool enable = false)
 
     tensix_sync();
 
-    if constexpr (thread_id == ThreadId::UnpackThreadId || thread_id == ThreadId::PackThreadId)
+    if constexpr (thread_id == ThreadId::UnpackThreadId)
     {
-        mailbox_write(ThreadId::MathThreadId, 1);
-        mailbox_read(ThreadId::MathThreadId);
+        mailbox_write(ThreadId::MathThreadId, fp32_dest_acc::UNPACK_READY);
+        const std::uint32_t math_done = mailbox_read(ThreadId::MathThreadId);
+        LLK_ASSERT(math_done == fp32_dest_acc::MATH_DONE, "Unexpected dest-acc message from math thread.");
+        TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
+    }
+    else if constexpr (thread_id == ThreadId::PackThreadId)
+    {
+        mailbox_write(ThreadId::MathThreadId, fp32_dest_acc::PACK_READY);
+        const std::uint32_t math_done = mailbox_read(ThreadId::MathThreadId);
+        LLK_ASSERT(math_done == fp32_dest_acc::MATH_DONE, "Unexpected dest-acc message from math thread.");
         TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
     }
     else
     {
-        mailbox_read(ThreadId::UnpackThreadId);
-        mailbox_read(ThreadId::PackThreadId);
+        const std::uint32_t unpack_ready = mailbox_read(ThreadId::UnpackThreadId);
+        const std::uint32_t pack_ready   = mailbox_read(ThreadId::PackThreadId);
+        LLK_ASSERT(unpack_ready == fp32_dest_acc::UNPACK_READY, "Unexpected dest-acc message from unpack thread.");
+        LLK_ASSERT(pack_ready == fp32_dest_acc::PACK_READY, "Unexpected dest-acc message from pack thread.");
 
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);
         cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
         TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
 
-        mailbox_write(ThreadId::UnpackThreadId, 1);
-        mailbox_write(ThreadId::PackThreadId, 1);
+        mailbox_write(ThreadId::UnpackThreadId, fp32_dest_acc::MATH_DONE);
+        mailbox_write(ThreadId::PackThreadId, fp32_dest_acc::MATH_DONE);
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -15,19 +15,6 @@
 using namespace ckernel::math;
 
 /**
- * @brief Enable or disable FP32 accumulation in the destination register for both FPU and SFPU.
- *
- * @param enable: True to enable FP32 dest accumulation, false to disable.
- */
-inline void _llk_math_set_fp32_dest_acc_(bool enable)
-{
-    // SFPU_Fp32_enabled is read by SFPLOAD/SFPSTORE (MOD0_FMT_SRCB), so the SFPU must drain too, not just the FPU.
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);
-}
-
-/**
  * @brief Configure the math (FPU) thread's ALU control registers for the given source data formats.
  *
  * Sets ZEROACC bank auto-detect, enables INT8 math when either source is Int8/Int32, and programs FP32 dest

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -455,18 +455,6 @@ inline void _llk_pack_reconfig_data_format_(
 }
 
 /**
- * @brief Enable or disable reading the destination register as 32-bit data for the packer.
- *
- * @param enable: True to read dest as 32-bit (FP32) data, false otherwise.
- * @note Stalls on the pack pipe before modifying the PCK_DEST_RD_CTRL config register.
- */
-inline void _llk_pack_set_fp32_dest_acc_(bool enable)
-{
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
-}
-
-/**
  * @brief One-time hardware configuration of the packer for a given data format and tile geometry.
  *
  * Programs the packer config registers (formats, strides, relu) for the chosen pack mode. Call once

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_fp32_dest_acc.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_fp32_dest_acc.h
@@ -25,11 +25,11 @@ using namespace ckernel;
  *      writes are visible.
  *
  * @tparam thread_id: TRISC thread compiling this specialization, values = <UnpackThreadId/MathThreadId/PackThreadId>
- * @param enable: True to enable FP32 dest accumulation, false to disable.
+ * @param enable: MATH only. True to enable FP32 dest accumulation, false to disable.
  * @note All three TRISC threads must call their specialization together. Not supported on Quasar.
  */
 template <ThreadId thread_id>
-inline void _llk_set_fp32_dest_acc_([[maybe_unused]] bool enable)
+inline void _llk_set_fp32_dest_acc_(bool enable = false)
 {
     static_assert(
         (thread_id == ThreadId::MathThreadId) || (thread_id == ThreadId::UnpackThreadId) || (thread_id == ThreadId::PackThreadId),
@@ -42,16 +42,13 @@ inline void _llk_set_fp32_dest_acc_([[maybe_unused]] bool enable)
     if constexpr (thread_id == ThreadId::UnpackThreadId || thread_id == ThreadId::PackThreadId)
     {
         mailbox_write(ThreadId::MathThreadId, 1);
-        const std::uint32_t config_issued = mailbox_read(ThreadId::MathThreadId);
-        (void)config_issued;
+        mailbox_read(ThreadId::MathThreadId);
         TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
     }
     else
     {
-        const std::uint32_t unpack_here = mailbox_read(ThreadId::UnpackThreadId);
-        const std::uint32_t pack_here   = mailbox_read(ThreadId::PackThreadId);
-        (void)unpack_here;
-        (void)pack_here;
+        mailbox_read(ThreadId::UnpackThreadId);
+        mailbox_read(ThreadId::PackThreadId);
 
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_fp32_dest_acc.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_fp32_dest_acc.h
@@ -10,8 +10,16 @@
 #include "ckernel_defs.h"
 #include "ckernel_instr_params.h"
 #include "ckernel_ops.h"
+#include "llk_assert.h"
 
 using namespace ckernel;
+
+namespace fp32_dest_acc
+{
+constexpr std::uint32_t UNPACK_READY = 0x46504101; // 'FPA' | 0x01
+constexpr std::uint32_t PACK_READY   = 0x46504102; // 'FPA' | 0x02
+constexpr std::uint32_t MATH_DONE    = 0x46504110; // 'FPA' | 0x10
+} // namespace fp32_dest_acc
 
 /**
  * @brief Coordinate a mid-kernel FP32 dest-acc reconfiguration across Unpack, Math, and Pack.
@@ -39,23 +47,33 @@ inline void _llk_set_fp32_dest_acc_(bool enable = false)
 
     tensix_sync();
 
-    if constexpr (thread_id == ThreadId::UnpackThreadId || thread_id == ThreadId::PackThreadId)
+    if constexpr (thread_id == ThreadId::UnpackThreadId)
     {
-        mailbox_write(ThreadId::MathThreadId, 1);
-        mailbox_read(ThreadId::MathThreadId);
+        mailbox_write(ThreadId::MathThreadId, fp32_dest_acc::UNPACK_READY);
+        const std::uint32_t math_done = mailbox_read(ThreadId::MathThreadId);
+        LLK_ASSERT(math_done == fp32_dest_acc::MATH_DONE, "Unexpected dest-acc message from math thread.");
+        TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
+    }
+    else if constexpr (thread_id == ThreadId::PackThreadId)
+    {
+        mailbox_write(ThreadId::MathThreadId, fp32_dest_acc::PACK_READY);
+        const std::uint32_t math_done = mailbox_read(ThreadId::MathThreadId);
+        LLK_ASSERT(math_done == fp32_dest_acc::MATH_DONE, "Unexpected dest-acc message from math thread.");
         TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
     }
     else
     {
-        mailbox_read(ThreadId::UnpackThreadId);
-        mailbox_read(ThreadId::PackThreadId);
+        const std::uint32_t unpack_ready = mailbox_read(ThreadId::UnpackThreadId);
+        const std::uint32_t pack_ready   = mailbox_read(ThreadId::PackThreadId);
+        LLK_ASSERT(unpack_ready == fp32_dest_acc::UNPACK_READY, "Unexpected dest-acc message from unpack thread.");
+        LLK_ASSERT(pack_ready == fp32_dest_acc::PACK_READY, "Unexpected dest-acc message from pack thread.");
 
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);
         cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
         TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
 
-        mailbox_write(ThreadId::UnpackThreadId, 1);
-        mailbox_write(ThreadId::PackThreadId, 1);
+        mailbox_write(ThreadId::UnpackThreadId, fp32_dest_acc::MATH_DONE);
+        mailbox_write(ThreadId::PackThreadId, fp32_dest_acc::MATH_DONE);
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_fp32_dest_acc.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_fp32_dest_acc.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
+
+using namespace ckernel;
+
+/**
+ * @brief Coordinate a mid-kernel FP32 dest-acc reconfiguration across Unpack, Math, and Pack.
+ *
+ * Dest-acc CFG is MATH-owned. tensix_sync drains each thread's Tensix FIFO (including FPU / SFPU /
+ * packer); the mailbox then holds RISC so no new work is issued until MATH has written dest-acc:
+ *   1. UNPACK/PACK tensix_sync, signal MATH, and wait.
+ *   2. MATH tensix_syncs, waits for both, programs ALU_ACC_CTRL and PCK_DEST_RD_CTRL, and releases
+ *      UNPACK/PACK.
+ *   3. Every thread STALLWAITs on TRISC_CFG, blocking unpacker / packer / FPU / SFPU until those
+ *      writes are visible.
+ *
+ * @tparam thread_id: TRISC thread compiling this specialization, values = <UnpackThreadId/MathThreadId/PackThreadId>
+ * @param enable: True to enable FP32 dest accumulation, false to disable.
+ * @note All three TRISC threads must call their specialization together. Not supported on Quasar.
+ */
+template <ThreadId thread_id>
+inline void _llk_set_fp32_dest_acc_([[maybe_unused]] bool enable)
+{
+    static_assert(
+        (thread_id == ThreadId::MathThreadId) || (thread_id == ThreadId::UnpackThreadId) || (thread_id == ThreadId::PackThreadId),
+        "_llk_set_fp32_dest_acc_ requires a TRISC thread");
+
+    constexpr std::uint32_t dest_acc_stall = p_stall::STALL_UNPACK | p_stall::STALL_PACK | p_stall::STALL_MATH | p_stall::STALL_SFPU;
+
+    tensix_sync();
+
+    if constexpr (thread_id == ThreadId::UnpackThreadId || thread_id == ThreadId::PackThreadId)
+    {
+        mailbox_write(ThreadId::MathThreadId, 1);
+        const std::uint32_t config_issued = mailbox_read(ThreadId::MathThreadId);
+        (void)config_issued;
+        TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
+    }
+    else
+    {
+        const std::uint32_t unpack_here = mailbox_read(ThreadId::UnpackThreadId);
+        const std::uint32_t pack_here   = mailbox_read(ThreadId::PackThreadId);
+        (void)unpack_here;
+        (void)pack_here;
+
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);
+        cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
+        TTI_STALLWAIT(dest_acc_stall, p_stall::TRISC_CFG);
+
+        mailbox_write(ThreadId::UnpackThreadId, 1);
+        mailbox_write(ThreadId::PackThreadId, 1);
+    }
+}

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -15,18 +15,6 @@
 using namespace ckernel::math;
 
 /**
- * @brief Enable or disable FP32 accumulation in the destination register for both FPU and SFPU.
- *
- * @param enable: True to enable FP32 dest accumulation, false to disable.
- */
-inline void _llk_math_set_fp32_dest_acc_(bool enable)
-{
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(enable);
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(enable);
-}
-
-/**
  * @brief Configure the math (FPU) thread's ALU control registers for the given source data formats.
  *
  * Programs the source A/B ALU formats, enables INT8 math when either source is Int8/Int32, and sets FP32 dest

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -319,18 +319,6 @@ inline void _llk_pack_reconfig_data_format_(
 }
 
 /**
- * @brief Enable or disable reading the destination register as 32-bit data for the packer.
- *
- * @param enable: True to read dest as 32-bit (FP32) data, false otherwise.
- * @note Stalls on the pack pipe before modifying the PCK_DEST_RD_CTRL config register.
- */
-inline void _llk_pack_set_fp32_dest_acc_(bool enable)
-{
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(enable);
-}
-
-/**
  * @brief One-time hardware configuration of the packer for a given data format and tile geometry.
  *
  * Programs the packer config registers (formats, strides, relu) for the chosen pack mode. Call once


### PR DESCRIPTION
## Summary
- Mid-kernel `enable_fp32_dest_acc` / `disable_fp32_dest_acc` previously programmed dest-acc CFG from MATH and PACK independently, with no Unpack participation. That can race with in-flight FPU / SFPU / packer / unpacker work done by varying threads.
- Move the protocol into LLK (`_llk_set_fp32_dest_acc_`). All three TRISCs `tensix_sync`, Unpack/Pack wait on a mailbox, MATH writes `ALU_ACC_CTRL` and `PCK_DEST_RD_CTRL`, then every thread `STALLWAIT`s on `TRISC_CFG`.
- Wormhole and Blackhole only. Quasar is unchanged (these APIs remain compile errors there).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=halgh/safefp32switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:halgh/safefp32switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=halgh/safefp32switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:halgh/safefp32switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=halgh/safefp32switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:halgh/safefp32switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=halgh/safefp32switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:halgh/safefp32switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=halgh/safefp32switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:halgh/safefp32switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=halgh/safefp32switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:halgh/safefp32switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=halgh/safefp32switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:halgh/safefp32switch)