### PR TITLE
Initialize fabric identity for emulated worker cores

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -3161,6 +3161,11 @@ static void setup_core_state(
     std::map<CoreCoord, std::vector<KernelInfo>>& core_kernels,
     uint32_t emule_sem_base,
     std::vector<CoreSetup>& core_setups) {
+    const auto fabric_node = MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(
+        device->id());
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t routing_table_base = static_cast<uint32_t>(
+        hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::ROUTING_TABLE));
     for (auto& [logical_core, ki_list] : core_kernels) {
         if (!sw_emu) {
             continue;
@@ -3170,6 +3175,12 @@ static void setup_core_state(
         if (!core) {
             continue;
         }
+        // Fabric initialization writes this routing-table identity on silicon. Mirror it here because
+        // SWEmule's launch-owned worker L1 does not retain the earlier control-plane broadcast.
+        auto* mesh_id = reinterpret_cast<uint16_t*>(core->l1_ptr(routing_table_base + 32));
+        auto* chip_id = reinterpret_cast<uint16_t*>(core->l1_ptr(routing_table_base + 34));
+        *mesh_id = static_cast<uint16_t>(*fabric_node.mesh_id);
+        *chip_id = static_cast<uint16_t>(fabric_node.chip_id);
         uint8_t phys_x = static_cast<uint8_t>(phys.x);
         uint8_t phys_y = static_cast<uint8_t>(phys.y);
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -63,6 +63,7 @@
 #include <tt-metalium/hal_types.hpp>
 
 #include "impl/context/metal_context.hpp"
+#include "hostdevcommon/fabric_common.h"  // routing_l1_info_t — identity field layout
 #include "llrt/metal_soc_descriptor.hpp"
 #include "umd/device/chip/sw_emule_chip.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
@@ -3161,11 +3162,10 @@ static void setup_core_state(
     std::map<CoreCoord, std::vector<KernelInfo>>& core_kernels,
     uint32_t emule_sem_base,
     std::vector<CoreSetup>& core_setups) {
-    const auto fabric_node = MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(
-        device->id());
-    const auto& hal = MetalContext::instance().hal();
+    auto& metal_ctx = MetalContext::instance(impl.get_context_id());
+    const auto fabric_node = metal_ctx.get_control_plane().get_fabric_node_id_from_physical_chip_id(device->id());
     const uint32_t routing_table_base = static_cast<uint32_t>(
-        hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::ROUTING_TABLE));
+        metal_ctx.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::ROUTING_TABLE));
     for (auto& [logical_core, ki_list] : core_kernels) {
         if (!sw_emu) {
             continue;
@@ -3177,10 +3177,9 @@ static void setup_core_state(
         }
         // Fabric initialization writes this routing-table identity on silicon. Mirror it here because
         // SWEmule's launch-owned worker L1 does not retain the earlier control-plane broadcast.
-        auto* mesh_id = reinterpret_cast<uint16_t*>(core->l1_ptr(routing_table_base + 32));
-        auto* chip_id = reinterpret_cast<uint16_t*>(core->l1_ptr(routing_table_base + 34));
-        *mesh_id = static_cast<uint16_t>(*fabric_node.mesh_id);
-        *chip_id = static_cast<uint16_t>(fabric_node.chip_id);
+        auto* routing_info = reinterpret_cast<tt::tt_fabric::routing_l1_info_t*>(core->l1_ptr(routing_table_base));
+        routing_info->my_mesh_id = static_cast<uint16_t>(*fabric_node.mesh_id);
+        routing_info->my_device_id = static_cast<uint16_t>(fabric_node.chip_id);
         uint8_t phys_x = static_cast<uint8_t>(phys.x);
         uint8_t phys_y = static_cast<uint8_t>(phys.y);
 


### PR DESCRIPTION
## Summary

- initialize each emulated worker core's fabric mesh/chip identity in routing-table L1 during program launch
- mirror the identity that fabric initialization provides on silicon
- keep the change isolated to the software-emulation setup path

Without this initialization, TP8 kernels launched through SWEmule read a zero/default fabric identity and cannot select their intended rank.

## Integration stack

The same patch is carried on `kostas/dspark-tp8-emule-metal-integration`, based on the tt-emule-blaze Metal pin `7102d85fe956ac55b533da3b7308a03dd0bfda67`. The two commits have the same stable patch ID.

## Validation

- DSpark TP8 reduce-to-all fused residual test: `1 passed`
- Blackhole emulator regressions: `20 passed`
- Wormhole emulator regressions: `36 passed`
- Quasar emulator regressions: `73 passed`
- `git diff --check`: clean

This is a draft while the complete fused DSpark layer's next producer/CB integration stall is investigated.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kostas/dspark-tp8-emule-fabric-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kostas/dspark-tp8-emule-fabric-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kostas/dspark-tp8-emule-fabric-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kostas/dspark-tp8-emule-fabric-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kostas/dspark-tp8-emule-fabric-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kostas/dspark-tp8-emule-fabric-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kostas/dspark-tp8-emule-fabric-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kostas/dspark-tp8-emule-fabric-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kostas/dspark-tp8-emule-fabric-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kostas/dspark-tp8-emule-fabric-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kostas/dspark-tp8-emule-fabric-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kostas/dspark-tp8-emule-fabric-identity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kostas/dspark-tp8-emule-fabric-identity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kostas/dspark-tp8-emule-fabric-identity)