### PR TITLE
Clamp sharded output grids to the shards they hold

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/math.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/tile.hpp>
@@ -211,6 +212,71 @@ TEST_P(NDShardingTensorSpecTests, TestTensorSpec) {
         case ShardingTensorSpecMethod::BlockSharded: tensor_spec = tensor_spec.block_sharded(cores.ranges()[0]); break;
     }
     EXPECT_EQ(tensor_spec.memory_config().nd_shard_spec().value().shard_shape, params.expected_shard_shape);
+}
+
+struct ShardedBuilderGridTrimParams {
+    Shape tensor_shape;
+    ShardingTensorSpecMethod method = ShardingTensorSpecMethod::HeightSharded;
+    CoreRangeSet grid;
+    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+    TensorMemoryLayout expected_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+    uint32_t expected_shard_height = 0;
+    uint32_t expected_shard_width = 0;
+    std::optional<CoreRangeSet> expected_grid;
+    std::vector<CoreCoord> cores_in_grid;
+    std::vector<CoreCoord> cores_not_in_grid;
+};
+
+class ShardedBuilderGridTrimTests : public ::testing::TestWithParam<ShardedBuilderGridTrimParams> {};
+
+// The width/height/block builders derive the shard shape from the grid and keep only the
+// cores that receive a shard: the first N in shard-assignment order for the linear
+// layouts, the leading rows x cols block for GRID_2D. Assert that contract directly, and
+// the invariant behind it: the grid holds exactly one core per shard.
+TEST_P(ShardedBuilderGridTrimTests, GridHoldsOnlyShards) {
+    const auto& params = GetParam();
+
+    TensorSpec tensor_spec(
+        params.tensor_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), MemoryConfig(BufferType::L1)));
+    switch (params.method) {
+        case ShardingTensorSpecMethod::WidthSharded:
+            tensor_spec = tensor_spec.width_sharded(params.grid, params.orientation);
+            break;
+        case ShardingTensorSpecMethod::HeightSharded:
+            tensor_spec = tensor_spec.height_sharded(params.grid, params.orientation);
+            break;
+        case ShardingTensorSpecMethod::BlockSharded:
+            ASSERT_EQ(params.grid.ranges().size(), 1u);
+            tensor_spec = tensor_spec.block_sharded(params.grid.ranges()[0], params.orientation);
+            break;
+        default: FAIL() << "method must be one of the width/height/block builders";
+    }
+
+    const auto& mem_config = tensor_spec.memory_config();
+    EXPECT_EQ(mem_config.memory_layout(), params.expected_layout);
+
+    ASSERT_TRUE(mem_config.shard_spec().has_value());
+    const auto& shard_spec = *mem_config.shard_spec();
+    EXPECT_EQ(shard_spec.shape[0], params.expected_shard_height);
+    EXPECT_EQ(shard_spec.shape[1], params.expected_shard_width);
+
+    ASSERT_TRUE(mem_config.nd_shard_spec().has_value());
+    EXPECT_EQ(mem_config.nd_shard_spec()->grid, shard_spec.grid);
+
+    if (params.expected_grid.has_value()) {
+        EXPECT_EQ(shard_spec.grid, *params.expected_grid);
+    }
+    for (const auto& core : params.cores_in_grid) {
+        EXPECT_TRUE(shard_spec.grid.contains(core)) << core.str() << " missing from " << shard_spec.grid.str();
+    }
+    for (const auto& core : params.cores_not_in_grid) {
+        EXPECT_FALSE(shard_spec.grid.contains(core)) << core.str() << " unexpectedly in " << shard_spec.grid.str();
+    }
+
+    const auto& physical = tensor_spec.physical_shape();
+    const uint64_t num_shards = static_cast<uint64_t>(div_up(physical.height(), shard_spec.shape[0])) *
+                                div_up(physical.width(), shard_spec.shape[1]);
+    EXPECT_EQ(shard_spec.grid.num_cores(), num_shards);
 }
 
 class NDShardingSqueezeRankStressTests : public ::testing::Test {};
@@ -852,6 +918,89 @@ INSTANTIATE_TEST_SUITE_P(
             .shard_shape_pages = Shape({5, 1, 1}),
             .expected_tensor_shape_pages = Shape({5, 121}),
             .expected_shard_shape_pages = Shape({5, 1}),
+        }));
+
+INSTANTIATE_TEST_SUITE_P(
+    NdShardingTests,
+    ShardedBuilderGridTrimTests,
+    ::testing::Values(
+        // 1x512x1 f32 tile: physical 512x32, the RMSNorm-mean geometry from an 11x8 grid.
+        ShardedBuilderGridTrimParams{
+            .tensor_shape = Shape({1, 512, 1}),
+            .method = ShardingTensorSpecMethod::HeightSharded,
+            .grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{10, 7})),
+            .orientation = ShardOrientation::ROW_MAJOR,
+            .expected_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+            .expected_shard_height = 32,
+            .expected_shard_width = 32,
+            // 16 shards keep the first 16 cores row-wise: all of row 0, then x=0..4 of row 1.
+            .cores_in_grid = {CoreCoord{0, 0}, CoreCoord{10, 0}, CoreCoord{4, 1}},
+            .cores_not_in_grid = {CoreCoord{5, 1}, CoreCoord{0, 2}, CoreCoord{10, 7}},
+        },
+        ShardedBuilderGridTrimParams{
+            .tensor_shape = Shape({1, 512, 1}),
+            .method = ShardingTensorSpecMethod::HeightSharded,
+            .grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{10, 7})),
+            .orientation = ShardOrientation::COL_MAJOR,
+            .expected_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+            .expected_shard_height = 32,
+            .expected_shard_width = 32,
+            // Column-wise assignment keeps columns x=0 and x=1 whole.
+            .cores_in_grid = {CoreCoord{0, 7}, CoreCoord{1, 0}, CoreCoord{1, 7}},
+            .cores_not_in_grid = {CoreCoord{2, 0}, CoreCoord{10, 7}},
+        },
+        ShardedBuilderGridTrimParams{
+            .tensor_shape = Shape({1, 512, 1}),
+            .method = ShardingTensorSpecMethod::WidthSharded,
+            .grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{10, 7})),
+            .orientation = ShardOrientation::ROW_MAJOR,
+            .expected_layout = TensorMemoryLayout::WIDTH_SHARDED,
+            .expected_shard_height = 512,
+            .expected_shard_width = 32,
+            .expected_grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{0, 0})),
+        },
+        ShardedBuilderGridTrimParams{
+            .tensor_shape = Shape({1, 512, 1}),
+            .method = ShardingTensorSpecMethod::BlockSharded,
+            .grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{10, 7})),
+            .orientation = ShardOrientation::ROW_MAJOR,
+            .expected_layout = TensorMemoryLayout::BLOCK_SHARDED,
+            .expected_shard_height = 64,
+            .expected_shard_width = 32,
+            // 8 height shards x 1 width shard keep the leading 1x8 column of the grid.
+            .expected_grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{0, 7})),
+        },
+        ShardedBuilderGridTrimParams{
+            .tensor_shape = Shape({1, 512, 1}),
+            .method = ShardingTensorSpecMethod::BlockSharded,
+            .grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{10, 7})),
+            .orientation = ShardOrientation::COL_MAJOR,
+            .expected_layout = TensorMemoryLayout::BLOCK_SHARDED,
+            .expected_shard_height = 64,
+            .expected_shard_width = 32,
+            // Transposed mapping keeps the leading 8x1 row of the grid.
+            .expected_grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{7, 0})),
+        },
+        // A tensor that fills the grid keeps it untouched: 8x11 shards on 88 cores.
+        ShardedBuilderGridTrimParams{
+            .tensor_shape = Shape({1, 512, 2048}),
+            .method = ShardingTensorSpecMethod::BlockSharded,
+            .grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{10, 7})),
+            .orientation = ShardOrientation::ROW_MAJOR,
+            .expected_layout = TensorMemoryLayout::BLOCK_SHARDED,
+            .expected_shard_height = 64,
+            .expected_shard_width = 192,
+            .expected_grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{10, 7})),
+        },
+        ShardedBuilderGridTrimParams{
+            .tensor_shape = Shape({1, 512, 32}),
+            .method = ShardingTensorSpecMethod::HeightSharded,
+            .grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{1, 1})),
+            .orientation = ShardOrientation::ROW_MAJOR,
+            .expected_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+            .expected_shard_height = 128,
+            .expected_shard_width = 32,
+            .expected_grid = CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{1, 1})),
         }));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/ttnn/unit_tests/operations/reduce/test_sharded_output_grid_fits_shards.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sharded_output_grid_fits_shards.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""A sharded tensor's grid must not hold more cores than it has shards.
+
+Reduce ops build their output spec by borrowing the *input's* core grid whenever the
+output memory config supplies a sharded layout but no shard spec
+(build_reduce_output_tensor_spec -> get_grid_and_orientation,
+ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp:207). The three
+TensorSpec sharding builders then honour that grid verbatim while deriving a shard
+shape that may need far fewer cores, so a 16x1-tile reduction result can claim the
+88- or 109-core grid of its 16x64-tile input.
+
+Nothing rejects it: the shard-count checks at tt_metal/impl/tensor/spec/tensor_spec.cpp
+only fire when there are too *few* cores. The numerics stay correct, which is why no
+functional test catches this -- the defect is in the spec, so it has to be asserted
+on the spec.
+
+Reachable from plain ttnn; a compiler that emits bare sharded layouts hits it on every
+reduction.
+"""
+
+import pytest
+import torch
+import ttnn
+
+TILE = 32
+
+
+def _shard_spec(memory_config):
+    spec = memory_config.shard_spec
+    return spec() if callable(spec) else spec
+
+
+def _grid(x_start, y_start, x_end, y_end):
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(x_start, y_start), ttnn.CoreCoord(x_end, y_end))})
+
+
+CASES = [
+    # label, input layout, input grid, input shard in tiles, tensor shape, dtype
+    (
+        "block_sharded 2x6 over 88 cores",
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        _grid(0, 0, 10, 7),
+        (2, 6),
+        (1, 512, 2048),
+        ttnn.float32,
+    ),
+    (
+        "width_sharded 37 tiles over 88 cores",
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        _grid(0, 0, 10, 7),
+        (16, 37),
+        (1, 512, 37 * TILE * 88),
+        ttnn.bfloat16,
+    ),
+]
+
+OUT_LAYOUTS = [
+    ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+    ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+]
+
+
+@pytest.mark.parametrize("keepdim", [True, False], ids=["keepdim", "no_keepdim"])
+@pytest.mark.parametrize("out_layout", OUT_LAYOUTS, ids=lambda l: str(l).split(".")[-1])
+@pytest.mark.parametrize("label, in_layout, in_grid, in_shard_tiles, shape, dtype", CASES, ids=[c[0] for c in CASES])
+def test_reduce_output_grid_fits_its_shards(
+    device, label, in_layout, in_grid, in_shard_tiles, shape, dtype, out_layout, keepdim
+):
+    in_mem = ttnn.MemoryConfig(
+        in_layout,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(in_grid, (in_shard_tiles[0] * TILE, in_shard_tiles[1] * TILE), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    # A layout and buffer type with no shard spec: the shape is left to tt-metal.
+    out_mem = ttnn.MemoryConfig(out_layout, ttnn.BufferType.L1)
+
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    x = ttnn.from_torch(
+        torch.randn(*shape, dtype=torch_dtype),
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in_mem,
+    )
+    out = ttnn.mean(x, dim=-1, keepdim=keepdim, memory_config=out_mem)
+
+    spec = _shard_spec(out.memory_config())
+    if spec is None:
+        ttnn.deallocate(x)
+        ttnn.deallocate(out)
+        pytest.skip(
+            f"{label} -> bare {str(out_layout).split('.')[-1]} (keepdim={keepdim}): "
+            "op returned an interleaved output, so there is no grid to check"
+        )
+
+    cores = spec.grid.num_cores()
+    shard_h, shard_w = spec.shape[0], spec.shape[1]
+    # ttnn Shape does not support slicing; materialise it first
+    padded = tuple(out.padded_shape)
+    height = 1
+    for d in padded[:-1]:
+        height *= d
+    shards = ((height + shard_h - 1) // shard_h) * ((padded[-1] + shard_w - 1) // shard_w)
+
+    ttnn.deallocate(x)
+    ttnn.deallocate(out)
+
+    assert cores <= shards, (
+        f"{label} -> bare {str(out_layout).split('.')[-1]}: output grid holds {cores} cores "
+        f"for {shards} shard(s) of {shard_h}x{shard_w} px. "
+        f"{cores - shards} core(s) have L1 reserved for data that does not exist."
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_sharded_output_grid_fits_shards.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sharded_output_grid_fits_shards.py
@@ -10,7 +10,8 @@ output memory config supplies a sharded layout but no shard spec
 ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp:207). The three
 TensorSpec sharding builders then honour that grid verbatim while deriving a shard
 shape that may need far fewer cores, so a 16x1-tile reduction result can claim the
-88- or 109-core grid of its 16x64-tile input.
+88-core grid of its 16x64-tile input (in the originating model, the vocab-loss sum
+claims the 109-core grid of its 16x4008-tile input for a single shard).
 
 Nothing rejects it: the shard-count checks at tt_metal/impl/tensor/spec/tensor_spec.cpp
 only fire when there are too *few* cores. The numerics stay correct, which is why no

--- a/tests/ttnn/unit_tests/operations/reduce/test_sharded_output_grid_fits_shards.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sharded_output_grid_fits_shards.py
@@ -65,6 +65,7 @@ OUT_LAYOUTS = [
 ]
 
 
+@pytest.mark.requires_grid_size((11, 8))
 @pytest.mark.parametrize("keepdim", [True, False], ids=["keepdim", "no_keepdim"])
 @pytest.mark.parametrize("out_layout", OUT_LAYOUTS, ids=lambda l: str(l).split(".")[-1])
 @pytest.mark.parametrize("label, in_layout, in_grid, in_shard_tiles, shape, dtype", CASES, ids=[c[0] for c in CASES])

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/tensor/tensor_types.hpp>
 #include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt-metalium/tensor/spec/memory_config/memory_config.hpp>
@@ -144,6 +145,35 @@ void validate_dtype_and_layout(DataType dtype, Layout layout) {
     supported_layout();
 }
 
+uint32_t aligned_extent(const Alignment& alignment, int dim_from_end, uint32_t extent) {
+    return static_cast<int>(alignment.size()) >= dim_from_end ? round_up(extent, alignment[-dim_from_end]) : extent;
+}
+
+uint32_t shards_needed(uint32_t total_extent, uint32_t shard_extent) {
+    return shard_extent == 0 ? 0 : div_up(total_extent, shard_extent);
+}
+
+CoreRangeSet first_n_cores(CoreRangeSet grid, uint32_t count, ShardOrientation orientation) {
+    if (count == 0 || count >= grid.num_cores()) {
+        return grid;
+    }
+    return CoreRangeSet(corerange_to_cores(grid, count, orientation == ShardOrientation::ROW_MAJOR))
+        .merge_ranges();
+}
+
+CoreRange leading_block(CoreRange grid, uint32_t rows, uint32_t cols) {
+    const auto size = grid.grid_size();
+    if (rows == 0 || cols == 0) {
+        return grid;
+    }
+    rows = rows < size.y ? rows : size.y;
+    cols = cols < size.x ? cols : size.x;
+    if (rows == size.y && cols == size.x) {
+        return grid;
+    }
+    return CoreRange(grid.start_coord, CoreCoord(grid.start_coord.x + cols - 1, grid.start_coord.y + rows - 1));
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -203,36 +233,41 @@ TensorSpec TensorSpec::sharded_across_dims_except(
 }
 
 TensorSpec TensorSpec::height_sharded(CoreRangeSet grid, ShardOrientation orientation) const {
-    auto num_cores = grid.num_cores();
-    auto shard_height = div_up(physical_shape().height(), num_cores);
+    const auto alignment = get_required_shard_shape_alignment(page_config());
+    const uint32_t shard_height = CMAKE_UNIQUE_NAMESPACE::aligned_extent(
+        alignment, 2, div_up(physical_shape().height(), grid.num_cores()));
+    grid = CMAKE_UNIQUE_NAMESPACE::first_n_cores(
+        std::move(grid), CMAKE_UNIQUE_NAMESPACE::shards_needed(physical_shape().height(), shard_height), orientation);
     NdShardSpec shard_spec(
-        Shape({static_cast<uint32_t>(shard_height), static_cast<uint32_t>(physical_shape().width())}),
-        std::move(grid),
-        orientation);
+        Shape({shard_height, static_cast<uint32_t>(physical_shape().width())}), std::move(grid), orientation);
     return sharded(std::move(shard_spec), ShardShapeAlignment::REQUIRED);
 }
 
 TensorSpec TensorSpec::width_sharded(CoreRangeSet grid, ShardOrientation orientation) const {
-    auto num_cores = grid.num_cores();
-    auto shard_width = div_up(physical_shape().width(), num_cores);
+    const auto alignment = get_required_shard_shape_alignment(page_config());
+    const uint32_t shard_width = CMAKE_UNIQUE_NAMESPACE::aligned_extent(
+        alignment, 1, div_up(physical_shape().width(), grid.num_cores()));
+    grid = CMAKE_UNIQUE_NAMESPACE::first_n_cores(
+        std::move(grid), CMAKE_UNIQUE_NAMESPACE::shards_needed(physical_shape().width(), shard_width), orientation);
     NdShardSpec shard_spec(
-        Shape({static_cast<uint32_t>(physical_shape().height()), static_cast<uint32_t>(shard_width)}),
-        std::move(grid),
-        orientation);
+        Shape({static_cast<uint32_t>(physical_shape().height()), shard_width}), std::move(grid), orientation);
     return sharded(std::move(shard_spec), ShardShapeAlignment::REQUIRED);
 }
 
 TensorSpec TensorSpec::block_sharded(CoreRange grid, ShardOrientation orientation) const {
-    auto grid_size = grid.grid_size();
-    auto shard_height =
-        div_up(physical_shape().height(), orientation == ShardOrientation::ROW_MAJOR ? grid_size.y : grid_size.x);
-    auto shard_width =
-        div_up(physical_shape().width(), orientation == ShardOrientation::ROW_MAJOR ? grid_size.x : grid_size.y);
+    const auto grid_size = grid.grid_size();
+    const bool row_major = orientation == ShardOrientation::ROW_MAJOR;
+    const auto alignment = page_config().get_recommended_shard_shape_alignment(data_type());
+    const uint32_t shard_height = CMAKE_UNIQUE_NAMESPACE::aligned_extent(
+        alignment, 2, div_up(physical_shape().height(), row_major ? grid_size.y : grid_size.x));
+    const uint32_t shard_width = CMAKE_UNIQUE_NAMESPACE::aligned_extent(
+        alignment, 1, div_up(physical_shape().width(), row_major ? grid_size.x : grid_size.y));
+    const uint32_t height_shards = CMAKE_UNIQUE_NAMESPACE::shards_needed(physical_shape().height(), shard_height);
+    const uint32_t width_shards = CMAKE_UNIQUE_NAMESPACE::shards_needed(physical_shape().width(), shard_width);
+    grid = CMAKE_UNIQUE_NAMESPACE::leading_block(
+        grid, row_major ? height_shards : width_shards, row_major ? width_shards : height_shards);
     NdShardSpec shard_spec(
-        Shape({static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)}),
-        grid,
-        orientation,
-        ShardDistributionStrategy::GRID_2D);
+        Shape({shard_height, shard_width}), grid, orientation, ShardDistributionStrategy::GRID_2D);
     return sharded(std::move(shard_spec), ShardShapeAlignment::RECOMMENDED);
 }
 

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -157,8 +157,7 @@ CoreRangeSet first_n_cores(CoreRangeSet grid, uint32_t count, ShardOrientation o
     if (count == 0 || count >= grid.num_cores()) {
         return grid;
     }
-    return CoreRangeSet(corerange_to_cores(grid, count, orientation == ShardOrientation::ROW_MAJOR))
-        .merge_ranges();
+    return select_from_corerangeset(grid, 0, count - 1, orientation == ShardOrientation::ROW_MAJOR);
 }
 
 CoreRange leading_block(CoreRange grid, uint32_t rows, uint32_t cols) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -179,8 +179,9 @@ MemoryConfig recompute_shard_spec_for_output(
         const uint32_t num_cores = source_shard_spec.grid.num_cores();
         const uint32_t phys_dim = is_height ? phys_h : phys_w;
 
-        // Preserve the input grid; height/width_sharded() rounds the per-core shape up
-        // to tile alignment without changing the grid itself.
+        // Seed from the input grid; height/width_sharded() rounds the per-core shape up
+        // to tile alignment and keeps only as many cores as that shape yields shards, so
+        // the grid shrinks when the output needs fewer shards than the input had cores.
         output_mem_config = is_height ? output_shape.height_sharded(source_shard_spec.grid, orientation).memory_config()
                                       : output_shape.width_sharded(source_shard_spec.grid, orientation).memory_config();
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
@@ -186,8 +186,9 @@ MemoryConfig recompute_shard_spec_for_output(
         const uint32_t num_cores = source_shard_spec.grid.num_cores();
         const uint32_t phys_dim = is_height ? phys_h : phys_w;
 
-        // Preserve the input grid; height/width_sharded() rounds the per-core shape up
-        // to tile alignment without changing the grid itself.
+        // Seed from the input grid; height/width_sharded() rounds the per-core shape up
+        // to tile alignment and keeps only as many cores as that shape yields shards, so
+        // the grid shrinks when the output needs fewer shards than the input had cores.
         output_mem_config = is_height ? output_shape.height_sharded(source_shard_spec.grid, orientation).memory_config()
                                       : output_shape.width_sharded(source_shard_spec.grid, orientation).memory_config();
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Relates to [tt-mlir#9189](https://github.com/tenstorrent/tt-mlir/issues/9189).

`TensorSpec::height_sharded` / `width_sharded` / `block_sharded` divide the tensor over
the given grid and round the shard shape up to tile alignment, but keep the grid as-is —
so when rounding shrinks the shard count, the grid keeps cores that hold no shard.
Validation only rejects too *few* cores, and reductions inherit the input's grid whenever
the output config has a sharded layout but no shard spec, so e.g. a `1x512x2048` input
block-sharded over 88 cores reduces to a `1x512x1` output with 8 shards still claiming all
88 cores (the vocab-loss sum: 1 shard on 109 cores).

Whether an over-provisioned grid is benign depends on how the consumer reads the tensor.
Ops that address by the **page map** (e.g. the universal reduce reader) never touch a
phantom core, so for them it is only wasted L1. But ops that derive work and output
placement from the **shard-spec grid** treat grid membership as data — and
`sharded_to_interleaved` is one of them: given a `BLOCK_SHARDED` input whose grid is wider
than the data, its writer runs on the phantom cores and **overruns the interleaved output,
silently corrupting adjacent DRAM**. This reproduces in pure ttnn, no tt-mlir involved: a
`(512x32)` tensor block-sharded on an 8x11 grid, relayouted to interleaved DRAM, comes back
14336/16384 elements wrong, while the correctly-provisioned 8x1 grid is exact. In
Llama 3.2 1B forward at `optimization-level=2` on Blackhole this is exactly what happened:
an RMSNorm stat's over-provisioned block-sharded grid made its `to_memory_config` spill
overrun and corrupt the adjacent layer-14 gate weight (loss 27.44 vs 3.496). Loss is
restored by this change alone; 104 of the plan's 819 ops change layout, all matching this
pattern.

This PR removes the trigger by never over-provisioning the grid. The op-level gap it
exploits — `sharded_to_interleaved` lacks the `BLOCK_SHARDED` "grid > data" clamp that its
HEIGHT/WIDTH paths already have — is a separate, complementary tt-metal fix.

The builders now compute the aligned shard shape first and trim the grid to the shards it
yields: first N cores in assignment order for height/width (via `select_from_corerangeset`,
preserving orientation and range order), the leading rows×cols rectangle for block
(`GRID_2D`). Shard shapes are bit-identical to before; only the grid changes. The reshape
over-pad warning now measures against the trimmed grid. The docstrings already promised
"just 1 shard per core"; this makes that true.

### Notes for reviewers

- Behaviour change: reducing to a single tile-row with `keepdim=False` now returns an
  interleaved output for height sharding (previously 88 cores for one shard); block
  sharding trims to 1 core instead.
- Reshape (`recompute_shard_spec_for_output`, generic + quasar) previously got its seeded
  grid back unchanged; outputs needing fewer shards than input cores now land on a trimmed
  grid. The config is only consumed as a data-movement target, but a consumer assuming
  output grid == input grid may now reshard — a look from someone who knows the
  sharded-reshape consumers would be welcome.
- Out of scope (not addressed here): the ND path (`sharded_across_dims*`, direct
  `sharded()`, reduce's `ND_SHARDED` branch) can still keep idle cores; validation
  rejecting hand-built over-claimed specs; intra-shard padding of a ragged last shard.

### Testing

- New pytest asserts `cores <= shards` on reduce output specs (2 geometries × 3 layouts ×
  keepdim): 10 passed / 2 skipped with the fix (interleaved fallback cells), 10 failed / 2
  passed without.
- New `ShardedBuilderGridTrimTests` (`test_tensor_nd_sharding.cpp`) pin the builder
  contract device-free: shard shapes, trim placement per orientation, no-trim early
  returns, legacy/ND grid agreement, cores == shards.
- `test_reshape.py` + `test_reduction.py`: 745 passed, 0 failed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bmalesevic/clamp-sharded-grid-to-shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bmalesevic/clamp-sharded-grid-to-shards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bmalesevic/clamp-sharded-grid-to-shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bmalesevic/clamp-sharded-grid-to-shards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bmalesevic/clamp-sharded-grid-to-shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bmalesevic/clamp-sharded-grid-to-shards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bmalesevic/clamp-sharded-grid-to-shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bmalesevic/clamp-sharded-grid-to-shards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bmalesevic/clamp-sharded-grid-to-shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bmalesevic/clamp-sharded-grid-to-shards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bmalesevic/clamp-sharded-grid-to-shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bmalesevic/clamp-sharded-grid-to-shards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bmalesevic/clamp-sharded-grid-to-shards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bmalesevic/clamp-sharded-grid-to-shards)




