### PR TITLE
Add support for dynamic logical l/n  trace support through tensors.

### DIFF
--- a/models/tt_dit/tests/unit/test_exp_ring_joint_attention.py
+++ b/models/tt_dit/tests/unit/test_exp_ring_joint_attention.py
@@ -9,7 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.tt_dit.tests.unit.test_ring_joint_attention import create_ring_joint_sdpa_submesh
+from models.tt_dit.tests.unit.test_ring_joint_attention import create_ring_joint_sdpa_submesh, logical_length_tensor
 from models.tt_dit.utils.padding import get_padded_vision_seq_len
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
@@ -434,3 +434,317 @@ def test_exp_ring_joint_sdpa_dit_bh_glx_custom(
         pcc_threshold,
         max_mse=max_mse,
     )
+
+
+# One captured exp-ring-joint SDPA segment plus its runtime args; 32 MB is ample headroom.
+LOGICAL_TENSOR_TRACE_REGION_SIZE = 32 * 1024 * 1024
+
+# This op is not bit-reproducible: two identical host-scalar calls on identical inputs differ (verified
+# on the unmodified op, scalar API only). So the logical_n tensor path is scored against the torch
+# golden and required to match the scalar path's PCC, rather than asserted bit-equal to it.
+PCC_THRESHOLD = 0.99
+PCC_TOLERANCE = 0.01
+
+
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {
+                "worker_l1_size": 1344544,
+                "trace_region_size": LOGICAL_TENSOR_TRACE_REGION_SIZE,
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(8192),
+            },
+            ttnn.Topology.Ring,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["ring"],
+)
+@pytest.mark.parametrize(
+    "mesh_device, num_links, b, nh, joint_seq_len, d, padded_seq_len, "
+    "rp_axis, rp_factor, up_axis, up_factor, q_chunk_size, k_chunk_size, logical_ns",
+    [
+        # logical_n values chosen so each SKIPS A DIFFERENT NUMBER OF KV CHUNKS, which is what makes the
+        # replay meaningful: the skipped count drives this op's credit caps, the injector's per-link gate
+        # demand and the writer's forwarded-chunk count, so a length baked at capture time desynchronizes
+        # them and hangs. ring_size=8 over padded 8192 gives 32 tiles per shard, and k_chunk=256 gives 8
+        # tiles per chunk, so the last shard holds 4 chunks starting at global tiles 224/232/240/248:
+        #   8192 -> nt 256, 0 skips, tile- and chunk-aligned (mask tile present but never applied)
+        #   8191 -> nt 256, 0 skips, sub-tile tail (partial column 31 stamped)
+        #   7936 -> nt 248, 1 skip,  tile-aligned tail (partial column 0, so unapplied)
+        #   7650 -> nt 240, 2 skips, sub-tile tail (partial column 2)
+        #   7200 -> nt 225, 3 skips, tile-aligned tail, near the largest padding the op allows
+        # The op's (padded - logical) < per-device rule puts the boundary in the last shard, which is
+        # also the joint shard -- so joint+boundary interaction is always exercised.
+        # joint_seq_len 1024 makes num_q_chunks = 4 local + 4 joint = 8, a multiple of the 4 SDPA grid
+        # columns this geometry yields, which the op requires. k_chunk=256 (8 tiles) is also what keeps
+        # the op's streaming-compute path enabled, which its compute kernel static_asserts on.
+        # nh=20 is chosen so the grid comes out 10 rows deep (5 heads/device x 2 segments/head), matching
+        # the row count and backward/forward worker split of the op's own passing 4x8 config. Shallower
+        # grids (4 rows / 2 workers per link) are not bit-reproducible on this op even on the host-scalar
+        # path.
+        ((4, 8), 2, 1, 20, 1024, 64, 8192, 1, 8, 0, 4, 256, 256, [8191, 8192, 7936, 7650, 7200]),
+    ],
+    ids=["m4x8"],
+    indirect=["mesh_device"],
+)
+def test_exp_ring_joint_sdpa_logical_n_tensor_trace_replay(
+    mesh_device,
+    num_links,
+    b,
+    nh,
+    joint_seq_len,
+    d,
+    padded_seq_len,
+    rp_axis,
+    rp_factor,
+    up_axis,
+    up_factor,
+    q_chunk_size,
+    k_chunk_size,
+    logical_ns,
+    all_gather_topology,
+    reset_seeds,
+):
+    """ONE captured trace, replayed once per logical_n with only the length tensor refreshed in place,
+    must score against the torch golden as well as the host-scalar path (the op is not bit-reproducible;
+    see PCC_THRESHOLD).
+
+    Inputs are uploaded once, so logical_n is the only thing distinguishing one replay from the next.
+    Catches the failure modes a single-dispatch test cannot: a stale read of the fixed-address tensor
+    (missing invalidate_l1_cache), and a chunk-skip count baked at capture time, which would leave the
+    reader's credit/gate demand out of step with the writer's forwarded-chunk count.
+    """
+    dtype = ttnn.bfloat16
+    submesh = create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_factor)
+    submesh.enable_program_cache()  # a trace replays cached programs; capture cannot JIT-compile
+
+    local_padded_N = padded_seq_len // rp_factor
+    for logical_n in logical_ns:
+        assert padded_seq_len - logical_n < local_padded_N, (
+            f"logical_n={logical_n} violates the op's own validation: (padded {padded_seq_len} - logical) "
+            f"must be < per-device {local_padded_N}"
+        )
+
+    full_compute_grid = submesh.compute_with_storage_grid_size()
+    # Grid derived from the op's own two shape rules rather than the full device grid: it reserves the
+    # last column for the fabric MUX and needs one Q chunk per SDPA column (so x = local chunks + 1),
+    # and every grid ROW must be covered by a head-segment (so y = B * NQH * segments-per-head).
+    num_local_q_chunks = math.ceil(local_padded_N / q_chunk_size)
+    num_joint_q_chunks = math.ceil(joint_seq_len / q_chunk_size)
+    num_q_chunks = num_local_q_chunks + num_joint_q_chunks
+    sdpa_grid_x = num_local_q_chunks
+    assert (
+        num_q_chunks % sdpa_grid_x == 0
+    ), f"num_q_chunks ({num_q_chunks}) must be a multiple of the {sdpa_grid_x} SDPA grid columns"
+    grid_rows = b * (nh // up_factor) * (num_q_chunks // sdpa_grid_x)
+    assert grid_rows <= full_compute_grid.y, f"needed {grid_rows} rows, device grid has {full_compute_grid.y}"
+    sdpa_compute_grid = (sdpa_grid_x + 1, grid_rows)
+
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = submesh.create_sub_device_manager([worker_sub_device], 0)
+    submesh.load_sub_device_manager(sub_device_manager)
+    submesh.set_sub_device_stall_group([worker_sub_device_id])
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(submesh, ccl_sub_device_crs, 0) for _ in range(num_links)]
+
+    spatial_shard_dims = [None, None]
+    spatial_shard_dims[rp_axis] = 2
+    spatial_shard_dims[up_axis] = 1
+    kv_buf_shard_dims = [None, None]
+    kv_buf_shard_dims[up_axis] = 1
+    # The exp op's joint is replicated: full L per device, head-sharded only.
+    joint_shard_dims = list(kv_buf_shard_dims)
+    joint_composer_dims = list(joint_shard_dims)
+    joint_composer_dims[rp_axis] = 0  # concat the per-device replicas into batch so all are compared
+
+    # Garbage (not zero) past logical_n: those rows must be masked out, and leaked garbage collapses the
+    # comparison where a leaked zero would barely move it.
+    padded_Q = 8.0 * fa_rand(b, nh, padded_seq_len, d)
+    padded_K = 8.0 * fa_rand(b, nh, padded_seq_len, d)
+    padded_V = 8.0 * fa_rand(b, nh, padded_seq_len, d)
+    joint_Q = 8.0 * fa_rand(b, nh, joint_seq_len, d)
+    joint_K = 8.0 * fa_rand(b, nh, joint_seq_len, d)
+    joint_V = 8.0 * fa_rand(b, nh, joint_seq_len, d)
+
+    def upload(host_tensor, dims):
+        return ttnn.from_torch(
+            host_tensor,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=dims),
+        )
+
+    # Allocated ONCE: under trace these addresses are baked into the capture.
+    tt_Q = upload(padded_Q, spatial_shard_dims)
+    tt_K = upload(padded_K, spatial_shard_dims)
+    tt_V = upload(padded_V, spatial_shard_dims)
+    tt_joint_Q = upload(joint_Q, joint_shard_dims)
+    tt_joint_K = upload(joint_K, joint_shard_dims)
+    tt_joint_V = upload(joint_V, joint_shard_dims)
+    persistent_kv_bufs = [
+        upload(torch.zeros(b, nh, padded_seq_len, d), kv_buf_shard_dims),
+        upload(torch.zeros(b, nh, padded_seq_len, d), kv_buf_shard_dims),
+    ]
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=sdpa_compute_grid,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        submesh.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    tt_logical_n = logical_length_tensor(submesh, logical_ns[0])
+
+    def load_length(logical_n):
+        """Deliver the length the way a traced runner does: in-place refresh, no reallocation."""
+        ttnn.copy_host_to_device_tensor(logical_length_tensor(submesh, logical_n, on_device=False), tt_logical_n)
+
+    def call(logical_n):
+        return ttnn.transformer.exp_ring_joint_scaled_dot_product_attention(
+            tt_Q,
+            tt_K,
+            tt_V,
+            tt_joint_Q,
+            tt_joint_K,
+            tt_joint_V,
+            persistent_output_buffer_k=persistent_kv_bufs[0],
+            persistent_output_buffer_v=persistent_kv_bufs[1],
+            joint_strategy="rear",
+            logical_n=logical_n,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            dim=2,
+            multi_device_global_semaphore=ccl_semaphore_handles,
+            num_links=num_links,
+            cluster_axis=rp_axis,
+            mesh_device=submesh,
+            topology=all_gather_topology,
+            subdevice_id=worker_sub_device_id,
+            # The op splits the grid rows into a backward and a forward fabric-direction half.
+            num_workers_per_link=grid_rows // 2,
+        )
+
+    spatial_composer = ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=tuple(submesh.shape), dims=spatial_shard_dims)
+    joint_composer = ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=tuple(submesh.shape), dims=joint_composer_dims)
+
+    def valid_rows(tt_out, tt_joint_out, logical_n):
+        spatial = ttnn.to_torch(tt_out, mesh_composer=spatial_composer)[:, :, :logical_n, :]
+        joint = ttnn.to_torch(tt_joint_out, mesh_composer=joint_composer)[:, :, :joint_seq_len, :]
+        return spatial, joint
+
+    def golden(logical_n):
+        """Torch reference for this length: real spatial rows [0, logical_n) plus the joint."""
+        q = torch.cat([padded_Q[:, :, :logical_n, :], joint_Q], dim=2)
+        k = torch.cat([padded_K[:, :, :logical_n, :], joint_K], dim=2)
+        v = torch.cat([padded_V[:, :, :logical_n, :], joint_V], dim=2)
+        gt = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=False)
+        return gt[:, :, :logical_n, :], gt[:, :, logical_n:, :]
+
+    def score(tt_out, tt_joint_out, logical_n):
+        """PCC of the spatial and joint outputs against the torch golden."""
+        got_spatial, got_joint = valid_rows(tt_out, tt_joint_out, logical_n)
+        ref_spatial, ref_joint = golden(logical_n)
+        _, spatial_pcc = comp_pcc(ref_spatial, got_spatial, PCC_THRESHOLD)
+        joint_pcc = None
+        if joint_seq_len > 0:
+            # A replicated joint output is one copy per ring device; score the first replica.
+            replica = got_joint[0:1] if got_joint.shape[0] > 1 else got_joint
+            _, joint_pcc = comp_pcc(ref_joint, replica, PCC_THRESHOLD)
+        return spatial_pcc, joint_pcc
+
+    def pcc_value(pcc_str):
+        # comp_pcc returns a message like "PCC: 0.9994..."; pull the number out.
+        return float(str(pcc_str).split(":")[-1].strip())
+
+    trace_id = None
+    try:
+        # 1) Scalar mode (logical_n as a host int) -- the pre-existing path.
+        scalar_pcc = {}
+        for logical_n in logical_ns:
+            tt_out, tt_joint_out, tt_stats = call(logical_n)
+            ttnn.synchronize_device(submesh)
+            scalar_pcc[logical_n] = score(tt_out, tt_joint_out, logical_n)
+            for t in (tt_out, tt_joint_out, tt_stats):
+                ttnn.deallocate(t)
+            logger.info(f"scalar  logical_n={logical_n}: spatial {scalar_pcc[logical_n][0]}")
+
+        # 2) Tensor mode (logical_n as a single-valued device tensor), eager.
+        tensor_pcc = {}
+        for logical_n in logical_ns:
+            load_length(logical_n)
+            tt_out, tt_joint_out, tt_stats = call(tt_logical_n)
+            ttnn.synchronize_device(submesh)
+            tensor_pcc[logical_n] = score(tt_out, tt_joint_out, logical_n)
+            for t in (tt_out, tt_joint_out, tt_stats):
+                ttnn.deallocate(t)
+            logger.info(f"tensor  logical_n={logical_n}: spatial {tensor_pcc[logical_n][0]}")
+
+        # 3) ONE captured trace, replayed per length with only the length tensor refreshed in place.
+        #    The capture's host scalar is the placeholder, identical for every length, so a replay that
+        #    scores well can only have picked the length up from the tensor.
+        load_length(logical_ns[0])
+        warm = call(tt_logical_n)
+        ttnn.synchronize_device(submesh)
+        for t in warm:
+            ttnn.deallocate(t)
+
+        trace_id = ttnn.begin_trace_capture(submesh, cq_id=0)
+        tt_out_traced, tt_joint_out_traced, _ = call(tt_logical_n)
+        ttnn.end_trace_capture(submesh, trace_id, cq_id=0)
+        ttnn.synchronize_device(submesh)
+
+        # Replay order is deliberately not ascending: forward, then descending (where a stale length
+        # would be too LARGE and over-attend), then out of order.
+        n = len(logical_ns)
+        replay_order = list(range(n)) + list(reversed(range(n))) + [0, n - 1, 1]
+        replay_pcc = {}
+        for replay_idx, i in enumerate(replay_order):
+            logical_n = logical_ns[i]
+            load_length(logical_n)
+            ttnn.execute_trace(submesh, trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(submesh)
+            got = score(tt_out_traced, tt_joint_out_traced, logical_n)
+            replay_pcc.setdefault(logical_n, got)
+            logger.info(f"replay {replay_idx} logical_n={logical_n}: spatial {got[0]}")
+
+        # ---- Verdict -------------------------------------------------------------------------
+        failures = []
+        for logical_n in logical_ns:
+            s = pcc_value(scalar_pcc[logical_n][0])
+            t = pcc_value(tensor_pcc[logical_n][0])
+            r = pcc_value(replay_pcc[logical_n][0])
+            logger.info(f"logical_n={logical_n}: scalar={s:.6f} tensor={t:.6f} replay={r:.6f}")
+            if s < PCC_THRESHOLD:
+                failures.append(f"logical_n={logical_n}: SCALAR path itself scores {s:.6f} < {PCC_THRESHOLD}")
+            # The tensor path must be as good as the scalar path, within the run-to-run spread this
+            # op already shows on identical inputs.
+            if t < s - PCC_TOLERANCE:
+                failures.append(f"logical_n={logical_n}: tensor {t:.6f} vs scalar {s:.6f} (tol {PCC_TOLERANCE})")
+            if r < s - PCC_TOLERANCE:
+                failures.append(f"logical_n={logical_n}: replay {r:.6f} vs scalar {s:.6f} (tol {PCC_TOLERANCE})")
+        assert not failures, "logical_n tensor transport regressed:\n  " + "\n  ".join(failures)
+
+        logger.success(
+            f"logical_n tensor: {n} lengths scored eager + {len(replay_order)} trace replays from ONE "
+            f"capture, all matching the host-scalar path's PCC within {PCC_TOLERANCE}"
+        )
+    finally:
+        if trace_id is not None:
+            ttnn.release_trace(submesh, trace_id)
+        submesh.reset_sub_device_stall_group()
+        submesh.clear_loaded_sub_device_manager()
+        submesh.remove_sub_device_manager(sub_device_manager)

--- a/models/tt_dit/tests/unit/test_ring_joint_attention.py
+++ b/models/tt_dit/tests/unit/test_ring_joint_attention.py
@@ -57,6 +57,18 @@ def create_global_semaphores(mesh_device, cores, initial_value):
     return ccl_semaphore_handles
 
 
+def logical_length_tensor(mesh_device, value, *, on_device=True):
+    """Single-valued uint32 tensor for the logical_n / logical_l transport, replicated to every device.
+    on_device=False returns the spec-matching host twin for ttnn.copy_host_to_device_tensor."""
+    return ttnn.from_torch(
+        torch.tensor([value], dtype=torch.int64).reshape(1, 1, 1, 1),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        **({"device": mesh_device} if on_device else {}),
+    )
+
+
 def create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_factor):
     submesh_shape = [0, 0]
     submesh_shape[rp_axis] = rp_factor
@@ -331,6 +343,8 @@ def run_ring_joint_sdpa(
     pcc_threshold,
     max_mse=None,
     fp32_dest_acc_en: bool = False,
+    # logical_n as a device tensor instead of a host int (logical_l stays defaulted). Pure transport change.
+    logical_as_tensor: bool = False,
 ):
     full_compute_grid = submesh.compute_with_storage_grid_size()
     sdpa_compute_grid = (full_compute_grid.x, full_compute_grid.y - 1)
@@ -468,6 +482,8 @@ def run_ring_joint_sdpa(
 
     tt_out_list = []
     tt_joint_out_list = []
+    # Allocated once, outside run_iters, so a traced capture bakes a stable address.
+    tt_logical_n = logical_length_tensor(submesh, base_seq_len) if logical_as_tensor else base_seq_len
 
     def run_iters(tt_out_list, tt_joint_out_list):
         with submesh.cache_entries_counter.measure():
@@ -482,7 +498,7 @@ def run_ring_joint_sdpa(
                     persistent_output_buffer_k=persistent_output_buffers[i][0],
                     persistent_output_buffer_v=persistent_output_buffers[i][1],
                     joint_strategy="rear",
-                    logical_n=base_seq_len,
+                    logical_n=tt_logical_n,
                     program_config=program_config,
                     compute_kernel_config=compute_kernel_config,
                     dim=2,
@@ -904,6 +920,9 @@ model_input_ids = [
         "4rpx2up",
     ],
 )
+# logical_n-only transport (replicated joint, logical_l defaulted): the shape family the DiT and
+# minimax_h3 callers use, checked against the host-int path over this whole matrix.
+@pytest.mark.parametrize("logical_as_tensor", [False, True], ids=["scalar", "tensor"])
 def test_ring_joint_sdpa_shapes(
     mesh_device,
     b,
@@ -921,6 +940,7 @@ def test_ring_joint_sdpa_shapes(
     rp_factor,
     up_axis,
     up_factor,
+    logical_as_tensor,
     all_gather_topology,
     skip_check,
     reset_seeds,
@@ -958,6 +978,7 @@ def test_ring_joint_sdpa_shapes(
         all_gather_topology,
         skip_check,
         0.999,
+        logical_as_tensor=logical_as_tensor,
     )
 
 
@@ -1297,6 +1318,7 @@ def run_ring_joint_sdpa_sharded_prompt(
     k_chunk_size,
     num_links,
     logical_l=None,
+    logical_as_tensor=False,
     topology=ttnn.Topology.Linear,
     pcc_threshold=0.999,
 ):
@@ -1305,7 +1327,14 @@ def run_ring_joint_sdpa_sharded_prompt(
     internal gather and the output joint tensor is also sharded L/P per device.
 
     logical_l (defaulting to padded_joint_seq_len) is the real joint length;
+
+    logical_as_tensor selects which lengths travel as device tensors: False/"none", True/"both", "n", "l".
+    Pure transport change, so the result must be identical; the garbage-filled pad tails make any missed
+    mask collapse PCC.
     """
+    tensor_modes = {False: "none", True: "both"}
+    tensor_mode = tensor_modes.get(logical_as_tensor, logical_as_tensor)
+    assert tensor_mode in ("none", "both", "n", "l"), f"bad logical_as_tensor={logical_as_tensor}"
     dtype = ttnn.bfloat16
 
     full_compute_grid = submesh.compute_with_storage_grid_size()
@@ -1480,8 +1509,8 @@ def run_ring_joint_sdpa_sharded_prompt(
         persistent_output_buffer_k=persistent_kv_bufs[0],
         persistent_output_buffer_v=persistent_kv_bufs[1],
         joint_strategy="rear",
-        logical_n=base_seq_len,
-        logical_l=logical_l,
+        logical_n=logical_length_tensor(submesh, base_seq_len) if tensor_mode in ("both", "n") else base_seq_len,
+        logical_l=logical_length_tensor(submesh, logical_l) if tensor_mode in ("both", "l") else logical_l,
         program_config=program_config,
         compute_kernel_config=compute_kernel_config,
         dim=2,
@@ -1522,6 +1551,71 @@ def run_ring_joint_sdpa_sharded_prompt(
     jout_pass, jout_pcc = comp_pcc(tt_joint_out_pt, gt_joint, pcc_threshold)
     logger.info(f"[sharded-joint] joint PCC={jout_pcc}")
     assert jout_pass, f"Joint PCC {jout_pcc} below threshold {pcc_threshold}"
+
+
+# The full matrix above covers "neither" and "both"; this covers the two mixed modes on a shape with a
+# sub-tile partial column on BOTH tails, where a crossed-over transport shows immediately.
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, b, nh, base_seq_len, padded_joint_seq_len, d, q_chunk_size, k_chunk_size, logical_l",
+    [
+        ((2, 4), 0, 1, 24, 63, 64, 64, 32, 32, 63),
+        ((4, 8), 0, 1, 24, 127, 128, 64, 32, 32, 127),
+    ],
+    ids=["m2x4", "m4x8"],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize("logical_as_tensor", ["n", "l"], ids=["n_only", "l_only"])
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            ttnn.Topology.Linear,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["line"],
+)
+def test_ring_joint_sdpa_sharded_prompt_mixed_logical_transport(
+    mesh_device,
+    sp_axis,
+    b,
+    nh,
+    base_seq_len,
+    padded_joint_seq_len,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    logical_l,
+    logical_as_tensor,
+    all_gather_topology,
+    reset_seeds,
+):
+    """One logical length as a device tensor, the other as a host int."""
+    sp_factor = mesh_device.shape[sp_axis]
+    up_axis = 1 - sp_axis
+    num_links = sharded_prompt_num_links(mesh_device.shape)
+    submesh = mesh_device.create_submesh(ttnn.MeshShape(*mesh_device.shape))
+    submesh.cache_entries_counter = CacheEntriesCounter(submesh)
+    padded_seq_len = get_padded_vision_seq_len(base_seq_len, sp_factor)
+    run_ring_joint_sdpa_sharded_prompt(
+        submesh,
+        b=b,
+        nh=nh,
+        base_seq_len=base_seq_len,
+        padded_seq_len=padded_seq_len,
+        padded_joint_seq_len=padded_joint_seq_len,
+        d=d,
+        rp_axis=sp_axis,
+        rp_factor=sp_factor,
+        up_axis=up_axis,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        num_links=num_links,
+        logical_l=logical_l,
+        logical_as_tensor=logical_as_tensor,
+        topology=all_gather_topology,
+    )
 
 
 def sharded_prompt_num_links(mesh_shape):
@@ -1597,6 +1691,8 @@ def sharded_prompt_num_links(mesh_shape):
     indirect=["device_params"],
     ids=["line"],
 )
+# Both ways of supplying logical_n / logical_l must agree over the whole matrix above.
+@pytest.mark.parametrize("logical_as_tensor", [False, True], ids=["scalar", "tensor"])
 def test_ring_joint_sdpa_sharded_prompt(
     mesh_device,
     sp_axis,
@@ -1608,6 +1704,7 @@ def test_ring_joint_sdpa_sharded_prompt(
     q_chunk_size,
     k_chunk_size,
     logical_l,
+    logical_as_tensor,
     all_gather_topology,
     reset_seeds,
 ):
@@ -1639,5 +1736,267 @@ def test_ring_joint_sdpa_sharded_prompt(
         k_chunk_size=k_chunk_size,
         num_links=num_links,
         logical_l=logical_l,
+        logical_as_tensor=logical_as_tensor,
         topology=all_gather_topology,
     )
+
+
+# One captured ring-joint SDPA segment plus its runtime args; 32 MB is ample headroom.
+LOGICAL_TENSOR_TRACE_REGION_SIZE = 32 * 1024 * 1024
+
+
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, b, nh, padded_seq_len, padded_joint_seq_len, d, q_chunk_size, k_chunk_size, logical_pairs",
+    [
+        # (logical_n, logical_l) pairs moving every live-driven geometry: full, sub-tile tails, emptied
+        # iterations, mixed. logical_l must exceed the per-device joint shard to select the sharded path;
+        # a fully-empty iteration needs ring_size >= 3, so the (4,8) row carries that case.
+        ((2, 4), 0, 1, 24, 128, 128, 64, 32, 32, [(128, 128), (95, 127), (64, 65), (127, 100)]),
+        ((4, 8), 0, 1, 24, 256, 256, 64, 32, 32, [(256, 256), (191, 127), (64, 65), (255, 200)]),
+    ],
+    ids=["m2x4", "m4x8"],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "trace_region_size": LOGICAL_TENSOR_TRACE_REGION_SIZE,
+            },
+            ttnn.Topology.Linear,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["line"],
+)
+# Both joint layouts, because they reach the transport differently: the sharded joint varies logical_n AND
+# logical_l, while the replicated joint (the DiT / minimax_h3 usage) pins logical_l by shape and varies
+# logical_n alone, leaving logical_lt compile-time.
+@pytest.mark.parametrize("joint_sharded", [True, False], ids=["sharded_joint", "replicated_joint"])
+def test_ring_joint_sdpa_logical_tensor_trace_replay(
+    mesh_device,
+    sp_axis,
+    b,
+    nh,
+    padded_seq_len,
+    padded_joint_seq_len,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    logical_pairs,
+    joint_sharded,
+    all_gather_topology,
+    reset_seeds,
+):
+    """ONE captured trace, replayed once per (logical_n, logical_l) pair with only the length tensors
+    refreshed in place, must match the host-scalar path bit-for-bit.
+
+    Inputs are uploaded once, so the lengths are the only thing distinguishing one replay from the next.
+    Catches the two multi-dispatch failure modes single-dispatch tests cannot: a stale read of the
+    fixed-address tensors (missing invalidate_l1_cache), and an iteration emptied by the live length but
+    marked active by the placeholder-derived mask (compute waits on work that never arrives).
+    """
+    sp_factor = mesh_device.shape[sp_axis]
+    up_axis = 1 - sp_axis
+    num_links = sharded_prompt_num_links(mesh_device.shape)
+    submesh = mesh_device.create_submesh(ttnn.MeshShape(*mesh_device.shape))
+    submesh.cache_entries_counter = CacheEntriesCounter(submesh)
+    assert padded_seq_len % sp_factor == 0, "padded_seq_len must be divisible by sp_factor"
+    assert padded_joint_seq_len % sp_factor == 0, "padded_joint_seq_len must be divisible by sp_factor"
+    submesh.enable_program_cache()  # a trace replays cached programs; capture cannot JIT-compile
+
+    dtype = ttnn.bfloat16
+    full_compute_grid = submesh.compute_with_storage_grid_size()
+    sdpa_compute_grid = (full_compute_grid.x, full_compute_grid.y - 1)
+    ccl_core_grid_offset = (0, full_compute_grid.y - 1)
+
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = submesh.create_sub_device_manager([worker_sub_device], 0)
+    submesh.load_sub_device_manager(sub_device_manager)
+    submesh.set_sub_device_stall_group([worker_sub_device_id])
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(submesh, ccl_sub_device_crs, 0) for _ in range(2)]
+
+    spatial_shard_dims = [None, None]
+    spatial_shard_dims[sp_axis] = 2
+    spatial_shard_dims[up_axis] = 1
+    kv_buf_shard_dims = [None, None]
+    kv_buf_shard_dims[up_axis] = 1
+    # Sharded joint: L/P per device (seq sharded), needing the internal gather. Replicated: full L per
+    # device, head-sharded only.
+    joint_shard_dims = list(spatial_shard_dims) if joint_sharded else list(kv_buf_shard_dims)
+    # A replicated joint output is a full copy per ring device; concat the replicas into batch so the
+    # comparison covers every one of them.
+    joint_composer_dims = list(joint_shard_dims)
+    if not joint_sharded:
+        joint_composer_dims[sp_axis] = 0
+
+    # Garbage (not zero) everywhere: rows past logical_n / logical_l must be masked out, and leaked
+    # garbage collapses the comparison where a leaked zero would barely move it.
+    padded_Q = 8.0 * fa_rand(b, nh, padded_seq_len, d)
+    padded_K = 8.0 * fa_rand(b, nh, padded_seq_len, d)
+    padded_V = 8.0 * fa_rand(b, nh, padded_seq_len, d)
+    joint_Q = 8.0 * fa_rand(b, nh, padded_joint_seq_len, d)
+    joint_K = 8.0 * fa_rand(b, nh, padded_joint_seq_len, d)
+    joint_V = 8.0 * fa_rand(b, nh, padded_joint_seq_len, d)
+
+    def upload(host_tensor, dims):
+        return ttnn.from_torch(
+            host_tensor,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=tuple(submesh.shape), dims=dims),
+        )
+
+    # Allocated ONCE: under trace these addresses are baked into the capture.
+    tt_Q = upload(padded_Q, spatial_shard_dims)
+    tt_K = upload(padded_K, spatial_shard_dims)
+    tt_V = upload(padded_V, spatial_shard_dims)
+    tt_joint_Q = upload(joint_Q, joint_shard_dims)
+    tt_joint_K = upload(joint_K, joint_shard_dims)
+    tt_joint_V = upload(joint_V, joint_shard_dims)
+    persistent_kv_bufs = [
+        upload(torch.zeros(b, nh, padded_seq_len, d), kv_buf_shard_dims),
+        upload(torch.zeros(b, nh, padded_seq_len, d), kv_buf_shard_dims),
+    ]
+    persistent_joint_kv_bufs = [
+        upload(torch.zeros(b, nh, padded_joint_seq_len, d), kv_buf_shard_dims),
+        upload(torch.zeros(b, nh, padded_joint_seq_len, d), kv_buf_shard_dims),
+    ]
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=sdpa_compute_grid,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        submesh.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    tt_logical_n = logical_length_tensor(submesh, logical_pairs[0][0])
+    tt_logical_l = logical_length_tensor(submesh, logical_pairs[0][1]) if joint_sharded else None
+
+    def load_lengths(logical_n, logical_l):
+        """Deliver a pair the way a traced runner does: in-place refresh, no reallocation."""
+        ttnn.copy_host_to_device_tensor(logical_length_tensor(submesh, logical_n, on_device=False), tt_logical_n)
+        if joint_sharded:
+            ttnn.copy_host_to_device_tensor(logical_length_tensor(submesh, logical_l, on_device=False), tt_logical_l)
+
+    def call(logical_n, logical_l):
+        joint_kwargs = (
+            {
+                "logical_l": logical_l,
+                "persistent_output_buffer_joint_k": persistent_joint_kv_bufs[0],
+                "persistent_output_buffer_joint_v": persistent_joint_kv_bufs[1],
+            }
+            if joint_sharded
+            else {}
+        )
+        return ttnn.transformer.ring_joint_scaled_dot_product_attention(
+            tt_Q,
+            tt_K,
+            tt_V,
+            tt_joint_Q,
+            tt_joint_K,
+            tt_joint_V,
+            persistent_output_buffer_k=persistent_kv_bufs[0],
+            persistent_output_buffer_v=persistent_kv_bufs[1],
+            joint_strategy="rear",
+            logical_n=logical_n,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            dim=2,
+            multi_device_global_semaphore=ccl_semaphore_handles,
+            num_links=num_links,
+            cluster_axis=sp_axis,
+            mesh_device=submesh,
+            topology=all_gather_topology,
+            subdevice_id=worker_sub_device_id,
+            ccl_core_grid_offset=ccl_core_grid_offset,
+            **joint_kwargs,
+        )
+
+    spatial_composer = ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=tuple(submesh.shape), dims=spatial_shard_dims)
+    joint_composer = ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=tuple(submesh.shape), dims=joint_composer_dims)
+
+    def valid_rows(tt_out, tt_joint_out, logical_n, logical_l):
+        # A replicated joint has no logical_l to vary: every row of it is real.
+        joint_rows = logical_l if joint_sharded else padded_joint_seq_len
+        spatial = ttnn.to_torch(tt_out, mesh_composer=spatial_composer)[:, :, :logical_n, :]
+        joint = ttnn.to_torch(tt_joint_out, mesh_composer=joint_composer)[:, :, :joint_rows, :]
+        return spatial, joint
+
+    trace_id = None
+    try:
+        # 1) Host-scalar references, eager, one program per pair. Same device inputs as the replays.
+        references = []
+        for logical_n, logical_l in logical_pairs:
+            tt_out, tt_joint_out, tt_stats = call(logical_n, logical_l)
+            ttnn.synchronize_device(submesh)
+            references.append(valid_rows(tt_out, tt_joint_out, logical_n, logical_l))
+            for t in (tt_out, tt_joint_out, tt_stats):
+                ttnn.deallocate(t)
+
+        # Guard against a vacuous pass: if every pair produced the same numbers, a replay reading a stale
+        # length would still match. Compare each pair's spatial output over the rows they share.
+        for i in range(1, len(logical_pairs)):
+            shared = min(logical_pairs[i][0], logical_pairs[0][0])
+            assert not torch.equal(references[i][0][:, :, :shared, :], references[0][0][:, :, :shared, :]), (
+                f"pairs {logical_pairs[0]} and {logical_pairs[i]} give identical output over their shared "
+                f"{shared} rows, so replays could not distinguish them; pick different lengths"
+            )
+
+        # 2) Compile the tensor-path program, then capture it ONCE. Its host scalars are the placeholders,
+        #    identical for every pair, so the capture holds no per-pair information at all.
+        load_lengths(*logical_pairs[0])
+        warm = call(tt_logical_n, tt_logical_l)
+        ttnn.synchronize_device(submesh)
+        for t in warm:
+            ttnn.deallocate(t)
+
+        trace_id = ttnn.begin_trace_capture(submesh, cq_id=0)
+        tt_out_traced, tt_joint_out_traced, _ = call(tt_logical_n, tt_logical_l)
+        ttnn.end_trace_capture(submesh, trace_id, cq_id=0)
+        ttnn.synchronize_device(submesh)
+
+        # 3) Replay the single capture. The order is deliberately not ascending: a forward pass, then a
+        #    descending pass (where a stale length is too LARGE and over-attends), then out of order.
+        n_pairs = len(logical_pairs)
+        replay_order = list(range(n_pairs)) + list(reversed(range(n_pairs))) + [0, n_pairs - 1, 1]
+        for replay_idx, i in enumerate(replay_order):
+            logical_n, logical_l = logical_pairs[i]
+            load_lengths(logical_n, logical_l)
+            ttnn.execute_trace(submesh, trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(submesh)
+            got_spatial, got_joint = valid_rows(tt_out_traced, tt_joint_out_traced, logical_n, logical_l)
+            ref_spatial, ref_joint = references[i]
+            for name, got, ref in (("spatial", got_spatial, ref_spatial), ("joint", got_joint, ref_joint)):
+                assert torch.equal(got, ref), (
+                    f"replay {replay_idx} of order {replay_order}: pair {i} "
+                    f"(logical_n={logical_n}, logical_l={logical_l}): traced {name} output differs from the "
+                    f"host-scalar path (max abs diff {(got - ref).abs().max().item()}). Matching pair "
+                    f"{i - 1} instead points at a stale length read."
+                )
+            logger.info(f"logical-tensor trace replay {replay_idx} (pair {i}={logical_pairs[i]}): bit-exact")
+
+        logger.success(
+            f"logical-tensor trace: 1 capture, {len(replay_order)} replays over {n_pairs} "
+            f"(logical_n, logical_l) pairs (order {replay_order}), all bit-exact vs the host-scalar path"
+        )
+    finally:
+        if trace_id is not None:
+            ttnn.release_trace(submesh, trace_id)
+        submesh.reset_sub_device_stall_group()
+        submesh.clear_loaded_sub_device_manager()
+        submesh.remove_sub_device_manager(sub_device_manager)

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_attention.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_attention.py
@@ -202,6 +202,8 @@ def test_ring_joint_sdpa_program_cache(
     ],
     ids=["sp2"],
 )
+# scalar = host int, tensor = single-valued device tensors (trace-dynamic transport); both must agree.
+@pytest.mark.parametrize("logical_as_tensor", [False, True], ids=["scalar", "tensor"])
 def test_ring_joint_sdpa_sharded_prompt(
     mesh_device,
     num_links,
@@ -213,6 +215,7 @@ def test_ring_joint_sdpa_sharded_prompt(
     d,
     q_chunk_size,
     k_chunk_size,
+    logical_as_tensor,
     all_gather_topology,
     reset_seeds,
 ):
@@ -237,5 +240,6 @@ def test_ring_joint_sdpa_sharded_prompt(
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         num_links=num_links,
+        logical_as_tensor=logical_as_tensor,
         topology=all_gather_topology,
     )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -914,6 +914,9 @@ def run_ring_joint_sdpa(
     rmse_threshold=None,
     do_check=True,
     num_iterations=1,
+    # logical_n as a device tensor instead of a host int. Pure transport change, so the accuracy check
+    # below must pass identically.
+    logical_as_tensor=False,
 ):
     """
     Run Ring Joint Attention SDPA using direct ttnn operations with auto-detected devices.
@@ -1086,6 +1089,14 @@ def run_ring_joint_sdpa(
 
         # Set logical_n to the original full sequence length
         corrected_logical_n = sq
+        if logical_as_tensor:
+            corrected_logical_n = ttnn.from_torch(
+                torch.tensor([sq], dtype=torch.int64).reshape(1, 1, 1, 1),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            )
 
         # Precompute mesh composer dims
         main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
@@ -4209,6 +4220,30 @@ STANDARD_MODEL_GROUPS, STANDARD_MODEL_GROUP_IDS = _generate_standard_model_group
 
 
 # === TEST 1: PERFORMANCE SWEEP (skipped on CI) ===
+# Causal / balanced-zigzag coverage for the logical_n tensor transport, where the ring-work masks
+# additionally carry the causal skip rule. models/tt_dit covers the non-causal shapes.
+@pytest.mark.parametrize(
+    "is_causal, is_balanced", [(True, False), (True, True), (False, False)], ids=["causal", "balanced", "noncausal"]
+)
+def test_ring_joint_attention_logical_tensor_accuracy(is_causal, is_balanced):
+    """logical_n read on-device must clear the same accuracy bar as the host scalar: run_ring_joint_sdpa
+    checks the CPU reference, so a mis-derived logical_nt or a missed tail mask shows up as a PCC failure."""
+    run_ring_joint_sdpa(
+        MESH_CONFIG,
+        1,  # b
+        8,  # nhq
+        8,  # nhk
+        256 * MESH_CONFIG.sp_size,  # sq: 256 per device, so half the local seq divides q_chunk_size (balanced case)
+        128,  # d_q
+        128,  # q_chunk_size
+        128,  # k_chunk_size
+        ttnn.bfloat16,
+        is_causal=is_causal,
+        is_balanced=is_balanced,
+        logical_as_tensor=True,
+    )
+
+
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.parametrize(
     "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",

--- a/tests/nightly/t3000/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/t3000/ccl/test_ring_joint_attention.py
@@ -660,6 +660,8 @@ def test_ring_joint_sdpa_create_perf_table(model_id):
     ],
     ids=["sp2"],
 )
+# scalar = host int, tensor = single-valued device tensors (trace-dynamic transport); both must agree.
+@pytest.mark.parametrize("logical_as_tensor", [False, True], ids=["scalar", "tensor"])
 def test_ring_joint_sdpa_sharded_prompt(
     mesh_device,
     num_links,
@@ -671,6 +673,7 @@ def test_ring_joint_sdpa_sharded_prompt(
     d,
     q_chunk_size,
     k_chunk_size,
+    logical_as_tensor,
     all_gather_topology,
     reset_seeds,
 ):
@@ -695,5 +698,6 @@ def test_ring_joint_sdpa_sharded_prompt(
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         num_links=num_links,
+        logical_as_tensor=logical_as_tensor,
         topology=all_gather_topology,
     )

--- a/tests/nightly/tg/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/tg/ccl/test_ring_joint_attention.py
@@ -298,6 +298,8 @@ def test_ring_joint_sdpa_program_cache(
     ],
     ids=["sp8", "sp4"],
 )
+# scalar = host int, tensor = single-valued device tensors (trace-dynamic transport); both must agree.
+@pytest.mark.parametrize("logical_as_tensor", [False, True], ids=["scalar", "tensor"])
 def test_ring_joint_sdpa_sharded_prompt(
     mesh_device,
     num_links,
@@ -309,6 +311,7 @@ def test_ring_joint_sdpa_sharded_prompt(
     d,
     q_chunk_size,
     k_chunk_size,
+    logical_as_tensor,
     all_gather_topology,
     reset_seeds,
 ):
@@ -333,5 +336,6 @@ def test_ring_joint_sdpa_sharded_prompt(
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         num_links=num_links,
+        logical_as_tensor=logical_as_tensor,
         topology=all_gather_topology,
     )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
@@ -165,6 +165,23 @@ void ExpRingJointSDPADeviceOperation::validate_on_program_cache_miss(
         N_global - args.logical_n,
         N_local);
 
+    if (tensor_args.has_logical_n_tensor()) {
+        const auto& t = tensor_args.logical_n_tensor.value();
+        TT_FATAL(
+            t.dtype() == DataType::UINT32 || t.dtype() == DataType::INT32,
+            "logical_n tensor must be UINT32 or INT32 (the kernels read element 0 as a raw 32-bit word). Got {}",
+            t.dtype());
+        TT_FATAL(t.storage_type() == StorageType::DEVICE, "logical_n tensor must be on device");
+        TT_FATAL(t.buffer() != nullptr, "logical_n tensor must be allocated on device");
+        TT_FATAL(
+            t.logical_volume() == 1,
+            "logical_n tensor must hold exactly one value (the kernels read page 0, element 0). Got volume {}",
+            t.logical_volume());
+        // Live-value range is a caller contract (unverifiable on host, as with kv_actual_isl): a live
+        // value violating (N_global - live_n) < N_local would empty a ring iteration, which the reader's
+        // credit/gate counts assume never happens.
+    }
+
     // Check shapes based on ring
     TT_FATAL(
         q_shape[2] * args.ring_size == k_shape[2],
@@ -462,7 +479,8 @@ ExpRingJointSDPAResult exp_ring_joint_scaled_dot_product_attention(
     const std::optional<float> scale,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     const uint32_t num_workers_per_link,
-    const uint32_t num_buffers_per_channel) {
+    const uint32_t num_buffers_per_channel,
+    const std::optional<ttnn::Tensor>& logical_n_tensor) {
     using OperationType = ttnn::prim::ExpRingJointSDPADeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -508,7 +526,8 @@ ExpRingJointSDPAResult exp_ring_joint_scaled_dot_product_attention(
         .joint_k = joint_tensor_k,
         .joint_v = joint_tensor_v,
         .gathered_k = persistent_output_buffer_k,
-        .gathered_v = persistent_output_buffer_v};
+        .gathered_v = persistent_output_buffer_v,
+        .logical_n_tensor = logical_n_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp
@@ -16,6 +16,8 @@
 
 namespace ttnn::prim {
 
+// The default hash is load-bearing: logical_n_tensor presence must reach it -- the kernels compile
+// differently when set. Any future custom compute_program_hash must include that presence bit.
 struct ExpRingJointSDPADeviceOperation {
     using operation_attributes_t = ExpRingJointSDPAParams;
     using tensor_args_t = ExpRingJointSDPAInputs;
@@ -51,6 +53,8 @@ ExpRingJointSDPAResult exp_ring_joint_scaled_dot_product_attention(
     std::optional<float> scale = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     uint32_t num_workers_per_link = 1,
-    uint32_t num_buffers_per_channel = 8);
+    uint32_t num_buffers_per_channel = 8,
+    // When set, logical_n above is the worst-case placeholder and the live value is read on-device.
+    const std::optional<ttnn::Tensor>& logical_n_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation_types.hpp
@@ -109,6 +109,13 @@ struct ExpRingJointSDPAInputs {
     std::optional<Tensor> joint_v;
     Tensor gathered_k;
     Tensor gathered_v;
+    // Trace-safe logical_n transport: a 1-element uint32 device tensor at a fixed DRAM address the host
+    // refreshes in place between replays. When present, logical_n above is the worst-case placeholder
+    // (padded_N) and every kernel reads the live value instead. Presence (not the value) enters the
+    // program hash, so one captured program serves every live length.
+    std::optional<Tensor> logical_n_tensor;
+
+    bool has_logical_n_tensor() const { return logical_n_tensor.has_value(); }
 };
 
 // Index constants for ExpRingJointSDPAResult vector

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
 
 #include <algorithm>
 #include <bit>
@@ -237,16 +238,26 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     const uint32_t Sq_chunk_t = q_chunk_size / tt::constants::TILE_HEIGHT;
     const uint32_t Sk_chunk_t = k_chunk_size / tt::constants::TILE_HEIGHT;
 
+    // Trace-safe logical_n: args.logical_n is the worst-case placeholder (padded_N) and the kernels read
+    // the live value. The placeholder already worst-cases every size derivation below EXCEPT the two mask
+    // derivations, which a chunk-aligned placeholder would resolve to "no mask" — CB geometry is fixed at
+    // program creation, so both are forced whenever the tensor is present.
+    const bool has_logical_n_tensor = tensor_args.has_logical_n_tensor();
+
     // Lightweight mask: only needed when any K/joint dimension has padding that doesn't fill a chunk.
     const bool local_n_has_padding = (local_padded_Nt % Sk_chunk_t) != 0;
-    const bool global_n_has_padding = (args.logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
+    const bool global_n_has_padding =
+        has_logical_n_tensor || (args.logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool joint_has_padding = L > 0 && (L % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
 
-    // Partial tile support when padding boundary falls inside a tile.
+    // Partial tile support when padding boundary falls inside a tile. The kernels stamp the live column
+    // into the forced tile and gate the stamp off when that column is 0 (see partial_tile_present).
     const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
     const uint32_t joint_l_partial_col = L % tt::constants::TILE_HEIGHT;
-    const uint32_t partial_mask_tiles = (global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
+    const bool has_global_n_partial_tile = ttnn::operations::transformer::sdpa::ring_joint::partial_tile_present(
+        global_n_partial_col, has_logical_n_tensor);
+    const uint32_t partial_mask_tiles = (has_global_n_partial_tile ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
     // Single CB holds: 1 neginf tile + up to 2 partial mask tiles
     const uint32_t total_lightweight_mask_tiles = 1 + partial_mask_tiles;
 
@@ -616,6 +627,11 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     reader_compile_time_args.push_back(receiver_semaphore_b_id);
     reader_compile_time_args.push_back(sender_semaphore_v_id);
     reader_compile_time_args.push_back(buddy_gate_semaphore_id);
+    // Trace-safe logical_n: presence flag, then the accessor args for the 1-element tensor. The accessor
+    // block is emitted unconditionally (nullptr when absent) so the CT-arg layout after it never shifts.
+    reader_compile_time_args.push_back(static_cast<uint32_t>(has_logical_n_tensor));
+    TensorAccessorArgs(has_logical_n_tensor ? tensor_args.logical_n_tensor->buffer() : nullptr)
+        .append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
         B,
@@ -641,8 +657,14 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         joint_l_partial_col,
         static_cast<std::uint32_t>(use_streaming_compute),
         static_cast<std::uint32_t>(out_out_subblock_h),
+        static_cast<std::uint32_t>(has_logical_n_tensor),
     };
 
+    // Trace-safe logical_n accessor block sits ahead of the output accessors so every downstream offset
+    // (out / joint_out / stats, and the MUX + AG block that chains off stats) keeps deriving normally.
+    // Emitted unconditionally (nullptr when absent) to keep the layout stable across both modes.
+    TensorAccessorArgs(has_logical_n_tensor ? tensor_args.logical_n_tensor->buffer() : nullptr)
+        .append_to(writer_compile_time_args);
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -676,6 +698,8 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         // max write) when several head-passes share a core. The 1-pass shapes are gated by
         // utilization-band perf tests calibrated on the scratch path.
         (num_passes > 1) ? 1u : 0u,  // use_l1_state_fifo
+        // Trace-safe logical_n: compute reads the live values from the reader's derived CB.
+        static_cast<uint32_t>(has_logical_n_tensor),
     };
 
     std::map<std::string, std::string> defines;
@@ -966,6 +990,25 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
                 .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_9),
                 .data_format = im_df,
                 .page_size = im_tile_size,
+            }}},
+        });
+    }
+
+    // Compute RISCs cannot NoC-read DRAM, so the reader publishes derived values here (slots per
+    // ring_joint_derived_slots.hpp) and compute reads them with read_tile_value. Must be UInt32:
+    // read_tile_value's indexing follows the CB format, and a float format misreads these raw words.
+    if (has_logical_n_tensor) {
+        constexpr uint32_t kDerivedPageBytes = 64;
+        static_assert(
+            ttnn::operations::transformer::sdpa::ring_joint::kDerivedSlotCount * sizeof(uint32_t) <= kDerivedPageBytes,
+            "derived slots must fit the page");
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = kDerivedPageBytes,
+            .core_ranges = sdpa_grid_set,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_13),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = kDerivedPageBytes,
             }}},
         });
     }
@@ -1564,6 +1607,20 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .math_approx_mode = math_approx_mode,
     };
+
+    // Live-length tensor address for all three kernels -- each derives chunk-skip counts from it and
+    // the credit/gate protocol requires they agree. Buffer* (not ->address()) so a cache hit re-patches it.
+    if (has_logical_n_tensor) {
+        auto* logical_n_buffer = tensor_args.logical_n_tensor->buffer();
+        const auto logical_n_common_args = [&]() {
+            KernelDescriptor::RTArgList args_list;
+            args_list.push_back(logical_n_buffer);
+            return args_list;
+        };
+        reader_kernel.emplace_common_runtime_args(logical_n_common_args());
+        writer_kernel.emplace_common_runtime_args(logical_n_common_args());
+        writer_fabric_kernel.emplace_common_runtime_args(logical_n_common_args());
+    }
 
     // Build backward and forward termination master core sets (1 per link per direction)
     // Backward masters: row 0 of both MUX client columns (top half = backward direction).

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -112,17 +112,17 @@ struct RingAccumulatorState {
 };
 
 // Ring-streaming lightweight-mask context. Field NAMES match LightweightMaskContext so sdpa_ring_v2's
-// generic `lw_mask.<field>` reads work for either type, BUT the 10 compile-time-constant fields are
-// template params (static constexpr → zero per-instance storage), leaving only the 3 per-ring-iter
-// runtime fields on the stack. Shrinks the live lw_mask object ~56 B → ~12 B on kernel_main's frame.
+// generic `lw_mask.<field>` reads work for either type, BUT the compile-time-constant fields are
+// template params (static constexpr → zero per-instance storage), leaving only the per-ring-iter
+// runtime fields on the stack. Shrinks the live lw_mask object ~56 B → ~20 B on kernel_main's frame.
+// The two partial columns are runtime fields because they may come from a device tensor per dispatch;
+// their CB tile INDICES stay compile-time.
 // Only the ring_joint_sdpa producer uses it; exp_ring keeps the plain LightweightMaskContext —
 // sdpa_ring_v2's MaskCtx template param is deduced per caller.
 template <
     uint32_t NeginfTileIdx,
     uint32_t CausalDiagTileIdx,
     uint32_t LocalNPaddedTiles,
-    uint32_t GlobalNPartialCol,
-    uint32_t JointLPartialCol,
     uint32_t GlobalNPartialTileIdx,
     uint32_t JointLPartialTileIdx,
     uint32_t StraddleMaskChunkId>
@@ -132,13 +132,13 @@ struct RingStreamingMaskCtx {
     uint32_t global_n_padded_tiles = 0;
     uint32_t joint_n_padded_tiles = 0;
     uint32_t straddle_num_padded_tiles = 0;
+    uint32_t global_n_partial_col = 0;
+    uint32_t joint_l_partial_col = 0;
     // Compile-time-constant fields (no per-instance storage):
     static constexpr uint32_t neginf_tile_idx = NeginfTileIdx;
     static constexpr uint32_t causal_diag_tile_idx = CausalDiagTileIdx;
     static constexpr uint32_t primary_diag_tile_idx = CausalDiagTileIdx;
     static constexpr uint32_t local_n_padded_tiles = LocalNPaddedTiles;
-    static constexpr uint32_t global_n_partial_col = GlobalNPartialCol;
-    static constexpr uint32_t joint_l_partial_col = JointLPartialCol;
     static constexpr uint32_t global_n_partial_tile_idx = GlobalNPartialTileIdx;
     static constexpr uint32_t joint_l_partial_tile_idx = JointLPartialTileIdx;
     static constexpr uint32_t straddle_mask_chunk_id = StraddleMaskChunkId;
@@ -2624,15 +2624,18 @@ void sdpa_ring_v2(
             if constexpr (lightweight_mask_enabled) {
                 if (apply_mask) {
                     bool partial_tile_selected = false;
+                    // Live column 0 = tile-aligned boundary this dispatch: no partial stamp.
                     if constexpr (global_n_mask_enabled) {
                         if (is_global_n_mask_chunk) {
-                            lw_partial_tile_idx = lw_mask.global_n_partial_tile_idx;
+                            lw_partial_tile_idx =
+                                lw_mask.global_n_partial_col > 0 ? lw_mask.global_n_partial_tile_idx : 0u;
                             partial_tile_selected = true;
                         }
                     }
                     if constexpr (joint_n_mask_enabled) {
                         if (!partial_tile_selected && is_joint_n_mask_chunk) {
-                            lw_partial_tile_idx = lw_mask.joint_l_partial_tile_idx;
+                            lw_partial_tile_idx =
+                                lw_mask.joint_l_partial_col > 0 ? lw_mask.joint_l_partial_tile_idx : 0u;
                         }
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -13,6 +13,9 @@
 #include "compute_common.hpp"
 #include "compute_streaming.hpp"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_fused_op_indexer.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
 void kernel_main() {
     constexpr uint32_t DHt = get_compile_time_arg_val(0);
@@ -20,8 +23,8 @@ void kernel_main() {
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(2);
     constexpr uint32_t local_padded_N = get_compile_time_arg_val(3);
     constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(4);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(5);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(6);
+    constexpr uint32_t logical_n_ct = get_compile_time_arg_val(5);
+    constexpr uint32_t logical_nt_ct = get_compile_time_arg_val(6);
     constexpr uint32_t Lt = get_compile_time_arg_val(7);
     constexpr uint32_t L = get_compile_time_arg_val(8);
     constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(9);
@@ -43,20 +46,29 @@ void kernel_main() {
     // Multi-pass programs keep per-pass accumulator state in the L1 FIFO; single-pass programs
     // use the original persist-in-scratch path (no FIFO entry/exit cost per ring iteration).
     constexpr bool use_state_fifo = get_compile_time_arg_val(21) == 1;
+    // When set, logical_n_ct/logical_nt_ct are worst-case placeholders; live values arrive via the
+    // reader's derived CB.
+    constexpr bool has_logical_n_tensor = get_compile_time_arg_val(22) == 1;
+    constexpr uint32_t cb_derived = tt::CBIndex::c_13;
 
     // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
     // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
     // Only needed when any K/joint dimension has padding that doesn't fill a chunk.
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
-    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool global_n_has_padding =
+        has_logical_n_tensor || (logical_n_ct % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0);
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
 
+    // Tile presence must match the factory's CB sizing and the writer's generation order
+    // (partial_tile_present is the one definition of that rule).
+    constexpr bool has_global_n_partial_tile =
+        ring_joint::partial_tile_present(global_n_partial_col, has_logical_n_tensor);
     constexpr uint32_t neginf_tile_idx = 0;
-    constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? 1 : 0;
+    constexpr uint32_t global_n_partial_tile_idx = has_global_n_partial_tile ? 1 : 0;
     constexpr uint32_t joint_l_partial_tile_idx =
-        (joint_l_partial_col > 0) ? (1 + (global_n_partial_col > 0 ? 1 : 0)) : 0;
-    constexpr uint32_t total_mask_tiles = 1 + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
+        (joint_l_partial_col > 0) ? (1 + (has_global_n_partial_tile ? 1 : 0)) : 0;
+    constexpr uint32_t total_mask_tiles = 1 + (has_global_n_partial_tile ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
     uint32_t argidx = 0;
     // Head-serial passes: this core owns flat Q chunks q_base + p * q_stride for p in [0, q_count),
@@ -103,6 +115,28 @@ void kernel_main() {
     // num_q_chunks so flat-id decoding stays consistent across host and kernels.
     constexpr uint32_t num_q_chunks =
         (local_padded_Nt + Sq_chunk_t - 1) / Sq_chunk_t + (Lt + Sq_chunk_t - 1) / Sq_chunk_t;
+
+    // Live length from the reader's derived CB, read ONCE so this kernel and the reader derive their
+    // chunk-skip decisions from the same single DRAM read. Must precede compute_kernel_hw_startup:
+    // read_tile_value rendezvouses UNPACK -> MATH/PACK through the mailboxes, and reading it after
+    // hw startup / matmul_init returns garbage.
+    uint32_t logical_n = logical_n_ct;
+    uint32_t logical_nt = logical_nt_ct;
+    uint32_t global_n_partial_col_live = global_n_partial_col;
+    if constexpr (has_logical_n_tensor) {
+        CircularBuffer cb_derived_obj(cb_derived);
+        cb_derived_obj.wait_front(1);
+        constexpr uint32_t kDerivedTile = 0;
+        logical_nt = ckernel::read_tile_value(cb_derived, kDerivedTile, ring_joint::kDerivedLogicalNt);
+        global_n_partial_col_live =
+            ckernel::read_tile_value(cb_derived, kDerivedTile, ring_joint::kDerivedGlobalNPartialCol);
+        cb_derived_obj.pop_front(1);
+        // Recover the element count: exact inverse of the reader's (logical_nt, partial_col) derivation.
+        logical_n = (logical_nt == 0)
+                        ? 0u
+                        : ((logical_nt - 1) * ring_joint::kTileHeight +
+                           (global_n_partial_col_live == 0 ? ring_joint::kTileHeight : global_n_partial_col_live));
+    }
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_q_in, cb_k_in, cb_qk_im);
     matmul_init(cb_q_in, cb_k_in);
@@ -173,7 +207,7 @@ void kernel_main() {
         lw_mask.neginf_tile_idx = neginf_tile_idx;
         lw_mask.local_n_padded_tiles = local_n_padded_tiles;
         lw_mask.joint_n_padded_tiles = joint_n_padded_tiles;
-        lw_mask.global_n_partial_col = global_n_partial_col;
+        lw_mask.global_n_partial_col = global_n_partial_col_live;
         lw_mask.joint_l_partial_col = joint_l_partial_col;
         lw_mask.global_n_partial_tile_idx = global_n_partial_tile_idx;
         lw_mask.joint_l_partial_tile_idx = joint_l_partial_tile_idx;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -17,6 +17,9 @@
 #include "compute_common.hpp"
 #include "compute_streaming.hpp"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_indexer.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
 template <bool kv_pad_rotation_enabled>
 constexpr void assert_kv_pad_rotation_streaming_only() {
@@ -88,7 +91,13 @@ void kernel_main() {
     constexpr bool joint_is_sharded = get_compile_time_arg_val(52) == 1;
     // Slot 53: true (unpadded) joint length in tiles (similar to spatial logical_nt). Drives the
     // per-ring-iteration joint tail mask and the joint out-of-bounds K-chunk skip.
-    constexpr uint32_t logical_lt = get_compile_time_arg_val(53);
+    constexpr uint32_t logical_lt_compile = get_compile_time_arg_val(53);
+    // Slots 54-55: logical-length transport. Compute cannot NoC-read DRAM, so the live values arrive
+    // through cb_kv_pad_derived from the reader; the compile-time values are the placeholder's.
+    constexpr bool has_logical_n_tensor = get_compile_time_arg_val(54) == 1;
+    constexpr bool has_logical_l_tensor = get_compile_time_arg_val(55) == 1;
+    constexpr bool has_logical_length_tensor = has_logical_n_tensor || has_logical_l_tensor;
+    uint32_t logical_lt = logical_lt_compile;
     constexpr uint32_t v_cb_physical_width_t = v_shares_k_buffer ? DHt : vDHt;
     // In-place latent-V (single-tile Q): read V straight from K^T instead of materializing it.
     // Shared with the program factory and reader via kt_inplace_v_enabled().
@@ -107,13 +116,17 @@ void kernel_main() {
     // Lightweight mask: all mask tiles live in cb_mask_in.
     // Layout: [neginf(0)] [causal_diag?(1)] [global_n_partial?] [joint_l_partial?]
     constexpr bool local_n_has_padding = kv_local_padded_Nt % Sk_chunk_t != 0;
-    constexpr bool global_n_has_padding = logical_n_compile % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    // A tensor-supplied length can land mid-chunk / mid-tile at any dispatch, so compile the mask path in
+    // regardless of the placeholder. Keep in sync with the factory and the writer (which generates them).
+    constexpr bool global_n_has_padding =
+        (logical_n_compile % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0) || has_logical_n_tensor;
     // Joint needs a mask when either the per-device joint shard is not a whole number of K-chunks
     // (Lt_local % Sk_chunk_t != 0 -> fully-padded trailing tiles, the local_n analogue), or real tokens
     // do not fill the last real shard's chunk (logical_lt % Sk_chunk_t != 0 or a sub-tile partial
     // column, the global_n analogue).
     constexpr bool joint_has_padding =
-        L > 0 && ((Lt_local % Sk_chunk_t != 0) || (logical_lt % Sk_chunk_t != 0) || (joint_l_partial_col != 0));
+        L > 0 && ((Lt_local % Sk_chunk_t != 0) || (logical_lt_compile % Sk_chunk_t != 0) ||
+                  (joint_l_partial_col != 0) || has_logical_l_tensor);
     constexpr bool needs_lightweight_mask =
         (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled || has_sliding_window;
 
@@ -121,11 +134,15 @@ void kernel_main() {
     constexpr uint32_t causal_diag_tile_idx = diag_tile_enabled ? 1 : 0;
     constexpr uint32_t edge_mask_tiles = has_sliding_window ? kSlidingWindowEdgeTiles : (diag_tile_enabled ? 1 : 0);
     constexpr uint32_t base_partial_offset = 1 + edge_mask_tiles;
-    constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? base_partial_offset : 0;
+    constexpr bool has_global_n_partial_tile =
+        ring_joint::partial_tile_present(global_n_partial_col, has_logical_n_tensor);
+    constexpr bool has_joint_l_partial_tile =
+        ring_joint::partial_tile_present(joint_l_partial_col, has_logical_l_tensor);
+    constexpr uint32_t global_n_partial_tile_idx = has_global_n_partial_tile ? base_partial_offset : 0;
     constexpr uint32_t joint_l_partial_tile_idx =
-        (joint_l_partial_col > 0) ? (base_partial_offset + (global_n_partial_col > 0 ? 1 : 0)) : 0;
+        has_joint_l_partial_tile ? (base_partial_offset + (has_global_n_partial_tile ? 1 : 0)) : 0;
     constexpr uint32_t total_mask_tiles =
-        1 + edge_mask_tiles + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
+        1 + edge_mask_tiles + (has_global_n_partial_tile ? 1 : 0) + (has_joint_l_partial_tile ? 1 : 0);
 
     constexpr uint32_t q_start_idx_t =
         chunked_enabled && !kv_pad_rotation_enabled ? logical_nt_compile - q_local_padded_Nt * ring_size : 0;
@@ -155,11 +172,11 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    // Compute fixed slot 51: trace-safe KV-pad derivation flag. Slots 52/53 are the sharded-joint
-    // scalars (joint_is_sharded, logical_lt) declared near the top of the kernel, so the CB block
-    // starts at 54.
+    // Compute fixed slot 51: trace-safe KV-pad derivation flag. Slots 52-55 (sharded-joint scalars and
+    // the logical-length transport flags) are declared near the top of the kernel, so the CB block
+    // starts at 56.
     constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(51) == 1;
-    constexpr uint32_t cb_arg_offset = 54;
+    constexpr uint32_t cb_arg_offset = 56;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -189,15 +206,36 @@ void kernel_main() {
     constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 23);
     constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 24);
 
-    if constexpr (kv_pad_from_metadata) {
+    // Placeholder-derived defaults, overwritten from the CB on the tensor path. 0 gates the stamp off.
+    uint32_t global_n_partial_col_live = global_n_partial_col;
+    uint32_t joint_l_partial_col_live = joint_l_partial_col;
+
+    if constexpr (kv_pad_from_metadata || has_logical_length_tensor) {
         CircularBuffer cb_derived(cb_kv_pad_derived);
         cb_derived.wait_front(1);
-        logical_nt = ckernel::read_tile_value(cb_kv_pad_derived, 0, 0);
-        kv_pad_q_pre_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 1);
-        kv_pad_q_pre_wrap_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 2);
-        kv_pad_q_post_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 3);
-        kv_pad_q_valid_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 4);
-        active_ring_iter_mask = ckernel::read_tile_value(cb_kv_pad_derived, 0, 5);
+        constexpr uint32_t kDerivedTile = 0;
+        logical_nt = ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedLogicalNt);
+        if constexpr (kv_pad_from_metadata) {
+            kv_pad_q_pre_wrap_start_tile =
+                ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedQPreWrapStartTile);
+            kv_pad_q_pre_wrap_tile_count =
+                ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedQPreWrapTileCount);
+            kv_pad_q_post_wrap_start_tile =
+                ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedQPostWrapStartTile);
+            kv_pad_q_valid_tile_count =
+                ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedQValidTileCount);
+        }
+        active_ring_iter_mask =
+            ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedActiveRingIterMask);
+        if constexpr (has_logical_n_tensor) {
+            global_n_partial_col_live =
+                ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedGlobalNPartialCol);
+        }
+        if constexpr (has_logical_l_tensor) {
+            logical_lt = ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedLogicalLt);
+            joint_l_partial_col_live =
+                ckernel::read_tile_value(cb_kv_pad_derived, kDerivedTile, ring_joint::kDerivedJointLPartialCol);
+        }
         cb_derived.pop_front(1);
     }
 
@@ -282,7 +320,7 @@ void kernel_main() {
         const uint32_t global_n_padded_tiles_iter =
             global_n_is_within_ring_iter ? Sk_chunk_t - global_n_valid_tiles_in_chunk : 0;
         // Sub-tile partial column exists only on the boundary shard (never a fully-real earlier one).
-        const bool global_n_apply_partial_col = global_n_is_within_ring_iter && (global_n_partial_col > 0);
+        const bool global_n_apply_partial_col = global_n_is_within_ring_iter && (global_n_partial_col_live > 0);
         const bool ring_iter_needs_global_n_mask =
             global_n_is_within_ring_iter && (global_n_padded_tiles_iter > 0 || global_n_apply_partial_col);
 
@@ -322,7 +360,7 @@ void kernel_main() {
         const uint32_t joint_n_padded_tiles_iter =
             joint_n_is_within_ring_iter ? Sk_chunk_t - joint_valid_tiles_in_chunk : 0;
         // Partial sub-tile column exists only on the boundary shard, never on a fully-real earlier one.
-        const bool joint_apply_partial_col = joint_boundary_in_shard && (joint_l_partial_col > 0);
+        const bool joint_apply_partial_col = joint_boundary_in_shard && (joint_l_partial_col_live > 0);
         const bool ring_iter_needs_joint_n_mask =
             do_joint_kv && joint_n_is_within_ring_iter && (joint_n_padded_tiles_iter > 0 || joint_apply_partial_col);
 
@@ -334,12 +372,12 @@ void kernel_main() {
             neginf_tile_idx,
             causal_diag_tile_idx,
             local_n_padded_tiles,
-            global_n_partial_col,
-            joint_l_partial_col,
             global_n_partial_tile_idx,
             joint_l_partial_tile_idx,
             straddle_chunk_id>
             lw_mask;
+        lw_mask.global_n_partial_col = global_n_partial_col_live;
+        lw_mask.joint_l_partial_col = joint_l_partial_col_live;
         lw_mask.is_causal = chunked_enabled || (is_causal && ring_iter == 0);
         // Straddle mask fires only on the rix>rid halved-range iters that would otherwise exclude
         // the straddle chunk. Must agree with the K-loop extension condition below.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -605,10 +605,14 @@ void fill_sliding_window_edge_tiles(Noc noc, uint32_t start_tile_idx) {
  *                         [leading_current(3)] [trailing_next(4)] [partial tiles...]
  * Tiles are pushed once and stay permanently fronted for the entire kernel lifetime.
  *
- * @tparam global_n_partial_col  Column within tile where global_n padding starts (0 = tile-aligned, no partial)
- * @tparam joint_l_partial_col   Column within tile where joint_l padding starts (0 = tile-aligned, no partial)
+ * @tparam global_n_partial_col  Column within tile where global_n padding starts (0 = tile-aligned, no
+ *                               partial). Presence only: decides whether the tile exists in the CB layout.
+ * @tparam joint_l_partial_col   As above, for the joint tail.
  * @tparam cb_mask_in            CB to generate mask tiles into (must be constexpr for get_tile_size)
  * @tparam is_causal_lw          Whether to include the causal diagonal tile
+ * @param global_n_partial_col_rt  Column actually stamped (defaults to the template value; tensor-path
+ *                                 callers pass the live one).
+ * @param joint_l_partial_col_rt   As above, for the joint tail.
  */
 template <
     uint32_t global_n_partial_col,
@@ -616,7 +620,10 @@ template <
     uint32_t cb_mask_in,
     bool is_causal_lw = false,
     uint32_t sliding_window_size = 0>
-void generate_lightweight_mask_tiles(Noc noc) {
+void generate_lightweight_mask_tiles(
+    Noc noc,
+    uint32_t global_n_partial_col_rt = global_n_partial_col,
+    uint32_t joint_l_partial_col_rt = joint_l_partial_col) {
     constexpr uint32_t partial_mask_tiles = (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
     constexpr bool has_sliding_window = sliding_window_size > 0;
     constexpr uint32_t sliding_diag_tiles = has_sliding_window ? kSlidingWindowEdgeTiles : 0;
@@ -643,10 +650,10 @@ void generate_lightweight_mask_tiles(Noc noc) {
     // Subsequent tiles: partial mask tiles for boundary conditions
     if constexpr (partial_mask_tiles > 0) {
         if constexpr (global_n_partial_col > 0) {
-            fill_vertical_tile_bf16<mask_tile_size_bytes>(noc, cb_mask_in, tile_idx++, global_n_partial_col);
+            fill_vertical_tile_bf16<mask_tile_size_bytes>(noc, cb_mask_in, tile_idx++, global_n_partial_col_rt);
         }
         if constexpr (joint_l_partial_col > 0) {
-            fill_vertical_tile_bf16<mask_tile_size_bytes>(noc, cb_mask_in, tile_idx++, joint_l_partial_col);
+            fill_vertical_tile_bf16<mask_tile_size_bytes>(noc, cb_mask_in, tile_idx++, joint_l_partial_col_rt);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_reader.cpp
@@ -11,6 +11,11 @@
 #include "api/core_local_mem.h"
 #include "dataflow_common.hpp"
 #include "exp_fused_op_indexer.hpp"
+#include "metadata_scalar_read.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
+
 void kernel_main() {
     Noc noc;
     noc.async_write_barrier();
@@ -21,8 +26,8 @@ void kernel_main() {
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);
     constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(5);
     constexpr uint32_t padded_Nt = get_compile_time_arg_val(6);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(7);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(8);
+    constexpr uint32_t logical_n_ct = get_compile_time_arg_val(7);
+    constexpr uint32_t logical_nt_ct = get_compile_time_arg_val(8);
     constexpr uint32_t Lt = get_compile_time_arg_val(9);
     constexpr uint32_t L = get_compile_time_arg_val(10);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(11);
@@ -113,6 +118,36 @@ void kernel_main() {
     const uint32_t sender_semaphore_v_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 6);
     // Split-head forwarding dedup buddy gate (see the AG gate below).
     const uint32_t buddy_gate_semaphore_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 7);
+
+    // When set, logical_n_ct/logical_nt_ct are worst-case placeholders; the live value is read below.
+    constexpr bool has_logical_n_tensor =
+        get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 8) == 1;
+    constexpr auto logical_n_args = TensorAccessorArgs<joint_v_args.next_compile_time_args_offset() + 9>();
+
+    constexpr uint32_t cb_derived = tt::CBIndex::c_13;
+
+    // Read the live length ONCE, before the ring loop, into locals. Every logical_n-dependent quantity
+    // below derives from these — including the chunk-skip predicate that sets this kernel's credit caps
+    // and the injector's per-link gate demand. A mid-loop re-read could observe a host rewrite and
+    // desynchronize those counts from the writer's, which forwards on the same predicate.
+    uint32_t logical_n = logical_n_ct;
+    uint32_t logical_nt = logical_nt_ct;
+    [[maybe_unused]] uint32_t global_n_partial_col_live = 0;
+    if constexpr (has_logical_n_tensor) {
+        // Borrow cb_q_in's L1 as read scratch: this runs before any Q is fetched into it.
+        logical_n = trace_metadata::read_metadata_scalar_u32(
+            noc, logical_n_args, get_common_arg_val<uint32_t>(0), CircularBuffer(tt::CBIndex::c_0).get_write_ptr());
+        logical_nt = ring_joint::tiles_for(logical_n);
+        global_n_partial_col_live = ring_joint::tile_partial_col(logical_n);
+
+        // Hand compute the values it cannot read itself (compute RISCs cannot NoC-read DRAM).
+        CircularBuffer cb_derived_obj(cb_derived);
+        cb_derived_obj.reserve_back(1);
+        CoreLocalMem<volatile uint32_t> d(cb_derived_obj.get_write_ptr());
+        d[ring_joint::kDerivedLogicalNt] = logical_nt;
+        d[ring_joint::kDerivedGlobalNPartialCol] = global_n_partial_col_live;
+        cb_derived_obj.push_back(1);
+    }
 
     // Receiver flips this to INVALID before each wait; initialize so the first iteration sees it as VALID.
     Semaphore<>(valid_semaphore_id).set(VALID);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -9,7 +9,11 @@
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
+#include "metadata_scalar_read.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
 #include "exp_fused_op_indexer.hpp"
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
 #ifdef USE_MUX
 #include "tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp"
@@ -75,8 +79,8 @@ void kernel_main() {
     constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);
     constexpr uint32_t local_padded_N = get_compile_time_arg_val(5);
     constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(6);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(7);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(8);
+    constexpr uint32_t logical_n_ct = get_compile_time_arg_val(7);
+    constexpr uint32_t logical_nt_ct = get_compile_time_arg_val(8);
     constexpr uint32_t Lt = get_compile_time_arg_val(9);
     constexpr uint32_t L = get_compile_time_arg_val(10);
     constexpr uint32_t num_local_q_chunks = get_compile_time_arg_val(11);
@@ -90,8 +94,13 @@ void kernel_main() {
     constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(19);
     constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(20);
     constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    // Trace-safe logical_n: when set, logical_n_ct above is only the worst-case placeholder.
+    constexpr bool has_logical_n_tensor = get_compile_time_arg_val(23) == 1;
 
-    constexpr auto out_args = TensorAccessorArgs<23>();
+    // Sits ahead of the output accessors so the offsets below (and the MUX/AG block chaining off
+    // stats_args_skip) keep deriving normally in both modes.
+    constexpr auto logical_n_args = TensorAccessorArgs<24>();
+    constexpr auto out_args = TensorAccessorArgs<logical_n_args.next_compile_time_args_offset()>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     // stats_args follows joint_out_args but is unused by the writer (stats are only
     // needed for multi-Q accumulator save/restore which this kernel doesn't support).
@@ -297,14 +306,39 @@ void kernel_main() {
         ckernel::ReduceDim::REDUCE_ROW,
         dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR>();
 
+    // Read the live length ONCE, before the ring loop. This kernel is a protocol participant, not just a
+    // mask producer: the MUX forwarding loop below skips chunks on the same predicate as the reader and
+    // sends one per-link atomic_inc per forwarded chunk, which is exactly what the reader's injector gate
+    // counts. Reader and writer must therefore derive identical values from the same tensor.
+    uint32_t logical_n = logical_n_ct;
+    uint32_t logical_nt = logical_nt_ct;
+    [[maybe_unused]] uint32_t global_n_partial_col_live = global_n_partial_col;
+    if constexpr (has_logical_n_tensor) {
+        // Borrow cb_mask_in's L1 as read scratch: this runs before the mask tiles are generated into it.
+        logical_n = trace_metadata::read_metadata_scalar_u32(
+            noc, logical_n_args, get_common_arg_val<uint32_t>(0), CircularBuffer(cb_mask_in).get_write_ptr());
+        logical_nt = ring_joint::tiles_for(logical_n);
+        global_n_partial_col_live = ring_joint::tile_partial_col(logical_n);
+    }
+
     // Lightweight mask: generate all mask tiles once into single CB before the ring loop.
     // Only needed when any K/joint dimension has padding that doesn't fill a chunk.
     constexpr bool local_n_has_padding = local_padded_Nt % Sk_chunk_t != 0;
-    constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
+    constexpr bool global_n_has_padding =
+        has_logical_n_tensor || (logical_n_ct % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0);
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask = local_n_has_padding || global_n_has_padding || joint_has_padding;
+    // partial_tile_present keeps tile presence in lock-step with the factory's CB sizing and compute's tile
+    // indices. A present tile needs a non-zero template column (fall back to 1) so
+    // generate_lightweight_mask_tiles allocates the slot; the stamped live column may still be 0, which
+    // compute ignores.
+    constexpr uint32_t global_n_partial_col_layout =
+        ring_joint::partial_tile_present(global_n_partial_col, has_logical_n_tensor)
+            ? (global_n_partial_col > 0 ? global_n_partial_col : 1u)
+            : 0u;
     if constexpr (needs_lightweight_mask) {
-        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in>(noc);
+        generate_lightweight_mask_tiles<global_n_partial_col_layout, joint_l_partial_col, cb_mask_in>(
+            noc, global_n_partial_col_live, joint_l_partial_col);
     }
 
     const uint32_t last_active_ring_iter =

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_kv_pad_derivation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_kv_pad_derivation.hpp
@@ -109,26 +109,55 @@ inline KvPadQMapping build_kv_pad_q_mapping_device(
     return m;
 }
 
+// Inputs to build_ring_work_masks_device. The sharded-joint trio defaults to the replicated-joint
+// behaviour, where every selected joint chunk counts.
+struct RingWorkMasksParams {
+    uint32_t device_index;
+    uint32_t ring_size;
+    uint32_t backward_writes_expected;
+    uint32_t forward_writes_expected;
+    uint32_t num_local_k_chunks;
+    uint32_t k_chunk_tile_count;
+    uint32_t kv_local_padded_Nt;
+    bool kernel_chunked;
+    uint32_t q_chunk_group_tile_count;
+    uint32_t q_local_padded_Nt;
+    uint32_t logical_nt;
+    uint32_t num_joint_k_chunks;
+    uint32_t joint_seq_len;
+    bool kv_pad_rotation_enabled;
+    bool kernel_is_causal;
+    bool is_balanced;
+    // Sharded-joint tail (mirrors the host's valid_joint_kv_chunks loop).
+    bool joint_is_sharded = false;
+    uint32_t joint_local_padded_Nt = 0;
+    uint32_t logical_lt = 0;
+};
+
 // Mirror of host build_ring_work_plan_impl (ring_joint_sdpa_program_factory.cpp:192). Walks the same
 // ring-id order via RingIdSequencer, marks ring iterations with non-padded spatial / joint KV work, and
 // applies the same causal unbalanced skip rule. logical_nt is the only per-chunk input.
-inline RingWorkMasks build_ring_work_masks_device(
-    uint32_t device_index,
-    uint32_t ring_size,
-    uint32_t backward_writes_expected,
-    uint32_t forward_writes_expected,
-    uint32_t num_local_k_chunks,
-    uint32_t k_chunk_tile_count,
-    uint32_t kv_local_padded_Nt,
-    bool kernel_chunked,
-    uint32_t q_chunk_group_tile_count,
-    uint32_t q_local_padded_Nt,
-    uint32_t logical_nt,
-    uint32_t num_joint_k_chunks,
-    uint32_t joint_seq_len,
-    bool kv_pad_rotation_enabled,
-    bool kernel_is_causal,
-    bool is_balanced) {
+inline RingWorkMasks build_ring_work_masks_device(const RingWorkMasksParams& p) {
+    const uint32_t device_index = p.device_index;
+    const uint32_t ring_size = p.ring_size;
+    const uint32_t backward_writes_expected = p.backward_writes_expected;
+    const uint32_t forward_writes_expected = p.forward_writes_expected;
+    const uint32_t num_local_k_chunks = p.num_local_k_chunks;
+    const uint32_t k_chunk_tile_count = p.k_chunk_tile_count;
+    const uint32_t kv_local_padded_Nt = p.kv_local_padded_Nt;
+    const bool kernel_chunked = p.kernel_chunked;
+    const uint32_t q_chunk_group_tile_count = p.q_chunk_group_tile_count;
+    const uint32_t q_local_padded_Nt = p.q_local_padded_Nt;
+    const uint32_t logical_nt = p.logical_nt;
+    const uint32_t num_joint_k_chunks = p.num_joint_k_chunks;
+    const uint32_t joint_seq_len = p.joint_seq_len;
+    const bool kv_pad_rotation_enabled = p.kv_pad_rotation_enabled;
+    const bool kernel_is_causal = p.kernel_is_causal;
+    const bool is_balanced = p.is_balanced;
+    const bool joint_is_sharded = p.joint_is_sharded;
+    const uint32_t joint_local_padded_Nt = p.joint_local_padded_Nt;
+    const uint32_t logical_lt = p.logical_lt;
+
     RingWorkMasks plan;
     plan.active_ring_iter_mask = 0;
     plan.single_valid_kv_chunk_mask = 0;
@@ -138,7 +167,22 @@ inline RingWorkMasks build_ring_work_masks_device(
 
     for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
         const uint32_t ring_id = seq.get_next_ring_id(noop_sync);
-        const bool joint_contributes = ring_id == ring_size - 1 && num_joint_k_chunks > 0 && joint_seq_len != 0;
+        const bool has_joint_work = num_joint_k_chunks > 0 && joint_seq_len != 0;
+        const bool joint_iter_selected = has_joint_work && (joint_is_sharded || ring_id == ring_size - 1);
+        uint32_t valid_joint_kv_chunks = 0;
+        if (joint_iter_selected) {
+            if (joint_is_sharded) {
+                for (uint32_t k = 0; k < num_joint_k_chunks; ++k) {
+                    const uint32_t joint_global_start_tile = ring_id * joint_local_padded_Nt + k * k_chunk_tile_count;
+                    if (joint_global_start_tile < logical_lt) {
+                        valid_joint_kv_chunks++;
+                    }
+                }
+            } else {
+                valid_joint_kv_chunks = num_joint_k_chunks;
+            }
+        }
+        const bool joint_contributes = valid_joint_kv_chunks > 0;
         uint32_t valid_spatial_kv_chunks = 0;
         for (uint32_t k_chunk = 0; k_chunk < num_local_k_chunks; ++k_chunk) {
             const uint32_t local_tile_start = k_chunk * k_chunk_tile_count;
@@ -155,7 +199,7 @@ inline RingWorkMasks build_ring_work_masks_device(
                 valid_spatial_kv_chunks++;
             }
         }
-        const uint32_t valid_kv_chunks = valid_spatial_kv_chunks + (joint_contributes ? num_joint_k_chunks : 0);
+        const uint32_t valid_kv_chunks = valid_spatial_kv_chunks + valid_joint_kv_chunks;
         const bool has_kv_work = (kernel_chunked && !kv_pad_rotation_enabled) || valid_spatial_kv_chunks > 0;
         const bool ring_iter_does_work =
             (has_kv_work || joint_contributes) && !(kernel_is_causal && device_index < ring_id && !is_balanced);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -11,6 +11,7 @@
 #include "dataflow_common.hpp"
 #include "chunked_prefill_utils.hpp"
 #include "ring_joint_kv_pad_derivation.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
 #include "metadata_scalar_read.hpp"
 #include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
@@ -294,7 +295,14 @@ void kernel_main() {
     constexpr bool joint_is_sharded = get_compile_time_arg_val(38) == 1;
     // Slot 39: true (unpadded) joint length in tiles (twins spatial logical_nt). Joint K chunks whose
     // global start tile is at/after logical_lt are pure padding and are skipped.
-    constexpr uint32_t logical_lt = get_compile_time_arg_val(39);
+    constexpr uint32_t logical_lt_compile = get_compile_time_arg_val(39);
+    // Slots 40-41: read live logical_n / logical_l from device tensors (common runtime args below), then
+    // re-derive logical_nt / logical_lt / the ring masks from them.
+    constexpr bool has_logical_n_tensor = get_compile_time_arg_val(40) == 1;
+    constexpr bool has_logical_l_tensor = get_compile_time_arg_val(41) == 1;
+    constexpr bool has_logical_length_tensor = has_logical_n_tensor || has_logical_l_tensor;
+    // Live joint tail in tiles; equals the compile-time value unless logical_l arrives as a tensor.
+    uint32_t logical_lt = logical_lt_compile;
 
     // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
     // and dropped by the compiler, eliminating runtime ternaries and joint generator uses.
@@ -304,9 +312,10 @@ void kernel_main() {
     // Sharded joint requires the gathered joint K/V buffers (only meaningful when joint K is present).
     constexpr bool has_gathered_joint_k = joint_is_sharded && has_joint_k;
 
-    // Slots 37-39 are the sharded-joint scalars (Lt_local, joint_is_sharded, logical_lt) declared
-    // above, so the tensor accessors start at compile-arg slot 40.
-    constexpr auto q_args = TensorAccessorArgs<40>();
+    // Slots 37-39 are the sharded-joint scalars (Lt_local, joint_is_sharded, logical_lt) and slots 40-41
+    // the logical-length transport flags, all declared above, so the tensor accessors start at slot 42.
+    constexpr uint32_t kFirstAccessorArgOffset = 42;
+    constexpr auto q_args = TensorAccessorArgs<kFirstAccessorArgOffset>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -318,10 +327,10 @@ void kernel_main() {
     constexpr uint32_t post_tensor_args_offset = attention_sink_args.next_compile_time_args_offset();
     // The metadata accessor (metadata path only) follows the tensor accessors and precedes the chain
     // semaphore compile args. Gate its offset on slot_from_metadata: when absent, fall back to a VALID
-    // (unused) accessor offset (q_args' slot 40) so TensorAccessorArgs<> -- instantiated unconditionally
+    // (unused) accessor offset (q_args' slot) so TensorAccessorArgs<> -- instantiated unconditionally
     // here -- never names a non-accessor compile arg (which would fail its internal static_assert).
     // The chain/CB compile args then start after the metadata accessor when present.
-    constexpr uint32_t meta_args_offset = slot_from_metadata ? post_tensor_args_offset : 40;
+    constexpr uint32_t meta_args_offset = slot_from_metadata ? post_tensor_args_offset : kFirstAccessorArgOffset;
     constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();  // slot_id accessor
     // kv_actual_isl gets its OWN accessor (a separately-allocated single-page DRAM tensor can land in a
     // different DRAM bank than slot_id, so the slot accessor's dspec reads the wrong bank for it -- the kv
@@ -332,8 +341,18 @@ void kernel_main() {
     constexpr auto kv_meta_args = TensorAccessorArgs<kv_meta_args_offset>();
     constexpr uint32_t chains_base_no_kv_pad =
         slot_from_metadata ? meta_args.next_compile_time_args_offset() : post_tensor_args_offset;
-    constexpr uint32_t chains_base_offset =
+    constexpr uint32_t post_meta_args_offset =
         kv_pad_from_metadata ? kv_meta_args.next_compile_time_args_offset() : chains_base_no_kv_pad;
+    // logical_n / logical_l accessors follow the metadata accessors, appended as a pair so these offsets do
+    // not depend on which one was supplied. Same VALID-fallback trick as meta_args above.
+    constexpr uint32_t logical_n_args_offset =
+        has_logical_length_tensor ? post_meta_args_offset : kFirstAccessorArgOffset;
+    constexpr auto logical_n_args = TensorAccessorArgs<logical_n_args_offset>();
+    constexpr uint32_t logical_l_args_offset =
+        has_logical_length_tensor ? logical_n_args.next_compile_time_args_offset() : logical_n_args_offset;
+    constexpr auto logical_l_args = TensorAccessorArgs<logical_l_args_offset>();
+    constexpr uint32_t chains_base_offset =
+        has_logical_length_tensor ? logical_l_args.next_compile_time_args_offset() : post_meta_args_offset;
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -460,7 +479,14 @@ void kernel_main() {
     constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 3);
     constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 4);
 
-    if constexpr (slot_from_metadata || kv_pad_from_metadata) {
+    // Common runtime args: metadata block first when present, then the logical-length pair.
+    constexpr uint32_t logical_length_common_arg_base =
+        slot_from_metadata ? ring_joint::kReaderMetadataCommonArgCount : 0;
+
+    [[maybe_unused]] uint32_t global_n_partial_col_live = 0;
+    [[maybe_unused]] uint32_t joint_l_partial_col_live = 0;
+
+    if constexpr (slot_from_metadata || kv_pad_from_metadata || has_logical_length_tensor) {
         Noc meta_noc;
         CircularBuffer cb_q_scratch(cb_q_in);
         const uint32_t meta_l1 = cb_q_scratch.get_write_ptr();
@@ -469,41 +495,93 @@ void kernel_main() {
                 trace_metadata::read_metadata_scalar_u32(meta_noc, meta_args, get_common_arg_val<uint32_t>(0), meta_l1);
             kv_cache_batch_idx = slot_id * get_common_arg_val<uint32_t>(1) + get_common_arg_val<uint32_t>(2);
         }
+        if constexpr (has_logical_n_tensor) {
+            const uint32_t logical_n_live = trace_metadata::read_metadata_scalar_u32(
+                meta_noc, logical_n_args, get_common_arg_val<uint32_t>(logical_length_common_arg_base), meta_l1);
+            logical_nt = ring_joint::tiles_for(logical_n_live);
+            global_n_partial_col_live = ring_joint::tile_partial_col(logical_n_live);
+        }
+        if constexpr (has_logical_l_tensor) {
+            const uint32_t logical_l_live = trace_metadata::read_metadata_scalar_u32(
+                meta_noc, logical_l_args, get_common_arg_val<uint32_t>(logical_length_common_arg_base + 1), meta_l1);
+            logical_lt = ring_joint::tiles_for(logical_l_live);
+            joint_l_partial_col_live = ring_joint::tile_partial_col(logical_l_live);
+        }
+        [[maybe_unused]] ring_joint::KvPadQMapping qmap{};
         if constexpr (kv_pad_from_metadata) {
             const uint32_t kv_actual_isl = trace_metadata::read_metadata_scalar_u32(
                 meta_noc, kv_meta_args, get_common_arg_val<uint32_t>(3), meta_l1);
             const uint32_t kv_actual_tile_count = kv_actual_isl / 32;
             logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_size_t * 32, 32);
-            const auto qmap = ring_joint::build_kv_pad_q_mapping_device(
+            qmap = ring_joint::build_kv_pad_q_mapping_device(
                 kv_actual_tile_count, logical_nt, ring_size, q_local_padded_Nt, fused_op_receiver.seq.ring_index);
-            const auto masks = ring_joint::build_ring_work_masks_device(
-                fused_op_receiver.seq.ring_index,
-                ring_size,
-                fused_op_receiver.seq.expected[0],
-                fused_op_receiver.seq.expected[1],
-                num_local_k_chunks,
-                Sk_chunk_t,
-                kv_local_padded_Nt,
-                chunked_enabled,
-                chunk_size_t,
-                q_local_padded_Nt,
-                logical_nt,
-                num_joint_k_chunks,
-                L,
-                kv_pad_rotation_enabled,
-                is_causal != 0,
-                is_balanced != 0);
+            // Joint trio stays defaulted: KV-pad rotation is validated incompatible with a sharded joint.
+            const auto masks = ring_joint::build_ring_work_masks_device({
+                .device_index = fused_op_receiver.seq.ring_index,
+                .ring_size = ring_size,
+                .backward_writes_expected = fused_op_receiver.seq.expected[0],
+                .forward_writes_expected = fused_op_receiver.seq.expected[1],
+                .num_local_k_chunks = num_local_k_chunks,
+                .k_chunk_tile_count = Sk_chunk_t,
+                .kv_local_padded_Nt = kv_local_padded_Nt,
+                .kernel_chunked = chunked_enabled,
+                .q_chunk_group_tile_count = chunk_size_t,
+                .q_local_padded_Nt = q_local_padded_Nt,
+                .logical_nt = logical_nt,
+                .num_joint_k_chunks = num_joint_k_chunks,
+                .joint_seq_len = L,
+                .kv_pad_rotation_enabled = kv_pad_rotation_enabled,
+                .kernel_is_causal = is_causal != 0,
+                .is_balanced = is_balanced != 0,
+            });
             active_ring_iter_mask = masks.active_ring_iter_mask;
+        } else if constexpr (has_logical_length_tensor) {
+            // Host masks assumed the placeholder (every iteration active). A smaller live length can empty
+            // an iteration, and an active bit there leaves compute waiting on work that never arrives.
+            const auto masks = ring_joint::build_ring_work_masks_device({
+                .device_index = fused_op_receiver.seq.ring_index,
+                .ring_size = ring_size,
+                .backward_writes_expected = fused_op_receiver.seq.expected[0],
+                .forward_writes_expected = fused_op_receiver.seq.expected[1],
+                .num_local_k_chunks = num_local_k_chunks,
+                .k_chunk_tile_count = Sk_chunk_t,
+                .kv_local_padded_Nt = kv_local_padded_Nt,
+                .kernel_chunked = chunked_enabled,
+                .q_chunk_group_tile_count = chunk_size_t,
+                .q_local_padded_Nt = q_local_padded_Nt,
+                .logical_nt = logical_nt,
+                .num_joint_k_chunks = num_joint_k_chunks,
+                .joint_seq_len = L,
+                .kv_pad_rotation_enabled = kv_pad_rotation_enabled,
+                .kernel_is_causal = is_causal != 0,
+                .is_balanced = is_balanced != 0,
+                .joint_is_sharded = joint_is_sharded,
+                .joint_local_padded_Nt = Lt_local,
+                .logical_lt = logical_lt,
+            });
+            active_ring_iter_mask = masks.active_ring_iter_mask;
+        }
 
+        if constexpr (kv_pad_from_metadata || has_logical_length_tensor) {
+            // Hand compute the values it cannot read itself (compute RISCs cannot NoC-read DRAM).
             CircularBuffer cb_derived(cb_kv_pad_derived);
             cb_derived.reserve_back(1);
             CoreLocalMem<volatile uint32_t> d(cb_derived.get_write_ptr());
-            d[0] = logical_nt;
-            d[1] = qmap.q_pre_wrap_start_tile;
-            d[2] = qmap.q_pre_wrap_tile_count;
-            d[3] = qmap.q_post_wrap_start_tile;
-            d[4] = qmap.q_valid_tile_count;
-            d[5] = active_ring_iter_mask;
+            d[ring_joint::kDerivedLogicalNt] = logical_nt;
+            if constexpr (kv_pad_from_metadata) {
+                d[ring_joint::kDerivedQPreWrapStartTile] = qmap.q_pre_wrap_start_tile;
+                d[ring_joint::kDerivedQPreWrapTileCount] = qmap.q_pre_wrap_tile_count;
+                d[ring_joint::kDerivedQPostWrapStartTile] = qmap.q_post_wrap_start_tile;
+                d[ring_joint::kDerivedQValidTileCount] = qmap.q_valid_tile_count;
+            }
+            d[ring_joint::kDerivedActiveRingIterMask] = active_ring_iter_mask;
+            if constexpr (has_logical_n_tensor) {
+                d[ring_joint::kDerivedGlobalNPartialCol] = global_n_partial_col_live;
+            }
+            if constexpr (has_logical_l_tensor) {
+                d[ring_joint::kDerivedLogicalLt] = logical_lt;
+                d[ring_joint::kDerivedJointLPartialCol] = joint_l_partial_col_live;
+            }
             cb_derived.push_back(1);
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
 #include "ring_joint_kv_pad_derivation.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
 #include "metadata_scalar_read.hpp"
 #include "fused_op_receiver.hpp"
 #include "ring_utils.hpp"
@@ -448,6 +449,11 @@ void kernel_main() {
     // Slot 37: true (unpadded) joint length in tiles (twins spatial logical_nt). Drives the joint
     // mask-generation gate together with joint_l_partial_col.
     constexpr uint32_t logical_lt = get_compile_time_arg_val(37);
+    // Slots 38-39: logical-length transport. Being a dataflow kernel, the writer NoC-reads the live values
+    // itself (as it already does for kv_actual_isl) and re-derives the masks and partial-column stamps.
+    constexpr bool has_logical_n_tensor = get_compile_time_arg_val(38) == 1;
+    constexpr bool has_logical_l_tensor = get_compile_time_arg_val(39) == 1;
+    constexpr bool has_logical_length_tensor = has_logical_n_tensor || has_logical_l_tensor;
     // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
     // path. The program factory masks kernel_is_causal off when chunked is on, so only one of
     // the two paths drives the stamp per program — but they share the CB slot layout.
@@ -462,15 +468,28 @@ void kernel_main() {
     // Effective joint length for masking: per-shard (L_local = L/ring_size) for sharded, full L for replicated.
     constexpr uint32_t L_effective = has_gathered_joint_k ? L / ring_size : L;
 
-    // Slots 34-37: sliding_window_size, kv_pad_from_metadata, joint_is_sharded, logical_lt.
-    constexpr auto out_args = TensorAccessorArgs<38>();
+    // Slots 34-39: sliding_window_size, kv_pad_from_metadata, joint_is_sharded, logical_lt, and the two
+    // logical-length transport flags.
+    constexpr uint32_t kFirstAccessorArgOffset = 40;
+    constexpr auto out_args = TensorAccessorArgs<kFirstAccessorArgOffset>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
     // Metadata accessor (metadata path only) follows the output accessors and precedes the CB compile
     // args; gate the offset on kv_pad_from_metadata so the no-metadata program never names a non-accessor
-    // compile arg (fall back to a valid unused accessor offset = out_args' slot 38).
-    constexpr uint32_t meta_args_offset = kv_pad_from_metadata ? stats_args.next_compile_time_args_offset() : 38;
+    // compile arg (fall back to a valid unused accessor offset = out_args' slot).
+    constexpr uint32_t meta_args_offset =
+        kv_pad_from_metadata ? stats_args.next_compile_time_args_offset() : kFirstAccessorArgOffset;
     constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();
+    // logical_n / logical_l accessors follow the metadata accessor, appended as a pair so the offsets do
+    // not depend on which one was supplied.
+    constexpr uint32_t post_meta_args_offset =
+        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : stats_args.next_compile_time_args_offset();
+    constexpr uint32_t logical_n_args_offset =
+        has_logical_length_tensor ? post_meta_args_offset : kFirstAccessorArgOffset;
+    constexpr auto logical_n_args = TensorAccessorArgs<logical_n_args_offset>();
+    constexpr uint32_t logical_l_args_offset =
+        has_logical_length_tensor ? logical_n_args.next_compile_time_args_offset() : logical_n_args_offset;
+    constexpr auto logical_l_args = TensorAccessorArgs<logical_l_args_offset>();
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
@@ -487,7 +506,7 @@ void kernel_main() {
 
     // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
     constexpr uint32_t cb_arg_offset =
-        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : stats_args.next_compile_time_args_offset();
+        has_logical_length_tensor ? logical_l_args.next_compile_time_args_offset() : post_meta_args_offset;
     constexpr uint32_t cb_mask_in = get_compile_time_arg_val(cb_arg_offset + 3);
     constexpr uint32_t cb_scale_in = get_compile_time_arg_val(cb_arg_offset + 4);
     constexpr uint32_t cb_identity_scale_in = get_compile_time_arg_val(cb_arg_offset + 5);
@@ -507,28 +526,81 @@ void kernel_main() {
 
     Noc noc;
 
+    // Common runtime args: kv_actual_isl slot first when present, then the logical-length pair.
+    constexpr uint32_t logical_length_common_arg_base =
+        kv_pad_from_metadata ? ring_joint::kWriterMetadataCommonArgCount : 0;
+    [[maybe_unused]] uint32_t global_n_partial_col_live = global_n_partial_col;
+    [[maybe_unused]] uint32_t joint_l_partial_col_live = joint_l_partial_col;
+
+    if constexpr (has_logical_length_tensor) {
+        CircularBuffer cb_meta_scratch(cb_out);
+        const uint32_t meta_l1 = cb_meta_scratch.get_write_ptr();
+        uint32_t logical_lt_live = logical_lt;
+        if constexpr (has_logical_n_tensor) {
+            const uint32_t logical_n_live = trace_metadata::read_metadata_scalar_u32(
+                noc, logical_n_args, get_common_arg_val<uint32_t>(logical_length_common_arg_base), meta_l1);
+            logical_nt = ring_joint::tiles_for(logical_n_live);
+            global_n_partial_col_live = ring_joint::tile_partial_col(logical_n_live);
+        }
+        if constexpr (has_logical_l_tensor) {
+            const uint32_t logical_l_live = trace_metadata::read_metadata_scalar_u32(
+                noc, logical_l_args, get_common_arg_val<uint32_t>(logical_length_common_arg_base + 1), meta_l1);
+            logical_lt_live = ring_joint::tiles_for(logical_l_live);
+            joint_l_partial_col_live = ring_joint::tile_partial_col(logical_l_live);
+        }
+        // Re-derive from the live lengths so the writer agrees with the reader about which iterations and
+        // chunks carry work; see the same call there.
+        const auto masks = ring_joint::build_ring_work_masks_device({
+            .device_index = fused_op_receiver.seq.ring_index,
+            .ring_size = ring_size,
+            .backward_writes_expected = fused_op_receiver.seq.expected[0],
+            .forward_writes_expected = fused_op_receiver.seq.expected[1],
+            .num_local_k_chunks = num_local_k_chunks,
+            .k_chunk_tile_count = Sk_chunk_t,
+            .kv_local_padded_Nt = kv_local_padded_Nt,
+            .kernel_chunked = chunked_enabled,
+            .q_chunk_group_tile_count = chunk_size_t,
+            .q_local_padded_Nt = q_local_padded_Nt,
+            .logical_nt = logical_nt,
+            .num_joint_k_chunks = num_joint_k_chunks,
+            .joint_seq_len = L,
+            // Always false here: the logical-length-tensor path is validated incompatible with KV-pad rotation.
+            .kv_pad_rotation_enabled = false,
+            .kernel_is_causal = is_causal != 0,
+            .is_balanced = is_balanced != 0,
+            .joint_is_sharded = joint_is_sharded,
+            // Writer slot 12 (Lt) is already the per-device joint tile count; matches the reader's Lt_local.
+            .joint_local_padded_Nt = Lt,
+            .logical_lt = logical_lt_live,
+        });
+        active_ring_iter_mask = masks.active_ring_iter_mask;
+        single_valid_kv_chunk_mask = masks.single_valid_kv_chunk_mask;
+    }
+
     if constexpr (kv_pad_from_metadata) {
         CircularBuffer cb_meta_scratch(cb_out);
         const uint32_t kv_actual_isl = trace_metadata::read_metadata_scalar_u32(
             noc, meta_args, get_common_arg_val<uint32_t>(0), cb_meta_scratch.get_write_ptr());
         logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_size_t * 32, 32);
-        const auto masks = ring_joint::build_ring_work_masks_device(
-            fused_op_receiver.seq.ring_index,
-            ring_size,
-            fused_op_receiver.seq.expected[0],
-            fused_op_receiver.seq.expected[1],
-            num_local_k_chunks,
-            Sk_chunk_t,
-            kv_local_padded_Nt,
-            chunked_enabled,
-            chunk_size_t,
-            q_local_padded_Nt,
-            logical_nt,
-            num_joint_k_chunks,
-            L,
-            true,
-            is_causal != 0,
-            is_balanced != 0);
+        // Joint trio stays defaulted: KV-pad rotation is validated incompatible with a sharded joint.
+        const auto masks = ring_joint::build_ring_work_masks_device({
+            .device_index = fused_op_receiver.seq.ring_index,
+            .ring_size = ring_size,
+            .backward_writes_expected = fused_op_receiver.seq.expected[0],
+            .forward_writes_expected = fused_op_receiver.seq.expected[1],
+            .num_local_k_chunks = num_local_k_chunks,
+            .k_chunk_tile_count = Sk_chunk_t,
+            .kv_local_padded_Nt = kv_local_padded_Nt,
+            .kernel_chunked = chunked_enabled,
+            .q_chunk_group_tile_count = chunk_size_t,
+            .q_local_padded_Nt = q_local_padded_Nt,
+            .logical_nt = logical_nt,
+            .num_joint_k_chunks = num_joint_k_chunks,
+            .joint_seq_len = L,
+            .kv_pad_rotation_enabled = true,
+            .kernel_is_causal = is_causal != 0,
+            .is_balanced = is_balanced != 0,
+        });
         active_ring_iter_mask = masks.active_ring_iter_mask;
         single_valid_kv_chunk_mask = masks.single_valid_kv_chunk_mask;
     }
@@ -570,15 +642,27 @@ void kernel_main() {
     //     not fill the last real shard's chunk — fully-padded trailing tiles and/or a sub-tile column.
     constexpr bool joint_has_padding =
         L > 0 && ((Lt % Sk_chunk_t != 0) || (logical_lt % Sk_chunk_t != 0) || (joint_l_partial_col != 0));
-    constexpr bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled || has_sliding_window;
+    constexpr bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) ||
+                                            diag_tile_enabled || has_sliding_window || has_logical_length_tensor;
+    // partial_tile_present keeps tile presence in lock-step with the factory's CB sizing and compute's tile
+    // indices. A present tile needs a non-zero template column (fall back to 1) so
+    // generate_lightweight_mask_tiles allocates the slot; the stamped live column may still be 0, which
+    // compute ignores.
+    constexpr uint32_t global_n_partial_col_layout =
+        ring_joint::partial_tile_present(global_n_partial_col, has_logical_n_tensor)
+            ? (global_n_partial_col > 0 ? global_n_partial_col : 1u)
+            : 0u;
+    constexpr uint32_t joint_l_partial_col_layout =
+        ring_joint::partial_tile_present(joint_l_partial_col, has_logical_l_tensor)
+            ? (joint_l_partial_col > 0 ? joint_l_partial_col : 1u)
+            : 0u;
     if constexpr (needs_lightweight_mask) {
         generate_lightweight_mask_tiles<
-            global_n_partial_col,
-            joint_l_partial_col,
+            global_n_partial_col_layout,
+            joint_l_partial_col_layout,
             cb_mask_in,
             (is_causal == 1) || chunked_enabled,
-            sliding_window_size>(noc);
+            sliding_window_size>(noc, global_n_partial_col_live, joint_l_partial_col_live);
     }
 
     uint32_t ring_index = fused_op_receiver.seq.ring_index;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Shared host/kernel contract for the trace-safe logical_n / logical_l transport: the cb_kv_pad_derived
+// slot layout, the common-runtime-arg bases, the partial-tile forcing rule, and the tile-math helpers.
+namespace ttnn::operations::transformer::sdpa::ring_joint {
+
+// cb_kv_pad_derived slot layout. The reader fills these (compute cannot NoC-read DRAM) and compute reads
+// them back by index. Slots 1-4 are the KV-pad Q-mapping (metadata path only); slots 6/7/8 are the
+// logical-length transport (tensor path only). Both paths write slots 0 and 5.
+constexpr uint32_t kDerivedLogicalNt = 0;
+constexpr uint32_t kDerivedQPreWrapStartTile = 1;
+constexpr uint32_t kDerivedQPreWrapTileCount = 2;
+constexpr uint32_t kDerivedQPostWrapStartTile = 3;
+constexpr uint32_t kDerivedQValidTileCount = 4;
+constexpr uint32_t kDerivedActiveRingIterMask = 5;
+constexpr uint32_t kDerivedGlobalNPartialCol = 6;
+constexpr uint32_t kDerivedLogicalLt = 7;
+constexpr uint32_t kDerivedJointLPartialCol = 8;
+constexpr uint32_t kDerivedSlotCount = 9;
+
+// Common-runtime-arg layout: the metadata block (when present) precedes the logical-length pair.
+constexpr uint32_t kReaderMetadataCommonArgCount = 4;  // slot_id addr, num_layers, layer_idx, kv_actual_isl addr
+constexpr uint32_t kWriterMetadataCommonArgCount = 1;  // kv_actual_isl addr
+
+// A tile-aligned placeholder implies partial column 0, but a device tensor can land mid-tile at any
+// dispatch, so the boundary tile must exist in the CB layout whenever a length tensor is in play. The
+// kernels stamp the live column into it and gate the stamp off when the live column is 0.
+constexpr bool partial_tile_present(uint32_t partial_col, bool has_length_tensor) {
+    return (partial_col != 0) || has_length_tensor;
+}
+
+// Tile-math for the dataflow kernels' live-length narrowing. TILE_HEIGHT is 32 on this op's tiles.
+constexpr uint32_t kTileHeight = 32;
+constexpr uint32_t tiles_for(uint32_t len) { return (len + kTileHeight - 1) / kTileHeight; }
+constexpr uint32_t tile_partial_col(uint32_t len) { return len % kTileHeight; }
+
+}  // namespace ttnn::operations::transformer::sdpa::ring_joint

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -310,6 +310,50 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         tensor_args.slot_id.has_value() == tensor_args.kv_actual_isl.has_value(),
         "metadata tensors slot_id and kv_actual_isl must be supplied together, or neither supplied");
 
+    // Kernels read element 0 as a raw 32-bit word; the value range is the caller's contract (as for
+    // slot_id / kv_actual_isl), so only dtype and residency are checked here.
+    for (const auto& [logical_tensor, name] : {
+             std::pair{&tensor_args.logical_n_tensor, "logical_n"},
+             std::pair{&tensor_args.logical_l_tensor, "logical_l"},
+         }) {
+        if (!logical_tensor->has_value()) {
+            continue;
+        }
+        const auto& t = logical_tensor->value();
+        TT_FATAL(
+            t.dtype() == DataType::UINT32 || t.dtype() == DataType::INT32,
+            "{} tensor must be UINT32 or INT32 (the kernels read element 0 as a raw 32-bit word). Got {}",
+            name,
+            t.dtype());
+        TT_FATAL(t.storage_type() == StorageType::DEVICE, "{} tensor must be on device", name);
+        TT_FATAL(t.buffer() != nullptr, "{} tensor must be allocated on device", name);
+    }
+    if (tensor_args.has_logical_n_tensor()) {
+        // These bake logical_n into host-computed structure (KV-pad Q mapping, sliding halo plan, chunked
+        // q_start_idx) and already have their own trace-safe transport via the metadata path.
+        TT_FATAL(
+            !args.has_kv_pad_rotation() && !tensor_args.has_metadata(),
+            "logical_n as a tensor is incompatible with the kv_actual_isl / metadata KV-pad rotation path, "
+            "which derives logical_n itself");
+        TT_FATAL(!args.has_sliding_window(), "logical_n as a tensor is incompatible with sliding-window attention");
+        TT_FATAL(
+            !tensor_args.is_chunked(),
+            "logical_n as a tensor is incompatible with chunked-shaped prefill (Q.seq < K.seq); use the "
+            "kv_actual_isl metadata path there");
+    }
+    if (tensor_args.has_logical_l_tensor()) {
+        // The placeholder is the padded ring total (per-shard L * ring_size), which selects the
+        // sharded-joint path; a replicated joint pins logical_l == L by shape and has nothing to vary.
+        TT_FATAL(
+            tensor_args.joint_is_sharded(),
+            "logical_l as a tensor requires the sharded-joint path (joint tensors present and ring_size > 1)");
+        // The kernels' kv_pad_from_metadata branch takes precedence and would ignore the live joint tail
+        // (mirrors the logical_n restriction above).
+        TT_FATAL(
+            !tensor_args.has_metadata(),
+            "logical_l as a tensor is incompatible with the slot_id / kv_actual_isl metadata path");
+    }
+
     if (tensor_args.attention_sink.has_value()) {
         const auto& attention_sink = tensor_args.attention_sink.value();
         TT_FATAL(args.is_causal, "RingJointSDPA attention_sink is supported only for causal attention");
@@ -721,7 +765,10 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(!args.is_balanced, "sharded joint is incompatible with is_balanced (zigzag)");
         TT_FATAL(!args.is_cross, "sharded joint is incompatible with is_cross");
         TT_FATAL(!args.kv_cache_batch_idx.has_value(), "sharded joint is incompatible with indexed KV cache");
-        TT_FATAL(!args.kv_actual_isl.has_value(), "sharded joint is incompatible with KV-pad rotation");
+        // Covers both the host-scalar and metadata-tensor forms (see the logical_l-tensor check above).
+        TT_FATAL(
+            !args.kv_actual_isl.has_value() && !tensor_args.has_metadata(),
+            "sharded joint is incompatible with KV-pad rotation");
 
         // Page-size parity: joint K/V are appended to the same fused all-gather list as spatial K/V.
         // The AG validator enforces uniform page size; assert explicitly for a clear error on divergence.
@@ -917,6 +964,9 @@ ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
         args.kv_cache_batch_idx.has_value(),
         kv_pad_rotation_enabled,
         tensor_args.has_metadata(),
+        // Presence changes how the kernels compile; the numeric attrs above hash as stable placeholders.
+        tensor_args.has_logical_n_tensor(),
+        tensor_args.has_logical_l_tensor(),
         args.kv_cache_num_layers,
         args.kv_cache_layer_idx,
         tensor_args.has_latent_v(),
@@ -1053,7 +1103,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const std::optional<ttnn::Tensor>& kv_actual_isl_tensor,
     const uint32_t kv_cache_num_layers,
     const uint32_t kv_cache_layer_idx,
-    const std::optional<uint32_t> sliding_window_size) {
+    const std::optional<uint32_t> sliding_window_size,
+    const std::optional<ttnn::Tensor>& logical_n_tensor,
+    const std::optional<ttnn::Tensor>& logical_l_tensor) {
     using OperationType = ttnn::prim::RingJointSDPADeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -1200,7 +1252,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         .gathered_joint_k = resolved_gathered_joint_k,
         .gathered_joint_v = resolved_gathered_joint_v,
         .slot_id = slot_id,
-        .kv_actual_isl = kv_actual_isl_tensor};
+        .kv_actual_isl = kv_actual_isl_tensor,
+        .logical_n_tensor = logical_n_tensor,
+        .logical_l_tensor = logical_l_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -69,6 +69,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const std::optional<ttnn::Tensor>& kv_actual_isl_tensor = std::nullopt,
     uint32_t kv_cache_num_layers = 1,
     uint32_t kv_cache_layer_idx = 0,
-    std::optional<uint32_t> sliding_window_size = std::nullopt);
+    std::optional<uint32_t> sliding_window_size = std::nullopt,
+    // When set, the logical_n / logical_l params above are worst-case placeholders (see RingJointSDPAInputs).
+    const std::optional<ttnn::Tensor>& logical_n_tensor = std::nullopt,
+    const std::optional<ttnn::Tensor>& logical_l_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -159,7 +159,18 @@ struct RingJointSDPAInputs {
     std::optional<Tensor> slot_id;
     std::optional<Tensor> kv_actual_isl;
 
+    // Trace-safe transport for logical_n / logical_l (opt-in, independent of the metadata path above):
+    // single-valued uint32/int32 device tensors read on-device each dispatch. When set, the matching
+    // RingJointSDPAParams scalar is a worst-case capacity placeholder (the padded ring total), so every
+    // host-side derivation stays valid and the kernels narrow it per dispatch.
+    std::optional<Tensor> logical_n_tensor;
+    std::optional<Tensor> logical_l_tensor;
+
     bool has_metadata() const { return slot_id.has_value() && kv_actual_isl.has_value(); }
+
+    bool has_logical_n_tensor() const { return logical_n_tensor.has_value(); }
+
+    bool has_logical_l_tensor() const { return logical_l_tensor.has_value(); }
 
     // Chunked-prefill is signalled implicitly by Q being shorter than the per-device K shard:
     // Q is the latest slab, K is the populated prefix from chunk 0 through the current chunk.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -7,6 +7,7 @@
 #include "kernels/sliding_window_geometry.hpp"
 #include "sliding_halo_layout.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_derived_slots.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_id_sequencer.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
 
@@ -1063,6 +1064,11 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // Lightweight mask: needed when any K/joint dimension has padding, or when causal/chunked
     // masking is active.
     const bool local_n_has_padding = (kv_local_padded_Nt % Sk_chunk_t) != 0;
+    // Placeholder attributes already worst-case every size derivation below, except partial-column tile
+    // presence -- CB geometry is fixed at program creation, so force those tiles whenever a tensor is
+    // present (see partial_tile_present); the kernels stamp the live column.
+    const bool has_logical_n_tensor = tensor_args.has_logical_n_tensor();
+    const bool has_logical_l_tensor = tensor_args.has_logical_l_tensor();
     const uint32_t global_n_partial_col = args.logical_n % tt::constants::TILE_HEIGHT;
     const uint32_t compile_time_logical_n = kv_pad_rotation_enabled ? 0 : static_cast<uint32_t>(args.logical_n);
     const uint32_t compile_time_logical_nt = kv_pad_rotation_enabled ? 0 : logical_nt;
@@ -1078,14 +1084,17 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // fully-padded trailing tiles and a sub-tile partial column (logical_l=63, L_local=32: 63 % 32 != 0).
     const bool joint_has_padding =
         L > 0 && (((Lt_local % Sk_chunk_t) != 0) || ((logical_l % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0));
-    const bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled || has_sliding_window;
+    const bool needs_lightweight_mask = (local_n_has_padding || global_n_has_padding || joint_has_padding) ||
+                                        diag_tile_enabled || has_sliding_window || has_logical_n_tensor ||
+                                        has_logical_l_tensor;
 
     // Partial tile support when the joint padding boundary falls inside a tile. Uses the true
     // logical length (logical_l % TILE_HEIGHT), mirroring global_n_partial_col = logical_n % TILE.
     const uint32_t joint_l_partial_col = logical_l % tt::constants::TILE_HEIGHT;
-    const uint32_t partial_mask_tiles =
-        (compile_time_global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
+    const bool has_global_n_partial_tile =
+        ring_joint::partial_tile_present(compile_time_global_n_partial_col, has_logical_n_tensor);
+    const bool has_joint_l_partial_tile = ring_joint::partial_tile_present(joint_l_partial_col, has_logical_l_tensor);
+    const uint32_t partial_mask_tiles = (has_global_n_partial_tile ? 1 : 0) + (has_joint_l_partial_tile ? 1 : 0);
     const uint32_t edge_mask_tiles = has_sliding_window ? kSlidingWindowEdgeTiles : (diag_tile_enabled ? 1 : 0);
     // Single CB holds neginf, either the causal diagonal or sliding edge palette, and partial masks.
     const uint32_t total_lightweight_mask_tiles = 1 + edge_mask_tiles + partial_mask_tiles;
@@ -1450,8 +1459,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         static_cast<uint32_t>(joint_is_sharded),
         // Slot 39: true (unpadded) joint length in tiles (twins spatial logical_nt). The reader uses it
         // to skip joint K chunks that lie entirely beyond the real joint tail (padding).
-        // Tensor accessors start at slot 40.
         logical_lt,
+        // Slots 40-41: logical-length transport. The reader NoC-reads the live values, re-derives
+        // logical_nt / logical_lt / the ring masks, and fans them to compute via cb_kv_pad_derived.
+        // Tensor accessors start at slot 42.
+        static_cast<uint32_t>(has_logical_n_tensor),
+        static_cast<uint32_t>(has_logical_l_tensor),
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
@@ -1486,6 +1499,15 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         if (kv_pad_from_metadata) {
             TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(reader_compile_time_args);
         }
+    }
+    // Appended as a pair when either is present (null accessor for the absent one) so kernel offsets do not
+    // depend on which was supplied. Separate accessors: the two single-page tensors can land in different
+    // DRAM banks, the same trap documented for slot_id/kv_actual_isl.
+    if (has_logical_n_tensor || has_logical_l_tensor) {
+        TensorAccessorArgs(has_logical_n_tensor ? tensor_args.logical_n_tensor->buffer() : nullptr)
+            .append_to(reader_compile_time_args);
+        TensorAccessorArgs(has_logical_l_tensor ? tensor_args.logical_l_tensor->buffer() : nullptr)
+            .append_to(reader_compile_time_args);
     }
 
     /**
@@ -1612,8 +1634,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         // Slot 36: sharded-joint flag. When true, one shard per ring iteration; do_joint_kv fires every iter.
         static_cast<uint32_t>(joint_is_sharded),
         // Slot 37: true (unpadded) joint length in tiles (twins spatial logical_nt). Combined with
-        // joint_l_partial_col it drives the joint mask-generation gate. Output accessors start at slot 38.
+        // joint_l_partial_col it drives the joint mask-generation gate.
         logical_lt,
+        // Slots 38-39: logical-length transport. The writer is a dataflow kernel, so it NoC-reads the live
+        // values itself rather than sharing the reader's L1 mailbox. Output accessors start at slot 40.
+        static_cast<uint32_t>(has_logical_n_tensor),
+        static_cast<uint32_t>(has_logical_l_tensor),
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -1621,6 +1647,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
     if (kv_pad_from_metadata) {
         TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(writer_compile_time_args);
+    }
+    if (has_logical_n_tensor || has_logical_l_tensor) {
+        TensorAccessorArgs(has_logical_n_tensor ? tensor_args.logical_n_tensor->buffer() : nullptr)
+            .append_to(writer_compile_time_args);
+        TensorAccessorArgs(has_logical_l_tensor ? tensor_args.logical_l_tensor->buffer() : nullptr)
+            .append_to(writer_compile_time_args);
     }
 
     std::vector<uint32_t> compute_compile_time_args = {
@@ -1682,8 +1714,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         // Slot 52: sharded-joint flag. When true, one shard per ring iteration; do_joint_kv fires every iter.
         static_cast<uint32_t>(joint_is_sharded),
         // Slot 53: true (unpadded) joint length in tiles (twins spatial logical_nt). Drives the
-        // per-ring-iteration joint tail mask and the joint out-of-bounds K-chunk skip. CB block starts at 54.
-        logical_lt};
+        // per-ring-iteration joint tail mask and the joint out-of-bounds K-chunk skip.
+        logical_lt,
+        // Slots 54-55: logical-length transport. Compute cannot NoC-read DRAM, so it takes the live values
+        // from cb_kv_pad_derived, which the reader fills. CB block starts at 56.
+        static_cast<uint32_t>(has_logical_n_tensor),
+        static_cast<uint32_t>(has_logical_l_tensor)};
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -2571,12 +2607,35 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     reader_kernel.compile_time_args = reader_compile_time_args;
     reader_kernel.defines = kernel_defines;
     reader_kernel.config = ReaderConfigDescriptor{};
-    if (slot_from_metadata) {
-        reader_kernel.emplace_common_runtime_args(
-            {tensor_args.slot_id->buffer()->address(),  // smuggled-rta-ok: metadata tensor addr (on-device)
-             args.kv_cache_num_layers,
-             args.kv_cache_layer_idx,
-             tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
+    // Layout: metadata block first (when present), then the logical-length pair, so the kernel's base index
+    // is ring_joint::kReaderMetadataCommonArgCount (or kWriterMetadataCommonArgCount) when its metadata block
+    // is present, else 0. Both slots are emplaced whenever either tensor is present. Passed as Buffer* (not
+    // ->address()) so a program-cache hit re-patches them if the tensor was reallocated.
+    const bool has_logical_length_tensor = has_logical_n_tensor || has_logical_l_tensor;
+    const auto append_logical_length_common_args = [&](KernelDescriptor::RTArgList& into) {
+        if (!has_logical_length_tensor) {
+            return;
+        }
+        for (const auto* logical_tensor : {&tensor_args.logical_n_tensor, &tensor_args.logical_l_tensor}) {
+            if (logical_tensor->has_value()) {
+                into.push_back((*logical_tensor)->buffer());
+            } else {
+                into.push_back(uint32_t{0});
+            }
+        }
+    };
+    if (slot_from_metadata || has_logical_length_tensor) {
+        KernelDescriptor::RTArgList reader_common_args;
+        if (slot_from_metadata) {
+            reader_common_args.push_back(
+                tensor_args.slot_id->buffer()->address());  // smuggled-rta-ok: metadata tensor addr (on-device)
+            reader_common_args.push_back(args.kv_cache_num_layers);
+            reader_common_args.push_back(args.kv_cache_layer_idx);
+            reader_common_args.push_back(
+                tensor_args.kv_actual_isl->buffer()->address());  // smuggled-rta-ok: metadata tensor addr (on-device)
+        }
+        append_logical_length_common_args(reader_common_args);
+        reader_kernel.emplace_common_runtime_args(reader_common_args);
     }
 
     KernelDescriptor writer_kernel{};
@@ -2587,9 +2646,14 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     writer_kernel.compile_time_args = writer_compile_time_args;
     writer_kernel.defines = kernel_defines;
     writer_kernel.config = WriterConfigDescriptor{};
-    if (kv_pad_from_metadata) {
-        writer_kernel.emplace_common_runtime_args(
-            {tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
+    if (kv_pad_from_metadata || has_logical_length_tensor) {
+        KernelDescriptor::RTArgList writer_common_args;
+        if (kv_pad_from_metadata) {
+            writer_common_args.push_back(
+                tensor_args.kv_actual_isl->buffer()->address());  // smuggled-rta-ok: metadata tensor addr (on-device)
+        }
+        append_logical_length_common_args(writer_common_args);
+        writer_kernel.emplace_common_runtime_args(writer_common_args);
     }
 
     KernelDescriptor compute_kernel{};

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -385,7 +385,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteExpRingJointAttentio
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
-    std::size_t logical_n,
+    const LogicalLength& logical_n,
     operations::transformer::SDPAProgramConfig program_config,
     const int32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
@@ -403,6 +403,18 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteExpRingJointAttentio
     const std::optional<ttnn::Tensor> joint_k = drop_if_empty(joint_tensor_k);
     const std::optional<ttnn::Tensor> joint_v = drop_if_empty(joint_tensor_v);
 
+    // Tensor path: the scalar attribute becomes the worst-case placeholder (see ExpRingJointSDPAInputs).
+    const std::size_t ring_size =
+        (cluster_axis == 0) ? mesh_device.get_view().num_rows() : mesh_device.get_view().num_cols();
+    const std::size_t padded_ring_n = static_cast<std::size_t>(input_tensor_k.logical_shape()[2]) * ring_size;
+    std::size_t logical_n_scalar = padded_ring_n;
+    std::optional<ttnn::Tensor> logical_n_tensor;
+    if (const auto* scalar = std::get_if<std::size_t>(&logical_n)) {
+        logical_n_scalar = *scalar;
+    } else {
+        logical_n_tensor = std::get<ttnn::Tensor>(logical_n);
+    }
+
     auto output_tensors = ttnn::prim::exp_ring_joint_scaled_dot_product_attention(
         input_tensor_q,
         input_tensor_k,  // AllGather input
@@ -413,7 +425,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteExpRingJointAttentio
         persistent_output_buffer_k,  // AllGather output / RingAttention input
         persistent_output_buffer_v,  // AllGather output / RingAttention input
         joint_strategy,
-        logical_n,
+        logical_n_scalar,
         std::move(program_config),
         dim,
         multi_device_global_semaphore,
@@ -425,7 +437,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteExpRingJointAttentio
         scale,
         compute_kernel_config,
         num_workers_per_link,
-        num_buffers_per_channel);
+        num_buffers_per_channel,
+        logical_n_tensor);
     return {
         output_tensors[prim::EXP_RING_JOINT_SDPA_OUTPUT_IDX],
         output_tensors[prim::EXP_RING_JOINT_SDPA_JOINT_OUTPUT_IDX],

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -216,8 +216,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
-    std::size_t logical_n,
-    std::size_t logical_l,
+    const LogicalLength& logical_n,
+    const LogicalLength& logical_l,
     ttnn::operations::transformer::SDPAProgramConfig program_config,
     const int32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
@@ -244,6 +244,24 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     const std::optional<ttnn::Tensor> joint_k = drop_if_empty(joint_tensor_k);
     const std::optional<ttnn::Tensor> joint_v = drop_if_empty(joint_tensor_v);
 
+    // Split each logical length into (scalar attribute, optional device tensor); on the tensor path the
+    // attribute becomes the worst-case placeholder (see RingJointSDPAInputs).
+    const std::size_t ring_size =
+        (cluster_axis == 0) ? mesh_device.get_view().num_rows() : mesh_device.get_view().num_cols();
+    const std::size_t padded_ring_n = static_cast<std::size_t>(input_tensor_k.logical_shape()[2]) * ring_size;
+    const std::size_t padded_ring_l =
+        joint_k.has_value() ? static_cast<std::size_t>(joint_k->logical_shape()[2]) * ring_size : 0;
+    const auto split_logical_length =
+        [](const LogicalLength& length,
+           std::size_t placeholder) -> std::pair<std::size_t, std::optional<ttnn::Tensor>> {
+        if (const auto* scalar = std::get_if<std::size_t>(&length)) {
+            return {*scalar, std::nullopt};
+        }
+        return {placeholder, std::get<ttnn::Tensor>(length)};
+    };
+    const auto [logical_n_scalar, logical_n_tensor] = split_logical_length(logical_n, padded_ring_n);
+    const auto [logical_l_scalar, logical_l_tensor] = split_logical_length(logical_l, padded_ring_l);
+
     auto topology_1d = ttnn::ccl::convert_2d_to_1d_topology(topology);
     auto output_tensors = ttnn::prim::ring_joint_scaled_dot_product_attention(
         input_tensor_q,
@@ -257,8 +275,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         persistent_output_buffer_joint_k,
         persistent_output_buffer_joint_v,
         joint_strategy,
-        logical_n,
-        logical_l,
+        logical_n_scalar,
+        logical_l_scalar,
         std::move(program_config),
         dim,
         multi_device_global_semaphore,
@@ -282,7 +300,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         std::nullopt,  // kv_actual_isl_tensor
         1,             // kv_cache_num_layers
         0,             // kv_cache_layer_idx
-        sliding_window_size);
+        sliding_window_size,
+        logical_n_tensor,
+        logical_l_tensor);
     return {
         output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX],
         output_tensors[prim::RING_JOINT_SDPA_JOINT_OUTPUT_IDX],

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <variant>
+
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/transformer/sdpa_config.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -12,6 +14,10 @@
 #include "ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp"
 
 namespace ttnn::transformer {
+
+// A logical (unpadded) sequence length: a host scalar, or a single-valued device tensor read on-device so
+// the value can change between replays of one captured trace.
+using LogicalLength = std::variant<std::size_t, ttnn::Tensor>;
 
 ttnn::Tensor scaled_dot_product_attention(
     const ttnn::Tensor& input_tensor_q,
@@ -89,8 +95,10 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
-    std::size_t logical_n,
-    std::size_t logical_l,
+    // The tensor form of logical_l always selects the sharded-joint path (its placeholder is the padded
+    // ring total); omit it for a replicated joint.
+    const LogicalLength& logical_n,
+    const LogicalLength& logical_l,
     operations::transformer::SDPAProgramConfig program_config,
     int32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -166,7 +166,9 @@ struct ExecuteExpRingJointAttention {
         ttnn::Tensor& persistent_output_buffer_k,
         ttnn::Tensor& persistent_output_buffer_v,
         const std::string& joint_strategy,
-        std::size_t logical_n,
+        // The tensor form transports the live length on-device so one captured trace replays at
+        // different lengths (its placeholder is the padded ring total).
+        const LogicalLength& logical_n,
         operations::transformer::SDPAProgramConfig program_config,
         int32_t dim,
         const std::vector<GlobalSemaphore>& multi_device_global_semaphore,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -35,8 +35,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
-    std::size_t logical_n,
-    std::size_t logical_l,
+    const ttnn::transformer::LogicalLength& logical_n,
+    const ttnn::transformer::LogicalLength& logical_l,
     const SDPAProgramConfig& program_config,
     std::optional<float> scale,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
@@ -603,11 +603,17 @@ void bind_sdpa(nb::module_& mod) {
             persistent_output_buffer_k (ttnn.Tensor): Persistent buffer for gathered K tensor.
             persistent_output_buffer_v (ttnn.Tensor): Persistent buffer for gathered V tensor.
             joint_strategy (str): Strategy for joint attention. Must be "rear".
-            logical_n (int): The logical sequence length N before sharding across devices.
-            logical_l (int, optional): The full prompt (joint) sequence length L before sharding.
+            logical_n (int or ttnn.Tensor): The logical sequence length N before sharding across devices.
+                A single-valued int32/uint32 device tensor is read on-device each dispatch, so one captured
+                trace can replay at different lengths (rewrite the tensor between replays). Not supported
+                with sliding-window attention, chunked-shaped prefill, or the kv_actual_isl KV-pad path.
+            logical_l (int or ttnn.Tensor, optional): The full prompt (joint) sequence length L before sharding.
                 Pass the full L when joint_tensor_q/k/v are sharded L/P per device.
-                The op infers the sharded path when per-device joint seq == logical_l / ring_size.
-                If 0 (default) or omitted, behaves as the replicated path (backward-compatible).
+                Omit (or pass 0) when the joint is replicated; that is the default, backward-compatible path.
+                The scalar form infers sharded only when per-device joint seq < logical_l (a scalar equal to
+                the per-device length still resolves to replicated). The tensor form makes the value
+                trace-dynamic and ALWAYS selects the sharded path (its placeholder is the padded ring total),
+                so never pass a tensor with a replicated joint. Requires joint tensors present and ring_size > 1.
             program_config (ttnn.SDPAProgramConfig): Program configuration for the operation.
             scale (float, optional): Scale factor for QK^T. Defaults to None.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to None.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -161,7 +161,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> exp_ring_joint_scaled_dot_p
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
-    std::size_t logical_n,
+    const ttnn::transformer::LogicalLength& logical_n,
     const SDPAProgramConfig& program_config,
     std::optional<float> scale,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,


### PR DESCRIPTION
### PR Category
Feature

### Summary
This enables transformer block tracing for DiTs models that support arbitrary padless sequence lengths.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/dynamic_logical_l_trace_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/dynamic_logical_l_trace_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/dynamic_logical_l_trace_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/dynamic_logical_l_trace_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/dynamic_logical_l_trace_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/dynamic_logical_l_trace_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/dynamic_logical_l_trace_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/dynamic_logical_l_trace_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/dynamic_logical_l_trace_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/dynamic_logical_l_trace_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/dynamic_logical_l_trace_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/dynamic_logical_l_trace_support). [The same test is also failing on main](https://github.com/tenstorrent/tt-metal/actions/runs/34929576637/job/104257255302).
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/dynamic_logical_l_trace_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/dynamic_logical_l_trace_support)