### PR TITLE
[exabox] health check: add didt matmul stress test + BMC FRU inventory capture

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -273,7 +273,9 @@ tests/tt_metal/tt_metal/test_kernels/sfpi/ @nathan-TT @kstevensTT
 
 # misc tests
 tests/didt/ @rdjogoTT @ttmtrajkovic @ctr-nradojevicTT @ctr-adjokicTT
-tests/tt_metal/tt_metal/deployment/ @rdjogoTT @ctr-nradojevicTT @ctr-adjokicTT
+
+# Deployment tests
+tests/tt_metal/tt_metal/deployment/ @gsarabandoTT @tt-mnijjar @mgajewskiTT @ctr-nradojevicTT @ctr-adjokicTT
 
 # TTNN
 ttnn/ @tenstorrent/metalium-developers-ttnn-core

--- a/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
+++ b/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
@@ -48,8 +48,9 @@ test: 1000 matmul iterations on the full (8, 4) mesh with a determinism
 re-check every 50, via the repo venv's pytest. Measured ~9 min on a BH galaxy
 (mostly cold bring-up + the 20 output readbacks); bump
 `--didt-workload-iterations` when triaging a suspect unit — a marginal chip
-that passed 1000 iterations failed under a 5000-iteration soak. `--timeout 0`
-is required (the repo-wide 300 s pytest-timeout kills the run otherwise), and
+that passed 1000 iterations failed under a 5000-iteration soak. `--timeout
+1200` overrides the repo-wide 300 s pytest-timeout (too short for this run)
+while still bounding a wedged run in standalone invocations, and
 zero-collected runs are recorded as FAIL, same trap as the zero-match gtest
 filters above. Needs the venv (`./create_venv.sh`) and standard mesh cabling —
 on torus-cabled units set `TT_MESH_GRAPH_DESC_PATH` to the matching descriptor

--- a/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
+++ b/tools/scaleout/exabox/health_check_test_suite/HEALTH_CHECK.md
@@ -26,11 +26,11 @@ Output goes to `./diag_report.json` by default; gtest logs to `./logs/<test>.log
 
 ## Tiers
 
-| Tier | Resets | Gtests | Duration | Use when |
+| Tier | Resets | Tests | Duration | Use when |
 |---|---|---|---|---|
 | `light`  | `tt-smi -r` × 1                            | eth_link_up                                                                | ~75 s   | Smoke check on every new unit |
 | `medium` | `tt-smi -r`, `tt-smi -glx_reset`          | eth_link_up + eth_bandwidth + gddr_fast (DRAM_TEST_FAST=1)                | ~5 min  | Pre-deployment validation |
-| `deploy` | `tt-smi -r`, `tt-smi -glx_reset` × 2      | eth_link_up + eth_bandwidth + full gddr matrix (3 DramDeployment tests)   | ~15 min | Final deploy gate |
+| `deploy` | `tt-smi -r`, `tt-smi -glx_reset` × 2      | eth_link_up + eth_bandwidth + full gddr matrix (3 DramDeployment tests) + didt_matmul_galaxy (pytest, ~9 min) | ~18 min | Final deploy gate |
 
 The eth deployment tests are registered as `TensixDeploymentEthernet<NN><Name>`
 (e.g. `TensixDeploymentEthernet00LinkUp`, `TensixDeploymentEthernet01Bandwidth`,
@@ -43,8 +43,20 @@ which `tests/tt_metal/tt_metal/deployment/sources.cmake` now compiles.
 (Filters without the index wildcard match zero tests, so gtest exits 0 and the
 check is silently recorded as PASS without running — avoid that form.)
 
-The reset cadence and test set are defined in `RESET_PLAN` / `TIER_TESTS` in
-`diag_runner.py`.
+The deploy tier also runs `didt_matmul_galaxy`, a pytest-based dI/dt stress
+test: 1000 matmul iterations on the full (8, 4) mesh with a determinism
+re-check every 50, via the repo venv's pytest. Measured ~9 min on a BH galaxy
+(mostly cold bring-up + the 20 output readbacks); bump
+`--didt-workload-iterations` when triaging a suspect unit — a marginal chip
+that passed 1000 iterations failed under a 5000-iteration soak. `--timeout 0`
+is required (the repo-wide 300 s pytest-timeout kills the run otherwise), and
+zero-collected runs are recorded as FAIL, same trap as the zero-match gtest
+filters above. Needs the venv (`./create_venv.sh`) and standard mesh cabling —
+on torus-cabled units set `TT_MESH_GRAPH_DESC_PATH` to the matching descriptor
+or fabric mesh mapping fails.
+
+The reset cadence and test set are defined in `RESET_PLAN` / `TIER_TESTS` /
+`PYTESTS` in `diag_runner.py`.
 
 ## Flags
 
@@ -75,6 +87,11 @@ Per-rev hardware expectations (Confluence SYS-4055):
 | RevC   | `00000473…` | `16G` | Gen5 |
 
 The detected rev is also recorded at the top of the JSON report as `detected_board_rev`.
+
+### Host
+| Check | Rule | On fail |
+|---|---|---|
+| `host_fru_info` | Store-only: BMC FRU inventory via `sudo -n ipmitool fru print`. UBB tray serials in the details; full field set in `data.devices`. | never alerts — **SKIP** when ipmitool/sudo/BMC is unavailable |
 
 ### PCIe
 | Check | Rule | On fail |

--- a/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
+++ b/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
@@ -194,10 +194,12 @@ PYTESTS = {
             "50",
             "-s",
             # pytest.ini sets a repo-wide 300s pytest-timeout; this run always
-            # exceeds it. Disable it; the health-check harness enforces its own
-            # wall-clock timeout around the whole diag run.
+            # exceeds it (~545s measured). 1200s keeps >2x headroom while still
+            # bounding a standalone deploy run if a device test wedges (the
+            # test-infrastructure wrapper adds its own wall-clock timeout, but
+            # run_diag.sh / container entrypoints invoke this script directly).
             "--timeout",
-            "0",
+            "1200",
         ],
     },
 }
@@ -1296,9 +1298,21 @@ GTEST_FAIL_RE = re.compile(r"\[\s*FAILED\s*\]\s+(\S+\.\S+)")
 
 # pytest progress markers. Counts come from the end-of-run summary line
 # ("===== 3 passed, 1 failed, 2 deselected in 600.12s ====="); failing node ids
-# from the short-summary "FAILED tests/..." lines.
+# from the short-summary "FAILED tests/..." lines and, for fixture/collection
+# errors, the "ERROR tests/..." lines.
 PYTEST_COUNT_RE = re.compile(r"(\d+) (passed|failed|error)")
-PYTEST_FAILED_LINE_RE = re.compile(r"^FAILED\s+(\S+)")
+PYTEST_FAILED_LINE_RE = re.compile(r"^(?:FAILED|ERROR)\s+(\S+)")
+
+
+def parse_pytest_summary_counts(line: str) -> tuple[int, int] | None:
+    """Extract (passed, failed) from a pytest end-of-run summary line, or None
+    if the line isn't one. Fixture/collection `error` counts fold into failed.
+    A "no tests ran" summary carries no counts and returns None — callers'
+    zero-initialized counts then record the run as FAIL, not a silent PASS."""
+    if not line.startswith("=") or not (" passed" in line or " failed" in line or " error" in line):
+        return None
+    counts = {word: int(num) for num, word in PYTEST_COUNT_RE.findall(line)}
+    return counts.get("passed", 0), counts.get("failed", 0) + counts.get("error", 0)
 
 
 def resolve_pytest(tt_metal: Path) -> str | None:
@@ -1330,6 +1344,9 @@ def run_pytest_test(
             )
             return
 
+    # cmd is built exclusively from the hardcoded PYTESTS table and the
+    # repo-resolved pytest binary — no user-controlled input — and is executed
+    # as an argv list (no shell).
     target = spec["target"]
     cmd = [pytest_bin, target, *spec["args"]]
     test_env = env.copy()
@@ -1383,11 +1400,11 @@ def run_pytest_test(
             logf.write(line)
             if m := PYTEST_FAILED_LINE_RE.match(line):
                 failures.append(m.group(1))
-            elif line.startswith("=") and (" passed" in line or " failed" in line or " error" in line):
-                counts = {word: int(num) for num, word in PYTEST_COUNT_RE.findall(line)}
-                passed = counts.get("passed", 0)
-                failed = counts.get("failed", 0) + counts.get("error", 0)
+            elif (counts := parse_pytest_summary_counts(line)) is not None:
+                passed, failed = counts
         rc = proc.wait()
+    # A node can appear in both a live FAILED line and the short summary.
+    failures = list(dict.fromkeys(failures))
     dt = time.time() - t0
 
     # Require passed > 0 so an over-narrow -k expression (0 tests collected,

--- a/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
+++ b/tools/scaleout/exabox/health_check_test_suite/diag_runner.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import shutil
 import socket
 import subprocess
@@ -167,16 +168,50 @@ TESTS = {
     "gddr_full": "*DramDeployment_*",
 }
 
+# Pytest-based tests, keyed like TESTS but run through the repo venv's pytest
+# (python_env/bin/pytest, falling back to PATH) instead of the gtest binary.
+# Each entry is a pytest node id plus its extra args.
+#
+# didt_matmul_galaxy: dI/dt worst-case matmul across the full galaxy mesh (8x4),
+# 1000 workload iterations with a determinism check every 50 (20 checks) —
+# catches droop-induced non-determinism the short deployment gtests don't.
+# Measured 545 s in-suite on a BH galaxy (bh-glx6u-28, 2026-09-01):
+# iterations ~69 ms each, each determinism check ~13 s (reads the full
+# 16k x 16k output back from all 32 chips), plus ~3.5 min cold 32-chip
+# bring-up/compile. Check density is the dominant cost: the same test at 5000 iterations
+# across all four dtype variants (-k galaxy) measures ~2 h. Note a longer
+# soak catches more: a marginal chip on the bench unit failed 2/10 checks at
+# 5000 iterations but passed shorter runs — bump iterations for deep triage.
+PYTESTS = {
+    "didt_matmul_galaxy": {
+        "target": "tests/didt/test_minimal_matmul.py::test_minimal_matmul",
+        "args": [
+            "-k",
+            "galaxy and bf16_HiFi2",
+            "--didt-workload-iterations",
+            "1000",
+            "--determinism-check-interval",
+            "50",
+            "-s",
+            # pytest.ini sets a repo-wide 300s pytest-timeout; this run always
+            # exceeds it. Disable it; the health-check harness enforces its own
+            # wall-clock timeout around the whole diag run.
+            "--timeout",
+            "0",
+        ],
+    },
+}
+
 # Tests executed per tier. ETH deployment tests (added in tt-metal #49215 and
 # compiled via tests/tt_metal/tt_metal/deployment/sources.cmake) are enabled here
 # to match the tier layout documented in run_diag.sh:
 #   light  -> eth link_up
 #   medium -> light + eth bandwidth + GDDR fast-pattern
-#   deploy -> full GDDR patterns + eth bandwidth
+#   deploy -> full GDDR patterns + eth bandwidth + didt matmul stress (pytest)
 TIER_TESTS = {
     "light": ["eth_link_up"],
     "medium": ["gddr_fast", "eth_link_up", "eth_bandwidth"],
-    "deploy": ["gddr_full", "eth_link_up", "eth_bandwidth"],
+    "deploy": ["gddr_full", "eth_link_up", "eth_bandwidth", "didt_matmul_galaxy"],
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -313,6 +348,89 @@ def take_snapshot(tt_smi: str, out_path: Path) -> dict:
         raise RuntimeError(f"snapshot file not written: {out_path}")
     with out_path.open() as f:
         return json.load(f)
+
+
+def parse_fru_print(text: str) -> list[dict]:
+    """Parse `ipmitool fru print` output into one {field: value} dict per FRU
+    device. Output is `Key : Value` lines; a `FRU Device Description` line
+    starts a new device block. Splitting on the first colon keeps values that
+    themselves contain colons (e.g. mfg date timestamps) intact.
+
+    Unpopulated fields ("---" placeholders on Galaxy BMCs) are dropped, which
+    also disposes of most of the repeated `* Extra` keys; a repeated key with a
+    real value keeps the last occurrence."""
+    devices: list[dict] = []
+    cur: dict | None = None
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key, value = key.strip(), value.strip()
+        if key == "FRU Device Description":
+            cur = {"description": value}
+            devices.append(cur)
+        elif cur is not None and key and value and value != "---":
+            cur[key] = value
+    return devices
+
+
+def collect_fru_info(phase: Phase, dry_run: bool) -> None:
+    """Capture the BMC FRU inventory (`ipmitool fru print`) into the report.
+
+    Store-only forensics — board/product part numbers, serials, and mfg dates
+    for correlating failures with specific hardware units. Never degrades the
+    run status: PASS when captured, SKIP when ipmitool / sudo / the BMC is
+    unavailable (e.g. offline --input-snapshot dev runs).
+    """
+    cmd = ["ipmitool", "fru", "print"]
+    if os.geteuid() != 0:
+        # -n: fail immediately rather than hang on a password prompt.
+        cmd = ["sudo", "-n"] + cmd
+    try:
+        cp = run(cmd, dry_run=dry_run, capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as e:
+        phase.add(Check(name="host_fru_info", status=SKIP, details=f"ipmitool unavailable: {e!r}", ip="other"))
+        return
+    if dry_run:
+        phase.add(Check(name="host_fru_info", status=SKIP, details=f"(dry) {' '.join(cmd)}", ip="other"))
+        return
+    if cp.returncode != 0:
+        first_err = ((cp.stderr or cp.stdout or "").strip().splitlines() or ["no output"])[0]
+        phase.add(
+            Check(
+                name="host_fru_info",
+                status=SKIP,
+                details=f"ipmitool fru print rc={cp.returncode}: {first_err}",
+                ip="other",
+            )
+        )
+        return
+    devices = parse_fru_print(cp.stdout)
+    if not devices:
+        phase.add(Check(name="host_fru_info", status=SKIP, details="no FRU devices parsed from output", ip="other"))
+        return
+    # UBB board serials are the tray serials used for hardware-swap tracking —
+    # surface them in the details; full field set is in data.devices.
+    ubb_serials = [
+        f"{d['description'].split(' ')[0]}={d['Board Serial']}"
+        for d in devices
+        if d.get("description", "").startswith("UBB") and d.get("Board Serial")
+    ]
+    detail_tail = "; ".join(ubb_serials)
+    if not detail_tail:
+        first = devices[0]
+        detail_tail = ", ".join(
+            f"{k}={first[k]}" for k in ("Product Name", "Product Serial", "Board Serial") if first.get(k)
+        )
+    phase.add(
+        Check(
+            name="host_fru_info",
+            status=PASS,
+            details=f"{len(devices)} FRU device(s) captured" + (f"; {detail_tail}" if detail_tail else ""),
+            data={"devices": devices},
+            ip="other",
+        )
+    )
 
 
 def validate_snapshot(snap: dict, phase: Phase) -> str | None:
@@ -1176,6 +1294,129 @@ GTEST_OK_RE = re.compile(r"\[\s*OK\s*\]\s+(\S+\.\S+)")
 GTEST_FAIL_RE = re.compile(r"\[\s*FAILED\s*\]\s+(\S+\.\S+)")
 
 
+# pytest progress markers. Counts come from the end-of-run summary line
+# ("===== 3 passed, 1 failed, 2 deselected in 600.12s ====="); failing node ids
+# from the short-summary "FAILED tests/..." lines.
+PYTEST_COUNT_RE = re.compile(r"(\d+) (passed|failed|error)")
+PYTEST_FAILED_LINE_RE = re.compile(r"^FAILED\s+(\S+)")
+
+
+def resolve_pytest(tt_metal: Path) -> str | None:
+    """Prefer the repo venv's pytest (has ttnn + test deps); fall back to PATH."""
+    venv_pytest = tt_metal / "python_env" / "bin" / "pytest"
+    if venv_pytest.is_file():
+        return str(venv_pytest)
+    return shutil.which("pytest")
+
+
+def run_pytest_test(
+    name: str, spec: dict, tt_metal: Path, env: dict, phase: Phase, dry_run: bool, logs_dir: Path
+) -> None:
+    """Run one PYTESTS entry, mirroring the gtest flow: stream output to the
+    per-test log, count testcases, and record a Check with the same
+    `passed=N failed=N` details format the CSV analyzer parses."""
+    pytest_bin = resolve_pytest(tt_metal)
+    if pytest_bin is None:
+        if dry_run:
+            pytest_bin = "pytest"  # display-only; nothing is executed
+        else:
+            phase.add(
+                Check(
+                    name=name,
+                    status=FAIL,
+                    details=f"pytest not found ({tt_metal}/python_env/bin/pytest or PATH)",
+                    ip="other",
+                )
+            )
+            return
+
+    target = spec["target"]
+    cmd = [pytest_bin, target, *spec["args"]]
+    test_env = env.copy()
+    test_env.setdefault("PYTHONPATH", str(tt_metal))
+    log_path = logs_dir / f"{name}.log"
+    # shlex.join keeps args with spaces (-k "galaxy and bf16_HiFi2") copy-pasteable
+    cmdline = shlex.join(cmd)
+    log(f"--- test '{name}' (pytest) ---")
+    log(f"  cmd:  {cmdline}")
+    log(f"  log:  {log_path}")
+
+    if dry_run:
+        print(f"  {name:30} (dry-run)")
+        phase.add(
+            Check(
+                name=name,
+                status=PASS,
+                ip="other",
+                details=f"(dry) target={target} log={log_path}",
+                data={
+                    "target": target,
+                    "command": cmdline,
+                    "rc": 0,
+                    "duration_s": 0.0,
+                    "log_file": str(log_path),
+                    "testcases": {"passed": 0, "failed": 0, "failures": []},
+                },
+            )
+        )
+        return
+
+    _emit_running(name)
+
+    t0 = time.time()
+    passed = 0
+    failed = 0
+    failures: list[str] = []
+    with log_path.open("w") as logf:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+            text=True,
+            env=test_env,
+            cwd=str(tt_metal),
+        )
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            # All pytest output goes to the log file only — keep the console clean.
+            logf.write(line)
+            if m := PYTEST_FAILED_LINE_RE.match(line):
+                failures.append(m.group(1))
+            elif line.startswith("=") and (" passed" in line or " failed" in line or " error" in line):
+                counts = {word: int(num) for num, word in PYTEST_COUNT_RE.findall(line)}
+                passed = counts.get("passed", 0)
+                failed = counts.get("failed", 0) + counts.get("error", 0)
+        rc = proc.wait()
+    dt = time.time() - t0
+
+    # Require passed > 0 so an over-narrow -k expression (0 tests collected,
+    # pytest rc=5) or an unparsed summary can't be recorded as a silent PASS —
+    # same trap as the zero-match gtest filters documented above TESTS.
+    status = PASS if rc == 0 and failed == 0 and passed > 0 else FAIL
+    suffix = f"({dt:.1f}s)"
+    if failed:
+        suffix += f"  passed={passed} failed={failed}"
+    _emit_result(name, status, suffix=suffix)
+    details = f"target={target} rc={rc} dur={dt:.1f}s " f"passed={passed} failed={failed} log={log_path}"
+    phase.add(
+        Check(
+            name=name,
+            status=status,
+            details=details,
+            data={
+                "target": target,
+                "command": cmdline,
+                "rc": rc,
+                "duration_s": dt,
+                "log_file": str(log_path),
+                "testcases": {"passed": passed, "failed": failed, "failures": failures},
+            },
+            ip="other",
+        )
+    )
+
+
 # Console summary helpers
 IP_ORDER = ("board", "pcie", "gddr", "eth", "asic", "fw", "thermal", "other")
 
@@ -1211,7 +1452,9 @@ def run_tests(tt_metal: Path, tier: str, phase: Phase, dry_run: bool, logs_dir: 
         (tt_metal / c for c in DEPLOYMENT_BIN_CANDIDATES if (tt_metal / c).is_file()),
         None,
     )
-    if binary is None:
+    if binary is None and any(n in TESTS for n in TIER_TESTS[tier]):
+        # Pytest-based entries don't need the gtest binary — record the FAIL
+        # for the gtest set but keep going so they still run.
         phase.add(
             Check(
                 name="deployment_binary_present",
@@ -1220,17 +1463,22 @@ def run_tests(tt_metal: Path, tier: str, phase: Phase, dry_run: bool, logs_dir: 
                 ip="other",
             )
         )
-        return
 
     env = os.environ.copy()
     env["TT_METAL_HOME"] = str(tt_metal)
     env["TT_METAL_RUNTIME_ROOT"] = str(tt_metal)  # newer name post-rename
-    # LD_LIBRARY_PATH: match the build dir of the binary we picked
-    env.setdefault("LD_LIBRARY_PATH", str(binary.parent.parent.parent / "lib"))
+    if binary is not None:
+        # LD_LIBRARY_PATH: match the build dir of the binary we picked
+        env.setdefault("LD_LIBRARY_PATH", str(binary.parent.parent.parent / "lib"))
 
     logs_dir.mkdir(parents=True, exist_ok=True)
 
     for name in TIER_TESTS[tier]:
+        if name in PYTESTS:
+            run_pytest_test(name, PYTESTS[name], tt_metal, env, phase, dry_run, logs_dir)
+            continue
+        if binary is None:
+            continue
         filt = TESTS[name]
         # `gddr_fast` tier hint: use DRAM_TEST_FAST=1
         test_env = env.copy()
@@ -1415,6 +1663,10 @@ def run_diag(
     except Exception as e:
         snap_phase.error = repr(e)
         snap_phase.add(Check(name="snapshot_capture", status=FAIL, details=repr(e)))
+    # Host FRU inventory (BMC identity: part numbers, serials, mfg dates) —
+    # store-only forensics alongside the chip-level snapshot checks; runs even
+    # when the tt-smi snapshot itself failed.
+    collect_fru_info(snap_phase, dry_run)
     snap_phase.duration_s = time.time() - t0
     snap_phase.rollup()
     report["phases"]["snapshot"] = asdict(snap_phase)

--- a/tools/scaleout/exabox/health_check_test_suite/run_diag.sh
+++ b/tools/scaleout/exabox/health_check_test_suite/run_diag.sh
@@ -11,6 +11,7 @@
 #   light   ~5 min  snapshot validate + 1 PCI reset + GDDR train/BIST + eth link_up
 #   medium          light + eth bandwidth + GDDR fast-pattern stress
 #   deploy          3 resets (1x -r then 2x -glx_reset) + full GDDR patterns + eth bandwidth
+#                   + didt matmul stress (pytest, galaxy mesh)
 #
 # Designed to match tt-metal's run_upstream_tests_vanilla.sh shape.
 # Can be used as the ENTRYPOINT of a docker image
@@ -27,7 +28,7 @@ Usage: $0 {light|medium|deploy} [diag_runner.py options]
 Tiers:
   light    Smoke check: snapshot validate + 1 PCI reset + GDDR train/BIST + eth link_up
   medium   light + eth bandwidth + GDDR fast-pattern stress
-  deploy   3 resets + full GDDR pattern set + eth bandwidth
+  deploy   3 resets + full GDDR pattern set + eth bandwidth + didt matmul stress (pytest)
 
 Forwarded options (see diag_runner.py --help for details):
   --dry-run              Print intended subprocess calls without executing destructive steps

--- a/tools/scaleout/exabox/tests/test_diag_runner_parsers.py
+++ b/tools/scaleout/exabox/tests/test_diag_runner_parsers.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for diag_runner.py's pure parsing helpers: the ipmitool FRU
+output parser and the pytest output markers (summary counts, failing-node
+lines). These lock in the text-parsing edge cases without needing hardware."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+SUITE_DIR = TESTS_DIR.parent / "health_check_test_suite"
+sys.path.insert(0, str(SUITE_DIR))
+
+from diag_runner import (  # noqa: E402
+    PYTEST_FAILED_LINE_RE,
+    parse_fru_print,
+    parse_pytest_summary_counts,
+)
+
+# Abridged real `ipmitool fru print` output from a BH Galaxy 6U (Quanta S7T).
+FRU_SAMPLE = """\
+FRU Device Description : Builtin FRU Device (ID 0)
+ Chassis Type          : Rack Mount Chassis
+ Chassis Part Number   : ---
+ Chassis Extra         : ---
+ Chassis Extra         : ---
+ Board Mfg Date        : Tue Nov 21 17:00:00 2023
+ Board Mfg             : Quanta Computer Inc.
+ Board Product         : S7T-MB
+ Board Serial          : S7TMBC3A251002007
+ Product Name          : ---
+
+FRU Device Description : FP_FRU (ID 1)
+ Chassis Serial        : QTWS7TKC260200001
+ Product Name          : Galaxy Blackhole 6U Server
+ Product Serial        : QTWS7TKC260200001
+
+FRU Device Description : UBB0_FRU (ID 2)
+ Board Product         : S7T-UBB-BH
+ Board Serial          : T38S7TBA00806010018
+ Board Part Number     : 38S7TBA0080
+"""
+
+
+class TestParseFruPrint(unittest.TestCase):
+    def test_devices_split_on_description_lines(self):
+        devices = parse_fru_print(FRU_SAMPLE)
+        self.assertEqual(len(devices), 3)
+        self.assertEqual(
+            [d["description"] for d in devices],
+            ["Builtin FRU Device (ID 0)", "FP_FRU (ID 1)", "UBB0_FRU (ID 2)"],
+        )
+
+    def test_colon_containing_values_survive(self):
+        devices = parse_fru_print(FRU_SAMPLE)
+        self.assertEqual(devices[0]["Board Mfg Date"], "Tue Nov 21 17:00:00 2023")
+
+    def test_placeholder_fields_dropped(self):
+        devices = parse_fru_print(FRU_SAMPLE)
+        self.assertNotIn("Chassis Part Number", devices[0])
+        self.assertNotIn("Product Name", devices[0])
+        self.assertNotIn("Chassis Extra", devices[0])
+        self.assertEqual(devices[1]["Product Name"], "Galaxy Blackhole 6U Server")
+
+    def test_repeated_key_keeps_last_real_value(self):
+        text = (
+            "FRU Device Description : X (ID 0)\n" " Board Extra           : first\n" " Board Extra           : second\n"
+        )
+        self.assertEqual(parse_fru_print(text)[0]["Board Extra"], "second")
+
+    def test_leading_keyless_lines_ignored(self):
+        # Key:value lines before any device block, and non-kv lines, are skipped.
+        self.assertEqual(parse_fru_print(" Board Serial : X\nnot a kv line\n"), [])
+
+    def test_empty_input(self):
+        self.assertEqual(parse_fru_print(""), [])
+
+
+class TestParsePytestSummaryCounts(unittest.TestCase):
+    def test_mixed_summary(self):
+        line = "===== 3 passed, 1 failed, 2 deselected in 600.12s =====\n"
+        self.assertEqual(parse_pytest_summary_counts(line), (3, 1))
+
+    def test_all_pass(self):
+        line = "========== 4 passed, 16 deselected in 4212.55s ==========\n"
+        self.assertEqual(parse_pytest_summary_counts(line), (4, 0))
+
+    def test_errors_count_as_failed(self):
+        self.assertEqual(parse_pytest_summary_counts("=== 2 passed, 1 error in 50.00s ===\n"), (2, 1))
+        self.assertEqual(parse_pytest_summary_counts("=== 16 deselected, 4 errors in 7.63s ===\n"), (0, 4))
+
+    def test_no_tests_ran_is_not_a_summary(self):
+        # No counts at all -> None; the caller's zero-initialized counts then
+        # record the run as FAIL rather than a silent PASS.
+        self.assertIsNone(parse_pytest_summary_counts("========== no tests ran in 0.12s ==========\n"))
+
+    def test_section_headers_and_ordinary_lines_ignored(self):
+        self.assertIsNone(parse_pytest_summary_counts("==================== ERRORS ====================\n"))
+        self.assertIsNone(
+            parse_pytest_summary_counts("==================== test session starts ====================\n")
+        )
+        self.assertIsNone(parse_pytest_summary_counts("collected 20 items / 16 deselected / 4 selected\n"))
+
+
+class TestPytestFailedLineRe(unittest.TestCase):
+    def test_failed_line_captures_node_id(self):
+        m = PYTEST_FAILED_LINE_RE.match(
+            "FAILED tests/didt/test_minimal_matmul.py::test_minimal_matmul[bf16_HiFi2-galaxy] - AssertionError\n"
+        )
+        assert m is not None
+        self.assertEqual(m.group(1), "tests/didt/test_minimal_matmul.py::test_minimal_matmul[bf16_HiFi2-galaxy]")
+
+    def test_error_line_captures_node_id(self):
+        m = PYTEST_FAILED_LINE_RE.match(
+            "ERROR tests/didt/test_minimal_matmul.py::test_minimal_matmul[bf16_HiFi2-galaxy] - RuntimeError: x\n"
+        )
+        assert m is not None
+        self.assertEqual(m.group(1), "tests/didt/test_minimal_matmul.py::test_minimal_matmul[bf16_HiFi2-galaxy]")
+
+    def test_bare_error_and_error_colon_lines_not_matched(self):
+        self.assertIsNone(PYTEST_FAILED_LINE_RE.match("ERROR\n"))
+        self.assertIsNone(PYTEST_FAILED_LINE_RE.match("ERROR: usage: pytest [options]\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What's changed

- **New pytest test type** in the health-check suite (`PYTESTS` table + `run_pytest_test` in `diag_runner.py`), mirroring the gtest flow: per-test log streaming, testcase accounting in the same `passed=N failed=N` details format the CSV analyzer parses, and FAIL on zero-collected runs (so an over-narrow `-k` can't silently pass — same trap as the zero-match gtest filters).
- **`didt_matmul_galaxy` added to the deploy tier**: `tests/didt/test_minimal_matmul.py::test_minimal_matmul -k "galaxy and bf16_HiFi2" --didt-workload-iterations 1000 --determinism-check-interval 50 -s --timeout 0`. Catches droop-induced non-determinism the deployment gtests don't. `--timeout 0` overrides the repo-wide 300 s pytest-timeout, which this run always exceeds.
- **`host_fru_info` snapshot check**: captures `sudo -n ipmitool fru print` (store-only, SKIP-never-FAIL), surfacing UBB tray serials in the details for hardware-swap tracking; full FRU field set lands in the JSON report.
- A missing gtest binary no longer aborts the tests phase — pytest entries still run.

### Sizing (measured, bh-glx6u-28 RevC galaxy, 2026-09-01)

~9 min in-suite: ~69 ms/iteration + ~13 s per determinism check (full 32-chip output readback) + ~3.5 min cold bring-up. The same test at 5000 iterations across all four dtype variants runs ~2 h. A marginal chip that passed 1000 iterations failed 2/10 checks under a 5000-iteration soak, so iterations are worth bumping for triage.

### Test plan

- Full deploy tier on bh-glx6u-28 (RevC BH galaxy): all tests PASS — gddr_full 59.8 s, eth_link_up 46.4 s, eth_bandwidth 170.9 s, didt_matmul_galaxy 545.5 s; `host_fru_info` PASS with 7 FRU devices; overall WARN (known `cpld_fw_old` + `post_reset_state_stable`), exit 0. Total ~17.5 min.
- FRU parser validated against real Galaxy BMC output (colon-containing timestamps, `---` placeholder dropping, repeated `Extra` keys); sudo-denied and no-ipmitool paths produce SKIP.
- Pytest accounting validated against mixed pass/fail, fixture-error, and no-tests-ran outputs; CSV analyzer `_testcases` regex verified against the new details format.
- Dry-run (`--dry-run --skip-reset --input-snapshot`) exercised for all tiers.

Logs: 
[bh-glx6u-28_deploy_diag_20260901.zip](https://github.com/user-attachments/files/31715846/bh-glx6u-28_deploy_diag_20260901.zip)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smohammadi/health-check-didt-fru)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smohammadi/health-check-didt-fru)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smohammadi/health-check-didt-fru)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smohammadi/health-check-didt-fru)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smohammadi/health-check-didt-fru)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smohammadi/health-check-didt-fru)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smohammadi/health-check-didt-fru)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smohammadi/health-check-didt-fru)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smohammadi/health-check-didt-fru)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smohammadi/health-check-didt-fru)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smohammadi/health-check-didt-fru)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smohammadi/health-check-didt-fru)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smohammadi/health-check-didt-fru)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smohammadi/health-check-didt-fru)