### PR TITLE
[tt-train] Fix gram matmul watcher deadlock

### DIFF
--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/helper_dram_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/helper_dram_reader.cpp
@@ -94,4 +94,10 @@ void kernel_main() {
             }
         }
     }
+
+    // Flush every outstanding NOC transaction before the kernel exits: an
+    // unflushed multicast/semaphore write or non-posted atomic can land after the
+    // next dispatch re-initialises semaphores and strand a counted wait forever.
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_receiver.cpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_receiver.cpp
@@ -79,5 +79,9 @@ void kernel_main() {
         }
     }
 
+    // Flush every outstanding NOC transaction before the kernel exits: an
+    // unflushed multicast/semaphore write or non-posted atomic can land after the
+    // next dispatch re-initialises semaphores and strand a counted wait forever.
+    noc_async_write_barrier();
     noc_async_atomic_barrier();
 }

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_receiver_writer.cpp
@@ -181,4 +181,10 @@ void kernel_main() {
 #endif
         }
     }
+
+    // Flush every outstanding NOC transaction before the kernel exits: an
+    // unflushed multicast/semaphore write or non-posted atomic can land after the
+    // next dispatch re-initialises semaphores and strand a counted wait forever.
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_sender.cpp
@@ -177,8 +177,12 @@ void kernel_main() {
 #endif
                         noc_semaphore_set_multicast_loopback_src(receiver_sem_addr, sem_mcast_addr, lower_num_dests);
 
-                        noc_semaphore_wait(receiver_sem_ptr, VALID);
-                        noc_semaphore_set(receiver_sem_ptr, INVALID);
+                        // receiver_sem_addr is the SOURCE of the multicast above, so our own
+                        // copy is already VALID -- waiting on it is a no-op, and clearing it
+                        // poisons the source for the next round (the group would be sent
+                        // INVALID). A write barrier is what actually proves our loopback copy
+                        // landed.
+                        noc_async_write_barrier();
                     } else {
                         noc_semaphore_wait(sender_sem_ptr, lower_num_dests);
                         noc_semaphore_set(sender_sem_ptr, 0);

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/kernels/mcast_sender.cpp
@@ -258,4 +258,10 @@ void kernel_main() {
 #endif
         }
     }
+
+    // Flush every outstanding NOC transaction before the kernel exits: an
+    // unflushed multicast/semaphore write or non-posted atomic can land after the
+    // next dispatch re-initialises semaphores and strand a counted wait forever.
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/54721

### PR Category
Bug fix

### Summary

#### Problem
`k_split_gram_matmul` deadlocks under `TT_METAL_WATCHER=1`. Only the waypoint instrumentation triggers it — `TT_METAL_WATCHER_DISABLE_WAYPOINT=1` passes while every other watcher feature still hangs — so it's pure timing perturbation exposing a latent race, not a watcher check firing.

#### Cause
`noc_semaphore_set_multicast*` sends the contents of its source address. In the loopback branch that source is the sender's own `receiver_sem`, primed to `VALID` at startup. So the two lines after the multicast are both wrong:

```
noc_semaphore_wait(receiver_sem_ptr, VALID);    // reads the source — can never block
noc_semaphore_set(receiver_sem_ptr, INVALID);   // wipes what the NEXT round sends from
```

The next lower block then multicasts INVALID to the whole group — unless the in-flight loopback write happens to land after the clear and restore `VALID`. Normally it does; under waypoint timing the clear wins and everyone waits forever for a VALID that was never sent.

#### Changes

1. aba6eb49 — add the missing `noc_async_write_barrier()` + `noc_async_atomic_barrier()` at kernel exit in the four DM kernels (matches `variable_matmul`). Separate pre-existing defect; clears watcher's "pending NOC transactions" assert but does not fix the deadlock.
2. 79002678 — delete the no-op wait and the poisoning clear; a write barrier is what actually proves the loopback copy landed.

The `VALID` priming stays deliberately — it's the multicast payload, not initialization.

#### Validation — previously: hangs on main under watcher 2/2, gate passes 3/3 on the branch, full gram suite green with and without watcher.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zbaczewski/gram-watcher-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zbaczewski/gram-watcher-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zbaczewski/gram-watcher-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zbaczewski/gram-watcher-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/gram-watcher-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/gram-watcher-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zbaczewski/gram-watcher-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zbaczewski/gram-watcher-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zbaczewski/gram-watcher-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zbaczewski/gram-watcher-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zbaczewski/gram-watcher-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zbaczewski/gram-watcher-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zbaczewski/gram-watcher-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zbaczewski/gram-watcher-deadlock)