### PR TITLE
[Cleanup] `CreateBuffer` deprecation

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
@@ -1,9 +1,9 @@
 CreateBuffer
 =================
 
-.. doxygenfunction:: tt::tt_metal::CreateBuffer(const InterleavedBufferConfig &config);
+.. doxygenfunction:: tt::tt_metal::CreateBuffer(const BufferConfig &config);
 .. doxygenfunction:: tt::tt_metal::CreateBuffer(const ShardedBufferConfig &config);
-.. doxygenfunction:: tt::tt_metal::CreateBuffer(const InterleavedBufferConfig &config, DeviceAddr address);
+.. doxygenfunction:: tt::tt_metal::CreateBuffer(const BufferConfig &config, DeviceAddr address);
 .. doxygenfunction:: tt::tt_metal::CreateBuffer(const ShardedBufferConfig &config, DeviceAddr address);
-.. doxygenfunction:: tt::tt_metal::CreateBuffer(const InterleavedBufferConfig &config, SubDeviceId sub_device_id);
+.. doxygenfunction:: tt::tt_metal::CreateBuffer(const BufferConfig &config, SubDeviceId sub_device_id);
 .. doxygenfunction:: tt::tt_metal::CreateBuffer(const ShardedBufferConfig &config, SubDeviceId sub_device_id);

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
@@ -1,6 +1,10 @@
 CreateBuffer
 =================
 
+.. deprecated::
+   All ``CreateBuffer`` overloads are deprecated in favor of ``tt::tt_metal::distributed::MeshBuffer::create``.
+   They will be removed after 2026-10-04.
+
 .. doxygenfunction:: tt::tt_metal::CreateBuffer(const BufferConfig &config);
 .. doxygenfunction:: tt::tt_metal::CreateBuffer(const ShardedBufferConfig &config);
 .. doxygenfunction:: tt::tt_metal::CreateBuffer(const BufferConfig &config, DeviceAddr address);

--- a/tests/tt_metal/distributed/test_mesh_allocator.cpp
+++ b/tests/tt_metal/distributed/test_mesh_allocator.cpp
@@ -7,9 +7,8 @@
 #include <cstddef>
 #include <memory>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
 namespace tt::tt_metal::distributed::test {
@@ -20,18 +19,14 @@ TEST_F(MeshAllocatorTest, BasicAllocationSanityCheck) {
     const size_t allocation_size = 1024 * 8;  // 1KB
     const tt::tt_metal::BufferType buffer_type = tt::tt_metal::BufferType::L1;
 
-    auto config = InterleavedBufferConfig{
-        .device = mesh_device_.get(),
-        .size = allocation_size,
-        .page_size = 1024,
-        .buffer_type = buffer_type,
-    };
-
-    auto buffer = CreateBuffer(config);
+    auto buffer = MeshBuffer::create(
+        ReplicatedBufferConfig{.size = allocation_size},
+        {.page_size = 1024, .buffer_type = buffer_type},
+        mesh_device_.get());
 
     EXPECT_TRUE(buffer->is_allocated());
     EXPECT_EQ(buffer->size(), allocation_size);
-    EXPECT_EQ(buffer->buffer_type(), buffer_type);
+    EXPECT_EQ(buffer->device_local_config().buffer_type, buffer_type);
 }
 
 }  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -179,12 +179,10 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
         CBConfig cb_config;
 
         auto buffer_size = cb_config.page_size;
-        tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = device->get_devices()[0],
-            .size = buffer_size,
-            .page_size = buffer_size,
-            .buffer_type = tt::tt_metal::BufferType::L1};
-        auto l1_buffer = CreateBuffer(buff_config);
+        auto l1_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = buffer_size},
+            {.page_size = buffer_size, .buffer_type = tt::tt_metal::BufferType::L1},
+            device.get());
 
         CoreRange cr({0, 0}, {0, 2});
         CoreRangeSet cr_set({cr});
@@ -195,7 +193,7 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
             CircularBufferConfig(
                 cb_config.page_size,
                 {{buffer_indices[0], cb_config.data_format}, {buffer_indices[1], cb_config.data_format}},
-                *l1_buffer)
+                *l1_buffer->get_reference_buffer())
                 .set_page_size(buffer_indices[0], cb_config.page_size)
                 .set_page_size(buffer_indices[1], cb_config.page_size);
         CreateCircularBuffer(program_, cr_set, config1);
@@ -357,12 +355,10 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
         CoreRangeSet cr_set({cr});
 
         auto buffer_size = cb_config.page_size;
-        tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = device->get_devices()[0],
-            .size = buffer_size,
-            .page_size = buffer_size,
-            .buffer_type = tt::tt_metal::BufferType::L1};
-        auto l1_buffer = CreateBuffer(buff_config);
+        auto l1_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = buffer_size},
+            {.page_size = buffer_size, .buffer_type = tt::tt_metal::BufferType::L1},
+            device.get());
 
         initialize_program(program_, cr_set);
 
@@ -382,7 +378,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
 
         validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
         // Update address of the first CB
-        UpdateDynamicCircularBufferAddress(program_, cb_ids[0], *l1_buffer);
+        UpdateDynamicCircularBufferAddress(program_, cb_ids[0], *l1_buffer->get_reference_buffer());
         golden_addresses_per_core[core0][0] = l1_buffer->address();
         validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
     }
@@ -607,21 +603,18 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         uint32_t num_tiles = 2;
         uint32_t buffer_size = single_tile_size * num_tiles;
 
-        tt::tt_metal::InterleavedBufferConfig dram_config{
-            .device = device->get_devices()[0],
-            .size = buffer_size,
-            .page_size = buffer_size,
-            .buffer_type = tt::tt_metal::BufferType::DRAM};
-
-        tt::tt_metal::InterleavedBufferConfig l1_config{
-            .device = device->get_devices()[0],
-            .size = buffer_size,
-            .page_size = buffer_size,
-            .buffer_type = tt::tt_metal::BufferType::L1};
-
-        auto src_dram_buffer = CreateBuffer(dram_config);
-        auto dst_dram_buffer = CreateBuffer(dram_config);
-        auto global_cb_buffer = CreateBuffer(l1_config);
+        auto src_dram_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = buffer_size},
+            {.page_size = buffer_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+            device.get());
+        auto dst_dram_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = buffer_size},
+            {.page_size = buffer_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+            device.get());
+        auto global_cb_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = buffer_size},
+            {.page_size = buffer_size, .buffer_type = tt::tt_metal::BufferType::L1},
+            device.get());
 
         uint32_t cb_index = 0;
         CircularBufferConfig cb_src0_config = CircularBufferConfig(buffer_size, {{cb_index, tt::DataFormat::Float16_b}})
@@ -672,13 +665,13 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
 
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        detail::WriteToBuffer(src_dram_buffer, src_vec);
+        distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, true);
 
         distributed::EnqueueMeshWorkload(cq, workload, false);
         distributed::Finish(cq);
 
         std::vector<uint32_t> result_vec;
-        detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
         EXPECT_EQ(src_vec, result_vec);
 
         std::vector<uint32_t> input_cb_data;
@@ -691,18 +684,18 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         EXPECT_EQ(src_vec, input_cb_data);
 
         // update cb address
-        UpdateDynamicCircularBufferAddress(program_, cb_src0, *global_cb_buffer);
+        UpdateDynamicCircularBufferAddress(program_, cb_src0, *global_cb_buffer->get_reference_buffer());
 
         // zero out dst buffer
         std::vector<uint32_t> zero_vec = create_constant_vector_of_bfloat16(buffer_size, 0);
-        detail::WriteToBuffer(dst_dram_buffer, zero_vec);
+        distributed::EnqueueWriteMeshBuffer(cq, dst_dram_buffer, zero_vec, true);
 
         // relaunch program
         distributed::EnqueueMeshWorkload(cq, workload, false);
         distributed::Finish(cq);
 
         std::vector<uint32_t> second_result_vec;
-        detail::ReadFromBuffer(dst_dram_buffer, second_result_vec);
+        distributed::EnqueueReadMeshBuffer(cq, second_result_vec, dst_dram_buffer, true);
         EXPECT_EQ(src_vec, second_result_vec);
 
         std::vector<uint32_t> second_cb_data;

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstddef>
@@ -35,36 +36,33 @@ constexpr size_t cb_page_size = 16;
 constexpr size_t n_cbs = 32;
 constexpr size_t data_buffer_size = cb_n_pages * cb_n_pages;
 
-std::vector<std::shared_ptr<Buffer>> create_output_buffers(
+std::vector<std::shared_ptr<distributed::MeshBuffer>> create_output_buffers(
     distributed::MeshWorkload& /*workload*/, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
-
-    std::vector<std::shared_ptr<Buffer>> output_buffers;
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> output_buffers;
     output_buffers.reserve(n_cbs);
     for (size_t i = 0; i < n_cbs; i++) {
         // Bootleg way to put a single buffer on a single core
-        auto const& buffer_config = ShardedBufferConfig{
-            device,
-            data_buffer_size,
-            data_buffer_size,
-            BufferType::L1,
-            TensorMemoryLayout::WIDTH_SHARDED,
-            ShardSpecBuffer(
-                CoreRangeSet(CoreRange(worker_core)),
-                {cb_n_pages, cb_n_pages},
-                ShardOrientation::ROW_MAJOR,
-                {cb_n_pages, cb_n_pages},
-                {1, 1}),
-        };
-        output_buffers.push_back(CreateBuffer(buffer_config));
+        output_buffers.push_back(distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = data_buffer_size},
+            {.page_size = data_buffer_size,
+             .buffer_type = BufferType::L1,
+             .sharding_args = BufferShardingArgs(
+                 ShardSpecBuffer(
+                     CoreRangeSet(CoreRange(worker_core)),
+                     {cb_n_pages, cb_n_pages},
+                     ShardOrientation::ROW_MAJOR,
+                     {cb_n_pages, cb_n_pages},
+                     {1, 1}),
+                 TensorMemoryLayout::WIDTH_SHARDED)},
+            mesh_device.get()));
     }
     return output_buffers;
 }
 
 std::vector<uint32_t> generate_rt_args(
-    uint32_t master_semaphore, uint32_t subordinate_semaphore, std::vector<std::shared_ptr<Buffer>> const& data_buffers) {
+    uint32_t master_semaphore,
+    uint32_t subordinate_semaphore,
+    const std::vector<std::shared_ptr<distributed::MeshBuffer>>& data_buffers) {
     std::vector<uint32_t> rt_args;
     rt_args.reserve(2 + n_cbs);
     rt_args.push_back(master_semaphore);
@@ -97,7 +95,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferNonBlockingAPIs) {
             cbs.push_back(CreateCircularBuffer(program_, worker_core, cb_config));
         }
 
-        const auto& master_data_buffers = create_output_buffers(workload, mesh_device);
+        auto master_data_buffers = create_output_buffers(workload, mesh_device);
         const auto& subordinate_data_buffers = create_output_buffers(workload, mesh_device);
 
         const std::vector<uint32_t>& kernel_ct_args{n_cbs, cb_n_pages};
@@ -123,9 +121,9 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferNonBlockingAPIs) {
         distributed::EnqueueMeshWorkload(cq, workload, false);
         distributed::Finish(cq);
 
-        std::vector<uint32_t> out_buf(data_buffer_size);
+        std::vector<uint32_t> out_buf;
         for (size_t i = 0; i < n_cbs; i++) {
-            tt::tt_metal::detail::ReadFromBuffer(master_data_buffers[i], out_buf);
+            distributed::EnqueueReadMeshBuffer(cq, out_buf, master_data_buffers[i], true);
 
             const uint8_t* raw_data = reinterpret_cast<uint8_t*>(out_buf.data());
             for (size_t pages_pushed = 0; pages_pushed < cb_n_pages; pages_pushed++) {

--- a/tests/tt_metal/tt_metal/api/cross_node_dfb_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/cross_node_dfb_test_utils.hpp
@@ -53,14 +53,14 @@ inline std::shared_ptr<Buffer> make_cross_node_data_buffer(
     BufferType buffer_type = BufferType::L1) {
     const uint32_t ring_size = entry_size * num_entries;
     const uint32_t num_cores = all_cores.num_cores();
-    return CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = ring_size * num_cores,
-        .page_size = ring_size,
-        .buffer_type = buffer_type,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1}),
-    });
+    return Buffer::create(
+        device,
+        ring_size * num_cores,
+        ring_size,
+        buffer_type,
+        BufferShardingArgs(
+            ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1}),
+            TensorMemoryLayout::HEIGHT_SHARDED));
 }
 
 inline uint32_t data_pattern_for_write_primitive(uint32_t write_primitive) {

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -240,7 +240,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
 }
 
 // Positive control for live-range lifetime identity. Same-address wrappers are
-// routine (Buffer::view subviews, the mesh workload's kernel-binary view buffers):
+// routine (MeshBuffer views, the mesh workload's kernel-binary view buffers):
 // a temporary non-owning buffer created at a live owner's address — usually with a
 // SMALLER size — registers a second range with the same start. Its destruction must
 // remove ITS range, not the owner's: a start-keyed removal would erase the owner's
@@ -263,8 +263,11 @@ TEST_F(UnitMeshFixture, OOB_Tensor_SameAddressTempBuffer_NoViolation) {
         // on the PHYSICAL device: that id's registry is the one the launch snapshot
         // consumes, where the owner's per-device buffer is registered.
         constexpr uint32_t temp_size = buffer_size / 4;
-        auto temp =
-            Buffer::create(this->device().get_devices()[0], owner->address(), temp_size, temp_size, BufferType::DRAM);
+        [[maybe_unused]] auto temp = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = temp_size},
+            {.page_size = temp_size, .buffer_type = BufferType::DRAM},
+            &this->device(),
+            owner->address());
     }
     // Access the owner PAST the temporary's extent — valid, must stay registered.
     uint32_t in_addr = static_cast<uint32_t>(owner->address()) + buffer_size / 2;

--- a/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
@@ -1350,14 +1350,14 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_PageSize) {
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping = {
         {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))}};
 
-    auto bad = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = 128 * 2,
-        .page_size = 128,  // should be entry_size * num_entries = 256 * 4
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {2, 1}),
-    });
+    auto bad = Buffer::create(
+        device,
+        128 * 2,
+        128,  // should be entry_size * num_entries = 256 * 4
+        BufferType::L1,
+        BufferShardingArgs(
+            ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {2, 1}),
+            TensorMemoryLayout::HEIGHT_SHARDED));
     EXPECT_THROW(experimental::CrossNodeDFB(device, mapping, 256, 4, *bad), std::exception);
 }
 
@@ -1368,14 +1368,14 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_Cores) {
     CoreRangeSet wrong_cores = CoreRangeSet(CoreRange({2, 0}, {2, 0})).merge(CoreRangeSet(CoreRange({3, 0}, {3, 0})));
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping = {
         {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))}};
-    auto bad = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = 256 * 4 * 2,
-        .page_size = 256 * 4,
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = ShardSpecBuffer(wrong_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {2, 1}),
-    });
+    auto bad = Buffer::create(
+        device,
+        256 * 4 * 2,
+        256 * 4,
+        BufferType::L1,
+        BufferShardingArgs(
+            ShardSpecBuffer(wrong_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {2, 1}),
+            TensorMemoryLayout::HEIGHT_SHARDED));
     EXPECT_THROW(experimental::CrossNodeDFB(device, mapping, 256, 4, *bad), std::exception);
 }
 
@@ -1385,12 +1385,7 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_BufferType) {
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping = {
         {CoreCoord(0, 0), CoreRangeSet(CoreRange({1, 0}, {1, 0}))}};
 
-    auto bad = CreateBuffer(InterleavedBufferConfig{
-        .device = device,
-        .size = 256 * 4,
-        .page_size = 256 * 4,
-        .buffer_type = BufferType::DRAM,
-    });
+    auto bad = Buffer::create(device, 256 * 4, 256 * 4, BufferType::DRAM);
     EXPECT_THROW(experimental::CrossNodeDFB(device, mapping, 256, 4, *bad), std::exception);
 }
 
@@ -1403,14 +1398,14 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_Size) {
 
     // page_size and grid match, but size is larger than page_size * num_all_cores.
     const uint32_t ring_size = 256 * 4;
-    auto bad = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = ring_size * 4,
-        .page_size = ring_size,
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {2, 1}),
-    });
+    auto bad = Buffer::create(
+        device,
+        ring_size * 4,
+        ring_size,
+        BufferType::L1,
+        BufferShardingArgs(
+            ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {2, 1}),
+            TensorMemoryLayout::HEIGHT_SHARDED));
     EXPECT_THROW(experimental::CrossNodeDFB(device, mapping, 256, 4, *bad), std::exception);
 }
 

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -59,13 +59,11 @@ KernelDescriptor MakeBlankReaderKernel(CoreCoord core = {0, 0}) {
 }
 
 std::shared_ptr<Buffer> MakeDramBuffer(IDevice* device, uint32_t size = 2048) {
-    InterleavedBufferConfig cfg{.device = device, .size = size, .page_size = size, .buffer_type = BufferType::DRAM};
-    return CreateBuffer(cfg);
+    return Buffer::create(device, size, size, BufferType::DRAM);
 }
 
 std::shared_ptr<Buffer> MakeL1Buffer(IDevice* device, uint32_t size = 2048) {
-    InterleavedBufferConfig cfg{.device = device, .size = size, .page_size = size, .buffer_type = BufferType::L1};
-    return CreateBuffer(cfg);
+    return Buffer::create(device, size, size, BufferType::L1);
 }
 
 MeshTensor MakeSingleTileL1MeshTensor(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/api/test_shard_grid_validation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shard_grid_validation.cpp
@@ -53,7 +53,13 @@ ShardedBufferConfig one_shard_config(IDevice* device, BufferType buffer_type, co
 }
 
 std::shared_ptr<Buffer> make_width_sharded_buffer(IDevice* device, BufferType buffer_type, const CoreCoord& core) {
-    return CreateBuffer(one_shard_config(device, buffer_type, core));
+    const auto config = one_shard_config(device, buffer_type, core);
+    return Buffer::create(
+        config.device,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        BufferShardingArgs(config.shard_parameters, config.buffer_layout));
 }
 
 // Constructs the buffer without allocating it: the explicit-address overload skips allocate_impl().
@@ -63,8 +69,14 @@ std::shared_ptr<Buffer> make_width_sharded_buffer(IDevice* device, BufferType bu
 // out, so an L1_SMALL config tensor there is constructed and never allocated.
 std::shared_ptr<Buffer> make_unallocated_width_sharded_buffer(
     IDevice* device, BufferType buffer_type, const CoreCoord& core) {
-    return CreateBuffer(
-        one_shard_config(device, buffer_type, core), device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const auto config = one_shard_config(device, buffer_type, core);
+    return Buffer::create(
+        config.device,
+        device->allocator()->get_base_allocator_addr(HalMemType::L1),
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        BufferShardingArgs(config.shard_parameters, config.buffer_layout));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
@@ -68,8 +68,15 @@ constexpr uint32_t TILE_PAGE_SIZE = TILE_H * TILE_W * TILE_ELEMENT_SIZE;
 constexpr uint32_t TILE_NUM_PAGES = 1;
 constexpr uint32_t TILE_TOTAL_SIZE = TILE_NUM_PAGES * TILE_PAGE_SIZE;
 
-void verify_default_page_size(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const Buffer* input_buffer) {
-    auto* device = mesh_device->get_devices()[0];
+std::shared_ptr<distributed::MeshBuffer> create_output_dram_buffer(distributed::MeshDevice& mesh_device) {
+    return distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = OUTPUT_PAGE_SIZE},
+        {.page_size = OUTPUT_PAGE_SIZE, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+}
+
+void verify_default_page_size(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const distributed::MeshBuffer& input_buffer) {
     auto& cq = mesh_device->mesh_command_queue();
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -79,15 +86,14 @@ void verify_default_page_size(const std::shared_ptr<distributed::MeshDevice>& me
     workload.add_program(device_range, std::move(program));
     auto& prog = workload.get_programs().at(device_range);
 
-    auto output_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device, .size = OUTPUT_PAGE_SIZE, .page_size = OUTPUT_PAGE_SIZE, .buffer_type = BufferType::DRAM});
+    auto output_buffer = create_output_dram_buffer(*mesh_device);
 
     CircularBufferConfig cb_config =
         CircularBufferConfig(OUTPUT_PAGE_SIZE, {{0, tt::DataFormat::RawUInt32}}).set_page_size(0, OUTPUT_PAGE_SIZE);
     CreateCircularBuffer(prog, KERNEL_CORE, cb_config);
 
     std::vector<uint32_t> compile_time_args;
-    TensorAccessorArgs(*input_buffer).append_to(compile_time_args);
+    TensorAccessorArgs(input_buffer).append_to(compile_time_args);
     TensorAccessorArgs(*output_buffer).append_to(compile_time_args);
 
     auto kernel = CreateKernel(
@@ -99,30 +105,31 @@ void verify_default_page_size(const std::shared_ptr<distributed::MeshDevice>& me
             .noc = NOC::RISCV_0_default,
             .compile_args = compile_time_args});
 
-    SetRuntimeArgs(prog, kernel, KERNEL_CORE, {input_buffer->address(), output_buffer->address()});
+    SetRuntimeArgs(prog, kernel, KERNEL_CORE, {input_buffer.address(), output_buffer->address()});
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> result;
-    detail::ReadFromBuffer(output_buffer, result);
+    distributed::EnqueueReadMeshBuffer(cq, result, output_buffer, true);
 
-    uint32_t expected_input = static_cast<uint32_t>(input_buffer->aligned_page_size());
+    const Buffer* input_device_buffer = input_buffer.get_reference_buffer();
+    uint32_t expected_input = static_cast<uint32_t>(input_device_buffer->aligned_page_size());
     EXPECT_EQ(result[0], expected_input) << "Input TensorAccessor.page_size should default to aligned_page_size. "
                                          << "Expected: " << expected_input << ", Got: " << result[0]
-                                         << ", Buffer page_size: " << input_buffer->page_size();
+                                         << ", Buffer page_size: " << input_device_buffer->page_size();
 
-    uint32_t expected_output = static_cast<uint32_t>(output_buffer->aligned_page_size());
+    const Buffer* output_device_buffer = output_buffer->get_reference_buffer();
+    uint32_t expected_output = static_cast<uint32_t>(output_device_buffer->aligned_page_size());
     EXPECT_EQ(result[1], expected_output) << "Output TensorAccessor.page_size should default to aligned_page_size. "
                                           << "Expected: " << expected_output << ", Got: " << result[1]
-                                          << ", Buffer page_size: " << output_buffer->page_size();
+                                          << ", Buffer page_size: " << output_device_buffer->page_size();
 }
 
 void verify_runtime_page_size(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const Buffer* input_buffer,
+    const distributed::MeshBuffer& input_buffer,
     uint32_t sentinel_page_size) {
-    auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -132,8 +139,7 @@ void verify_runtime_page_size(
     workload.add_program(device_range, std::move(program));
     auto& prog = workload.get_programs().at(device_range);
 
-    auto output_buffer = CreateBuffer(InterleavedBufferConfig{
-        .device = device, .size = OUTPUT_PAGE_SIZE, .page_size = OUTPUT_PAGE_SIZE, .buffer_type = BufferType::DRAM});
+    auto output_buffer = create_output_dram_buffer(*mesh_device);
 
     CircularBufferConfig cb_config =
         CircularBufferConfig(OUTPUT_PAGE_SIZE, {{0, tt::DataFormat::RawUInt32}}).set_page_size(0, OUTPUT_PAGE_SIZE);
@@ -159,7 +165,7 @@ void verify_runtime_page_size(
             .noc = NOC::RISCV_0_default,
             .compile_args = compile_time_args});
 
-    SetRuntimeArgs(prog, kernel, KERNEL_CORE, {input_buffer->address(), output_buffer->address()});
+    SetRuntimeArgs(prog, kernel, KERNEL_CORE, {input_buffer.address(), output_buffer->address()});
     // The input's dynamic page size rides common runtime arg 0 -- the channel the device accessor
     // reads via get_aligned_page_size() when the RuntimePageSize bit is set.
     SetCommonRuntimeArgs(prog, kernel, {sentinel_page_size});
@@ -168,28 +174,30 @@ void verify_runtime_page_size(
     distributed::Finish(cq);
 
     std::vector<uint32_t> result;
-    detail::ReadFromBuffer(output_buffer, result);
+    distributed::EnqueueReadMeshBuffer(cq, result, output_buffer, true);
 
     EXPECT_EQ(result[0], sentinel_page_size)
         << "RuntimePageSize input accessor must report the runtime (common-arg) page size, not a "
            "static CTA value. Expected sentinel "
         << sentinel_page_size << ", got " << result[0];
 
-    uint32_t expected_output = static_cast<uint32_t>(output_buffer->aligned_page_size());
+    uint32_t expected_output = static_cast<uint32_t>(output_buffer->get_reference_buffer()->aligned_page_size());
     EXPECT_EQ(result[1], expected_output)
         << "Output accessor page size must be intact -- proves the input's A-collapse (one fewer CTA "
            "word) did not shift the output accessor's CTA offset. Expected "
         << expected_output << ", got " << result[1];
 }
 
-std::shared_ptr<Buffer> create_interleaved_buffer(
-    IDevice* device, uint32_t page_size, uint32_t num_pages, BufferType buffer_type) {
-    return CreateBuffer(InterleavedBufferConfig{
-        .device = device, .size = num_pages * page_size, .page_size = page_size, .buffer_type = buffer_type});
+std::shared_ptr<distributed::MeshBuffer> create_interleaved_buffer(
+    distributed::MeshDevice& mesh_device, uint32_t page_size, uint32_t num_pages, BufferType buffer_type) {
+    return distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_pages * page_size},
+        {.page_size = page_size, .buffer_type = buffer_type},
+        &mesh_device);
 }
 
-std::shared_ptr<Buffer> create_legacy_sharded_buffer(
-    IDevice* device,
+std::shared_ptr<distributed::MeshBuffer> create_legacy_sharded_buffer(
+    distributed::MeshDevice& mesh_device,
     uint32_t page_size,
     uint32_t num_pages,
     BufferType buffer_type,
@@ -200,22 +208,16 @@ std::shared_ptr<Buffer> create_legacy_sharded_buffer(
     ShardSpecBuffer shard_spec(
         shard_grid, shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape_in_pages);
 
-    return CreateBuffer(tt_metal::ShardedBufferConfig{
-        .device = device,
-        .size = num_pages * page_size,
-        .page_size = page_size,
-        .buffer_type = buffer_type,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = shard_spec});
+    return distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_pages * page_size},
+        {.page_size = page_size,
+         .buffer_type = buffer_type,
+         .sharding_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED)},
+        &mesh_device);
 }
 
-struct NdShardedBufferResult {
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
-    Buffer* device_buffer;
-};
-
-NdShardedBufferResult create_nd_sharded_buffer(
-    distributed::MeshDevice* mesh_device,
+std::shared_ptr<distributed::MeshBuffer> create_nd_sharded_buffer(
+    distributed::MeshDevice& mesh_device,
     uint32_t page_size,
     uint32_t total_size,
     BufferType buffer_type,
@@ -227,17 +229,14 @@ NdShardedBufferResult create_nd_sharded_buffer(
     auto buffer_dist_spec = BufferDistributionSpec::from_shard_spec(
         std::move(tensor_shape), std::move(shard_shape), page_shape, core_range, ShardOrientation::ROW_MAJOR);
 
-    distributed::DeviceLocalBufferConfig device_local_config{
-        .page_size = page_size,
-        .buffer_type = buffer_type,
-        .sharding_args = BufferShardingArgs(buffer_dist_spec),
-    };
-
-    distributed::ReplicatedBufferConfig mesh_config{.size = total_size};
-    auto mesh_buffer = distributed::MeshBuffer::create(mesh_config, device_local_config, mesh_device);
-    Buffer* device_buffer = mesh_buffer->get_reference_buffer();
-
-    return {mesh_buffer, device_buffer};
+    return distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_size},
+        {
+            .page_size = page_size,
+            .buffer_type = buffer_type,
+            .sharding_args = BufferShardingArgs(buffer_dist_spec),
+        },
+        &mesh_device);
 }
 
 }  // namespace
@@ -248,33 +247,29 @@ namespace tt::tt_metal {
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramRowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
-        verify_default_page_size(mesh_device, buffer.get());
+        auto buffer = create_interleaved_buffer(*mesh_device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedDramTilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM);
-        verify_default_page_size(mesh_device, buffer.get());
+        auto buffer = create_interleaved_buffer(*mesh_device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1RowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::L1);
-        verify_default_page_size(mesh_device, buffer.get());
+        auto buffer = create_interleaved_buffer(*mesh_device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::L1);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1Tilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        auto buffer = create_interleaved_buffer(device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1);
-        verify_default_page_size(mesh_device, buffer.get());
+        auto buffer = create_interleaved_buffer(*mesh_device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
@@ -282,11 +277,10 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1Tili
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorRuntimePageSizeInterleavedDram) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         // Input is a real interleaved row-major DRAM buffer; its address is passed to the kernel but
         // its page size is NOT -- the accessor must read the page size from the runtime sentinel.
-        auto input = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
-        verify_runtime_page_size(mesh_device, input.get(), RUNTIME_PAGE_SIZE_SENTINEL);
+        auto input = create_interleaved_buffer(*mesh_device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
+        verify_runtime_page_size(mesh_device, *input, RUNTIME_PAGE_SIZE_SENTINEL);
     }
 }
 
@@ -294,49 +288,45 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorRuntimePageSizeInterleavedDram) 
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDramRowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device,
+            *mesh_device,
             RM_PAGE_SIZE,
             RM_NUM_PAGES,
             BufferType::DRAM,
             {RM_NUM_ROWS, RM_NUM_COLS},
             {1, RM_NUM_COLS},
             {RM_NUM_PAGES, 1});
-        verify_default_page_size(mesh_device, buffer.get());
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedDramTilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
-        verify_default_page_size(mesh_device, buffer.get());
+            *mesh_device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::DRAM, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1RowMajor) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device,
+            *mesh_device,
             RM_PAGE_SIZE,
             RM_NUM_PAGES,
             BufferType::L1,
             {RM_NUM_ROWS, RM_NUM_COLS},
             {1, RM_NUM_COLS},
             {RM_NUM_PAGES, 1});
-        verify_default_page_size(mesh_device, buffer.get());
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1Tilized) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto buffer = create_legacy_sharded_buffer(
-            device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
-        verify_default_page_size(mesh_device, buffer.get());
+            *mesh_device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1, {TILE_H, TILE_W}, {TILE_H, TILE_W}, {1, 1});
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
@@ -344,57 +334,57 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeLegacyShardedL1Ti
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeNdShardedDramRowMajor) {
     for (auto& mesh_device : devices_) {
-        auto result = create_nd_sharded_buffer(
-            mesh_device.get(),
+        auto buffer = create_nd_sharded_buffer(
+            *mesh_device,
             RM_PAGE_SIZE,
             RM_TOTAL_SIZE,
             BufferType::DRAM,
             Shape({RM_NUM_ROWS, RM_NUM_COLS}),
             Shape({RM_NUM_ROWS, RM_NUM_COLS}),
             Shape2D(1, RM_NUM_COLS));
-        verify_default_page_size(mesh_device, result.device_buffer);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeNdShardedDramTilized) {
     for (auto& mesh_device : devices_) {
-        auto result = create_nd_sharded_buffer(
-            mesh_device.get(),
+        auto buffer = create_nd_sharded_buffer(
+            *mesh_device,
             TILE_PAGE_SIZE,
             TILE_TOTAL_SIZE,
             BufferType::DRAM,
             Shape({TILE_H, TILE_W}),
             Shape({TILE_H, TILE_W}),
             Shape2D(TILE_H, TILE_W));
-        verify_default_page_size(mesh_device, result.device_buffer);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeNdShardedL1RowMajor) {
     for (auto& mesh_device : devices_) {
-        auto result = create_nd_sharded_buffer(
-            mesh_device.get(),
+        auto buffer = create_nd_sharded_buffer(
+            *mesh_device,
             RM_PAGE_SIZE,
             RM_TOTAL_SIZE,
             BufferType::L1,
             Shape({RM_NUM_ROWS, RM_NUM_COLS}),
             Shape({RM_NUM_ROWS, RM_NUM_COLS}),
             Shape2D(1, RM_NUM_COLS));
-        verify_default_page_size(mesh_device, result.device_buffer);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeNdShardedL1Tilized) {
     for (auto& mesh_device : devices_) {
-        auto result = create_nd_sharded_buffer(
-            mesh_device.get(),
+        auto buffer = create_nd_sharded_buffer(
+            *mesh_device,
             TILE_PAGE_SIZE,
             TILE_TOTAL_SIZE,
             BufferType::L1,
             Shape({TILE_H, TILE_W}),
             Shape({TILE_H, TILE_W}),
             Shape2D(TILE_H, TILE_W));
-        verify_default_page_size(mesh_device, result.device_buffer);
+        verify_default_page_size(mesh_device, *buffer);
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -40,6 +40,7 @@
 #include <tt-metalium/dispatch_core_common.hpp>
 #include "dispatch_test_utils.hpp"
 #include "impl/dispatch/dispatch_settings.hpp"
+#include "impl/dispatch/slow_dispatch.hpp"
 #include "gtest/gtest.h"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/math.hpp>
@@ -228,36 +229,18 @@ vector<ShardedSubBufferStressTestConfig> generate_sharded_sub_buffer_test_config
 
 // These are helper functions that are used for Slow Dispatch based IO. These are used in tests mixing Fast Dispatch IO
 // with Slow Dispatch for validation.
-void WriteToUnitMeshBuffer(
+std::shared_ptr<distributed::MeshBuffer> CreateSlowDispatchMeshBufferView(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const TestBufferConfig& config,
-    const std::vector<uint32_t>& src,
     const std::shared_ptr<distributed::MeshBuffer>& buf,
     const std::optional<BufferShardingArgs>& sharding_args) {
-    auto* device = mesh_device->get_devices()[0];
-    std::shared_ptr<Buffer> slow_dispatch_buffer;
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = config.page_size, .buffer_type = config.buftype, .bottom_up = false};
     if (sharding_args.has_value()) {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
-    } else {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype);
+        local_config.sharding_args = sharding_args.value();
     }
-    detail::WriteToBuffer(*slow_dispatch_buffer, src);
-}
-
-void ReadFromUnitMeshBuffer(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const TestBufferConfig& config,
-    std::vector<uint32_t>& dst,
-    const std::shared_ptr<distributed::MeshBuffer>& buf,
-    const std::optional<BufferShardingArgs>& sharding_args) {
-    auto* device = mesh_device->get_devices()[0];
-    std::shared_ptr<Buffer> slow_dispatch_buffer;
-    if (sharding_args.has_value()) {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
-    } else {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype);
-    }
-    detail::ReadFromBuffer(*slow_dispatch_buffer, dst);
+    return distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buf->size()}, local_config, mesh_device.get(), buf->address());
 }
 
 // These are helper functions used to write and read from a region of a MeshBuffer (sub-buffer)
@@ -358,7 +341,9 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             if (cq_write) {
                 distributed::WriteShard(cq, bufa, src, device_coord);
             } else {
-                WriteToUnitMeshBuffer(mesh_device, config, src, bufa, config.sharding_args);
+                auto slow_dispatch_buffer =
+                    CreateSlowDispatchMeshBufferView(mesh_device, config, bufa, config.sharding_args);
+                slow_dispatch::WriteToBuffer(*slow_dispatch_buffer, src);
                 if (config.buftype == BufferType::DRAM) {
                     tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
                 } else {
@@ -376,7 +361,9 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             if (cq_read) {
                 distributed::ReadShard(cq, result, bufa, device_coord);
             } else {
-                ReadFromUnitMeshBuffer(mesh_device, config, result, bufa, config.sharding_args);
+                auto slow_dispatch_buffer =
+                    CreateSlowDispatchMeshBufferView(mesh_device, config, bufa, config.sharding_args);
+                slow_dispatch::ReadFromBuffer(*slow_dispatch_buffer, result);
             }
 
             EXPECT_EQ(src, result);
@@ -501,7 +488,9 @@ void stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
                 if (cq_write) {
                     distributed::WriteShard(cq, buf, src, device_coord, false);
                 } else {
-                    local_test_functions::WriteToUnitMeshBuffer(mesh_device, test_config, src, buf, std::nullopt);
+                    auto slow_dispatch_buffer =
+                        CreateSlowDispatchMeshBufferView(mesh_device, test_config, buf, std::nullopt);
+                    slow_dispatch::WriteToBuffer(*slow_dispatch_buffer, src);
                     const auto device_id = mesh_device->get_device_ids()[0];
                     if (buftype == BufferType::DRAM) {
                         tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device_id);
@@ -519,7 +508,9 @@ void stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
                 if (cq_read) {
                     distributed::ReadShard(cq, res, buf, device_coord, true);
                 } else {
-                    local_test_functions::ReadFromUnitMeshBuffer(mesh_device, test_config, res, buf, std::nullopt);
+                    auto slow_dispatch_buffer =
+                        CreateSlowDispatchMeshBufferView(mesh_device, test_config, buf, std::nullopt);
+                    slow_dispatch::ReadFromBuffer(*slow_dispatch_buffer, res);
                 }
                 EXPECT_EQ(src, res);
             }

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -370,14 +370,22 @@ TEST_F(ServiceCoreFdFixture, ServiceCoreShardedL1BufferOnClaimedCore) {
             {1, kPageSize / sizeof(uint32_t)})};
 
     // Unclaimed, it is just a core the allocator knows nothing about.
-    EXPECT_ANY_THROW(tt::tt_metal::CreateBuffer(config));
+    auto create_buffer = [&] {
+        return Buffer::create(
+            config.device,
+            config.size,
+            config.page_size,
+            config.buffer_type,
+            BufferShardingArgs(config.shard_parameters, config.buffer_layout));
+    };
+    EXPECT_ANY_THROW(create_buffer());
 
     MetalContext::instance().get_service_core_manager().claim(device, {core});
-    EXPECT_NO_THROW(tt::tt_metal::CreateBuffer(config));
+    EXPECT_NO_THROW(create_buffer());
     MetalContext::instance().get_service_core_manager().release(device, {core});
 
     // Released, it is rejected again -- the exception is the claim, not the coordinate.
-    EXPECT_ANY_THROW(tt::tt_metal::CreateBuffer(config));
+    EXPECT_ANY_THROW(create_buffer());
 }
 
 // The same exception reached through MeshBuffer::create(), which is how every socket path actually

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include "hostdevcommon/common_values.hpp"
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
@@ -390,7 +391,7 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
     std::vector<uint32_t> full_input;
     full_input.reserve(numel * sender_receivers.size());
 
-    std::vector<std::shared_ptr<tt_metal::Buffer>> output_buffers;
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> output_buffers;
     output_buffers.reserve(sender_receivers.size());
 
     for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
@@ -411,15 +412,16 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
 
         auto& program = programs[device_id];
 
-        auto input_buffer = CreateBuffer(
-            tt_metal::InterleavedBufferConfig{device->get_devices()[0], cfg.size_bytes, cfg.page_size_bytes, cfg.input_buffer_type});
-        tt_metal::detail::WriteToBuffer(input_buffer, inputs[i]);
-        output_buffers.emplace_back(CreateBuffer(tt_metal::InterleavedBufferConfig{
-            device->get_devices()[0],
-            cfg.size_bytes * sender_receivers.size(),
-            cfg.page_size_bytes,
-            cfg.output_buffer_type}));
-        tt_metal::detail::WriteToBuffer(output_buffers[i], all_zeros);
+        auto input_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = cfg.size_bytes},
+            {.page_size = cfg.page_size_bytes, .buffer_type = cfg.input_buffer_type},
+            device.get());
+        distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, inputs[i], true);
+        output_buffers.emplace_back(distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = cfg.size_bytes * sender_receivers.size()},
+            {.page_size = cfg.page_size_bytes, .buffer_type = cfg.output_buffer_type},
+            device.get()));
+        distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), output_buffers[i], all_zeros, true);
 
         auto eth_sender_kernel = tt_metal::CreateKernel(
             program,
@@ -432,8 +434,8 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
                     uint32_t(num_bytes_per_send >> 4),
                     uint32_t(device->get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core).x),
                     uint32_t(device->get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core).y),
-                    uint32_t(input_buffer->buffer_type() == tt_metal::BufferType::DRAM),
-                    uint32_t(output_buffers[i]->buffer_type() == tt_metal::BufferType::DRAM)}});
+                    uint32_t(input_buffer->device_local_config().buffer_type == tt_metal::BufferType::DRAM),
+                    uint32_t(output_buffers[i]->device_local_config().buffer_type == tt_metal::BufferType::DRAM)}});
 
         tt_metal::SetRuntimeArgs(
             program,
@@ -471,7 +473,7 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
                     uint32_t(device->ethernet_core_from_logical_core(eth_sender_core).x),
                     uint32_t(device->ethernet_core_from_logical_core(eth_sender_core).y),
                     uint32_t(
-                        output_buffers[i]->buffer_type() ==
+                        output_buffers[i]->device_local_config().buffer_type ==
                         tt_metal::BufferType::DRAM)}});  // probably want to use NOC_1 here
 
         tt_metal::SetRuntimeArgs(
@@ -508,7 +510,7 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
         const auto& device = std::get<0>(sender_receivers[i]);
         const auto& core = std::get<2>(sender_receivers[i]);
         std::vector<uint32_t> readback_vec;
-        tt_metal::detail::ReadFromBuffer(output_buffers[i], readback_vec);
+        distributed::EnqueueReadMeshBuffer(device->mesh_command_queue(), readback_vec, output_buffers[i], true);
         auto a = std::mismatch(full_input.begin(), full_input.end(), readback_vec.begin());
         bool p = (a.first == full_input.end());
         pass &= p;

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "layernorm_fw_program_factory.hpp"
 
 #include <cstdint>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "metal/common/program_utils.hpp"
@@ -352,8 +353,11 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
         tt::tt_metal::TensorAccessorArgs(rstd_buffer).append_to(writer_compile_time_args);
     } else {
         // Add dummy TensorAccessorArgs for mean and rstd (they won't be used)
-        auto dummy_buffer =
-            tt::tt_metal::CreateBuffer(tt::tt_metal::BufferConfig{device, 0, 0, tt::tt_metal::BufferType::DRAM});
+        auto dummy_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+            tt::tt_metal::distributed::ReplicatedBufferConfig{.size = 0},
+            tt::tt_metal::distributed::DeviceLocalBufferConfig{
+                .page_size = 0, .buffer_type = tt::tt_metal::BufferType::DRAM},
+            input.device());
         tt::tt_metal::TensorAccessorArgs(dummy_buffer).append_to(writer_compile_time_args);
         tt::tt_metal::TensorAccessorArgs(dummy_buffer).append_to(writer_compile_time_args);
     }

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -120,7 +120,8 @@ struct BufferConfig {
     BufferType buffer_type;
 };
 
-using InterleavedBufferConfig = BufferConfig;
+using InterleavedBufferConfig
+    [[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]] = BufferConfig;
 
 // copied from above instead of using inheritance such that we can use
 // designator constructor

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -388,11 +388,11 @@ GlobalSemaphore CreateGlobalSemaphore(
 *
 *  | Argument        | Description                                                       | Type                      | Valid Range | Required |
 *  |-----------------|------------------------------------------------------------------ |---------------------------|-------------|----------|
-*  | config          | Config for the buffer                                             | InterleavedBufferConfig   |             | Yes      |
+*  | config          | Config for the buffer                                             | BufferConfig              |             | Yes      |
 */
 // clang-format on
 [[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config);
+std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config);
 
 // clang-format off
 /**
@@ -402,12 +402,12 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config);
 *
 *  | Argument        | Description                                                       | Type                      | Valid Range | Required |
 *  |-----------------|------------------------------------------------------------------ |---------------------------|-------------|----------|
-*  | config          | Config for the buffer                                             | InterleavedBufferConfig   |             | Yes      |
+*  | config          | Config for the buffer                                             | BufferConfig              |             | Yes      |
 *  | address         | Device address of the buffer                                      | DeviceAddr                |             | No       |
 */
 // clang-format on
 [[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, DeviceAddr address);
+std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config, DeviceAddr address);
 
 // clang-format off
 /**
@@ -417,12 +417,12 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, Devi
 *
 *  | Argument        | Description                                                       | Type                      | Valid Range | Required |
 *  |-----------------|------------------------------------------------------------------ |---------------------------|-------------|----------|
-*  | config          | Config for the buffer                                             | InterleavedBufferConfig   |             | Yes      |
+*  | config          | Config for the buffer                                             | BufferConfig              |             | Yes      |
 *  | sub_device_id   | The sub-device id to allocate on                                  | SubDeviceId               |             | No       |
 */
 // clang-format on
 [[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, SubDeviceId sub_device_id);
+std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config, SubDeviceId sub_device_id);
 
 // clang-format off
 /**

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -391,6 +391,7 @@ GlobalSemaphore CreateGlobalSemaphore(
 *  | config          | Config for the buffer                                             | InterleavedBufferConfig   |             | Yes      |
 */
 // clang-format on
+[[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config);
 
 // clang-format off
@@ -405,6 +406,7 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config);
 *  | address         | Device address of the buffer                                      | DeviceAddr                |             | No       |
 */
 // clang-format on
+[[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, DeviceAddr address);
 
 // clang-format off
@@ -419,6 +421,7 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, Devi
 *  | sub_device_id   | The sub-device id to allocate on                                  | SubDeviceId               |             | No       |
 */
 // clang-format on
+[[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, SubDeviceId sub_device_id);
 
 // clang-format off
@@ -432,6 +435,7 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, SubD
 *  | config          | Config for the buffer                                             | ShardedBufferConfig       |             | Yes      |
 */
 // clang-format on
+[[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config);
 
 // clang-format off
@@ -446,6 +450,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config);
 *  | address         | Device address of the buffer                                      | DeviceAddr                |             | No       |
 */
 // clang-format on
+[[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, DeviceAddr address);
 
 // clang-format off
@@ -460,6 +465,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, DeviceAd
 *  | sub_device_id   | The sub-device id to allocate on                                  |                           |             | No       |
 */
 // clang-format on
+[[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDeviceId sub_device_id);
 
 // clang-format off
@@ -473,6 +479,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDevic
 *  | buffer   | The buffer to deallocate from device | Buffer & |             | Yes      |
 */
 // clang-format on
+[[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
 void DeallocateBuffer(Buffer& buffer);
 
 // clang-format off

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -210,8 +210,7 @@ public:
     static AnyBuffer create(
         const tt::tt_metal::ShardedBufferConfig& config, std::optional<uint64_t> address = std::nullopt);
     [[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
-    static AnyBuffer create(
-        const tt::tt_metal::InterleavedBufferConfig& config, std::optional<uint64_t> address = std::nullopt);
+    static AnyBuffer create(const tt::tt_metal::BufferConfig& config, std::optional<uint64_t> address = std::nullopt);
 
     Buffer* get_buffer() const;
     bool is_mesh_buffer() const;

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -206,8 +206,10 @@ private:
 class AnyBuffer {
 public:
     AnyBuffer() = default;
+    [[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
     static AnyBuffer create(
         const tt::tt_metal::ShardedBufferConfig& config, std::optional<uint64_t> address = std::nullopt);
+    [[deprecated("Use distributed::MeshBuffer instead. This API will be removed after 2026-10-04.")]]
     static AnyBuffer create(
         const tt::tt_metal::InterleavedBufferConfig& config, std::optional<uint64_t> address = std::nullopt);
 

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -517,10 +517,13 @@ AnyBuffer AnyBuffer::create(const tt::tt_metal::ShardedBufferConfig& config, std
     // TODO #20966: Remove single device support and branches + dynamic_cast
     auto* mesh_device = dynamic_cast<MeshDevice*>(config.device);
     if (!mesh_device) {
+        const auto sharding_args = BufferShardingArgs(config.shard_parameters, config.buffer_layout);
         if (address.has_value()) {
-            return AnyBuffer{CreateBuffer(config, *address)};
+            return AnyBuffer{Buffer::create(
+                config.device, *address, config.size, config.page_size, config.buffer_type, sharding_args)};
         }
-        return AnyBuffer{CreateBuffer(config)};
+        return AnyBuffer{
+            Buffer::create(config.device, config.size, config.page_size, config.buffer_type, sharding_args)};
     }
     MeshBufferConfig mesh_config = ReplicatedBufferConfig{
         .size = config.size,
@@ -538,9 +541,10 @@ AnyBuffer AnyBuffer::create(const tt::tt_metal::InterleavedBufferConfig& config,
     auto* mesh_device = dynamic_cast<MeshDevice*>(config.device);
     if (!mesh_device) {
         if (address.has_value()) {
-            return AnyBuffer{CreateBuffer(config, *address)};
+            return AnyBuffer{
+                Buffer::create(config.device, *address, config.size, config.page_size, config.buffer_type)};
         }
-        return AnyBuffer{CreateBuffer(config)};
+        return AnyBuffer{Buffer::create(config.device, config.size, config.page_size, config.buffer_type)};
     }
     MeshBufferConfig mesh_config = ReplicatedBufferConfig{
         .size = config.size,

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -536,7 +536,7 @@ AnyBuffer AnyBuffer::create(const tt::tt_metal::ShardedBufferConfig& config, std
     return MeshBuffer::create(mesh_config, local_config, mesh_device, address);
 }
 
-AnyBuffer AnyBuffer::create(const tt::tt_metal::InterleavedBufferConfig& config, std::optional<uint64_t> address) {
+AnyBuffer AnyBuffer::create(const tt::tt_metal::BufferConfig& config, std::optional<uint64_t> address) {
     // TODO #20966: Remove single device support and branches + dynamic_cast
     auto* mesh_device = dynamic_cast<MeshDevice*>(config.device);
     if (!mesh_device) {

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1757,13 +1757,13 @@ GlobalSemaphore CreateGlobalSemaphore(
     return GlobalSemaphore(device, std::move(cores), initial_value, buffer_type);
 }
 
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
+std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config) {
     return Buffer::create(config.device, config.size, config.page_size, config.buffer_type);
 }
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, DeviceAddr address) {
+std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config, DeviceAddr address) {
     return Buffer::create(config.device, address, config.size, config.page_size, config.buffer_type);
 }
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, SubDeviceId sub_device_id) {
+std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config, SubDeviceId sub_device_id) {
     return Buffer::create(
         config.device, config.size, config.page_size, config.buffer_type, std::nullopt, std::nullopt, sub_device_id);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_op_device_operation_types.hpp
@@ -10,6 +10,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
@@ -30,14 +31,14 @@ struct StridedReduceScatterProgramArtifacts {
     // Index into the reader RT args where addcmul_a_address lives (0 = not used).
     uint32_t reader_addcmul_rt_arg_offset = 0;
     // Per-core MM signaling: privately allocated L1 backing for the per-MM-core progress counter array
-    std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
+    std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> mm_progress_counters_buffer;
     // The counter-array L1 address baked into the reader + MM runtime args at build time
     uint32_t mm_progress_counters_addr = 0;
     // Rolling-window return path: backing L1 buffer for the per-RS-reader credit counters (one
     // shard/row per MM core). Held for the same reason as the array above — its L1 address is baked
     // into the reader + MM runtime args, so freeing it would leave both kernels polling memory the
     // allocator has handed to something else.
-    std::shared_ptr<tt::tt_metal::Buffer> rs_credit_counters_buffer;
+    std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> rs_credit_counters_buffer;
     // Credit-array L1 address baked into the reader + MM runtime args at build time
     uint32_t rs_credit_counters_addr = 0;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -7,6 +7,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/math.hpp>
@@ -444,7 +445,7 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     }
     bool fuse_mm_op = mm_fused_op_signaler.has_value();
     // Per-core MM signaling: L1 array of per-MM-core progress counters, one row per RS worker core
-    std::shared_ptr<tt::tt_metal::Buffer> mm_progress_counters_buffer;
+    std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> mm_progress_counters_buffer;
     uint32_t captured_mm_progress_counters_addr = 0;
     if (fuse_mm_op) {
         mm_fused_op_signaler->init_strided_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
@@ -486,13 +487,13 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
                 tt::tt_metal::ShardOrientation::ROW_MAJOR,
                 {1, num_mm_core_slots},
                 {num_rs_cores, num_mm_core_slots});
-            mm_progress_counters_buffer = tt::tt_metal::CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-                .device = mesh_device,
-                .size = num_rs_cores * counters_row_bytes,
-                .page_size = counters_row_bytes,
-                .buffer_type = tt::tt_metal::BufferType::L1,
-                .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
-                .shard_parameters = counter_shard_spec});
+            mm_progress_counters_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+                tt::tt_metal::distributed::ReplicatedBufferConfig{.size = num_rs_cores * counters_row_bytes},
+                {.page_size = counters_row_bytes,
+                 .buffer_type = tt::tt_metal::BufferType::L1,
+                 .sharding_args = tt::tt_metal::BufferShardingArgs(
+                     counter_shard_spec, tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED)},
+                mesh_device);
             mm_fused_op_signaler->mm_progress_counters_addr =
                 static_cast<uint32_t>(mm_progress_counters_buffer->address());
         }
@@ -508,7 +509,7 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
     // HEIGHT_SHARDED over the MM grid => the row is at the same local L1 address on every MM core.
     // Signalling walks an explicit list of MM core NOC coords, mirroring how the matmul signals the
     // RS (OpSignaler::signal_op_per_core) rather than multicasting to a rectangle.
-    std::shared_ptr<tt::tt_metal::Buffer> rs_credit_counters_buffer;
+    std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> rs_credit_counters_buffer;
     const uint32_t num_rs_readers = num_directions_per_link * num_links * num_workers_per_direction;
     uint32_t rs_credit_counters_addr = 0;
     std::vector<CoreCoord> mm_cores_noc;
@@ -558,13 +559,13 @@ StridedReduceScatterProgramArtifacts build_ring_strided_reduce_scatter_async_pro
                 tt::tt_metal::ShardOrientation::ROW_MAJOR,
                 {1, num_rs_readers},
                 {num_mm_cores, num_rs_readers});
-            rs_credit_counters_buffer = tt::tt_metal::CreateBuffer(tt::tt_metal::ShardedBufferConfig{
-                .device = mesh_device,
-                .size = num_mm_cores * credit_row_bytes,
-                .page_size = credit_row_bytes,
-                .buffer_type = tt::tt_metal::BufferType::L1,
-                .buffer_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
-                .shard_parameters = credit_shard_spec});
+            rs_credit_counters_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+                tt::tt_metal::distributed::ReplicatedBufferConfig{.size = num_mm_cores * credit_row_bytes},
+                {.page_size = credit_row_bytes,
+                 .buffer_type = tt::tt_metal::BufferType::L1,
+                 .sharding_args = tt::tt_metal::BufferShardingArgs(
+                     credit_shard_spec, tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED)},
+                mesh_device);
             rs_credit_counters_addr = static_cast<uint32_t>(rs_credit_counters_buffer->address());
         }
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Advances #51835

Public runtime APIs are all supposed to be natively distributed/multi-device by now.

In this PR we deprecate APIs that allow to create a single-device buffer:
- `CreateBuffer` used only once outside of runtime. It's replaced with:
  - `MeshBuffer::create` where it's straightforward to do.
  - `Buffer::create` otherwise.
- `DeallocateBuffer` used only in tests.
- `InterleavedBufferConfig` alias used only as a parameter for buffer creation.
- `AnyBuffer` constructors which are used only internally and won't be needed after 2026-09-20 per this deprecation https://github.com/tenstorrent/tt-metal/issues/53199

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-create-buffer-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-create-buffer-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-create-buffer-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-create-buffer-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-create-buffer-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-create-buffer-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-create-buffer-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-create-buffer-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-create-buffer-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-create-buffer-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-create-buffer-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-create-buffer-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-create-buffer-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-create-buffer-deprecation)