### PR TITLE
[Performance]: Use cached L1 on FD command path on Quasar

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -64,16 +64,6 @@ uint32_t wrap_gt(uint32_t a, uint32_t b) {
     return diff > 0;
 }
 
-// EXPERIMENT: tag the relay packets the dispatcher reads with a load -- command headers and the
-// sub-command arrays behind them -- so the receiving NIU snoops them into its cache, replacing the
-// dispatcher-side invalidations. Bulk payload is left untagged: the dispatcher only forwards it, and
-// that read is served from TL1 by the NIU rather than through the cache.
-// Merging is gated on whether a non-power-of-2 transfer is safe in inline-write mode, since TileLink
-// rounds the size up and may touch bytes outside the transfer.
-#ifndef FD_QSR_RELAY_SNOOP
-#define FD_QSR_RELAY_SNOOP 1
-#endif
-
 // Choosing the view for a sync word on Quasar: match the transport that publishes it, and use the same
 // view on both sides -- a cached store can sit dirty while an uncached poll reads TL1 and never sees it.
 //   Local CPU store (same-tile DM to DM): cached. DM caches are coherent with each other.
@@ -174,29 +164,15 @@ FORCE_INLINE void cq_noc_async_wwrite_with_state(
 // config (dst_noc, VC..) have been specified.
 // flush_last_transfer sets the flush packet tag on the final transfer so that a credit atomic issued after
 // this call -- typically from CBWriter::release_pages -- cannot commit to L1 ahead of the payload.
-// snoop_transfers tags every packet so the receiving NIU updates the destination's cache in place; set it
-// only for bytes the destination reads with a load, since it costs the receiver L2 write traffic.
 // No-op on tt-1xx, which has no packet tags.
 template <
     bool write_last_packet = true,
     bool update_counters = false,
     enum CQNocWait wait_first = CQ_NOC_WAIT,
     uint32_t cmd_buf = NCRISC_WR_CMD_BUF,
-    bool flush_last_transfer = false,
-    bool snoop_transfers = false>
+    bool flush_last_transfer = false>
 inline uint32_t cq_noc_async_write_with_state_any_len(
     uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1, uint8_t noc = noc_index) {
-    static_assert(
-        !snoop_transfers || write_last_packet,
-        "snoop_transfers requires write_last_packet: the tag is persistent cmd-buf state and is cleared after the "
-        "final transfer, so a call that does not issue it would leak the tag onto unrelated writes.");
-#if defined(ARCH_QUASAR)
-    // Snoop is per-packet, so it must be set before the first of the burst-sized transfers below. Flush
-    // instead covers every packet that precedes it, so it is only needed on the last.
-    if constexpr (snoop_transfers) {
-        noc_set_packet_tags<cmd_buf>(/*snoop=*/true, /*flush=*/false);
-    }
-#endif
     if (size > NOC_MAX_BURST_SIZE) {
         cq_noc_async_write_with_state<CQ_NOC_SnDL, wait_first, CQ_NOC_SEND, cmd_buf, update_counters>(
             src_addr, dst_addr, NOC_MAX_BURST_SIZE, ndests);
@@ -214,13 +190,13 @@ inline uint32_t cq_noc_async_write_with_state_any_len(
     if constexpr (write_last_packet) {
 #if defined(ARCH_QUASAR)
         if constexpr (flush_last_transfer) {
-            noc_set_packet_tags<cmd_buf>(/*snoop=*/snoop_transfers, /*flush=*/true);
+            noc_set_packet_tags<cmd_buf>(/*snoop=*/false, /*flush=*/true);
         }
 #endif
         cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_WAIT, CQ_NOC_SEND, cmd_buf, update_counters>(
             src_addr, dst_addr, size, ndests, noc);
 #if defined(ARCH_QUASAR)
-        if constexpr (flush_last_transfer || snoop_transfers) {
+        if constexpr (flush_last_transfer) {
             noc_set_packet_tags<cmd_buf>(/*snoop=*/false, /*flush=*/false);
         }
 #endif
@@ -748,7 +724,7 @@ template <uint32_t l1_to_local_cache_copy_chunk, uint32_t l1_cache_elements_roun
 FORCE_INLINE void careful_copy_from_l1_to_local_cache(
     volatile uint32_t tt_l1_ptr* l1_ptr, uint32_t count, uint32_t* l1_cache) {
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-    if constexpr (invalidate_source && !FD_QSR_RELAY_SNOOP) {
+    if constexpr (invalidate_source) {
         // Upstream relayed the source by NoC write, which does not snoop, so a cached copy left over from an
         // earlier ring wrap is stale. Range covers the up-to-chunk-1 elements this function reads past count.
         // Prefetcher callers leave this off: both of its fetch paths already invalidate the extent they read.

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -64,8 +64,22 @@ uint32_t wrap_gt(uint32_t a, uint32_t b) {
     return diff > 0;
 }
 
-// On Quasar, accesses to L1 semaphores must bypass the L1 D$ via the uncached alias so that
-// updates from other RISCs/cores are visible. No-op on BH/WH.
+// EXPERIMENT: tag the relay packets the dispatcher reads with a load -- command headers and the
+// sub-command arrays behind them -- so the receiving NIU snoops them into its cache, replacing the
+// dispatcher-side invalidations. Bulk payload is left untagged: the dispatcher only forwards it, and
+// that read is served from TL1 by the NIU rather than through the cache.
+// Merging is gated on whether a non-power-of-2 transfer is safe in inline-write mode, since TileLink
+// rounds the size up and may touch bytes outside the transfer.
+#ifndef FD_QSR_RELAY_SNOOP
+#define FD_QSR_RELAY_SNOOP 1
+#endif
+
+// Choosing the view for a sync word on Quasar: match the transport that publishes it, and use the same
+// view on both sides -- a cached store can sit dirty while an uncached poll reads TL1 and never sees it.
+//   Local CPU store (same-tile DM to DM): cached. DM caches are coherent with each other.
+//   NoC atomic: uncached. Whether the NIU's atomic port raises a snoop is unconfirmed and FD sends every
+//   packet snoop-off, so a cached poll may never observe the update.
+// No-op on BH/WH.
 constexpr FORCE_INLINE uintptr_t l1_uncached_addr(uintptr_t addr) {
 #ifdef ARCH_QUASAR
     return addr + MEM_L1_UNCACHED_BASE;
@@ -160,15 +174,29 @@ FORCE_INLINE void cq_noc_async_wwrite_with_state(
 // config (dst_noc, VC..) have been specified.
 // flush_last_transfer sets the flush packet tag on the final transfer so that a credit atomic issued after
 // this call -- typically from CBWriter::release_pages -- cannot commit to L1 ahead of the payload.
+// snoop_transfers tags every packet so the receiving NIU updates the destination's cache in place; set it
+// only for bytes the destination reads with a load, since it costs the receiver L2 write traffic.
 // No-op on tt-1xx, which has no packet tags.
 template <
     bool write_last_packet = true,
     bool update_counters = false,
     enum CQNocWait wait_first = CQ_NOC_WAIT,
     uint32_t cmd_buf = NCRISC_WR_CMD_BUF,
-    bool flush_last_transfer = false>
+    bool flush_last_transfer = false,
+    bool snoop_transfers = false>
 inline uint32_t cq_noc_async_write_with_state_any_len(
     uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1, uint8_t noc = noc_index) {
+    static_assert(
+        !snoop_transfers || write_last_packet,
+        "snoop_transfers requires write_last_packet: the tag is persistent cmd-buf state and is cleared after the "
+        "final transfer, so a call that does not issue it would leak the tag onto unrelated writes.");
+#if defined(ARCH_QUASAR)
+    // Snoop is per-packet, so it must be set before the first of the burst-sized transfers below. Flush
+    // instead covers every packet that precedes it, so it is only needed on the last.
+    if constexpr (snoop_transfers) {
+        noc_set_packet_tags<cmd_buf>(/*snoop=*/true, /*flush=*/false);
+    }
+#endif
     if (size > NOC_MAX_BURST_SIZE) {
         cq_noc_async_write_with_state<CQ_NOC_SnDL, wait_first, CQ_NOC_SEND, cmd_buf, update_counters>(
             src_addr, dst_addr, NOC_MAX_BURST_SIZE, ndests);
@@ -186,13 +214,13 @@ inline uint32_t cq_noc_async_write_with_state_any_len(
     if constexpr (write_last_packet) {
 #if defined(ARCH_QUASAR)
         if constexpr (flush_last_transfer) {
-            noc_set_packet_tags<cmd_buf>(/*snoop=*/false, /*flush=*/true);
+            noc_set_packet_tags<cmd_buf>(/*snoop=*/snoop_transfers, /*flush=*/true);
         }
 #endif
         cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_WAIT, CQ_NOC_SEND, cmd_buf, update_counters>(
             src_addr, dst_addr, size, ndests, noc);
 #if defined(ARCH_QUASAR)
-        if constexpr (flush_last_transfer) {
+        if constexpr (flush_last_transfer || snoop_transfers) {
             noc_set_packet_tags<cmd_buf>(/*snoop=*/false, /*flush=*/false);
         }
 #endif
@@ -339,10 +367,7 @@ class CBWriter {
 public:
     FORCE_INLINE void acquire_pages(uint32_t n) {
         volatile tt_l1_ptr uint32_t* sem_addr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(get_semaphore<programmable_core_type>(my_sem_id)));
-
-        // Ensure last sem_inc has landed
-        noc_async_atomic_barrier();
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>((get_semaphore<programmable_core_type>(my_sem_id)));
 
         WAYPOINT("DAPW");
         // Use a wrapping compare here to compare distance
@@ -360,7 +385,7 @@ public:
     // unless it calls release_all_pages to return partially-consumed blocks.
     FORCE_INLINE void wait_all_pages(uint32_t n) {
         volatile tt_l1_ptr uint32_t* sem_addr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(get_semaphore<programmable_core_type>(my_sem_id)));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>((get_semaphore<programmable_core_type>(my_sem_id)));
 
         // Downstream component sets the MSB as a terminate bit
         // Mask that off to avoid a race between the sem count and terminate
@@ -719,9 +744,18 @@ constexpr uint32_t l1_to_local_cache_copy_chunk = 6;
 // NOTE: CAREFUL USING THIS FUNCTION
 // It is call "careful_copy" because you need to be careful...
 // It copies beyond count by up to 5 elements make sure src and dst addresses are safe
-template <uint32_t l1_to_local_cache_copy_chunk, uint32_t l1_cache_elements_rounded>
+template <uint32_t l1_to_local_cache_copy_chunk, uint32_t l1_cache_elements_rounded, bool invalidate_source = false>
 FORCE_INLINE void careful_copy_from_l1_to_local_cache(
     volatile uint32_t tt_l1_ptr* l1_ptr, uint32_t count, uint32_t* l1_cache) {
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    if constexpr (invalidate_source && !FD_QSR_RELAY_SNOOP) {
+        // Upstream relayed the source by NoC write, which does not snoop, so a cached copy left over from an
+        // earlier ring wrap is stale. Range covers the up-to-chunk-1 elements this function reads past count.
+        // Prefetcher callers leave this off: both of its fetch paths already invalidate the extent they read.
+        invalidate_l2_cache_range(
+            reinterpret_cast<uintptr_t>(l1_ptr), sizeof(uint32_t) * (count + l1_to_local_cache_copy_chunk - 1));
+    }
+#endif
     uint32_t n = 0;
     ASSERT(l1_to_local_cache_copy_chunk == 6);
     ASSERT(count <= l1_cache_elements_rounded);

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -64,11 +64,12 @@ uint32_t wrap_gt(uint32_t a, uint32_t b) {
     return diff > 0;
 }
 
-// Choosing the view on Quasar; both sides of a word must agree. No-op on BH/WH.
-//   Local CPU store, same-tile DM to DM: cached. DM caches are coherent with each other.
-//   NoC atomic: uncached unless the increment sets the snoop bit, which FD leaves off because empherical
-//   experiments snooping was some cycles more expensive than uncached poll.
-//   With it off a cached poll never sees the update.
+// Choosing the view on Quasar; both sides of a word must agree. No-op on BH/WH. A credit travels the
+// same transport as the payload it publishes, so the payload picks the view:
+//   Consumer to producer (free pages back to the prefetcher): cached local store. No payload crosses and
+//   DM caches are coherent. Valid only while both stages share one L1.
+//   Producer to consumer (payload pushed over the NoC) and worker completion counts: uncached. FD leaves
+//   the snoop bit off on NoC atomics, so a cached poll never sees the increment.
 //   Read back by the NIU as a transfer source: uncached. The NIU reads TL1, outside DM coherence.
 constexpr FORCE_INLINE uintptr_t l1_uncached_addr(uintptr_t addr) {
 #ifdef ARCH_QUASAR

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -64,12 +64,12 @@ uint32_t wrap_gt(uint32_t a, uint32_t b) {
     return diff > 0;
 }
 
-// Choosing the view for a sync word on Quasar: match the transport that publishes it, and use the same
-// view on both sides -- a cached store can sit dirty while an uncached poll reads TL1 and never sees it.
-//   Local CPU store (same-tile DM to DM): cached. DM caches are coherent with each other.
-//   NoC atomic: uncached. Whether the NIU's atomic port raises a snoop is unconfirmed and FD sends every
-//   packet snoop-off, so a cached poll may never observe the update.
-// No-op on BH/WH.
+// Choosing the view on Quasar; both sides of a word must agree. No-op on BH/WH.
+//   Local CPU store, same-tile DM to DM: cached. DM caches are coherent with each other.
+//   NoC atomic: uncached unless the increment sets the snoop bit, which FD leaves off because empherical
+//   experiments snooping was some cycles more expensive than uncached poll.
+//   With it off a cached poll never sees the update.
+//   Read back by the NIU as a transfer source: uncached. The NIU reads TL1, outside DM coherence.
 constexpr FORCE_INLINE uintptr_t l1_uncached_addr(uintptr_t addr) {
 #ifdef ARCH_QUASAR
     return addr + MEM_L1_UNCACHED_BASE;
@@ -98,7 +98,8 @@ FORCE_INLINE volatile T tt_l1_ptr* uncached_l1_ptr(uintptr_t addr) {
 // Returns a pointer to the L1 worker completion counter for `stream`. Workers signal completion
 // into L1 (DISPATCH_MESSAGE_ADDR) on Quasar rather than NOC stream registers. `completion_counter_offset`
 // selects this CQ's range of counters, when multiple CQs share this dispatch core. `first_stream_used`
-// is the index of the first stream used by this CQ.
+// is the index of the first stream used by this CQ. Workers increment it with a NoC atomic, so every
+// access to it uses the uncached view.
 FORCE_INLINE volatile uint32_t* worker_completion_sem_addr(
     uint32_t stream, uint32_t first_stream_used, uint32_t completion_counter_offset) {
     return uncached_l1_ptr<uint32_t>(
@@ -758,10 +759,15 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
     std::array<uint32_t, max_num_worker_sems>& workers_per_sub_device,
     volatile tt_l1_ptr uint32_t* sub_device_worker_counts_update,
     uintptr_t dispatch_telemetry_base) {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t num_sub_devices = cmd->set_sub_device_worker_counts.num_sub_devices;
     ASSERT(num_sub_devices <= max_num_worker_sems);
-    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // Reaches past the header window invalidated at command entry.
+    invalidate_l2_cache_range(cmd_ptr + sizeof(CQDispatchCmd), num_sub_devices * sizeof(uint32_t));
+#endif
+    volatile tt_l1_ptr uint32_t* data_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd_ptr + sizeof(CQDispatchCmd));
 
     static uint32_t local_sub_device_worker_counts_update = 0;
 

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -64,13 +64,9 @@ uint32_t wrap_gt(uint32_t a, uint32_t b) {
     return diff > 0;
 }
 
-// Choosing the view on Quasar; both sides of a word must agree. No-op on BH/WH. A credit travels the
-// same transport as the payload it publishes, so the payload picks the view:
-//   Consumer to producer (free pages back to the prefetcher): cached local store. No payload crosses and
-//   DM caches are coherent. Valid only while both stages share one L1.
-//   Producer to consumer (payload pushed over the NoC) and worker completion counts: uncached. FD leaves
-//   the snoop bit off on NoC atomics, so a cached poll never sees the increment.
-//   Read back by the NIU as a transfer source: uncached. The NIU reads TL1, outside DM coherence.
+// On Quasar, an L1 word shared with another agent must use the uncached alias, on both the writing and
+// the reading side: NoC writes and atomics do not snoop the DM caches, and the NIU reads TL1 directly.
+// No-op on BH/WH.
 constexpr FORCE_INLINE uintptr_t l1_uncached_addr(uintptr_t addr) {
 #ifdef ARCH_QUASAR
     return addr + MEM_L1_UNCACHED_BASE;
@@ -99,8 +95,7 @@ FORCE_INLINE volatile T tt_l1_ptr* uncached_l1_ptr(uintptr_t addr) {
 // Returns a pointer to the L1 worker completion counter for `stream`. Workers signal completion
 // into L1 (DISPATCH_MESSAGE_ADDR) on Quasar rather than NOC stream registers. `completion_counter_offset`
 // selects this CQ's range of counters, when multiple CQs share this dispatch core. `first_stream_used`
-// is the index of the first stream used by this CQ. Workers increment it with a NoC atomic, so every
-// access to it uses the uncached view.
+// is the index of the first stream used by this CQ.
 FORCE_INLINE volatile uint32_t* worker_completion_sem_addr(
     uint32_t stream, uint32_t first_stream_used, uint32_t completion_counter_offset) {
     return uncached_l1_ptr<uint32_t>(
@@ -344,8 +339,8 @@ template <
 class CBWriter {
 public:
     FORCE_INLINE void acquire_pages(uint32_t n) {
-        volatile tt_l1_ptr uint32_t* sem_addr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>((get_semaphore<programmable_core_type>(my_sem_id)));
+        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+            l1_uncached_addr(get_semaphore<programmable_core_type>(my_sem_id)));
 
         WAYPOINT("DAPW");
         // Use a wrapping compare here to compare distance
@@ -362,8 +357,8 @@ public:
     // Wait for all n pages to be available. If the consumer is using blocks, it may never return all pages at once
     // unless it calls release_all_pages to return partially-consumed blocks.
     FORCE_INLINE void wait_all_pages(uint32_t n) {
-        volatile tt_l1_ptr uint32_t* sem_addr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>((get_semaphore<programmable_core_type>(my_sem_id)));
+        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+            l1_uncached_addr(get_semaphore<programmable_core_type>(my_sem_id)));
 
         // Downstream component sets the MSB as a terminate bit
         // Mask that off to avoid a race between the sem count and terminate

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -722,16 +722,29 @@ constexpr uint32_t l1_to_local_cache_copy_chunk = 6;
 // NOTE: CAREFUL USING THIS FUNCTION
 // It is call "careful_copy" because you need to be careful...
 // It copies beyond count by up to 5 elements make sure src and dst addresses are safe
-template <uint32_t l1_to_local_cache_copy_chunk, uint32_t l1_cache_elements_rounded, bool invalidate_source = false>
+// first_line_invalidated says the caller already invalidated the line holding l1_ptr, so this skips it. Set it
+// only when the source cannot have wrapped away from the command header whose invalidate covers that line.
+template <
+    uint32_t l1_to_local_cache_copy_chunk,
+    uint32_t l1_cache_elements_rounded,
+    bool invalidate_source = false,
+    bool first_line_invalidated = false>
 FORCE_INLINE void careful_copy_from_l1_to_local_cache(
     volatile uint32_t tt_l1_ptr* l1_ptr, uint32_t count, uint32_t* l1_cache) {
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     if constexpr (invalidate_source) {
-        // Upstream relayed the source by NoC write, which does not snoop, so a cached copy left over from an
-        // earlier ring wrap is stale. Range covers the up-to-chunk-1 elements this function reads past count.
-        // Prefetcher callers leave this off: both of its fetch paths already invalidate the extent they read.
-        invalidate_l2_cache_range(
-            reinterpret_cast<uintptr_t>(l1_ptr), sizeof(uint32_t) * (count + l1_to_local_cache_copy_chunk - 1));
+        // The source arrived over the NoC, which does not snoop, so a cached copy left over from an earlier
+        // ring wrap is stale. Range covers the up-to-chunk-1 elements this function reads past count.
+        uintptr_t start = reinterpret_cast<uintptr_t>(l1_ptr);
+        uint32_t size = sizeof(uint32_t) * (count + l1_to_local_cache_copy_chunk - 1);
+        if constexpr (first_line_invalidated) {
+            // Shrink by what is skipped, not just advance: keeping the size would push the range one line
+            // past the array and hand back the line just saved. A short array can skip past its own end.
+            const uint32_t skipped = round_up_pow2(start, L2_CACHE_LINE_SIZE) - start;
+            start += skipped;
+            size = skipped < size ? size - skipped : 0;
+        }
+        invalidate_l2_cache_range(start, size);
     }
 #endif
     uint32_t n = 0;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -193,7 +193,13 @@ struct NocReleasePolicy {
     template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id>
     static FORCE_INLINE void release(uint32_t pages) {
 #ifdef ARCH_QUASAR
-        Semaphore<programmable_core_type>(sem_id).up(pages);
+        // get_semaphore() resolves sem_id against THIS core's sem_l1_base, so a local store reaches upstream
+        // only while prefetcher and dispatcher are co-resident DMs sharing that base. Split across tiles it
+        // would silently write local L1 at upstream's offset and upstream would never see credits -- use the
+        // #else path, and move the reader to the uncached view with it.
+        // Non-atomic RMW, so exactly one agent may ever increment this semaphore.
+        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(sem_id));
+        *sem_addr += pages;
 #else
         uint32_t sem_addr = get_semaphore<programmable_core_type>(sem_id);
         noc_semaphore_inc(get_noc_addr_helper(noc_xy, sem_addr), pages, noc_idx);
@@ -334,8 +340,7 @@ void completion_queue_push_back(uint32_t num_pages) {
 }
 
 void process_write_host_h() {
-    volatile tt_l1_ptr CQDispatchCmd* cmd =
-        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(l1_uncached_addr(cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmd* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>((cmd_ptr));
 
     // We will send the cmd back in the first X bytes, this makes the logic of reserving/pushing completion queue
     // pages much simpler since we are always sending writing full pages (except for last page)
@@ -351,8 +356,7 @@ void process_write_host_h() {
 #endif
     constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
     if (is_event) {
-        last_event =
-            reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr + sizeof(CQDispatchCmd)))[0];
+        last_event = reinterpret_cast<volatile uint32_t tt_l1_ptr*>((data_ptr + sizeof(CQDispatchCmd)))[0];
     }
     while (wlength != 0) {
         uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(wlength);
@@ -510,8 +514,7 @@ void relay_to_next_cb(uintptr_t data_ptr, uint64_t wlength) {
 }
 
 void process_write_host_d() {
-    volatile tt_l1_ptr CQDispatchCmd* cmd =
-        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(l1_uncached_addr(cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmd* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>((cmd_ptr));
     // Remember: host transfer command includes the command in the payload, don't add it here
     uint64_t length = load_aligned<uint64_t>(&cmd->write_linear_host.length);
     uintptr_t data_ptr = cmd_ptr;
@@ -520,8 +523,7 @@ void process_write_host_d() {
 }
 
 void relay_write_h() {
-    volatile tt_l1_ptr CQDispatchCmdLarge* cmd =
-        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmdLarge*>(l1_uncached_addr(cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmdLarge* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmdLarge*>(cmd_ptr);
     uint64_t length = sizeof(CQDispatchCmdLarge) + load_aligned<uint64_t>(&cmd->write_linear.length);
     uintptr_t data_ptr = cmd_ptr;
 
@@ -533,8 +535,7 @@ void process_exec_buf_end_d() { relay_to_next_cb(cmd_ptr, sizeof(CQDispatchCmd))
 // Note that for non-paged writes, the number of writes per page is always 1
 // This means each noc_write frees up a page
 void process_write_linear(uint32_t num_mcast_dests) {
-    volatile tt_l1_ptr CQDispatchCmdLarge* cmd =
-        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmdLarge*>(l1_uncached_addr(cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmdLarge* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmdLarge*>(cmd_ptr);
     bool multicast = num_mcast_dests > 0;
     if (not multicast) {
         num_mcast_dests = 1;
@@ -588,8 +589,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
 }
 
 void process_write() {
-    volatile tt_l1_ptr CQDispatchCmdLarge* cmd =
-        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmdLarge*>(l1_uncached_addr(cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmdLarge* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmdLarge*>(cmd_ptr);
     uint32_t num_mcast_dests = cmd->write_linear.num_mcast_dests;
     process_write_linear(num_mcast_dests);
 }
@@ -601,8 +601,7 @@ void process_write() {
 // that the standalone function no longer spills; on its own the isolation cost ~5%.
 template <bool is_dram>
 __attribute__((noinline)) void process_write_paged() {
-    volatile tt_l1_ptr CQDispatchCmd* cmd =
-        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(l1_uncached_addr(cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmd* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(cmd_ptr);
 
     uint32_t page_id = load_aligned<uint16_t>(&cmd->write_paged.start_page);
     uint32_t base_addr = load_aligned<uint32_t>(&cmd->write_paged.base_addr);
@@ -715,15 +714,14 @@ __attribute__((noinline)) void process_write_paged() {
 // this command can't be too many pages.  All pages are released at the end
 template <bool mcast, typename WritePackedSubCmd>
 void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
 
     uint32_t count = load_aligned<uint16_t>(&cmd->write_packed.count);
     ASSERT(count <= (mcast ? packed_write_max_multicast_sub_cmds : packed_write_max_unicast_sub_cmds));
     constexpr uint32_t sub_cmd_size = sizeof(WritePackedSubCmd);
     // Copying in a burst is about a 30% net gain vs reading one value per loop below
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr + sizeof(CQDispatchCmd))),
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd)),
         count * sub_cmd_size / sizeof(uint32_t),
         l1_cache);
 
@@ -842,8 +840,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
 //  - so a better practical full size is 3-4 full sets of 4K kernel binaries
 // May eventually want a separate implementation for tensix vs eth dispatch
 void process_write_packed_large(uint32_t* l1_cache) {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
 
     uint32_t count = load_aligned<uint16_t>(&cmd->write_packed_large.count);
     ASSERT(count <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS);
@@ -854,8 +851,8 @@ void process_write_packed_large(uint32_t* l1_cache) {
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
     constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeSubCmd);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr + sizeof(CQDispatchCmd))),
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd)),
         count * sub_cmd_size / sizeof(uint32_t),
         l1_cache);
 
@@ -975,8 +972,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
 
 // Unicast variant of packed large write with uint32_t length and discard support
 void process_write_packed_large_unicast(uint32_t* l1_cache) {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
 
     uint32_t count = load_aligned<uint16_t>(&cmd->write_packed_large_unicast.count);
     ASSERT(count <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
@@ -987,8 +983,8 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
     constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr + sizeof(CQDispatchCmd))),
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd)),
         count * sub_cmd_size / sizeof(uint32_t),
         l1_cache);
 
@@ -1052,8 +1048,7 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
 }
 
 static uintptr_t process_debug_cmd(uintptr_t cmd_ptr) {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     return cmd_ptr + load_aligned<uint32_t>(&cmd->debug.stride);
 }
 
@@ -1078,8 +1073,7 @@ FORCE_INLINE void wait_worker_completion(uint32_t stream, uint32_t wait_count) {
 }
 
 static void process_wait() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     auto flags = cmd->wait.flags;
 
     uint32_t barrier = flags & CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER;
@@ -1103,7 +1097,7 @@ static void process_wait() {
     uint32_t heartbeat = 0;
     if (wait_memory) {
         uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
-        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr));
+        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
         // DPRINT("DISPATCH WAIT 0x{:08x} count {}\n", addr, count);
         do {
             invalidate_l1_cache();
@@ -1137,11 +1131,13 @@ static void process_wait() {
     }
     if (clear_memory) {
         uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr)) = 0;
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr) = 0;
     }
     if (notify_prefetch) {
 #ifdef ARCH_QUASAR
-        Semaphore<programmable_core_type>(upstream_sync_sem).up(1);
+        auto* sem_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(upstream_sync_sem));
+        *sem_addr += 1;
 #else
         noc_semaphore_inc(
             get_noc_addr_helper(upstream_noc_xy, get_semaphore<programmable_core_type>(upstream_sync_sem)),
@@ -1154,8 +1150,7 @@ static void process_wait() {
 }
 
 static void process_delay_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t count = load_aligned<uint32_t>(&cmd->delay.delay);
     for (volatile uint32_t i = 0; i < count; i++);
     cmd_ptr += sizeof(CQDispatchCmd);
@@ -1163,8 +1158,7 @@ static void process_delay_cmd() {
 
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t stream = load_aligned<uint32_t>(&cmd->mcast.wait_stream);
     // The go signal embedded in the command does not meet NOC alignment requirements, but cmd_ptr does
     // (the prefetcher writes it over the NOC), so the go signal is copied there. storage_offset lands that
@@ -1175,7 +1169,7 @@ void process_go_signal_mcast_cmd() {
     // then reads the same physical location via the cached-form source address.
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr);
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached =
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr);
     uint32_t go_signal_value = load_aligned<uint32_t>(&cmd->mcast.go_signal);
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
@@ -1246,8 +1240,7 @@ void process_go_signal_mcast_cmd() {
 FORCE_INLINE
 void process_notify_dispatch_s_go_signal_cmd() {
     // Update free running counter on dispatch_s, signalling that it's safe to send a go signal to workers
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t wait = cmd->notify_dispatch_s_go_signal.wait;
     // write barrier to wait before sending the go signal
     if (wait) {
@@ -1270,7 +1263,7 @@ void process_notify_dispatch_s_go_signal_cmd() {
             noc_inline_dw_write(dispatch_s_notify_addr, num_go_signals_safe_to_send[set_index]);
         } else {
             volatile tt_l1_ptr uint32_t* notify_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(dispatch_s_sync_sem_addr));
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dispatch_s_sync_sem_addr);
             *notify_ptr = (*notify_ptr) + 1;
         }
         // Unset the bit
@@ -1281,8 +1274,7 @@ void process_notify_dispatch_s_go_signal_cmd() {
 
 FORCE_INLINE
 void set_go_signal_noc_data() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t num_words = load_aligned<uint32_t>(&cmd->set_go_signal_noc_data.num_words);
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
     volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
@@ -1295,8 +1287,13 @@ void set_go_signal_noc_data() {
 static inline bool process_cmd_d(uintptr_t& cmd_ptr, uint32_t* l1_cache) {
     bool done = false;
 re_run_command:
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM) && !FD_QSR_RELAY_SNOOP
+    // Upstream relays this command by NoC write, which does not snoop, so the header must be dropped before
+    // it is read cached. Sized to CQDispatchCmdLarge because the variant is unknown until cmd_id is read.
+    // Sub-command arrays past the header are covered by careful_copy's own invalidate.
+    invalidate_l2_cache_range(cmd_ptr, sizeof(CQDispatchCmdLarge));
+#endif
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     DeviceTimestampedData("process_cmd_d_dispatch", (uint32_t)cmd->base.cmd_id);
     switch (cmd->base.cmd_id) {
         case CQ_DISPATCH_CMD_WRITE_LINEAR:
@@ -1409,7 +1406,7 @@ re_run_command:
             // DPRINT("cmd_set_sub_device_worker_counts\n");
             ASSERT(!dispatch_s_enabled);
             cmd_ptr += set_sub_device_worker_counts<telemetry_enabled>(
-                l1_uncached_addr(cmd_ptr),
+                (cmd_ptr),
                 workers_per_sub_device,
                 &dispatch_telemetry_control->sub_device_worker_counts_update,
                 dispatch_telemetry_base);
@@ -1438,7 +1435,7 @@ re_run_command:
 
             ASSERT(offset_count <= std::size(write_offset));
             volatile uint32_t tt_l1_ptr* cmd_write_offset =
-                reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr + sizeof(CQDispatchCmd)));
+                reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd));
 
             for (uint32_t i = 0; i < offset_count; i++) {
                 write_offset[i] = cmd_write_offset[i];
@@ -1479,8 +1476,7 @@ re_run_command:
 static inline bool process_cmd_h(uintptr_t& cmd_ptr) {
     bool done = false;
 
-    volatile CQDispatchCmd tt_l1_ptr* cmd =
-        reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
 
     DeviceTimestampedData("process_cmd_h_dispatch", (uint32_t)cmd->base.cmd_id);
     switch (cmd->base.cmd_id) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -193,10 +193,9 @@ struct NocReleasePolicy {
     template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id>
     static FORCE_INLINE void release(uint32_t pages) {
 #ifdef ARCH_QUASAR
-        // get_semaphore() resolves sem_id against THIS core's sem_l1_base, so a local store reaches upstream
-        // only while prefetcher and dispatcher are co-resident DMs sharing that base. Split across tiles it
-        // would silently write local L1 at upstream's offset and upstream would never see credits -- use the
-        // #else path, and move the reader to the uncached view with it.
+        // get_semaphore() returns an offset into this core's L1, so this local store
+        // works only because prefetcher and dispatcher are on same dispatch engines sharing one L1.
+        // A split _h/_d build must go over the NoC instead. See the checklist at the top of cq_prefetch.cpp.
         // Non-atomic RMW, so exactly one agent may ever increment this semaphore.
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(sem_id));
         *sem_addr += pages;
@@ -340,7 +339,7 @@ void completion_queue_push_back(uint32_t num_pages) {
 }
 
 void process_write_host_h() {
-    volatile tt_l1_ptr CQDispatchCmd* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>((cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmd* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(cmd_ptr);
 
     // We will send the cmd back in the first X bytes, this makes the logic of reserving/pushing completion queue
     // pages much simpler since we are always sending writing full pages (except for last page)
@@ -356,7 +355,7 @@ void process_write_host_h() {
 #endif
     constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
     if (is_event) {
-        last_event = reinterpret_cast<volatile uint32_t tt_l1_ptr*>((data_ptr + sizeof(CQDispatchCmd)))[0];
+        last_event = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr + sizeof(CQDispatchCmd))[0];
     }
     while (wlength != 0) {
         uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(wlength);
@@ -514,7 +513,7 @@ void relay_to_next_cb(uintptr_t data_ptr, uint64_t wlength) {
 }
 
 void process_write_host_d() {
-    volatile tt_l1_ptr CQDispatchCmd* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>((cmd_ptr));
+    volatile tt_l1_ptr CQDispatchCmd* cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(cmd_ptr);
     // Remember: host transfer command includes the command in the payload, don't add it here
     uint64_t length = load_aligned<uint64_t>(&cmd->write_linear_host.length);
     uintptr_t data_ptr = cmd_ptr;
@@ -1287,7 +1286,7 @@ void set_go_signal_noc_data() {
 static inline bool process_cmd_d(uintptr_t& cmd_ptr, uint32_t* l1_cache) {
     bool done = false;
 re_run_command:
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM) && !FD_QSR_RELAY_SNOOP
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     // Upstream relays this command by NoC write, which does not snoop, so the header must be dropped before
     // it is read cached. Sized to CQDispatchCmdLarge because the variant is unknown until cmd_id is read.
     // Sub-command arrays past the header are covered by careful_copy's own invalidate.

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1096,7 +1096,8 @@ static void process_wait() {
     uint32_t heartbeat = 0;
     if (wait_memory) {
         uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
-        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
+        // Worker completion counter, incremented by workers with a NoC atomic.
+        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr));
         // DPRINT("DISPATCH WAIT 0x{:08x} count {}\n", addr, count);
         do {
             invalidate_l1_cache();
@@ -1130,7 +1131,8 @@ static void process_wait() {
     }
     if (clear_memory) {
         uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr) = 0;
+        // Same counter as above; a cached store here would race the workers' atomics.
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr)) = 0;
     }
     if (notify_prefetch) {
 #ifdef ARCH_QUASAR
@@ -1168,7 +1170,7 @@ void process_go_signal_mcast_cmd() {
     // then reads the same physical location via the cached-form source address.
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr);
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached =
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr);
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
     uint32_t go_signal_value = load_aligned<uint32_t>(&cmd->mcast.go_signal);
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
@@ -1261,6 +1263,7 @@ void process_notify_dispatch_s_go_signal_cmd() {
             num_go_signals_safe_to_send[set_index]++;
             noc_inline_dw_write(dispatch_s_notify_addr, num_go_signals_safe_to_send[set_index]);
         } else {
+            // dispatch_s polls this word cached too; the NoC branch above would need the uncached view.
             volatile tt_l1_ptr uint32_t* notify_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dispatch_s_sync_sem_addr);
             *notify_ptr = (*notify_ptr) + 1;
@@ -1276,11 +1279,16 @@ void set_go_signal_noc_data() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t num_words = load_aligned<uint32_t>(&cmd->set_go_signal_noc_data.num_words);
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
-    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // Reaches past the header window invalidated at command entry.
+    invalidate_l2_cache_range(cmd_ptr + sizeof(CQDispatchCmd), num_words * sizeof(uint32_t));
+#endif
+    volatile tt_l1_ptr uint32_t* data_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd_ptr + sizeof(CQDispatchCmd));
     for (uint32_t i = 0; i < num_words; ++i) {
         go_signal_noc_data[i] = *(data_ptr++);
     }
-    cmd_ptr = round_up_pow2(l1_cached_addr(reinterpret_cast<uintptr_t>(data_ptr)), L1_ALIGNMENT);
+    cmd_ptr = round_up_pow2(reinterpret_cast<uintptr_t>(data_ptr), L1_ALIGNMENT);
 }
 
 static inline bool process_cmd_d(uintptr_t& cmd_ptr, uint32_t* l1_cache) {
@@ -1433,6 +1441,11 @@ re_run_command:
             uint32_t offset_count = cmd->set_write_offset.offset_count;
 
             ASSERT(offset_count <= std::size(write_offset));
+            // These offsets fit the window process_cmd_d already invalidated, so unlike the other
+            // variable-length payloads this one needs no invalidate of its own. Raising the max would.
+            static_assert(
+                sizeof(CQDispatchCmd) + sizeof(uint32_t) * CQ_DISPATCH_MAX_WRITE_OFFSETS <= sizeof(CQDispatchCmdLarge),
+                "offsets are read past the header window process_cmd_d invalidates in the worst cmd_ptr alignment");
             volatile uint32_t tt_l1_ptr* cmd_write_offset =
                 reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd));
 
@@ -1474,6 +1487,10 @@ re_run_command:
 
 static inline bool process_cmd_h(uintptr_t& cmd_ptr) {
     bool done = false;
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // As in process_cmd_d: upstream relays this command by NoC write, which does not snoop.
+    invalidate_l2_cache_range(cmd_ptr, sizeof(CQDispatchCmdLarge));
+#endif
 
     volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1297,7 +1297,7 @@ re_run_command:
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     // Upstream relays this command by NoC write, which does not snoop, so the header must be dropped before
     // it is read cached. Sized to CQDispatchCmdLarge because the variant is unknown until cmd_id is read.
-    // Sub-command arrays past the header are covered by careful_copy's own invalidate.
+    // CPU reads past this window carry their own invalidate; payload handed to the NIU needs none.
     invalidate_l2_cache_range(cmd_ptr, sizeof(CQDispatchCmdLarge));
 #endif
     volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -719,7 +719,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
     ASSERT(count <= (mcast ? packed_write_max_multicast_sub_cmds : packed_write_max_unicast_sub_cmds));
     constexpr uint32_t sub_cmd_size = sizeof(WritePackedSubCmd);
     // Copying in a burst is about a 30% net gain vs reading one value per loop below
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true, true>(
         reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd)),
         count * sub_cmd_size / sizeof(uint32_t),
         l1_cache);
@@ -850,7 +850,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
     constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeSubCmd);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true, true>(
         reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd)),
         count * sub_cmd_size / sizeof(uint32_t),
         l1_cache);
@@ -982,7 +982,7 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
     constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true, true>(
         reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + sizeof(CQDispatchCmd)),
         count * sub_cmd_size / sizeof(uint32_t),
         l1_cache);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -193,12 +193,7 @@ struct NocReleasePolicy {
     template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id>
     static FORCE_INLINE void release(uint32_t pages) {
 #ifdef ARCH_QUASAR
-        // get_semaphore() returns an offset into this core's L1, so this local store
-        // works only because prefetcher and dispatcher are on same dispatch engines sharing one L1.
-        // A split _h/_d build must go over the NoC instead. See the checklist at the top of cq_prefetch.cpp.
-        // Non-atomic RMW, so exactly one agent may ever increment this semaphore.
-        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(sem_id));
-        *sem_addr += pages;
+        Semaphore<programmable_core_type>(sem_id).up(pages);
 #else
         uint32_t sem_addr = get_semaphore<programmable_core_type>(sem_id);
         noc_semaphore_inc(get_noc_addr_helper(noc_xy, sem_addr), pages, noc_idx);
@@ -1096,7 +1091,6 @@ static void process_wait() {
     uint32_t heartbeat = 0;
     if (wait_memory) {
         uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
-        // Worker completion counter, incremented by workers with a NoC atomic.
         volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr));
         // DPRINT("DISPATCH WAIT 0x{:08x} count {}\n", addr, count);
         do {
@@ -1131,14 +1125,11 @@ static void process_wait() {
     }
     if (clear_memory) {
         uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
-        // Same counter as above; a cached store here would race the workers' atomics.
         *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr)) = 0;
     }
     if (notify_prefetch) {
 #ifdef ARCH_QUASAR
-        auto* sem_addr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(upstream_sync_sem));
-        *sem_addr += 1;
+        Semaphore<programmable_core_type>(upstream_sync_sem).up(1);
 #else
         noc_semaphore_inc(
             get_noc_addr_helper(upstream_noc_xy, get_semaphore<programmable_core_type>(upstream_sync_sem)),

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -336,7 +336,8 @@ FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
 template <uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 #ifdef ARCH_QUASAR
-    Semaphore<programmable_core_type>(sem_id).up(n);
+    auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(sem_id));
+    *sem_addr += n;
 #else
     dispatch_s_noc_semaphore_inc(get_noc_addr_helper(noc_xy, get_semaphore<programmable_core_type>(sem_id)), n, my_noc_index);
 #endif

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -315,6 +315,7 @@ FORCE_INLINE void update_worker_completion_count_on_dispatch_d() {
 
 template <uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
+    // The prefetcher publishes these credits with a NoC atomic.
     volatile tt_l1_ptr uint32_t* sem_addr = uncached_l1_ptr<uint32_t>(get_semaphore<programmable_core_type>(sem_id));
 
     WAYPOINT("DAPW");
@@ -345,12 +346,12 @@ FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t sync_index = load_aligned<uint32_t>(&cmd->mcast.wait_stream) - first_stream_used;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
 
     volatile tt_l1_ptr uint32_t* sync_sem_addr =
-        uncached_l1_ptr<uint32_t>(dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
 
     WAYPOINT("DCW");
     // Wait for notification from dispatch_d, signalling that it's safe to send the go signal
@@ -479,7 +480,7 @@ void process_go_signal_mcast_cmd() {
 
 FORCE_INLINE
 void process_dispatch_s_wait_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     // Limited Usage of Wait CMD: dispatch_s should get a wait command only if it's not on the
     // same core as dispatch_d and is used to clear the worker count
     ASSERT(
@@ -509,7 +510,7 @@ void process_dispatch_s_wait_cmd() {
 
 FORCE_INLINE
 void set_num_worker_sems() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     num_worker_sems = load_aligned<uint32_t>(&cmd->set_num_worker_sems.num_worker_sems);
     ASSERT(num_worker_sems <= max_num_worker_sems);
     cmd_ptr += sizeof(CQDispatchCmd);
@@ -517,14 +518,19 @@ void set_num_worker_sems() {
 
 FORCE_INLINE
 void set_go_signal_noc_data() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t num_words = load_aligned<uint32_t>(&cmd->set_go_signal_noc_data.num_words);
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
-    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // Reaches past the header window invalidated at command entry.
+    invalidate_l2_cache_range(cmd_ptr + sizeof(CQDispatchCmd), num_words * sizeof(uint32_t));
+#endif
+    volatile tt_l1_ptr uint32_t* data_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd_ptr + sizeof(CQDispatchCmd));
     for (uint32_t i = 0; i < num_words; ++i) {
         go_signal_noc_data[i] = *(data_ptr++);
     }
-    cmd_ptr = round_up_pow2(l1_cached_addr(reinterpret_cast<uintptr_t>(data_ptr)), L1_ALIGNMENT);
+    cmd_ptr = round_up_pow2(reinterpret_cast<uintptr_t>(data_ptr), L1_ALIGNMENT);
 }
 
 // When dispatch_d runs on the same core, it issues transactions on dispatch_s's dedicated NOC
@@ -625,8 +631,12 @@ void kernel_main() {
         device_print_dispatcher.execute();
 #endif
         cb_acquire_pages_dispatch_s<my_noc_xy, my_dispatch_cb_sem_id>(1);
-
-        volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+        // Upstream relays this command by NoC write, which does not snoop, so the header must be dropped before
+        // it is read cached. Arrays past the header stay uncached.
+        invalidate_l2_cache_range(cmd_ptr, sizeof(CQDispatchCmd));
+#endif
+        volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);
         DeviceTimestampedData("process_cmd_d_dispatch_subordinate", (uint32_t)cmd->base.cmd_id);
         if (rt_profiler_enabled) {
             const bool is_profiled_cmd = cmd->base.cmd_id == CQ_DISPATCH_CMD_SEND_GO_SIGNAL ||
@@ -692,7 +702,7 @@ void kernel_main() {
             default: DPRINT("dispatcher_s invalid command\n"); ASSERT(0);
         }
         // Dispatch s only supports single page commands for now
-        ASSERT(cmd_ptr <= (l1_cached_addr(reinterpret_cast<uintptr_t>(cmd)) + cb_page_size));
+        ASSERT(cmd_ptr <= (reinterpret_cast<uintptr_t>(cmd) + cb_page_size));
         cmd_ptr = round_up_pow2(cmd_ptr, cb_page_size);
         // Release a single page to prefetcher. Assumption is that all dispatch_s commands fit inside a single page for
         // now.

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -633,7 +633,8 @@ void kernel_main() {
         cb_acquire_pages_dispatch_s<my_noc_xy, my_dispatch_cb_sem_id>(1);
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
         // Upstream relays this command by NoC write, which does not snoop, so the header must be dropped before
-        // it is read cached. Arrays past the header stay uncached.
+        // it is read cached. CPU reads past this window carry their own invalidate; payload handed to
+        // the NIU needs none.
         invalidate_l2_cache_range(cmd_ptr, sizeof(CQDispatchCmd));
 #endif
         volatile CQDispatchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(cmd_ptr);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -315,7 +315,6 @@ FORCE_INLINE void update_worker_completion_count_on_dispatch_d() {
 
 template <uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
-    // The prefetcher publishes these credits with a NoC atomic.
     volatile tt_l1_ptr uint32_t* sem_addr = uncached_l1_ptr<uint32_t>(get_semaphore<programmable_core_type>(sem_id));
 
     WAYPOINT("DAPW");
@@ -337,8 +336,7 @@ FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
 template <uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 #ifdef ARCH_QUASAR
-    auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(sem_id));
-    *sem_addr += n;
+    Semaphore<programmable_core_type>(sem_id).up(n);
 #else
     dispatch_s_noc_semaphore_inc(get_noc_addr_helper(noc_xy, get_semaphore<programmable_core_type>(sem_id)), n, my_noc_index);
 #endif

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -2052,7 +2052,7 @@ void* copy_into_l1_cache(
     uint32_t& stride) {
     uint32_t remaining_stride = exec_buf_state.length;
     uint32_t remaining = (exec_buf_state.length - cmd_header_size);
-    volatile uint32_t tt_l1_ptr* l1_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + cmd_header_size);
+    volatile uint32_t tt_l1_ptr* l1_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr + cmd_header_size);
     uint32_t* l1_cache_pos = l1_cache;
     while (sub_cmds_length > remaining) {
         uint32_t amt = remaining / sizeof(uint32_t);
@@ -2396,7 +2396,7 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
 
     process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
     return stride;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -27,9 +27,12 @@
 #include "noc/noc_parameters.h"  // PCIE_ALIGNMENT
 
 // FABRIC_RELAY is defined exactly when !is_hd(), so this catches an _h/_d build.
-// Quasar FD assumes prefetcher and dispatcher share a Tensix; remote-chip support needs cross-Tensix verification.
-// That includes payload-before-credit ordering: these builds relay over fabric, where the NoC packet flush tag
-// this file relies on does not apply.
+// Quasar FD assumes prefetcher and dispatcher share a Tensix. A split build must resolve:
+//   - Payload-before-credit ordering: fabric relay does not honour the NoC packet flush tag this file uses.
+//   - Credit return: NocReleasePolicy::release uses a local store, which reaches only a co-resident DM.
+//     The NoC path is needed instead, and the reader moves to the uncached view with it.
+//   - DispatchSRelayInlineState shares cmd buf 0 with DispatchRelayInlineState, so both inherit one
+//     DEST_COORD; valid only while dispatch_s is co-resident.
 #if defined(ARCH_QUASAR) && defined(FABRIC_RELAY)
 #error "Quasar FD supports the _hd prefetcher only; the split _h/_d variants are not supported yet."
 #endif
@@ -378,7 +381,13 @@ FORCE_INLINE void write_downstream(
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
 #else
-            cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
+            cq_noc_async_write_with_state_any_len<
+                true,
+                true,
+                CQNocWait::CQ_NOC_WAIT,
+                downstream_cmd_buf,
+                /*flush_last_transfer=*/false,
+                /*snoop_transfers=*/FD_QSR_RELAY_SNOOP>(
                 static_cast<uint32_t>(data_ptr),
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
@@ -400,7 +409,8 @@ FORCE_INLINE void write_downstream(
         true,
         CQNocWait::CQ_NOC_WAIT,
         downstream_cmd_buf,
-        /*flush_last_transfer=*/true>(
+        /*flush_last_transfer=*/true,
+        /*snoop_transfers=*/FD_QSR_RELAY_SNOOP>(
         static_cast<uint32_t>(data_ptr),
         get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
         length);
@@ -795,7 +805,12 @@ void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_
                     fence,
                     cmd_ptr);
 #endif
-
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+                // NoC reads land in TL1 without snooping the DM cache, so lines this ring region left
+                // cached from an earlier wrap are stale. Every command the prefetcher reads comes through
+                // here.
+                invalidate_l2_cache_range(inflight[idx].read_start, inflight[idx].reserved_size);
+#endif
                 noc_async_read_barrier_with_trid(inflight[idx].trid);
 
 #if ENABLE_PREFETCH_DPRINTS
@@ -857,13 +872,13 @@ void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_
 }
 
 uint32_t process_debug_cmd(uintptr_t cmd_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     return load_aligned<uint32_t>(&cmd->debug.stride);
 }
 
 template <bool cmddat_wrap_enable, typename RelayInlineState>
 static uint32_t process_relay_inline_cmd(uintptr_t cmd_ptr, uint32_t& local_downstream_data_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
@@ -906,7 +921,7 @@ static uint32_t process_relay_inline_cmd(uintptr_t cmd_ptr, uint32_t& local_down
 // NOTE: this routine assumes we're sending a command header and that is LESS THAN A PAGE
 template <bool cmddat_wrap_enable>
 static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& dispatch_data_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
 
     uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
@@ -917,7 +932,11 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     }
     // On Quasar these writes carry no flush tag: this routine does not release the page, so the header
     // and the payload that follows are published by one release_pages, and the flush on the payload's
-    // last transfer covers all packets before it.
+    // last transfer covers all packets before it. They do carry the snoop tag -- the dispatcher reads
+    // this header with a load, unlike the payload that follows it.
+#if defined(ARCH_QUASAR) && FD_QSR_RELAY_SNOOP
+    noc_set_packet_tags<NCRISC_WR_CMD_BUF>(/*snoop=*/true, /*flush=*/false);
+#endif
     uint32_t remaining = cmddat_q_end - data_ptr;
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
@@ -929,6 +948,9 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     }
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
     dispatch_data_ptr += length;
+#if defined(ARCH_QUASAR) && FD_QSR_RELAY_SNOOP
+    noc_set_packet_tags<NCRISC_WR_CMD_BUF>(/*snoop=*/false, /*flush=*/false);
+#endif
 
     return load_aligned<uint32_t>(&cmd->relay_inline.stride);
 }
@@ -1381,7 +1403,7 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     // This ensures that a previous cmd using the scratch buf has finished
     noc_async_writes_flushed();
 
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t base_addr = load_aligned<uint32_t>(&cmd->relay_paged.base_addr);
     uint32_t page_size = load_aligned<uint32_t>(&cmd->relay_paged.page_size);
     uint32_t pages = load_aligned<uint32_t>(&cmd->relay_paged.pages);
@@ -1638,7 +1660,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cac
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_paged_packed.total_length);
     uint32_t sub_cmds_length =
         load_aligned<uint16_t>(&cmd->relay_paged_packed.count) * sizeof(CQPrefetchRelayPagedPackedSubCmd);
@@ -1653,7 +1675,7 @@ uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
         careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
+            reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
         l1_cache_pos += amt;
@@ -1668,7 +1690,7 @@ uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
     // Store a sentinel non 0 value at the end to save a test/branch in read path
     ((CQPrefetchRelayPagedPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
 
@@ -1710,7 +1732,7 @@ uint32_t process_relay_linear_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_p
     // This ensures that a previous cmd using the scratch buf has finished
     noc_async_writes_flushed();
 
-    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmdLarge>(cmd_ptr);
+    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmdLarge tt_l1_ptr*>(cmd_ptr);
     uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear.noc_xy_addr);
     uint64_t read_addr = load_aligned<uint64_t>(&cmd->relay_linear.addr);
     uint64_t wlength = load_aligned<uint64_t>(&cmd->relay_linear.length);
@@ -1785,8 +1807,8 @@ uint32_t process_stall(uintptr_t cmd_ptr) {
     count++;
 
     WAYPOINT("PSW");
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        uncached_l1_ptr<uint32_t>(get_semaphore<programmable_core_type>(my_downstream_sync_sem_id));
+    volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        get_semaphore<programmable_core_type>(my_downstream_sync_sem_id));
     uint32_t heartbeat = 0;
     do {
         invalidate_l1_cache();
@@ -1851,6 +1873,11 @@ void paged_read_into_cmddat_q(uintptr_t& cmd_ptr, PrefetchExecBufState& exec_buf
                 pages_to_read--;
             }
         }
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+        // Same as fetch_q_get_cmds: the NoC read does not snoop. Safe ahead of the barrier because nothing
+        // reads the region until it returns.
+        invalidate_l2_cache_range(cmd_ptr, initial_read_length);
+#endif
         noc_async_read_barrier_with_trid(1);
         // update length always after barrier to make sure data in cmddat_q
         exec_buf_state.page_id = page_id;
@@ -1859,6 +1886,10 @@ void paged_read_into_cmddat_q(uintptr_t& cmd_ptr, PrefetchExecBufState& exec_buf
         exec_buf_state.read_ptr = read_ptr;
     } else {
         ASSERT(exec_buf_state.length == 0);
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+        // As above; prefetch_length is the extent the previous call issued.
+        invalidate_l2_cache_range(cmd_ptr, exec_buf_state.prefetch_length);
+#endif
         // add barrier to wait for prefetch noc read to complete
         noc_async_read_barrier_with_trid(1);
         // update always after barrier to make sure data in cmddat_q
@@ -1914,7 +1945,7 @@ void paged_read_into_cmddat_q(uintptr_t& cmd_ptr, PrefetchExecBufState& exec_buf
 template <typename RelayInlineState>
 FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     uintptr_t& cmd_ptr, uint32_t& local_downstream_data_ptr, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
@@ -1971,7 +2002,7 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     uintptr_t& cmd_ptr, uint32_t& dispatch_data_ptr, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
 
     uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
@@ -2048,7 +2079,7 @@ void* copy_into_l1_cache(
         exec_buf_state.length = 0;
         cmd_ptr += remaining_stride;
         paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        l1_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr);
+        l1_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr);
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
     }
@@ -2070,7 +2101,7 @@ void* copy_into_l1_cache(
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_paged_packed_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_paged_packed.total_length);
     uint32_t sub_cmds_length =
         load_aligned<uint16_t>(&cmd->relay_paged_packed.count) * sizeof(CQPrefetchRelayPagedPackedSubCmd);
@@ -2092,7 +2123,7 @@ uint32_t process_exec_buf_cmd(
     // dispatch on eth cores is memory constrained, so exec_buf reuses the cmddat_q
     // prefetch_h stalls upon issuing an exec_buf to prevent conflicting use of the cmddat_q,
     // the exec_buf contains the release commands
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr_outer);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr_outer);
 
     // setup exec_buf_state the first time
     exec_buf_state.page_id = 0;
@@ -2128,7 +2159,7 @@ uint32_t process_paged_to_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream
     // This ensures that a previous cmd using the ringbuffer have completed.
     noc_async_writes_flushed();
 
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t start_page = cmd->paged_to_ringbuffer.start_page;
     uint32_t base_addr = load_aligned<uint32_t>(&cmd->paged_to_ringbuffer.base_addr);
     uint8_t log2_page_size = cmd->paged_to_ringbuffer.log2_page_size;
@@ -2174,7 +2205,7 @@ uint32_t process_paged_to_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream
 }
 
 uint32_t process_set_ringbuffer_offset(uintptr_t cmd_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t offset = load_aligned<uint32_t>(&cmd->set_ringbuffer_offset.offset);
 
     if (cmd->set_ringbuffer_offset.update_wp) {
@@ -2214,7 +2245,7 @@ void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t count = load_aligned<uint16_t>(&cmd->relay_ringbuffer.count);
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
     uint32_t stride = load_aligned<uint32_t>(&cmd->relay_ringbuffer.stride);
@@ -2227,7 +2258,7 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
         careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
+            reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
         l1_cache_pos += amt;
@@ -2242,7 +2273,7 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
 
     process_relay_ringbuffer_sub_cmds(count, l1_cache);
     return stride;
@@ -2251,7 +2282,7 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_ringbuffer_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t count = load_aligned<uint16_t>(&cmd->relay_ringbuffer.count);
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
     uint32_t stride = load_aligned<uint32_t>(&cmd->relay_ringbuffer.stride);
@@ -2348,7 +2379,7 @@ void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_l
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear_packed.noc_xy_addr);
     uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_linear_packed.total_length);
     uint32_t sub_cmds_length =
@@ -2364,7 +2395,7 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
         careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
+            reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
         l1_cache_pos += amt;
@@ -2388,7 +2419,7 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_linear_packed_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear_packed.noc_xy_addr);
     uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_linear_packed.total_length);
     uint32_t sub_cmds_length =
@@ -2407,7 +2438,7 @@ bool process_cmd(
     uint32_t& stride,
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     bool done = false;
 
     switch (cmd->base.cmd_id) {
@@ -2605,7 +2636,7 @@ static void relay_linear_to_downstream(
 // Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
 uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr) {
     volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
-    cmd = uncached_l1_ptr<CQPrefetchCmdLarge>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+    cmd = reinterpret_cast<volatile CQPrefetchCmdLarge tt_l1_ptr*>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
     uint64_t wlength = load_aligned<uint64_t>(&cmd->relay_linear_h.length);
     uint32_t scratch_read_addr = scratch_db_top[0];
     constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
@@ -2687,7 +2718,7 @@ uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data
 // Combines packed linear reads (multiple sub-commands) with H-variant relay to remote device.
 uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd =
-        uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+        reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
     uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear_packed.noc_xy_addr);
     uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_linear_packed.total_length);
     uint32_t sub_cmds_length =
@@ -2699,7 +2730,7 @@ uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstre
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader) + sizeof(CQPrefetchCmd);
     uint32_t amt = sub_cmds_length / sizeof(uint32_t);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache);
+        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache);
 
     // Setup scratch buffer for relay
     uint32_t scratch_read_addr = scratch_db_top[0];
@@ -2997,7 +3028,7 @@ void kernel_main_h() {
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
 
         volatile CQPrefetchCmd tt_l1_ptr* cmd =
-            uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+            reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
         uint32_t cmd_id = cmd->base.cmd_id;
         // Infer that an exec_buf command is to be executed based on the stall state.
         const bool is_exec_buf = (stall_state == StallState::STALLED);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -381,13 +381,7 @@ FORCE_INLINE void write_downstream(
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
 #else
-            cq_noc_async_write_with_state_any_len<
-                true,
-                true,
-                CQNocWait::CQ_NOC_WAIT,
-                downstream_cmd_buf,
-                /*flush_last_transfer=*/false,
-                /*snoop_transfers=*/FD_QSR_RELAY_SNOOP>(
+            cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
                 static_cast<uint32_t>(data_ptr),
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
@@ -409,8 +403,7 @@ FORCE_INLINE void write_downstream(
         true,
         CQNocWait::CQ_NOC_WAIT,
         downstream_cmd_buf,
-        /*flush_last_transfer=*/true,
-        /*snoop_transfers=*/FD_QSR_RELAY_SNOOP>(
+        /*flush_last_transfer=*/true>(
         static_cast<uint32_t>(data_ptr),
         get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
         length);
@@ -932,11 +925,7 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     }
     // On Quasar these writes carry no flush tag: this routine does not release the page, so the header
     // and the payload that follows are published by one release_pages, and the flush on the payload's
-    // last transfer covers all packets before it. They do carry the snoop tag -- the dispatcher reads
-    // this header with a load, unlike the payload that follows it.
-#if defined(ARCH_QUASAR) && FD_QSR_RELAY_SNOOP
-    noc_set_packet_tags<NCRISC_WR_CMD_BUF>(/*snoop=*/true, /*flush=*/false);
-#endif
+    // last transfer covers all packets before it.
     uint32_t remaining = cmddat_q_end - data_ptr;
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
@@ -948,9 +937,6 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     }
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
     dispatch_data_ptr += length;
-#if defined(ARCH_QUASAR) && FD_QSR_RELAY_SNOOP
-    noc_set_packet_tags<NCRISC_WR_CMD_BUF>(/*snoop=*/false, /*flush=*/false);
-#endif
 
     return load_aligned<uint32_t>(&cmd->relay_inline.stride);
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -30,7 +30,6 @@
 // Quasar FD assumes prefetcher and dispatcher share a Tensix. A split build must resolve:
 //   - Payload-before-credit ordering: fabric relay does not honour the NoC packet flush tag this file uses.
 //   - Credit return: NocReleasePolicy::release uses a local store, which reaches only a co-resident DM.
-//     The NoC path is needed instead, and the reader moves to the uncached view with it.
 //   - DispatchSRelayInlineState shares cmd buf 0 with DispatchRelayInlineState, so both inherit one
 //     DEST_COORD; valid only while dispatch_s is co-resident.
 #if defined(ARCH_QUASAR) && defined(FABRIC_RELAY)
@@ -1790,8 +1789,8 @@ uint32_t process_stall(uintptr_t cmd_ptr) {
     count++;
 
     WAYPOINT("PSW");
-    volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        get_semaphore<programmable_core_type>(my_downstream_sync_sem_id));
+    volatile tt_l1_ptr uint32_t* sem_addr =
+        uncached_l1_ptr<uint32_t>(get_semaphore<programmable_core_type>(my_downstream_sync_sem_id));
     uint32_t heartbeat = 0;
     do {
         invalidate_l1_cache();

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -798,12 +798,6 @@ void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_
                     fence,
                     cmd_ptr);
 #endif
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-                // NoC reads land in TL1 without snooping the DM cache, so lines this ring region left
-                // cached from an earlier wrap are stale. Every command the prefetcher reads comes through
-                // here.
-                invalidate_l2_cache_range(inflight[idx].read_start, inflight[idx].reserved_size);
-#endif
                 noc_async_read_barrier_with_trid(inflight[idx].trid);
 
 #if ENABLE_PREFETCH_DPRINTS
@@ -1660,7 +1654,7 @@ uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_
     if (cmddat_wrap_enable && sub_cmds_length > remaining) {
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
             reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
@@ -1675,8 +1669,11 @@ uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_
                    ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
+    careful_copy_from_l1_to_local_cache<
+        l1_to_local_cache_copy_chunk,
+        l1_cache_elements_rounded,
+        true,
+        !cmddat_wrap_enable>(reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
     // Store a sentinel non 0 value at the end to save a test/branch in read path
     ((CQPrefetchRelayPagedPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
 
@@ -1859,11 +1856,6 @@ void paged_read_into_cmddat_q(uintptr_t& cmd_ptr, PrefetchExecBufState& exec_buf
                 pages_to_read--;
             }
         }
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-        // Same as fetch_q_get_cmds: the NoC read does not snoop. Safe ahead of the barrier because nothing
-        // reads the region until it returns.
-        invalidate_l2_cache_range(cmd_ptr, initial_read_length);
-#endif
         noc_async_read_barrier_with_trid(1);
         // update length always after barrier to make sure data in cmddat_q
         exec_buf_state.page_id = page_id;
@@ -1872,10 +1864,6 @@ void paged_read_into_cmddat_q(uintptr_t& cmd_ptr, PrefetchExecBufState& exec_buf
         exec_buf_state.read_ptr = read_ptr;
     } else {
         ASSERT(exec_buf_state.length == 0);
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-        // As above; prefetch_length is the extent the previous call issued.
-        invalidate_l2_cache_range(cmd_ptr, exec_buf_state.prefetch_length);
-#endif
         // add barrier to wait for prefetch noc read to complete
         noc_async_read_barrier_with_trid(1);
         // update always after barrier to make sure data in cmddat_q
@@ -2056,7 +2044,7 @@ void* copy_into_l1_cache(
     uint32_t* l1_cache_pos = l1_cache;
     while (sub_cmds_length > remaining) {
         uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
             l1_ptr, amt, l1_cache_pos);
 
         l1_cache_pos += amt;
@@ -2077,7 +2065,7 @@ void* copy_into_l1_cache(
                    ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
         l1_ptr, amt, l1_cache_pos);
 
     // Return a pointer to right after the last copy
@@ -2243,7 +2231,7 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
     if (cmddat_wrap_enable && sub_cmds_length > remaining) {
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
             reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
@@ -2258,8 +2246,11 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
                    ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
+    careful_copy_from_l1_to_local_cache<
+        l1_to_local_cache_copy_chunk,
+        l1_cache_elements_rounded,
+        true,
+        !cmddat_wrap_enable>(reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
 
     process_relay_ringbuffer_sub_cmds(count, l1_cache);
     return stride;
@@ -2380,7 +2371,7 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
     if (cmddat_wrap_enable && sub_cmds_length > remaining) {
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
             reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
@@ -2395,8 +2386,11 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
                    ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
+    careful_copy_from_l1_to_local_cache<
+        l1_to_local_cache_copy_chunk,
+        l1_cache_elements_rounded,
+        true,
+        !cmddat_wrap_enable>(reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache_pos);
 
     process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
     return stride;
@@ -2424,6 +2418,11 @@ bool process_cmd(
     uint32_t& stride,
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state) {
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // Every command invalidates its own header extent, sized to CQPrefetchCmdLarge because the variant is
+    // unknown until cmd_id is read. Both fetch paths reach this, so exec_buf is covered too.
+    invalidate_l2_cache_range(cmd_ptr, sizeof(CQPrefetchCmdLarge));
+#endif
     volatile CQPrefetchCmd tt_l1_ptr* cmd = reinterpret_cast<volatile CQPrefetchCmd tt_l1_ptr*>(cmd_ptr);
     bool done = false;
 
@@ -2715,7 +2714,7 @@ uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstre
     // Copy sub-commands into L1 cache (same pattern as process_relay_linear_packed_cmd)
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader) + sizeof(CQPrefetchCmd);
     uint32_t amt = sub_cmds_length / sizeof(uint32_t);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded, true>(
         reinterpret_cast<volatile uint32_t tt_l1_ptr*>(data_ptr), amt, l1_cache);
 
     // Setup scratch buffer for relay


### PR DESCRIPTION
### PR Category
Performance

### Summary
Relates to https://github.com/tenstorrent/tt-metal/issues/49781
Quasar  prefetcher/dispatcher uses uncached accesses to read command data. Uncached loads are expensive as compared to cache, and consequently stall the CPU pipeline. This PR moves the command read path to cached view and adds targeted `invalidate_l2_cache_range` calls where the bytes arrived over the NoC. 

Deliberately not converted: 
1. any host-visible pointers (`prefetch_q_rd_ptr`, completion-queue pointers)
2. any type of semaphores updates.
3. `aligned_go_signal_storage_uncached` in dispatch_s, dispatch.
4. `worker_completion_sem_addr` which workers increment over NoC atomic.

### Cache invalidation policy

In Prefetcher: once per fetch + two exec_buf sites. The extents are disjoint, so each line is invalidated exactly once within a single fetch cycle. All nine prefetcher `careful_copy` callers therefore pass invalidate_source = false.

In Dispatcher and dispatch_s: the header is invalidated at each command entry. Payload past that invalidates when applicable - in `careful_copy ... ` invalidate_source for sub-cmds, or sized from a count in the header (`set_go_signal_noc_data` in both kernels, `set_sub_device_worker_counts`). The extent isn't known until the header invalidate has already happened, which is also why the header invalidate is sized to `CQDispatchCmdLarge` by default.

The prefetcher can set snoop bit and relay packets so the receiving NIU packets the dispatcher's cache in place, removing the current dispatcher invalidate calls. But this was reverted for perf, not correctness: FD is prefetcher-bound, so this pays cycles on the bottleneck.

### Notes for reviewers
- Focus on the policy decision above. 
- The `noc_async_atomic_barrier()` was removed in `CBWriter::acquire_pages` for all archs -- wasn't really needed/useful


Improvements:

On Quasar:

Configuration | Transfer Size (Bytes) | Uncached + Barrier (Cycles) | Cache Opt + No Barrier (Cycles) | Total Cumulative Imp. (%)
-- | -- | -- | -- | --
256B × 1 | 256 | 1,358.90 | 1,299.30 | 4.39%
256B × 5 | 1,280 | 1,735.20 | 1,681.40 | 3.10%
256B × 35 | 8,960 | 4,673.60 | 3,883.60 | 16.90%
2,048B × 1 | 2,048 | 1,387.30 | 1,335.90 | 3.71%
2,048B × 5 | 10,240 | 1,857.10 | 1,790.00 | 3.61%
2,048B × 35 | 71,680 | 5,846.70 | 5,043.80 | 13.73%
12,288B × 1 | 12,288 | 1,669.90 | 1,617.40 | 3.14%
12,288B × 5 | 61,440 | 2,784.90 | 2,728.70 | 2.02%
12,288B × 35 | 430,080 | 17,403.50 | 15,604.00 | 10.34%



On BH (only barrier removal impacts BH/WH):


Configuration | Transfer Size (Bytes) | Baseline: With Barrier (Cycles) | Optimized: Barrier Removed (Cycles) | Barrier Removal Imp. (%)
-- | -- | -- | -- | --
256B × 1 | 256 | 1,164.40 | 1,161.90 | None (within noise margin)
256B × 5 | 1,280 | 1,495.00 | 1,495.80 | None (within noise margin)
256B × 35 | 8,960 | 3,803.00 | 3,790.10 | 0.34%
2,048B × 1 | 2,048 | 1,242.90 | 1,244.20 | None (within noise margin)
2,048B × 5 | 10,240 | 1,577.20 | 1,560.60 | 1.05%
2,048B × 35 | 71,680 | 5,279.10 | 4,991.30 | 5.45%
12,288B × 1 | 12,288 | 1,506.80 | 1,495.80 | None (within noise margin)
12,288B × 5 | 61,440 | 3,615.30 | 3,547.40 | 1.88%
12,288B × 35 | 430,080 | 19,972.20 | 19,552.20 | 2.10%





Quasar emulator prefetcher/dispatcher tests pass:
<img width="1299" height="194" alt="image" src="https://github.com/user-attachments/assets/957d9eda-0a25-479d-8dcf-6e9d80aa4b7e" />

<img width="1391" height="197" alt="image" src="https://github.com/user-attachments/assets/8dbac920-76fd-4875-bc4c-6152dad9c605" />

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fd_cache_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fd_cache_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fd_cache_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fd_cache_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fd_cache_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fd_cache_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fd_cache_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fd_cache_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fd_cache_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fd_cache_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fd_cache_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fd_cache_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fd_cache_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fd_cache_opt)