### PR TITLE
Propagate the softplus boundary fix to the Quasar kernel

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -51,11 +51,15 @@ sfpi_inline void _calculate_softplus_body_(const float beta, const float beta_re
     sfpi::vFloat val = sfpi::dst_reg[0]; // load x from dest (SFPLOAD)
     sfpi::vFloat t   = beta * val;
 
-    // Linear region (t >= threshold): softplus(x) = x; default for every lane so the single store covers it.
+    // Linear region (t > threshold): softplus(x) = x; default for every lane so the single store covers it.
     sfpi::vFloat result = val;
 
-    // `t < threshold` relies on vConstNeg1/LREG11 == -1.0 (re-established per launch by _init_sfpu_config_reg_).
-    v_if (t < threshold)
+    // The boundary lane belongs to the nonlinear side: torch documents the linear fallback as
+    // `input * beta > threshold`, so at exactly t == threshold the answer is log1p(exp(t))/beta,
+    // not x. wormhole_b0 and blackhole were corrected to `<=` in #54208; this copy predates that
+    // fix and kept the strict form. `<=` is also the comparison shape #53058 prefers on Quasar.
+    // Relies on vConstNeg1/LREG11 == -1.0 (re-established per launch by _init_sfpu_config_reg_).
+    v_if (t <= threshold)
     {
         sfpi::vFloat a = sfpi::abs(t);
         sfpi::vFloat residual;


### PR DESCRIPTION
Completes #53261 on the third architecture.

#54208 corrected the softplus boundary on `wormhole_b0` and `blackhole`. While
re-checking that fix against `main` I found the same comparison in a third kernel
copy and said so on #53261 at the time; #54208's description records that the quasar
copy was left untouched there. This is that follow-up.

`tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h:58` still
reads `v_if (t < threshold)`. torch documents the linear fallback as
`input * beta > threshold`, so at exactly `t == threshold` the result should be
`log1p(exp(t)) / beta`, not `x`. The strict comparison sends the boundary lane down
the linear branch instead.

The change is the same one-character correction #54208 applied to the other two
architectures, `<` to `<=`, plus a comment recording why the boundary belongs to the
nonlinear side. `<=` is also the comparison shape #53058 prefers on Quasar.

No behaviour changes for any lane other than exactly `t == threshold`.
