### PR TITLE
[Test Only] Skip the slowest reduce tests on ttsim

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -27,6 +27,10 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
   - tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill_v_embedding_space.py
 
+  # Long-running tests that cause the group's 40-minute job timeout on ttsim (#54860); still run on HW.
+  - tests/ttnn/unit_tests/operations/reduce/test_reduction.py::test_std_var_wide_low_variance
+  - tests/ttnn/unit_tests/operations/reduce/test_reduction.py::test_2d_topk
+
   # Likely OOM killer related failures -- probably need to run these tests serially
   - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob
 
@@ -50,6 +54,10 @@ blackhole:
   - tests/ttnn/unit_tests/base_functionality/test_to_layout.py::test_to_layout_fp8_input_to_tile
   - tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
   - tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+
+  # Long-running tests that cause the group's 40-minute job timeout on ttsim (#54860); still run on HW.
+  - tests/ttnn/unit_tests/operations/reduce/test_reduction.py::test_std_var_wide_low_variance
+  - tests/ttnn/unit_tests/operations/reduce/test_reduction.py::test_2d_topk
 
   # Likely OOM killer related failures -- probably need to run these tests serially
   - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob


### PR DESCRIPTION
### PR Category
- Test Only

### Summary
The `ttnn reduce group` overruns its 40-minute job timeout on both simulator SKUs (`sim_wh_n150`, `sim_bh_p150`), while the same suite finishes in ~14 min on every hardware SKU. Measured from the failing job logs, two tests dominate the simulator cost:

- `test_std_var_wide_low_variance` — 4 cases, ~10 min each
- `test_2d_topk` — 651s (BH) / 577s (WH) for its largest params

Deselecting these on ttsim brings both simulator jobs back under the timeout, confirmed by a green run. Hardware coverage is unchanged.

- Closes #54860

### Notes for reviewers
- Simulator-only: the skip list is applied as `--deselect` for `sim_*` SKUs, so `wh_n300_civ2` / `bh_p100` / `bh_p150b_civ2` still run the full grid.
- These tests pass on ttsim; they are just slow. Nothing here is a correctness skip.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-reduce-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-reduce-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-reduce-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-reduce-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-reduce-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-reduce-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-reduce-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-reduce-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-reduce-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-reduce-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-reduce-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-reduce-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-reduce-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-reduce-timeout)