### PR TITLE
Add the perf warehouse upload step to the LLK perf nightly

### DIFF
--- a/.github/actions/upload-data-via-sftp/llk_perf_batchfile.txt
+++ b/.github/actions/upload-data-via-sftp/llk_perf_batchfile.txt
@@ -1,0 +1,2 @@
+put -r generated/llk_perf/*.parquet
+ls -hal

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -246,7 +246,15 @@ jobs:
           # One Parquet per shard, already named <run_id>-<arch>-<job_index>,
           # so a flat copy cannot collide. generated/<producer>/ is where every
           # other producer in this repo stages its upload.
-          find perf-data -name '*.parquet' -exec cp {} generated/llk_perf/ \;
+          #
+          # Prefix every name with llk_perf_. The upload lands in a remote
+          # directory this repo shares between producers, where a bare
+          # <run_id>-<arch>-<shard> says nothing about who owns the file. The
+          # prefix is greppable, it is what an ingest rule can key on, and it
+          # matches what helpers.perf.backfill sends for the older nights.
+          find perf-data -name '*.parquet' | while read -r f; do
+            cp "$f" "generated/llk_perf/llk_perf_$(basename "$f")"
+          done
           ls -l generated/llk_perf
           if [ -z "$(ls -A generated/llk_perf)" ]; then
             echo "::error::no run Parquet in the perf-data artifacts"

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -19,6 +19,11 @@ on:
         required: false
         default: false
         type: boolean
+      only-group:
+        description: "Run only this split group (1-5). Empty runs every group."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   checks: write
@@ -39,7 +44,8 @@ jobs:
     runs-on: ubuntu-slim
     needs: [build-images]
     outputs:
-      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      # An unset trim step yields "", which is falsy, so the full matrix wins.
+      matrix: ${{ steps.trim.outputs.matrix || steps.build-matrix.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/llk_perf_tests.yaml
     steps:
@@ -85,6 +91,25 @@ jobs:
             ${{ env.TESTS_YAML_PATH }} \
             "$ENABLED_SKUS" \
             ./.github/sku_config.yaml
+      - name: Keep only one split group
+        id: trim
+        if: ${{ inputs.only-group != '' }}
+        env:
+          MATRIX: ${{ steps.build-matrix.outputs.matrix }}
+          ONLY_GROUP: ${{ inputs.only-group }}
+        run: |
+          # One shard instead of ten. A change to this workflow can then be
+          # tested end to end without occupying every perf machine for two
+          # hours. Fails loud on a group number that matches nothing, so a typo
+          # cannot silently run no tests at all.
+          FILTER='import json, os, sys
+          rows = json.loads(os.environ["MATRIX"])
+          group = os.environ["ONLY_GROUP"]
+          keep = [r for r in rows if str(r.get("split_group")) == group]
+          if not keep:
+              sys.exit("no matrix row with split_group=" + group)
+          print("matrix=" + json.dumps(keep))'
+          python3 -c "$FILTER" >> "$GITHUB_OUTPUT"
 
   compile-quasar-perf:
     if: ${{ inputs.architecture == 'all' || inputs.architecture == 'quasar' }}

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -260,10 +260,16 @@ jobs:
             echo "::error::no run Parquet in the perf-data artifacts"
             exit 1
           fi
+      # LLK perf has its own SFTP writer and its own ingest bucket
+      # (data_iac#655: user llk-perf-run, home data-pipeline-llk-perf-run-ingest).
+      # Only that bucket has the llk_perf_run wrangler behind it
+      # (data_airflow dags/pipelines/llk_perf_run), which loads the file into
+      # LLK_PERF.{RUNS,TEST_EXECUTIONS,MEASUREMENTS}. Another producer's writer
+      # would put the file in a bucket where nothing reads it.
       - name: Upload perf data
         uses: ./.github/actions/upload-data-via-sftp
         with:
-          ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}
+          ssh-private-key: ${{ secrets.SFTP_LLK_PERF_WRITER_KEY }}
           sftp-batchfile: .github/actions/upload-data-via-sftp/llk_perf_batchfile.txt
-          username: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_CICD_WRITER_HOSTNAME }}
+          username: ${{ secrets.SFTP_LLK_PERF_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_LLK_PERF_WRITER_HOSTNAME }}

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -227,6 +227,14 @@ jobs:
     if: ${{ always() && inputs.upload-to-warehouse }}
     runs-on: ubuntu-latest
     steps:
+      # The upload action is a local action, so the repo has to be on disk
+      # before it can be resolved. Checkout also clears the workspace, so it
+      # must come before the artifacts are downloaded into it.
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          fetch-depth: 1
       - name: Download this run's perf data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -234,35 +242,20 @@ jobs:
           path: perf-data
       - name: Collect the run Parquets
         run: |
-          mkdir -p upload
+          mkdir -p generated/llk_perf
           # One Parquet per shard, already named <run_id>-<arch>-<job_index>,
-          # so a flat copy cannot collide.
-          find perf-data -name '*.parquet' -exec cp {} upload/ \;
-          ls -l upload
-          if [ -z "$(ls -A upload)" ]; then
+          # so a flat copy cannot collide. generated/<producer>/ is where every
+          # other producer in this repo stages its upload.
+          find perf-data -name '*.parquet' -exec cp {} generated/llk_perf/ \;
+          ls -l generated/llk_perf
+          if [ -z "$(ls -A generated/llk_perf)" ]; then
             echo "::error::no run Parquet in the perf-data artifacts"
             exit 1
           fi
-      - name: Upload over SFTP
-        working-directory: upload
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SFTP_LLK_PERF_KEY }}
-          # Neither of these is a credential, so they stay readable in the diff.
-          # Move them to secrets or vars if infra prefers.
-          SFTP_HOST: "s-dbd4b8a190fa40a4b.server.transfer.us-east-2.amazonaws.com"
-          SFTP_USER: "llk-perf-run"
-        run: |
-          if [ -z "$SSH_PRIVATE_KEY" ]; then
-            echo "::error::secret SFTP_LLK_PERF_KEY is not set in this repository"
-            exit 1
-          fi
-          printf '%s\n' "$SSH_PRIVATE_KEY" > id_key
-          chmod go-rwx id_key
-          # The fingerprint the server must have installed for $SFTP_USER. A
-          # fingerprint is public; the key file itself is never printed.
-          ssh-keygen -lf id_key
-          { for f in *.parquet; do echo "put $f"; done; echo "ls -hal"; } > batchfile
-          # -v names the offered key and the server's answer. BatchMode=yes
-          # fails at once instead of waiting for a password.
-          sftp -v -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
-            -i id_key -b batchfile "$SFTP_USER@$SFTP_HOST"
+      - name: Upload perf data
+        uses: ./.github/actions/upload-data-via-sftp
+        with:
+          ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/llk_perf_batchfile.txt
+          username: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_CICD_WRITER_HOSTNAME }}

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -266,10 +266,19 @@ jobs:
       # (data_airflow dags/pipelines/llk_perf_run), which loads the file into
       # LLK_PERF.{RUNS,TEST_EXECUTIONS,MEASUREMENTS}. Another producer's writer
       # would put the file in a bucket where nothing reads it.
+      # Host and user are literals on purpose: neither is a credential, and the
+      # warehouse owner has to be able to read what we connect as. Only the key
+      # is a secret.
+      #
+      # The user is "llk-perf-run-writer", not "llk-perf-run". data_iac's
+      # aws_transfer_user sets user_name = "${block.name}-${block.permission}"
+      # (resources/aws_sftp/main.tf L127-134, comment: `user_name ex: cicd + "-"
+      # + reader`), so "llk-perf-run" is only the project tag. Both spellings
+      # are refused today; see the PR description.
       - name: Upload perf data
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_LLK_PERF_WRITER_KEY }}
           sftp-batchfile: .github/actions/upload-data-via-sftp/llk_perf_batchfile.txt
-          username: ${{ secrets.SFTP_LLK_PERF_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_LLK_PERF_WRITER_HOSTNAME }}
+          username: "llk-perf-run-writer"
+          hostname: "s-dbd4b8a190fa40a4b.server.transfer.us-east-2.amazonaws.com"

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -197,11 +197,10 @@ jobs:
     name: "Upload perf data to the warehouse"
     needs: [llk-perf-exec]
     # always(): a shard that failed still produced Parquets worth keeping.
+    # The job is not shielded: a refused login fails it, and fails the run. That
+    # is the behaviour the scheduled nightly will have when the default flips.
     if: ${{ always() && inputs.upload-to-warehouse }}
     runs-on: ubuntu-latest
-    # The warehouse has not authorised our key yet, so a refused login must not
-    # turn the nightly red. Remove this line once the login works.
-    continue-on-error: true
     steps:
       - name: Download this run's perf data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         default: true
         type: boolean
+      upload-to-warehouse:
+        description: "Upload the run's Parquet to the perf warehouse over SFTP"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   checks: write
@@ -187,3 +192,53 @@ jobs:
             ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-*-run.xml
           include_passed: true
           annotate_only: true
+
+  upload-perf-data:
+    name: "Upload perf data to the warehouse"
+    needs: [llk-perf-exec]
+    # always(): a shard that failed still produced Parquets worth keeping.
+    if: ${{ always() && inputs.upload-to-warehouse }}
+    runs-on: ubuntu-latest
+    # The warehouse has not authorised our key yet, so a refused login must not
+    # turn the nightly red. Remove this line once the login works.
+    continue-on-error: true
+    steps:
+      - name: Download this run's perf data
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: perf-data-*
+          path: perf-data
+      - name: Collect the run Parquets
+        run: |
+          mkdir -p upload
+          # One Parquet per shard, already named <run_id>-<arch>-<job_index>,
+          # so a flat copy cannot collide.
+          find perf-data -name '*.parquet' -exec cp {} upload/ \;
+          ls -l upload
+          if [ -z "$(ls -A upload)" ]; then
+            echo "::error::no run Parquet in the perf-data artifacts"
+            exit 1
+          fi
+      - name: Upload over SFTP
+        working-directory: upload
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SFTP_LLK_PERF_KEY }}
+          # Neither of these is a credential, so they stay readable in the diff.
+          # Move them to secrets or vars if infra prefers.
+          SFTP_HOST: "s-dbd4b8a190fa40a4b.server.transfer.us-east-2.amazonaws.com"
+          SFTP_USER: "llk-perf-run"
+        run: |
+          if [ -z "$SSH_PRIVATE_KEY" ]; then
+            echo "::error::secret SFTP_LLK_PERF_KEY is not set in this repository"
+            exit 1
+          fi
+          printf '%s\n' "$SSH_PRIVATE_KEY" > id_key
+          chmod go-rwx id_key
+          # The fingerprint the server must have installed for $SFTP_USER. A
+          # fingerprint is public; the key file itself is never printed.
+          ssh-keygen -lf id_key
+          { for f in *.parquet; do echo "put $f"; done; echo "ls -hal"; } > batchfile
+          # -v names the offered key and the server's answer. BatchMode=yes
+          # fails at once instead of waiting for a password.
+          sftp -v -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+            -i id_key -b batchfile "$SFTP_USER@$SFTP_HOST"

--- a/.github/workflows/llk-perf.yaml
+++ b/.github/workflows/llk-perf.yaml
@@ -46,8 +46,9 @@ jobs:
       architecture: ${{ inputs.architecture || 'all' }}
       # Nightly runs always use speed-of-light; manual runs use the checkbox.
       speed-of-light: ${{ github.event_name == 'schedule' || inputs.speed-of-light }}
-      # Off for the scheduled nightly until the warehouse key is authorised.
-      # A scheduled run has no inputs, so the expression falls through to false.
+      # Off for the scheduled nightly until the warehouse key is authorised. A
+      # scheduled run has no inputs, so the expression falls through to false.
+      # Turning it on for every night is this one expression -> true.
       upload-to-warehouse: ${{ inputs.upload-to-warehouse || false }}
     secrets: inherit
 

--- a/.github/workflows/llk-perf.yaml
+++ b/.github/workflows/llk-perf.yaml
@@ -21,6 +21,11 @@ on:
         required: false
         default: true
         type: boolean
+      upload-to-warehouse:
+        description: "Upload the run's Parquet to the perf warehouse over SFTP"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   checks: write
@@ -41,6 +46,9 @@ jobs:
       architecture: ${{ inputs.architecture || 'all' }}
       # Nightly runs always use speed-of-light; manual runs use the checkbox.
       speed-of-light: ${{ github.event_name == 'schedule' || inputs.speed-of-light }}
+      # Off for the scheduled nightly until the warehouse key is authorised.
+      # A scheduled run has no inputs, so the expression falls through to false.
+      upload-to-warehouse: ${{ inputs.upload-to-warehouse || false }}
     secrets: inherit
 
   llk-perf-summary:

--- a/.github/workflows/llk-perf.yaml
+++ b/.github/workflows/llk-perf.yaml
@@ -26,6 +26,11 @@ on:
         required: false
         default: false
         type: boolean
+      only-group:
+        description: "Run only this split group (1-5). Empty runs every group."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   checks: write
@@ -50,6 +55,8 @@ jobs:
       # scheduled run has no inputs, so the expression falls through to false.
       # Turning it on for every night is this one expression -> true.
       upload-to-warehouse: ${{ inputs.upload-to-warehouse || false }}
+      # Empty for a scheduled run, which therefore keeps every group.
+      only-group: ${{ inputs.only-group || '' }}
     secrets: inherit
 
   llk-perf-summary:


### PR DESCRIPTION
This is how the LLK perf nightly uploads to the warehouse, and
where it stops. Not for merge until the login works.

## The failing run

**https://github.com/tenstorrent/tt-metal/actions/runs/33611787902/job/100201452119**

`Collect the run Parquets` — success, files present.
`Upload over SFTP` — failure:

256 SHA256:3zG3UStNf/ZcZUzM3ycqSTWeCETKeX8/ttid9oSKdMY [nstojic@tenstorrent.com](mailto:nstojic@tenstorrent.com) (ED25519)
debug1: Authenticating to s-dbd4b8a190fa40a4b...:22 as 'llk-perf-run'
debug1: Offering public key: id_key ED25519 SHA256:3zG3UStNf/ZcZUzM3ycqSTWeCETKeX8/ttid9oSKdMY
debug1: Authentications that can continue: publickey
llk-perf-run@s-dbd4b8a190fa40a4b...: Permission denied (publickey).



The runner has no ssh-agent and no `~/.ssh`, so the only key offered is the one
from our secret, and its fingerprint is printed before the connection. It is
the key from data_iac#655 (`ssh_public_keys.nikola_stojic`).

That run used an earlier commit on this branch, which inlined `sftp -v` so the
transcript would be readable. The step now calls the shared action; see below.

## What the job does

1. `actions/download-artifact` — pull this run's `perf-data-*` artefacts.
2. Collect every shard's Parquet into `generated/llk_perf/`, prefixed
   `llk_perf_`, matching `generated/benchmark_data/` and friends.
3. `./.github/actions/upload-data-via-sftp` with our own batchfile:

put -r generated/llk_perf/*.parquet
ls -hal



`ls -hal` is last, and `sftp -b` stops at the first failed command, so a
listing in the log is proof every `put` succeeded.

Host and user are literals in the diff — neither is a credential, and you need
to be able to read what we connect as. Only the key is a secret.

## Two config notes

**1. The user name.** We were given `llk-perf-run`. The real user is
`llk-perf-run-writer` — `aws_transfer_user` sets
`user_name = "${block.name}-${block.permission}"`
([main.tf L127-134](https://github.com/tenstorrent/data_iac/blob/5c7105d1120b2391adb1c8d33236fae52d465d81/terraform/resources/aws_sftp/main.tf#L127-L134),
its own comment: `user_name ex: cicd + "-" + reader`). `llk-perf-run` is only
the `project` tag. **Both spellings are refused today.**

**2. It looks like the `aws_sftp` apply is pending.** `aws_transfer_server`
exists in exactly one file in data_iac, one state file, no tfvars — so all 38
SFTP users share one server. `cicd` is entry ~14 in that same `sftp_users`
list, and tt-metal's `_produce-data.yaml` uploads as `cicd-writer` to that
server several times an hour, successfully. `llk-perf-run` is the last entry,
added when #655 merged on Aug 28, and is the only one refused. So the server,
the keys and the mechanism all work — our entry just does not seem to be live.

Could you run `terraform apply` on `terraform/resources/aws_sftp`?

Or, if that needs a window: the `llk_perf_run` Airflow asset watches the
**bucket**, not SFTP
(`create_s3_ingest_asset(bucket_name="ttdata-data-pipeline-llk-perf-run-ingest")`).
Write access to that bucket, or you dropping 30 ready Parquet files in it for
me (8.5 MB, 648,915 rows from the Aug 28 / Aug 29 / Sep 1 nightlies), unblocks
us today without any SFTP change.

## Safety while the login is broken

- `upload-to-warehouse` is a dispatch input, default `false`, and a scheduled
  run has no inputs — so the 03:00 nightly is untouched.
- No `continue-on-error`: a refused login fails the job and fails the run.
- `only-group` runs one shard instead of ten, so testing this costs one machine
  for ~42 minutes instead of ten for two hours.

## Related

- `nstojictt/perf-run-id-per-file` — `run_id` unique per file, so your
  `REPLAY_KEY = "RUN_ID"` delete-then-insert does not make our ten shards
  overwrite each other; and `PIPELINE` lowercased to `pr` to match your rows.
- `nstojictt/perf-sftp-backfill` — the CLI that loads the older nights.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-nightly-warehouse-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-nightly-warehouse-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-nightly-warehouse-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-nightly-warehouse-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-nightly-warehouse-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-nightly-warehouse-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-nightly-warehouse-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-nightly-warehouse-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-nightly-warehouse-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-nightly-warehouse-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-nightly-warehouse-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-nightly-warehouse-upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-nightly-warehouse-upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-nightly-warehouse-upload)