### PR TITLE
[Bug fix] matmul: drain the last-K-tile padding stores before the in0 multicast reads them

### DIFF
--- a/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
@@ -5,6 +5,13 @@
 #pragma once
 
 #include <tt-metalium/constants.hpp>
+#if !defined(ARCH_QUASAR)
+// ckernel::load_blocking (the store drain in drain_pad_stores) is WH/BH only: Quasar's ckernel.h has no
+// load_blocking, and from a data-movement build it #errors unless COMPILE_FOR_TRISC is defined. The Quasar
+// branch below uses a plain volatile load instead, so the header is not needed there. Same guard as
+// data_movement/common/kernels/common.hpp.
+#include "ckernel.h"
+#endif
 
 /**
  * @brief Pads a face within a tile.
@@ -360,6 +367,55 @@ constexpr uint32_t blockfloat_mantissa_bits() {
 }
 
 /**
+ * @brief Bytes occupied by one padded tile of the given format.
+ */
+template <DataFormat data_format>
+constexpr uint32_t padded_tile_bytes() {
+    using namespace tt::constants;
+    constexpr uint32_t elems = TILE_HEIGHT * TILE_WIDTH;
+    constexpr uint32_t mantissa_bits = blockfloat_mantissa_bits<data_format>();
+    if constexpr (data_format == DataFormat::Float32) {
+        return elems * sizeof(uint32_t);
+    } else if constexpr (mantissa_bits > 0) {
+        // exponent section (one byte per face row) + packed mantissas
+        constexpr uint32_t num_faces = (TILE_WIDTH / FACE_WIDTH) * (TILE_HEIGHT / FACE_HEIGHT);
+        return num_faces * FACE_HEIGHT + elems * mantissa_bits / BITS_PER_BYTE;
+    } else {
+        return elems * sizeof(uint16_t);
+    }
+}
+
+/**
+ * @brief Forces the padding stores of one tile to be processed by L1 before the caller hands the
+ * tile to another L1 client (the NoC multicast in the matmul in0 senders).
+ *
+ * The padding is written with baby-RISCV stores. A store can retire before its write-request
+ * reaches L1, and the RISCV core and the NoC are different L1 clients with no program-order
+ * guarantee between them (tt-isa-documentation TensixTile/BabyRISCV/MemoryOrdering.md: "there is
+ * no general mechanism to ensure that a store's write-request has been processed before a
+ * subsequent memory operation's request is emitted"). A blocking load of an address this core has
+ * just stored to is processed by L1 only after that store, and the RISCV's L1 access port
+ * processes its requests in order, so reading back the tile's last word orders every earlier
+ * padding store ahead of whatever the caller issues next. Same construction as #50374
+ * (deepseek_grouped_gate) and the pad reader's loop-back guard.
+ *
+ * Every padding pattern writes the tile's last word: right padding covers column 31 of every row,
+ * bottom padding covers row 31, and the block-float variants zero the mantissa of face 3, row 15,
+ * column 15 in both cases.
+ */
+template <DataFormat data_format>
+inline void drain_pad_stores(uint32_t l1_tile_ptr) {
+    constexpr uint32_t last_word = padded_tile_bytes<data_format>() - sizeof(uint32_t);
+    volatile tt_l1_ptr uint32_t* drain_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_tile_ptr + last_word);
+#if defined(ARCH_QUASAR)
+    // Quasar has no ckernel::load_blocking; a volatile load is the local ordering barrier there.
+    (void)*drain_ptr;
+#else
+    (void)ckernel::load_blocking(drain_ptr);
+#endif
+}
+
+/**
  * @brief Pads the last K tile in a matrix multiplication operation.
  *
  * This function handles padding for the last K tile in a matrix multiplication operation.
@@ -386,6 +442,7 @@ void pad_last_ktile(uint32_t l1_write_addr_in0) {
         fill_pad_tile_blockfloat<mantissa_bits, in0_last_ktile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(
             l1_write_addr_in0);
     }
+    drain_pad_stores<in0_data_format>(l1_write_addr_in0);
 }
 
 /**
@@ -415,4 +472,5 @@ void pad_last_transposed_ktile(uint32_t l1_write_addr_in0) {
         fill_pad_tile_blockfloat<mantissa_bits, /*num_elements_unpadded_w=*/TILE_WIDTH, in0_last_ktile_h>(
             l1_write_addr_in0);
     }
+    drain_pad_stores<in0_data_format>(l1_write_addr_in0);
 }


### PR DESCRIPTION
## PR Category

Bug fix (store visibility).

## Summary

Fixes #55141, which carries the analysis and the scope.

When K is not a multiple of 32, the in0 multicast senders zero the padding of the last K tile with baby-RISCV stores and then point the NoC at that block. A store can retire before its write-request reaches L1, and the RISCV core and the NoC are different L1 clients with no program-order guarantee between them, so the multicast can publish a partially written tile.

`tt-isa-documentation`'s `TensixTile/BabyRISCV/MemoryOrdering.md` §"Enforcing stronger ordering" is explicit that emission order and processing order are different things:

> There is no _general_ mechanism to ensure that a store's write-request has been processed before a subsequent memory operation's request is emitted.

and the one construction it prescribes is a readback from the same address. `pad_last_ktile` and `pad_last_transposed_ktile` now end with `drain_pad_stores<data_format>()`, a blocking load of the tile's last word. Every padding pattern writes that word: right padding covers column 31 of every row, bottom padding covers row 31, and the block-float variants zero the mantissa of face 3 row 15 column 15 in both cases.

This is the guard #50374 established for the same hazard in `deepseek_grouped_gate`, which the tree now carries in nine kernels; these three senders, the most-used multicast in the tree, did not have it.

One header, so every caller is covered.

## Cost

One blocking load per padded tile per block, and only when `K % 32 != 0`. No path that did not already call these functions gains an instruction.

## Verified

P300 (Blackhole), this branch rebased onto `afea9f7bea1`:

`tests/ttnn/unit_tests/operations/matmul/test_matmul.py -k test_matmul_padding` — **12 passed** (the `dram_sharded`, `multicast1d_sharded`, `multicast1d` and `reuse` configs x no / 1-face / 2-face padding).

## Not verified

- **No failing test demonstrates the bug**, for the reason #50374 gives: the window is a few L1-port cycles and there is no lever to delay a baby-RISCV store. This is filed and fixed as the class, on the same footing as #50374.
- **The Quasar branch is untested.** `ckernel::load_blocking` is WH/BH only, so `drain_pad_stores` has an `#if defined(ARCH_QUASAR)` arm using a plain volatile load, the same split `data_movement/common/kernels/common.hpp` already uses. On Blackhole only the `#else` arm compiles, so the Quasar arm has not been built or run here.
- Wormhole: the ordering rule is the same on both arch pages of `MemoryOrdering.md` and the guard is arch-neutral, but tests were run on Blackhole only.

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `afea9f7bea1`
* Hardware: P300 (Blackhole)
