### PR TITLE
[Bug fix] full / pad / index_fill: drain RISC fills before the NoC reads them

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -10,6 +11,12 @@
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
+#if !defined(ARCH_QUASAR)
+// ckernel::load_blocking (the store drain below) is WH/BH only: Quasar's ckernel.h has no load_blocking,
+// and from a data-movement build it #errors unless COMPILE_FOR_TRISC is defined. The Quasar branch uses a
+// plain volatile load instead. Same guard as data_movement/common/kernels/common.hpp.
+#include "ckernel.h"
+#endif
 
 inline __attribute__((always_inline)) void fill_pad_dfb_with_val(
     Noc& noc, DataflowBuffer& dfb, const uint32_t num_bytes_risc, uint32_t num_noc_transfer, const uint32_t val) {
@@ -18,6 +25,18 @@ inline __attribute__((always_inline)) void fill_pad_dfb_with_val(
     for (uint32_t i = 0; i < num_bytes_risc / 2; ++i) {
         ptr[i] = val;
     }
+    // The seed above is baby-RISCV stores and the loop-back noc.async_read below uses it as its source.
+    // A store can retire before its write-request lands in L1, and the RISCV core and the NoC are
+    // different L1 clients with no program-order guarantee between them
+    // (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). Read back the last seeded word so the seed
+    // is processed before the first loop-back read is issued. Same guard as the interleaved reader of
+    // this op (reader_pad_dims_rm_interleaved_v2.cpp) and #50374.
+#if defined(ARCH_QUASAR)
+    // Quasar has no ckernel::load_blocking; a volatile load is the local ordering barrier there.
+    (void)*(ptr + (num_bytes_risc / 2) - 1);
+#else
+    (void)ckernel::load_blocking(ptr + (num_bytes_risc / 2) - 1);
+#endif
 
     uint32_t pad_val_addr = dfb.get_write_ptr();
     uint32_t l1_write_addr = pad_val_addr;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
@@ -3,12 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
+#if !defined(ARCH_QUASAR)
+// ckernel::load_blocking (the store drain below) is WH/BH only: Quasar's ckernel.h has no load_blocking,
+// and from a data-movement build it #errors unless COMPILE_FOR_TRISC is defined. The Quasar branch uses a
+// plain volatile load instead. Same guard as data_movement/common/kernels/common.hpp.
+#include "ckernel.h"
+#endif
 
 void kernel_main() {
     const auto num_unpadded_W = get_arg(args::num_unpadded_W);
@@ -38,6 +45,17 @@ void kernel_main() {
     for (uint32_t z = 0; z < num_elems; z++) {
         pad_buffer[z] = pad_value;
     }
+    // The fill above is baby-RISCV stores and pad_tiles() below hands this buffer to the NoC as the
+    // source of every pad-tile write. A store can retire before its write-request lands in L1, and the
+    // RISCV core and the NoC are different L1 clients with no program-order guarantee between them
+    // (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). Read back the last filled word so the fill
+    // is processed before the first NoC write is issued. Same construction as #50374.
+#if defined(ARCH_QUASAR)
+    // Quasar has no ckernel::load_blocking; a volatile load is the local ordering barrier there.
+    (void)*(pad_buffer + num_elems - 1);
+#else
+    (void)ckernel::load_blocking(pad_buffer + num_elems - 1);
+#endif
 
     uint32_t src_tile_id = 0;
     uint32_t dst_tile_id = 0;

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/full_kernel_common.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/full_kernel_common.hpp
@@ -4,7 +4,14 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/dataflow/dataflow_buffer.h"
+#if !defined(ARCH_QUASAR)
+// ckernel::load_blocking (the store drain below) is WH/BH only: Quasar's ckernel.h has no load_blocking,
+// and from a data-movement build it #errors unless COMPILE_FOR_TRISC is defined. The Quasar branch uses a
+// plain volatile load instead. Same guard as data_movement/common/kernels/common.hpp.
+#include "ckernel.h"
+#endif
 
 union value {
     float f;
@@ -20,4 +27,19 @@ inline void zero_buffer(const DataflowBuffer& dfb, uint32_t bytes) {
     Noc noc;
     noc.async_write_zeros(dfb, bytes);
     noc.write_zeros_l1_barrier();
+}
+
+// The non-zero fill is baby-RISCV stores and the page is then handed to the NoC as the source of
+// every output write. A store can retire before its write-request reaches L1, and the RISCV core
+// and the NoC are different L1 clients with no program-order guarantee between them
+// (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). Read back the last word of the page: the
+// RISCV's L1 port processes its requests in order, so once that load returns every fill store has
+// landed. Same construction as #50374 (deepseek_grouped_gate) and the pad reader's loop-back guard.
+inline void drain_fill_stores(uint32_t write_addr, uint32_t bytes) {
+#if defined(ARCH_QUASAR)
+    // Quasar has no ckernel::load_blocking; a volatile load is the local ordering barrier there.
+    (void)*(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr + bytes - 4));
+#else
+    (void)ckernel::load_blocking(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr + bytes - 4));
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
@@ -51,6 +51,7 @@ void kernel_main() {
             ptr[i] = val.f;
         }
 #endif
+        drain_fill_stores(write_addr, page_size);
     }
 
     dfb.push_back(1);

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_nd_sharded.cpp
@@ -52,6 +52,7 @@ void kernel_main() {
             ptr[i] = val.f;
         }
 #endif
+        drain_fill_stores(write_addr, page_size);
     }
 
     dfb.push_back(1);

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full_sharded.cpp
@@ -53,6 +53,7 @@ void kernel_main() {
             ptr[i] = val.f;
         }
 #endif
+        drain_fill_stores(write_addr, page_size);
     }
 
     dfb.push_back(1);

--- a/ttnn/cpp/ttnn/operations/index_fill/device/kernels/writer_index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/kernels/writer_index_fill.cpp
@@ -6,7 +6,14 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#if !defined(ARCH_QUASAR)
+// ckernel::load_blocking (the store drain below) is WH/BH only: Quasar's ckernel.h has no load_blocking,
+// and from a data-movement build it #errors unless COMPILE_FOR_TRISC is defined. The Quasar branch uses a
+// plain volatile load instead. Same guard as data_movement/common/kernels/common.hpp.
+#include "ckernel.h"
+#endif
 #include <algorithm>
+#include <cstdint>
 
 bool contains_element(uint32_t* arr, uint32_t size, uint32_t val) {
     return std::find(arr, arr + size, val) != arr + size;
@@ -66,6 +73,17 @@ void kernel_main() {
         for (uint32_t i = 0; i < row_size; ++i) {
             fill_ptr[i] = fill_value;
         }
+        // The fill is baby-RISCV stores and the page is the NoC's source for every filled row below.
+        // A store can retire before its write-request lands in L1, and the RISCV core and the NoC are
+        // different L1 clients with no program-order guarantee between them
+        // (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). Read back the last filled element so
+        // the fill is processed before the first NoC write is issued. Same construction as #50374.
+#if defined(ARCH_QUASAR)
+        // Quasar has no ckernel::load_blocking; a volatile load is the local ordering barrier there.
+        (void)*(fill_ptr + row_size - 1);
+#else
+        (void)ckernel::load_blocking(fill_ptr + row_size - 1);
+#endif
     }
     cb_fill.push_back(onepage);
 
@@ -104,11 +122,24 @@ void kernel_main() {
             // so all matching indices are filled before the page is split into output writes.
             if constexpr (is_last_dim) {
                 auto* input_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(input_addr);
+                volatile tt_l1_ptr IntType* last_written = nullptr;
                 for (uint32_t i = 0; i < index_size; ++i) {
                     uint32_t global_col = index_ptr[i];
                     if (global_col >= col_start && global_col < col_start + row_size) {
-                        input_ptr[global_col - col_start] = fill_value;
+                        last_written = input_ptr + (global_col - col_start);
+                        *last_written = fill_value;
                     }
+                }
+                // These are baby-RISCV stores into the page the NoC writes out immediately below; the
+                // store queue can still hold them when the NoC command is issued (MemoryOrdering.md).
+                // Read the last one back so all of them are processed first. Same construction as #50374.
+                if (last_written != nullptr) {
+#if defined(ARCH_QUASAR)
+                    // Quasar has no ckernel::load_blocking; a volatile load is the local ordering barrier there.
+                    (void)*(last_written);
+#else
+                    (void)ckernel::load_blocking(last_written);
+#endif
                 }
             }
 


### PR DESCRIPTION
## PR Category

Bug fix (store visibility).

## Summary

Fixes #55142, which carries the site-by-site analysis.

`full`, `pad` and `index_fill` build a page with baby-RISCV stores and then point the NoC at that page — as the source of a write to DRAM, or of the loop-back reads that replicate it. A store can retire before its write-request reaches L1, and the RISCV core and the NoC are different L1 clients with no program-order guarantee between them, so the NoC can read a partially written page.

`tt-isa-documentation`'s `TensixTile/BabyRISCV/MemoryOrdering.md` §"Enforcing stronger ordering":

> There is no _general_ mechanism to ensure that a store's write-request has been processed before a subsequent memory operation's request is emitted.

and it prescribes a readback from the same address. That is the guard #50374 established for `deepseek_grouped_gate`, and which the interleaved-v2 reader of `pad` already carries; these five sites in the same and neighbouring ops did not.

| site | what sat between the stores and the NoC |
|---|---|
| `full/.../writer_full.cpp`, `writer_full_sharded.cpp`, `writer_full_nd_sharded.cpp` | `push_back` / `wait_front` — stream-register traffic, not a readback |
| `pad/.../writer_unary_pad_dims_interleaved.cpp` | nothing |
| `pad/.../writer_pad_dims_rm_sharded.cpp` | nothing (the interleaved-v2 reader of the same op guards the same loop-back construction) |
| `index_fill/.../writer_index_fill.cpp`, pre-fill | `push_back` / `wait_front` |
| `index_fill/.../writer_index_fill.cpp`, per-row scatter | nothing — the tightest window of the set |

Added: `drain_fill_stores()` in `full_kernel_common.hpp` for the three `full` writers, a readback of the last pad word in the tiled pad writer, one of the last seed word before the loop-back reads in the rm-sharded pad writer, and in `index_fill` one after the pre-fill plus one of the last scattered element — tracked in a pointer, since which columns are written is data-dependent.

## Cost

One blocking load per filled page. All of them sit outside the per-stick / per-tile loops except the `index_fill` scatter guard, which is one load per output page.

## Verified

P300 (Blackhole), this branch rebased onto `afea9f7bea1`:

* `tests/ttnn/unit_tests/operations/data_movement/test_full.py` — **864 passed**
* `tests/ttnn/unit_tests/operations/data_movement/test_pad.py` — **632 passed**, 81 skipped, 6 xfailed
* `tests/ttnn/nightly/unit_tests/operations/data_movement/test_index_fill.py` — **162 passed**, 36 skipped

## Not verified

- **No failing test demonstrates the bug**, per #50374's own argument: the window is a few L1-port cycles and there is no lever to delay a baby-RISCV store. Fixed as the class.
- **The Quasar arms are untested.** `ckernel::load_blocking` is WH/BH only, so each guard has an `#if defined(ARCH_QUASAR)` arm using a plain volatile load — the same split `data_movement/common/kernels/common.hpp` already uses, and the reason the `ckernel.h` includes are guarded too. On Blackhole only the `#else` arm compiles, so the Quasar arms have not been built or run here.
- Wormhole: the ordering rule is the same on both arch pages and the guard is arch-neutral, but tests were run on Blackhole only.

## Noted in passing, not fixed

`writer_pad_dims_rm_sharded.cpp` writes `num_bytes_risc / 2` **words**, i.e. twice the bytes its name says, and its first loop-back read copies the seed onto itself. Harmless, and left alone to keep this change to the one concern.

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `afea9f7bea1`
* Hardware: P300 (Blackhole)
