### PR TITLE
[LLK] Restore tanhshrink Newton iterations to 2

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -59,10 +59,7 @@ inline void calculate_tanhshrink() {
                 sfpi::vFloat axc = ax;
                 axc = sfpi::min(axc, 9.0f);
                 sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
-                // Denominator 1+e is provably well-conditioned here: |x|>1 so
-                // e = exp(-2|x|) in (0, e^-2], giving 1+e in [1, 1+e^-2] >= 1.
-                // A single Newton refinement therefore suffices (2->1 iterations).
-                sfpi::vFloat sig = sfpu_reciprocal_iter<1>(1.0f + e);  // sigmoid(2|x|)
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(1.0f + e);  // sigmoid(2|x|)
                 sfpi::vFloat tanh_ax = 2.f * sig - 1.0f;               // tanh(|x|)
                 result = sfpi::copysgn(ax - tanh_ax, x);
             } else {


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #54430.

The Wormhole `tanhshrink` fp32 path (`is_fp32_dest_acc_en=true`) was calling
`sfpu_reciprocal_iter<1>` on its `|x|>1` branch. Per `ckernel_sfpu_recip.h`'s own
contract, `<1>` is the bfloat16/float16 variant and `<2>` is the one documented as
sufficient for float32:

```
// max_iter = 2: sufficient for float32 precision (<=1 ulps).
// max_iter = 1: sufficient for bfloat16/float16 precision (<=0.5 ulps).
```

I introduced this in #48925, reasoning that "Denominator 1+e is provably
well-conditioned here ... A single Newton refinement therefore suffices". The
conditioning premise is correct — `1+e` is in `[1, 1+e^-2]` — but it is the wrong
premise. Newton's convergence is quadratic in the *seed's* relative error, which the
denominator's conditioning does not improve. The seed is a degree-2 minimax fit at
~1e-2, so one step reaches ~1e-4 and two reach ~1e-7; fp32 eps is 1.19e-7, so two
steps is the first that reaches fp32 precision and one does not. That is also why the
otherwise byte-identical Blackhole copy of this file kept `<2>`.

This restores `<2>`, and drops the three comment lines from #48925 that asserted one
step suffices. The Wormhole and Blackhole copies of `ckernel_sfpu_tanhshrink.h` are
now byte-identical again, which was the case before #48925 and is worth keeping:
across all 107 kernels present in both `wormhole_b0` and `blackhole`, this was the
only iteration-count divergence between the two architectures.

Thanks to @tzh476 for the report, the root-cause analysis, and the error-chain
derivation — all of which this summary follows.

### Measured on device

A/B on a Wormhole n300, `Float32 -> Float32` with `dest_acc=Yes`, 16,380 finite
points concentrated just above `|x|=1` and spread over `(1, 9]`. Golden is mpmath at
200-bit precision, correctly rounded to fp32. `/tmp/tt-llk-build` wiped between the
two builds, since the ELF cache does not key on header content.

| | max ULP | mean ULP | fraction >2 ULP |
|---|---|---|---|
| `<1>` (as merged), \|x\|>1 | 4893 | 1588.62 | 99.41% |
| `<2>` (this PR), \|x\|>1 | **12** | **1.24** | 16.01% |
| `<1>` / `<2>`, \|x\|<=1 (control) | 3 / 3 | 0.41 / 0.41 | 0.10% |

Worst large-path point, `x = 1.0000093`: **4893 -> 5 ULP**.

The reporter's independent host reimplementation predicted 4896 -> 15 ULP over an
exhaustive sweep of all 26,214,399 fp32 values in `(1.0, 9.0]`; the silicon agrees
with that model.

Scope is confined to the fp32 `|x|>1` branch, as intended:

- the `|x|<=1` polynomial path is unchanged (3 ULP in both builds);
- `+/-inf`, `NaN` and `1e30` produce identical results in both builds;
- the bf16 path is bit-identical across 16,381 points.

### Performance cost

`MATH_ISOLATE`, `perf_eltwise_unary_sfpu` with `mathop:Tanhshrink dest_acc:Yes
approx_mode:No`:

| | cycles |
|---|---|
| `<1>` (as merged) | 405,069 |
| `<2>` (this PR) | 422,897 |

**+4.4%** on the fp32-dest path. That is the real cost of the second Newton step and
I think it is clearly worth paying for 4893 -> 12 ULP, but flagging it explicitly
rather than leaving it for someone to find. The bf16 path is untouched and pays
nothing.

### Notes for reviewers

The part I would most like a second opinion on is not the one-line change but the CI
gap that let #48925 through.

The only ULP guard for this op, `test_tanhshrink_ulp` in
`tests/ttnn/unit_tests/operations/eltwise/test_activation.py`, builds its input as
`dtype=torch.bfloat16` and gates at 2 ULP. It cannot see this class of regression at
all: one bf16 ULP is 2^16 fp32 ULP, so a 4893-fp32-ULP error rounds away to nothing
before the assertion. Nothing else in the tree exercises this branch at ULP
granularity, so the same edit could land again tomorrow with CI green.

I have deliberately kept this PR to the revert alone. Happy to add an fp32
counterpart to that guard — a handful of points just above 1.0 with `ttnn.float32`,
gated at ~16 ULP, which would have failed on #48925 — either here or as a follow-up,
whichever reviewers prefer.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/fix_tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/fix_tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/fix_tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/fix_tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/fix_tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/fix_tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/fix_tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/fix_tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/fix_tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/fix_tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/fix_tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/fix_tanhshrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/fix_tanhshrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/fix_tanhshrink)
