### PR TITLE
Parse the counter config word layout from counters.h instead of hand-copying it

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
@@ -22,15 +22,6 @@ COUNTER_BANK_NAMES = {
     4: "TDMA_PACK",
 }
 
-# Config word layout (must match counters.h:
-# PERF_CFG_VALID_BIT / PERF_CFG_L1_MUX_SHIFT / PERF_CFG_COUNTER_SHIFT / PERF_CFG_BANK_MASK).
-PERF_CFG_VALID_BIT = 1 << 31
-PERF_CFG_L1_MUX_SHIFT = 17
-PERF_CFG_L1_MUX_MASK = 0x7
-PERF_CFG_COUNTER_SHIFT = 8
-PERF_CFG_COUNTER_MASK = 0x1FF
-PERF_CFG_BANK_MASK = 0xFF
-
 
 # --- Counter id -> name tables, parsed live from the canonical metal hw_counters.h ---
 
@@ -54,6 +45,32 @@ def _metal_root() -> Path:
     raise RuntimeError(
         "Could not locate tt_metal/hw/inc/internal/tt-1xx above this file"
     )
+
+
+def _parse_perf_cfg(text: str) -> dict:
+    """PERF_CFG_* constants from counters.h: a literal or literal << literal, u/U suffixes allowed."""
+    cfg = {}
+    for name, expr in re.findall(r"PERF_CFG_([A-Z0-9_]+)\s*=\s*([^;]+);", text):
+        expr = re.sub(r"(0[xX][0-9a-fA-F]+|\d+)[uUlL]+", r"\1", expr).strip()
+        m = re.fullmatch(r"(0[xX][0-9a-fA-F]+|\d+)(?:\s*<<\s*(\d+))?", expr)
+        if m is None:
+            raise RuntimeError(
+                f"PERF_CFG_{name} in counters.h is not a plain literal or shift: {expr!r}"
+            )
+        cfg[name] = int(m.group(1), 0) << int(m.group(2) or "0")
+    return cfg
+
+
+# Config word layout, parsed from the device-side header so the two cannot drift apart.
+_PERF_CFG = _parse_perf_cfg(
+    (_metal_root() / "tt_metal/tt-llk/tests/helpers/include/counters.h").read_text()
+)
+PERF_CFG_VALID_BIT = _PERF_CFG["VALID_BIT"]
+PERF_CFG_L1_MUX_SHIFT = _PERF_CFG["L1_MUX_SHIFT"]
+PERF_CFG_L1_MUX_MASK = _PERF_CFG["L1_MUX_MASK"]
+PERF_CFG_COUNTER_SHIFT = _PERF_CFG["COUNTER_SHIFT"]
+PERF_CFG_COUNTER_MASK = _PERF_CFG["COUNTER_MASK"]
+PERF_CFG_BANK_MASK = _PERF_CFG["BANK_MASK"]
 
 
 def _parse_hw_counters(text: str) -> dict:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
@@ -47,17 +47,20 @@ def _metal_root() -> Path:
     )
 
 
+_C_LITERAL = r"0[xX][0-9a-fA-F]+|\d+"
+
+
 def _parse_perf_cfg(text: str) -> dict:
     """PERF_CFG_* constants from counters.h: a literal or literal << literal, u/U suffixes allowed."""
     cfg = {}
     for name, expr in re.findall(r"PERF_CFG_([A-Z0-9_]+)\s*=\s*([^;]+);", text):
-        expr = re.sub(r"(0[xX][0-9a-fA-F]+|\d+)[uUlL]+", r"\1", expr).strip()
-        m = re.fullmatch(r"(0[xX][0-9a-fA-F]+|\d+)(?:\s*<<\s*(\d+))?", expr)
+        expr = re.sub(rf"({_C_LITERAL})[uUlL]+", r"\1", expr).strip()
+        m = re.fullmatch(rf"({_C_LITERAL})(?:\s*<<\s*({_C_LITERAL}))?", expr)
         if m is None:
             raise RuntimeError(
                 f"PERF_CFG_{name} in counters.h is not a plain literal or shift: {expr!r}"
             )
-        cfg[name] = int(m.group(1), 0) << int(m.group(2) or "0")
+        cfg[name] = int(m.group(1), 0) << int(m.group(2) or "0", 0)
     return cfg
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
-from helpers.counters import _parse_perf_cfg
+from helpers.counters import _metal_root, _parse_perf_cfg
 from helpers.llk_params import ApproximationMode, DestAccumulation, PerfRunType
 from helpers.perf.core import (
     PerfConfig,
@@ -796,12 +796,8 @@ def _cfg_header(*lines):
 
 def test_perf_cfg_matches_the_device_header():
     # Parity with the values counters.py used to hand-copy from counters.h.
-    assert _parse_perf_cfg(
-        (
-            Path(os.environ["TT_METAL_HOME"])
-            / "tt_metal/tt-llk/tests/helpers/include/counters.h"
-        ).read_text()
-    ) == {
+    header = _metal_root() / "tt_metal/tt-llk/tests/helpers/include/counters.h"
+    assert _parse_perf_cfg(header.read_text()) == {
         "VALID_BIT": 1 << 31,
         "L1_MUX_SHIFT": 17,
         "L1_MUX_MASK": 0x7,

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+from helpers.counters import _parse_perf_cfg
 from helpers.llk_params import ApproximationMode, DestAccumulation, PerfRunType
 from helpers.perf.core import (
     PerfConfig,
@@ -787,3 +788,55 @@ def test_catalog_check_skips_a_base_name_with_no_entry():
     # The static gate already fails a perf test missing from the catalog, and
     # combine globs whatever is on disk, so this must not fail a partial run.
     _assert_matches_catalog(_frame(), "perf_absent_from_catalog", "x.csv")
+
+
+def _cfg_header(*lines):
+    return "\n".join(f"constexpr std::uint32_t PERF_CFG_{line};" for line in lines)
+
+
+def test_perf_cfg_matches_the_device_header():
+    # Parity with the values counters.py used to hand-copy from counters.h.
+    assert _parse_perf_cfg(
+        (
+            Path(os.environ["TT_METAL_HOME"])
+            / "tt_metal/tt-llk/tests/helpers/include/counters.h"
+        ).read_text()
+    ) == {
+        "VALID_BIT": 1 << 31,
+        "L1_MUX_SHIFT": 17,
+        "L1_MUX_MASK": 0x7,
+        "COUNTER_SHIFT": 8,
+        "COUNTER_MASK": 0x1FF,
+        "BANK_MASK": 0xFF,
+    }
+
+
+def test_perf_cfg_accepts_every_literal_form():
+    # Same value written four legal ways, including a hex shift operand.
+    assert _parse_perf_cfg(
+        _cfg_header(
+            "A = 1u << 31",
+            "B = 1 << 0x1Fu",
+            "C = 0x80000000u",
+            "D = 2147483648",
+        )
+    ) == {"A": 1 << 31, "B": 1 << 31, "C": 1 << 31, "D": 1 << 31}
+
+
+def test_perf_cfg_rejects_anything_it_cannot_parse():
+    # Silent mis-parsing is the failure this module exists to prevent, so a form
+    # outside the documented grammar must raise rather than yield a wrong number.
+    for expr in (
+        "A = (1u << 31)",
+        "A = 1u << 31 | 0x7u",
+        "A = VALID_BIT",
+        "A = 1u + 1u",
+    ):
+        with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+            RuntimeError, match="not a plain literal or shift"
+        ):
+            _parse_perf_cfg(_cfg_header(expr))
+
+
+def test_perf_cfg_missing_constant_is_absent_not_zero():
+    assert "VALID_BIT" not in _parse_perf_cfg(_cfg_header("BANK_MASK = 0xFFu"))


### PR DESCRIPTION
Fixes #55151.

The Python counter decode carried a hand copy of the config word bit layout under a comment saying it must match `counters.h`, with nothing checking that it did. If a shift or mask changed on the device side, the host would keep decoding config words on the old layout without a sound. The Tracy name table drifting from its enum already showed how quietly that class of bug lands, so this closes the same hole here.

The six constants are now parsed out of `counters.h` at import time, sitting next to the `hw_counters.h` name-table parser this file already has. The header expressions are a literal or a literal shifted by a literal; anything fancier fails the import with a message naming the constant, and a constant going missing fails on lookup. Neither case can silently fall back to stale numbers.

Verified:
- parsed values equal the old hand copy exactly, all six
- a synthetic fancy expression is rejected loudly, and a missing constant raises at import
- Blackhole run through producer and consumer with the change in place, counter columns populated

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-parse-config-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf-parse-config-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-parse-config-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf-parse-config-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf-parse-config-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf-parse-config-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf-parse-config-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf-parse-config-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf-parse-config-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf-parse-config-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf-parse-config-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf-parse-config-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf-parse-config-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf-parse-config-layout)