### PR TITLE
[Performance] MiniMax-M3 KV PCC: read one slot on device instead of 60 full-cache gathers

### DIFF
--- a/models/common/utils.py
+++ b/models/common/utils.py
@@ -51,3 +51,37 @@ def top_k_top_p_filtering(
         indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
         logits[indices_to_remove] = filter_value
     return logits
+
+
+def blockcyclic_positions(sp: int, chunk_size_global: int, seq_len_cache: int) -> torch.Tensor:
+    """Global natural position held by each block-cyclic shard row (device-major: an SP-contiguous
+    split of the cache's seq dim yields each chip's rows).
+
+    Shard row r -> chip c = r // seq_len_local, local row lr = r % seq_len_local, and that row holds
+    global position (lr // chunk_local) * chunk_size_global + c * chunk_local + (lr % chunk_local) --
+    the inverse of the update_padded_kv_cache writer. Returns a [seq_len_cache] index tensor.
+    """
+    seq_len_local = seq_len_cache // sp
+    chunk_local = chunk_size_global // sp
+    c = torch.arange(sp).repeat_interleave(seq_len_local)
+    lr = torch.arange(seq_len_local).repeat(sp)
+    slab, off = lr // chunk_local, lr % chunk_local
+    return slab * chunk_size_global + c * chunk_local + off
+
+
+def block_cyclic_reorder(matrix: torch.Tensor, chunk_local: int, sp_factor: int, seq_dim: int = 2) -> torch.Tensor:
+    """Reorder a [.., seq, ..] matrix into block-cyclic order keyed by `chunk_local`.
+
+    Splits the sequence into blocks of `chunk_local` rows and concatenates them so that device c's
+    contiguous shard (after a plain SP shard over `seq_dim`) holds blocks c, c+sp, c+2sp, ... — the
+    same block-cyclic layout the per-chip KV cache writes into. This makes the indexed-RoPE op's
+    contiguous, `update_idxt`-offset read of each device's cos/sin shard land on the right global
+    positions, including the boundary chip's older-then-wrap rows.
+    """
+    seq_len = matrix.shape[seq_dim]
+    assert seq_len % chunk_local == 0, f"seq_len {seq_len} must be a multiple of chunk_local {chunk_local}"
+    num_blocks = seq_len // chunk_local
+    assert num_blocks % sp_factor == 0, f"num_blocks {num_blocks} must be a multiple of sp_factor {sp_factor}"
+    blocks = list(torch.split(matrix, chunk_local, dim=seq_dim))
+    order = [b for c in range(sp_factor) for b in range(c, num_blocks, sp_factor)]
+    return torch.cat([blocks[b] for b in order], dim=seq_dim)

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -93,9 +93,10 @@ def plan(n_tokens, chunk_size, chunked):
 
 
 def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config):
-    """Per-layer K / V / index_k PCC: device cache (gather_layer) vs the golden trace. The device
-    stores K / index_k Meta-RoPE swizzled over the rotary slice; the golden is HF half-split, so
-    permute the golden's rotary slice (identity tail) before comparing. V is raw (no swizzle).
+    """Per-layer K / V / index_k PCC: device cache (one slot read, then host un-rotate) vs the golden
+    trace. The device stores K / index_k Meta-RoPE swizzled over the rotary slice; the golden is HF
+    half-split, so permute the golden's rotary slice (identity tail) before comparing. V is raw (no
+    swizzle).
 
     Fails if overall min PCC is below PREFILL_STANDALONE_CHUNKED_PCC (default 0.88), matching
     models/demos/minimax_m3/tt/runners/prefill_kv_validation.py.
@@ -103,6 +104,7 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
     from safetensors import safe_open
 
     from models.common.utility_functions import comp_pcc
+    from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions
 
     threshold = float(os.environ.get("PREFILL_STANDALONE_CHUNKED_PCC", "0.88"))
     head_dim = hf_config.head_dim
@@ -116,8 +118,17 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
     kv_dir = Path(golden_dir) / "kv_cache"
     logger.info(f"[kv-pcc] per-layer K / V / index_k vs golden ({golden_dir}):")
     mins = {"k": 1.0, "v": 1.0, "index_k": 1.0}
+    # One device slice + mesh compose per cache (read_slot_kv), not 60 full-buffer gathers.
+    p = blockcyclic_positions(runtime.config.sp_factor, runtime.config.chunk_size, runtime.config.max_seq_len)
+
+    def _naturalize(block):
+        nat = torch.empty_like(block)
+        nat[..., p, :] = block
+        return nat[..., :n_tokens, :]
+
+    k_nat, v_nat, ik_nat = (_naturalize(t) for t in runtime.read_slot_kv(kv_cache, 0))
     for L in range(num_layers):
-        dev_k, dev_v, dev_ik = runtime.gather_layer(kv_cache, slot_id=0, layer_idx=L, n_tokens=n_tokens)
+        dev_k, dev_v, dev_ik = k_nat[L].unsqueeze(0), v_nat[L].unsqueeze(0), ik_nat[L].unsqueeze(0)
         with safe_open(str(kv_dir / f"layer_{L}.safetensors"), framework="pt") as h:
             keys = set(h.keys())
             g_k = h.get_tensor(f"key_cache_layer_{L}").float()[:, :, :n_tokens, :][..., src]  # HF -> Meta

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -93,10 +93,13 @@ def plan(n_tokens, chunk_size, chunked):
 
 
 def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config):
-    """Per-layer K / V / index_k PCC: device cache (one slot read, then host un-rotate) vs the golden
-    trace. The device stores K / index_k Meta-RoPE swizzled over the rotary slice; the golden is HF
-    half-split, so permute the golden's rotary slice (identity tail) before comparing. V is raw (no
-    swizzle).
+    """Per-layer K / V / index_k PCC: device cache vs the golden trace. The device stores K / index_k
+    Meta-RoPE swizzled over the rotary slice; the golden is HF half-split, so permute the golden's
+    rotary slice (identity tail) before comparing. V is raw (no swizzle).
+
+    The whole slot is read back ONCE (``read_slot_kv``: a device-side slot slice plus one mesh compose
+    per cache) and each layer is un-rotated on host. Reading per layer instead would re-copy the packed
+    cache num_layers times over PCIe.
 
     Fails if overall min PCC is below PREFILL_STANDALONE_CHUNKED_PCC (default 0.88), matching
     models/demos/minimax_m3/tt/runners/prefill_kv_validation.py.
@@ -104,7 +107,6 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
     from safetensors import safe_open
 
     from models.common.utility_functions import comp_pcc
-    from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions
 
     threshold = float(os.environ.get("PREFILL_STANDALONE_CHUNKED_PCC", "0.88"))
     head_dim = hf_config.head_dim
@@ -118,17 +120,11 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
     kv_dir = Path(golden_dir) / "kv_cache"
     logger.info(f"[kv-pcc] per-layer K / V / index_k vs golden ({golden_dir}):")
     mins = {"k": 1.0, "v": 1.0, "index_k": 1.0}
-    # One device slice + mesh compose per cache (read_slot_kv), not 60 full-buffer gathers.
-    p = blockcyclic_positions(runtime.config.sp_factor, runtime.config.chunk_size, runtime.config.max_seq_len)
-
-    def _naturalize(block):
-        nat = torch.empty_like(block)
-        nat[..., p, :] = block
-        return nat[..., :n_tokens, :]
-
-    k_nat, v_nat, ik_nat = (_naturalize(t) for t in runtime.read_slot_kv(kv_cache, 0))
+    k_blk, v_blk, ik_blk = runtime.read_slot_kv(kv_cache, 0)  # still block-cyclic; un-rotated per layer below
     for L in range(num_layers):
-        dev_k, dev_v, dev_ik = k_nat[L].unsqueeze(0), v_nat[L].unsqueeze(0), ik_nat[L].unsqueeze(0)
+        dev_k = runtime.naturalize_kv_block(k_blk[L], n_tokens).unsqueeze(0)
+        dev_v = runtime.naturalize_kv_block(v_blk[L], n_tokens).unsqueeze(0)
+        dev_ik = runtime.naturalize_kv_block(ik_blk[L], n_tokens).unsqueeze(0)
         with safe_open(str(kv_dir / f"layer_{L}.safetensors"), framework="pt") as h:
             keys = set(h.keys())
             g_k = h.get_tensor(f"key_cache_layer_{L}").float()[:, :, :n_tokens, :][..., src]  # HF -> Meta

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -107,6 +107,7 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
     from safetensors import safe_open
 
     from models.common.utility_functions import comp_pcc
+    from models.demos.minimax_m3.tt.runners.prefill_kv_validation import naturalize_kv_block
 
     threshold = float(os.environ.get("PREFILL_STANDALONE_CHUNKED_PCC", "0.88"))
     head_dim = hf_config.head_dim
@@ -121,10 +122,11 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
     logger.info(f"[kv-pcc] per-layer K / V / index_k vs golden ({golden_dir}):")
     mins = {"k": 1.0, "v": 1.0, "index_k": 1.0}
     k_blk, v_blk, ik_blk = runtime.read_slot_kv(kv_cache, 0)  # still block-cyclic; un-rotated per layer below
+    sp, chunk, seq = runtime.config.sp_factor, runtime.config.chunk_size, runtime.config.max_seq_len
     for L in range(num_layers):
-        dev_k = runtime.naturalize_kv_block(k_blk[L], n_tokens).unsqueeze(0)
-        dev_v = runtime.naturalize_kv_block(v_blk[L], n_tokens).unsqueeze(0)
-        dev_ik = runtime.naturalize_kv_block(ik_blk[L], n_tokens).unsqueeze(0)
+        dev_k = naturalize_kv_block(k_blk[L], n_tokens, sp, chunk, seq).unsqueeze(0)
+        dev_v = naturalize_kv_block(v_blk[L], n_tokens, sp, chunk, seq).unsqueeze(0)
+        dev_ik = naturalize_kv_block(ik_blk[L], n_tokens, sp, chunk, seq).unsqueeze(0)
         with safe_open(str(kv_dir / f"layer_{L}.safetensors"), framework="pt") as h:
             keys = set(h.keys())
             g_k = h.get_tensor(f"key_cache_layer_{L}").float()[:, :, :n_tokens, :][..., src]  # HF -> Meta

--- a/models/demos/minimax_m3/tt/runners/prefill_kv_validation.py
+++ b/models/demos/minimax_m3/tt/runners/prefill_kv_validation.py
@@ -3,7 +3,8 @@
 
 """MiniMax-M3 KV-cache golden PCC validation (bring-up only — never used in serving).
 
-Per-layer K / V / index_k PCC: the device cache (``runtime.gather_layer``) vs the golden trace written
+Per-layer K / V / index_k PCC: the device cache (one ``runtime.read_slot_kv`` read-back, un-rotated per
+layer on host) vs the golden trace written
 by ``scripts/generate_golden_kv_cache.py`` (keys ``key/value/index_k_cache_layer_N``, HF layout). The
 device stores K / index_k Meta-RoPE swizzled over the rotary slice (``ModelArgs.load_state_dict`` ->
 ``convert_hf_qkv_to_meta_format_partial``), so we permute the golden's rotary slice (HF half-split ->
@@ -75,9 +76,14 @@ def kv_cache_pcc_check(
         f"{n_tokens} tokens, layers [{first_layer_idx}, {first_layer_idx + num_layers}):"
     )
     mins = {"k": 1.0, "v": 1.0, "index_k": 1.0}
+    # One slot read-back (device-side slice + one mesh compose per cache); each layer is un-rotated on
+    # host below. Reading per layer would re-copy the packed cache num_layers times over PCIe.
+    k_blk, v_blk, ik_blk = runtime.read_slot_kv(kv_cache, slot_id)
     for L in range(num_layers):
         gL = first_layer_idx + L  # device layer L == global (golden) layer first_layer_idx + L
-        dev_k, dev_v, dev_ik = runtime.gather_layer(kv_cache, slot_id=slot_id, layer_idx=L, n_tokens=n_tokens)
+        dev_k = runtime.naturalize_kv_block(k_blk[L], n_tokens).unsqueeze(0)
+        dev_v = runtime.naturalize_kv_block(v_blk[L], n_tokens).unsqueeze(0)
+        dev_ik = runtime.naturalize_kv_block(ik_blk[L], n_tokens).unsqueeze(0)
         with safe_open(str(kv_dir / f"layer_{gL}.safetensors"), framework="pt") as h:
             keys = set(h.keys())
             g_k = h.get_tensor(f"key_cache_layer_{gL}").float()[:, :, :n_tokens, :][..., src]  # HF -> Meta

--- a/models/demos/minimax_m3/tt/runners/prefill_kv_validation.py
+++ b/models/demos/minimax_m3/tt/runners/prefill_kv_validation.py
@@ -4,7 +4,7 @@
 """MiniMax-M3 KV-cache golden PCC validation (bring-up only — never used in serving).
 
 Per-layer K / V / index_k PCC: the device cache (one ``runtime.read_slot_kv`` read-back, un-rotated per
-layer on host) vs the golden trace written
+layer on host via ``naturalize_kv_block``) vs the golden trace written
 by ``scripts/generate_golden_kv_cache.py`` (keys ``key/value/index_k_cache_layer_N``, HF layout). The
 device stores K / index_k Meta-RoPE swizzled over the rotary slice (``ModelArgs.load_state_dict`` ->
 ``convert_hf_qkv_to_meta_format_partial``), so we permute the golden's rotary slice (HF half-split ->
@@ -23,7 +23,22 @@ import torch
 from loguru import logger
 
 from models.common.utility_functions import comp_pcc
+from models.common.utils import blockcyclic_positions
 from models.demos.common.prefill.runners.runner_utils import resolve_trace_dir
+
+
+def naturalize_kv_block(
+    block: torch.Tensor, n_tokens: int, sp_factor: int, chunk_size: int, max_seq_len: int
+) -> torch.Tensor:
+    """Un-rotate a host cache block from on-device block-cyclic seq order to NATURAL token order.
+
+    ``block`` is ``[..., seq_cache, head_dim]`` (seq is dim -2), the ConcatMesh2dToTensor layout.
+    Inverse of the ``update_padded_kv_cache`` writer. Returns ``[..., n_tokens, head_dim]``.
+    """
+    p = blockcyclic_positions(sp_factor, chunk_size, max_seq_len)
+    nat = torch.empty_like(block)
+    nat[..., p, :] = block
+    return nat[..., :n_tokens, :]
 
 
 def _hf_to_meta_rotary_perm(head_dim: int, rotary_dim: int) -> torch.Tensor:
@@ -79,11 +94,12 @@ def kv_cache_pcc_check(
     # One slot read-back (device-side slice + one mesh compose per cache); each layer is un-rotated on
     # host below. Reading per layer would re-copy the packed cache num_layers times over PCIe.
     k_blk, v_blk, ik_blk = runtime.read_slot_kv(kv_cache, slot_id)
+    sp, chunk, seq = runtime.config.sp_factor, chunk_size, runtime.config.max_seq_len
     for L in range(num_layers):
         gL = first_layer_idx + L  # device layer L == global (golden) layer first_layer_idx + L
-        dev_k = runtime.naturalize_kv_block(k_blk[L], n_tokens).unsqueeze(0)
-        dev_v = runtime.naturalize_kv_block(v_blk[L], n_tokens).unsqueeze(0)
-        dev_ik = runtime.naturalize_kv_block(ik_blk[L], n_tokens).unsqueeze(0)
+        dev_k = naturalize_kv_block(k_blk[L], n_tokens, sp, chunk, seq).unsqueeze(0)
+        dev_v = naturalize_kv_block(v_blk[L], n_tokens, sp, chunk, seq).unsqueeze(0)
+        dev_ik = naturalize_kv_block(ik_blk[L], n_tokens, sp, chunk, seq).unsqueeze(0)
         with safe_open(str(kv_dir / f"layer_{gL}.safetensors"), framework="pt") as h:
             keys = set(h.keys())
             g_k = h.get_tensor(f"key_cache_layer_{gL}").float()[:, :, :n_tokens, :][..., src]  # HF -> Meta

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -399,31 +399,62 @@ class TtPrefillRuntime:
         assert self.compiled, "Call compile() before set_layer_completion_sink()"
         self._layer_completion_sink = sink
 
+    def _slot_block(self, tensor, start: int, end: int, *, collapse_tp: bool = False, composer=None):
+        """This range of user-major packed-cache rows, gathered to host in one mesh compose.
+
+        Same pattern as DeepSeek ``TtPrefillRuntime.read_slot_kv._slot_block``: slice on device with
+        DRAM_MEMORY_CONFIG (the cache is ND-sharded ROUND_ROBIN_1D; slicing into another ND-shard
+        miscomputes the DRAM core on read-back), then ``ConcatMesh2dToTensor`` ``dims=(2, 1)`` so SP
+        concatenates on seq and TP on heads — one ``to_torch`` instead of per-chip ``get_device_tensors``.
+        ``collapse_tp`` keeps a single TP replica (index_k is replicated across cols). Returns
+        ``[end - start, heads(or 1), seq_cache, head_dim]`` in on-device (block-cyclic) seq order.
+        """
+        if composer is None:
+            composer = ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(2, 1), mesh_shape=self.mesh_device.shape)
+        s = list(tensor.shape)
+        sl = ttnn.slice(
+            tensor,
+            [start, 0, 0, 0],
+            [end, s[1], s[2], s[3]],
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        host = ttnn.to_torch(sl, mesh_composer=composer).float()
+        ttnn.deallocate(sl)
+        return host[:, :1] if collapse_tp else host
+
+    def naturalize_kv_block(self, block: torch.Tensor, n_tokens: int) -> torch.Tensor:
+        """Un-rotate a host cache block from on-device block-cyclic seq order to NATURAL token order.
+
+        ``block`` is ``[..., seq_cache, head_dim]`` (seq is dim -2), the ConcatMesh2dToTensor layout.
+        Inverse of the ``update_padded_kv_cache`` writer. Returns ``[..., n_tokens, head_dim]``.
+        """
+        p = blockcyclic_positions(self.config.sp_factor, self.config.chunk_size, self.config.max_seq_len)
+        nat = torch.empty_like(block)
+        nat[..., p, :] = block
+        return nat[..., :n_tokens, :]
+
     def gather_layer(self, kv_cache, slot_id: int, layer_idx: int, n_tokens: int):
         """Read one layer's device cache back to NATURAL token order (un-rotating the block-cyclic SP
         layout). Returns (k, v, index_k) torch tensors in DEVICE convention (K / index_k are Meta-RoPE
         swizzled over the rotary slice — the caller reconciles vs the HF golden). Shapes:
         k,v -> [1, num_kv_heads, n_tokens, head_dim]; index_k -> [1, 1, n_tokens, head_dim] (zeros on
         dense layers, which carry no index_k). Optional bring-up hook — never used in production
-        serving."""
-        sp = self.config.sp_factor
-        cols = self.config.tp_factor  # K/V head c on col c; index_k replicated -> read col 0
-        nkv = self.hf_config.num_key_value_heads
-        slot = slot_id * self.config.num_layers + layer_idx
-        # shard-row -> natural global position (inverse of the update_padded_kv_cache writer).
-        p = blockcyclic_positions(sp, self.config.chunk_size, self.config.max_seq_len)
+        serving.
 
-        def gather(cache_tensor, col):
-            dts = ttnn.get_device_tensors(cache_tensor)
-            dev = torch.cat([ttnn.to_torch(dts[r * cols + col])[slot, 0].float() for r in range(sp)], dim=0)
-            nat = torch.empty_like(dev)
-            nat[p] = dev
-            return nat[:n_tokens]
-
-        k = torch.stack([gather(kv_cache.k, c) for c in range(nkv)], dim=0).unsqueeze(0)
-        v = torch.stack([gather(kv_cache.v, c) for c in range(nkv)], dim=0).unsqueeze(0)
-        index_k = gather(kv_cache.index_k, 0).unsqueeze(0).unsqueeze(0)
-        return k, v, index_k
+        Slices the packed row on device and composes the mesh once per cache (see ``_slot_block``),
+        matching DeepSeek slot readback — not per-chip ``to_torch`` of the full packed buffer. A caller
+        that walks EVERY layer should read the slot once (``read_slot_kv``) and un-rotate each layer with
+        ``naturalize_kv_block`` instead of calling this per layer.
+        """
+        packed = slot_id * self.config.num_layers + layer_idx
+        composer = ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(2, 1), mesh_shape=self.mesh_device.shape)
+        return (
+            self.naturalize_kv_block(self._slot_block(kv_cache.k, packed, packed + 1, composer=composer), n_tokens),
+            self.naturalize_kv_block(self._slot_block(kv_cache.v, packed, packed + 1, composer=composer), n_tokens),
+            self.naturalize_kv_block(
+                self._slot_block(kv_cache.index_k, packed, packed + 1, collapse_tp=True, composer=composer), n_tokens
+            ),
+        )
 
     def kv_migration_stages(self, kv_cache, first_layer_idx=None, num_my_layers=None):
         """One ``KvCacheStage`` per migratable device cache, in the order ``build_kv_chunk_table``
@@ -478,26 +509,18 @@ class TtPrefillRuntime:
         """Read one slot's KV cache from device to host: ``[k, v, index_k]``, one host tensor per cache
         tensor, each ``[num_layers, heads(or 1), seq_cache, head_dim]`` (index_k collapsed to one TP
         replica), in the raw on-device (block-cyclic) layout — not un-rotated to natural token order.
-        DRAM_MEMORY_CONFIG on the slice is REQUIRED — the cache is ND-sharded ROUND_ROBIN_1D, and slicing
-        into another ND-shard miscomputes the DRAM core on host read-back."""
-        mesh_device = self.mesh_device
-        num_layers = self.config.num_layers
 
-        def _block(tensor, collapse_tp: bool):
-            s = list(tensor.shape)
-            sl = ttnn.slice(
-                tensor,
-                [slot * num_layers, 0, 0, 0],
-                [(slot + 1) * num_layers, s[1], s[2], s[3]],
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
-            block = ttnn.to_torch(
-                sl, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
-            ).float()  # [num_layers, nkv (or cols), seq_cache, head_dim]
-            ttnn.deallocate(sl)
-            return block[:, :1] if collapse_tp else block
-
-        return [_block(kv_cache.k, False), _block(kv_cache.v, False), _block(kv_cache.index_k, True)]
+        Mirrors DeepSeek ``TtPrefillRuntime.read_slot_kv``: one device slice + one mesh compose per
+        cache (see ``_slot_block``).
+        """
+        start = slot * self.config.num_layers
+        end = start + self.config.num_layers
+        composer = ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(2, 1), mesh_shape=self.mesh_device.shape)
+        return [
+            self._slot_block(kv_cache.k, start, end, composer=composer),
+            self._slot_block(kv_cache.v, start, end, composer=composer),
+            self._slot_block(kv_cache.index_k, start, end, collapse_tp=True, composer=composer),
+        ]
 
     def kv_cache_pcc_check(
         self,

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -38,7 +38,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.mla.utils import block_cyclic_reorder, blockcyclic_positions
+from models.common.utils import block_cyclic_reorder
 
 
 @dataclass
@@ -399,40 +399,6 @@ class TtPrefillRuntime:
         assert self.compiled, "Call compile() before set_layer_completion_sink()"
         self._layer_completion_sink = sink
 
-    def _slot_block(self, tensor, start: int, end: int, *, collapse_tp: bool = False, composer=None):
-        """This range of user-major packed-cache rows, gathered to host in one mesh compose.
-
-        Same pattern as DeepSeek ``TtPrefillRuntime.read_slot_kv._slot_block``: slice on device with
-        DRAM_MEMORY_CONFIG (the cache is ND-sharded ROUND_ROBIN_1D; slicing into another ND-shard
-        miscomputes the DRAM core on read-back), then ``ConcatMesh2dToTensor`` ``dims=(2, 1)`` so SP
-        concatenates on seq and TP on heads — one ``to_torch`` instead of per-chip ``get_device_tensors``.
-        ``collapse_tp`` keeps a single TP replica (index_k is replicated across cols). Returns
-        ``[end - start, heads(or 1), seq_cache, head_dim]`` in on-device (block-cyclic) seq order.
-        """
-        if composer is None:
-            composer = ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(2, 1), mesh_shape=self.mesh_device.shape)
-        s = list(tensor.shape)
-        sl = ttnn.slice(
-            tensor,
-            [start, 0, 0, 0],
-            [end, s[1], s[2], s[3]],
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-        host = ttnn.to_torch(sl, mesh_composer=composer).float()
-        ttnn.deallocate(sl)
-        return host[:, :1] if collapse_tp else host
-
-    def naturalize_kv_block(self, block: torch.Tensor, n_tokens: int) -> torch.Tensor:
-        """Un-rotate a host cache block from on-device block-cyclic seq order to NATURAL token order.
-
-        ``block`` is ``[..., seq_cache, head_dim]`` (seq is dim -2), the ConcatMesh2dToTensor layout.
-        Inverse of the ``update_padded_kv_cache`` writer. Returns ``[..., n_tokens, head_dim]``.
-        """
-        p = blockcyclic_positions(self.config.sp_factor, self.config.chunk_size, self.config.max_seq_len)
-        nat = torch.empty_like(block)
-        nat[..., p, :] = block
-        return nat[..., :n_tokens, :]
-
     def gather_layer(self, kv_cache, slot_id: int, layer_idx: int, n_tokens: int):
         """Read one layer's device cache back to NATURAL token order (un-rotating the block-cyclic SP
         layout). Returns (k, v, index_k) torch tensors in DEVICE convention (K / index_k are Meta-RoPE
@@ -441,18 +407,22 @@ class TtPrefillRuntime:
         dense layers, which carry no index_k). Optional bring-up hook — never used in production
         serving.
 
-        Slices the packed row on device and composes the mesh once per cache (see ``_slot_block``),
-        matching DeepSeek slot readback — not per-chip ``to_torch`` of the full packed buffer. A caller
-        that walks EVERY layer should read the slot once (``read_slot_kv``) and un-rotate each layer with
-        ``naturalize_kv_block`` instead of calling this per layer.
+        Thin wrapper over ``read_slot_kv`` + ``naturalize_kv_block``. A caller that walks EVERY layer
+        should read the slot once and un-rotate each layer itself instead of calling this per layer.
         """
-        packed = slot_id * self.config.num_layers + layer_idx
-        composer = ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(2, 1), mesh_shape=self.mesh_device.shape)
+        from models.demos.minimax_m3.tt.runners.prefill_kv_validation import naturalize_kv_block
+
+        k_blk, v_blk, ik_blk = self.read_slot_kv(kv_cache, slot_id)
+        cfg = self.config
         return (
-            self.naturalize_kv_block(self._slot_block(kv_cache.k, packed, packed + 1, composer=composer), n_tokens),
-            self.naturalize_kv_block(self._slot_block(kv_cache.v, packed, packed + 1, composer=composer), n_tokens),
-            self.naturalize_kv_block(
-                self._slot_block(kv_cache.index_k, packed, packed + 1, collapse_tp=True, composer=composer), n_tokens
+            naturalize_kv_block(k_blk[layer_idx], n_tokens, cfg.sp_factor, cfg.chunk_size, cfg.max_seq_len).unsqueeze(
+                0
+            ),
+            naturalize_kv_block(v_blk[layer_idx], n_tokens, cfg.sp_factor, cfg.chunk_size, cfg.max_seq_len).unsqueeze(
+                0
+            ),
+            naturalize_kv_block(ik_blk[layer_idx], n_tokens, cfg.sp_factor, cfg.chunk_size, cfg.max_seq_len).unsqueeze(
+                0
             ),
         )
 
@@ -510,16 +480,37 @@ class TtPrefillRuntime:
         tensor, each ``[num_layers, heads(or 1), seq_cache, head_dim]`` (index_k collapsed to one TP
         replica), in the raw on-device (block-cyclic) layout — not un-rotated to natural token order.
 
-        Mirrors DeepSeek ``TtPrefillRuntime.read_slot_kv``: one device slice + one mesh compose per
-        cache (see ``_slot_block``).
+        One device slice + one mesh compose per cache. DRAM_MEMORY_CONFIG on the slice is required —
+        the cache is ND-sharded ROUND_ROBIN_1D, and slicing into another ND-shard miscomputes the DRAM
+        core on host read-back.
         """
         start = slot * self.config.num_layers
         end = start + self.config.num_layers
         composer = ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(2, 1), mesh_shape=self.mesh_device.shape)
+
+        def _slot_block(tensor, *, collapse_tp: bool = False):
+            """This slot's packed-cache rows, gathered to host in one mesh compose.
+
+            ``ConcatMesh2dToTensor`` ``dims=(2, 1)`` so SP concatenates on seq and TP on heads — one
+            ``to_torch`` instead of per-chip ``get_device_tensors``. ``collapse_tp`` keeps a single TP
+            replica (index_k is replicated across cols). Returns
+            ``[end - start, heads(or 1), seq_cache, head_dim]`` in on-device (block-cyclic) seq order.
+            """
+            s = list(tensor.shape)
+            sl = ttnn.slice(
+                tensor,
+                [start, 0, 0, 0],
+                [end, s[1], s[2], s[3]],
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            host = ttnn.to_torch(sl, mesh_composer=composer).float()
+            ttnn.deallocate(sl)
+            return host[:, :1] if collapse_tp else host
+
         return [
-            self._slot_block(kv_cache.k, start, end, composer=composer),
-            self._slot_block(kv_cache.v, start, end, composer=composer),
-            self._slot_block(kv_cache.index_k, start, end, collapse_tp=True, composer=composer),
+            _slot_block(kv_cache.k),
+            _slot_block(kv_cache.v),
+            _slot_block(kv_cache.index_k, collapse_tp=True),
         ]
 
     def kv_cache_pcc_check(


### PR DESCRIPTION
# [Performance] MiniMax-M3 KV PCC: read one slot on device instead of 60 full-cache gathers

## Summary

- MiniMax-M3 KV PCC was the slowest test in `blaze-models-prefill-tests` because the 60-layer check copied the full packed cache off every chip, then kept only `[slot, 0]`.
- Read the **user slot once** on device (`ttnn.slice` + one `ConcatMesh2dToTensor` `to_torch` per K / V / `index_k`). On host, map the cache from SP **block-cyclic** order back to natural token order (`blockcyclic_positions`, same map as the old `gather_layer`) and PCC against the golden. Meta-RoPE permute and the PCC threshold are unchanged.
- Bring-up / CI only — production prefill never reads the KV cache back to the host.

## Problem

`gather_layer` did:

```python
ttnn.to_torch(dts[r * cols + col])[slot, 0]
```

`to_torch` ran **before** the `[slot, 0]` index, so ~15 GB moved per layer to use ~250 MB. Across 60 layers that is on the order of ~900 GB of PCIe. On the pre-change Blaze log this was **25.0 min (52%)** of a **47.8 min** python run (~25 s/layer).

## Change

| File | What |
| --- | --- |
| `tt/tt_prefill_runtime.py` | `_slot_block` (DeepSeek-style device slice + mesh compose, `DRAM_MEMORY_CONFIG` for ND `ROUND_ROBIN_1D`); `naturalize_kv_block`; `read_slot_kv` / `gather_layer` share that path |
| `tests/galaxy_prefill_kv_pcc.py` | Blaze harness: one `read_slot_kv`, then per-layer host un-rotate |
| `tt/runners/prefill_kv_validation.py` | Same for engine / bring-up `kv_cache_pcc_check` |

PCC loops no longer call `gather_layer` 60 times. `gather_layer` is still available for a single layer, but it now slices that packed row on device instead of a full-shard `get_device_tensors` read.

## Measured

Same Blaze job: `(MiniMax-M3-428B) chunked prefill KV accuracy longbook 55k@5k`. Min PCC unchanged (**0.89116**, threshold 0.88).

| Phase | Before (main) | After (`833e42`) |
| --- | --- | --- |
| **KV PCC** | **25.0 min ** | **6.5 min (−18.5)** |

PCC after the change: **2.0 min** `read_slot_kv` (device slot slice + 3 mesh `to_torch`s) then **~4.6 s/layer** golden load + `comp_pcc`. Before: **~25 s/layer** of full-shard D2H.

## Test plan

- [ ] Warm tilized-cache Blaze: `(MiniMax-M3-428B) chunked prefill KV accuracy longbook 55k@5k` — confirm PCC still ≥ 0.88 and wall time.
- [ ] Compare per-layer K / V / `index_k` PCC lines to a pre-change log (should match).
- [ ] Python-only; no C++ rebuild.

### CIs
- https://github.com/tenstorrent/tt-metal/actions/runs/33624683870

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/m3-kv-pcc-slice-on-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/m3-kv-pcc-slice-on-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/m3-kv-pcc-slice-on-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/m3-kv-pcc-slice-on-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/m3-kv-pcc-slice-on-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/m3-kv-pcc-slice-on-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/m3-kv-pcc-slice-on-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/m3-kv-pcc-slice-on-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/m3-kv-pcc-slice-on-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/m3-kv-pcc-slice-on-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/m3-kv-pcc-slice-on-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/m3-kv-pcc-slice-on-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/m3-kv-pcc-slice-on-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/m3-kv-pcc-slice-on-device)