### PR TITLE
[Test Only] MiniMax-M3: gather TP-sharded residual in unit tests

### DIFF
--- a/models/demos/minimax_m3/tests/test_factory.py
+++ b/models/demos/minimax_m3/tests/test_factory.py
@@ -186,6 +186,22 @@ def parametrize_weights(use_real=False):
     return pytest.mark.parametrize("use_real_weights", [use_real], ids=["real" if use_real else "random"])
 
 
+def compose_tp_hidden(device_tensors, row, cols):
+    """Reassemble one mesh row's residual hidden onto the host.
+
+    Under a sharded residual each TP column holds ``emb/tp``; concat them on the last dim.
+    Under a replicated residual column 0 already has full emb.
+    """
+    from models.demos.minimax_m3.tt.residual import use_sharded_residual
+
+    if use_sharded_residual() and cols > 1:
+        return torch.cat(
+            [ttnn.to_torch(device_tensors[row * cols + c]).float() for c in range(cols)],
+            dim=-1,
+        )
+    return ttnn.to_torch(device_tensors[row * cols]).float()
+
+
 # Test helper functions
 def compare_tensors(tt_tensor, torch_tensor, mesh_device, pcc_threshold=0.99):
     """Universal tensor comparison - handles both TT tensors and already-converted torch tensors"""

--- a/models/demos/minimax_m3/tests/unit/test_attention_chunked_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_attention_chunked_vs_ref.py
@@ -32,7 +32,7 @@ from models.demos.minimax_m3.tt.model import create_rope_setup
 from models.demos.minimax_m3.utils.general_utils import get_default_num_links
 from models.demos.minimax_m3.utils.weight_conversion import convert_hf_qkv_to_meta_format_partial
 
-from ..test_factory import parametrize_mesh_with_fabric
+from ..test_factory import compose_tp_hidden, parametrize_mesh_with_fabric
 
 HIDDEN, NQ, NKV, HEAD_DIM, ROTARY_DIM, THETA, EPS = 6144, 64, 4, 128, 64, 5_000_000.0, 1e-6
 NIDX, INDEX_DIM = 4, 128
@@ -157,9 +157,10 @@ def test_attention_chunked(mesh_device, device_params, layer_kind, chunk_local, 
         return attn(x_tt, rope_mats=rope_range(a, b), kv_cache=kv_cache, user_id=0, cached_len=cached_len)
 
     def gather_seq(out):
-        # out: SP-sharded on rows (seq), full hidden on each TP col after o_proj reduce. Take col 0.
+        # out: SP-sharded on rows (seq). Hidden is full-emb on each TP col (replicated residual) or
+        # emb/tp per col (sharded residual). Concat SP on seq and TP on hidden as needed.
         dts = ttnn.get_device_tensors(out)
-        return torch.cat([ttnn.to_torch(dts[r * cols + 0]).float() for r in range(rows)], dim=2)  # [1,1,S,H]
+        return torch.cat([compose_tp_hidden(dts, r, cols) for r in range(rows)], dim=2)  # [1,1,S,H]
 
     # --- single-shot golden over the full sequence (fresh cache) ---
     kvc_ss = allocate_kv_caches(mesh_device, num_layers=1, max_seq_len=total, sp_axis=sp_axis, num_users=1)
@@ -331,7 +332,7 @@ def test_attention_chunked_vs_cpu_ref(mesh_device, device_params, layer_kind, ch
 
     def gather_seq(out):
         dts = ttnn.get_device_tensors(out)
-        return torch.cat([ttnn.to_torch(dts[r * cols + 0]).float() for r in range(rows)], dim=2)
+        return torch.cat([compose_tp_hidden(dts, r, cols) for r in range(rows)], dim=2)
 
     kvc = allocate_kv_caches(mesh_device, num_layers=1, max_seq_len=total, sp_axis=sp_axis, num_users=1)
     run(x[:, :chunk], 0, chunk, 0, kvc)

--- a/models/demos/minimax_m3/tests/unit/test_attention_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_attention_vs_ref.py
@@ -30,7 +30,7 @@ from models.demos.minimax_m3.tt.model import create_rope_setup
 from models.demos.minimax_m3.utils.general_utils import get_default_num_links
 from models.demos.minimax_m3.utils.weight_conversion import convert_hf_qkv_to_meta_format_partial
 
-from ..test_factory import parametrize_mesh_with_fabric
+from ..test_factory import compose_tp_hidden, parametrize_mesh_with_fabric
 
 # M3 attention dims (text_config).
 HIDDEN, NQ, NKV, HEAD_DIM, ROTARY_DIM, THETA, EPS = 6144, 64, 4, 128, 64, 5_000_000.0, 1e-6
@@ -86,8 +86,8 @@ def test_attention_prefill_vs_ref(mesh_device, device_params, seq_len, reset_see
     """Full M3 GQA attention block vs self-authored torch reference, random weights.
 
     (1,1) = TP=1. (8,4) = TP=4 (M3's KV-head-limited tensor-parallel), exercising the o_proj
-    reduce-scatter/all-gather CCL; attention output is full-hidden replicated post-allreduce, so
-    device[0] holds the full result. Needs TT_MESH_GRAPH_DESC_PATH=single_bh_galaxy ([8,4])."""
+    closing CCL (reduce-scatter under a sharded residual, all-reduce under a replicated one).
+    Needs TT_MESH_GRAPH_DESC_PATH=single_bh_galaxy ([8,4])."""
     torch.manual_seed(0)
     x = torch.randn(1, seq_len, HIDDEN) * 0.1
 
@@ -175,7 +175,9 @@ def test_attention_prefill_vs_ref(mesh_device, device_params, seq_len, reset_see
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
     tt_out = attn(x_tt, rope_mats=rope_mats, position_idx=None, kv_cache=None)
-    out = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).reshape(1, seq_len, HIDDEN)
+    # Seq is replicated; concat TP columns when the residual is emb/tp-sharded.
+    cols = mesh_device.shape[1]
+    out = compose_tp_hidden(ttnn.get_device_tensors(tt_out), 0, cols).reshape(1, seq_len, HIDDEN)
 
     passing, pcc = comp_pcc(ref_out, out, 0.97)
     logger.info(f"attention prefill vs ref: {pcc}")

--- a/models/demos/minimax_m3/tests/unit/test_dense_mlp_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_dense_mlp_vs_ref.py
@@ -23,7 +23,7 @@ from models.demos.minimax_m3.tt.ccl import CCLManager
 from models.demos.minimax_m3.tt.dense_mlp import DenseMLP
 from models.demos.minimax_m3.utils.general_utils import get_default_num_links
 
-from ..test_factory import parametrize_mesh_with_fabric
+from ..test_factory import compose_tp_hidden, parametrize_mesh_with_fabric
 
 
 def _torch_dense_mlp(x, gate_w, up_w, down_w, alpha, limit):
@@ -47,8 +47,7 @@ def _torch_dense_mlp(x, gate_w, up_w, down_w, alpha, limit):
 )
 def test_dense_mlp_vs_ref(mesh_device, device_params, seq_len, hidden, inter, reset_seeds):
     """DenseMLP vs torch reference, random weights. (1,1)=TP=1; (8,4)=TP=4 (gate/up col-parallel +
-    down-proj all-reduce). Output is full-hidden post-allreduce -> device[0] holds it. (8,4) needs
-    TT_MESH_GRAPH_DESC_PATH=single_bh_galaxy."""
+    down-proj reduce-scatter/all-reduce). (8,4) needs TT_MESH_GRAPH_DESC_PATH=single_bh_galaxy."""
     alpha, limit = 1.702, 7.0
     x = torch.randn(1, 1, seq_len, hidden) * 0.1
     # HF Linear layout [out, in]; small scale so post-clamp distribution isn't degenerate.
@@ -83,7 +82,8 @@ def test_dense_mlp_vs_ref(mesh_device, device_params, seq_len, hidden, inter, re
     )
 
     out_tt = mlp(x_tt)
-    out = ttnn.to_torch(ttnn.get_device_tensors(out_tt)[0]).reshape(1, 1, seq_len, hidden)
+    cols = mesh_device.shape[1]
+    out = compose_tp_hidden(ttnn.get_device_tensors(out_tt), 0, cols).reshape(1, 1, seq_len, hidden)
 
     passing, pcc = comp_pcc(ref, out, 0.99)
     logger.info(f"dense_mlp seq={seq_len} hidden={hidden} inter={inter}: {pcc}")

--- a/models/demos/minimax_m3/tests/unit/test_ep_moe_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_ep_moe_vs_ref.py
@@ -34,7 +34,7 @@ from models.demos.minimax_m3.tt.ccl import CCLManager
 from models.demos.minimax_m3.tt.mlp import MLP
 from models.demos.minimax_m3.utils.general_utils import get_default_num_links
 
-from ..test_factory import parametrize_mesh_with_fabric
+from ..test_factory import compose_tp_hidden, parametrize_mesh_with_fabric
 
 # Real M3 MoE dims (from configs/MiniMax-M3/config.json).
 HIDDEN, E, TOPK = 6144, 128, 4
@@ -130,13 +130,12 @@ def test_ep_moe_vs_ref(mesh_device, device_params, seq_len, reset_seeds):
         device=mesh_device,
         dtype=ttnn.bfloat16,
     )
-    out = mlp(tt_x)  # [1, 1, S, H] per device (full emb, replicated across cols)
+    out = mlp(tt_x)  # per device [1, 1, S, H] (replicated residual) or [1, 1, S, H/tp] (sharded)
     ttnn.synchronize_device(mesh_device)
 
-    # Per-row read: device index = r*cols (col 0; all cols hold the same all-gathered full-emb output).
     dts = ttnn.get_device_tensors(out)
     for r in range(rows):
-        row = ttnn.to_torch(dts[r * cols]).float().reshape(-1, HIDDEN)[:seq_len]
+        row = compose_tp_hidden(dts, r, cols).reshape(-1, HIDDEN)[:seq_len]
         passing, pcc = comp_pcc(ref[r], row, 0.95)
         logger.info(f"prompt{r}: pcc={pcc}")
         assert passing, f"prompt {r} EP MoE PCC fail: {pcc}"

--- a/models/demos/minimax_m3/tests/unit/test_parallel_embedding_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_parallel_embedding_vs_ref.py
@@ -4,9 +4,9 @@
 """PCC of TtParallelEmbedding vs torch F.embedding, for BOTH sharding modes:
 
   * 1D (shard_vocab_on_sp=False): emb_dim sharded on TP, vocab replicated across SP. No CCL in the
-    lookup; one TP all-gather rebuilds full hidden.
+    lookup; a TP all-gather rebuilds full hidden only under a replicated residual.
   * 2D (shard_vocab_on_sp=True):  vocab ALSO sharded on SP (Megatron vocab-parallel) -> per-row masked
-    lookup + SP reduce-scatter(seq) + TP all-gather. ~0.5 GiB/device less at the cost of 2 SP CCL ops.
+    lookup + SP reduce-scatter(seq) + (replicated residual only) TP all-gather.
 
 Both must reproduce the exact torch gather (embedding is a copy — no compute — so PCC ~1.0 in bf16).
 The 2D case is the real check: the per-row vocab mask + cross-SP reduce must reassemble every token's
@@ -28,7 +28,7 @@ from models.demos.minimax_m3.tt.ccl import CCLManager
 from models.demos.minimax_m3.tt.parallel_embedding import TtParallelEmbedding
 from models.demos.minimax_m3.utils.general_utils import get_default_num_links
 
-from ..test_factory import parametrize_mesh_with_fabric
+from ..test_factory import compose_tp_hidden, parametrize_mesh_with_fabric
 
 VOCAB, EMB_DIM = 2048, 256  # VOCAB % sp(8) == 0 and % tp(4) == 0; EMB_DIM % tp == 0
 
@@ -70,11 +70,10 @@ def test_parallel_embedding(mesh_device, device_params, shard_vocab, reset_seeds
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(sp_axis, None)),
     )
 
-    out = emb.forward(tt_tokens)  # per device [1, 1, s_local, EMB_DIM], SP-seq-sharded, TP-replicated
+    out = emb.forward(tt_tokens)  # per device [1, 1, s_local, EMB_DIM] or [..., EMB_DIM/tp]
 
-    # Reassemble: full hidden is TP-replicated, so col 0 suffices; concat the SP rows' seq shards.
     dts = ttnn.get_device_tensors(out)
-    full = torch.cat([ttnn.to_torch(dts[r * cols]).float() for r in range(rows)], dim=2)  # [1,1,S,EMB_DIM]
+    full = torch.cat([compose_tp_hidden(dts, r, cols) for r in range(rows)], dim=2)  # [1,1,S,EMB_DIM]
 
     ref = F.embedding(tokens.long(), table.float()).reshape(1, 1, S, EMB_DIM)
 


### PR DESCRIPTION
### Summary

MiniMax-M3 unit tests still gathered residual outputs as if every TP column held full hidden. After #52698 the default residual is `emb/tp`-sharded (`M3_SHARDED_RESIDUAL=1`), so those gathers reshape-crash (e.g. `[1, 2048, 6144]` vs `3145728` elements) or compare against a quarter of the vector.

This updates the host compose path only: concat TP columns on the last dim when the residual is sharded, keep column 0 when `M3_SHARDED_RESIDUAL=0`. Production kernels/CCL are unchanged. Inputs to attention/MLP stay full-emb, matching the layer’s pre-norm all-gather contract.

Touched tests:
- `test_attention_chunked` / `test_attention_chunked_vs_cpu_ref`
- `test_attention_prefill_vs_ref`
- `test_dense_mlp_vs_ref`
- `test_ep_moe_vs_ref`
- `test_parallel_embedding` (`1d_hidden` and `2d_vocab`)

### Test plan
- [ ] On a Blackhole Galaxy 8×4, default residual (`M3_SHARDED_RESIDUAL` unset):
  ```bash
  pytest models/demos/minimax_m3/tests/unit/ \
    -k "test_attention_chunked_vs_cpu_ref[blackhole-dense-chunk256-8x4] or \
        test_attention_prefill_vs_ref[blackhole-s128-8x4] or \
        test_dense_mlp_vs_ref[blackhole-s128-8x4] or \
        test_ep_moe_vs_ref[blackhole-s128-8x4] or \
        test_parallel_embedding[blackhole-1d_hidden-8x4] or \
        test_parallel_embedding[blackhole-2d_vocab-8x4]" \
    -s
  ```
- [ ] Same tests with `M3_SHARDED_RESIDUAL=0` (replicated residual bisect path).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/m3-unit-tests-sharded-residual)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/m3-unit-tests-sharded-residual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/m3-unit-tests-sharded-residual)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/m3-unit-tests-sharded-residual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/m3-unit-tests-sharded-residual)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/m3-unit-tests-sharded-residual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/m3-unit-tests-sharded-residual)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/m3-unit-tests-sharded-residual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/m3-unit-tests-sharded-residual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/m3-unit-tests-sharded-residual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/m3-unit-tests-sharded-residual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/m3-unit-tests-sharded-residual)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/m3-unit-tests-sharded-residual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/m3-unit-tests-sharded-residual)