### PR TITLE
prefill/ci: route the test matrix by group, not by token lists

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -28,6 +28,12 @@ on:
         required: false
         type: string
         default: ""
+        description: "Comma-separated test_groups this invocation must not run"
+      include-test-group:
+        required: false
+        type: string
+        default: ""
+        description: "Comma-separated test_groups this invocation is limited to"
       resource-prefix:
         required: true
         type: string
@@ -91,11 +97,10 @@ jobs:
           MATRIX="$MATRIX"
           TEST_TYPE="${{ inputs.test-type }}"
           EXCLUDE_GROUP="${{ inputs.exclude-test-group }}"
+          INCLUDE_GROUP="${{ inputs.include-test-group }}"
           if [ -z "$TEST_TYPE" ] || \
             echo "$TEST_TYPE" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -Fxq "all"; then
-            if [ -n "$EXCLUDE_GROUP" ]; then
-              MATRIX=$(echo "$MATRIX" | jq -c --arg g "$EXCLUDE_GROUP" '[.[] | select(.test_group != $g)]')
-            fi
+            :
           else
             MATRIX=$(echo "$MATRIX" | jq -c --arg sel "$TEST_TYPE" '
               ($sel | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $tokens
@@ -105,10 +110,21 @@ jobs:
                     or (($e.test_tags // []) | any(. as $f | $tokens | index($f)))
                 ) ]
             ')
-            if [ "$MATRIX" = "[]" ]; then
-              echo "::error::No tests found for test-type '$TEST_TYPE'. Ensure each selected test-type or test-group is defined in the test matrix (TESTS_YAML_PATH=${{ env.TESTS_YAML_PATH }})."
-              exit 1
-            fi
+          fi
+          # Group routing runs after selection, and unconditionally: a test_tag selects entries
+          # across groups, so a group this invocation does not own can enter on any selection,
+          # not just "all". Both inputs take a list because an invocation can disown several.
+          if [ -n "$EXCLUDE_GROUP" ]; then
+            MATRIX=$(echo "$MATRIX" | jq -c --arg sel "$EXCLUDE_GROUP" '
+              ($sel | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $drop
+              | [ .[] | . as $e | select((($drop | index($e.test_group)) | not)) ]
+            ')
+          fi
+          if [ -n "$INCLUDE_GROUP" ]; then
+            MATRIX=$(echo "$MATRIX" | jq -c --arg sel "$INCLUDE_GROUP" '
+              ($sel | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $keep
+              | [ .[] | . as $e | select($keep | index($e.test_group)) ]
+            ')
           fi
           echo "filtered_matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$MATRIX" >> $GITHUB_OUTPUT
@@ -121,8 +137,10 @@ jobs:
         run: |
           FILTERED=$(echo "$MATRIX" | jq -c --arg sp "${{ inputs.sp-config }}" '[.[] | select(.sp_config == $sp)]')
           if [ "$FILTERED" = "[]" ]; then
-            echo "::error::No tests found for sp_config '${{ inputs.sp-config }}' in ${TESTS_YAML_PATH}"
-            exit 1
+            # The selection is validated against the tests YAML before the build, so an empty
+            # slice here is not a bad token -- it means this invocation owns none of what was
+            # selected. multihost-tests is skipped and the run stays green.
+            echo "::notice::No ${{ inputs.sp-config }} test selected for this invocation; contributing no legs."
           fi
           echo "matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$FILTERED" >> $GITHUB_OUTPUT
@@ -146,6 +164,7 @@ jobs:
   multihost-tests:
     name: ${{ matrix.test-group.name }}
     needs: load-test-matrix
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
 

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -98,6 +98,16 @@ jobs:
           TEST_TYPE="${{ inputs.test-type }}"
           EXCLUDE_GROUP="${{ inputs.exclude-test-group }}"
           INCLUDE_GROUP="${{ inputs.include-test-group }}"
+          # The group inputs are caller constants and bypass validate_test_type_selection.py, so a
+          # typo would otherwise filter the matrix to nothing and skip silently. Checked against the
+          # unfiltered matrix, since the selection below can legitimately leave a group empty.
+          KNOWN_GROUPS=$(echo "$MATRIX" | jq -r '[.[] | .test_group // empty] | unique | join(" ")')
+          for g in $(echo "$EXCLUDE_GROUP,$INCLUDE_GROUP" | tr ',' ' '); do
+            if ! echo "$KNOWN_GROUPS" | grep -qw "$g"; then
+              echo "::error::Unknown test_group '$g' for ${{ inputs.enabled-skus }}; known groups: $KNOWN_GROUPS"
+              exit 1
+            fi
+          done
           if [ -z "$TEST_TYPE" ] || \
             echo "$TEST_TYPE" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -Fxq "all"; then
             :

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -90,10 +90,6 @@ jobs:
 
   Galaxy-Blaze-models-prefill:
     needs: [validate-test-type, check-harbor, build-artifact]
-    # Skip when only a focused-job stage was requested: sdpa_perf and prefill_runner_kv_pcc
-    # each have their own impl invocation and no sc1 matrix entry, so running the sc1 caller
-    # for them would fail on an empty matrix. "all"/"module" still select this job.
-    if: ${{ needs.validate-test-type.outputs.test-type != 'sdpa_perf' && needs.validate-test-type.outputs.test-type != 'prefill_runner_kv_pcc' }}
     permissions:
       id-token: write
       contents: read
@@ -112,8 +108,6 @@ jobs:
 
   Galaxy-Blaze-models-prefill-SDPA-Perf-tests:
     needs: [validate-test-type, check-harbor, build-artifact]
-    # Runs for the default "all" and when the sdpa_perf group is selected (alone or with others).
-    if: ${{ needs.validate-test-type.outputs.test-type == 'all' || contains(needs.validate-test-type.outputs.test-type, 'sdpa_perf') }}
     permissions:
       id-token: write
       contents: read
@@ -125,8 +119,10 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: bh_sc1,bh_sc1_high_power
       sp-config: sc1
-      # Select the perf entry by its test_group so adding more perf checks needs no workflow edit.
-      test-type: sdpa_perf
+      test-type: ${{ needs.validate-test-type.outputs.test-type }}
+      # Own the perf group and nothing else, so a tag shared with a functional entry
+      # (mla, determinism, kimi_k3) selects the perf entry here and only here.
+      include-test-group: sdpa_perf
       resource-prefix: sdpa-perf
 
   Galaxy-Blaze-models-prefill-sc4:
@@ -134,23 +130,6 @@ jobs:
     # 4-galaxy (SC4) disaggregated-prefill runner+producer KV-PCC leg. Its own impl
     # invocation because the impl filters the matrix by sp_config, and this is the only
     # sc4 entry (the sc1 job's enabled-skus + sp_config filters already exclude it).
-    # Runs for the default "all", for the "module" group, and when its own stage is selected.
-    # Tokens that can select an sc4 entry: its test_type, its test_group, or any of its
-    # test_tags (kimi_k2_7 / glm_5_2 / runner / kv_cache). Firing this caller for a selection
-    # with no sc4 entry fails on an empty matrix, so the list stays exact.
-    #
-    # Each token is comma-wrapped on BOTH sides because contains() is substring-based while the
-    # impl's filter matches whole tokens. Without the wrapping, `kv_cache_table` (sc1-only)
-    # satisfies contains(..., 'kv_cache') and fires this caller, whose filter then finds no sc4
-    # entry and fails the run -- which is exactly what happened on run 33065088619. The validator
-    # emits the selection as ",".join(tokens) with no spaces, so ',<token>,' is an exact match.
-    if: ${{ needs.validate-test-type.outputs.test-type == 'all'
-      || contains(format(',{0},', needs.validate-test-type.outputs.test-type), ',module,')
-      || contains(format(',{0},', needs.validate-test-type.outputs.test-type), ',prefill_runner_kv_pcc,')
-      || contains(format(',{0},', needs.validate-test-type.outputs.test-type), ',kimi_k2_7,')
-      || contains(format(',{0},', needs.validate-test-type.outputs.test-type), ',glm_5_2,')
-      || contains(format(',{0},', needs.validate-test-type.outputs.test-type), ',runner,')
-      || contains(format(',{0},', needs.validate-test-type.outputs.test-type), ',kv_cache,') }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
**CI on this branch**

- Blaze Models Prefill tests, `test-type=all`: https://github.com/tenstorrent/tt-metal/actions/runs/33644361341
- (Blackhole) e2e tests: https://github.com/tenstorrent/tt-metal/actions/runs/33644378738

---

Routing in this workflow derived from hand-maintained lists of dispatch tokens in the callers, plus an `exclude-test-group` filter that compared a single scalar and ran only under `all`. This replaces both with group-based routing: `exclude-test-group` becomes a list applied after selection and unconditionally, `include-test-group` is added as its positive form, and the fan-out skips on an empty matrix so "this invocation owns nothing" is a representable state rather than a fatal error. No caller names a dispatch token any more.

Two files, `.github/workflows/` only. No test, model, or script is touched.

**Verification.** Every one of the 50 valid dispatch tokens was replayed offline through the real `prepare_test_matrix.py` and `validate_test_type_selection.py`, main vs this branch. **39 route identically; 11 change, all in the intended direction:**

| tokens | main | this branch |
|---|---|---|
| `kimi_k2_7` | **red** — module job dies on an empty matrix | green, module job skips |
| `module,sdpa_perf`, `ccl,sdpa_perf` | perf legs scheduled twice | scheduled once |
| `ring_joint_sdpa_perf` | 1 duplicate, and runs both perf legs | runs exactly the 1 requested |
| `ccl`, `sdpa`, `high_bw_all_gather_perf`, `mla`, `determinism`, `kimi_k2_6`, `kimi_k3` | an `sdpa_perf` leg runs inside the long functional module job (main's `exclude-test-group` only applies under `all`) | it runs in the focused perf job — same coverage, correct timeout and resource prefix |

Set-identical otherwise: no token gains or loses a leg.

Walkthrough of each change below.

---

impl, change 1 — declare include-test-group, document both


```
       exclude-test-group:
         ...
+        description: "Comma-separated test_groups this invocation must not run"
+      include-test-group:
+        required: false
+        type: string
+        default: ""
+        description: "Comma-separated test_groups this invocation is limited to"

```
exclude is a blacklist, include a whitelist. Both default "" = off, so every existing call site is unaffected. The description on exclude is new too — it had none, and the two only make sense read together.

Needed because the SDPA caller (change 6) stops pinning test-type and has to say which group it owns.

---

impl, change 2 — the all branch becomes a no-op
```

           if [ -z "$TEST_TYPE" ] || ... grep -Fxq "all"; then
-            if [ -n "$EXCLUDE_GROUP" ]; then
-              MATRIX=$(... select(.test_group != $g))
-            fi
+            :
```

Group filtering moves out of the branch. The if/else now does one thing only: selection. all selects everything, anything else selects by token. That separation is the point — routing was tangled inside the selection logic, which is why it only ran on one branch.

: is bash's no-op; the branch has to have a body.

---

impl, change 3 — drop the selection-empty hard error
```

-            if [ "$MATRIX" = "[]" ]; then
-              echo "::error::No tests found for test-type '$TEST_TYPE'..."
-              exit 1
-            fi
```

This error was doing two jobs, and only one of them was real:

- catching a typo'd token — already done, earlier and better, by validate-test-type (.github/scripts/utils/validate_test_type_selection.py:114-128), which derives the valid token set from the tests YAML and rejects anything else before the build runs.
- catching "this invocation selected nothing" — not an error at all. -f test-type=kimi_k2_7 selects only sc4 entries; the module invocation legitimately owns none of them. On main that reddens the run. Verified: it's one of the 4 tokens whose behaviour changes.

---

impl, change 4 — group routing, after selection, unconditional
```

+          # Group routing runs after selection, and unconditionally: a test_tag selects entries
+          # across groups, so a group this invocation does not own can enter on any selection,
+          # not just "all". Both inputs take a list because an invocation can disown several.
+          if [ -n "$EXCLUDE_GROUP" ]; then
+            MATRIX=$(... ($sel | split(",") ...) as $drop
+              | [ .[] | . as $e | select((($drop | index($e.test_group)) | not)) ])
+          fi
+          if [ -n "$INCLUDE_GROUP" ]; then
+            ... as $keep | [ .[] | . as $e | select($keep | index($e.test_group)) ]
+          fi
```

This is the actual bug fix. Three defects in one line of main:

1. select(.test_group != $g) compared a scalar. exclude-test-group: sdpa_perf,disagg_prefill would have been matched as one literal string and dropped nothing. Not reachable on main (only one group is ever excluded there), but it blocks any second group.
2. It ran only under all. Selection is by test_type OR test_group OR test_tags, and tags cross group boundaries — the sdpa_perf legs carry mla, determinism, kimi_k2_6, kimi_k3, ccl. So a tag drags a disowned group into an invocation that has its own dedicated job. -f test-type=module,sdpa_perf scheduled both perf legs twice, once per job.
3. It ran before nothing — order didn't matter on all, but it does now: exclude/include must see the selected set, not the whole matrix.

split(",") + gsub trim + index() is the same token-normalization the selection step already uses, so a, b and a,b behave identically.

---

impl, change 5 — empty sp_config slice is a notice

```
           if [ "$FILTERED" = "[]" ]; then
-            echo "::error::No tests found for sp_config '...'"
-            exit 1
+            # The selection is validated against the tests YAML before the build, so an empty
+            # slice here is not a bad token -- it means this invocation owns none of what was
+            # selected. multihost-tests is skipped and the run stays green.
+            echo "::notice::No ${{ inputs.sp-config }} test selected for this invocation; contributing no legs."
```

Same reasoning as change 3, at the last filter. This one is load-bearing for change 4: once exclude works, -f test-type=ccl empties the module job's slice, and main would fail the run over it.

---

impl, change 6 — skip the fan-out on an empty matrix

```
   multihost-tests:
     needs: load-test-matrix
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
```

The keystone, and the reason the caller cleanup below is possible at all. 31 of the 61 reusable *-impl.yaml workflows in this repo already carry this exact line (ops-sanity-impl.yaml:86, fabric-sanity-tests-impl.yaml:75, …). This one didn't — which is why it had to hard-error on an empty matrix, and why the callers grew token lists to avoid ever producing one.

Without it, "empty matrix" has no representation: it's either a fatal error or an undefined fan-out. With it, an invocation that owns nothing contributes nothing and the run is green.

---

caller, change 7 — module job's skip guard deleted

```
-    # Skip when only a focused-job stage was requested: sdpa_perf and prefill_runner_kv_pcc
-    # each have their own impl invocation and no sc1 matrix entry, so running the sc1 caller
-    # for them would fail on an empty matrix. "all"/"module" still select this job.
-    if: ${{ ...test-type != 'sdpa_perf' && ...test-type != 'prefill_runner_kv_pcc' }}
```

The comment says outright what it was for: "would fail on an empty matrix." Change 6 removed that failure, so the guard has no purpose.

It was also wrong: != compares the whole selection string, so module,sdpa_perf doesn't equal sdpa_perf and the guard passed — which is how that duplicate got scheduled. It can't be fixed in an if: either; the correct predicate is "every selected token belongs to another invocation", which GHA expressions can't express.

exclude-test-group: sdpa_perf stays. That's what keeps the long functional job from picking up the perf legs, and now it actually works.

---

caller, change 8 — SDPA job: guard deleted, pin replaced by include-test-group

```
-    # Runs for the default "all" and when the sdpa_perf group is selected (alone or with others).
-    if: ${{ ...test-type == 'all' || contains(...test-type, 'sdpa_perf') }}
...
-      # Select the perf entry by its test_group so adding more perf checks needs no workflow edit.
-      test-type: sdpa_perf
+      test-type: ${{ needs.validate-test-type.outputs.test-type }}
+      # Own the perf group and nothing else, so a tag shared with a functional entry
+      # (mla, determinism, kimi_k3) selects the perf entry here and only here.
+      include-test-group: sdpa_perf
```

Two coupled edits:

The guard used a bare substring contains, so it fired on sdpa_perf but not on ccl, sdpa, mla, determinism, kimi_k2_6, kimi_k3 — all of which select a perf leg. On main that didn't lose coverage, because the broken exclude let the module job run those legs instead. Fix exclude and that becomes silent coverage loss, so the guard has to go in the same PR.

The pin had to go with it. test-type: sdpa_perf ignores what the user asked for, so a guardless pinned caller would run both perf legs on every dispatch — a bh_sc1_high_power galaxy burned on -f test-type=mla_chunked. Passing the selection through plus include-test-group: sdpa_perf means: run what was asked for, but only from my group. -f test-type=ring_joint_sdpa_perf now runs 1 leg instead of 2.

---

caller, change 9 — sc4 job's 6-token list deleted

```
-    # Tokens that can select an sc4 entry: ... Firing this caller for a selection
-    # with no sc4 entry fails on an empty matrix, so the list stays exact.
-    # ... Without the wrapping, `kv_cache_table` (sc1-only) satisfies contains(..., 'kv_cache')
-    # and fires this caller, whose filter then finds no sc4 entry and fails the run --
-    # which is exactly what happened on run 33065088619.
-    if: ${{ ...== 'all'
-      || contains(format(',{0},', ...), ',module,')
-      || ... ',prefill_runner_kv_pcc,') ... ',kimi_k2_7,') ... ',glm_5_2,')
-      || ... ',runner,') ... ',kv_cache,') }}
```

This is the drift, documented in its own comment with the run number. Six tokens hand-copied from the sc4 entries' test_type + test_group + test_tags; add a tag in the tests YAML and this list is silently stale. The comma-wrapping was itself a patch for a production failure (kv_cache_table matching kv_cache).

Nothing replaces it. enabled-skus: bh_sc4 + sp-config: sc4 already identify this invocation's slice exactly, and change 6 makes an empty slice a skip. The 3-line comment explaining why sc4 is a separate invocation is kept — that's still non-obvious.

---

impl, change 10 — reject an unknown test-group input

```
+          KNOWN_GROUPS=$(echo "$MATRIX" | jq -r '[.[] | .test_group // empty] | unique | join(" ")')
+          for g in $(echo "$EXCLUDE_GROUP,$INCLUDE_GROUP" | tr ',' ' '); do
+            if ! echo "$KNOWN_GROUPS" | grep -qw "$g"; then
+              echo "::error::Unknown test_group '$g' for ${{ inputs.enabled-skus }}; known groups: $KNOWN_GROUPS"
+              exit 1
+            fi
+          done
```

The group inputs are caller constants and never reach `validate_test_type_selection.py`, so with change 6 in place a typo (`sdpa-perf` for `sdpa_perf`) would filter the matrix to nothing and skip green — a config typo turning into silent coverage loss. Checked against the *unfiltered* matrix, because the token selection below can legitimately leave a valid group empty.

Exercised against all three caller configs plus the typo case: module and SDPA-perf pass, sc4 (no group inputs) passes, `sdpa-perf` fails the step loudly.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill_ci_group_filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill_ci_group_filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill_ci_group_filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill_ci_group_filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill_ci_group_filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill_ci_group_filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill_ci_group_filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill_ci_group_filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill_ci_group_filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill_ci_group_filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill_ci_group_filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill_ci_group_filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill_ci_group_filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill_ci_group_filter)

