### PR TITLE
multihost sku: switch to new runners

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -179,29 +179,29 @@ skus:
   # exabox-multihost-ci-* labels mark multihost routing; do not reuse for other runners.
   bh_sc1:
     runs_on:
-      - exabox-multihost-ci-sc1
+      - exabox-multihost-ci-volcano-sc1
 
   # Like bh_sc1, but high-power pool (exabox.tenstorrent.com/power=14kw).
   # exabox-multihost-ci-* labels mark multihost routing; do not reuse for other runners.
   bh_sc1_high_power:
     runs_on:
-      - exabox-multihost-ci-sc1-hp
+      - exabox-multihost-ci-volcano-sc1-hp
 
   # exabox-multihost-ci-* labels mark multihost routing; do not reuse for other runners.
   bh_sc4:
     runs_on:
-      - exabox-multihost-ci-sc4
+      - exabox-multihost-ci-volcano-sc4
 
   # Like bh_sc4, but high-power pool (exabox.tenstorrent.com/power=14kw).
   # exabox-multihost-ci-* labels mark multihost routing; do not reuse for other runners.
   bh_sc4_high_power:
     runs_on:
-      - exabox-multihost-ci-sc4-hp
+      - exabox-multihost-ci-volcano-sc4-hp
 
   # exabox-multihost-ci-* labels mark multihost routing; do not reuse for other runners.
   bh_sc16:
     runs_on:
-      - exabox-multihost-ci-sc16
+      - exabox-multihost-ci-volcano-sc16
 
   cpu_medium:
     runs_on:


### PR DESCRIPTION


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=switch-to-canary-ssh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:switch-to-canary-ssh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=switch-to-canary-ssh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:switch-to-canary-ssh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=switch-to-canary-ssh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:switch-to-canary-ssh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=switch-to-canary-ssh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:switch-to-canary-ssh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=switch-to-canary-ssh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:switch-to-canary-ssh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=switch-to-canary-ssh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:switch-to-canary-ssh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=switch-to-canary-ssh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:switch-to-canary-ssh)