### PR TITLE
prefill/d2h: destroy the D2H stream service before the mesh closes

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -816,6 +816,11 @@ class TtPrefillRuntime:
         release = getattr(self.model, "release_sub_device_managers", None)
         if release is not None:
             release()
+        # The D2H ack service is baked into the capture, so this holds the last reference to it once
+        # the caller has dropped its own. Releasing its device service cores and their L1 needs the
+        # mesh still open, so keeping it alive past close leaves those cores claimed for the life of
+        # the process.
+        self._trace_d2h_service = None
 
     def set_layer_ack_channel(self, layer_ack_channel) -> None:
         """Register the per-layer-ack channel (docs/scheduler/prefill.md §3.11).

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -817,9 +817,9 @@ class TtPrefillRuntime:
         if release is not None:
             release()
         # The D2H ack service is baked into the capture, so this holds the last reference to it once
-        # the caller has dropped its own. Releasing its device service cores and their L1 needs the
-        # mesh still open, so keeping it alive past close leaves those cores claimed for the life of
-        # the process.
+        # the caller has dropped its own. Its device-side teardown -- barrier, termination signal,
+        # service-core L1 release -- only works while the mesh is open, so it has to run from here
+        # rather than from wherever the last reference happens to drop.
         self._trace_d2h_service = None
 
     def set_layer_ack_channel(self, layer_ack_channel) -> None:

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -480,8 +480,13 @@ uint32_t D2HSocket::required_config_buffer_size() {
 }
 
 D2HSocket::~D2HSocket() noexcept {
+    // An owning service holds the mesh by shared_ptr, so a socket can outlive close(): the mesh
+    // object is alive but its command queues are gone, its service cores are already released and
+    // the host FIFO window is unmapped. Each device-side step then costs a full barrier timeout and
+    // a failed L1 release, per socket, so gate them on the mesh actually being open.
+    const bool device_live = mesh_device_ != nullptr && mesh_device_->is_initialized();
     try {
-        if (!exported_) {
+        if (!exported_ && device_live) {
             barrier(1000);
         }
     } catch (const std::exception& e) {
@@ -489,7 +494,7 @@ D2HSocket::~D2HSocket() noexcept {
     } catch (...) {
         log_warning(LogMetal, "D2HSocket destructor: barrier failed with unknown exception");
     }
-    if (svc_config_l1_addr_.has_value()) {
+    if (svc_config_l1_addr_.has_value() && device_live) {
         try {
             config_buffer_.reset();
             auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager();

--- a/ttnn/core/services/d2h_socket_service.cpp
+++ b/ttnn/core/services/d2h_socket_service.cpp
@@ -621,6 +621,11 @@ D2HStreamService::D2HStreamService(
 }
 
 D2HStreamService::~D2HStreamService() {
+    // mesh_device_ is a shared_ptr, so the mesh can still be alive but already CLOSED when the last
+    // reference to this service drops. A closed mesh has cleared its command queues, released the
+    // service cores this would free, and unmapped the host FIFO window barrier() polls (untimed), so
+    // non-null is not enough to touch it -- gate on the mesh actually being open.
+    const bool device_live = mesh_device_ != nullptr && mesh_device_->is_initialized();
     try {
         stop_host_read_workers();
         if (!is_owner_) {
@@ -628,22 +633,21 @@ D2HStreamService::~D2HStreamService() {
             return;
         }
 
-        barrier();
-        signal_termination();
-
-        if (mesh_device_) {
+        if (device_live) {
+            barrier();
+            signal_termination();
             distributed::Finish(mesh_device_->mesh_command_queue());
         }
 
         auto& svc = tt::tt_metal::internal::service_core_manager();
-        if (mesh_device_) {
+        if (device_live) {
             for (const auto& [coord, core] : service_cores_) {
                 auto* d = mesh_device_->get_device(coord);
                 svc.wait_done(d, core);
             }
         }
 
-        if (mesh_device_) {
+        if (device_live) {
             for (const auto& [coord, addr] : termination_addrs_) {
                 auto* d = mesh_device_->get_device(coord);
                 svc.deallocate_l1(d, service_cores_.at(coord), addr);
@@ -677,7 +681,16 @@ D2HStreamService::~D2HStreamService() {
                 mesh_id_claimed_cores_.clear();
             }
         }
+    } catch (const std::exception& e) {
+        log_warning(tt::LogOp, "D2HStreamService: shutdown failed: {}", e.what());
+    } catch (...) {
+        log_warning(tt::LogOp, "D2HStreamService: shutdown failed with unknown exception");
+    }
 
+    // Outside the block above, and only reached by an owner: the descriptor is host state that needs
+    // no open mesh, and a leftover file makes the next service on this host read a stale manifest.
+    // It has to go even when the device-side release was skipped or threw part-way.
+    try {
         if (!descriptor_path_.empty()) {
             if (std::remove(descriptor_path_.c_str()) == 0 || errno == ENOENT) {
                 distributed::ShmResourceTracker::instance().untrack_file(descriptor_path_);
@@ -685,9 +698,9 @@ D2HStreamService::~D2HStreamService() {
             descriptor_path_.clear();
         }
     } catch (const std::exception& e) {
-        log_warning(tt::LogOp, "D2HStreamService: shutdown failed: {}", e.what());
+        log_warning(tt::LogOp, "D2HStreamService: descriptor cleanup failed: {}", e.what());
     } catch (...) {
-        log_warning(tt::LogOp, "D2HStreamService: shutdown failed with unknown exception");
+        log_warning(tt::LogOp, "D2HStreamService: descriptor cleanup failed with unknown exception");
     }
 }
 


### PR DESCRIPTION
A traced prefill runner runs `~D2HStreamService()` against a mesh that is already closed, and the destructor throws part-way through, leaking the device resources it was supposed to release.

Two files: the runtime drops its reference at the right time, and the destructor stops trusting caller ordering.

**Symptom.** Every traced runner run, on every rank, ~1 ms after `[pp rank N] shutdown complete`:

```
TT_FATAL @ tt_metal/distributed/mesh_device.cpp:845: cq_id 0 is out of range
D2HStreamService: shutdown failed: ...
```

The destructor catches it and logs a warning, so the job stays green. That is the whole reason this went unnoticed. It is not one line either — the skipped release cascades into 260 `D2HSocket destructor: service-core L1 release failed` warnings, one per socket.

**Cause.** `set_d2h_ack_service()` parks the service on the runtime object. The runtime outlives `close_mesh_device()`, so Python destroys the service at interpreter teardown — after the mesh is closed. `mesh_device_` is a `shared_ptr`, so the mesh is still *alive*, just closed: `close_impl` has already run `mesh_command_queues_.clear()`, and `Finish(mesh_device_->mesh_command_queue())` trips the bounds check above.

Only the traced path is affected. The ack is a device op, so a capture has to bake the service in and therefore hold a reference; the eager path passes it per `prefill_chunk()` call and stores nothing. The untraced GLM leg is the control — same runs, no warnings.

**What the throw costs.** It aborts the whole `try` block, so everything after `Finish` is skipped: `svc.wait_done()`, every `deallocate_l1`, and `svc.release()` of the service cores. Those cores stay claimed and their L1 stays allocated for the life of the process.

Two more hazards were sitting in the same window, unguarded on main and reachable the same way:

- `signal_termination()` issues `WriteToDeviceL1` through a destructed UMD cluster.
- `D2HSocket::barrier()` (`d2h_socket.cpp:661`) polls a host-mapped FIFO window in a `while` loop that only breaks on timeout when `timeout_ms.has_value()`. The destructor passes no timeout, and a closed device has unmapped that window — an **unbounded hang**, not a throw.

Both now sit behind the same gate.

---

**Change 1 — `tt_prefill_runtime.py`: drop the reference in `release_trace()`**

```python
         release = getattr(self.model, "release_sub_device_managers", None)
         if release is not None:
             release()
+        self._trace_d2h_service = None
```

This is the cause fix. `release_trace()` is already the documented hook for freeing the capture *before* the driver closes the mesh, and the driver already calls it in that order (`prefill_runner.py:505-511`, immediately ahead of `close_mesh_device`). The service was simply not in it.

**Change 2 — `d2h_socket_service.cpp`: gate device work on the mesh being open**

```cpp
+    const bool device_live = mesh_device_ != nullptr && mesh_device_->is_initialized();
     try {
         ...
-        barrier();
-        signal_termination();
-
-        if (mesh_device_) {
+        if (device_live) {
+            barrier();
+            signal_termination();
             distributed::Finish(mesh_device_->mesh_command_queue());
         }
```

The three existing `if (mesh_device_)` guards become `if (device_live)`; `barrier()` and `signal_termination()` move under it from no guard at all. `is_initialized()` is the correct predicate: `close_impl` clears `is_internal_state_initialized`, so it is false exactly when the command queues are gone and the cores are already released.

Change 1 alone would fix the observed failure, but a destructor must not depend on its caller's teardown order, and I can't statically prove the Python drop is always the last reference — `self.model.forward(..., d2h_service=...)` hands it down per call. Change 2 is the guarantee.

**Change 3 — descriptor removal moves after the `catch`**

```cpp
+    } catch (const std::exception& e) {
+        log_warning(tt::LogOp, "D2HStreamService: shutdown failed: {}", e.what());
+    ...
+    try {
         if (!descriptor_path_.empty()) {
             if (std::remove(descriptor_path_.c_str()) == 0 || errno == ENOENT) {
                 distributed::ShmResourceTracker::instance().untrack_file(descriptor_path_);
```

`/dev/shm/tt_d2h_stream_service_<id>.bin` is host state, and a leftover file makes the next service on the host read a stale manifest. It was inside the `try`, so the throw above skipped it too. It now runs even when the device-side release was gated off or threw part-way.

Not exercised by the prefill runner, which exports only its H2D descriptor (`prefill_runner.py:532`) and leaves `descriptor_path_` empty on the D2H service — the only `_d2h` exports are in `deepseek_v3_b1` (`micro_ops/pipeline_block/op.py:1311`, `demo/stage.py:1127`). Included because the failure mode is the same one, at the same place, for the path that does use it.

The non-owner early `return` still sits inside the first `try` and so skips this block. That is safe: `export_descriptor` `TT_FATAL`s for non-owners (line 986), so `descriptor_path_` is only ever set on an owner.

---

**Validation** — Blaze prefill runner CI, `test-type=prefill_runner_kv_pcc`, 4-rank SC4.

| | before ([33623009765](https://github.com/tenstorrent/tt-metal/actions/runs/33623009765)) | after ([33635644328](https://github.com/tenstorrent/tt-metal/actions/runs/33635644328)) |
|---|---|---|
| `D2HStreamService: shutdown failed` | 8 — all 4 ranks | **0** |
| `service-core L1 release failed` | 260 — one per socket | **0** |
| `cq_id 0 is out of range` | 17 | **0** |
| KV PCC gate | PASS 4/4 | PASS 4/4 — 0.985 / 0.939 / 0.918 / 0.892 |

Kimi-K2.7 is the traced leg and the one that exercises this. The GLM-5.2 leg in the same run failed in the pre-test `Setup multihost job` step (`POST_RESET failed for device 12`, `Recovery failed after 10 attempts`) — the test step was skipped, so no code ran; a re-run is in flight.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/d2h_teardown_order)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/d2h_teardown_order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/d2h_teardown_order)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/d2h_teardown_order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/d2h_teardown_order)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/d2h_teardown_order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/d2h_teardown_order)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/d2h_teardown_order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/d2h_teardown_order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/d2h_teardown_order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/d2h_teardown_order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/d2h_teardown_order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/d2h_teardown_order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/d2h_teardown_order)
