### PR TITLE
[Feature] tt_dit: opt-in small_m_matmul backend for Linear / ColParallelLinear, autotuner and device-perf gate

### DIFF
--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -42,6 +42,83 @@ _FUSED_GELU_VARIANTS = {
 }
 
 
+# --------------------------------------------------------------------------------------
+# small_m_matmul backend
+# --------------------------------------------------------------------------------------
+# ttnn.experimental.small_m_matmul is a DRAM-bandwidth-optimal matmul for small M / wide N.
+# It keeps the in0 k-slice L1-resident and reads in1 from a DRAM WIDTH_SHARDED (8-bank) weight,
+# so the weight LAYOUT is part of the op's contract: it is chosen at construction and enforced by
+# Parameter at load, never reshaped per forward. Opting in is explicit (`use_small_m_matmul=True`)
+# and failure is loud -- there is deliberately no silent fallback to minimal_matmul, because a
+# silent fallback would hide the fact that the layout cost was paid for nothing.
+#
+# Construction can only check what is knowable from the weight: arch, dtype, local N feasibility,
+# bank count. M and the fusion-dependent L1 footprint are known only in forward, so the op's own
+# planner remains the authority and will raise there.
+
+# The 8-bank width shard requires 7*ceil(Nt/8) < Nt, i.e. the trailing bank must hold real data.
+_SMALL_M_BANKS = 8
+
+
+def _small_m_n_feasible(n: int) -> bool:
+    """Mirror of plan::nt_width_shard_feasible so construction can reject before the weight is laid out."""
+    nt = math.ceil(n / ttnn.TILE_SIZE)
+    return 7 * math.ceil(nt / _SMALL_M_BANKS) < nt
+
+
+def _validate_small_m(*, name, mesh_device, dtype, local_k, local_n, fuse_swiglu, fsdp_mesh_axis):
+    """Static (weight-only) admission check for the small_m_matmul backend.
+
+    Raises ValueError with the actual reason. Deliberately strict: every rejection here is a
+    condition under which the op could not run at ANY M, so failing at construction is strictly
+    better than failing on the first forward.
+    """
+    if not is_blackhole():
+        msg = f"{name}: use_small_m_matmul requires Blackhole"
+        raise ValueError(msg)
+    if dtype != ttnn.bfloat16:
+        msg = f"{name}: use_small_m_matmul requires a bfloat16 weight, got {dtype}"
+        raise ValueError(msg)
+    if fuse_swiglu:
+        msg = f"{name}: use_small_m_matmul does not implement fuse_swiglu"
+        raise ValueError(msg)
+    if fsdp_mesh_axis is not None and mesh_device.shape[fsdp_mesh_axis] > 1:
+        # An FSDP-gathered weight materialises interleaved at runtime; re-sharding it into the
+        # 8-bank width layout every forward would cost more than the matmul saves.
+        msg = f"{name}: use_small_m_matmul is incompatible with FSDP weight gathering"
+        raise ValueError(msg)
+    if not _small_m_n_feasible(local_n):
+        nt = math.ceil(local_n / ttnn.TILE_SIZE)
+        msg = (
+            f"{name}: use_small_m_matmul cannot serve local N={local_n} (Nt={nt}). The in1 DRAM width "
+            f"shard across {_SMALL_M_BANKS} banks requires 7*ceil(Nt/8) < Nt; workable widths are "
+            f"Nt = 8, 15, 16, 22, 23, 24, 29.. (N = 256, 480, 512, 704, 736, 768, 928..). NOTE this is "
+            f"the per-device N after tensor-parallel sharding, so the same layer can be feasible at one "
+            f"TP factor and infeasible at another."
+        )
+        raise ValueError(msg)
+    dram_grid = mesh_device.dram_grid_size()
+    if dram_grid.x * dram_grid.y < _SMALL_M_BANKS:
+        msg = (
+            f"{name}: use_small_m_matmul needs >= {_SMALL_M_BANKS} DRAM banks, "
+            f"device exposes {dram_grid.x}x{dram_grid.y}"
+        )
+        raise ValueError(msg)
+    return ttnn.create_small_m_weight_memory_config(ttnn.Shape([local_k, local_n]), dtype, mesh_device)
+
+
+def _check_small_m_dtype(name, dtype):
+    """small_m_matmul fixes its output to bfloat16; an explicit request for anything else is an error.
+
+    A caller-supplied ``compute_kernel_config`` is accepted and ignored: the op takes no such
+    argument (numerics are fixed at HiFi2 + fp32 dest accumulation), and every DiT call site passes
+    the module's own default, so rejecting it would make the flag unusable on the paths it targets.
+    """
+    if dtype is not None and dtype != ttnn.bfloat16:
+        msg = f"{name}: use_small_m_matmul fixes the output dtype to bfloat16, cannot honour dtype={dtype}"
+        raise ValueError(msg)
+
+
 def maybe_cast_activation(x: ttnn.Tensor, activation_dtype) -> ttnn.Tensor:
     """Cast an activation that is about to cross the fabric, if a quant config asked for it.
 
@@ -89,6 +166,7 @@ class Linear(Module):
         # Branch addition kept over main: the H3 / Qwen3-VL layers pass an explicit config for
         # the sites that need more precision than the shared default.
         compute_kernel_config=None,
+        use_small_m_matmul=False,
     ):
         super().__init__()
 
@@ -119,7 +197,26 @@ class Linear(Module):
             packer_l1_acc=True,
         )
 
-        self.weight = Parameter(total_shape=[self.in_features, self.out_features], device=mesh_device, dtype=dtype)
+        self.use_small_m_matmul = use_small_m_matmul
+        weight_memory_config = ttnn.DRAM_MEMORY_CONFIG
+        if use_small_m_matmul:
+            # Weights are replicated here, so local N == out_features.
+            weight_memory_config = _validate_small_m(
+                name="Linear",
+                mesh_device=mesh_device,
+                dtype=dtype,
+                local_k=self.in_features,
+                local_n=self.out_features,
+                fuse_swiglu=self.fuse_swiglu,
+                fsdp_mesh_axis=None,
+            )
+
+        self.weight = Parameter(
+            total_shape=[self.in_features, self.out_features],
+            device=mesh_device,
+            dtype=dtype,
+            memory_config=weight_memory_config,
+        )
         self.bias = Parameter(total_shape=[1, self.out_features], device=mesh_device, dtype=dtype) if bias else None
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -135,6 +232,16 @@ class Linear(Module):
             state["bias"] = bias
 
     def forward(self, x: ttnn.Tensor, compute_kernel_config=None, dtype=None, default_block_size=None) -> ttnn.Tensor:
+        if self.use_small_m_matmul:
+            _check_small_m_dtype("Linear", dtype)
+            output = ttnn.experimental.small_m_matmul(
+                x,
+                self.weight.data,
+                bias_tensor=self.bias.data if self.bias is not None else None,
+                fused_activation=self.fused_activation_fn,
+            )
+            return _apply_activation_fn(output, self.activation_fn)
+
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], self.weight.data.padded_shape[-1]
         core_grid = get_matmul_core_grid(self.mesh_device)
         matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
@@ -189,6 +296,7 @@ class ColParallelLinear(Module):
         # the sites that need more precision than the shared default.
         compute_kernel_config=None,
         pin_output_bf16=False,
+        use_small_m_matmul=False,
     ):
         super().__init__()
 
@@ -237,19 +345,35 @@ class ColParallelLinear(Module):
             packer_l1_acc=True,
         )
 
+        self._mesh_axis_size = self.mesh_device.shape[self.mesh_axis] if self.mesh_axis is not None else 1
+
+        self.use_small_m_matmul = use_small_m_matmul
+        weight_memory_config = ttnn.DRAM_MEMORY_CONFIG
+        if use_small_m_matmul:
+            # Column parallel: the weight is sharded on N, so the layout must be built from the LOCAL
+            # width. A layer can therefore be feasible at one TP factor and infeasible at another.
+            weight_memory_config = _validate_small_m(
+                name="ColParallelLinear",
+                mesh_device=mesh_device,
+                dtype=dtype,
+                local_k=self.in_features,
+                local_n=self.out_features // self._mesh_axis_size,
+                fuse_swiglu=self.fuse_swiglu,
+                fsdp_mesh_axis=fsdp_mesh_axis,
+            )
+
         self.weight = Parameter(
             total_shape=[self.in_features, self.out_features],
             mesh_axes=[fsdp_mesh_axis, mesh_axis],
             device=mesh_device,
             dtype=dtype,
+            memory_config=weight_memory_config,
         )
         self.bias = (
             Parameter(total_shape=[1, self.out_features], mesh_axes=[None, mesh_axis], device=mesh_device, dtype=dtype)
             if bias
             else None
         )
-
-        self._mesh_axis_size = self.mesh_device.shape[self.mesh_axis] if self.mesh_axis is not None else 1
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         weight = state.pop("weight", None)
@@ -342,6 +466,153 @@ class ColParallelLinear(Module):
             out = ttnn.reshape(out, tuple(out.shape)[-orig_rank:])
         return out
 
+    def _small_m_gather_input(self, x: ttnn.Tensor, parallel_config) -> ttnn.Tensor:
+        """Stand-alone all-gather of the activation along K, replacing the fused AG-matmul's gather.
+
+        This is the intermediate composition the small-M matmul is meant for: an unfused gather
+        followed by a much faster single-chip matmul. The gather is the same persistent-buffer
+        all_gather_async the fused op performs internally, just hoisted out.
+        """
+        if parallel_config is None or parallel_config.tensor_parallel.factor <= 1:
+            return x
+        return self.ccl_manager.all_gather_persistent_buffer(
+            x, dim=-1, mesh_axis=parallel_config.tensor_parallel.mesh_axis
+        )
+
+    def forward_fused_addcmul(
+        self,
+        x: ttnn.Tensor,
+        addcmul_a: ttnn.Tensor,
+        addcmul_b: ttnn.Tensor,
+        scalar: float = 1.0,
+        *,
+        compute_kernel_config=None,
+        parallel_config=None,
+        dtype=None,
+    ) -> ttnn.Tensor:
+        """ColParallel projection with a fused addcmul epilogue: ``addcmul_a + scalar * (x@W + bias) * addcmul_b``.
+
+        Single-chunk only. Exists so call sites that need the ternary epilogue (LTX/Wan ``to_out``) follow
+        this layer's configured matmul backend (including ``use_small_m_matmul``) instead of inlining the
+        dispatch. With the flag off this is exactly the routing those call sites used to inline: known shapes
+        at TP>1 go to the strided (fabric) AG-matmul, other TP>1 shapes to the AG-matmul, TP==1 to
+        ``dit_minimal_matmul_addcmul_fused``.
+        """
+        x = maybe_cast_activation(x, self.activation_dtype)
+        if self.pin_output_bf16:
+            dtype = resolve_output_dtype(dtype, x)
+
+        if self.fsdp_mesh_axis is not None and self.mesh_device.shape[self.fsdp_mesh_axis] > 1:
+            unsqueezed_weight = ttnn.unsqueeze_to_4D(self.weight.data)
+            weight = self.ccl_manager.all_gather_persistent_buffer(
+                unsqueezed_weight, dim=2, mesh_axis=self.fsdp_mesh_axis
+            )
+            weight = ttnn.reshape(weight, (weight.shape[-2], weight.shape[-1]))
+        else:
+            weight = self.weight.data
+
+        bias = self.bias.data if self.bias is not None else None
+
+        if self.use_small_m_matmul:
+            _check_small_m_dtype("ColParallelLinear", dtype)
+            x = self._small_m_gather_input(x, parallel_config)
+            return ttnn.experimental.small_m_matmul(
+                x,
+                weight,
+                bias_tensor=bias,
+                fused_ternary_scalar=scalar,
+                fused_ternary_input_a=addcmul_a,
+                fused_ternary_input_b=addcmul_b,
+            )
+
+        compute_kernel_config = compute_kernel_config or self.compute_config
+        if parallel_config is not None and parallel_config.tensor_parallel.factor > 1:
+            M, K, N_out = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
+            full_grid = self.mesh_device.compute_with_storage_grid_size()
+            tp_axis = parallel_config.tensor_parallel.mesh_axis
+
+            # Known shapes route the addcmul projection to the strided AG-matmul (out = a + scalar*matmul*b).
+            fabric_cfg = get_fabric_agmm_config(M, K, N_out, 1, full_grid)
+            if fabric_cfg is not None:
+                dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+                fabric_matmul_config = ttnn.MinimalMatmulConfig(
+                    M_block_size=fabric_cfg.M_block_size,
+                    K_block_size=fabric_cfg.K_block_size,
+                    N_block_size=fabric_cfg.N_block_size,
+                    subblock_h=fabric_cfg.subblock_h,
+                    subblock_w=fabric_cfg.subblock_w,
+                    compute_with_storage_grid_size=fabric_cfg.mm_core_grid,
+                )
+                outputs = ttnn.experimental.strided_all_gather_minimal_matmul_async(
+                    x,
+                    weight,
+                    persistent_output_buffer=self.ccl_manager.get_ag_ping_pong_buffer(
+                        x.shape, 3, tp_axis, dtype=x.get_dtype()
+                    ),
+                    dim=3,
+                    multi_device_global_semaphore=self.ccl_manager.get_strided_ag_mm_semaphore(
+                        tp_axis, fabric_cfg.num_workers_per_link
+                    ),
+                    strided_all_gather_core_grid_offset=fabric_cfg.ag_core_grid_offset,
+                    num_links=self.ccl_manager.num_links,
+                    memory_config_ag=dram,
+                    topology=self.ccl_manager.topology,
+                    cluster_axis=tp_axis,
+                    bias=bias,
+                    config=fabric_matmul_config,
+                    memory_config_mm=dram,
+                    compute_kernel_config=compute_kernel_config,
+                    num_workers_per_link=fabric_cfg.num_workers_per_link,
+                    num_buffers_per_channel=fabric_cfg.num_buffers_per_channel,
+                    read_local_slice_from_input=True,
+                    fused_ternary_input_a=addcmul_a,
+                    fused_ternary_input_b=addcmul_b,
+                    fused_ternary_scalar=scalar,
+                    chunks=1,
+                )
+                # Op returns [all_gather_output, matmul_chunk_0]; take the single matmul chunk.
+                return outputs[1]
+
+            core_grid = ttnn.CoreCoord(full_grid.x, full_grid.y - 1)
+            matmul_config = get_matmul_config(M, K, N_out, core_grid)
+            ag_persistent_buffer = self.ccl_manager.get_ag_ping_pong_buffer(x.shape, 3, tp_axis, dtype=x.get_dtype())
+            ag_global_semaphores = self.ccl_manager.get_ag_ping_pong_semaphore(tp_axis)
+            return ttnn.experimental.all_gather_minimal_matmul_async(
+                input_tensor=x,
+                weight_tensor=weight,
+                bias_tensor=bias,
+                config=matmul_config,
+                compute_kernel_config=compute_kernel_config,
+                persistent_output_buffer=ag_persistent_buffer,
+                multi_device_global_semaphore=ag_global_semaphores,
+                num_links=self.ccl_manager.num_links,
+                topology=self.ccl_manager.topology,
+                cluster_axis=tp_axis,
+                barrier_semaphore=None,
+                force_transpose=True,
+                num_workers_per_link=full_grid.x // self.ccl_manager.num_links,
+                num_buffers_per_channel=48 if not is_blackhole() else 24,
+                scalar=scalar,
+                addcmul_input_tensor1=addcmul_a,
+                addcmul_input_tensor2=addcmul_b,
+                dtype=dtype,
+            )[0]
+
+        M, K, N_out = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
+        core_grid = self.mesh_device.compute_with_storage_grid_size()
+        matmul_config = get_matmul_config(M, K, N_out, core_grid)
+        return ttnn.experimental.dit_minimal_matmul_addcmul_fused(
+            x,
+            weight,
+            scalar,
+            addcmul_a,
+            addcmul_b,
+            bias_tensor=bias,
+            config=matmul_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+        )
+
     def forward(
         self,
         x: ttnn.Tensor,
@@ -390,6 +661,43 @@ class ColParallelLinear(Module):
             weight = ttnn.reshape(weight, (weight.shape[-2], weight.shape[-1]))
         else:
             weight = self.weight.data
+
+        if self.use_small_m_matmul:
+            _check_small_m_dtype("ColParallelLinear", dtype)
+            tp = parallel_config is not None and parallel_config.tensor_parallel.factor > 1
+            x = self._small_m_gather_input(x, parallel_config)
+            bias = self.bias.data if self.bias is not None else None
+            if addcmul_a is not None:
+                if self.fused_activation_fn is not None:
+                    msg = "use_small_m_matmul cannot fuse an activation together with addcmul"
+                    raise ValueError(msg)
+                return ttnn.experimental.small_m_matmul(
+                    x,
+                    weight,
+                    bias_tensor=bias,
+                    fused_ternary_scalar=addcmul_scalar,
+                    fused_ternary_input_a=addcmul_a,
+                    fused_ternary_input_b=addcmul_b,
+                )
+            # Match the fused paths' return convention exactly so the flag is a drop-in: at TP>1 a
+            # single chunk returns a bare tensor, at TP==1 any non-None `chunks` returns a list.
+            if self.chunks is not None and (self.chunks > 1 or not tp):
+                outputs = ttnn.experimental.small_m_matmul_split(
+                    x,
+                    weight,
+                    chunks=self.chunks,
+                    dim=-1,
+                    bias_tensor=bias,
+                    fused_activation=self.fused_activation_fn,
+                )
+                return [_apply_activation_fn(o, self.activation_fn) for o in outputs]
+            output = ttnn.experimental.small_m_matmul(
+                x,
+                weight,
+                bias_tensor=bias,
+                fused_activation=self.fused_activation_fn,
+            )
+            return _apply_activation_fn(output, self.activation_fn)
 
         parallel_config_tp = parallel_config.tensor_parallel.factor if parallel_config is not None else 1
         needs_gather = x.padded_shape[-1] != weight.padded_shape[-2]  # If gathered, switch to non fused AGMM

--- a/models/tt_dit/models/transformers/ltx/attention_ltx.py
+++ b/models/tt_dit/models/transformers/ltx/attention_ltx.py
@@ -11,12 +11,11 @@ import torch
 import ttnn
 from models.common.utility_functions import is_blackhole
 
-from ....layers.linear import ColParallelLinear, LoRAColParallelLinear, maybe_cast_activation, resolve_output_dtype
+from ....layers.linear import ColParallelLinear, LoRAColParallelLinear, maybe_cast_activation
 from ....layers.module import Module
 from ....layers.normalization import DistributedRMSNorm
 from ....parallel.config import DiTParallelConfig
 from ....parallel.manager import CCLManager
-from ....utils.matmul import get_fabric_agmm_config, get_matmul_config
 from ....utils.substate import pop_substate, rename_substate
 from ....utils.tensor import bf16_tensor
 from .quant_config import LtxQuantProfile
@@ -432,118 +431,21 @@ class LTXAttention(Module):
         parallel_config: DiTParallelConfig | None = None,
         dtype=None,
     ) -> ttnn.Tensor:
-        """Fused to_out projection + addcmul: output = residual + (matmul(x, W) + bias) * gate."""
-        to_out = self.to_out
-        # to_out inlines the AG-matmul rather than calling ColParallelLinear.forward, so it has to
-        # honour the activation cast itself. The addcmul residual/gate stay bf16 — the kernel ties
-        # their tile size to the weight's, not the activation's — and the output is the residual
-        # stream, so it must be pinned back to bf16 rather than inheriting the bf8 activation.
-        x = maybe_cast_activation(x, to_out.activation_dtype)
-        if to_out.pin_output_bf16:
-            dtype = resolve_output_dtype(dtype, x)
+        """Fused to_out projection + addcmul: output = residual + (matmul(x, W) + bias) * gate.
 
-        if to_out.fsdp_mesh_axis is not None and to_out.mesh_device.shape[to_out.fsdp_mesh_axis] > 1:
-            unsqueezed_weight = ttnn.unsqueeze_to_4D(to_out.weight.data)
-            weight = self.ccl_manager.all_gather_persistent_buffer(
-                unsqueezed_weight, dim=2, mesh_axis=to_out.fsdp_mesh_axis
-            )
-            weight = ttnn.reshape(weight, (weight.shape[-2], weight.shape[-1]))
-        else:
-            weight = to_out.weight.data
-
-        if parallel_config is not None and parallel_config.tensor_parallel.factor > 1:
-            M, K, N_out = x.padded_shape[-2], weight.padded_shape[-2], weight.padded_shape[-1]
-            full_grid = self.mesh_device.compute_with_storage_grid_size()
-
-            # Known shapes route the addcmul to_out to the strided AG-matmul (out = a + scalar*matmul*b)
-            fabric_cfg = get_fabric_agmm_config(M, K, N_out, 1, full_grid)
-            if fabric_cfg is not None:
-                tp_axis = parallel_config.tensor_parallel.mesh_axis
-                dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
-                fabric_matmul_config = ttnn.MinimalMatmulConfig(
-                    M_block_size=fabric_cfg.M_block_size,
-                    K_block_size=fabric_cfg.K_block_size,
-                    N_block_size=fabric_cfg.N_block_size,
-                    subblock_h=fabric_cfg.subblock_h,
-                    subblock_w=fabric_cfg.subblock_w,
-                    compute_with_storage_grid_size=fabric_cfg.mm_core_grid,
-                )
-                outputs = ttnn.experimental.strided_all_gather_minimal_matmul_async(
-                    x,
-                    weight,
-                    persistent_output_buffer=self.ccl_manager.get_ag_ping_pong_buffer(
-                        x.shape, 3, tp_axis, dtype=x.get_dtype()
-                    ),
-                    dim=3,
-                    multi_device_global_semaphore=self.ccl_manager.get_strided_ag_mm_semaphore(
-                        tp_axis, fabric_cfg.num_workers_per_link
-                    ),
-                    strided_all_gather_core_grid_offset=fabric_cfg.ag_core_grid_offset,
-                    num_links=self.ccl_manager.num_links,
-                    memory_config_ag=dram,
-                    topology=self.ccl_manager.topology,
-                    cluster_axis=tp_axis,
-                    bias=to_out.bias.data if to_out.bias is not None else None,
-                    config=fabric_matmul_config,
-                    memory_config_mm=dram,
-                    compute_kernel_config=compute_kernel_config or to_out.compute_config,
-                    num_workers_per_link=fabric_cfg.num_workers_per_link,
-                    num_buffers_per_channel=fabric_cfg.num_buffers_per_channel,
-                    read_local_slice_from_input=True,
-                    fused_ternary_input_a=addcmul_residual,
-                    fused_ternary_input_b=addcmul_gate,
-                    fused_ternary_scalar=1.0,
-                    chunks=1,
-                )
-                # Op returns [all_gather_output, matmul_chunk_0]; take the single matmul chunk.
-                return outputs[1]
-
-            core_grid = ttnn.CoreCoord(full_grid.x, full_grid.y - 1)
-            matmul_config = get_matmul_config(M, K, N_out, core_grid)
-
-            ag_persistent_buffer = self.ccl_manager.get_ag_ping_pong_buffer(
-                x.shape, 3, parallel_config.tensor_parallel.mesh_axis, dtype=x.get_dtype()
-            )
-            ag_global_semaphores = self.ccl_manager.get_ag_ping_pong_semaphore(
-                parallel_config.tensor_parallel.mesh_axis
-            )
-            output = ttnn.experimental.all_gather_minimal_matmul_async(
-                input_tensor=x,
-                weight_tensor=weight,
-                bias_tensor=to_out.bias.data if to_out.bias is not None else None,
-                config=matmul_config,
-                compute_kernel_config=compute_kernel_config or to_out.compute_config,
-                persistent_output_buffer=ag_persistent_buffer,
-                multi_device_global_semaphore=ag_global_semaphores,
-                num_links=self.ccl_manager.num_links,
-                topology=self.ccl_manager.topology,
-                cluster_axis=parallel_config.tensor_parallel.mesh_axis,
-                barrier_semaphore=None,
-                force_transpose=True,
-                num_workers_per_link=full_grid.x // self.ccl_manager.num_links,
-                num_buffers_per_channel=48 if not is_blackhole() else 24,
-                scalar=1.0,
-                addcmul_input_tensor1=addcmul_residual,
-                addcmul_input_tensor2=addcmul_gate,
-                dtype=dtype,
-            )[0]
-        else:
-            M, K, N_out = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
-            core_grid = self.mesh_device.compute_with_storage_grid_size()
-            matmul_config = get_matmul_config(M, K, N_out, core_grid)
-
-            output = ttnn.experimental.dit_minimal_matmul_addcmul_fused(
-                x,
-                weight,
-                1.0,
-                addcmul_residual,
-                addcmul_gate,
-                bias_tensor=to_out.bias.data if to_out.bias is not None else None,
-                config=matmul_config,
-                compute_kernel_config=compute_kernel_config or to_out.compute_config,
-                dtype=dtype,
-            )
-        return output
+        Delegates to ColParallelLinear.forward_fused_addcmul rather than inlining the dispatch, so
+        this call site follows to_out's configured matmul backend (including use_small_m_matmul).
+        Inlining it here previously made the projection invisible to any per-layer backend choice.
+        """
+        return self.to_out.forward_fused_addcmul(
+            x,
+            addcmul_residual,
+            addcmul_gate,
+            1.0,
+            compute_kernel_config=compute_kernel_config,
+            parallel_config=parallel_config,
+            dtype=dtype,
+        )
 
     def _gate_is_live(self) -> bool:
         """True when the gate projection will actually run (and so will gather its input).

--- a/models/tt_dit/tests/unit/test_linear_small_m.py
+++ b/models/tt_dit/tests/unit/test_linear_small_m.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coverage for the ``use_small_m_matmul`` backend on Linear / ColParallelLinear.
+
+Three things are worth testing separately here, because they fail in different places:
+
+1. WEIGHT LAYOUT, decided at construction. The op reads in1 from a DRAM WIDTH_SHARDED (8-bank)
+   buffer, so the layout is part of the op's contract and Parameter enforces it at load.
+2. ADMISSION, also at construction. Every rejection covered below is a condition under which the
+   op could not run at ANY M, so it must fail before a weight is laid out -- not on first forward.
+3. NUMERICS of each dispatch path (plain, chunked, TP gather, fused addcmul).
+
+All of these require Blackhole: the op is Blackhole-only.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+
+from ...layers.linear import ColParallelLinear, Linear
+from ...parallel.config import DiTParallelConfig
+from ...parallel.manager import CCLManager
+from ...utils.check import assert_quality
+from ...utils.tensor import bf16_tensor
+from ...utils.test import mesh_device_config_to_string
+
+pytestmark = pytest.mark.skipif(not is_blackhole(), reason="small_m_matmul is Blackhole-only")
+
+# Shapes are small M / wide N with an N whose LOCAL width satisfies 7*ceil(Nt/8) < Nt.
+# N=2048 -> Nt=64 and N=768 -> Nt=24 are both feasible; N=384 -> Nt=12 is deliberately not.
+_M, _K, _N = 256, 2048, 2048
+
+
+def _mesh_1x1():
+    return pytest.mark.parametrize("mesh_device", [(1, 1)], ids=mesh_device_config_to_string, indirect=True)
+
+
+def _torch_linear(K, N, bias=True):
+    m = torch.nn.Linear(K, N, bias=bias).to(dtype=torch.bfloat16)
+    m.eval()
+    return m
+
+
+# ---------------------------------------------------------------------------------------------
+# 1. Weight layout
+# ---------------------------------------------------------------------------------------------
+
+
+@_mesh_1x1()
+def test_small_m_weight_is_width_sharded(mesh_device: ttnn.MeshDevice) -> None:
+    """The weight must land in the 8-bank DRAM width shard at LOAD time, with no per-forward reshard."""
+    torch_model = _torch_linear(_K, _N)
+    tt_model = Linear(_K, _N, mesh_device=mesh_device, use_small_m_matmul=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    mem = tt_model.weight.data.memory_config()
+    assert mem.memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+    assert mem.buffer_type == ttnn.BufferType.DRAM
+    # Exactly 8 banks, one shard column each.
+    assert mem.shard_spec.num_cores() == 8
+
+    # The bias is untouched: only in1 carries the layout requirement.
+    assert tt_model.bias.data.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+
+
+@_mesh_1x1()
+def test_small_m_flag_off_leaves_layout_alone(mesh_device: ttnn.MeshDevice) -> None:
+    """Opting out must not perturb the default interleaved weight."""
+    tt_model = Linear(_K, _N, mesh_device=mesh_device)
+    tt_model.load_torch_state_dict(_torch_linear(_K, _N).state_dict())
+    assert tt_model.weight.data.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+
+
+# ---------------------------------------------------------------------------------------------
+# 2. Admission
+# ---------------------------------------------------------------------------------------------
+
+
+@_mesh_1x1()
+def test_small_m_rejects_infeasible_n(mesh_device: ttnn.MeshDevice, expect_error) -> None:
+    """N=384 gives Nt=12, where 7*ceil(12/8)=14 >= 12: the trailing banks would be all padding."""
+    with expect_error(ValueError, "cannot serve local N=384"):
+        Linear(_K, 384, mesh_device=mesh_device, use_small_m_matmul=True)
+
+
+@_mesh_1x1()
+def test_small_m_rejects_swiglu(mesh_device: ttnn.MeshDevice, expect_error) -> None:
+    with expect_error(ValueError, "does not implement fuse_swiglu"):
+        Linear(_K, _N, activation_fn="swiglu", mesh_device=mesh_device, use_small_m_matmul=True)
+
+
+@_mesh_1x1()
+def test_small_m_rejects_non_bf16_weight(mesh_device: ttnn.MeshDevice, expect_error) -> None:
+    with expect_error(ValueError, "requires a bfloat16 weight"):
+        Linear(_K, _N, dtype=ttnn.bfloat8_b, mesh_device=mesh_device, use_small_m_matmul=True)
+
+
+@_mesh_1x1()
+def test_small_m_rejects_output_dtype_at_forward(mesh_device: ttnn.MeshDevice, expect_error) -> None:
+    """Numerics are fixed, so an explicit non-bf16 output dtype is an error rather than ignored."""
+    tt_model = Linear(_K, _N, mesh_device=mesh_device, use_small_m_matmul=True)
+    tt_model.load_torch_state_dict(_torch_linear(_K, _N).state_dict())
+    x = bf16_tensor(torch.randn((1, 1, _M, _K), dtype=torch.bfloat16), device=mesh_device)
+    with expect_error(ValueError, "fixes the output dtype to bfloat16"):
+        tt_model(x, dtype=ttnn.bfloat8_b)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [((1, 2), {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True})],
+    ids=mesh_device_config_to_string,
+    indirect=True,
+)
+def test_small_m_rejects_fsdp(mesh_device: ttnn.MeshDevice, expect_error) -> None:
+    """An FSDP-gathered weight materialises interleaved at runtime; re-sharding it per forward
+    would cost more than the matmul saves, so the combination is refused up front."""
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    with expect_error(ValueError, "incompatible with FSDP weight gathering"):
+        ColParallelLinear(
+            _K,
+            _N,
+            mesh_device=mesh_device,
+            mesh_axis=0,
+            fsdp_mesh_axis=1,
+            ccl_manager=ccl_manager,
+            use_small_m_matmul=True,
+        )
+
+
+# ---------------------------------------------------------------------------------------------
+# 3. Numerics
+# ---------------------------------------------------------------------------------------------
+
+
+@_mesh_1x1()
+@pytest.mark.parametrize("bias", [True, False], ids=["bias", "no_bias"])
+@pytest.mark.parametrize("activation_fn", [None, "gelu_tanh", "silu"], ids=["none", "fused_gelu", "unfused_silu"])
+def test_small_m_linear(mesh_device: ttnn.MeshDevice, bias: bool, activation_fn) -> None:
+    """Covers both fusion routes: gelu_tanh rides the op's fused_activation, silu is applied after."""
+    torch_model = _torch_linear(_K, _N, bias=bias)
+    tt_model = Linear(_K, _N, bias=bias, activation_fn=activation_fn, mesh_device=mesh_device, use_small_m_matmul=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    torch_input = torch.randn((1, 1, _M, _K), dtype=torch.bfloat16)
+    with torch.no_grad():
+        torch_output = torch_model(torch_input)
+        if activation_fn == "gelu_tanh":
+            torch_output = torch.nn.functional.gelu(torch_output, approximate="tanh")
+        elif activation_fn == "silu":
+            torch_output = torch.nn.functional.silu(torch_output)
+
+    tt_output = tt_model(bf16_tensor(torch_input, device=mesh_device))
+    assert_quality(torch_output, ttnn.to_torch(tt_output), pcc=0.999_500)
+
+
+@_mesh_1x1()
+@pytest.mark.parametrize("chunks", [2, 3], ids=["chunks2", "chunks3"])
+def test_small_m_col_parallel_chunks(mesh_device: ttnn.MeshDevice, chunks: int) -> None:
+    """Chunked output goes through small_m_matmul_split, which writes each chunk directly."""
+    N = 768 * chunks
+    torch_model = _torch_linear(_K, N)
+    tt_model = ColParallelLinear(_K, N, mesh_device=mesh_device, mesh_axis=0, chunks=chunks, use_small_m_matmul=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    torch_input = torch.randn((1, 1, _M, _K), dtype=torch.bfloat16)
+    with torch.no_grad():
+        torch_output = torch_model(torch_input)
+
+    tt_outputs = tt_model(bf16_tensor(torch_input, device=mesh_device))
+    assert len(tt_outputs) == chunks
+    tt_output = torch.cat([ttnn.to_torch(o) for o in tt_outputs], dim=-1)
+    assert_quality(torch_output, tt_output, pcc=0.999_500)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [((1, 2), {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "require_exact_physical_num_devices": True})],
+    ids=mesh_device_config_to_string,
+    indirect=True,
+)
+def test_small_m_col_parallel_tp_gather(mesh_device: ttnn.MeshDevice) -> None:
+    """The target composition: stand-alone all-gather along K, then the single-chip small-M matmul.
+
+    Input arrives fractured on K (that is what the fused AG-matmul would have gathered), output
+    comes back fractured on N.
+    """
+    tp_axis = 1
+    tp = mesh_device.shape[tp_axis]
+    torch_model = _torch_linear(_K, _N)
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    tt_model = ColParallelLinear(
+        _K,
+        _N,
+        mesh_device=mesh_device,
+        mesh_axis=tp_axis,
+        ccl_manager=ccl_manager,
+        use_small_m_matmul=True,
+    )
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    parallel_config = DiTParallelConfig.from_tuples(cfg=(1, 0), sp=(1, 0), tp=(tp, tp_axis))
+
+    torch_input = torch.randn((1, 1, _M, _K), dtype=torch.bfloat16)
+    with torch.no_grad():
+        torch_output = torch_model(torch_input)
+
+    # Fracture the activation on K across the TP axis, mirroring the fused op's pre-gather input.
+    shard_dims = [None, None]
+    shard_dims[tp_axis] = -1
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=shard_dims, mesh_shape=tuple(mesh_device.shape)),
+    )
+
+    tt_output = tt_model(tt_input, parallel_config=parallel_config)
+
+    out_dims = [None, None]
+    out_dims[tp_axis] = -1
+    out_dims[1 - tp_axis] = 0
+    tt_output = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=out_dims, mesh_shape=tuple(mesh_device.shape)),
+    )
+    assert_quality(torch_output, tt_output[:1], pcc=0.999_500)
+
+
+@_mesh_1x1()
+def test_small_m_fused_addcmul(mesh_device: ttnn.MeshDevice) -> None:
+    """forward_fused_addcmul: residual + scalar * (x@W + bias) * gate, in one op."""
+    scalar = 0.5
+    torch_model = _torch_linear(_K, _N)
+    tt_model = ColParallelLinear(_K, _N, mesh_device=mesh_device, mesh_axis=0, use_small_m_matmul=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    torch_input = torch.randn((1, 1, _M, _K), dtype=torch.bfloat16)
+    torch_residual = torch.randn((1, 1, _M, _N), dtype=torch.bfloat16)
+    torch_gate = torch.randn((1, 1, 1, _N), dtype=torch.bfloat16)
+    with torch.no_grad():
+        torch_output = torch_residual + scalar * torch_model(torch_input) * torch_gate
+
+    tt_output = tt_model.forward_fused_addcmul(
+        bf16_tensor(torch_input, device=mesh_device),
+        bf16_tensor(torch_residual, device=mesh_device),
+        bf16_tensor(torch_gate, device=mesh_device),
+        scalar,
+    )
+    assert_quality(torch_output, ttnn.to_torch(tt_output), pcc=0.999_500)

--- a/tests/ttnn/perf_tests/operations/matmul/test_small_m_matmul_perf.py
+++ b/tests/ttnn/perf_tests/operations/matmul/test_small_m_matmul_perf.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Golden PERFORMANCE regression suite for ttnn.experimental.small_m_matmul (Blackhole).
+
+Ten shapes chosen so every production code path is covered, and a regression in any of them trips a threshold:
+
+  Mt          1, 2, 4, 8, 16
+  reduction   linear chain AND ring reduce-scatter
+  placement   bank-local AND in1-near (M-split) AND 2D mesh
+  scale       7 us .. 228 us of device time; 24 .. 96 cores
+
+Everything runs at DEFAULTS (config=None, no env override), so this measures what actually ships.
+
+Correctness is asserted alongside every timing -- PCC AND a zero-non-finite count -- so a perf pass can never
+mask a numerical break.
+
+MEASUREMENT. Device time comes from the device-profiler CSV demuxed by run-host-id -- the method every number in
+this op's optimisation campaign used -- not host wall, which would fold dispatch overhead into a 7 us shape. The
+profiler CSV is only written when the device CLOSES (verified: absent after ttnn.synchronize_device and after
+ttnn.ReadDeviceProfiler, present only after close_device), so each shape is measured in its own SUBPROCESS that
+opens a device, runs the op and closes it. That also isolates shapes from one another. The measurement worker is
+tools/small_m_matmul_autotune/prod_sweep_worker.py, reused rather than duplicated so the demux logic has one source
+of truth.
+
+Because these tests spawn their own device they must NOT take the `device` fixture -- holding the device here
+would stop the subprocess from opening it. For the same reason this module must be run in its OWN pytest
+invocation: any module before it in the same session still holds a device, and every measurement would then
+block in UMD cluster init until it timed out. A probe up front detects that and skips with that reason.
+
+THRESHOLDS are measured median device times PLUS a margin sized to the measured noise floor: 8% for shapes
+under 30 us (iteration spread there reaches 12%) and 5% for the rest (spread <= 4%). Every regression this
+campaign actually caught was 9-33%, so the margins are wide enough not to flake and tight enough to catch
+anything real. Update a golden number only alongside a deliberate, measured perf change.
+
+GOLDENS ARE PER BOARD, keyed by the compute grid (`compute_with_storage_grid_size`) that the measurement
+worker reports for the device it ran on. A golden
+measured on one harvest configuration is NOT a threshold on another: the core budget feeds the picker's own
+feasibility rule (8*Pk*Ns*Sm <= available cores), and DRAM/clock behaviour differs between a single-card dev
+part and a Galaxy tray chip. This was not always keyed -- the original set was written as "on this board"
+without naming it, and running it on a 12x10 Galaxy chip reported six false regressions of +5..+14% against
+11x10 numbers. An unknown board SKIPS with instructions rather than inventing a verdict.
+
+    11x10 (110 cores)  single-card dev part, where the optimisation campaign ran
+    12x10 (120 cores)  Galaxy tray chip
+
+Run with (needs a profiler-enabled build, which is the default of build_metal.sh):
+    SMALL_M_MATMUL_PERF=1 pytest tests/ttnn/perf_tests/operations/matmul/test_small_m_matmul_perf.py
+
+The SMALL_M_MATMUL_PERF gate keeps this suite out of any pytest invocation that did not ask for it: it is a
+device-perf gate with per-board goldens, not a unit test.
+"""
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from models.common.utility_functions import is_blackhole
+
+pytestmark = [
+    pytest.mark.models_device_performance_bare_metal,
+    pytest.mark.skipif(
+        os.environ.get("SMALL_M_MATMUL_PERF") != "1",
+        reason="device-perf gate: needs a profiler build and its own pytest invocation; set SMALL_M_MATMUL_PERF=1",
+    ),
+]
+
+WORKER = "tools/small_m_matmul_autotune/prod_sweep_worker.py"
+NBLOCKS = 2  # worker runs 2 warmup + 12 timed per block; median over all 24 timed iterations
+PCC_MIN = 0.999
+# 240s per shape. The measured work is milliseconds (24 iterations of a 7-260us op); the rest is one device
+# open, a JIT compile and one close -- ~60-90s for the largest shape here. 900s was ten minutes of nothing
+# to say, and when the device was unavailable it burned the full budget PER SHAPE before failing.
+TIMEOUT_S = 240
+
+# What each shape exercises -- board-independent, so it lives outside the per-board tables.
+COVERS = {
+    (32, 2048, 512): "Mt1 chain bank-local 64c; smallest, overhead-dominated",
+    (32, 6144, 9216): "Mt1 chain bank-local 24c; highest DRAM efficiency, 98% of peak",
+    (64, 2048, 1024): "Mt2 reduce-scatter bank-local 64c",
+    (128, 6144, 4608): "Mt4 chain bank-local 96c",
+    (256, 2048, 1024): "Mt8 reduce-scatter in1-near 64c; noisiest shape in the corpus",
+    (256, 6144, 768): "Mt8 chain mesh 96c",
+    (256, 15360, 768): "Mt8 reduce-scatter mesh 80c; deep K",
+    (256, 6144, 6144): "Mt8 reduce-scatter 96c; large square",
+    (512, 6144, 2304): "Mt16 chain mesh 96c",
+    (512, 6144, 4608): "Mt16 chain mesh 96c; the one compute-floor-bound shape",
+}
+
+# board -> {shape: (golden median device us, margin fraction)}. See GOLDENS ARE PER BOARD above.
+GOLDEN = {
+    # 11x10 / 110 cores -- the single-card dev part the optimisation campaign ran on.
+    "11x10": {
+        (32, 2048, 512): (7.32, 0.08),
+        (32, 6144, 9216): (227.89, 0.05),
+        (64, 2048, 1024): (12.16, 0.08),
+        (128, 6144, 4608): (125.27, 0.05),
+        (256, 2048, 1024): (19.54, 0.08),
+        (256, 6144, 768): (35.72, 0.05),
+        (256, 15360, 768): (81.30, 0.05),
+        (256, 6144, 6144): (177.57, 0.05),
+        (512, 6144, 2304): (109.95, 0.05),
+        (512, 6144, 4608): (180.16, 0.05),
+    },
+    # 12x10 / 120 cores -- Galaxy tray chip. Measured at defaults, block-median spread 0.3-1.8%, PCC >= 0.999986,
+    # zero non-finite. The picked configs match the 11x10 board on every shape sampled, so the differences here
+    # are board behaviour rather than the picker reacting to the wider grid.
+    "12x10": {
+        (32, 2048, 512): (7.76, 0.08),
+        (32, 6144, 9216): (258.90, 0.05),
+        (64, 2048, 1024): (13.53, 0.08),
+        (128, 6144, 4608): (140.24, 0.05),
+        (256, 2048, 1024): (19.48, 0.08),
+        (256, 6144, 768): (37.24, 0.05),
+        (256, 15360, 768): (85.81, 0.05),
+        (256, 6144, 6144): (194.70, 0.05),
+        (512, 6144, 2304): (112.63, 0.05),
+        (512, 6144, 4608): (188.45, 0.05),
+    },
+}
+
+SHAPES = list(COVERS.keys())
+
+
+_DEVICE_FREE = []
+
+
+def _device_available():
+    """Can a SUBPROCESS open the device? Cached; probed once per module.
+
+    Every measurement runs in its own process (the profiler CSV is only written on device close), so this
+    module only works when nothing else holds the device. In a combined pytest session the modules that ran
+    before it hold one via the `device` fixture, and each measurement then blocks in UMD cluster init until it
+    hits TIMEOUT_S -- 900s per shape, ten shapes, all failing. A short probe turns that into one fast, honest
+    skip that names the cause.
+    """
+    if not _DEVICE_FREE:
+        root = os.environ.get("TT_METAL_HOME") or os.getcwd()
+        code = "import ttnn;d=ttnn.open_device(device_id=0);ttnn.close_device(d);print('DEVICE_FREE')"
+        try:
+            p = subprocess.run([sys.executable, "-c", code], cwd=root, capture_output=True, text=True, timeout=120)
+            _DEVICE_FREE.append("DEVICE_FREE" in p.stdout)
+        except subprocess.TimeoutExpired:
+            _DEVICE_FREE.append(False)
+    return _DEVICE_FREE[0]
+
+
+def _measure(M, K, N):
+    """Measure one shape in a fresh process; returns the worker's result dict."""
+    root = os.environ.get("TT_METAL_HOME") or os.getcwd()
+    worker = os.path.join(root, WORKER)
+    assert os.path.exists(worker), f"measurement worker not found at {worker}"
+    env = dict(os.environ)
+    env["TT_METAL_DEVICE_PROFILER"] = "1"  # required for the device-time CSV
+    proc = subprocess.run(
+        [sys.executable, worker, str(M), str(K), str(N), str(NBLOCKS)],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_S,
+    )
+    line = next((l for l in proc.stdout.splitlines() if l.startswith("SWEEP_JSON ")), None)
+    assert line, (
+        f"measurement worker produced no result for {M}x{K}x{N} (rc={proc.returncode}).\n"
+        f"stdout tail:\n{proc.stdout[-1500:]}\nstderr tail:\n{proc.stderr[-1500:]}"
+    )
+    return json.loads(line[len("SWEEP_JSON ") :])
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="small-M matmul is Blackhole-only")
+@pytest.mark.parametrize("shape", SHAPES, ids=lambda s: f"{s[0]}x{s[1]}x{s[2]}")
+def test_small_m_matmul_golden_perf(shape):
+    M, K, N = shape
+    covers = COVERS[shape]
+    if not _device_available():
+        pytest.skip(
+            "the device is not available to a subprocess -- another test in this pytest session is holding it. "
+            "Every measurement here runs in its own process, so this module must be run in its OWN pytest "
+            "invocation: SMALL_M_MATMUL_PERF=1 pytest tests/ttnn/perf_tests/operations/matmul/test_small_m_matmul_perf.py"
+        )
+
+    # Measure FIRST, then select the golden by the board the measurement actually ran on. An earlier version
+    # queried the board up front by opening a device here; that fails whenever this module shares a pytest
+    # session with tests using the session-scoped `device` fixture (the device is still held), and it turned
+    # that failure into a SKIP -- silently disabling the whole perf gate in exactly the full-suite run CI does.
+    # Taking the board from the worker's own result cannot mask a failure and needs no second device open.
+    res = _measure(M, K, N)
+    assert res.get("outcome") == "ok", (
+        f"{M}x{K}x{N} failed to run: {res.get('err')}. If this says the device could not be opened, another "
+        f"test in this pytest session is holding it -- run this module in its own invocation."
+    )
+    board = res.get("board")
+    assert board, f"{M}x{K}x{N}: worker reported no board key (stale worker?)"
+    if board not in GOLDEN or shape not in GOLDEN[board]:
+        pytest.skip(
+            f"no perf golden for board {board} (shape {M}x{K}x{N}). Perf goldens are board-specific; add a "
+            f"'{board}' entry to GOLDEN by measuring this shape at defaults with "
+            f"tools/small_m_matmul_autotune/prod_sweep_worker.py, rather than comparing against another board."
+        )
+    golden_us, margin = GOLDEN[board][shape]
+    limit_us = golden_us * (1.0 + margin)
+
+    # correctness is checked on the same program the timing uses, so a perf pass cannot mask a numerical break
+    pcc = res.get("pcc")
+    assert pcc is not None and pcc >= PCC_MIN, f"{M}x{K}x{N} PCC {pcc} < {PCC_MIN} ({covers})"
+
+    # FINITENESS, asserted separately from PCC. The reduce-scatter CB wrap bug corrupted ~0.015% of elements,
+    # which as finite garbage would leave PCC at ~0.9999 and pass the threshold above; NaN only tripped PCC
+    # because it poisons the whole correlation. Half these shapes exercise reduce-scatter, so the property has
+    # to be checked here and not inferred from PCC.
+    n_nonfinite = res.get("n_nonfinite")
+    assert n_nonfinite is not None, f"{M}x{K}x{N} worker reported no non-finite count (stale worker?)"
+    assert n_nonfinite == 0, f"{M}x{K}x{N} produced {n_nonfinite} non-finite output elements ({covers})"
+
+    median = res["median_us"]
+    assert median <= limit_us, (
+        f"{M}x{K}x{N} PERF REGRESSION: {median:.2f} us > {limit_us:.2f} us "
+        f"(golden {golden_us:.2f} us +{margin * 100:.0f}% on board {board}). Covers: {covers}. "
+        f"block medians={res.get('block_medians')} over {res.get('n_iters')} iterations"
+    )

--- a/tests/ttnn/unit_tests/operations/matmul/test_small_m_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_small_m_matmul.py
@@ -533,24 +533,30 @@ def test_small_m_fused_validation(device, expect_error):
 
 @pytest.mark.skipif(not is_blackhole(), reason="small-M matmul is Blackhole-only")
 def test_small_m_picker_planner_parity_small_nt(device, expect_error):
-    # config=None on a bank-infeasible Nt (Nt <= 7*ceil(Nt/8)) must be rejected cleanly by the picker,
-    # not crash later in build_plan(). Nt=9 (N=288): 7*ceil(9/8)=14 >= 9 -> infeasible. A feasible small
-    # Nt=8 (N=256) must still work. Guards picker/planner feasibility parity (shared nt_width_shard_feasible).
+    # A bank-infeasible Nt (Nt <= 7*ceil(Nt/8)) must be rejected cleanly, not crash later in
+    # build_plan(). Nt=9 (N=288): 7*ceil(9/8)=14 >= 9 -> infeasible. A feasible small Nt=8 (N=256)
+    # must still work. Guards feasibility parity across the three places that share
+    # nt_width_shard_feasible: the weight memory-config builder, the picker, and the planner.
+    #
+    # The rejection now lands at the memory-config builder, which is the EARLIEST reachable point:
+    # the op cannot be called at all without a width-sharded weight, so an infeasible N is refused
+    # before a buffer is allocated rather than after. The picker/planner guards behind it are
+    # unreachable through the public path by construction, which is the intent.
     M, K = 32, 2048
     for N, feasible in [(288, False), (256, True)]:
         t0 = torch.randn(1, 1, M, K, dtype=torch.bfloat16)
         t1 = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+        if not feasible:
+            # the bank-interval limit: Nt=9 cannot fill the 8-bank in1 width shard
+            with expect_error(RuntimeError, "cannot serve N=288"):
+                ttnn.create_small_m_weight_memory_config(list(t1.shape), ttnn.bfloat16, device)
+            continue
         a0 = ttnn.from_torch(t0, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
         wcfg = ttnn.create_small_m_weight_memory_config(list(t1.shape), ttnn.bfloat16, device)
         a1 = ttnn.from_torch(t1, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=wcfg)
-        if feasible:
-            out = ttnn.experimental.small_m_matmul(a0, a1)  # config=None -> auto
-            got = ttnn.to_torch(ttnn.from_device(out))[0, 0]
-            assert_with_pcc((t0.float() @ t1.float())[0, 0], got.float(), 0.999)
-        else:
-            # the bank-interval limit: Nt=9 cannot fill the 8-bank in1 width shard
-            with expect_error(RuntimeError, "cannot serve this N"):
-                ttnn.experimental.small_m_matmul(a0, a1)  # picker must reject, not FATAL in build_plan
+        out = ttnn.experimental.small_m_matmul(a0, a1)  # config=None -> auto
+        got = ttnn.to_torch(ttnn.from_device(out))[0, 0]
+        assert_with_pcc((t0.float() @ t1.float())[0, 0], got.float(), 0.999)
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="small-M matmul is Blackhole-only")

--- a/tools/small_m_matmul_autotune/README.md
+++ b/tools/small_m_matmul_autotune/README.md
@@ -1,0 +1,45 @@
+# small_m_matmul offline autotuner
+
+Offline configuration sweep for `ttnn.experimental.small_m_matmul`. It measures candidate configurations on
+hardware and emits entries for `kTable` in
+`ttnn/cpp/ttnn/operations/experimental/small_m_matmul/device/small_m_matmul_config.cpp`, which the shipped
+picker consults. Tuning is offline by design: the operator itself does no file I/O, keeps no global state and
+never measures on first call.
+
+Requires a profiler-enabled build (the `build_metal.sh` default), a Blackhole device that nothing else holds,
+and must run from the repo root with `TT_METAL_HOME` set.
+
+```bash
+# tune shapes, print the winning tuple per shape
+python3 tools/small_m_matmul_autotune/autotune.py 512x6144x768 32x6144x6144
+
+# wider shortlist, more confirmation relaunches, and write the kTable patch (prints the diff to review)
+python3 tools/small_m_matmul_autotune/autotune.py 512x6144x768 --topk 16 --relaunches 3 --apply
+```
+
+| option | default | meaning |
+| --- | --- | --- |
+| `--topk` | 8 | shortlist depth per ranker (3 rankers, unioned) |
+| `--relaunches` | 2 | fresh processes used to confirm a win |
+| `--min-gain` | 1.5 | percent; below this the shipped pick is kept |
+| `--apply` | off | write `kTable` via `apply_table.py` and show the diff |
+
+## What it guarantees
+
+1. **Feasible configurations only.** Candidates come from `autotune_feas.enumerate_full`, a Python mirror of the
+   C++ `pick_plan` / `compute_cb_sizes` rules, so nothing that would `TT_FATAL` at program build is launched.
+   The mirror hard-codes the Blackhole p150 constants (L1 budget, core limits); keep it in step with the C++.
+2. **Correctness before timing.** Each candidate's first call is untimed and gated on PCC >= 0.999 against a
+   torch reference and a zero-non-finite check; a wrong config can never win on speed.
+3. **Warm, repeated, relaunched.** Device time comes from the profiler, not host wall. A winner is re-confirmed
+   against the shipped pick across `--relaunches` fresh processes, and every relaunch must agree.
+4. **The shipped configuration is always a candidate.** `config=None` is measured alongside the shortlist and a
+   winner is reported only if it beats it by more than `--min-gain` percent.
+
+## Files
+
+- `autotune.py` — driver: shortlist by cost models, measure, confirm, optionally apply.
+- `autotune_feas.py` — feasibility mirror of the C++ planner rules.
+- `prod_sweep_worker.py` — one-shape measurement worker (opens a device, runs the op, parses the profiler CSV).
+  Also used by `tests/ttnn/perf_tests/operations/matmul/test_small_m_matmul_perf.py`.
+- `apply_table.py` — rewrites `kTable` entries in `small_m_matmul_config.cpp` in place.

--- a/tools/small_m_matmul_autotune/apply_table.py
+++ b/tools/small_m_matmul_autotune/apply_table.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Apply confirmed winners to kTable. Updates existing rows in place, appends new keys.
+
+Written as a script because doing this by hand produced malformed `{{{` entries last time (caught in the
+diff, not by the compiler). Verifies the brace shape of every line it writes and refuses to save otherwise.
+
+usage: apply_table.py "SHAPE=Pk,Ns,Sm,kb,nsb[:note]" ...
+"""
+import re, sys
+
+F = "ttnn/cpp/ttnn/operations/experimental/small_m_matmul/device/small_m_matmul_config.cpp"
+cd = lambda v: -(-v // 32)
+items = []
+for a in sys.argv[1:]:
+    shape, _, rest = a.partition("=")
+    cfg, _, note = rest.partition(":")
+    M, K, N = (int(x) for x in shape.split("x"))
+    items.append(((cd(M), cd(K), cd(N)), shape, ",".join(str(int(x)) for x in cfg.split(",")), note))
+s = open(F).read()
+body_start = s.index("kTable = {")
+body_end = s.index("};", body_start)
+body = s[body_start:body_end]
+n_upd = n_add = 0
+for key, shape, cfg, note in items:
+    a, b, c = key
+    pat = re.compile(r"\{\{%d,\s*%d,\s*%d\},\s*\{([\d,\s]+)\}\},[^\n]*" % (a, b, c))
+    m = pat.search(body)
+    cfg_sp = ", ".join(cfg.split(","))
+    if m:
+        was = re.sub(r"\s+", "", m.group(1))
+        if was == cfg.replace(" ", ""):
+            print("  %-17s already %s, skipped" % (shape, cfg))
+            continue
+        body = (
+            body[: m.start()]
+            + "{{%d, %d, %d}, {%s}},  // %s  %s(was %s)" % (a, b, c, cfg_sp, shape, (note + " " if note else ""), was)
+            + body[m.end() :]
+        )
+        n_upd += 1
+        print("  %-17s UPDATE %s -> %s" % (shape, was, cfg))
+    else:
+        body = body.rstrip() + "\n        {{%d, %d, %d}, {%s}},  // %s  %s\n    " % (a, b, c, cfg_sp, shape, note)
+        n_add += 1
+        print("  %-17s ADD    %s" % (shape, cfg))
+bad = [l for l in body.splitlines() if "{{{" in l or re.search(r"\}\},\s*\{", l)]
+if bad:
+    print("REFUSING TO SAVE - malformed lines:")
+    [print("   ", l[:90]) for l in bad]
+    sys.exit(1)
+open(F, "w").write(s[:body_start] + body + s[body_end:])
+print("%d updated, %d added" % (n_upd, n_add))

--- a/tools/small_m_matmul_autotune/autotune.py
+++ b/tools/small_m_matmul_autotune/autotune.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""AUTOTUNER for ttnn.experimental.small_m_matmul: rank a shortlist, MEASURE it, cache the winner.
+
+USER-FACING DOCUMENTATION lives at the top of the entry point that wraps this script:
+tests/ttnn/unit_tests/operations/matmul/test_small_m_matmul_autotune.py -- how to run it, the env vars, what it
+guarantees, why measuring beats a better cost formula, and a worked example. Kept in ONE place so the two
+cannot drift; what follows is only this script's own internals.
+
+WHAT THE CACHE IS
+    kTable in small_m_matmul_config.cpp. This tool emits ready-to-apply entries; apply_table.py writes them.
+    That keeps the runtime picker unchanged (no file I/O, no global state, no first-call measurement inside
+    an op) and reuses the cache mechanism that already ships.
+
+RANKING
+    Uses the component-wise PHYSICAL model, which beat the shipped cost model as a ranker at every shortlist
+    size on held-out shapes (top-4: 3.14% vs 5.02% mean; top-4 worst 13.2% vs 31.7%). It is NOT used as a
+    chooser -- as a chooser it LOSES to the shipped picker, which is why this tool measures.
+
+USAGE
+    python3 tools/small_m_matmul_autotune/autotune.py 256x2048x1024 512x6144x768 ...
+    python3 tools/small_m_matmul_autotune/autotune.py --shapes-file shapes.txt [--topk 8] [--relaunches 2] [--apply]
+    Emits, per shape, the measured winner and an apply_table.py argument line (or applies it with --apply).
+    Must run from the repo root with TT_METAL_HOME set (the profiler worker needs it).
+"""
+import argparse, json, os, statistics, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from autotune_feas import enumerate_full  # noqa: E402  (exact mirror of the C++ feasibility rules)
+
+WORKER = os.path.join(HERE, "prod_sweep_worker.py")
+TILE, CLK = 2048.0, 1350.0
+BW_DRAM, BW_CORE, BW_NOC, CYC_MAC = 512.0e3, 21.0e3, 25.0e3, 46.0
+LAT_REQ, BLK_OVH, EPS_OVL = 0.3795, 14.45, 0.01671
+cd = lambda v: -(-v // 32)
+
+
+def phys_cost(Mt, Kt, Nt, cfg, g):
+    """Component-wise physical cost in microseconds (ranking only)."""
+    Pk, Ns, Sm, kb, nsb = cfg
+    area, out_t = g["sub_area"], g["out_tiles"]
+    t_agg = (Ns * Mt * Kt + Kt * Nt + Mt * Nt) * TILE / BW_DRAM
+    in1 = g["Ktl"] * g["Nown"] * TILE
+    t_in1 = in1 / BW_CORE + LAT_REQ * (g["Ktl"] * g["Nbpc"] / float(kb))
+    t_in0 = (g["Mblk"] * g["Ktl"] * TILE * 0.875 + (Sm - 1) * in1) / BW_NOC
+    t_comp = CYC_MAC * (g["Mblk"] * g["Nown"] * g["Ktl"]) * (1.0 + BLK_OVH / (area * kb)) / CLK
+    gg = Pk - 1.0 if Pk > 1 else 0.0
+    t_red = (gg / Pk * out_t * TILE / BW_NOC) if g["rs"] else (gg * area * TILE / BW_NOC)
+    s = t_agg + t_in1 + t_in0 + t_comp
+    mx = max(t_agg, t_in1, t_in0, t_comp)
+    return mx + EPS_OVL * (s - mx) + t_red
+
+
+def shipped_cost(Mt, Kt, Nt, cfg, g):
+    """The cost model that currently ships (used as a SECOND ranker, not as an authority)."""
+    Pk, Ns, Sm, kb, nsb = cfg
+    readT = Kt * Nt / min(g["cores"], 24)
+    area = min(g["sub_area"], 6)
+    kbe = min(kb, 2)
+    compT = g["Mblk"] * g["Nown"] * g["Ktl"] / ((kbe / (kbe + 0.5)) * (area / (area + 2.0)))
+    ovlT = g["Mblk"] * g["Nown"] * g["Ktl"] / g["Nbpc"]
+    return (max(readT, compT) + ovlT) * (1.0 + 0.5 * (g["wasteK"] + g["wasteN"])) + 0.8 * max(0, Pk - 1) * g[
+        "Mblk"
+    ] * g["Nown"]
+
+
+def shortlist(Mt, Kt, Nt, k):
+    """UNION of the top-k under BOTH rankers.
+
+    The physical model is the better ranker on average (held out, top-4: 3.1% vs 5.0% mean regret) but it has
+    a real tail -- measured on three shapes at Kt=192 its top-8 did NOT contain the shipped pick, which was
+    4-6% FASTER than anything it shortlisted. Neither ranker dominates, and measuring the union costs only a
+    few more runs than measuring one, so take both. The shipped pick is measured separately during
+    confirmation, so the effective candidate set is (physical top-k) U (shipped-cost top-k) U {shipped pick}.
+    """
+    cands = enumerate_full(Mt, Kt, Nt)
+    if not cands:
+        return []
+    out, seen = [], set()
+    pools = [
+        (phys_cost, cands),
+        (shipped_cost, cands),
+        # The guarded fallback picks an Sm=1 ANCHOR for non-table shapes; ranking over all Sm buries it
+        # under Sm>1 candidates, so rank the Sm==1 subset separately to make sure it is covered.
+        (shipped_cost, [cg for cg in cands if cg[0][2] == 1]),
+    ]
+    for costf, pool in pools:
+        if not pool:
+            continue
+        ranked = sorted(
+            pool,
+            key=lambda cg: (costf(Mt, Kt, Nt, cg[0], cg[1]), -cg[1]["sub_area"] * cg[0][3], -cg[1]["cores"], cg[0]),
+        )
+        for cfg, _ in ranked[:k]:
+            if cfg not in seen:
+                seen.add(cfg)
+                out.append(cfg)
+    return out
+
+
+def measure(M, K, N, cfg, env):
+    """Median device us for one config, or None. cfg=None measures the shipped pick (config=None)."""
+    a = [sys.executable, WORKER, str(M), str(K), str(N), "2"] + ([",".join(map(str, cfg))] if cfg else [])
+    try:
+        r = subprocess.run(a, capture_output=True, text=True, env=env, timeout=600)
+    except subprocess.TimeoutExpired:
+        return None
+    line = next((x for x in r.stdout.splitlines() if x.startswith("SWEEP_JSON")), None)
+    if not line:
+        return None
+    d = json.loads(line[11:])
+    # CORRECTNESS BEFORE TIMING. The worker computes PCC on its first (untimed) call, so a config that is
+    # wrong is discarded before its timing is ever considered. Both gates matter and they catch different
+    # things: PCC catches "numerics are wrong", the finite count catches a handful of NaN/Inf among millions
+    # of elements, which barely moves PCC but is a hard failure (a reduce-scatter CB wrap bug was exactly that).
+    if d.get("outcome") != "ok" or d.get("pcc", 0) < 0.999:
+        return None
+    if d.get("n_nonfinite", 0) != 0 or d.get("finite") is False:
+        return None
+    return d["median_us"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("shapes", nargs="*", help="MxKxN")
+    ap.add_argument("--shapes-file")
+    ap.add_argument("--topk", type=int, default=8)
+    ap.add_argument(
+        "--relaunches", type=int, default=2, help="fresh relaunches used to CONFIRM the winner beats the shipped pick"
+    )
+    ap.add_argument("--min-gain", type=float, default=1.5, help="percent; below this, keep the shipped pick")
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="write the confirmed winners into kTable via apply_table.py, then show the diff. "
+        "Tuning stays OFFLINE either way -- this edits a source table that the runtime "
+        "picker already consults; it never adds measurement to the operator.",
+    )
+    a = ap.parse_args()
+    shapes = list(a.shapes)
+    if a.shapes_file:
+        shapes += [l.split()[0] for l in open(a.shapes_file) if l.strip() and not l.startswith("#")]
+    if not shapes:
+        ap.error("give shapes as MxKxN, or --shapes-file")
+    env = dict(os.environ, TT_METAL_DEVICE_PROFILER="1")
+    env.pop("TT_SMALL_M_LOG_CFG", None)
+    apply_args = []
+    for nm in shapes:
+        M, K, N = (int(x) for x in nm.lower().split("x"))
+        Mt, Kt, Nt = cd(M), cd(K), cd(N)
+        sl = shortlist(Mt, Kt, Nt, a.topk)
+        if not sl:
+            print("[%s] no feasible config -- the small-M matmul cannot serve this shape" % nm, flush=True)
+            continue
+        # Measure the SHIPPED pick alongside the shortlist so the reported best is the best of everything
+        # tried, and so the tool can never propose something slower than what already ships.
+        shipped_us = measure(M, K, N, None, env)
+        results = []
+        for cfg in sl:
+            us = measure(M, K, N, cfg, env)
+            if us is not None:
+                results.append((us, cfg))
+        if not results:
+            print("[%s] every shortlisted config failed to measure" % nm, flush=True)
+            continue
+        results.sort()
+        best_us, best_cfg = results[0]
+        if shipped_us is not None and shipped_us <= best_us:
+            print(
+                "[%s] %d shortlisted; shipped pick %.2f us already best (shortlist best %s @ %.2f us)"
+                % (nm, len(results), shipped_us, ",".join(map(str, best_cfg)), best_us),
+                flush=True,
+            )
+            continue
+        # CONFIRM against the shipped pick with fresh relaunches -- a single reading is not enough on this
+        # hardware (this gate rejected 6 of 32 apparent wins during the campaign).
+        gains = []
+        for _ in range(max(1, a.relaunches)):
+            base = measure(M, K, N, None, env)
+            cand = measure(M, K, N, best_cfg, env)
+            if base and cand:
+                gains.append(100.0 * (cand - base) / base)
+        cs = ",".join(map(str, best_cfg))
+        if gains and all(g < -a.min_gain for g in gains):
+            verdict = "CONFIRMED %s" % "/".join("%+.1f%%" % g for g in gains)
+            apply_args.append('"%s=%s:AUTOTUNE %+.1f%%"' % (nm, cs, statistics.mean(gains)))
+        else:
+            verdict = "keep shipped pick (%s)" % ("/".join("%+.1f%%" % g for g in gains) if gains else "no baseline")
+        print(
+            "[%s] shortlist %d measured, best %s @ %.2f us -- %s" % (nm, len(results), cs, best_us, verdict), flush=True
+        )
+    if not apply_args:
+        print("\n# nothing to apply: the shipped pick was within %.1f%% on every shape" % a.min_gain)
+        return
+    cmd = "python3 tools/small_m_matmul_autotune/apply_table.py \\\n  " + " \\\n  ".join(apply_args)
+    if not a.apply:
+        print("\n# apply with:\n" + cmd)
+        return
+    # Strip the shell quoting the printed form carries; argv here needs the bare strings.
+    bare = [x.strip('"') for x in apply_args]
+    r = subprocess.run([sys.executable, os.path.join(HERE, "apply_table.py")] + bare, capture_output=True, text=True)
+    print(r.stdout + r.stderr, end="")
+    if r.returncode != 0:
+        print("apply_table.py FAILED; kTable not modified")
+        return
+    tbl = "ttnn/cpp/ttnn/operations/experimental/small_m_matmul/device/small_m_matmul_config.cpp"
+    print("\n# kTable patch (review before committing):")
+    print(subprocess.run(["git", "diff", "--", tbl], capture_output=True, text=True).stdout, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/small_m_matmul_autotune/autotune_feas.py
+++ b/tools/small_m_matmul_autotune/autotune_feas.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Feasibility + geometry mirror of the CURRENT C++ picker, re-derived from source 2026-08-03.
+
+CRITICAL: this must track small_m_matmul_plan.hpp::compute_cb_sizes and _config.cpp::pick_plan EXACTLY.
+The previous mirror was stale w.r.t. the c_2 wrap fix (it still used cb2 = 2*out_blk under reduce-scatter,
+where the shipped code now uses 2*ceil(out_blk/Pk)). That staleness made the mirror reject configs the
+picker accepts, which is how a heuristic validated on a restricted candidate set got deployed over a wider
+one and regressed 4-34%. Enumeration ranges below are the picker's OWN loops, not a sweep's subset.
+"""
+cdiv = lambda a, b: -(-a // b)
+rup = lambda a, b: cdiv(a, b) * b
+TB, TF = 2048, 4096
+kCb1Depth, kCb7Depth = 4, 2
+kL1Budget = 1440 * 1024
+kNumBanks, kMinCores, kMaxCores = 8, 16, 104
+
+
+def nt_width_shard_feasible(Nt):
+    return 7 * cdiv(Nt, 8) < Nt
+
+
+def rscatter_selected(Pk, Kt, Mblk, N_sub):
+    rs_T = Mblk * N_sub
+    feasible = (Pk > 1) and (rs_T >= Pk)
+    mc = cdiv(rs_T, Pk)
+    return feasible and Pk >= 4 and N_sub >= 2 and (Kt <= 64 or (Pk <= 6 and mc >= 2))
+
+
+def l1_bytes(Pk, Kt, Mblk, Kslice, nsb, kb):
+    out = Mblk * nsb
+    rs = rscatter_selected(Pk, Kt, Mblk, nsb)
+    cb0 = Mblk * Kslice
+    cb1 = kCb1Depth * kb * nsb
+    cb3 = out  # fp32
+    cb7 = kCb7Depth * out if (Pk > 1 and not rs) else 0
+    cb2 = 2 * cdiv(out, Pk) if rs else 2 * out  # <-- the c_2 fix
+    rs_slice = cdiv(out, Pk) if rs else 0
+    cb8 = cb9 = 2 * rs_slice
+    bf16 = cb0 + cb1 + cb2 + cb7 + cb8 + cb9
+    return bf16 * TB + cb3 * TF
+
+
+def geo(Mt, Kt, Nt, Ns, Pk, Sm, kb, nsb):
+    """None if infeasible, else the geometry dict the cost models consume."""
+    if not nt_width_shard_feasible(Nt):
+        return None
+    cores = kNumBanks * Pk * Ns * Sm
+    if cores < kMinCores or cores > kMaxCores:
+        return None
+    Ktl = rup(cdiv(Kt, Pk), kb * kNumBanks)
+    wasteK = Pk * Ktl / Kt - 1.0
+    if wasteK > 0.20:
+        return None
+    Mblk = cdiv(Mt, Sm)
+    Nband = cdiv(Nt, kNumBanks)
+    Nown = cdiv(Nband, Ns)
+    if nsb > Nown:
+        return None
+    Nbpc = cdiv(Nown, nsb)
+    wasteN = kNumBanks * Ns * Nbpc * nsb / Nt - 1.0
+    if wasteN > 0.20:
+        return None
+    if l1_bytes(Pk, Kt, Mblk, Ktl, nsb, kb) > kL1Budget:
+        return None
+    return dict(
+        cores=cores,
+        Ktl=Ktl,
+        Mblk=Mblk,
+        Nown=Nown,
+        Nbpc=Nbpc,
+        wasteK=wasteK,
+        wasteN=wasteN,
+        rs=1 if rscatter_selected(Pk, Kt, Mblk, nsb) else 0,
+        out_tiles=Mblk * Nown,
+        sub_area=Mblk * nsb,
+    )
+
+
+def enumerate_full(Mt, Kt, Nt):
+    """EXACTLY the picker's enumeration: Pk 1..12, Ns 1..6, Sm 1..Mt, kb {1,2,4,8}, nsb 1..Nown."""
+    Nband = cdiv(Nt, kNumBanks)
+    out = []
+    for Pk in range(1, 13):
+        for Ns in range(1, 7):
+            Nown = cdiv(Nband, Ns)
+            for Sm in range(1, Mt + 1):
+                for kb in (1, 2, 4, 8):
+                    for nsb in range(1, Nown + 1):
+                        g = geo(Mt, Kt, Nt, Ns, Pk, Sm, kb, nsb)
+                        if g:
+                            out.append(((Pk, Ns, Sm, kb, nsb), g))
+    return out

--- a/tools/small_m_matmul_autotune/prod_sweep_worker.py
+++ b/tools/small_m_matmul_autotune/prod_sweep_worker.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""One shape, fully-default production run: absolute PCC + N measurement blocks of kernel wall time.
+
+DEFAULTS ONLY: config=None (the picker chooses), no diagnostic mask, no env override that changes behaviour.
+TT_SMALL_M_LOG_CFG may be set by the driver -- it only makes the factory log which config / reduction strategy
+/ placement it picked, and does not alter the program.
+
+Kernel wall comes from the device-profiler CSV demuxed by run-host-id, so it is device time for the op alone,
+not host wall. Each block is 2 warmup + TIMED timed iterations on resident inputs; multiple blocks in one
+process give an iteration-level stability estimate.
+
+argv: M K N [nblocks] [config]   config = "auto" (picker, default) or "Pk,Ns,Sm,kb,nsb"
+Emits one line: SWEEP_JSON {...}
+"""
+import csv
+import json
+import os
+import statistics
+import sys
+
+import torch
+import ttnn
+
+ROOT = os.environ.get("TT_METAL_HOME", os.getcwd())
+CSV_PATH = f"{ROOT}/generated/profiler/.logs/profile_log_device.csv"
+FREQ = 1.35e9
+WARMUP, TIMED = 2, 12
+
+M, K, N = (int(x) for x in sys.argv[1:4])
+NBLOCKS = int(sys.argv[4]) if len(sys.argv) > 4 else 2
+CFG = sys.argv[5] if len(sys.argv) > 5 else "auto"
+
+
+def parse_runids():
+    if not os.path.exists(CSV_PATH):
+        return {}
+    raw = {}
+    for row in csv.reader(open(CSV_PATH)):
+        if len(row) < 12 or not row[10].strip().endswith("-KERNEL"):
+            continue
+        raw.setdefault(row[7].strip(), {}).setdefault((row[1], row[2], row[3]), []).append(
+            (row[11].strip(), int(row[5]))
+        )
+    out = {}
+    for runid, cr in raw.items():
+        durs, start = {}, None
+        for kk, lst in cr.items():
+            st = None
+            for t, c in lst:
+                if t == "ZONE_START":
+                    st = c
+                    start = c if start is None else min(start, c)
+                elif t == "ZONE_END" and st is not None:
+                    durs[kk] = c - st
+                    st = None
+        if durs:
+            out[runid] = {"wall": max(durs.values()) / FREQ * 1e6, "start": start or 0}
+    return out
+
+
+def pcc(a, b):
+    # float64: in fp32 the dot/norm accumulation over millions of elements rounds enough to return values
+    # slightly ABOVE 1.0 (seen: 1.000036), which reads as a broken metric in a report.
+    x, y = a.flatten().double(), b.flatten().double()
+    x = x - x.mean()
+    y = y - y.mean()
+    d = (x.norm() * y.norm()).item()
+    return 1.0 if d == 0 else torch.dot(x, y).item() / d
+
+
+def main():
+    try:
+        os.remove(CSV_PATH)
+    except OSError:
+        pass
+    res = {"M": M, "K": K, "N": N, "outcome": "runtime", "err": "", "cfg_req": CFG}
+    labels = []
+    dev = ttnn.open_device(device_id=0)
+    # Report the BOARD that actually ran this measurement. Perf goldens are board-specific -- the compute grid
+    # differs between harvest configurations (an 11x10 dev part vs a 12x10 Galaxy chip), and a golden from one
+    # board is not a threshold on another. Reporting it here, from the device that ran the op, means the
+    # consumer cannot compare against the wrong board's numbers.
+    _g = dev.compute_with_storage_grid_size()
+    res["board"] = f"{_g.x}x{_g.y}"
+    res["board_cores"] = _g.x * _g.y
+    ran = False
+    try:
+        t0 = torch.randn(1, 1, M, K)
+        t1 = torch.randn(1, 1, K, N)
+        ref = (t0.bfloat16().float() @ t1.bfloat16().float())[0, 0]
+        a0 = ttnn.from_torch(t0, layout=ttnn.TILE_LAYOUT, device=dev, dtype=ttnn.bfloat16)
+        wc = ttnn.create_small_m_weight_memory_config(list(t1.shape), ttnn.bfloat16, dev)
+        a1 = ttnn.from_torch(t1, layout=ttnn.TILE_LAYOUT, device=dev, dtype=ttnn.bfloat16, memory_config=wc)
+
+        cfg = None
+        if CFG != "auto":
+            pk, ns, sm, kbt, nst = (int(x) for x in CFG.split(","))
+            cfg = ttnn.SmallMMatmulConfig(
+                k_slices=pk, n_slices=ns, m_slices=sm, k_block_tiles=kbt, n_subblock_tiles=nst
+            )
+
+        def call(label):
+            out = ttnn.experimental.small_m_matmul(a0, a1, config=cfg)  # None => production picker
+            labels.append(label)
+            return out
+
+        o = call("pcc")
+        ttnn.synchronize_device(dev)
+        got = ttnn.to_torch(ttnn.from_device(o))[0, 0]
+        res["pcc"] = round(pcc(ref, got), 6)
+        # EXPLICIT finite check, separate from PCC. A handful of NaN/Inf among millions of elements barely
+        # moves PCC but is a hard correctness failure -- a reduce-scatter CB wrap bug was exactly that.
+        # Count them rather than just asserting, so a regression says how bad it is.
+        finite = torch.isfinite(got)
+        res["n_nonfinite"] = int((~finite).sum())
+        res["finite"] = bool(res["n_nonfinite"] == 0)
+        res["out_absmax"] = round(float(got[finite].abs().max()) if finite.any() else float("nan"), 4)
+
+        for b in range(NBLOCKS):
+            for _ in range(WARMUP):
+                call(f"b{b}_w")
+            for _ in range(TIMED):
+                call(f"b{b}_t")
+            ttnn.synchronize_device(dev)
+        ran = True
+    except Exception as e:  # noqa: BLE001
+        res["err"] = str(e)[:300]
+    finally:
+        ttnn.close_device(dev)  # flushes the profiler CSV
+
+    if not ran:
+        print("SWEEP_JSON " + json.dumps(res), flush=True)
+        return
+    rid = parse_runids()
+    order = sorted(rid, key=lambda r: rid[r]["start"])
+    if len(order) != len(labels):
+        res["err"] = "demux misalign {} vs {}".format(len(order), len(labels))
+        print("SWEEP_JSON " + json.dumps(res), flush=True)
+        return
+    blocks = []
+    for b in range(NBLOCKS):
+        w = [rid[i]["wall"] for i, lab in zip(order, labels) if lab == "b{}_t".format(b)]
+        if w:
+            blocks.append([round(x, 3) for x in w])
+    allw = [x for b in blocks for x in b]
+    if not allw:
+        res["err"] = "no timed iterations recovered"
+        print("SWEEP_JSON " + json.dumps(res), flush=True)
+        return
+    res["blocks"] = blocks
+    res["block_medians"] = [round(statistics.median(b), 3) for b in blocks]
+    res["median_us"] = round(statistics.median(allw), 3)
+    res["min_us"] = round(min(allw), 3)
+    res["max_us"] = round(max(allw), 3)
+    res["n_iters"] = len(allw)
+    res["outcome"] = "ok"
+    print("SWEEP_JSON " + json.dumps(res), flush=True)
+
+
+main()

--- a/ttnn/cpp/ttnn/operations/experimental/small_m_matmul/device/small_m_matmul_config.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/small_m_matmul/device/small_m_matmul_config.cpp
@@ -392,6 +392,21 @@ MemoryConfig create_small_m_weight_memory_config(const ttnn::Shape& weight_shape
     const uint32_t Kt = cdiv(K, TILE_HEIGHT);
     const uint32_t Nt = cdiv(N, TILE_WIDTH);
 
+    // Reject a width the op itself cannot serve, HERE rather than at the first forward. Building a
+    // valid-looking MemoryConfig for an infeasible N lets a caller lay a weight down at load time and
+    // only discover at program build that no config exists -- by which point the layout choice is
+    // already baked into the loaded parameter. Same bank-interval constraint pick_plan enforces.
+    TT_FATAL(
+        plan::nt_width_shard_feasible(Nt),
+        "create_small_m_weight_memory_config cannot serve N={} (Nt={} tiles): in1 is DRAM width-sharded "
+        "across {} banks, which requires 7*ceil(Nt/8) < Nt so that every bank holds real data. The "
+        "smallest workable widths are Nt = 8, 15, 16, 22, 23, 24, 29.. (N = 256, 480, 512, 704, 736, "
+        "768, 928..). This is a SHAPE-DOMAIN limit of the small-M matmul: use a standard matmul for "
+        "this N. NOTE at tensor parallelism this is the LOCAL (per-device) N, not the global one.",
+        N,
+        Nt,
+        kNumBanks);
+
     // Config-independent + minimal padding: K is NOT padded (shard height = the tile-aligned K rows;
     // the balanced-tail reader never reads beyond valid K). N is padded up to a multiple of 8 tiles so
     // the width shard divides evenly across the 8 banks. Shard spec depends only on (K, N).


### PR DESCRIPTION
### PR Category
Feature

### Summary
Stacked on the `small_m_matmul` op PR (base branch `cglagovich/small-m-matmul-op`; retarget to `main` once that merges). Second half of #52865.

- **tt_dit:** `Linear` and `ColParallelLinear` gain `use_small_m_matmul=False`. When set, the weight is stored DRAM width-sharded for the op and `forward()` routes to `ttnn.experimental.small_m_matmul` (including split output, fused bias / activation, and the `addcmul_a` / `addcmul_b` epilogue that `forward()` on main accepts). The default-off path is unchanged.
- **`ColParallelLinear.forward_fused_addcmul`:** carries the fused ternary projection the LTX `to_out` used to inline, on top of main's current routing (strided fabric AG-matmul for known shapes, AG-matmul otherwise, single-chip `dit_minimal_matmul_addcmul_fused` at TP==1), plus the small-M branch. `LtxAttention._to_out_fused_addcmul` delegates to it so the projection follows the layer's configured backend.
- **`tools/small_m_matmul_autotune/`** (was `tools/mm_sweep/picker_gen`): offline sweep that measures candidate configs on hardware and emits `kTable` entries for the op's picker. README documents the CLI.
- **`tests/ttnn/perf_tests/operations/matmul/test_small_m_matmul_perf.py`:** golden device-time gate with per-board goldens (11x10 dev part, 12x10 Galaxy tray). Lives under `perf_tests` and is additionally gated on `SMALL_M_MATMUL_PERF=1`: it needs a profiler build, spawns one subprocess per shape and must own the device, so it is deliberately not collected as a unit test.

### Notes for reviewers
- **Behaviour change to call out:** `LoRAMixin.forward_fused_addcmul` now intercepts the LTX `to_out` projection, so runtime-mode LoRA raises instead of silently dropping the delta as the inlined code did. Fuse-mode LoRA is unaffected.
- No model turns `use_small_m_matmul` on yet; `models/tt_dit/tests/unit/test_linear_small_m.py` is the consumer (1x1 and 1x2 mesh cases, Blackhole only).
- `autotune_feas.py` mirrors the C++ planner feasibility rules and hard-codes the p150 constants; it is a tool, not a runtime dependency.
- The pytest wrapper around the autotuner from #52865 is dropped in favour of the tool's own CLI.

### Testing
Run on a Blackhole p150 (bh-30):
- `models/tt_dit/tests/unit/test_linear_small_m.py`: 15 passed, 2 skipped (the 1x2 mesh cases need two chips)
- `SMALL_M_MATMUL_PERF=1 pytest tests/ttnn/perf_tests/operations/matmul/test_small_m_matmul_perf.py`: 10 passed, all shapes within their 11x10 goldens
