### PR TITLE
[Bug fix] Remove the stale 8x4 fabric xfail from test_mlp_2d_vs_reference_from_model_args

### DIFF
--- a/models/common/tests/modules/mlp/test_mlp_2d.py
+++ b/models/common/tests/modules/mlp/test_mlp_2d.py
@@ -441,11 +441,6 @@ def test_mlp_2d_vs_reference(
     indirect=True,
 )
 @pytest.mark.parametrize("seq_len", (512, 32))
-@pytest.mark.xfail(
-    reason="TT_FATAL @ tt_metal/fabric/fabric.cpp:174 forwarding_direction: no forwarding "
-    "direction D0 to D28 on the 8x4 mesh. The 4x8 orientation passes. Remove once fixed.",
-    strict=True,  # Fail if the 8x4 fabric path is accidentally fixed (so we know to update)
-)
 def test_mlp_2d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice, seq_len):
     """
     Test that MLP2D class matches the HuggingFace/Meta reference model.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

`test_mlp_2d_vs_reference_from_model_args` carries `@pytest.mark.xfail(strict=True)` for a fabric routing bug that has since been fixed. Both parameters now pass, and `strict=True` reports each unexpected pass as a failure, so **`TT-Transformers MLP 2D module unit tests [wh_galaxy_perf]` is red on `main`**:

```
FAILED models/common/tests/modules/mlp/test_mlp_2d.py::test_mlp_2d_vs_reference_from_model_args[32-8x4]  - [XPASS(strict)]
FAILED models/common/tests/modules/mlp/test_mlp_2d.py::test_mlp_2d_vs_reference_from_model_args[512-8x4] - [XPASS(strict)]
2 failed, 11 passed, 1 xfailed
```

Reproduced on `main` at `83dd62c87be` — run [33620587456](https://github.com/tenstorrent/tt-metal/actions/runs/33620587456). The marker referenced `TT_FATAL @ tt_metal/fabric/fabric.cpp:174 forwarding_direction: no forwarding direction D0 to D28 on the 8x4 mesh`, which no longer triggers.

This removes only that marker.

### Why it matters beyond the red job

This is the **only** test that builds a real tt_transformers `ModelArgs` on a 32-device mesh, so it is the only CI coverage of the `is_galaxy` branch of `models/tt_transformers/tt/model_config.py`. It feeds `FF1_OUT_REDUCE_SCATTER_MEMCFG` into `reduce_scatter_minimal_async` via `models/common/modules/mlp/mlp_2d.py:329`, unconditionally on the decode path (unlike `tt_transformers/tt/mlp.py:234`, which guards on `dim == 8192`). While it was xfailed, that entire path was silently uncovered — which is how #53838 came to change those layouts with no test signal.

### Not changed

The sibling `xfail` on `test_ttnn_linear_2d_mesh_topology_bug` is left in place; it still xfails, so that TTNN bug is still live.

### Validation

Draft pending a `wh_galaxy_perf` run of `TT-Transformers MLP 2D module unit tests` on this branch. The expectation is 13 passed, 1 xfailed.

Related: #53838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/unxfail-mlp2d-8x4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/unxfail-mlp2d-8x4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/unxfail-mlp2d-8x4)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/unxfail-mlp2d-8x4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/unxfail-mlp2d-8x4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/unxfail-mlp2d-8x4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/unxfail-mlp2d-8x4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/unxfail-mlp2d-8x4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/unxfail-mlp2d-8x4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/unxfail-mlp2d-8x4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/unxfail-mlp2d-8x4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/unxfail-mlp2d-8x4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/unxfail-mlp2d-8x4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/unxfail-mlp2d-8x4)