### PR TITLE
Add --docker-args to recover.sh/mpi-docker to pass extra args to docker run

### DIFF
--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -7,6 +7,8 @@ print_usage() {
     echo "  --image <image>           (Optional) Docker image to use"
     echo "  --empty-entrypoint        (Optional) Pass --entrypoint=\"\" to docker run"
     echo "  --volume <path>           (Optional) Extra host path to mount into the container (repeatable)"
+    echo "  --docker-arg <arg>        (Optional) Extra argument passed verbatim to 'docker run' (repeatable)"
+    echo "                            e.g. --docker-arg --cap-add=SYS_PTRACE --docker-arg --shm-size=2g"
     echo "  --mpi-interface <iface>   (Optional) Network interface to pin MPI to (default: ens5f0np0)"
     echo "                            Passed to --prtemca oob_tcp_if_include and --mca btl_tcp_if_include."
     echo "                            Interface names vary by site; override on non-Markham clusters."
@@ -47,6 +49,8 @@ default() {
     local image="ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
     local empty_entrypoint=false
     local extra_volumes=""
+    # Extra 'docker run' args (repeatable --docker-arg); %q-quoted to survive the eval below.
+    local docker_extra_args=""
     local print_flag=false
     local print_only=false
     # Host-tag each rank's output (replaces mpirun's [jobid,rank] --tag-output).
@@ -90,6 +94,26 @@ default() {
                     exit 1
                 fi
                 extra_volumes="$extra_volumes -v ${vol}:${vol}"
+                shift
+                ;;
+            --docker-arg)
+                # A docker arg may start with '-' (e.g. --cap-add), so don't reject dash-prefixed values.
+                if [[ $# -lt 2 || -z "$2" ]]; then
+                    echo "Error: --docker-arg requires a non-empty value"
+                    print_usage
+                    exit 1
+                fi
+                docker_extra_args="$docker_extra_args $(printf '%q' "$2")"
+                shift 2
+                ;;
+            --docker-arg=*)
+                local da="${1#--docker-arg=}"
+                if [[ -z "$da" ]]; then
+                    echo "Error: --docker-arg requires a non-empty value"
+                    print_usage
+                    exit 1
+                fi
+                docker_extra_args="$docker_extra_args $(printf '%q' "$da")"
                 shift
                 ;;
             --mpi-interface)
@@ -298,7 +322,7 @@ default() {
         fi
 
         # Build docker command
-        local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes $entrypoint_opt $image $executable"
+        local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes$docker_extra_args $entrypoint_opt $image $executable"
 
         # Single segment without per-rank args
         if [[ "$tag_host" == true ]]; then
@@ -375,7 +399,7 @@ default() {
             fi
 
             # Build docker command for this group
-            local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes $entrypoint_opt $image $executable"
+            local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes$docker_extra_args $entrypoint_opt $image $executable"
 
             # Combine this group's MPI args with docker command
             if [[ "$tag_host" == true ]]; then

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -45,6 +45,16 @@ print_usage() {
     echo "  $0 --image myimage --oversubscribe --timeout 300 --host host1,host2 ./myapp"
 }
 
+# Single-quote a bash -c payload for the eval below. A single-quoted string cannot
+# contain a single quote by any escaping, so each one is emitted as '\'' (close,
+# escaped quote, reopen). Without this a value like --docker-arg --env=X=it's
+# terminates the wrapper and the whole command fails to parse.
+sq_wrap() {
+    local payload="$1"
+    payload=${payload//\'/\'\\\'\'}
+    printf "'%s'" "$payload"
+}
+
 default() {
     local image="ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
     local empty_entrypoint=false
@@ -326,9 +336,9 @@ default() {
 
         # Single segment without per-rank args
         if [[ "$tag_host" == true ]]; then
-            mpirun_segments+=("bash -c 'set -o pipefail; $docker_cmd 2>&1 | $host_tag_pipe'")
+            mpirun_segments+=("bash -c $(sq_wrap "set -o pipefail; $docker_cmd 2>&1 | $host_tag_pipe")")
         else
-            mpirun_segments+=("bash -c '$docker_cmd'")
+            mpirun_segments+=("bash -c $(sq_wrap "$docker_cmd")")
         fi
     else
         # Multi-executable mode with per-rank specifications
@@ -403,9 +413,9 @@ default() {
 
             # Combine this group's MPI args with docker command
             if [[ "$tag_host" == true ]]; then
-                mpirun_segments+=("${mpi_args[*]} bash -c 'set -o pipefail; $docker_cmd 2>&1 | $host_tag_pipe'")
+                mpirun_segments+=("${mpi_args[*]} bash -c $(sq_wrap "set -o pipefail; $docker_cmd 2>&1 | $host_tag_pipe")")
             else
-                mpirun_segments+=("${mpi_args[*]} bash -c '$docker_cmd'")
+                mpirun_segments+=("${mpi_args[*]} bash -c $(sq_wrap "$docker_cmd")")
             fi
         done
     fi

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -74,6 +74,9 @@ Optional:
                                             (auto-detected if not specified)
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
+    --docker-args <args>                    Extra arguments passed verbatim to 'docker run' (quoted string).
+                                            Only used with --use-docker.
+                                            e.g. --docker-args "--cap-add=SYS_PTRACE --shm-size=2g"
     --output <directory>                    Output directory for logs and validation artifacts
                                             (default: "<comma-separated-hosts>-<timestamp>").
                                             Passed to run_cluster_validation as --output-path so the
@@ -142,6 +145,7 @@ MPI_EXTRA_ARGS=()
 OUTPUT_DIR=""  # default computed after --hosts is known: "<comma-separated-hosts>-<timestamp>"
 RERUN_ON_RETRAIN=false
 VALIDATION_EXTRA_ARGS=()
+DOCKER_EXTRA_ARGS=()
 REGENERATE_ON_FAILURE=true
 
 # Minimum required tt-smi/KMD/firmware versions (TT_SMI_MIN_VERSION, KMD_MIN_VERSION,
@@ -273,6 +277,15 @@ while [[ $# -gt 0 ]]; do
             fi
             read -ra _extra <<< "$2"
             MPI_EXTRA_ARGS+=("${_extra[@]}")
+            shift 2
+            ;;
+        --docker-args)
+            if [[ -z "$2" ]]; then
+                echo "Error: --docker-args requires a non-empty value"
+                exit 1
+            fi
+            read -ra _extra <<< "$2"
+            DOCKER_EXTRA_ARGS+=("${_extra[@]}")
             shift 2
             ;;
         --output)
@@ -438,6 +451,12 @@ else
     DESCRIPTOR_ARGS+=(--cabling-descriptor-path "$CABLING_DESCRIPTOR_PATH" --deployment-descriptor-path "$DEPLOYMENT_DESCRIPTOR_PATH")
 fi
 
+# Expand --docker-args tokens into repeatable --docker-arg flags for mpi-docker.
+DOCKER_ARG_FLAGS=()
+for _darg in "${DOCKER_EXTRA_ARGS[@]}"; do
+    DOCKER_ARG_FLAGS+=(--docker-arg "$_darg")
+done
+
 # Print summary
 echo "=========================================="
 echo "Cluster recovery"
@@ -501,6 +520,7 @@ elif [[ "$SKIP_MPI_STRESS_TEST" == false ]]; then
             --empty-entrypoint \
             --tag-host \
             --mpi-interface "$MPI_IF" \
+            "${DOCKER_ARG_FLAGS[@]}" \
             "${MPI_EXTRA_ARGS[@]}" \
             --host "$HOSTS" \
             --map-by ppr:1:node \
@@ -620,6 +640,7 @@ elif [[ "$SKIP_VALIDATION" == false ]]; then
                 --tag-host \
                 --mpi-interface "$MPI_IF" \
                 --volume /data/scaleout_configs \
+                "${DOCKER_ARG_FLAGS[@]}" \
                 "${MPI_EXTRA_ARGS[@]}" \
                 --host "$HOSTS" \
                 ./build/tools/scaleout/run_cluster_validation \
@@ -710,6 +731,7 @@ if [[ "$REGENERATE_ON_FAILURE" == true && $VALIDATION_EXIT -ne 0 ]]; then
                     --empty-entrypoint \
                     --mpi-interface "$MPI_IF" \
                     "${REGEN_VOLUMES[@]}" \
+                    "${DOCKER_ARG_FLAGS[@]}" \
                     --host "$FIRST_HOST" -np 1 \
                     ./build/tools/scaleout/run_regen_descriptors \
                     "${REGEN_ARGS[@]}" || echo "Warning: descriptor regeneration failed (see error above)"


### PR DESCRIPTION
## Summary
- `recover.sh` had no CLI way to pass extra `docker run` arguments — they were hardcoded in `mpi-docker`.
- Adds `--docker-args "<string>"` to `recover.sh`, forwarded to every container it launches (validation, descriptor regen, MPI stress test).
- Adds a repeatable `--docker-arg <arg>` passthrough in `mpi-docker` that injects args verbatim into `docker run`.

## tests

recover.sh --docker-args "--shm-size=2g --label=a=1" on 16 BH Galaxy hosts: reset + validation passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/recover-docker-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/recover-docker-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/recover-docker-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/recover-docker-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/recover-docker-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/recover-docker-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/recover-docker-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/recover-docker-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/recover-docker-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/recover-docker-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/recover-docker-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/recover-docker-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/recover-docker-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/recover-docker-args)