### PR TITLE
Revert "Fix byte/word unit mismatch in active_erisc.cc initialize_local_memory"

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -110,7 +110,9 @@ inline void initialize_local_memory() {
     uint32_t* data_image = (uint32_t*)MEM_AERISC_INIT_LOCAL_L1_BASE_SCRATCH;
     extern uint32_t __ldm_data_start[];
     extern uint32_t __ldm_data_end[];
-    l1_to_local_mem_copy(__ldm_data_start, data_image, L1WordCount::from_range(__ldm_data_start, __ldm_data_end));
+    const uint32_t ldm_data_size = (uint32_t)__ldm_data_end - (uint32_t)__ldm_data_start;
+    // Copy data from data_image in __ldm_data_start for ldm_data_size bytes
+    l1_to_local_mem_copy(__ldm_data_start, data_image, ldm_data_size);
 }
 
 #define STR(x) #x

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -49,7 +49,7 @@ extern int32_t bank_to_l1_offset[NUM_L1_BANKS];
 extern uint8_t worker_logical_col_to_virtual_col[round_up_to_mult_of_4(noc_size_x)];
 extern uint8_t worker_logical_row_to_virtual_row[round_up_to_mult_of_4(noc_size_y)];
 
-void l1_to_local_mem_copy(uint32_t* dst, uint32_t tt_l1_ptr* src, L1WordCount len);
+void l1_to_local_mem_copy(uint32_t* dst, uint32_t tt_l1_ptr* src, int32_t len);
 
 inline void do_crt1(uint32_t tt_l1_ptr* data_image) {
     // Clear bss.
@@ -61,7 +61,7 @@ inline void do_crt1(uint32_t tt_l1_ptr* data_image) {
     extern uint32_t __ldm_data_start[];
     extern uint32_t __ldm_data_end[];
     if (__ldm_data_start != data_image) {
-        l1_to_local_mem_copy(__ldm_data_start, data_image, L1WordCount::from_range(__ldm_data_start, __ldm_data_end));
+        l1_to_local_mem_copy(__ldm_data_start, data_image, __ldm_data_end - __ldm_data_start);
     }
 }
 
@@ -74,7 +74,7 @@ inline void do_thread_crt1(uint32_t tt_l1_ptr* data_image) {
     // Copy thread initialized data.
     extern thread_local uint32_t __ldm_tdata_start[];
     extern thread_local uint32_t __ldm_tdata_end[];
-    l1_to_local_mem_copy(__ldm_tdata_start, data_image, L1WordCount::from_range(__ldm_tdata_start, __ldm_tdata_end));
+    l1_to_local_mem_copy(__ldm_tdata_start, data_image, __ldm_tdata_end - __ldm_tdata_start);
 }
 
 inline void noc_bank_table_init(uint64_t mem_bank_to_noc_addr) {
@@ -85,49 +85,37 @@ inline void noc_bank_table_init(uint64_t mem_bank_to_noc_addr) {
     static_assert(
         l1_to_noc_size_bytes % 4 == 0, "l1_bank_to_noc_xy size must be 4-byte aligned for l1_to_local_mem_copy");
     l1_to_local_mem_copy(
-        (uint*)dram_bank_to_noc_xy,
-        (uint tt_l1_ptr*)mem_bank_to_noc_addr,
-        L1WordCount::from_bytes(dram_to_noc_size_bytes));
+        (uint*)dram_bank_to_noc_xy, (uint tt_l1_ptr*)mem_bank_to_noc_addr, dram_to_noc_size_bytes >> 2);
     l1_to_local_mem_copy(
         (uint*)l1_bank_to_noc_xy,
         (uint tt_l1_ptr*)(mem_bank_to_noc_addr + dram_to_noc_size_bytes),
-        L1WordCount::from_bytes(l1_to_noc_size_bytes));
+        l1_to_noc_size_bytes >> 2);
 
-    constexpr int32_t dram_offsets_size_bytes = sizeof(bank_to_dram_offset);
-    static_assert(
-        dram_offsets_size_bytes % 4 == 0, "bank_to_dram_offset size must be 4-byte aligned for l1_to_local_mem_copy");
+    int32_t dram_offsets_size_bytes = sizeof(bank_to_dram_offset);
     l1_to_local_mem_copy(
         (uint*)bank_to_dram_offset,
         (uint tt_l1_ptr*)(mem_bank_to_noc_addr + dram_to_noc_size_bytes + l1_to_noc_size_bytes),
-        L1WordCount::from_bytes(dram_offsets_size_bytes));
-    constexpr int32_t l1_offsets_size_bytes = sizeof(bank_to_l1_offset);
-    static_assert(
-        l1_offsets_size_bytes % 4 == 0, "bank_to_l1_offset size must be 4-byte aligned for l1_to_local_mem_copy");
+        dram_offsets_size_bytes >> 2);
+    int32_t l1_offsets_size_bytes = sizeof(bank_to_l1_offset);
     l1_to_local_mem_copy(
         (uint*)bank_to_l1_offset,
         (uint tt_l1_ptr*)(mem_bank_to_noc_addr + dram_to_noc_size_bytes + l1_to_noc_size_bytes +
                           dram_offsets_size_bytes),
-        L1WordCount::from_bytes(l1_offsets_size_bytes));
+        l1_offsets_size_bytes >> 2);
 }
 
 inline void noc_worker_logical_to_virtual_map_init(uint64_t worker_logical_to_virtual_map_addr) {
-    constexpr int32_t worker_logical_col_to_virtual_col_size_bytes = sizeof(worker_logical_col_to_virtual_col);
-    static_assert(
-        worker_logical_col_to_virtual_col_size_bytes % 4 == 0,
-        "worker_logical_col_to_virtual_col size must be 4-byte aligned for l1_to_local_mem_copy");
+    int32_t worker_logical_col_to_virtual_col_size_bytes = sizeof(worker_logical_col_to_virtual_col);
     l1_to_local_mem_copy(
         (uint*)worker_logical_col_to_virtual_col,
         (uint tt_l1_ptr*)(worker_logical_to_virtual_map_addr),
-        L1WordCount::from_bytes(worker_logical_col_to_virtual_col_size_bytes));
+        worker_logical_col_to_virtual_col_size_bytes >> 2);
 
-    constexpr int32_t worker_logical_row_to_virtual_row_size_bytes = sizeof(worker_logical_row_to_virtual_row);
-    static_assert(
-        worker_logical_row_to_virtual_row_size_bytes % 4 == 0,
-        "worker_logical_row_to_virtual_row size must be 4-byte aligned for l1_to_local_mem_copy");
+    int32_t worker_logical_row_to_virtual_row_size_bytes = sizeof(worker_logical_row_to_virtual_row);
     l1_to_local_mem_copy(
         (uint*)worker_logical_row_to_virtual_row,
         (uint tt_l1_ptr*)(worker_logical_to_virtual_map_addr + worker_logical_col_to_virtual_col_size_bytes),
-        L1WordCount::from_bytes(worker_logical_row_to_virtual_row_size_bytes));
+        worker_logical_row_to_virtual_row_size_bytes >> 2);
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/internal/risc_attribs.h
+++ b/tt_metal/hw/inc/internal/risc_attribs.h
@@ -5,7 +5,6 @@
 #ifndef _RISC_ATTRIBS_H_
 #define _RISC_ATTRIBS_H_
 
-#include <stddef.h>
 #include <stdint.h>
 
 union tt_uint64_t {
@@ -18,18 +17,6 @@ union tt_uint64_t {
 
 #define tt_l1_ptr __attribute__((rvtt_l1_ptr))
 #define tt_reg_ptr __attribute__((rvtt_reg_ptr))
-
-// Distinguishes a count of 32-bit words from a byte count at the type level, so a byte count can't be
-// passed where l1_to_local_mem_copy expects words.
-struct L1WordCount {
-    int32_t words;
-    static constexpr L1WordCount from_bytes(size_t bytes) { return {(int32_t)(bytes / 4)}; }
-    template <typename T>
-    static constexpr L1WordCount from_range(T* start, T* end) {
-        static_assert(sizeof(T) == sizeof(uint32_t), "L1WordCount ranges must use 32-bit elements");
-        return {static_cast<int32_t>(end - start)};
-    }
-};
 
 // This enum is used to specify the dest location type for inline writes.
 // It is needed because inline writes use all 4 memory ports and may hang on Blackhole when there is back-pressure.

--- a/tt_metal/hw/toolchain/substitutes.cpp
+++ b/tt_metal/hw/toolchain/substitutes.cpp
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include <cstddef>
 
-#include "internal/risc_attribs.h"
-
 using namespace std;
 
 extern "C" int atexit(void (*f)(void)) { return 0; }
@@ -41,8 +39,7 @@ extern "C" void wzerorange(uint32_t* start, uint32_t* end) {
 }
 
 // Let the LTO decide if this needs to be inline.
-void l1_to_local_mem_copy(uint32_t* dst, uint32_t __attribute__((rvtt_l1_ptr)) * src, L1WordCount len_) {
-    int32_t len = len_.words;
+void l1_to_local_mem_copy(uint32_t* dst, uint32_t __attribute__((rvtt_l1_ptr))* src, int32_t len) {
 #pragma GCC unroll 0
     while (len >= 3) {
         auto v0 = src[0], v1 = src[1], v2 = src[2];


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#54487 Caused a performance regression on sdxl at https://github.com/tenstorrent/tt-metal/actions/runs/33544351217 . Apparently the codegen is different enough to cause some performance problems.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:revert-54487-anirudhsathiyaTT/active-erisc-word-count-51238)