### PR TITLE
[Performance] Add opt-in JIT precompiled headers for TRISC, BRISC and NCRISC kernel targets

### DIFF
--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -95,7 +95,7 @@
     ./build/test/tt_metal/unit_tests_misc
     ./build/test/tt_metal/unit_tests_jit_build
     # Exercise the opt-in path with fresh kernel compiles, including RVV flag variants.
-    TT_METAL_JIT_PCH=1 TT_METAL_FORCE_JIT_COMPILE=1 ./build/test/tt_metal/unit_tests_jit_build --gtest_filter='Trisc2RvvMockBlackholeFixture.*'
+    TT_METAL_JIT_PCH=1 TT_METAL_JIT_PCH_STRICT=1 TT_METAL_FORCE_JIT_COMPILE=1 ./build/test/tt_metal/unit_tests_jit_build --gtest_filter='Trisc2RvvMockBlackholeFixture.*'
     ./build/test/tt_metal/unit_tests_noc
   skus:
     wh_n150_civ2:

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -94,6 +94,8 @@
     ./build/test/tt_metal/unit_tests_device
     ./build/test/tt_metal/unit_tests_misc
     ./build/test/tt_metal/unit_tests_jit_build
+    # Exercise the opt-in path with fresh kernel compiles, including RVV flag variants.
+    TT_METAL_JIT_PCH=1 TT_METAL_FORCE_JIT_COMPILE=1 ./build/test/tt_metal/unit_tests_jit_build --gtest_filter='Trisc2RvvMockBlackholeFixture.*'
     ./build/test/tt_metal/unit_tests_noc
   skus:
     wh_n150_civ2:

--- a/tests/tt_metal/tt_metal/api/emule/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/emule/sources.cmake
@@ -25,6 +25,7 @@ list(
     ${CMAKE_CURRENT_LIST_DIR}/test_emule_host_wait.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_host_alignment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_metadata_size.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_named_compile_time_args.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_noc_without_barrier.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_padded_write.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_semaphore_write.cpp

--- a/tests/tt_metal/tt_metal/api/emule/test_named_compile_time_args.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_named_compile_time_args.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <string>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "multi_device_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using EmuleNamedCompileTimeArgsTest = GenericMeshDeviceFixture;
+
+TEST_F(EmuleNamedCompileTimeArgsTest, FreshJitUsesTheEmulatorNamedApi) {
+    const auto mesh_device = get_mesh_device();
+    distributed::MeshWorkload workload;
+    const auto range = distributed::MeshCoordinateRange(mesh_device->shape());
+    workload.add_program(range, CreateProgram());
+    auto& program = workload.get_programs().at(range);
+
+    // Change the source identity each run so a disk-cache hit cannot hide a broken
+    // wrapper include sequence. The static_assert checks the API at JIT compile time.
+    const std::string source = "// fresh JIT " + std::to_string(getpid()) + " " +
+                               std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) +
+                               "\n"
+                               "#include \"api/compile_time_args.h\"\n"
+                               "static_assert(get_named_compile_time_arg_val(\"n\") == 7);\n"
+                               "void kernel_main() {}\n";
+    CreateKernelFromString(
+        program,
+        source,
+        CoreCoord{0, 0},
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .named_compile_args = {{"n", 7}}});
+    auto& cq = mesh_device->mesh_command_queue();
+    ASSERT_NO_THROW(distributed::EnqueueMeshWorkload(cq, workload, false));
+    ASSERT_NO_THROW(distributed::Finish(cq));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/jit_build/jit_test_tools.hpp
+++ b/tests/tt_metal/tt_metal/jit_build/jit_test_tools.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include <tt_stl/assert.hpp>
+
+#include "llrt/rtoptions.hpp"
+
+namespace tt::jit_build::test {
+
+// Use the runtime's root selection and the same SFPI search order as JitBuildEnv.
+struct JitTestTools {
+    std::filesystem::path root = llrt::RunTimeOptions().get_root_dir();
+
+    std::string compiler() const {
+        for (const auto& sfpi : {root / "runtime/sfpi", std::filesystem::path("/opt/tenstorrent/sfpi")}) {
+            const auto gxx = sfpi / "compiler/bin/riscv-tt-elf-g++";
+            if (std::filesystem::is_regular_file(gxx)) {
+                return gxx.string();
+            }
+        }
+        TT_THROW("SFPI compiler missing: checked {}/runtime/sfpi and /opt/tenstorrent/sfpi", root.string());
+    }
+
+    std::string hw_include_dir() const {
+        const auto inc = root / "tt_metal/hw/inc";
+        TT_FATAL(
+            std::filesystem::is_regular_file(inc / "api/named_compile_time_args.h"),
+            "JIT headers missing from {}",
+            inc.string());
+        return inc.string();
+    }
+};
+
+}  // namespace tt::jit_build::test

--- a/tests/tt_metal/tt_metal/jit_build/sources.cmake
+++ b/tests/tt_metal/tt_metal/jit_build/sources.cmake
@@ -7,6 +7,7 @@ set(UNIT_TESTS_JIT_BUILD_SRC
     test_file_renamer.cpp
     test_jit_build_telemetry.cpp
     test_jit_compile_deduper.cpp
+    test_jit_pch.cpp
     test_kernel_signature_parser.cpp
     test_named_ct_arg_channels.cpp
     test_named_ct_arg_map.cpp

--- a/tests/tt_metal/tt_metal/jit_build/test_jit_pch.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_jit_pch.cpp
@@ -11,18 +11,18 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "jit_build/depend.hpp"
 #include "jit_build/jit_build_utils.hpp"
 #include "jit_build/pch.hpp"
+#include "jit_test_tools.hpp"
 
 namespace tt::jit_build {
 
-// Exercise the production PCH cache with small, writable host headers. No device or
-// SFPI installation is needed. CXX can select a GCC executable on hosts where g++
-// names Clang; GCC's -H output proves that each consumer actually loaded the PCH.
+// Compile writable headers with SFPI and verify PCH consumption without a device.
 class JitPchTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -35,25 +35,7 @@ protected:
         std::filesystem::create_directories(source_);
         std::filesystem::create_directories(consumer_);
 
-        const char* cxx = std::getenv("CXX");
-        const std::vector<std::string> candidates = {cxx == nullptr ? "g++" : cxx, "g++"};
-        const auto probe_log = scratch_ / "compiler.log";
-        for (const auto& candidate : candidates) {
-            std::filesystem::remove(probe_log);
-            auto probe = utils::tokenize_flags(candidate);
-            probe.insert(probe.end(), {"-dM", "-E", "-x", "c++", "/dev/null"});
-            if (utils::exec_command(probe, scratch_.string(), probe_log.string())) {
-                const std::string macros = read(probe_log);
-                if (macros.find("#define __GNUC__ ") != std::string::npos &&
-                    macros.find("#define __clang__ ") == std::string::npos) {
-                    compiler_ = candidate;
-                    break;
-                }
-            }
-        }
-        if (compiler_.empty()) {
-            GTEST_SKIP() << "GCC is required to test .gch consumption; set CXX to a GCC executable";
-        }
+        compiler_ = test::JitTestTools{}.compiler();
         write(source_ / "umbrella.h", "#pragma once\n#include \"value.h\"\n");
         write(source_ / "value.h", "#pragma once\nconstexpr int value = 1;\n");
     }
@@ -85,10 +67,10 @@ protected:
             compiler_,
             source_.string(),
             (scratch_ / cache).string(),
-            "host",
+            "blackhole",
             "umbrella.h",
             "O0",
-            "-std=c++17 -MMD",
+            "-mcpu=tt-bh-tensix -std=c++17 -MMD",
             includes(),
             {"-DFORCE_INLINE=inline"});
     }
@@ -109,7 +91,7 @@ protected:
         const auto args = utils::build_gpp_argv(
             compiler_,
             "O0",
-            "-std=c++17 -MMD -H -Werror=invalid-pch",
+            "-mcpu=tt-bh-tensix -std=c++17 -MMD -H -Werror=invalid-pch",
             includes(),
             defines,
             source.string(),
@@ -130,26 +112,8 @@ protected:
     }
 
     void use_named_api() {
-        // Test binaries may be copied away from the build host's absolute source path.
-        const char* metal_home = std::getenv("TT_METAL_HOME");
-        const std::vector<std::filesystem::path> roots = {
-            metal_home == nullptr ? std::filesystem::current_path() : std::filesystem::path(metal_home),
-            std::filesystem::current_path(),
-            std::filesystem::path(__FILE__).parent_path()};
-        for (auto root : roots) {
-            for (root = std::filesystem::absolute(root); !root.empty(); root = root.parent_path()) {
-                const auto inc = root / "tt_metal/hw/inc";
-                if (std::filesystem::exists(inc / "api/named_compile_time_args.h")) {
-                    extra_includes_ = " -I" + inc.string();
-                    write(source_ / "umbrella.h", "#include \"api/compile_time_args.h\"\n");
-                    return;
-                }
-                if (root == root.root_path()) {
-                    break;
-                }
-            }
-        }
-        FAIL() << "cannot locate tt_metal/hw/inc; set TT_METAL_HOME to the source or installed JIT tree";
+        extra_includes_ = " -I" + test::JitTestTools{}.hw_include_dir();
+        write(source_ / "umbrella.h", "#include \"api/compile_time_args.h\"\n");
     }
 
     std::filesystem::path scratch_;
@@ -216,6 +180,22 @@ TEST_F(JitPchTest, FailedPchBuildRequestsTextualFallback) {
     write(source_ / "umbrella.h", "#include \"missing_generated_header.h\"\n");
     EXPECT_TRUE(ensure().empty());
     ASSERT_NO_FATAL_FAILURE(consume({}, "static_assert(1 + 1 == 2);\n"));
+}
+
+TEST_F(JitPchTest, StrictValidationRequiresTheExpectedPch) {
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    const auto log = (consumer_ / "compile.log").string();
+    ASSERT_NO_FATAL_FAILURE(consume({}, "static_assert(1 + 1 == 2);\n"));
+    EXPECT_THROW(require_pch_consumed(log, pch), std::runtime_error);
+    EXPECT_THROW(require_pch_consumed(log, {}), std::runtime_error);
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
+    EXPECT_NO_THROW(require_pch_consumed(log, pch));
+    EXPECT_THROW(require_pch_consumed(log, pch + ".other"), std::runtime_error);
+    write(log, "x " + pch + ".gch\n");
+    EXPECT_THROW(require_pch_consumed(log, pch), std::runtime_error);
+    std::filesystem::remove(log);
+    EXPECT_THROW(require_pch_consumed(log, pch), std::runtime_error);
 }
 
 TEST_F(JitPchTest, DistinctNamedMapsShareAnAcceptedPch) {

--- a/tests/tt_metal/tt_metal/jit_build/test_jit_pch.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_jit_pch.cpp
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "jit_build/depend.hpp"
+#include "jit_build/jit_build_utils.hpp"
+#include "jit_build/pch.hpp"
+
+namespace tt::jit_build {
+
+// Exercise the production PCH cache with small, writable host headers. No device or
+// SFPI installation is needed. CXX can select a GCC executable on hosts where g++
+// names Clang; GCC's -H output proves that each consumer actually loaded the PCH.
+class JitPchTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        auto pattern = (std::filesystem::temp_directory_path() / "jit_pch_test_XXXXXX").string();
+        const char* directory = mkdtemp(pattern.data());
+        ASSERT_NE(directory, nullptr);
+        scratch_ = directory;
+        source_ = scratch_ / "source";
+        consumer_ = scratch_ / "consumer";
+        std::filesystem::create_directories(source_);
+        std::filesystem::create_directories(consumer_);
+
+        const char* cxx = std::getenv("CXX");
+        const std::vector<std::string> candidates = {cxx == nullptr ? "g++" : cxx, "g++"};
+        const auto probe_log = scratch_ / "compiler.log";
+        for (const auto& candidate : candidates) {
+            std::filesystem::remove(probe_log);
+            auto probe = utils::tokenize_flags(candidate);
+            probe.insert(probe.end(), {"-dM", "-E", "-x", "c++", "/dev/null"});
+            if (utils::exec_command(probe, scratch_.string(), probe_log.string())) {
+                const std::string macros = read(probe_log);
+                if (macros.find("#define __GNUC__ ") != std::string::npos &&
+                    macros.find("#define __clang__ ") == std::string::npos) {
+                    compiler_ = candidate;
+                    break;
+                }
+            }
+        }
+        if (compiler_.empty()) {
+            GTEST_SKIP() << "GCC is required to test .gch consumption; set CXX to a GCC executable";
+        }
+        write(source_ / "umbrella.h", "#pragma once\n#include \"value.h\"\n");
+        write(source_ / "value.h", "#pragma once\nconstexpr int value = 1;\n");
+    }
+
+    void TearDown() override {
+        pch_cache_clear();
+        clear_file_hash_cache();
+        if (!scratch_.empty()) {
+            std::filesystem::remove_all(scratch_);
+        }
+    }
+
+    static std::string read(const std::filesystem::path& path) {
+        std::ifstream file(path);
+        return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+    }
+
+    static void write(const std::filesystem::path& path, const std::string& content) {
+        std::ofstream file(path);
+        file << content;
+        file.close();
+        ASSERT_FALSE(file.fail()) << path;
+    }
+
+    std::string includes() const { return "-I. -I.. -I" + source_.string() + extra_includes_; }
+
+    std::string ensure(const std::string& cache = "cache") const {
+        return ensure_pch(
+            compiler_,
+            source_.string(),
+            (scratch_ / cache).string(),
+            "host",
+            "umbrella.h",
+            "O0",
+            "-std=c++17 -MMD",
+            includes(),
+            {"-DFORCE_INLINE=inline"});
+    }
+
+    void consume(
+        const std::string& pch, const std::string& body, const std::vector<std::string>& extra_defines = {}) const {
+        const auto source = consumer_ / "consumer.cpp";
+        const std::string object = (consumer_ / "consumer.o").string();
+        const std::string dep = (consumer_ / "consumer.d").string();
+        const std::string log = (consumer_ / "compile.log").string();
+        ASSERT_NO_FATAL_FAILURE(write(source, body));
+        std::filesystem::remove(log);
+        std::vector<std::string> defines = {"-DFORCE_INLINE=inline"};
+        if (!pch.empty()) {
+            defines.insert(defines.end(), {"-include", pch});
+        }
+        defines.insert(defines.end(), extra_defines.begin(), extra_defines.end());
+        const auto args = utils::build_gpp_argv(
+            compiler_,
+            "O0",
+            "-std=c++17 -MMD -H -Werror=invalid-pch",
+            includes(),
+            defines,
+            source.string(),
+            utils::GppAction::Compile,
+            object,
+            dep);
+        ASSERT_TRUE(utils::exec_command(args, consumer_.string(), log)) << read(log);
+        if (!pch.empty()) {
+            ASSERT_NE(read(log).find("! " + pch + ".gch"), std::string::npos) << read(log);
+            merge_pch_deps_into_kernel_d(dep, object, pch + ".d");
+        }
+        write_dependency_hashes(consumer_.string(), object, object + ".dephash");
+        ASSERT_TRUE(dependencies_up_to_date_file(object + ".dephash"));
+    }
+
+    bool consumer_up_to_date() const {
+        return dependencies_up_to_date_file((consumer_ / "consumer.o.dephash").string());
+    }
+
+    void use_named_api() {
+        // Test binaries may be copied away from the build host's absolute source path.
+        const char* metal_home = std::getenv("TT_METAL_HOME");
+        const std::vector<std::filesystem::path> roots = {
+            metal_home == nullptr ? std::filesystem::current_path() : std::filesystem::path(metal_home),
+            std::filesystem::current_path(),
+            std::filesystem::path(__FILE__).parent_path()};
+        for (auto root : roots) {
+            for (root = std::filesystem::absolute(root); !root.empty(); root = root.parent_path()) {
+                const auto inc = root / "tt_metal/hw/inc";
+                if (std::filesystem::exists(inc / "api/named_compile_time_args.h")) {
+                    extra_includes_ = " -I" + inc.string();
+                    write(source_ / "umbrella.h", "#include \"api/compile_time_args.h\"\n");
+                    return;
+                }
+                if (root == root.root_path()) {
+                    break;
+                }
+            }
+        }
+        FAIL() << "cannot locate tt_metal/hw/inc; set TT_METAL_HOME to the source or installed JIT tree";
+    }
+
+    std::filesystem::path scratch_;
+    std::filesystem::path source_;
+    std::filesystem::path consumer_;
+    std::string compiler_;
+    std::string extra_includes_;
+};
+
+TEST_F(JitPchTest, ReusesUnchangedPchAndMergesItsDependencies) {
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
+    const auto sentinel = std::filesystem::file_time_type::clock::now() - std::chrono::hours(24);
+    std::filesystem::last_write_time(pch + ".gch", sentinel);
+    EXPECT_EQ(ensure(), pch);
+    EXPECT_EQ(std::filesystem::last_write_time(pch + ".gch"), sentinel);
+    const std::string hashes = read(consumer_ / "consumer.o.dephash");
+    EXPECT_NE(hashes.find((source_ / "value.h").string()), std::string::npos);
+    EXPECT_NE(hashes.find((source_ / "umbrella.h").string()), std::string::npos);
+}
+
+TEST_F(JitPchTest, RebuildsAfterTransitiveHeaderEdit) {
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
+    write(source_ / "value.h", "#pragma once\nconstexpr int value = 22;\n");
+    ASSERT_FALSE(consumer_up_to_date());
+    ASSERT_EQ(ensure(), pch);
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 22);\n"));
+}
+
+TEST_F(JitPchTest, RebuildsAfterOriginalUmbrellaEdit) {
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
+    write(source_ / "umbrella.h", "#pragma once\n#include \"value.h\"\nconstexpr int added = 21;\n");
+    ASSERT_FALSE(consumer_up_to_date());
+    ASSERT_EQ(ensure(), pch);
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1 && added == 21);\n"));
+}
+
+TEST_F(JitPchTest, SeparatesOutputRootsInOneProcess) {
+    const auto first = ensure("first");
+    const auto second = ensure("second");
+    ASSERT_FALSE(first.empty());
+    ASSERT_FALSE(second.empty());
+    ASSERT_NE(first, second);
+    ASSERT_NO_FATAL_FAILURE(consume(first, "static_assert(value == 1);\n"));
+    ASSERT_NO_FATAL_FAILURE(consume(second, "static_assert(value == 1);\n"));
+}
+
+TEST_F(JitPchTest, CacheClearDropsCompletedEntries) {
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    std::filesystem::remove(pch + ".gch");
+    pch_cache_clear();
+    clear_file_hash_cache();
+    ASSERT_EQ(ensure(), pch);
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
+}
+
+TEST_F(JitPchTest, FailedPchBuildRequestsTextualFallback) {
+    write(source_ / "umbrella.h", "#include \"missing_generated_header.h\"\n");
+    EXPECT_TRUE(ensure().empty());
+    ASSERT_NO_FATAL_FAILURE(consume({}, "static_assert(1 + 1 == 2);\n"));
+}
+
+TEST_F(JitPchTest, DistinctNamedMapsShareAnAcceptedPch) {
+    ASSERT_NO_FATAL_FAILURE(use_named_api());
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    for (const unsigned value : {7u, 21u}) {
+        const auto map_header = consumer_ / "named.h";
+        write(map_header, utils::format_named_ct_arg_map_header({{"n", value}}));
+        ASSERT_EQ(ensure(), pch);
+        ASSERT_NO_FATAL_FAILURE(consume(
+            pch,
+            "#include \"api/compile_time_args.h\"\n#include \"api/named_compile_time_args.h\"\n"
+            "static_assert(get_named_compile_time_arg_val(\"n\") == " +
+                std::to_string(value) + ");\n",
+            {"-include", map_header.string()}));
+    }
+}
+
+TEST_F(JitPchTest, PublicIncludeExposesNamedApiWithAndWithoutPch) {
+    ASSERT_NO_FATAL_FAILURE(use_named_api());
+    const std::string body =
+        "#define KERNEL_COMPILE_TIME_ARG_MAP {\"n\",7}\n"
+        "#include \"api/compile_time_args.h\"\n"
+        "static_assert(get_named_compile_time_arg_val(\"n\") == 7);\n";
+    ASSERT_NO_FATAL_FAILURE(consume({}, body));
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    ASSERT_NO_FATAL_FAILURE(consume(pch, body));
+}
+
+}  // namespace tt::jit_build

--- a/tests/tt_metal/tt_metal/jit_build/test_jit_pch.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_jit_pch.cpp
@@ -63,6 +63,10 @@ protected:
     std::string includes() const { return "-I. -I.. -I" + source_.string() + extra_includes_; }
 
     std::string ensure(const std::string& cache = "cache") const {
+        std::vector<std::string> defines = {"-DFORCE_INLINE=inline"};
+        if (defer_args_) {
+            defines.emplace_back("-DTT_METAL_PCH_BUILD=1");
+        }
         return ensure_pch(
             compiler_,
             source_.string(),
@@ -72,11 +76,14 @@ protected:
             "O0",
             "-mcpu=tt-bh-tensix -std=c++17 -MMD",
             includes(),
-            {"-DFORCE_INLINE=inline"});
+            defines);
     }
 
     void consume(
-        const std::string& pch, const std::string& body, const std::vector<std::string>& extra_defines = {}) const {
+        const std::string& pch,
+        const std::string& body,
+        const std::vector<std::string>& extra_defines = {},
+        const std::vector<uint32_t>& ct_args = {}) const {
         const auto source = consumer_ / "consumer.cpp";
         const std::string object = (consumer_ / "consumer.o").string();
         const std::string dep = (consumer_ / "consumer.d").string();
@@ -86,6 +93,14 @@ protected:
         std::vector<std::string> defines = {"-DFORCE_INLINE=inline"};
         if (!pch.empty()) {
             defines.insert(defines.end(), {"-include", pch});
+            if (defer_args_) {
+                defines.emplace_back("-DTT_METAL_PCH_BUILD=1");
+            }
+        }
+        if (defer_args_) {
+            const auto generated = consumer_ / "args.h";
+            write(generated, utils::format_ct_args_header(ct_args));
+            defines.insert(defines.end(), {"-include", generated.string()});
         }
         defines.insert(defines.end(), extra_defines.begin(), extra_defines.end());
         const auto args = utils::build_gpp_argv(
@@ -112,6 +127,7 @@ protected:
     }
 
     void use_named_api() {
+        defer_args_ = true;
         extra_includes_ = " -I" + test::JitTestTools{}.hw_include_dir();
         write(source_ / "umbrella.h", "#include \"api/compile_time_args.h\"\n");
     }
@@ -121,6 +137,7 @@ protected:
     std::filesystem::path consumer_;
     std::string compiler_;
     std::string extra_includes_;
+    bool defer_args_ = false;
 };
 
 TEST_F(JitPchTest, ReusesUnchangedPchAndMergesItsDependencies) {
@@ -176,10 +193,58 @@ TEST_F(JitPchTest, CacheClearDropsCompletedEntries) {
     ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
 }
 
+TEST_F(JitPchTest, ReusesDiskPchWithoutAnInMemoryEntry) {
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    const auto sentinel = std::filesystem::file_time_type::clock::now() - std::chrono::hours(24);
+    std::filesystem::last_write_time(pch + ".gch", sentinel);
+    pch_cache_clear();
+    clear_file_hash_cache();
+    ASSERT_EQ(ensure(), pch);
+    EXPECT_EQ(std::filesystem::last_write_time(pch + ".gch"), sentinel);
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
+}
+
+TEST_F(JitPchTest, DistinctPositionalArgsShareAnAcceptedPch) {
+    ASSERT_NO_FATAL_FAILURE(use_named_api());
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    const auto sentinel = std::filesystem::file_time_type::clock::now() - std::chrono::hours(24);
+    std::filesystem::last_write_time(pch + ".gch", sentinel);
+    for (const std::vector<uint32_t>& values : {std::vector<uint32_t>{7}, {21, 42}, {}}) {
+        std::string body = "#include \"api/compile_time_args.h\"\nstatic_assert(kernel_compile_time_args.size() == " +
+                           std::to_string(values.size()) + ");\n";
+        for (size_t i = 0; i < values.size(); ++i) {
+            body += "static_assert(get_compile_time_arg_val(" + std::to_string(i) +
+                    ") == " + std::to_string(values[i]) + ");\n";
+        }
+        ASSERT_NO_FATAL_FAILURE(
+            consume(pch, body, {"-DUNUSED_KERNEL_DEFINE=" + std::to_string(values.size())}, values));
+        ASSERT_NO_FATAL_FAILURE(consume({}, body, {}, values));
+        ASSERT_EQ(ensure(), pch);
+        EXPECT_EQ(std::filesystem::last_write_time(pch + ".gch"), sentinel);
+    }
+}
+
 TEST_F(JitPchTest, FailedPchBuildRequestsTextualFallback) {
     write(source_ / "umbrella.h", "#include \"missing_generated_header.h\"\n");
     EXPECT_TRUE(ensure().empty());
     ASSERT_NO_FATAL_FAILURE(consume({}, "static_assert(1 + 1 == 2);\n"));
+}
+
+TEST_F(JitPchTest, ProfileLimitKeepsExistingPchUsable) {
+    const auto pch = ensure();
+    ASSERT_FALSE(pch.empty());
+    const auto cache = scratch_ / "cache/pch/blackhole";
+    // Include reservations from other processes, even before they publish a .gch.
+    for (size_t i = 1; i < 64; ++i) {
+        std::filesystem::create_directories(cache / ("reserved-" + std::to_string(i)));
+    }
+    EXPECT_EQ(ensure(), pch);
+    extra_includes_ = " -I" + consumer_.string();
+    EXPECT_TRUE(ensure().empty());
+    extra_includes_.clear();
+    ASSERT_NO_FATAL_FAILURE(consume(pch, "static_assert(value == 1);\n"));
 }
 
 TEST_F(JitPchTest, StrictValidationRequiresTheExpectedPch) {

--- a/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_channels.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_channels.cpp
@@ -7,6 +7,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -83,6 +85,71 @@ void kernel_main() {}
     EXPECT_FALSE(artifacts.legacy_header);
     EXPECT_TRUE(artifacts.blaze_header);
     EXPECT_FALSE(artifacts.legacy_force_include);
+}
+
+TEST_F(NamedCtArgChannelsMockBlackholeFixture, PositionalValuesAndKernelDefinesShareFirmwarePch) {
+    const auto& options = MetalContext::instance().rtoptions();
+    if (!options.get_jit_pch_strict()) {
+        GTEST_SKIP() << "Run with TT_METAL_JIT_PCH=1 TT_METAL_JIT_PCH_STRICT=1 TT_METAL_FORCE_JIT_COMPILE=1";
+    }
+    ASSERT_TRUE(options.get_force_jit_compile());
+    std::map<std::filesystem::path, std::filesystem::file_time_type> first_pch;
+    for (const std::vector<uint32_t>& values : {std::vector<uint32_t>{7}, {21, 42}, {}}) {
+        const std::string source = R"(
+#include "api/compile_time_args.h"
+static_assert(kernel_compile_time_args.size() == EXPECTED_COUNT);
+#if EXPECTED_COUNT > 0
+static_assert(get_compile_time_arg_val(0) == EXPECTED_VALUE);
+#endif
+void kernel_main() {}
+)";
+        KernelDescriptor descriptor = {
+            .kernel_source = source,
+            .source_type = KernelDescriptor::SourceType::SOURCE_CODE,
+            .core_ranges = CoreRange(CoreCoord{0, 0}),
+            .compile_time_args = values,
+            .defines =
+                {{"EXPECTED_COUNT", std::to_string(values.size())},
+                 {"EXPECTED_VALUE", std::to_string(values.empty() ? 0 : values.front())}},
+            // Appended kernel include paths must not create new PCH profiles.
+            .compiler_include_paths =
+                {std::filesystem::path(options.get_root_dir()) / (values.empty() ? "tests" : "tt_metal")},
+        };
+        ProgramDescriptor::KernelDescriptors descriptors;
+        descriptor.config = DataMovementConfigDescriptor{};
+        descriptors.push_back(descriptor);
+        descriptor.config = DataMovementConfigDescriptor{.processor = DataMovementProcessor::RISCV_1};
+        descriptors.push_back(descriptor);
+        descriptor.config = ComputeConfigDescriptor{};
+        descriptors.push_back(descriptor);
+        Program program(ProgramDescriptor{.kernels = descriptors});
+        auto* device = devices_.at(0).get();
+        program.impl().compile(device);
+        const auto& env = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env;
+        std::map<std::filesystem::path, std::filesystem::file_time_type> accepted_pch;
+        for (size_t i = 0; i < descriptors.size(); ++i) {
+            const auto dir = std::filesystem::path(env.get_out_kernel_root_path()) /
+                             program.impl().get_kernel(i)->get_full_kernel_name();
+            for (const auto& file : std::filesystem::recursive_directory_iterator(dir)) {
+                if (!file.path().string().ends_with(".o.log")) {
+                    continue;
+                }
+                std::ifstream log(file.path());
+                for (std::string line; std::getline(log, line);) {
+                    if (line.starts_with("! ") && line.ends_with(".gch")) {
+                        const std::filesystem::path pch = line.substr(2);
+                        accepted_pch.emplace(pch, std::filesystem::last_write_time(pch));
+                    }
+                }
+            }
+        }
+        ASSERT_EQ(accepted_pch.size(), 5u) << "BRISC, NCRISC and all three TRISCs must consume a PCH";
+        if (first_pch.empty()) {
+            first_pch = accepted_pch;
+        } else {
+            EXPECT_EQ(accepted_pch, first_pch) << "Kernel values or include paths rebuilt a PCH";
+        }
+    }
 }
 
 TEST_F(NamedCtArgChannelsMockBlackholeFixture, LegacyFieldPreservesBothApis) {

--- a/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -149,9 +150,14 @@ TEST(NamedCtArgMap, HeaderDefinesTheMacroAndIsIncludeGuarded) {
     EXPECT_NE(header.find("#pragma once"), std::string::npos);
     EXPECT_NE(header.find(R"(#define KERNEL_COMPILE_TIME_ARG_MAP {"cb_in0",1})"), std::string::npos);
     // The macro must be the whole body on one logical line: a stray newline inside the map would
-    // terminate the #define and silently truncate the arg list.
+    // terminate the #define and silently truncate the arg list. Everything after that line is the
+    // include that turns the macro into the get_named_compile_time_arg_val API -- performed here,
+    // in the generated header, because under TT_METAL_JIT_PCH the kernel's own include of
+    // compile_time_args.h re-includes as a no-op (the guard is already satisfied inside the PCH).
     const std::size_t define_pos = header.find("#define KERNEL_COMPILE_TIME_ARG_MAP");
-    EXPECT_EQ(header.find('\n', define_pos), header.size() - 1);
+    const std::size_t define_end = header.find('\n', define_pos);
+    ASSERT_NE(define_end, std::string::npos);
+    EXPECT_EQ(header.substr(define_end), "\n\n#include \"api/named_compile_time_args.h\"\n");
 }
 
 TEST(NamedCtArgMap, HeaderIsByteIdenticalForEqualMaps) {
@@ -197,6 +203,33 @@ TEST(NamedCtArgMap, HeaderNameIsRelativeSoItResolvesOnBothCompileHosts) {
     EXPECT_TRUE(NAMED_CT_ARG_MAP_HEADER.ends_with(".h"));
 }
 
+// Locate the real tt_metal/hw/inc tree, which real compiles carry as an absolute -I and the
+// generated map header needs to resolve its trailing #include "api/named_compile_time_args.h".
+// TT_METAL_HOME when set (as in CI), otherwise walk up from cwd, which covers running the test
+// binary from anywhere inside the repo or its build tree.
+std::filesystem::path find_hw_inc_dir() {
+    namespace fs = std::filesystem;
+    auto probe = [](fs::path base) -> fs::path {
+        std::error_code ec;
+        for (base = fs::absolute(base, ec); !base.empty(); base = base.parent_path()) {
+            const fs::path candidate = base / "tt_metal" / "hw" / "inc";
+            if (fs::exists(candidate / "api" / "named_compile_time_args.h", ec)) {
+                return candidate;
+            }
+            if (base == base.root_path()) {
+                break;
+            }
+        }
+        return {};
+    };
+    if (const char* home = std::getenv("TT_METAL_HOME")) {
+        if (const auto found = probe(home); !found.empty()) {
+            return found;
+        }
+    }
+    return probe(std::filesystem::current_path());
+}
+
 // End-to-end check of the delivery mechanism, in the directory layout the real compiles use: the
 // generated header sits in the per-kernel dir and the compiler runs with cwd = a per-target subdir,
 // reaching it through the "-I.." on every compile. Both the local build and the JIT compile server
@@ -207,6 +240,11 @@ TEST(NamedCtArgMap, HeaderNameIsRelativeSoItResolvesOnBothCompileHosts) {
 // toolchain: what is under test is name resolution and macro visibility, not code generation.
 TEST(NamedCtArgMap, ForceIncludedHeaderResolvesFromTargetSubdirAndDefinesTheMap) {
     namespace fs = std::filesystem;
+
+    const fs::path hw_inc = find_hw_inc_dir();
+    if (hw_inc.empty()) {
+        GTEST_SKIP() << "tt_metal/hw/inc not locatable (TT_METAL_HOME unset and cwd outside the repo)";
+    }
 
     const fs::path kernel_dir = fs::temp_directory_path() / "tt_named_ct_arg_map_test" / "kernel";
     const fs::path target_dir = kernel_dir / "ncrisc";
@@ -220,30 +258,28 @@ TEST(NamedCtArgMap, ForceIncludedHeaderResolvesFromTargetSubdirAndDefinesTheMap)
         ASSERT_TRUE(header.good());
     }
 
-    // Mirrors hw/inc/api/compile_time_args.h: build the lookup table from the macro and resolve a
-    // name at compile time, so a missing or malformed map fails the compile.
+    // Calls the real get_named_compile_time_arg_val API, which the generated header brings in via
+    // its trailing include of api/named_compile_time_args.h. Resolving names at compile time means
+    // a missing or malformed map -- or an undeclared API -- fails the compile.
     const fs::path src = kernel_dir / "consumer.cpp";
     {
         std::ofstream f(src);
-        f << "#include <string_view>\n#include <utility>\n#include <cstdint>\n"
-             "constexpr std::pair<std::string_view, uint32_t> named_args_map[] = {KERNEL_COMPILE_TIME_ARG_MAP};\n"
-             "constexpr uint32_t get_named_ct_arg(std::string_view name) {\n"
-             "    for (const auto& [n, v] : named_args_map) { if (n == name) { return v; } }\n"
-             "    return 0xFFFFFFFFu;\n"
-             "}\n"
-             "static_assert(get_named_ct_arg(\"cb_in0\") == 7);\n"
-             "static_assert(get_named_ct_arg(\"num_tiles\") == 64);\n";
+        f << "static_assert(get_named_compile_time_arg_val(\"cb_in0\") == 7);\n"
+             "static_assert(get_named_compile_time_arg_val(\"num_tiles\") == 64);\n"
+             "int main() { return 0; }\n";
         ASSERT_TRUE(f.good());
     }
 
     // -I. / -I.. and cwd = target dir replicate JitBuildEnv's include list and exec_command's
-    // working directory. The bare -include must resolve through -I.. alone.
+    // working directory; the absolute -I<hw/inc> replicates the include path every real compile
+    // carries. The bare -include must resolve through -I.. alone.
     const std::vector<std::string> args = {
         "c++",
         "-std=c++17",
         "-fsyntax-only",
         "-I.",
         "-I..",
+        "-I" + hw_inc.string(),
         "-include",
         std::string(NAMED_CT_ARG_MAP_HEADER),
         "../consumer.cpp"};

--- a/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "jit_build/jit_build_utils.hpp"
+#include "jit_test_tools.hpp"
 
 // The named compile-time-arg map (KERNEL_COMPILE_TIME_ARG_MAP) is delivered to kernels as a
 // force-included generated header rather than a -D define. These tests cover the formatter that
@@ -202,48 +203,13 @@ TEST(NamedCtArgMap, HeaderNameIsRelativeSoItResolvesOnBothCompileHosts) {
     EXPECT_TRUE(NAMED_CT_ARG_MAP_HEADER.ends_with(".h"));
 }
 
-// Locate the real tt_metal/hw/inc tree, which real compiles carry as an absolute -I and the
-// generated map header needs to resolve its trailing #include "api/named_compile_time_args.h".
-// TT_METAL_HOME when set (as in CI), otherwise walk up from cwd, which covers running the test
-// binary from anywhere inside the repo or its build tree.
-std::filesystem::path find_hw_inc_dir() {
-    namespace fs = std::filesystem;
-    auto probe = [](fs::path base) -> fs::path {
-        std::error_code ec;
-        for (base = fs::absolute(base, ec); !base.empty(); base = base.parent_path()) {
-            const fs::path candidate = base / "tt_metal" / "hw" / "inc";
-            if (fs::exists(candidate / "api" / "named_compile_time_args.h", ec)) {
-                return candidate;
-            }
-            if (base == base.root_path()) {
-                break;
-            }
-        }
-        return {};
-    };
-    if (const char* home = std::getenv("TT_METAL_HOME")) {
-        if (const auto found = probe(home); !found.empty()) {
-            return found;
-        }
-    }
-    return probe(std::filesystem::current_path());
-}
-
-// End-to-end check of the delivery mechanism, in the directory layout the real compiles use: the
-// generated header sits in the per-kernel dir and the compiler runs with cwd = a per-target subdir,
-// reaching it through the "-I.." on every compile. Both the local build and the JIT compile server
-// arrange things this way, which is what lets a bare -include work identically on both -- an
-// absolute client-side path would compile locally and then fail on the server.
-//
-// Uses the host compiler and only the preprocessor, so it needs neither a device nor the RISC-V
-// toolchain: what is under test is name resolution and macro visibility, not code generation.
+// SFPI must resolve the generated map through -I.. from a per-target directory.
 TEST(NamedCtArgMap, ForceIncludedHeaderResolvesFromTargetSubdirAndDefinesTheMap) {
     namespace fs = std::filesystem;
 
-    const fs::path hw_inc = find_hw_inc_dir();
-    if (hw_inc.empty()) {
-        GTEST_SKIP() << "tt_metal/hw/inc not locatable (TT_METAL_HOME unset and cwd outside the repo)";
-    }
+    const test::JitTestTools tools;
+    const std::string hw_inc = tools.hw_include_dir();
+    const std::string compiler = tools.compiler();
 
     const fs::path kernel_dir = fs::temp_directory_path() / "tt_named_ct_arg_map_test" / "kernel";
     const fs::path target_dir = kernel_dir / "ncrisc";
@@ -273,22 +239,19 @@ TEST(NamedCtArgMap, ForceIncludedHeaderResolvesFromTargetSubdirAndDefinesTheMap)
     // working directory; the absolute -I<hw/inc> replicates the include path every real compile
     // carries. The bare -include must resolve through -I.. alone.
     const std::vector<std::string> args = {
-        "c++",
+        compiler,
+        "-mcpu=tt-bh-tensix",
         "-std=c++17",
         "-fsyntax-only",
         "-I.",
         "-I..",
-        "-I" + hw_inc.string(),
+        "-I" + hw_inc,
         "-include",
         std::string(NAMED_CT_ARG_MAP_HEADER),
         "../consumer.cpp"};
     if (!exec_command(args, target_dir.string(), (target_dir / "compile.log").string())) {
         std::ifstream log(target_dir / "compile.log");
         const std::string output((std::istreambuf_iterator<char>(log)), std::istreambuf_iterator<char>());
-        // A host compiler is not guaranteed at test runtime; a missing one is not a product failure.
-        if (output.find("c++") != std::string::npos && output.find("not found") != std::string::npos) {
-            GTEST_SKIP() << "no host c++ compiler available";
-        }
         FAIL() << "force-included map header failed to compile:\n" << output;
     }
 

--- a/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
@@ -151,9 +151,8 @@ TEST(NamedCtArgMap, HeaderDefinesTheMacroAndIsIncludeGuarded) {
     EXPECT_NE(header.find(R"(#define KERNEL_COMPILE_TIME_ARG_MAP {"cb_in0",1})"), std::string::npos);
     // The macro must be the whole body on one logical line: a stray newline inside the map would
     // terminate the #define and silently truncate the arg list. Everything after that line is the
-    // include that turns the macro into the get_named_compile_time_arg_val API -- performed here,
-    // in the generated header, because under TT_METAL_JIT_PCH the kernel's own include of
-    // compile_time_args.h re-includes as a no-op (the guard is already satisfied inside the PCH).
+    // include that turns the macro into the get_named_compile_time_arg_val API. In a PCH build
+    // the prelude saw no map, so this must work without another include from the consumer.
     const std::size_t define_pos = header.find("#define KERNEL_COMPILE_TIME_ARG_MAP");
     const std::size_t define_end = header.find('\n', define_pos);
     ASSERT_NE(define_end, std::string::npos);

--- a/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
@@ -156,7 +156,36 @@ protected:
                 .compile_args = {512 * 1024, 64},
             });
         program.impl().compile(device);
-        return program.impl().get_kernel(handle);
+        auto kernel = program.impl().get_kernel(handle);
+        if (MetalContext::instance().rtoptions().get_jit_pch_strict()) {
+            EXPECT_NO_FATAL_FAILURE(require_pack_pch(kernel));
+        }
+        return kernel;
+    }
+
+    // Check the scalar and RVV pack compiles independently of build.cpp's eligibility check.
+    void require_pack_pch(const std::shared_ptr<Kernel>& kernel) {
+        const auto& rtoptions = MetalContext::instance().rtoptions();
+        ASSERT_TRUE(rtoptions.get_jit_pch_enabled());
+        ASSERT_TRUE(rtoptions.get_force_jit_compile()) << "Strict fixture checks require fresh compile logs";
+        const auto log_path = std::filesystem::path(kernel_elf_path(kernel, 2)).parent_path() / "trisck.o.log";
+        std::ifstream log(log_path);
+        ASSERT_TRUE(log.is_open()) << log_path;
+        auto& manager = BuildEnvManager::get_instance(kernel->get_context_id());
+        const auto pch_root =
+            std::filesystem::path(
+                manager.get_device_build_env(devices_.at(0)->build_id()).build_env.get_out_root_path()) /
+            "pch/trisc2";
+        for (std::string line; std::getline(log, line);) {
+            if (line.starts_with("! ")) {
+                const std::filesystem::path accepted = line.substr(2);
+                if (accepted.filename() == "trisc_pch.h.gch" && accepted.parent_path().parent_path() == pch_root) {
+                    ASSERT_TRUE(std::filesystem::is_regular_file(accepted)) << accepted;
+                    return;
+                }
+            }
+        }
+        FAIL() << "TRISC2 did not consume its PCH: " << log_path;
     }
 
     // Path of the kernel's compiled ELF for one compute processor (0=unpack, 1=math, 2=pack).
@@ -198,6 +227,8 @@ TEST_F(Trisc2RvvMockBlackholeFixture, KnobOffRecipesCarryNoVectorFlags) {
 
 TEST_F(Trisc2RvvMockBlackholeFixture, KnobOnFlagsReachOnlyThePackRecipe) {
     if (!sfpi_supports_bh_zve32f()) {
+        ASSERT_FALSE(MetalContext::instance().rtoptions().get_jit_pch_strict())
+            << "Strict PCH validation requires SFPI with RVV support";
         GTEST_SKIP() << "bundled sfpi toolchain does not accept " << kBhRvvMarch;
     }
     auto kernel_off = compile_rvv_kernel(/*enable_trisc2_rvv=*/false);
@@ -216,6 +247,8 @@ TEST_F(Trisc2RvvMockBlackholeFixture, KnobOnFlagsReachOnlyThePackRecipe) {
 
 TEST_F(Trisc2RvvMockBlackholeFixture, VaddKernelCompilesToVectorCode) {
     if (!sfpi_supports_bh_zve32f()) {
+        ASSERT_FALSE(MetalContext::instance().rtoptions().get_jit_pch_strict())
+            << "Strict PCH validation requires SFPI with RVV support";
         GTEST_SKIP() << "bundled sfpi toolchain does not accept " << kBhRvvMarch;
     }
     auto kernel_on = compile_rvv_kernel(/*enable_trisc2_rvv=*/true);

--- a/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
@@ -172,10 +172,9 @@ protected:
         std::ifstream log(log_path);
         ASSERT_TRUE(log.is_open()) << log_path;
         auto& manager = BuildEnvManager::get_instance(kernel->get_context_id());
+        const auto& env = manager.get_device_build_env(devices_.at(0)->build_id()).build_env;
         const auto pch_root =
-            std::filesystem::path(
-                manager.get_device_build_env(devices_.at(0)->build_id()).build_env.get_out_root_path()) /
-            "pch/trisc2";
+            std::filesystem::path(env.get_out_root_path()) / std::to_string(env.get_build_key()) / "pch/trisc2";
         for (std::string line; std::getline(log, line);) {
             if (line.starts_with("! ")) {
                 const std::filesystem::path accepted = line.substr(2);

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
@@ -19,6 +19,13 @@
 // kernel. Precompiling dataflow_api.h therefore needs it decoupled from the
 // per-kernel descriptors first.
 //
+// Omitting those two does not keep every generated file out of reach: with
+// TT_METAL_DPRINT_CORES set, kernel_profiler.hpp reaches dprint_tile.h, which
+// includes chlkc_descriptors.h unconditionally. The PCH build strips the
+// "-I."/"-I.." roots through which per-kernel files resolve, so in that
+// configuration it fails outright -- logged by ensure_pch -- and every compile
+// falls back to plain parsing rather than sharing one kernel's descriptors.
+//
 // Everything from kernel_includes.hpp onwards is also left out: that is the
 // generated per-kernel body and the conditional includes that follow it.
 //

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Umbrella header for the optional BRISC precompiled header (TT_METAL_JIT_PCH=1).
+// These are the includes brisck.cc parses before it reaches kernel_includes.hpp
+// and that are identical for every BRISC target, in source order.
+//
+// Two headers from that prelude are deliberately omitted:
+//   internal/firmware_common.h
+//   api/dataflow/dataflow_api.h
+// dataflow_api.h (reached both directly and via firmware_common.h) decides
+// whether to define get_tile_size/get_tile_hw/get_tile_num_faces/get_dataformat
+// with __has_include("chlkc_descriptors.h"). That descriptor header is generated
+// per kernel and resolved via -I.. from the kernel's own build directory, so it
+// does not exist where the shared PCH is built: the PCH would bake in "absent"
+// and those four APIs would vanish for every kernel. Baking in one kernel's
+// descriptors instead is worse, since the tables are constexpr and differ per
+// kernel. Precompiling dataflow_api.h therefore needs it decoupled from the
+// per-kernel descriptors first.
+//
+// Everything from kernel_includes.hpp onwards is also left out: that is the
+// generated per-kernel body and the conditional includes that follow it.
+//
+// Keep this in sync with the prelude in brisck.cc.
+
+#pragma once
+
+#include <unistd.h>
+#include <cstdint>
+
+#include "risc_common.h"
+#include "tensix.h"
+#include "tensix_types.h"
+#include "noc.h"
+#include "noc_overlay_parameters.h"
+#include "ckernel_structs.h"
+#include "stream_io_map.h"
+#include "c_tensix_core.h"
+#include "noc_nonblocking_api.h"
+#include "tools/profiler/kernel_profiler.hpp"
+#include "tools/profiler/noc_debugging_profiler.hpp"
+#include "internal/debug/stack_usage.h"

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
@@ -2,40 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Umbrella header for the optional BRISC precompiled header (TT_METAL_JIT_PCH=1).
-// These are the includes brisck.cc parses before it reaches kernel_includes.hpp
-// and that are identical for every BRISC target, in source order.
-//
-// Two headers from that prelude are deliberately omitted:
-//   internal/firmware_common.h
-//   api/dataflow/dataflow_api.h
-// dataflow_api.h (reached both directly and via firmware_common.h) decides
-// whether to define get_tile_size/get_tile_hw/get_tile_num_faces/get_dataformat
-// with __has_include("chlkc_descriptors.h"). That descriptor header is generated
-// per kernel and resolved via -I.. from the kernel's own build directory, so it
-// does not exist where the shared PCH is built: the PCH would bake in "absent"
-// and those four APIs would vanish for every kernel. Baking in one kernel's
-// descriptors instead is worse, since the tables are constexpr and differ per
-// kernel. Precompiling dataflow_api.h therefore needs it decoupled from the
-// per-kernel descriptors first.
-//
-// Omitting those two does not keep every generated file out of reach: with
-// TT_METAL_DPRINT_CORES set, kernel_profiler.hpp reaches dprint_tile.h, which
-// includes chlkc_descriptors.h unconditionally. The PCH build strips the
-// "-I."/"-I.." roots through which per-kernel files resolve, so in that
-// configuration it fails outright -- logged by ensure_pch -- and every compile
-// falls back to plain parsing rather than sharing one kernel's descriptors.
-//
-// Everything from kernel_includes.hpp onwards is also left out: that is the
-// generated per-kernel body and the conditional includes that follow it.
-//
-// <unistd.h> is absent from both this umbrella and the prelude: brisck.cc included it
-// without using any POSIX declaration, and it reached the PCH through here, costing six
-// newlib headers per build. Both copies went in one commit deliberately. Dropping it from
-// the umbrella alone would not remove that parse but relocate it into every BRISC compile,
-// since brisck.cc would still pull it in textually after the PCH boundary.
-//
-// Keep this in sync with the prelude in brisck.cc.
+// Shared BRISC prelude; keep include order in sync with brisck.cc.
+// Exclude firmware_common.h and dataflow_api.h: their __has_include checks and
+// constexpr tables depend on per-kernel chlkc_descriptors.h. The generated body
+// (kernel_includes.hpp) and subsequent includes also stay outside the PCH.
+// DPRINT can still reach descriptors through kernel_profiler.hpp; without the
+// per-kernel include roots, PCH creation then fails and normal builds fall back.
 
 #pragma once
 

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h
@@ -29,11 +29,16 @@
 // Everything from kernel_includes.hpp onwards is also left out: that is the
 // generated per-kernel body and the conditional includes that follow it.
 //
+// <unistd.h> is absent from both this umbrella and the prelude: brisck.cc included it
+// without using any POSIX declaration, and it reached the PCH through here, costing six
+// newlib headers per build. Both copies went in one commit deliberately. Dropping it from
+// the umbrella alone would not remove that parse but relocate it into every BRISC compile,
+// since brisck.cc would still pull it in textually after the PCH boundary.
+//
 // Keep this in sync with the prelude in brisck.cc.
 
 #pragma once
 
-#include <unistd.h>
 #include <cstdint>
 
 #include "risc_common.h"

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Umbrella header for the optional NCRISC precompiled header (TT_METAL_JIT_PCH=1).
+// These are the includes ncrisck.cc parses before it reaches kernel_includes.hpp
+// and that are identical for every NCRISC target, in source order.
+//
+// Two headers from that prelude are deliberately omitted:
+//   internal/firmware_common.h
+//   api/dataflow/dataflow_api.h
+// See brisc_pch.h for why: dataflow_api.h gates four data-format APIs behind
+// __has_include("chlkc_descriptors.h"), a per-kernel generated header that is
+// absent where the shared PCH is built.
+//
+// Everything from kernel_includes.hpp onwards is also left out: that is the
+// generated per-kernel body and the conditional includes that follow it. Note
+// that unlike brisck.cc, ncrisck.cc includes stack_usage.h after the generated
+// body, so it does not belong here either.
+//
+// The PERF_DUMP block is reproduced verbatim: the PCH is built with the same
+// defines as the compile that consumes it, so it resolves the same way.
+//
+// Keep this in sync with the prelude in ncrisck.cc.
+
+#pragma once
+
+#include <cstdint>
+
+#include "risc_common.h"
+#include "tensix.h"
+#include "tensix_types.h"
+#include "noc.h"
+#include "noc_overlay_parameters.h"
+#include "noc_nonblocking_api.h"
+#include "stream_io_map.h"
+#ifdef PERF_DUMP
+#include "risc_perf.h"
+#endif
+#include "tools/profiler/kernel_profiler.hpp"
+#include "tools/profiler/noc_debugging_profiler.hpp"
+#include "internal/tensix_functions.h"
+#include "c_tensix_core.h"

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h
@@ -11,7 +11,9 @@
 //   api/dataflow/dataflow_api.h
 // See brisc_pch.h for why: dataflow_api.h gates four data-format APIs behind
 // __has_include("chlkc_descriptors.h"), a per-kernel generated header that is
-// absent where the shared PCH is built.
+// absent where the shared PCH is built. As there, DPRINT makes the descriptors
+// reachable through kernel_profiler.hpp regardless; the PCH build then fails
+// loudly (no "-I."/"-I.." roots) and compiles fall back to plain parsing.
 //
 // Everything from kernel_includes.hpp onwards is also left out: that is the
 // generated per-kernel body and the conditional includes that follow it. Note

--- a/tt_metal/hw/firmware/src/tt-1xx/sources.cmake
+++ b/tt_metal/hw/firmware/src/tt-1xx/sources.cmake
@@ -6,6 +6,7 @@ set(FIRMWARE_JIT_API_FILES
     active_erisck.cc
     brisc.cc
     brisck.cc
+    brisc_pch.h
     drisc.cc
     drisck.cc
     erisc.cc
@@ -15,9 +16,11 @@ set(FIRMWARE_JIT_API_FILES
     idle_erisck.cc
     ncrisc.cc
     ncrisck.cc
+    ncrisc_pch.h
     subordinate_erisc.cc
     tdma_xmov.c
     trisc.cc
     trisck.cc
+    trisc_pch.h
     tt_eth_api.cpp
 )

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h
@@ -13,6 +13,13 @@
 //    CTSTR(FULL_KERNEL_NAME). Baking that in would either tie the PCH to a
 //    single kernel or silently freeze the "<unknown>" fallback into it.
 //
+// Ordering caveat: in trisck.cc, kernel_profiler.hpp and stack_usage.h parse
+// after chlkc_list.h, whose defines_generated.h carries the kernel's defines --
+// a kernel's FORCE_WATCHER_OFF is visible to them there, but not here. All of
+// its consumers are inert unless WATCHER_ENABLED is set, so compile_one skips
+// the PCH for TRISC targets whenever the watcher is on rather than precompile
+// the wrong state.
+//
 // Keep this in sync with the prelude in trisck.cc.
 
 #pragma once

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Umbrella header for the optional TRISC precompiled header (TT_METAL_JIT_PCH=1).
+// These are the includes trisck.cc parses identically for every TRISC target;
+// precompiling them removes roughly half of each target's compile time.
+//
+// Two headers trisck.cc includes are deliberately left out:
+//  - chlkc_list.h pulls in the per-kernel generated kernel body, which is the
+//    part that legitimately differs between targets.
+//  - sanitizer/api.h reaches tt-llk's sanitizer/output.h, which expands
+//    CTSTR(FULL_KERNEL_NAME). Baking that in would either tie the PCH to a
+//    single kernel or silently freeze the "<unknown>" fallback into it.
+//
+// Keep this in sync with the prelude in trisck.cc.
+
+#pragma once
+
+#include "internal/firmware_common.h"
+#include "tools/profiler/kernel_profiler.hpp"
+#include "internal/debug/stack_usage.h"

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -58,8 +58,9 @@ constexpr uint32_t get_ct_arg() {
 
 #endif  // TT_METAL_COMPILE_TIME_ARGS_H
 
-// Outside the guard on purpose: the named-argument API has to stay re-includable,
-// so that a translation unit which includes this header before
-// KERNEL_COMPILE_TIME_ARG_MAP is defined still picks the API up afterwards. See
-// named_compile_time_args.h.
-#include "api/named_compile_time_args.h"
+// The named-argument API lives in api/named_compile_time_args.h, which every
+// definer of KERNEL_COMPILE_TIME_ARG_MAP includes itself, directly after the
+// #define -- the generated map header and the emulator wrapper both do. This
+// header deliberately does not tail-include it: under TT_METAL_JIT_PCH this
+// header sits inside the precompiled prelude, where the macro does not exist
+// yet, so an include from here could only ever bake in the disabled state.

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -7,9 +7,6 @@
 
 #include <array>
 #include <cstdint>
-#ifdef KERNEL_COMPILE_TIME_ARG_MAP
-#include <string_view>
-#endif
 
 template <class T, class... Ts>
 FORCE_INLINE constexpr std::array<T, sizeof...(Ts)> make_array(Ts... values) {
@@ -27,27 +24,6 @@ constexpr uint32_t get_ct_arg() {
     static_assert(Idx < kernel_compile_time_args.size(), "Index out of range");
     return kernel_compile_time_args[Idx];
 }
-
-#ifdef KERNEL_COMPILE_TIME_ARG_MAP
-namespace {
-constexpr std::pair<std::string_view, uint32_t> named_args_map[] = {KERNEL_COMPILE_TIME_ARG_MAP};
-}
-#endif
-
-// TODO #28026: Migrate to C++20 standards when available, see related issue for more details.
-#ifdef KERNEL_COMPILE_TIME_ARG_MAP
-constexpr uint32_t get_named_ct_arg(std::string_view name) {
-    for (const auto& [arg_name, arg_value] : named_args_map) {
-        if (name == arg_name) {
-            return arg_value;
-        }
-    }
-    // This should never be reached if the named argument is defined in KERNEL_COMPILE_TIME_ARG_MAP.
-    // Upon reaching this point, compilation should fail.
-    // Note: Compilation currently fails with a segfault.
-    __builtin_unreachable();  // Invalid named compile time argument
-}
-#endif
 
 // clang-format off
 /**
@@ -79,8 +55,11 @@ constexpr uint32_t get_named_ct_arg(std::string_view name) {
  * | arg_name              | The name of the argument           | string literal        | defined names | True   |
  */
 // clang-format on
-#ifdef KERNEL_COMPILE_TIME_ARG_MAP
-constexpr uint32_t get_named_compile_time_arg_val(std::string_view name) { return get_named_ct_arg(name); }
-#endif
 
 #endif  // TT_METAL_COMPILE_TIME_ARGS_H
+
+// Outside the guard on purpose: the named-argument API has to stay re-includable,
+// so that a translation unit which includes this header before
+// KERNEL_COMPILE_TIME_ARG_MAP is defined still picks the API up afterwards. See
+// named_compile_time_args.h.
+#include "api/named_compile_time_args.h"

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -39,28 +39,9 @@ constexpr uint32_t get_ct_arg() {
 // clang-format on
 #define get_compile_time_arg_val(arg_idx) get_ct_arg<arg_idx>()
 
-// clang-format off
-/**
- * Returns the value of a named constexpr argument from kernel_compile_time_args array provided during kernel creation using
- * CreateKernel calls. The name-to-index mapping is defined via KERNEL_COMPILE_TIME_ARG_MAP. Migrating all existing kernels to
- * use named compile time arguments is not a trivial task, so backward-compatibility is maintained by allowing the use of the
- * get_compile_time_arg_val function with an index. get_compile_time_arg_val can be deprecated in the future upon completion
- * of the migration and by request. See vecadd_multi_core.cpp for an example of how to use named compile time arguments.
- * Note: Return value must be stored in a constexpr variable to guarantee compile time evaluation.
- *
- * Return value: constexpr uint32_t
- *
- * | Argument              | Description                        | Type                  | Valid Range | Required |
- * |-----------------------|------------------------------------|-----------------------|-------------|----------|
- * | arg_name              | The name of the argument           | string literal        | defined names | True   |
- */
-// clang-format on
-
 #endif  // TT_METAL_COMPILE_TIME_ARGS_H
 
-// The named-argument API lives in api/named_compile_time_args.h, which every
-// definer of KERNEL_COMPILE_TIME_ARG_MAP includes itself, directly after the
-// #define -- the generated map header and the emulator wrapper both do. This
-// header deliberately does not tail-include it: under TT_METAL_JIT_PCH this
-// header sits inside the precompiled prelude, where the macro does not exist
-// yet, so an include from here could only ever bake in the disabled state.
+// Preserve the named API for callers that define the map and include this header
+// directly. Keep this outside the positional API's guard so a map defined after
+// PCH consumption can still declare the named API on a later include.
+#include "api/named_compile_time_args.h"

--- a/tt_metal/hw/inc/api/compile_time_args.h
+++ b/tt_metal/hw/inc/api/compile_time_args.h
@@ -13,17 +13,10 @@ FORCE_INLINE constexpr std::array<T, sizeof...(Ts)> make_array(Ts... values) {
     return {T(values)...};
 }
 
-#ifndef KERNEL_COMPILE_TIME_ARGS
-#define KERNEL_COMPILE_TIME_ARGS
-#endif
-
-constexpr auto kernel_compile_time_args = make_array<std::uint32_t>(KERNEL_COMPILE_TIME_ARGS);
-
+// Tensor-accessor templates in the shared prelude call this with dependent
+// indices. Its definition and argument array arrive before instantiation.
 template <uint32_t Idx>
-constexpr uint32_t get_ct_arg() {
-    static_assert(Idx < kernel_compile_time_args.size(), "Index out of range");
-    return kernel_compile_time_args[Idx];
-}
+constexpr uint32_t get_ct_arg();
 
 // clang-format off
 /**
@@ -40,6 +33,26 @@ constexpr uint32_t get_ct_arg() {
 #define get_compile_time_arg_val(arg_idx) get_ct_arg<arg_idx>()
 
 #endif  // TT_METAL_COMPILE_TIME_ARGS_H
+
+// Precompile the library headers and helper, then materialize the kernel's
+// positional arguments after loading the PCH. Do not inspect the argument macro
+// while building the PCH: even an #ifndef would constrain GCC's macro validation.
+#if !defined(TT_METAL_PCH_BUILD) && !defined(TT_METAL_POSITIONAL_CT_ARGS_DEFINED)
+#define TT_METAL_POSITIONAL_CT_ARGS_DEFINED
+
+#ifndef KERNEL_COMPILE_TIME_ARGS
+#define KERNEL_COMPILE_TIME_ARGS
+#endif
+
+constexpr auto kernel_compile_time_args = make_array<std::uint32_t>(KERNEL_COMPILE_TIME_ARGS);
+
+template <uint32_t Idx>
+constexpr uint32_t get_ct_arg() {
+    static_assert(Idx < kernel_compile_time_args.size(), "Index out of range");
+    return kernel_compile_time_args[Idx];
+}
+
+#endif  // positional arguments available
 
 // Preserve the named API for callers that define the map and include this header
 // directly. Keep this outside the positional API's guard so a map defined after

--- a/tt_metal/hw/inc/api/named_compile_time_args.h
+++ b/tt_metal/hw/inc/api/named_compile_time_args.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// The named compile-time argument API, split out of api/compile_time_args.h.
+//
+// Deliberately has no #pragma once and no include guard of its own. It must stay
+// re-includable because it depends on KERNEL_COMPILE_TIME_ARG_MAP, which
+// named_ct_arg_map_generated.h defines per kernel. Under TT_METAL_JIT_PCH the
+// precompiled prelude already contains compile_time_args.h, parsed before that
+// macro existed, so a once-only header would have its declarations suppressed for
+// good. Instead the body below is gated on the macro and made idempotent by
+// TT_METAL_NAMED_CT_ARGS_DEFINED, which is only set once the macro is present.
+// That lets the generated map header include this file straight after defining
+// the macro, whether or not a PCH is in play.
+//
+// Kept separate from compile_time_args.h so the generated header can pull in just
+// this part: compile_time_args.h needs FORCE_INLINE, which is not yet defined at
+// the point a force-included header is processed.
+
+#if defined(KERNEL_COMPILE_TIME_ARG_MAP) && !defined(TT_METAL_NAMED_CT_ARGS_DEFINED)
+#define TT_METAL_NAMED_CT_ARGS_DEFINED
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+namespace {
+constexpr std::pair<std::string_view, uint32_t> named_args_map[] = {KERNEL_COMPILE_TIME_ARG_MAP};
+}
+
+// TODO #28026: Migrate to C++20 standards when available, see related issue for more details.
+constexpr uint32_t get_named_ct_arg(std::string_view name) {
+    for (const auto& [arg_name, arg_value] : named_args_map) {
+        if (name == arg_name) {
+            return arg_value;
+        }
+    }
+    // This should never be reached if the named argument is defined in KERNEL_COMPILE_TIME_ARG_MAP.
+    // Upon reaching this point, compilation should fail.
+    // Note: Compilation currently fails with a segfault.
+    __builtin_unreachable();  // Invalid named compile time argument
+}
+
+// clang-format off
+/**
+ * Returns the value of a named constexpr argument from kernel_compile_time_args array provided during kernel creation using
+ * CreateKernel calls. The name-to-index mapping is defined via KERNEL_COMPILE_TIME_ARG_MAP. Migrating all existing kernels to
+ * use named compile time arguments is not a trivial task, so backward-compatibility is maintained by allowing the use of the
+ * get_compile_time_arg_val function with an index. get_compile_time_arg_val can be deprecated in the future upon completion
+ * of the migration and by request. See vecadd_multi_core.cpp for an example of how to use named compile time arguments.
+ * Note: Return value must be stored in a constexpr variable to guarantee compile time evaluation.
+ *
+ * Return value: constexpr uint32_t
+ *
+ * | Argument              | Description                        | Type                  | Valid Range | Required |
+ * |-----------------------|------------------------------------|-----------------------|-------------|----------|
+ * | arg_name              | The name of the argument           | string literal        | defined names | True   |
+ */
+// clang-format on
+constexpr uint32_t get_named_compile_time_arg_val(std::string_view name) { return get_named_ct_arg(name); }
+
+#endif  // KERNEL_COMPILE_TIME_ARG_MAP && !TT_METAL_NAMED_CT_ARGS_DEFINED

--- a/tt_metal/hw/inc/api/named_compile_time_args.h
+++ b/tt_metal/hw/inc/api/named_compile_time_args.h
@@ -44,8 +44,8 @@ constexpr uint32_t get_named_ct_arg(std::string_view name) {
 
 // clang-format off
 /**
- * Returns the value of a named constexpr argument from kernel_compile_time_args array provided during kernel creation using
- * CreateKernel calls. The name-to-index mapping is defined via KERNEL_COMPILE_TIME_ARG_MAP. Migrating all existing kernels to
+ * Returns the value of a named constexpr argument provided during kernel creation using CreateKernel calls.
+ * The name-to-value mapping is defined via KERNEL_COMPILE_TIME_ARG_MAP. Migrating all existing kernels to
  * use named compile time arguments is not a trivial task, so backward-compatibility is maintained by allowing the use of the
  * get_compile_time_arg_val function with an index. get_compile_time_arg_val can be deprecated in the future upon completion
  * of the migration and by request. See vecadd_multi_core.cpp for an example of how to use named compile time arguments.

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -2,6 +2,7 @@ set(HW_JIT_API_HEADERS
     inc/experimental/blaze_rt_arg.h
     inc/api/alignment.h
     inc/api/compile_time_args.h
+    inc/api/named_compile_time_args.h
     inc/api/remote_circular_buffer.h
     inc/api/socket_api.h
     inc/api/dataflow/dataflow_api.h

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1046,11 +1046,8 @@ static std::function<void()> jit_compile_kernel(
         if (!named_compile_args.empty()) {
             f << "#define KERNEL_COMPILE_TIME_ARG_MAP "
               << tt::jit_build::utils::format_named_ct_arg_map(named_compile_args) << "\n";
-            // Turns the macro into the get_named_compile_time_arg_val API. Included
-            // here, like the generated map header on the device path does, because
-            // compile_time_args.h no longer tail-includes it; see that header.
-            f << "#include \"api/named_compile_time_args.h\"\n";
         }
+        // The emulator's jit_kernel_stubs.hpp supplies its own named-argument API.
         f << "#include \"jit_kernel_stubs.hpp\"\n";
         // Metal-2.0 `namespace args` (base).
         emit_metal2_namespaces(f, bindings, named_compile_args);

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1046,6 +1046,10 @@ static std::function<void()> jit_compile_kernel(
         if (!named_compile_args.empty()) {
             f << "#define KERNEL_COMPILE_TIME_ARG_MAP "
               << tt::jit_build::utils::format_named_ct_arg_map(named_compile_args) << "\n";
+            // Turns the macro into the get_named_compile_time_arg_val API. Included
+            // here, like the generated map header on the device path does, because
+            // compile_time_args.h no longer tail-includes it; see that header.
+            f << "#include \"api/named_compile_time_args.h\"\n";
         }
         f << "#include \"jit_kernel_stubs.hpp\"\n";
         // Metal-2.0 `namespace args` (base).

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1047,7 +1047,6 @@ static std::function<void()> jit_compile_kernel(
             f << "#define KERNEL_COMPILE_TIME_ARG_MAP "
               << tt::jit_build::utils::format_named_ct_arg_map(named_compile_args) << "\n";
         }
-        // The emulator's jit_kernel_stubs.hpp supplies its own named-argument API.
         f << "#include \"jit_kernel_stubs.hpp\"\n";
         // Metal-2.0 `namespace args` (base).
         emit_metal2_namespaces(f, bindings, named_compile_args);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -117,6 +117,10 @@ std::string_view pch_umbrella_for(std::string_view kernel_src) {
     if (kernel_src == "ncrisck.cc") {
         return "tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h";
     }
+    // active_erisck.cc deliberately has no entry. A PCH is buildable for it, but it
+    // measured as nothing (48 of 4133 targets), and the umbrella would have to omit
+    // noc_nonblocking_api.h as well: once the dataflow headers are gone it becomes the
+    // first to reach risc_common.h, which uses MY_NOC_ENCODING before it is defined.
     return {};
 }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -135,6 +135,84 @@ std::string_view pch_umbrella_for(std::string_view kernel_src_path) {
     return {};
 }
 
+// One entry per staged header path, held by shared_ptr so a build already in flight
+// keeps its entry alive across a pch_cache_clear().
+struct PchEntry {
+    std::mutex mutex;
+    bool ok = false;
+    bool failed = false;
+};
+
+std::mutex pch_map_mutex;
+std::unordered_map<std::string, std::shared_ptr<PchEntry>> pch_entries;
+
+// Keyed by the staged header path rather than by the recipe key alone: that path also
+// embeds out_root, so two build environments pointing at different cache roots get
+// separate entries instead of the first one reporting success for a .gch the second
+// never built.
+std::shared_ptr<PchEntry> pch_entry_for(const std::string& header) {
+    std::lock_guard lock(pch_map_mutex);
+    std::shared_ptr<PchEntry>& entry = pch_entries[header];
+    if (!entry) {
+        entry = std::make_shared<PchEntry>();
+    }
+    return entry;
+}
+
+// ClearKernelCache() also clears the file-hash cache, which is what makes a mid-run
+// header edit visible to need_compile(); an entry that survived it would keep handing
+// out a .gch built from the pre-edit contents.
+void pch_cache_clear() {
+    std::lock_guard lock(pch_map_mutex);
+    pch_entries.clear();
+}
+
+// Publishes the dependency-hash sidecar that later calls in this process use to decide
+// whether a built .gch still matches its closure. Every rule in the .d is flattened
+// under one label because the target GCC records there follows the output name it was
+// given, which is a per-process temp path.
+bool write_pch_dephash(
+    const std::string& dep_path, const std::string& dir, const std::string& gch, const std::string& hash_path) {
+    jit_build::ParsedDependencies parsed;
+    {
+        std::ifstream dep_file(dep_path);
+        if (!dep_file.is_open()) {
+            return false;
+        }
+        parsed = jit_build::parse_dependency_file(dep_file);
+    }
+    if (parsed.empty()) {
+        return false;
+    }
+    jit_build::ParsedDependencies flattened;
+    std::vector<std::string>& deps = flattened[gch];
+    for (const auto& [target, dep_list] : parsed) {
+        deps.insert(deps.end(), dep_list.begin(), dep_list.end());
+    }
+
+    const std::string tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(hash_path);
+    {
+        std::ofstream hash_file(tmp);
+        if (!hash_file.is_open()) {
+            return false;
+        }
+        jit_build::write_dependency_hashes(flattened, dir, gch, hash_file);
+        hash_file.close();
+        if (hash_file.fail()) {
+            std::error_code ec;
+            fs::remove(tmp, ec);
+            return false;
+        }
+    }
+    std::error_code ec;
+    fs::rename(tmp, hash_path, ec);
+    if (ec) {
+        fs::remove(tmp, ec);
+        return false;
+    }
+    return true;
+}
+
 // Returns the header path to force-include for this compile recipe, building the
 // PCH on first use. Returns empty if a PCH is unavailable, in which case the
 // caller simply compiles without one.
@@ -187,32 +265,38 @@ std::string ensure_pch(
     const fs::path dir = fs::path(out_root) / "pch" / target_name / fmt::format("{:016x}", key);
     const fs::path header = dir / umbrella.filename();
     const std::string gch = header.string() + ".gch";
+    const std::string dep = header.string() + ".d";
+    const std::string dephash = gch + ".dephash";
 
-    // Each key is built once per process. The map lock is held only for the entry
-    // lookup; the build runs under the entry's own once_flag, so distinct keys build
-    // in parallel and compiles whose key is already built never wait. A fresh process
-    // deliberately rebuilds rather than trusting a .gch found on disk: the key does
-    // not cover header contents, so an existing file could predate a source edit.
-    // Every shared-path write goes through a unique temp file and an atomic rename --
-    // concurrent processes rebuilding the same key never expose a partial file, and a
-    // compile holding the old .gch open keeps reading it after the rename.
-    struct Entry {
-        std::once_flag once;
-        bool ok = false;
-    };
-    std::shared_ptr<Entry> entry;
-    {
-        static std::mutex map_mutex;
-        static std::unordered_map<uint64_t, std::shared_ptr<Entry>> entries;
-        std::lock_guard lock(map_mutex);
-        auto [it, inserted] = entries.try_emplace(key);
-        if (inserted) {
-            it->second = std::make_shared<Entry>();
-        }
-        entry = it->second;
+    // The map lock is held only for the entry lookup; the build runs under the entry's
+    // own mutex, so distinct keys build in parallel and compiles whose key is already
+    // built and still valid never wait. A fresh process rebuilds rather than trusting a
+    // .gch found on disk: the key does not cover header contents, so an existing file
+    // could predate a source edit. Every shared-path write goes through a unique temp
+    // file and an atomic rename -- concurrent processes rebuilding the same key never
+    // expose a partial file, and a compile holding the old .gch open keeps reading it
+    // after the rename.
+    const std::shared_ptr<PchEntry> entry = pch_entry_for(header.string());
+    std::lock_guard entry_lock(entry->mutex);
+
+    // A failed build is not retried: giving up on the PCH for the rest of the process
+    // costs one wasted build, retrying per compile would cost thousands.
+    if (entry->failed) {
+        return {};
     }
 
-    std::call_once(entry->once, [&] {
+    // A successful build is not trusted for the rest of the process either. The key
+    // covers flags and defines but not header contents, and ClearKernelCache() drops
+    // the file-hash cache that makes a mid-run header edit visible to need_compile().
+    // An entry that outlived such an edit would keep force-including a .gch holding
+    // the pre-edit contents while every consumer wrote a dephash sidecar computed from
+    // the current ones -- marking objects compiled against stale headers as up to date
+    // on disk, for this run and every later one.
+    if (entry->ok && jit_build::dependencies_up_to_date_file(dephash)) {
+        return header.string();
+    }
+
+    const bool built = [&] {
         std::error_code ec;
         fs::create_directories(dir, ec);
         const std::string header_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(header);
@@ -226,10 +310,9 @@ std::string ensure_pch(
                 "PCH: could not stage {}: {}; compiling without it",
                 header.string(),
                 ec.message());
-            return;
+            return false;
         }
 
-        const std::string dep = header.string() + ".d";
         const std::string gch_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(gch);
         const std::string dep_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(dep);
 
@@ -254,6 +337,21 @@ std::string ensure_pch(
         const std::string log = gch_tmp + ".log";
         bool ok = tt::jit_build::utils::exec_command(args, dir.string(), log);
         if (ok) {
+            // -MMD lists the staged copy the compiler was handed, never the umbrella in
+            // the source tree it was copied from. That path is recorded explicitly so it
+            // reaches every consumer's dephash through merge_pch_deps_into_kernel_d.
+            // need_compile() runs before this function, so without it an edited umbrella
+            // leaves every object built against the old one reported as up to date, and
+            // the staged copy is never refreshed.
+            std::ofstream dep_out(dep_tmp, std::ios::app);
+            dep_out << gch << ": " << (fs::path(root) / umbrella).string() << '\n';
+            dep_out.flush();
+            ok = dep_out.good();
+            if (!ok) {
+                log_warning(tt::LogBuildKernels, "PCH: could not record {} in {}", umbrella_rel, dep_tmp);
+            }
+        }
+        if (ok) {
             fs::rename(dep_tmp, dep, ec);
             if (!ec) {
                 fs::rename(gch_tmp, gch, ec);
@@ -262,6 +360,10 @@ std::string ensure_pch(
                 log_warning(tt::LogBuildKernels, "PCH: could not publish {}: {}", gch, ec.message());
                 ok = false;
             }
+        }
+        if (ok && !write_pch_dephash(dep, dir.string(), gch, dephash)) {
+            log_warning(tt::LogBuildKernels, "PCH: could not record the closure of {} in {}", gch, dephash);
+            ok = false;
         }
         if (ok) {
             fs::remove(log, ec);
@@ -272,9 +374,11 @@ std::string ensure_pch(
             log_warning(
                 tt::LogBuildKernels, "PCH: build failed for {} (log: {}); compiling without it", target_name, log);
         }
-        entry->ok = ok;
-    });
-    return entry->ok ? header.string() : std::string{};
+        return ok;
+    }();
+    entry->ok = built;
+    entry->failed = !built;
+    return built ? header.string() : std::string{};
 }
 
 // A compile that consumed a PCH emits a truncated .d: -MMD lists only what was parsed
@@ -1395,6 +1499,7 @@ void jit_build_once(size_t hash, const std::function<void()>& build_fn) {
 void jit_build_cache_clear() {
     JitBuildCache::inst().clear();
     jit_build::clear_file_hash_cache();
+    pch_cache_clear();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -25,7 +25,6 @@
 #include <mutex>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 #include <enchantum/enchantum.hpp>
@@ -82,38 +81,7 @@ void report_result(const string& target_name, string_view op, const string& cmd,
     }
 }
 
-// Opt-in precompiled headers for kernel targets (TT_METAL_JIT_PCH=1).
-//
-// Each kernel source re-parses a fixed prelude -- the includes ahead of the
-// generated per-kernel body -- in every target built from it. Those preludes are
-// identical across kernels and account for roughly half of a target's compile
-// time, so precompiling them about halves the compile step.
-//
-// Two GCC constraints shape the implementation:
-//  - A PCH is silently ignored once the first token has been seen, so it must be
-//    force-included ahead of the per-kernel named-ct-arg header.
-//  - GCC validates command-line macros against the state recorded in the PCH:
-//    any macro the precompiled prelude tests or expands (even just via #ifdef,
-//    which the prelude does for KERNEL_COMPILE_TIME_ARGS and FULL_KERNEL_NAME)
-//    must match exactly. One PCH is therefore needed per distinct define set,
-//    and any define whose value is unique per kernel must be kept off the
-//    command line entirely (see FULL_KERNEL_NAME in export_target_recipe).
-bool jit_pch_enabled() {
-    static const bool enabled = [] {
-        // Same convention as RunTimeOptions' is_env_enabled: only a leading '1' turns a
-        // TT_METAL_* boolean on, so "0", "false" and "" all leave it off.
-        const char* v = std::getenv("TT_METAL_JIT_PCH");
-        return v != nullptr && v[0] == '1';
-    }();
-    return enabled;
-}
-
-// Umbrella header for a kernel source's shareable prelude, relative to the tt-metal
-// root. Each one mirrors the includes its source parses before reaching the generated
-// per-kernel body. Matched on the architecture-qualified path suffix rather than the
-// bare filename, so another generation's source of the same name (tt-2xx has its own
-// trisck.cc) never picks up a tt-1xx umbrella; a source with no entry here simply
-// compiles without a PCH.
+// Match architecture-qualified sources; other targets compile without a PCH.
 std::string_view pch_umbrella_for(std::string_view kernel_src_path) {
     auto matches = [&](std::string_view suffix) {
         return kernel_src_path.size() >= suffix.size() &&
@@ -128,10 +96,6 @@ std::string_view pch_umbrella_for(std::string_view kernel_src_path) {
     if (matches("/tt-1xx/ncrisck.cc")) {
         return "tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h";
     }
-    // active_erisck.cc deliberately has no entry. A PCH is buildable for it, but it
-    // measured as nothing (48 of 4133 targets), and the umbrella would have to omit
-    // noc_nonblocking_api.h as well: once the dataflow headers are gone it becomes the
-    // first to reach risc_common.h, which uses MY_NOC_ENCODING before it is defined.
     return {};
 }
 
@@ -724,23 +688,19 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     const std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
 
     std::vector<std::string> defines = recipe.defines;
-    // A PCH parses ahead of the whole translation unit, so every macro that can change
-    // how an umbrella header parses must reach the PCH build. DM targets pass kernel
-    // defines on the command line (process_defines_at_compile_), which lands them in
-    // the PCH key; TRISC routes them through a generated header (chlkc_list.h ->
-    // defines_generated.h) that the umbrella must exclude, so a kernel define like
-    // FORCE_WATCHER_OFF would go unseen by umbrella headers that the source parses
-    // after chlkc_list.h (stack_usage.h, kernel_profiler.hpp's debug subtree). Every
-    // consumer of that define is inert unless WATCHER_ENABLED is set, so the PCH stays
-    // on for the common case and those targets skip it while the watcher is on.
-    const bool pch_defines_visible =
-        this->process_defines_at_compile_ || !env_.get_rtoptions().get_watcher_enabled();
-    // pch_umbrella_for returns a view of a string literal, so this outlives the call.
-    const std::string_view pch_umbrella = (jit_pch_enabled() && pch_defines_visible)
-                                              ? pch_umbrella_for(this->srcs_[src_index])
-                                              : std::string_view{};
+    // TRISC generated defines arrive too late for Watcher's FORCE_WATCHER_OFF handling.
+    const auto& rtoptions = env_.get_rtoptions();
+    const bool pch_defines_visible = this->process_defines_at_compile_ || !rtoptions.get_watcher_enabled();
+    const bool pch_strict = rtoptions.get_jit_pch_strict();
+    const auto pch_umbrella = pch_umbrella_for(this->srcs_[src_index]);
+    const bool use_pch = rtoptions.get_jit_pch_enabled() && pch_defines_visible && !pch_umbrella.empty();
+    TT_FATAL(
+        !pch_strict || pch_umbrella.empty() || use_pch,
+        "Strict PCH mode requires PCH enabled and compatible Watcher settings for {}",
+        target_name_);
+    std::string pch_header;
     std::string pch_dep_path;
-    if (!pch_umbrella.empty()) {
+    if (use_pch) {
         // The PCH is built from the same recipe minus any force-included headers:
         // those are per-kernel, and a PCH that consumed them could not be shared.
         std::vector<std::string> pch_defines;
@@ -752,7 +712,7 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
             }
             pch_defines.push_back(defines[i]);
         }
-        const std::string pch_header = jit_build::ensure_pch(
+        pch_header = jit_build::ensure_pch(
             env_.gpp_,
             env_.get_root_path(),
             env_.get_out_root_path(),
@@ -762,15 +722,13 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
             cflags,
             recipe.includes,
             pch_defines);
+        TT_FATAL(!pch_strict || !pch_header.empty(), "Strict PCH mode: creation failed for {}", target_name_);
         if (!pch_header.empty()) {
             // Must precede every other -include so no token is seen first.
             defines.insert(defines.begin(), pch_header);
             defines.insert(defines.begin(), "-include");
-            // GCC falls back to plain textual inclusion, silently, whenever it rejects
-            // a PCH (flag or macro-state mismatch). Surface that in the compile log.
-            // A warning rather than an error -- the base cflags carry -Werror -- since
-            // a rejected PCH costs speed, not correctness.
-            cflags += " -Winvalid-pch -Wno-error=invalid-pch";
+            // Normal builds warn and fall back; strict validation requires actual consumption.
+            cflags += pch_strict ? " -H -Werror=invalid-pch" : " -Winvalid-pch -Wno-error=invalid-pch";
             pch_dep_path = pch_header + ".d";
         }
     }
@@ -801,6 +759,9 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     fs::remove(log_file.path());
     bool result = tt::jit_build::utils::exec_command(args, out_dir, log_file.path());
     report_result(this->target_name_, "compile", fmt::format("{}", fmt::join(args, " ")), log_file.path(), result);
+    if (pch_strict && !pch_umbrella.empty()) {
+        jit_build::require_pch_consumed(log_file.path(), pch_header);
+    }
     if (result && !pch_dep_path.empty()) {
         jit_build::merge_pch_deps_into_kernel_d(temp_d_path, obj_temp_path, pch_dep_path);
     }
@@ -1108,16 +1069,8 @@ tt::jit_build::TargetRecipe JitBuildState::export_target_recipe(const JitBuildSe
         });
     }
     if (settings) {
-        // FULL_KERNEL_NAME: consumed only by the LLK sanitizer (CTSTR(FULL_KERNEL_NAME)). Emitted
-        // shell-free as one verbatim argv element with literal quotes (the unified/remote-JIT
-        // path does no shell expansion).
-        //
-        // With the sanitizer off the macro is dead -- sanitizer/output.h substitutes "<unknown>" --
-        // so it is omitted entirely rather than gated on TT_METAL_JIT_PCH. That keeps the exported
-        // recipe deterministic (the remote compile server sees the same recipe whichever way the
-        // client sets that variable), and keeps this per-kernel-unique value off the command line,
-        // where GCC would validate it against a shared PCH and reduce the PCH to one per kernel.
-        // With the sanitizer on, correctness wins and the define stays, costing PCH reuse.
+        // Only the sanitizer needs this unique name. Omitting it otherwise permits PCH sharing
+        // and keeps exported recipes independent of the client's PCH setting.
         if (env_.get_rtoptions().get_sanitizer_settings().enabled) {
             defines.push_back(fmt::format(R"(-DFULL_KERNEL_NAME="{}")", settings->get_full_kernel_name()));
         }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -233,24 +233,21 @@ std::string ensure_pch(
         const std::string gch_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(gch);
         const std::string dep_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(dep);
 
-        std::vector<std::string> args = tt::jit_build::utils::tokenize_flags(gpp);
-        args.push_back("-" + opt_level);
-        for (auto& tok : tt::jit_build::utils::tokenize_flags(cflags)) {
-            args.push_back(std::move(tok));
-        }
-        args.insert(args.end(), include_args.begin(), include_args.end());
-        args.insert(args.end(), defines.begin(), defines.end());
-        // Record the PCH's own dependency closure. A kernel compile that consumes the
-        // PCH emits a truncated .d (-MMD stops at the PCH boundary), so compile_one
-        // merges this file back in to keep the dephash cache honest.
-        args.push_back("-MMD");
-        args.push_back("-MF");
-        args.push_back(dep_tmp);
-        args.push_back("-x");
-        args.push_back("c++-header");
-        args.push_back(header.string());
-        args.push_back("-o");
-        args.push_back(gch_tmp);
+        // Built through the same argv builder as the kernel compiles: any drift between
+        // the two flag sets makes GCC reject the PCH. The .d (via the -MMD already in
+        // cflags) records the PCH's dependency closure; a kernel compile that consumes
+        // the PCH emits a truncated .d of its own (-MMD stops at the PCH boundary), so
+        // compile_one merges this file back in to keep the dephash cache honest.
+        const std::vector<std::string> args = tt::jit_build::utils::build_gpp_argv(
+            gpp,
+            opt_level,
+            cflags,
+            fmt::format("{}", fmt::join(include_args, " ")),
+            defines,
+            header.string(),
+            tt::jit_build::utils::GppAction::PrecompileHeader,
+            gch_tmp,
+            dep_tmp);
 
         // The log is per-temp (and so per-process): concurrent rebuilds of one key must
         // not interleave writes. Removed on success, kept for the warning on failure.
@@ -903,9 +900,21 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     const std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
 
     std::vector<std::string> defines = recipe.defines;
+    // A PCH parses ahead of the whole translation unit, so every macro that can change
+    // how an umbrella header parses must reach the PCH build. DM targets pass kernel
+    // defines on the command line (process_defines_at_compile_), which lands them in
+    // the PCH key; TRISC routes them through a generated header (chlkc_list.h ->
+    // defines_generated.h) that the umbrella must exclude, so a kernel define like
+    // FORCE_WATCHER_OFF would go unseen by umbrella headers that the source parses
+    // after chlkc_list.h (stack_usage.h, kernel_profiler.hpp's debug subtree). Every
+    // consumer of that define is inert unless WATCHER_ENABLED is set, so the PCH stays
+    // on for the common case and those targets skip it while the watcher is on.
+    const bool pch_defines_visible =
+        this->process_defines_at_compile_ || !env_.get_rtoptions().get_watcher_enabled();
     // pch_umbrella_for returns a view of a string literal, so this outlives the call.
-    const std::string_view pch_umbrella =
-        jit_pch_enabled() ? pch_umbrella_for(this->srcs_[src_index]) : std::string_view{};
+    const std::string_view pch_umbrella = (jit_pch_enabled() && pch_defines_visible)
+                                              ? pch_umbrella_for(this->srcs_[src_index])
+                                              : std::string_view{};
     std::string pch_dep_path;
     if (!pch_umbrella.empty()) {
         // The PCH is built from the same recipe minus any force-included headers:

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -7,6 +7,7 @@
 #include "build_cache_telemetry.hpp"
 #include "jit_build_cache.hpp"
 #include "jit_device_config.hpp"
+#include "pch.hpp"
 
 #include <algorithm>
 #include <array>
@@ -21,7 +22,6 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
-#include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -133,286 +133,6 @@ std::string_view pch_umbrella_for(std::string_view kernel_src_path) {
     // noc_nonblocking_api.h as well: once the dataflow headers are gone it becomes the
     // first to reach risc_common.h, which uses MY_NOC_ENCODING before it is defined.
     return {};
-}
-
-// One entry per staged header path, held by shared_ptr so a build already in flight
-// keeps its entry alive across a pch_cache_clear().
-struct PchEntry {
-    std::mutex mutex;
-    bool ok = false;
-    bool failed = false;
-};
-
-std::mutex pch_map_mutex;
-std::unordered_map<std::string, std::shared_ptr<PchEntry>> pch_entries;
-
-// Keyed by the staged header path rather than by the recipe key alone: that path also
-// embeds out_root, so two build environments pointing at different cache roots get
-// separate entries instead of the first one reporting success for a .gch the second
-// never built.
-std::shared_ptr<PchEntry> pch_entry_for(const std::string& header) {
-    std::lock_guard lock(pch_map_mutex);
-    std::shared_ptr<PchEntry>& entry = pch_entries[header];
-    if (!entry) {
-        entry = std::make_shared<PchEntry>();
-    }
-    return entry;
-}
-
-// ClearKernelCache() also clears the file-hash cache, which is what makes a mid-run
-// header edit visible to need_compile(); an entry that survived it would keep handing
-// out a .gch built from the pre-edit contents.
-void pch_cache_clear() {
-    std::lock_guard lock(pch_map_mutex);
-    pch_entries.clear();
-}
-
-// Publishes the dependency-hash sidecar that later calls in this process use to decide
-// whether a built .gch still matches its closure. Every rule in the .d is flattened
-// under one label because the target GCC records there follows the output name it was
-// given, which is a per-process temp path.
-bool write_pch_dephash(
-    const std::string& dep_path, const std::string& dir, const std::string& gch, const std::string& hash_path) {
-    jit_build::ParsedDependencies parsed;
-    {
-        std::ifstream dep_file(dep_path);
-        if (!dep_file.is_open()) {
-            return false;
-        }
-        parsed = jit_build::parse_dependency_file(dep_file);
-    }
-    if (parsed.empty()) {
-        return false;
-    }
-    jit_build::ParsedDependencies flattened;
-    std::vector<std::string>& deps = flattened[gch];
-    for (const auto& [target, dep_list] : parsed) {
-        deps.insert(deps.end(), dep_list.begin(), dep_list.end());
-    }
-
-    const std::string tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(hash_path);
-    {
-        std::ofstream hash_file(tmp);
-        if (!hash_file.is_open()) {
-            return false;
-        }
-        jit_build::write_dependency_hashes(flattened, dir, gch, hash_file);
-        hash_file.close();
-        if (hash_file.fail()) {
-            std::error_code ec;
-            fs::remove(tmp, ec);
-            return false;
-        }
-    }
-    std::error_code ec;
-    fs::rename(tmp, hash_path, ec);
-    if (ec) {
-        fs::remove(tmp, ec);
-        return false;
-    }
-    return true;
-}
-
-// Returns the header path to force-include for this compile recipe, building the
-// PCH on first use. Returns empty if a PCH is unavailable, in which case the
-// caller simply compiles without one.
-//
-// `defines` must already have any -include pairs stripped, and must otherwise
-// match the compile exactly, or GCC will reject the result.
-std::string ensure_pch(
-    const std::string& gpp,
-    const std::string& root,
-    const std::string& out_root,
-    const std::string& target_name,
-    std::string_view umbrella_rel,
-    const std::string& opt_level,
-    const std::string& cflags,
-    const std::string& includes,
-    const std::vector<std::string>& defines) {
-    // The relative include roots ("-I.", "-I..") resolve against a kernel's own build
-    // directory and are how a compile reaches per-kernel generated headers. A PCH must
-    // not consume anything per-kernel, so they are dropped from the PCH build: if an
-    // umbrella ever grows a (transitive) dependency on a generated header, its PCH
-    // build fails loudly and every compile falls back to plain parsing, instead of one
-    // kernel's generated state -- or a negative __has_include probe -- being silently
-    // baked into all the other kernels sharing the key.
-    std::vector<std::string> include_args;
-    for (auto& tok : tt::jit_build::utils::tokenize_flags(includes)) {
-        if (tok == "-I." || tok == "-I..") {
-            continue;
-        }
-        include_args.push_back(std::move(tok));
-    }
-
-    // One PCH per distinct recipe. Blaze passes compile-time args through generated
-    // headers, so this stays at one key per target type there; kernels that carry
-    // per-kernel -D defines or include paths (common in ttnn) fan out to one PCH
-    // build per distinct set, which is part of why the feature is opt-in.
-    tt::StableHasher hasher;
-    hasher.update(target_name);
-    hasher.update(std::string(umbrella_rel));
-    hasher.update(opt_level);
-    hasher.update(cflags);
-    for (const auto& inc : include_args) {
-        hasher.update(inc);
-    }
-    for (const auto& define : defines) {
-        hasher.update(define);
-    }
-    const uint64_t key = hasher.digest();
-
-    const fs::path umbrella = fs::path(std::string(umbrella_rel));
-    const fs::path dir = fs::path(out_root) / "pch" / target_name / fmt::format("{:016x}", key);
-    const fs::path header = dir / umbrella.filename();
-    const std::string gch = header.string() + ".gch";
-    const std::string dep = header.string() + ".d";
-    const std::string dephash = gch + ".dephash";
-
-    // The map lock is held only for the entry lookup; the build runs under the entry's
-    // own mutex, so distinct keys build in parallel and compiles whose key is already
-    // built and still valid never wait. A fresh process rebuilds rather than trusting a
-    // .gch found on disk: the key does not cover header contents, so an existing file
-    // could predate a source edit. Every shared-path write goes through a unique temp
-    // file and an atomic rename -- concurrent processes rebuilding the same key never
-    // expose a partial file, and a compile holding the old .gch open keeps reading it
-    // after the rename.
-    const std::shared_ptr<PchEntry> entry = pch_entry_for(header.string());
-    std::lock_guard entry_lock(entry->mutex);
-
-    // A failed build is not retried: giving up on the PCH for the rest of the process
-    // costs one wasted build, retrying per compile would cost thousands.
-    if (entry->failed) {
-        return {};
-    }
-
-    // A successful build is not trusted for the rest of the process either. The key
-    // covers flags and defines but not header contents, and ClearKernelCache() drops
-    // the file-hash cache that makes a mid-run header edit visible to need_compile().
-    // An entry that outlived such an edit would keep force-including a .gch holding
-    // the pre-edit contents while every consumer wrote a dephash sidecar computed from
-    // the current ones -- marking objects compiled against stale headers as up to date
-    // on disk, for this run and every later one.
-    if (entry->ok && jit_build::dependencies_up_to_date_file(dephash)) {
-        return header.string();
-    }
-
-    const bool built = [&] {
-        std::error_code ec;
-        fs::create_directories(dir, ec);
-        const std::string header_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(header);
-        fs::copy_file(fs::path(root) / umbrella, header_tmp, fs::copy_options::overwrite_existing, ec);
-        if (!ec) {
-            fs::rename(header_tmp, header, ec);
-        }
-        if (ec) {
-            log_warning(
-                tt::LogBuildKernels,
-                "PCH: could not stage {}: {}; compiling without it",
-                header.string(),
-                ec.message());
-            return false;
-        }
-
-        const std::string gch_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(gch);
-        const std::string dep_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(dep);
-
-        // Built through the same argv builder as the kernel compiles: any drift between
-        // the two flag sets makes GCC reject the PCH. The .d (via the -MMD already in
-        // cflags) records the PCH's dependency closure; a kernel compile that consumes
-        // the PCH emits a truncated .d of its own (-MMD stops at the PCH boundary), so
-        // compile_one merges this file back in to keep the dephash cache honest.
-        const std::vector<std::string> args = tt::jit_build::utils::build_gpp_argv(
-            gpp,
-            opt_level,
-            cflags,
-            fmt::format("{}", fmt::join(include_args, " ")),
-            defines,
-            header.string(),
-            tt::jit_build::utils::GppAction::PrecompileHeader,
-            gch_tmp,
-            dep_tmp);
-
-        // The log is per-temp (and so per-process): concurrent rebuilds of one key must
-        // not interleave writes. Removed on success, kept for the warning on failure.
-        const std::string log = gch_tmp + ".log";
-        bool ok = tt::jit_build::utils::exec_command(args, dir.string(), log);
-        if (ok) {
-            // -MMD lists the staged copy the compiler was handed, never the umbrella in
-            // the source tree it was copied from. That path is recorded explicitly so it
-            // reaches every consumer's dephash through merge_pch_deps_into_kernel_d.
-            // need_compile() runs before this function, so without it an edited umbrella
-            // leaves every object built against the old one reported as up to date, and
-            // the staged copy is never refreshed.
-            std::ofstream dep_out(dep_tmp, std::ios::app);
-            dep_out << gch << ": " << (fs::path(root) / umbrella).string() << '\n';
-            dep_out.flush();
-            ok = dep_out.good();
-            if (!ok) {
-                log_warning(tt::LogBuildKernels, "PCH: could not record {} in {}", umbrella_rel, dep_tmp);
-            }
-        }
-        if (ok) {
-            fs::rename(dep_tmp, dep, ec);
-            if (!ec) {
-                fs::rename(gch_tmp, gch, ec);
-            }
-            if (ec) {
-                log_warning(tt::LogBuildKernels, "PCH: could not publish {}: {}", gch, ec.message());
-                ok = false;
-            }
-        }
-        if (ok && !write_pch_dephash(dep, dir.string(), gch, dephash)) {
-            log_warning(tt::LogBuildKernels, "PCH: could not record the closure of {} in {}", gch, dephash);
-            ok = false;
-        }
-        if (ok) {
-            fs::remove(log, ec);
-            log_info(tt::LogBuildKernels, "PCH: built {} for {}", gch, target_name);
-        } else {
-            fs::remove(gch_tmp, ec);
-            fs::remove(dep_tmp, ec);
-            log_warning(
-                tt::LogBuildKernels, "PCH: build failed for {} (log: {}); compiling without it", target_name, log);
-        }
-        return ok;
-    }();
-    entry->ok = built;
-    entry->failed = !built;
-    return built ? header.string() : std::string{};
-}
-
-// A compile that consumed a PCH emits a truncated .d: -MMD lists only what was parsed
-// after the PCH boundary, which would blind the dephash sidecar to edits of any header
-// inside the umbrella. Append the PCH's own dependency closure (recorded at PCH build
-// time, see ensure_pch) under the kernel object's target -- parse_dependency_file
-// accumulates rules for one target across lines. On any failure the kernel .d is
-// removed, which drops the sidecar and forces a recompile next run: slower, never stale.
-void merge_pch_deps_into_kernel_d(
-    const std::string& kernel_d_path, const std::string& kernel_obj, const std::string& pch_d_path) {
-    std::ifstream pch_d(pch_d_path);
-    std::ofstream out(kernel_d_path, std::ios::app);
-    bool ok = pch_d.is_open() && out.is_open();
-    if (ok) {
-        const jit_build::ParsedDependencies deps = jit_build::parse_dependency_file(pch_d);
-        ok = !deps.empty();
-        for (const auto& [target, dep_list] : deps) {
-            for (const auto& dep : dep_list) {
-                out << kernel_obj << ": " << dep << '\n';
-            }
-        }
-        out.flush();
-        ok = ok && out.good();
-    }
-    if (!ok) {
-        out.close();
-        std::error_code ec;
-        fs::remove(kernel_d_path, ec);
-        log_warning(
-            tt::LogBuildKernels,
-            "PCH: could not merge {} into {}; dropping the .d so this object is rebuilt next run",
-            pch_d_path,
-            kernel_d_path);
-    }
 }
 
 void hard_link_or_copy(const std::filesystem::path& target, const std::filesystem::path& link) {
@@ -1032,7 +752,7 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
             }
             pch_defines.push_back(defines[i]);
         }
-        const std::string pch_header = ensure_pch(
+        const std::string pch_header = jit_build::ensure_pch(
             env_.gpp_,
             env_.get_root_path(),
             env_.get_out_root_path(),
@@ -1082,7 +802,7 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     bool result = tt::jit_build::utils::exec_command(args, out_dir, log_file.path());
     report_result(this->target_name_, "compile", fmt::format("{}", fmt::join(args, " ")), log_file.path(), result);
     if (result && !pch_dep_path.empty()) {
-        merge_pch_deps_into_kernel_d(temp_d_path, obj_temp_path, pch_dep_path);
+        jit_build::merge_pch_deps_into_kernel_d(temp_d_path, obj_temp_path, pch_dep_path);
     }
     jit_build::write_dependency_hashes(out_dir, obj_temp_path, obj_temp_path + ".dephash");
     fs::remove(temp_d_path);  // .d file not needed after hash is written
@@ -1499,7 +1219,7 @@ void jit_build_once(size_t hash, const std::function<void()>& build_fn) {
 void jit_build_cache_clear() {
     JitBuildCache::inst().clear();
     jit_build::clear_file_hash_cache();
-    pch_cache_clear();
+    jit_build::pch_cache_clear();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <enchantum/enchantum.hpp>
@@ -78,6 +79,105 @@ void report_result(const string& target_name, string_view op, const string& cmd,
     } else if (!result) {
         TT_THROW("Failed to open {} failure log file {}", op, log_file);
     }
+}
+
+// Opt-in precompiled headers for TRISC kernel targets (TT_METAL_JIT_PCH=1).
+//
+// trisck.cc re-parses a fixed prelude (see trisc_pch.h) in every TRISC target.
+// That prelude accounts for roughly half of a TRISC target's compile time and is
+// identical across kernels, so precompiling it about halves the compile step.
+//
+// Two GCC constraints shape the implementation:
+//  - A PCH is silently ignored once the first token has been seen, so it must be
+//    force-included ahead of the per-kernel named-ct-arg header.
+//  - GCC validates every command-line macro against the state recorded in the
+//    PCH, whether or not the PCH references that macro. One PCH is therefore
+//    needed per distinct define set, and any define whose value is unique per
+//    kernel must be kept off the command line entirely (see FULL_KERNEL_NAME in
+//    export_target_recipe).
+bool jit_pch_enabled() {
+    static const bool enabled = [] {
+        const char* v = std::getenv("TT_METAL_JIT_PCH");
+        return v != nullptr && *v != '\0' && *v != '0';
+    }();
+    return enabled;
+}
+
+// Path of the umbrella header, relative to the tt-metal root.
+constexpr std::string_view PCH_UMBRELLA_REL = "tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h";
+
+// Returns the header path to force-include for this compile recipe, building the
+// PCH on first use. Returns empty if a PCH is unavailable, in which case the
+// caller simply compiles without one.
+//
+// `defines` must already have any -include pairs stripped, and must otherwise
+// match the compile exactly, or GCC will reject the result.
+std::string ensure_pch(
+    const std::string& gpp,
+    const std::string& root,
+    const std::string& out_root,
+    const std::string& target_name,
+    const std::string& opt_level,
+    const std::string& cflags,
+    const std::string& includes,
+    const std::vector<std::string>& defines) {
+    tt::StableHasher hasher;
+    hasher.update(target_name);
+    hasher.update(opt_level);
+    hasher.update(cflags);
+    hasher.update(includes);
+    for (const auto& define : defines) {
+        hasher.update(define);
+    }
+    const uint64_t key = hasher.digest();
+
+    const fs::path dir = fs::path(out_root) / "pch" / target_name / fmt::format("{:016x}", key);
+    const fs::path header = dir / "trisc_pch.h";
+
+    // One PCH per key, built once per process. The lock is held across the build
+    // so concurrent compiles wait rather than racing on the same output; with a
+    // handful of keys this serializes only a few hundred milliseconds.
+    static std::mutex mutex;
+    static std::unordered_map<uint64_t, bool> built;
+    std::lock_guard lock(mutex);
+    if (auto it = built.find(key); it != built.end()) {
+        return it->second ? header.string() : std::string{};
+    }
+
+    bool ok = false;
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    fs::copy_file(fs::path(root) / PCH_UMBRELLA_REL, header, fs::copy_options::overwrite_existing, ec);
+    if (ec) {
+        log_warning(
+            tt::LogBuildKernels, "PCH: could not stage {}: {}; compiling without it", header.string(), ec.message());
+    } else {
+        std::vector<std::string> args = tt::jit_build::utils::tokenize_flags(gpp);
+        args.push_back("-" + opt_level);
+        for (auto& tok : tt::jit_build::utils::tokenize_flags(cflags)) {
+            args.push_back(std::move(tok));
+        }
+        for (auto& tok : tt::jit_build::utils::tokenize_flags(includes)) {
+            args.push_back(std::move(tok));
+        }
+        args.insert(args.end(), defines.begin(), defines.end());
+        args.push_back("-x");
+        args.push_back("c++-header");
+        args.push_back(header.string());
+        args.push_back("-o");
+        args.push_back(header.string() + ".gch");
+
+        const std::string log = header.string() + ".gch.log";
+        ok = tt::jit_build::utils::exec_command(args, dir.string(), log);
+        if (ok) {
+            log_info(tt::LogBuildKernels, "PCH: built {} for {}", header.string() + ".gch", target_name);
+        } else {
+            log_warning(
+                tt::LogBuildKernels, "PCH: build failed for {} (log: {}); compiling without it", target_name, log);
+        }
+    }
+    built.emplace(key, ok);
+    return ok ? header.string() : std::string{};
 }
 
 void hard_link_or_copy(const std::filesystem::path& target, const std::filesystem::path& link) {
@@ -668,12 +768,41 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     const std::string obj_temp_path = out_dir + this->temp_objs_[src_index];
     const std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
 
+    std::vector<std::string> defines = recipe.defines;
+    if (jit_pch_enabled() && fs::path(this->srcs_[src_index]).filename() == "trisck.cc") {
+        // The PCH is built from the same recipe minus any force-included headers:
+        // those are per-kernel, and a PCH that consumed them could not be shared.
+        std::vector<std::string> pch_defines;
+        pch_defines.reserve(defines.size());
+        for (size_t i = 0; i < defines.size(); ++i) {
+            if (defines[i] == "-include") {
+                ++i;  // skip the header argument that follows
+                continue;
+            }
+            pch_defines.push_back(defines[i]);
+        }
+        const std::string pch_header = ensure_pch(
+            env_.gpp_,
+            env_.get_root_path(),
+            env_.get_out_root_path(),
+            target_name_,
+            recipe.compiler_opt_level,
+            cflags,
+            recipe.includes,
+            pch_defines);
+        if (!pch_header.empty()) {
+            // Must precede every other -include so no token is seen first.
+            defines.insert(defines.begin(), pch_header);
+            defines.insert(defines.begin(), "-include");
+        }
+    }
+
     std::vector<std::string> args = tt::jit_build::utils::build_gpp_argv(
         env_.gpp_,
         recipe.compiler_opt_level,
         cflags,
         recipe.includes,
-        recipe.defines,
+        defines,
         this->srcs_[src_index],
         tt::jit_build::utils::GppAction::Compile,
         obj_temp_path,
@@ -1001,7 +1130,18 @@ tt::jit_build::TargetRecipe JitBuildState::export_target_recipe(const JitBuildSe
         // FULL_KERNEL_NAME: consumed by the LLK sanitizer (CTSTR(FULL_KERNEL_NAME)). Emitted
         // shell-free as one verbatim argv element with literal quotes (the unified/remote-JIT
         // path does no shell expansion).
-        defines.push_back(fmt::format(R"(-DFULL_KERNEL_NAME="{}")", settings->get_full_kernel_name()));
+        //
+        // Its value is unique per kernel, and GCC validates every command-line macro against the
+        // state recorded in a precompiled header even when the PCH never references it. Leaving it
+        // on the command line therefore reduces a shared PCH to a per-kernel one. When the LLK
+        // sanitizer is disabled, sanitizer/output.h supplies a "<unknown>" fallback, so under
+        // TT_METAL_JIT_PCH it can be omitted; with the sanitizer enabled correctness wins and the
+        // define stays (costing PCH reuse).
+        const bool llk_sanitizer_enabled = std::any_of(
+            defines.begin(), defines.end(), [](const std::string& d) { return d.rfind("-DLLK_SAN_ENABLE", 0) == 0; });
+        if (!jit_pch_enabled() || llk_sanitizer_enabled) {
+            defines.push_back(fmt::format(R"(-DFULL_KERNEL_NAME="{}")", settings->get_full_kernel_name()));
+        }
         settings->process_compile_time_args([&defines](const std::vector<uint32_t>& values) {
             if (!values.empty()) {
                 defines.push_back(fmt::format("-DKERNEL_COMPILE_TIME_ARGS={}", fmt::join(values, ",")));

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -81,11 +81,12 @@ void report_result(const string& target_name, string_view op, const string& cmd,
     }
 }
 
-// Opt-in precompiled headers for TRISC kernel targets (TT_METAL_JIT_PCH=1).
+// Opt-in precompiled headers for kernel targets (TT_METAL_JIT_PCH=1).
 //
-// trisck.cc re-parses a fixed prelude (see trisc_pch.h) in every TRISC target.
-// That prelude accounts for roughly half of a TRISC target's compile time and is
-// identical across kernels, so precompiling it about halves the compile step.
+// Each kernel source re-parses a fixed prelude -- the includes ahead of the
+// generated per-kernel body -- in every target built from it. Those preludes are
+// identical across kernels and account for roughly half of a target's compile
+// time, so precompiling them about halves the compile step.
 //
 // Two GCC constraints shape the implementation:
 //  - A PCH is silently ignored once the first token has been seen, so it must be
@@ -103,8 +104,21 @@ bool jit_pch_enabled() {
     return enabled;
 }
 
-// Path of the umbrella header, relative to the tt-metal root.
-constexpr std::string_view PCH_UMBRELLA_REL = "tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h";
+// Umbrella header for a kernel source's shareable prelude, relative to the tt-metal
+// root. Each one mirrors the includes its source parses before reaching the generated
+// per-kernel body; a source with no entry here simply compiles without a PCH.
+std::string_view pch_umbrella_for(std::string_view kernel_src) {
+    if (kernel_src == "trisck.cc") {
+        return "tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h";
+    }
+    if (kernel_src == "brisck.cc") {
+        return "tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h";
+    }
+    if (kernel_src == "ncrisck.cc") {
+        return "tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h";
+    }
+    return {};
+}
 
 // Returns the header path to force-include for this compile recipe, building the
 // PCH on first use. Returns empty if a PCH is unavailable, in which case the
@@ -117,12 +131,14 @@ std::string ensure_pch(
     const std::string& root,
     const std::string& out_root,
     const std::string& target_name,
+    std::string_view umbrella_rel,
     const std::string& opt_level,
     const std::string& cflags,
     const std::string& includes,
     const std::vector<std::string>& defines) {
     tt::StableHasher hasher;
     hasher.update(target_name);
+    hasher.update(std::string(umbrella_rel));
     hasher.update(opt_level);
     hasher.update(cflags);
     hasher.update(includes);
@@ -131,8 +147,9 @@ std::string ensure_pch(
     }
     const uint64_t key = hasher.digest();
 
+    const fs::path umbrella = fs::path(std::string(umbrella_rel));
     const fs::path dir = fs::path(out_root) / "pch" / target_name / fmt::format("{:016x}", key);
-    const fs::path header = dir / "trisc_pch.h";
+    const fs::path header = dir / umbrella.filename();
 
     // One PCH per key, built once per process. The lock is held across the build
     // so concurrent compiles wait rather than racing on the same output; with a
@@ -147,7 +164,7 @@ std::string ensure_pch(
     bool ok = false;
     std::error_code ec;
     fs::create_directories(dir, ec);
-    fs::copy_file(fs::path(root) / PCH_UMBRELLA_REL, header, fs::copy_options::overwrite_existing, ec);
+    fs::copy_file(fs::path(root) / umbrella, header, fs::copy_options::overwrite_existing, ec);
     if (ec) {
         log_warning(
             tt::LogBuildKernels, "PCH: could not stage {}: {}; compiling without it", header.string(), ec.message());
@@ -769,7 +786,10 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     const std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
 
     std::vector<std::string> defines = recipe.defines;
-    if (jit_pch_enabled() && fs::path(this->srcs_[src_index]).filename() == "trisck.cc") {
+    const std::string kernel_src_name = fs::path(this->srcs_[src_index]).filename().string();
+    // pch_umbrella_for returns a view of a string literal, so this outlives the call.
+    const std::string_view pch_umbrella = jit_pch_enabled() ? pch_umbrella_for(kernel_src_name) : std::string_view{};
+    if (!pch_umbrella.empty()) {
         // The PCH is built from the same recipe minus any force-included headers:
         // those are per-kernel, and a PCH that consumed them could not be shared.
         std::vector<std::string> pch_defines;
@@ -786,6 +806,7 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
             env_.get_root_path(),
             env_.get_out_root_path(),
             target_name_,
+            pch_umbrella,
             recipe.compiler_opt_level,
             cflags,
             recipe.includes,

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -91,30 +92,40 @@ void report_result(const string& target_name, string_view op, const string& cmd,
 // Two GCC constraints shape the implementation:
 //  - A PCH is silently ignored once the first token has been seen, so it must be
 //    force-included ahead of the per-kernel named-ct-arg header.
-//  - GCC validates every command-line macro against the state recorded in the
-//    PCH, whether or not the PCH references that macro. One PCH is therefore
-//    needed per distinct define set, and any define whose value is unique per
-//    kernel must be kept off the command line entirely (see FULL_KERNEL_NAME in
-//    export_target_recipe).
+//  - GCC validates command-line macros against the state recorded in the PCH:
+//    any macro the precompiled prelude tests or expands (even just via #ifdef,
+//    which the prelude does for KERNEL_COMPILE_TIME_ARGS and FULL_KERNEL_NAME)
+//    must match exactly. One PCH is therefore needed per distinct define set,
+//    and any define whose value is unique per kernel must be kept off the
+//    command line entirely (see FULL_KERNEL_NAME in export_target_recipe).
 bool jit_pch_enabled() {
     static const bool enabled = [] {
+        // Same convention as RunTimeOptions' is_env_enabled: only a leading '1' turns a
+        // TT_METAL_* boolean on, so "0", "false" and "" all leave it off.
         const char* v = std::getenv("TT_METAL_JIT_PCH");
-        return v != nullptr && *v != '\0' && *v != '0';
+        return v != nullptr && v[0] == '1';
     }();
     return enabled;
 }
 
 // Umbrella header for a kernel source's shareable prelude, relative to the tt-metal
 // root. Each one mirrors the includes its source parses before reaching the generated
-// per-kernel body; a source with no entry here simply compiles without a PCH.
-std::string_view pch_umbrella_for(std::string_view kernel_src) {
-    if (kernel_src == "trisck.cc") {
+// per-kernel body. Matched on the architecture-qualified path suffix rather than the
+// bare filename, so another generation's source of the same name (tt-2xx has its own
+// trisck.cc) never picks up a tt-1xx umbrella; a source with no entry here simply
+// compiles without a PCH.
+std::string_view pch_umbrella_for(std::string_view kernel_src_path) {
+    auto matches = [&](std::string_view suffix) {
+        return kernel_src_path.size() >= suffix.size() &&
+               kernel_src_path.substr(kernel_src_path.size() - suffix.size()) == suffix;
+    };
+    if (matches("/tt-1xx/trisck.cc")) {
         return "tt_metal/hw/firmware/src/tt-1xx/trisc_pch.h";
     }
-    if (kernel_src == "brisck.cc") {
+    if (matches("/tt-1xx/brisck.cc")) {
         return "tt_metal/hw/firmware/src/tt-1xx/brisc_pch.h";
     }
-    if (kernel_src == "ncrisck.cc") {
+    if (matches("/tt-1xx/ncrisck.cc")) {
         return "tt_metal/hw/firmware/src/tt-1xx/ncrisc_pch.h";
     }
     // active_erisck.cc deliberately has no entry. A PCH is buildable for it, but it
@@ -140,12 +151,33 @@ std::string ensure_pch(
     const std::string& cflags,
     const std::string& includes,
     const std::vector<std::string>& defines) {
+    // The relative include roots ("-I.", "-I..") resolve against a kernel's own build
+    // directory and are how a compile reaches per-kernel generated headers. A PCH must
+    // not consume anything per-kernel, so they are dropped from the PCH build: if an
+    // umbrella ever grows a (transitive) dependency on a generated header, its PCH
+    // build fails loudly and every compile falls back to plain parsing, instead of one
+    // kernel's generated state -- or a negative __has_include probe -- being silently
+    // baked into all the other kernels sharing the key.
+    std::vector<std::string> include_args;
+    for (auto& tok : tt::jit_build::utils::tokenize_flags(includes)) {
+        if (tok == "-I." || tok == "-I..") {
+            continue;
+        }
+        include_args.push_back(std::move(tok));
+    }
+
+    // One PCH per distinct recipe. Blaze passes compile-time args through generated
+    // headers, so this stays at one key per target type there; kernels that carry
+    // per-kernel -D defines or include paths (common in ttnn) fan out to one PCH
+    // build per distinct set, which is part of why the feature is opt-in.
     tt::StableHasher hasher;
     hasher.update(target_name);
     hasher.update(std::string(umbrella_rel));
     hasher.update(opt_level);
     hasher.update(cflags);
-    hasher.update(includes);
+    for (const auto& inc : include_args) {
+        hasher.update(inc);
+    }
     for (const auto& define : defines) {
         hasher.update(define);
     }
@@ -154,51 +186,132 @@ std::string ensure_pch(
     const fs::path umbrella = fs::path(std::string(umbrella_rel));
     const fs::path dir = fs::path(out_root) / "pch" / target_name / fmt::format("{:016x}", key);
     const fs::path header = dir / umbrella.filename();
+    const std::string gch = header.string() + ".gch";
 
-    // One PCH per key, built once per process. The lock is held across the build
-    // so concurrent compiles wait rather than racing on the same output; with a
-    // handful of keys this serializes only a few hundred milliseconds.
-    static std::mutex mutex;
-    static std::unordered_map<uint64_t, bool> built;
-    std::lock_guard lock(mutex);
-    if (auto it = built.find(key); it != built.end()) {
-        return it->second ? header.string() : std::string{};
+    // Each key is built once per process. The map lock is held only for the entry
+    // lookup; the build runs under the entry's own once_flag, so distinct keys build
+    // in parallel and compiles whose key is already built never wait. A fresh process
+    // deliberately rebuilds rather than trusting a .gch found on disk: the key does
+    // not cover header contents, so an existing file could predate a source edit.
+    // Every shared-path write goes through a unique temp file and an atomic rename --
+    // concurrent processes rebuilding the same key never expose a partial file, and a
+    // compile holding the old .gch open keeps reading it after the rename.
+    struct Entry {
+        std::once_flag once;
+        bool ok = false;
+    };
+    std::shared_ptr<Entry> entry;
+    {
+        static std::mutex map_mutex;
+        static std::unordered_map<uint64_t, std::shared_ptr<Entry>> entries;
+        std::lock_guard lock(map_mutex);
+        auto [it, inserted] = entries.try_emplace(key);
+        if (inserted) {
+            it->second = std::make_shared<Entry>();
+        }
+        entry = it->second;
     }
 
-    bool ok = false;
-    std::error_code ec;
-    fs::create_directories(dir, ec);
-    fs::copy_file(fs::path(root) / umbrella, header, fs::copy_options::overwrite_existing, ec);
-    if (ec) {
-        log_warning(
-            tt::LogBuildKernels, "PCH: could not stage {}: {}; compiling without it", header.string(), ec.message());
-    } else {
+    std::call_once(entry->once, [&] {
+        std::error_code ec;
+        fs::create_directories(dir, ec);
+        const std::string header_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(header);
+        fs::copy_file(fs::path(root) / umbrella, header_tmp, fs::copy_options::overwrite_existing, ec);
+        if (!ec) {
+            fs::rename(header_tmp, header, ec);
+        }
+        if (ec) {
+            log_warning(
+                tt::LogBuildKernels,
+                "PCH: could not stage {}: {}; compiling without it",
+                header.string(),
+                ec.message());
+            return;
+        }
+
+        const std::string dep = header.string() + ".d";
+        const std::string gch_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(gch);
+        const std::string dep_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(dep);
+
         std::vector<std::string> args = tt::jit_build::utils::tokenize_flags(gpp);
         args.push_back("-" + opt_level);
         for (auto& tok : tt::jit_build::utils::tokenize_flags(cflags)) {
             args.push_back(std::move(tok));
         }
-        for (auto& tok : tt::jit_build::utils::tokenize_flags(includes)) {
-            args.push_back(std::move(tok));
-        }
+        args.insert(args.end(), include_args.begin(), include_args.end());
         args.insert(args.end(), defines.begin(), defines.end());
+        // Record the PCH's own dependency closure. A kernel compile that consumes the
+        // PCH emits a truncated .d (-MMD stops at the PCH boundary), so compile_one
+        // merges this file back in to keep the dephash cache honest.
+        args.push_back("-MMD");
+        args.push_back("-MF");
+        args.push_back(dep_tmp);
         args.push_back("-x");
         args.push_back("c++-header");
         args.push_back(header.string());
         args.push_back("-o");
-        args.push_back(header.string() + ".gch");
+        args.push_back(gch_tmp);
 
-        const std::string log = header.string() + ".gch.log";
-        ok = tt::jit_build::utils::exec_command(args, dir.string(), log);
+        // The log is per-temp (and so per-process): concurrent rebuilds of one key must
+        // not interleave writes. Removed on success, kept for the warning on failure.
+        const std::string log = gch_tmp + ".log";
+        bool ok = tt::jit_build::utils::exec_command(args, dir.string(), log);
         if (ok) {
-            log_info(tt::LogBuildKernels, "PCH: built {} for {}", header.string() + ".gch", target_name);
+            fs::rename(dep_tmp, dep, ec);
+            if (!ec) {
+                fs::rename(gch_tmp, gch, ec);
+            }
+            if (ec) {
+                log_warning(tt::LogBuildKernels, "PCH: could not publish {}: {}", gch, ec.message());
+                ok = false;
+            }
+        }
+        if (ok) {
+            fs::remove(log, ec);
+            log_info(tt::LogBuildKernels, "PCH: built {} for {}", gch, target_name);
         } else {
+            fs::remove(gch_tmp, ec);
+            fs::remove(dep_tmp, ec);
             log_warning(
                 tt::LogBuildKernels, "PCH: build failed for {} (log: {}); compiling without it", target_name, log);
         }
+        entry->ok = ok;
+    });
+    return entry->ok ? header.string() : std::string{};
+}
+
+// A compile that consumed a PCH emits a truncated .d: -MMD lists only what was parsed
+// after the PCH boundary, which would blind the dephash sidecar to edits of any header
+// inside the umbrella. Append the PCH's own dependency closure (recorded at PCH build
+// time, see ensure_pch) under the kernel object's target -- parse_dependency_file
+// accumulates rules for one target across lines. On any failure the kernel .d is
+// removed, which drops the sidecar and forces a recompile next run: slower, never stale.
+void merge_pch_deps_into_kernel_d(
+    const std::string& kernel_d_path, const std::string& kernel_obj, const std::string& pch_d_path) {
+    std::ifstream pch_d(pch_d_path);
+    std::ofstream out(kernel_d_path, std::ios::app);
+    bool ok = pch_d.is_open() && out.is_open();
+    if (ok) {
+        const jit_build::ParsedDependencies deps = jit_build::parse_dependency_file(pch_d);
+        ok = !deps.empty();
+        for (const auto& [target, dep_list] : deps) {
+            for (const auto& dep : dep_list) {
+                out << kernel_obj << ": " << dep << '\n';
+            }
+        }
+        out.flush();
+        ok = ok && out.good();
     }
-    built.emplace(key, ok);
-    return ok ? header.string() : std::string{};
+    if (!ok) {
+        out.close();
+        std::error_code ec;
+        fs::remove(kernel_d_path, ec);
+        log_warning(
+            tt::LogBuildKernels,
+            "PCH: could not merge {} into {}; dropping the .d so this object is rebuilt next run",
+            pch_d_path,
+            kernel_d_path);
+    }
 }
 
 void hard_link_or_copy(const std::filesystem::path& target, const std::filesystem::path& link) {
@@ -790,9 +903,10 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     const std::string temp_d_path = fs::path(obj_temp_path).replace_extension("d").string();
 
     std::vector<std::string> defines = recipe.defines;
-    const std::string kernel_src_name = fs::path(this->srcs_[src_index]).filename().string();
     // pch_umbrella_for returns a view of a string literal, so this outlives the call.
-    const std::string_view pch_umbrella = jit_pch_enabled() ? pch_umbrella_for(kernel_src_name) : std::string_view{};
+    const std::string_view pch_umbrella =
+        jit_pch_enabled() ? pch_umbrella_for(this->srcs_[src_index]) : std::string_view{};
+    std::string pch_dep_path;
     if (!pch_umbrella.empty()) {
         // The PCH is built from the same recipe minus any force-included headers:
         // those are per-kernel, and a PCH that consumed them could not be shared.
@@ -819,6 +933,12 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
             // Must precede every other -include so no token is seen first.
             defines.insert(defines.begin(), pch_header);
             defines.insert(defines.begin(), "-include");
+            // GCC falls back to plain textual inclusion, silently, whenever it rejects
+            // a PCH (flag or macro-state mismatch). Surface that in the compile log.
+            // A warning rather than an error -- the base cflags carry -Werror -- since
+            // a rejected PCH costs speed, not correctness.
+            cflags += " -Winvalid-pch -Wno-error=invalid-pch";
+            pch_dep_path = pch_header + ".d";
         }
     }
 
@@ -848,6 +968,9 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     fs::remove(log_file.path());
     bool result = tt::jit_build::utils::exec_command(args, out_dir, log_file.path());
     report_result(this->target_name_, "compile", fmt::format("{}", fmt::join(args, " ")), log_file.path(), result);
+    if (result && !pch_dep_path.empty()) {
+        merge_pch_deps_into_kernel_d(temp_d_path, obj_temp_path, pch_dep_path);
+    }
     jit_build::write_dependency_hashes(out_dir, obj_temp_path, obj_temp_path + ".dephash");
     fs::remove(temp_d_path);  // .d file not needed after hash is written
 }
@@ -1152,19 +1275,17 @@ tt::jit_build::TargetRecipe JitBuildState::export_target_recipe(const JitBuildSe
         });
     }
     if (settings) {
-        // FULL_KERNEL_NAME: consumed by the LLK sanitizer (CTSTR(FULL_KERNEL_NAME)). Emitted
+        // FULL_KERNEL_NAME: consumed only by the LLK sanitizer (CTSTR(FULL_KERNEL_NAME)). Emitted
         // shell-free as one verbatim argv element with literal quotes (the unified/remote-JIT
         // path does no shell expansion).
         //
-        // Its value is unique per kernel, and GCC validates every command-line macro against the
-        // state recorded in a precompiled header even when the PCH never references it. Leaving it
-        // on the command line therefore reduces a shared PCH to a per-kernel one. When the LLK
-        // sanitizer is disabled, sanitizer/output.h supplies a "<unknown>" fallback, so under
-        // TT_METAL_JIT_PCH it can be omitted; with the sanitizer enabled correctness wins and the
-        // define stays (costing PCH reuse).
-        const bool llk_sanitizer_enabled = std::any_of(
-            defines.begin(), defines.end(), [](const std::string& d) { return d.rfind("-DLLK_SAN_ENABLE", 0) == 0; });
-        if (!jit_pch_enabled() || llk_sanitizer_enabled) {
+        // With the sanitizer off the macro is dead -- sanitizer/output.h substitutes "<unknown>" --
+        // so it is omitted entirely rather than gated on TT_METAL_JIT_PCH. That keeps the exported
+        // recipe deterministic (the remote compile server sees the same recipe whichever way the
+        // client sets that variable), and keeps this per-kernel-unique value off the command line,
+        // where GCC would validate it against a shared PCH and reduce the PCH to one per kernel.
+        // With the sanitizer on, correctness wins and the define stays, costing PCH reuse.
+        if (env_.get_rtoptions().get_sanitizer_settings().enabled) {
             defines.push_back(fmt::format(R"(-DFULL_KERNEL_NAME="{}")", settings->get_full_kernel_name()));
         }
         settings->process_compile_time_args([&defines](const std::vector<uint32_t>& values) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -701,32 +701,33 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     std::string pch_header;
     std::string pch_dep_path;
     if (use_pch) {
-        // The PCH is built from the same recipe minus any force-included headers:
-        // those are per-kernel, and a PCH that consumed them could not be shared.
-        std::vector<std::string> pch_defines;
-        pch_defines.reserve(defines.size());
-        for (size_t i = 0; i < defines.size(); ++i) {
-            if (defines[i] == "-include") {
-                ++i;  // skip the header argument that follows
-                continue;
+        // Share a firmware profile, independent of kernel values, names and source
+        // directories. NOC selection affects the shared prelude and has a fixed set
+        // of variants. Other kernel defines stay on the consumer command line: GCC
+        // rejects the PCH if one changes a macro actually used by the prelude.
+        std::vector<std::string> pch_defines = tt::jit_build::utils::tokenize_flags(defines_);
+        for (const auto& define : defines) {
+            if (define.starts_with("-DNOC_INDEX=") || define.starts_with("-DNOC_MODE=")) {
+                pch_defines.push_back(define);
             }
-            pch_defines.push_back(defines[i]);
         }
+        pch_defines.emplace_back("-DTT_METAL_PCH_BUILD=1");
         pch_header = jit_build::ensure_pch(
             env_.gpp_,
             env_.get_root_path(),
-            env_.get_out_root_path(),
+            (fs::path(env_.get_out_root_path()) / std::to_string(env_.get_build_key())).string(),
             target_name_,
             pch_umbrella,
             recipe.compiler_opt_level,
             cflags,
-            recipe.includes,
+            includes_,
             pch_defines);
         TT_FATAL(!pch_strict || !pch_header.empty(), "Strict PCH mode: creation failed for {}", target_name_);
         if (!pch_header.empty()) {
             // Must precede every other -include so no token is seen first.
             defines.insert(defines.begin(), pch_header);
             defines.insert(defines.begin(), "-include");
+            defines.emplace_back("-DTT_METAL_PCH_BUILD=1");
             // Normal builds warn and fall back; strict validation requires actual consumption.
             cflags += pch_strict ? " -H -Werror=invalid-pch" : " -Winvalid-pch -Wno-error=invalid-pch";
             pch_dep_path = pch_header + ".d";
@@ -1074,11 +1075,11 @@ tt::jit_build::TargetRecipe JitBuildState::export_target_recipe(const JitBuildSe
         if (env_.get_rtoptions().get_sanitizer_settings().enabled) {
             defines.push_back(fmt::format(R"(-DFULL_KERNEL_NAME="{}")", settings->get_full_kernel_name()));
         }
-        settings->process_compile_time_args([&defines](const std::vector<uint32_t>& values) {
-            if (!values.empty()) {
-                defines.push_back(fmt::format("-DKERNEL_COMPILE_TIME_ARGS={}", fmt::join(values, ",")));
-            }
-        });
+        // Always supply the header, including for an empty list. It completes the
+        // positional API after PCH loading; the exported recipe is also valid when
+        // compiling ordinarily or on the remote server.
+        defines.emplace_back("-include");
+        defines.emplace_back(tt::jit_build::utils::CT_ARGS_HEADER);
         // KERNEL_COMPILE_TIME_ARG_MAP arrives as a force-included header (written by genfiles,
         // see write_named_ct_arg_map_header) rather than a -D define, because one define is one
         // argv element and the map alone can exceed the per-element MAX_ARG_STRLEN. Two argv

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -105,6 +105,14 @@ void write_file(const string& path, const string& content) {
     }
 }
 
+// Always emit positional arguments, including an empty list, in the generated
+// files sent to both the local compiler and the remote JIT server.
+void write_ct_args_header(const string& out_dir, const JitBuildSettings& settings) {
+    settings.process_compile_time_args([&out_dir](const std::vector<uint32_t>& args) {
+        write_file(out_dir + string(jit_build::utils::CT_ARGS_HEADER), jit_build::utils::format_ct_args_header(args));
+    });
+}
+
 // Writes the named compile-time-arg map header, which build.cpp force-includes (-include) in place
 // of a -DKERNEL_COMPILE_TIME_ARG_MAP define; see NAMED_CT_ARG_MAP_HEADER for why the map cannot ride
 // on the command line. Emitted only for the legacy map API, including Metal 2.0 kernels.
@@ -722,6 +730,7 @@ void jit_build_genfiles_kernel_include(
     }
     // No #include line: this one is force-included by the compile recipe so the map is defined
     // before any header that reads it (api/compile_time_args.h) can be pulled in.
+    write_ct_args_header(out_dir, settings);
     write_named_ct_arg_map_header(out_dir, settings);
     ////////////////////////////////////////////////////////////
     // Blaze-only experimental named args
@@ -759,6 +768,7 @@ void jit_build_genfiles_triscs_src(
     }
     // No prolog #include: force-included by the compile recipe instead, so the map is defined ahead
     // of any header that reads it (api/compile_time_args.h).
+    write_ct_args_header(out_dir, settings);
     write_named_ct_arg_map_header(out_dir, settings);
     ////////////////////////////////////////////////////////////
     // Blaze-only experimental named args

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -249,8 +249,14 @@ std::string format_named_ct_arg_map(const std::unordered_map<std::string, std::u
 }
 
 std::string format_named_ct_arg_map_header(const std::unordered_map<std::string, std::uint32_t>& named_args) {
+    // The include turns the macro into the get_named_compile_time_arg_val API right
+    // here, rather than relying on the kernel to include compile_time_args.h after
+    // this header. That indirect route breaks under TT_METAL_JIT_PCH, where
+    // compile_time_args.h is already in the precompiled prelude and so re-includes as
+    // a no-op. named_compile_time_args.h is re-includable and needs nothing that is
+    // not yet defined at force-include time; see the comment there.
     return "// AUTO-GENERATED -- do not edit.\n#pragma once\n\n#define KERNEL_COMPILE_TIME_ARG_MAP " +
-           format_named_ct_arg_map(named_args) + "\n";
+           format_named_ct_arg_map(named_args) + "\n\n#include \"api/named_compile_time_args.h\"\n";
 }
 
 void create_file(const std::string& file_path_str) {

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -108,6 +108,18 @@ std::vector<std::string> build_gpp_argv(
             args.push_back(out_path);
             args.push_back(src);
             break;
+        case GppAction::PrecompileHeader:
+            // -x c++-header must precede the input for GCC to emit a PCH. The -MF pins
+            // down the .d that the -MMD in the base cflags would otherwise derive from
+            // -o; ensure_pch merges it into each consuming kernel's .d.
+            args.push_back("-x");
+            args.push_back("c++-header");
+            args.push_back("-o");
+            args.push_back(out_path);
+            args.push_back(src);
+            args.push_back("-MF");
+            args.push_back(dep_path);
+            break;
     }
     return args;
 }

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -261,12 +261,10 @@ std::string format_named_ct_arg_map(const std::unordered_map<std::string, std::u
 }
 
 std::string format_named_ct_arg_map_header(const std::unordered_map<std::string, std::uint32_t>& named_args) {
-    // The include turns the macro into the get_named_compile_time_arg_val API right
-    // here, rather than relying on the kernel to include compile_time_args.h after
-    // this header. That indirect route breaks under TT_METAL_JIT_PCH, where
-    // compile_time_args.h is already in the precompiled prelude and so re-includes as
-    // a no-op. named_compile_time_args.h is re-includable and needs nothing that is
-    // not yet defined at force-include time; see the comment there.
+    // Declare the named API as soon as the map is available. In a PCH build the
+    // earlier include of compile_time_args.h saw no map, and consumers need not
+    // include it again. The separate API header also avoids requiring FORCE_INLINE
+    // while this generated header is being force-included.
     return "// AUTO-GENERATED -- do not edit.\n#pragma once\n\n#define KERNEL_COMPILE_TIME_ARG_MAP " +
            format_named_ct_arg_map(named_args) + "\n\n#include \"api/named_compile_time_args.h\"\n";
 }

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -24,6 +24,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <fmt/ranges.h>
+
 #include <tt-logger/tt-logger.hpp>
 
 #include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
@@ -258,6 +260,17 @@ std::string format_named_ct_arg_map(const std::unordered_map<std::string, std::u
         out += '}';
     }
     return out;
+}
+
+std::string format_ct_args_header(const std::vector<std::uint32_t>& args) {
+    // Without PCH, firmware includes declare the API once FORCE_INLINE is available.
+    // With PCH, the shared declarations already exist; finish the API here, before
+    // any later firmware headers or kernel body can use the positional arguments.
+    return fmt::format(
+        "// AUTO-GENERATED -- do not edit.\n#pragma once\n\n#define KERNEL_COMPILE_TIME_ARGS {}\n"
+        "#ifdef TT_METAL_PCH_BUILD\n#undef TT_METAL_PCH_BUILD\n"
+        "#include \"api/compile_time_args.h\"\n#endif\n",
+        fmt::join(args, ","));
 }
 
 std::string format_named_ct_arg_map_header(const std::unordered_map<std::string, std::uint32_t>& named_args) {

--- a/tt_metal/jit_build/jit_build_utils.hpp
+++ b/tt_metal/jit_build/jit_build_utils.hpp
@@ -28,15 +28,18 @@ std::vector<std::string> tokenize_flags(const std::string& flags);
 
 // What a gpp invocation should do with its source.
 enum class GppAction {
-    Compile,     // -c -o <out_obj> <src> -MF <dep>   (produces an object + .d depfile)
-    Preprocess,  // -E -o <out>        <src>          (self-contained .ii; keeps line markers)
+    Compile,           // -c -o <out_obj> <src> -MF <dep>                (produces an object + .d depfile)
+    Preprocess,        // -E -o <out>        <src>                       (self-contained .ii; keeps line markers)
+    PrecompileHeader,  // -x c++-header -o <out_gch> <src> -MF <dep>     (produces a .gch + .d depfile)
 };
 // Build the argv for a single gpp invocation from recipe fields. The argv is for
 // exec_command() (posix_spawn, NO shell), so defines/flags containing shell metacharacters
 // (e.g. -DFULL_KERNEL_NAME="<name>") are passed verbatim — each define is
 // its own argv element and is never re-quoted or shell-split. `opt_level` is the bare level
-// without the leading dash (e.g. "O3"). `dep_path` is used only for Compile.
-// One argv builder shared by the local compile, the remote compile server, and preprocess-and-ship.
+// without the leading dash (e.g. "O3"). `dep_path` is used only for Compile and PrecompileHeader.
+// One argv builder shared by the local compile, the remote compile server, preprocess-and-ship,
+// and the PCH build — sharing it is what keeps PCH flags and compile flags from drifting apart,
+// which GCC would answer by silently rejecting the PCH.
 std::vector<std::string> build_gpp_argv(
     const std::string& gpp,
     const std::string& opt_level,

--- a/tt_metal/jit_build/jit_build_utils.hpp
+++ b/tt_metal/jit_build/jit_build_utils.hpp
@@ -68,6 +68,10 @@ std::vector<std::string> build_gpp_argv(
 // the RPC, where an absolute client-side path would not exist on the server.
 inline constexpr std::string_view NAMED_CT_ARG_MAP_HEADER = "named_ct_arg_map_generated.h";
 
+// Like the named map, positional values belong to the kernel, after PCH loading.
+inline constexpr std::string_view CT_ARGS_HEADER = "compile_time_args_generated.h";
+std::string format_ct_args_header(const std::vector<std::uint32_t>& args);
+
 // Render |named_args| as the initializer body of KERNEL_COMPILE_TIME_ARG_MAP:
 //   {"a",1},{"b",2}
 // Empty when |named_args| is empty. Entries are emitted in ascending key order so the text is

--- a/tt_metal/jit_build/pch.cpp
+++ b/tt_metal/jit_build/pch.cpp
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pch.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <tt-logger/tt-logger.hpp>
+
+#include "common/stable_hash.hpp"
+#include "depend.hpp"
+#include "jit_build_utils.hpp"
+
+namespace tt::jit_build {
+namespace fs = std::filesystem;
+namespace {
+
+// One entry per staged header path, held by shared_ptr so a build already in flight
+// keeps its entry alive across a pch_cache_clear().
+struct PchEntry {
+    std::mutex mutex;
+    bool ok = false;
+    bool failed = false;
+};
+
+std::mutex pch_map_mutex;
+std::unordered_map<std::string, std::shared_ptr<PchEntry>> pch_entries;
+
+// Keyed by the staged header path rather than by the recipe key alone: that path also
+// embeds out_root, so two build environments pointing at different cache roots get
+// separate entries instead of the first one reporting success for a .gch the second
+// never built.
+std::shared_ptr<PchEntry> pch_entry_for(const std::string& header) {
+    std::lock_guard lock(pch_map_mutex);
+    std::shared_ptr<PchEntry>& entry = pch_entries[header];
+    if (!entry) {
+        entry = std::make_shared<PchEntry>();
+    }
+    return entry;
+}
+
+// Publishes the dependency-hash sidecar that later calls in this process use to decide
+// whether a built .gch still matches its closure. Every rule in the .d is flattened
+// under one label because the target GCC records there follows the output name it was
+// given, which is a per-process temp path.
+bool write_pch_dephash(
+    const std::string& dep_path, const std::string& dir, const std::string& gch, const std::string& hash_path) {
+    jit_build::ParsedDependencies parsed;
+    {
+        std::ifstream dep_file(dep_path);
+        if (!dep_file.is_open()) {
+            return false;
+        }
+        parsed = jit_build::parse_dependency_file(dep_file);
+    }
+    if (parsed.empty()) {
+        return false;
+    }
+    jit_build::ParsedDependencies flattened;
+    std::vector<std::string>& deps = flattened[gch];
+    for (const auto& [target, dep_list] : parsed) {
+        deps.insert(deps.end(), dep_list.begin(), dep_list.end());
+    }
+
+    const std::string tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(hash_path);
+    {
+        std::ofstream hash_file(tmp);
+        if (!hash_file.is_open()) {
+            return false;
+        }
+        jit_build::write_dependency_hashes(flattened, dir, gch, hash_file);
+        hash_file.close();
+        if (hash_file.fail()) {
+            std::error_code ec;
+            fs::remove(tmp, ec);
+            return false;
+        }
+    }
+    std::error_code ec;
+    fs::rename(tmp, hash_path, ec);
+    if (ec) {
+        fs::remove(tmp, ec);
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+// ClearKernelCache() also clears the file-hash cache, which is what makes a mid-run
+// header edit visible to need_compile(); an entry that survived it would keep handing
+// out a .gch built from the pre-edit contents.
+void pch_cache_clear() {
+    std::lock_guard lock(pch_map_mutex);
+    pch_entries.clear();
+}
+
+// Returns the header path to force-include for this compile recipe, building the
+// PCH on first use. Returns empty if a PCH is unavailable, in which case the
+// caller simply compiles without one.
+//
+// `defines` must already have any -include pairs stripped, and must otherwise
+// match the compile exactly, or GCC will reject the result.
+std::string ensure_pch(
+    const std::string& gpp,
+    const std::string& root,
+    const std::string& out_root,
+    const std::string& target_name,
+    std::string_view umbrella_rel,
+    const std::string& opt_level,
+    const std::string& cflags,
+    const std::string& includes,
+    const std::vector<std::string>& defines) {
+    // The relative include roots ("-I.", "-I..") resolve against a kernel's own build
+    // directory and are how a compile reaches per-kernel generated headers. A PCH must
+    // not consume anything per-kernel, so they are dropped from the PCH build: if an
+    // umbrella ever grows a (transitive) dependency on a generated header, its PCH
+    // build fails loudly and every compile falls back to plain parsing, instead of one
+    // kernel's generated state -- or a negative __has_include probe -- being silently
+    // baked into all the other kernels sharing the key.
+    std::vector<std::string> include_args;
+    for (auto& tok : tt::jit_build::utils::tokenize_flags(includes)) {
+        if (tok == "-I." || tok == "-I..") {
+            continue;
+        }
+        include_args.push_back(std::move(tok));
+    }
+
+    // One PCH per distinct recipe. Blaze passes compile-time args through generated
+    // headers, so this stays at one key per target type there; kernels that carry
+    // per-kernel -D defines or include paths (common in ttnn) fan out to one PCH
+    // build per distinct set, which is part of why the feature is opt-in.
+    tt::StableHasher hasher;
+    hasher.update(target_name);
+    hasher.update(std::string(umbrella_rel));
+    hasher.update(opt_level);
+    hasher.update(cflags);
+    for (const auto& inc : include_args) {
+        hasher.update(inc);
+    }
+    for (const auto& define : defines) {
+        hasher.update(define);
+    }
+    const uint64_t key = hasher.digest();
+
+    const fs::path umbrella = fs::path(std::string(umbrella_rel));
+    const fs::path dir = fs::path(out_root) / "pch" / target_name / fmt::format("{:016x}", key);
+    const fs::path header = dir / umbrella.filename();
+    const std::string gch = header.string() + ".gch";
+    const std::string dep = header.string() + ".d";
+    const std::string dephash = gch + ".dephash";
+
+    // The map lock is held only for the entry lookup; the build runs under the entry's
+    // own mutex, so distinct keys build in parallel and compiles whose key is already
+    // built and still valid never wait. A fresh process rebuilds rather than trusting a
+    // .gch found on disk: the key does not cover header contents, so an existing file
+    // could predate a source edit. Every shared-path write goes through a unique temp
+    // file and an atomic rename -- concurrent processes rebuilding the same key never
+    // expose a partial file, and a compile holding the old .gch open keeps reading it
+    // after the rename.
+    const std::shared_ptr<PchEntry> entry = pch_entry_for(header.string());
+    std::lock_guard entry_lock(entry->mutex);
+
+    // A failed build is not retried: giving up on the PCH for the rest of the process
+    // costs one wasted build, retrying per compile would cost thousands.
+    if (entry->failed) {
+        return {};
+    }
+
+    // A successful build is not trusted for the rest of the process either. The key
+    // covers flags and defines but not header contents, and ClearKernelCache() drops
+    // the file-hash cache that makes a mid-run header edit visible to need_compile().
+    // An entry that outlived such an edit would keep force-including a .gch holding
+    // the pre-edit contents while every consumer wrote a dephash sidecar computed from
+    // the current ones -- marking objects compiled against stale headers as up to date
+    // on disk, for this run and every later one.
+    if (entry->ok && jit_build::dependencies_up_to_date_file(dephash)) {
+        return header.string();
+    }
+
+    const bool built = [&] {
+        std::error_code ec;
+        fs::create_directories(dir, ec);
+        const std::string header_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(header);
+        fs::copy_file(fs::path(root) / umbrella, header_tmp, fs::copy_options::overwrite_existing, ec);
+        if (!ec) {
+            fs::rename(header_tmp, header, ec);
+        }
+        if (ec) {
+            log_warning(
+                tt::LogBuildKernels,
+                "PCH: could not stage {}: {}; compiling without it",
+                header.string(),
+                ec.message());
+            return false;
+        }
+
+        const std::string gch_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(gch);
+        const std::string dep_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(dep);
+
+        // Built through the same argv builder as the kernel compiles: any drift between
+        // the two flag sets makes GCC reject the PCH. The .d (via the -MMD already in
+        // cflags) records the PCH's dependency closure; a kernel compile that consumes
+        // the PCH emits a truncated .d of its own (-MMD stops at the PCH boundary), so
+        // compile_one merges this file back in to keep the dephash cache honest.
+        const std::vector<std::string> args = tt::jit_build::utils::build_gpp_argv(
+            gpp,
+            opt_level,
+            cflags,
+            fmt::format("{}", fmt::join(include_args, " ")),
+            defines,
+            header.string(),
+            tt::jit_build::utils::GppAction::PrecompileHeader,
+            gch_tmp,
+            dep_tmp);
+
+        // The log is per-temp (and so per-process): concurrent rebuilds of one key must
+        // not interleave writes. Removed on success, kept for the warning on failure.
+        const std::string log = gch_tmp + ".log";
+        bool ok = tt::jit_build::utils::exec_command(args, dir.string(), log);
+        if (ok) {
+            // -MMD lists the staged copy the compiler was handed, never the umbrella in
+            // the source tree it was copied from. That path is recorded explicitly so it
+            // reaches every consumer's dephash through merge_pch_deps_into_kernel_d.
+            // need_compile() runs before this function, so without it an edited umbrella
+            // leaves every object built against the old one reported as up to date, and
+            // the staged copy is never refreshed.
+            std::ofstream dep_out(dep_tmp, std::ios::app);
+            dep_out << gch << ": " << (fs::path(root) / umbrella).string() << '\n';
+            dep_out.flush();
+            ok = dep_out.good();
+            if (!ok) {
+                log_warning(tt::LogBuildKernels, "PCH: could not record {} in {}", umbrella_rel, dep_tmp);
+            }
+        }
+        if (ok) {
+            fs::rename(dep_tmp, dep, ec);
+            if (!ec) {
+                fs::rename(gch_tmp, gch, ec);
+            }
+            if (ec) {
+                log_warning(tt::LogBuildKernels, "PCH: could not publish {}: {}", gch, ec.message());
+                ok = false;
+            }
+        }
+        if (ok && !write_pch_dephash(dep, dir.string(), gch, dephash)) {
+            log_warning(tt::LogBuildKernels, "PCH: could not record the closure of {} in {}", gch, dephash);
+            ok = false;
+        }
+        if (ok) {
+            fs::remove(log, ec);
+            log_info(tt::LogBuildKernels, "PCH: built {} for {}", gch, target_name);
+        } else {
+            fs::remove(gch_tmp, ec);
+            fs::remove(dep_tmp, ec);
+            log_warning(
+                tt::LogBuildKernels, "PCH: build failed for {} (log: {}); compiling without it", target_name, log);
+        }
+        return ok;
+    }();
+    entry->ok = built;
+    entry->failed = !built;
+    return built ? header.string() : std::string{};
+}
+
+// A compile that consumed a PCH emits a truncated .d: -MMD lists only what was parsed
+// after the PCH boundary, which would blind the dephash sidecar to edits of any header
+// inside the umbrella. Append the PCH's own dependency closure (recorded at PCH build
+// time, see ensure_pch) under the kernel object's target -- parse_dependency_file
+// accumulates rules for one target across lines. On any failure the kernel .d is
+// removed, which drops the sidecar and forces a recompile next run: slower, never stale.
+void merge_pch_deps_into_kernel_d(
+    const std::string& kernel_d_path, const std::string& kernel_obj, const std::string& pch_d_path) {
+    std::ifstream pch_d(pch_d_path);
+    std::ofstream out(kernel_d_path, std::ios::app);
+    bool ok = pch_d.is_open() && out.is_open();
+    if (ok) {
+        const jit_build::ParsedDependencies deps = jit_build::parse_dependency_file(pch_d);
+        ok = !deps.empty();
+        for (const auto& [target, dep_list] : deps) {
+            for (const auto& dep : dep_list) {
+                out << kernel_obj << ": " << dep << '\n';
+            }
+        }
+        out.flush();
+        ok = ok && out.good();
+    }
+    if (!ok) {
+        out.close();
+        std::error_code ec;
+        fs::remove(kernel_d_path, ec);
+        log_warning(
+            tt::LogBuildKernels,
+            "PCH: could not merge {} into {}; dropping the .d so this object is rebuilt next run",
+            pch_d_path,
+            kernel_d_path);
+    }
+}
+
+}  // namespace tt::jit_build

--- a/tt_metal/jit_build/pch.cpp
+++ b/tt_metal/jit_build/pch.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
 
 #include "common/stable_hash.hpp"
 #include "depend.hpp"
@@ -27,8 +28,7 @@ namespace tt::jit_build {
 namespace fs = std::filesystem;
 namespace {
 
-// One entry per staged header path, held by shared_ptr so a build already in flight
-// keeps its entry alive across a pch_cache_clear().
+// Shared ownership keeps in-flight entries alive across cache clearing.
 struct PchEntry {
     std::mutex mutex;
     bool ok = false;
@@ -38,10 +38,7 @@ struct PchEntry {
 std::mutex pch_map_mutex;
 std::unordered_map<std::string, std::shared_ptr<PchEntry>> pch_entries;
 
-// Keyed by the staged header path rather than by the recipe key alone: that path also
-// embeds out_root, so two build environments pointing at different cache roots get
-// separate entries instead of the first one reporting success for a .gch the second
-// never built.
+// The full header path separates output roots as well as recipes.
 std::shared_ptr<PchEntry> pch_entry_for(const std::string& header) {
     std::lock_guard lock(pch_map_mutex);
     std::shared_ptr<PchEntry>& entry = pch_entries[header];
@@ -51,10 +48,7 @@ std::shared_ptr<PchEntry> pch_entry_for(const std::string& header) {
     return entry;
 }
 
-// Publishes the dependency-hash sidecar that later calls in this process use to decide
-// whether a built .gch still matches its closure. Every rule in the .d is flattened
-// under one label because the target GCC records there follows the output name it was
-// given, which is a per-process temp path.
+// Flatten rules under the final target; GCC records the temporary output name.
 bool write_pch_dephash(
     const std::string& dep_path, const std::string& dir, const std::string& gch, const std::string& hash_path) {
     jit_build::ParsedDependencies parsed;
@@ -99,20 +93,27 @@ bool write_pch_dephash(
 
 }  // namespace
 
-// ClearKernelCache() also clears the file-hash cache, which is what makes a mid-run
-// header edit visible to need_compile(); an entry that survived it would keep handing
-// out a .gch built from the pre-edit contents.
+void require_pch_consumed(const std::string& log_path, const std::string& header) {
+    TT_FATAL(!header.empty(), "Strict PCH mode: no header requested (log: {})", log_path);
+    std::ifstream log(log_path);
+    TT_FATAL(log.is_open(), "Strict PCH mode: cannot read {}", log_path);
+    const std::string expected = "! " + header + ".gch";
+    for (std::string line; std::getline(log, line);) {
+        if (line == expected) {
+            return;
+        }
+    }
+    TT_THROW("Strict PCH mode: compiler did not consume {}.gch (log: {})", header, log_path);
+}
+
+// Drop completed and failed entries; existing users retain their shared ownership.
 void pch_cache_clear() {
     std::lock_guard lock(pch_map_mutex);
     pch_entries.clear();
 }
 
-// Returns the header path to force-include for this compile recipe, building the
-// PCH on first use. Returns empty if a PCH is unavailable, in which case the
-// caller simply compiles without one.
-//
-// `defines` must already have any -include pairs stripped, and must otherwise
-// match the compile exactly, or GCC will reject the result.
+// Returns the staged header to force-include, or empty to request ordinary compilation.
+// The caller must remove per-kernel -include pairs from defines.
 std::string ensure_pch(
     const std::string& gpp,
     const std::string& root,
@@ -123,13 +124,9 @@ std::string ensure_pch(
     const std::string& cflags,
     const std::string& includes,
     const std::vector<std::string>& defines) {
-    // The relative include roots ("-I.", "-I..") resolve against a kernel's own build
-    // directory and are how a compile reaches per-kernel generated headers. A PCH must
-    // not consume anything per-kernel, so they are dropped from the PCH build: if an
-    // umbrella ever grows a (transitive) dependency on a generated header, its PCH
-    // build fails loudly and every compile falls back to plain parsing, instead of one
-    // kernel's generated state -- or a negative __has_include probe -- being silently
-    // baked into all the other kernels sharing the key.
+    // These roots expose per-kernel generated headers and cannot be shared.
+    // Required generated includes then fail; umbrellas must also exclude headers
+    // whose __has_include probes would silently capture the wrong state.
     std::vector<std::string> include_args;
     for (auto& tok : tt::jit_build::utils::tokenize_flags(includes)) {
         if (tok == "-I." || tok == "-I..") {
@@ -138,10 +135,8 @@ std::string ensure_pch(
         include_args.push_back(std::move(tok));
     }
 
-    // One PCH per distinct recipe. Blaze passes compile-time args through generated
-    // headers, so this stays at one key per target type there; kernels that carry
-    // per-kernel -D defines or include paths (common in ttnn) fan out to one PCH
-    // build per distinct set, which is part of why the feature is opt-in.
+    // Distinct flags, defines or include paths require separate PCH builds.
+    // Recipes with few consumers may cost more than ordinary compilation.
     tt::StableHasher hasher;
     hasher.update(target_name);
     hasher.update(std::string(umbrella_rel));
@@ -162,30 +157,18 @@ std::string ensure_pch(
     const std::string dep = header.string() + ".d";
     const std::string dephash = gch + ".dephash";
 
-    // The map lock is held only for the entry lookup; the build runs under the entry's
-    // own mutex, so distinct keys build in parallel and compiles whose key is already
-    // built and still valid never wait. A fresh process rebuilds rather than trusting a
-    // .gch found on disk: the key does not cover header contents, so an existing file
-    // could predate a source edit. Every shared-path write goes through a unique temp
-    // file and an atomic rename -- concurrent processes rebuilding the same key never
-    // expose a partial file, and a compile holding the old .gch open keeps reading it
-    // after the rename.
+    // Serialize validation/builds per entry, allowing different recipes to proceed.
+    // Fresh processes rebuild. Atomic renames protect each file from partial reads;
+    // publication of the header, .d, .gch and sidecar is not one transaction.
     const std::shared_ptr<PchEntry> entry = pch_entry_for(header.string());
     std::lock_guard entry_lock(entry->mutex);
 
-    // A failed build is not retried: giving up on the PCH for the rest of the process
-    // costs one wasted build, retrying per compile would cost thousands.
+    // Retry failures only after cache clearing, not once per consuming kernel.
     if (entry->failed) {
         return {};
     }
 
-    // A successful build is not trusted for the rest of the process either. The key
-    // covers flags and defines but not header contents, and ClearKernelCache() drops
-    // the file-hash cache that makes a mid-run header edit visible to need_compile().
-    // An entry that outlived such an edit would keep force-including a .gch holding
-    // the pre-edit contents while every consumer wrote a dephash sidecar computed from
-    // the current ones -- marking objects compiled against stale headers as up to date
-    // on disk, for this run and every later one.
+    // Recipe keys exclude contents, so validate the dependency hashes before reuse.
     if (entry->ok && jit_build::dependencies_up_to_date_file(dephash)) {
         return header.string();
     }
@@ -210,11 +193,7 @@ std::string ensure_pch(
         const std::string gch_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(gch);
         const std::string dep_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(dep);
 
-        // Built through the same argv builder as the kernel compiles: any drift between
-        // the two flag sets makes GCC reject the PCH. The .d (via the -MMD already in
-        // cflags) records the PCH's dependency closure; a kernel compile that consumes
-        // the PCH emits a truncated .d of its own (-MMD stops at the PCH boundary), so
-        // compile_one merges this file back in to keep the dephash cache honest.
+        // Match consumer flags and record the closure that kernel -MMD output omits.
         const std::vector<std::string> args = tt::jit_build::utils::build_gpp_argv(
             gpp,
             opt_level,
@@ -226,17 +205,12 @@ std::string ensure_pch(
             gch_tmp,
             dep_tmp);
 
-        // The log is per-temp (and so per-process): concurrent rebuilds of one key must
-        // not interleave writes. Removed on success, kept for the warning on failure.
+        // Keep separate logs for concurrent processes and retain failures for diagnosis.
         const std::string log = gch_tmp + ".log";
         bool ok = tt::jit_build::utils::exec_command(args, dir.string(), log);
         if (ok) {
-            // -MMD lists the staged copy the compiler was handed, never the umbrella in
-            // the source tree it was copied from. That path is recorded explicitly so it
-            // reaches every consumer's dephash through merge_pch_deps_into_kernel_d.
-            // need_compile() runs before this function, so without it an edited umbrella
-            // leaves every object built against the old one reported as up to date, and
-            // the staged copy is never refreshed.
+            // GCC sees only the staged copy. Track the source umbrella too so edits
+            // invalidate consumers before ensure_pch is called again.
             std::ofstream dep_out(dep_tmp, std::ios::app);
             dep_out << gch << ": " << (fs::path(root) / umbrella).string() << '\n';
             dep_out.flush();
@@ -275,12 +249,8 @@ std::string ensure_pch(
     return built ? header.string() : std::string{};
 }
 
-// A compile that consumed a PCH emits a truncated .d: -MMD lists only what was parsed
-// after the PCH boundary, which would blind the dephash sidecar to edits of any header
-// inside the umbrella. Append the PCH's own dependency closure (recorded at PCH build
-// time, see ensure_pch) under the kernel object's target -- parse_dependency_file
-// accumulates rules for one target across lines. On any failure the kernel .d is
-// removed, which drops the sidecar and forces a recompile next run: slower, never stale.
+// Add the PCH dependency closure omitted by the consumer's -MMD output.
+// If merging fails, drop the .d to prevent reuse with incomplete dependency hashes.
 void merge_pch_deps_into_kernel_d(
     const std::string& kernel_d_path, const std::string& kernel_obj, const std::string& pch_d_path) {
     std::ifstream pch_d(pch_d_path);

--- a/tt_metal/jit_build/pch.cpp
+++ b/tt_metal/jit_build/pch.cpp
@@ -4,6 +4,10 @@
 
 #include "pch.hpp"
 
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -31,9 +35,60 @@ namespace {
 // Shared ownership keeps in-flight entries alive across cache clearing.
 struct PchEntry {
     std::mutex mutex;
-    bool ok = false;
     bool failed = false;
 };
+
+// Coordinate processes sharing TT_METAL_CACHE. O_CLOEXEC prevents the compiler
+// from keeping a lock alive if its parent exits during construction.
+class PchFileLock {
+public:
+    explicit PchFileLock(const fs::path& path) : fd_(::open(path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600)) {
+        if (fd_ >= 0 && ::flock(fd_, LOCK_EX) != 0) {
+            ::close(fd_);
+            fd_ = -1;
+        }
+    }
+    ~PchFileLock() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+    PchFileLock(const PchFileLock&) = delete;
+    PchFileLock& operator=(const PchFileLock&) = delete;
+    explicit operator bool() const { return fd_ >= 0; }
+
+private:
+    int fd_;
+};
+
+// A backstop for unusual combinations of firmware/compiler options. Count reserved
+// profile directories, including builds in flight, rather than just completed .gch
+// files. Never evict a PCH that a compiler may be about to consume.
+bool reserve_profile(const fs::path& cache, const fs::path& dir) {
+    constexpr size_t max_profiles = 64;
+    fs::create_directories(cache);
+    const PchFileLock lock(cache / "admission.lock");
+    if (!lock) {
+        return false;
+    }
+    if (fs::is_directory(dir)) {
+        return true;
+    }
+    size_t profiles = 0;
+    for (const auto& target : fs::directory_iterator(cache)) {
+        if (target.is_directory()) {
+            for (const auto& profile : fs::directory_iterator(target.path())) {
+                profiles += profile.is_directory();
+            }
+        }
+    }
+    if (profiles >= max_profiles) {
+        log_warning(tt::LogBuildKernels, "PCH: profile limit reached in {}; compiling without it", cache.string());
+        return false;
+    }
+    fs::create_directories(dir);
+    return true;
+}
 
 std::mutex pch_map_mutex;
 std::unordered_map<std::string, std::shared_ptr<PchEntry>> pch_entries;
@@ -113,7 +168,7 @@ void pch_cache_clear() {
 }
 
 // Returns the staged header to force-include, or empty to request ordinary compilation.
-// The caller must remove per-kernel -include pairs from defines.
+// The caller supplies only a shared firmware profile, with no kernel arguments.
 std::string ensure_pch(
     const std::string& gpp,
     const std::string& root,
@@ -135,9 +190,10 @@ std::string ensure_pch(
         include_args.push_back(std::move(tok));
     }
 
-    // Distinct flags, defines or include paths require separate PCH builds.
-    // Recipes with few consumers may cost more than ordinary compilation.
+    // Only genuine firmware/compiler profile differences create new PCH files.
+    // The output root is scoped by JitBuildEnv's build key, including SFPI version.
     tt::StableHasher hasher;
+    hasher.update(gpp);
     hasher.update(target_name);
     hasher.update(std::string(umbrella_rel));
     hasher.update(opt_level);
@@ -151,15 +207,14 @@ std::string ensure_pch(
     const uint64_t key = hasher.digest();
 
     const fs::path umbrella = fs::path(std::string(umbrella_rel));
-    const fs::path dir = fs::path(out_root) / "pch" / target_name / fmt::format("{:016x}", key);
+    const fs::path cache = fs::path(out_root) / "pch";
+    const fs::path dir = cache / target_name / fmt::format("{:016x}", key);
     const fs::path header = dir / umbrella.filename();
     const std::string gch = header.string() + ".gch";
     const std::string dep = header.string() + ".d";
     const std::string dephash = gch + ".dephash";
 
-    // Serialize validation/builds per entry, allowing different recipes to proceed.
-    // Fresh processes rebuild. Atomic renames protect each file from partial reads;
-    // publication of the header, .d, .gch and sidecar is not one transaction.
+    // Serialize validation/builds per entry, allowing different profiles to proceed.
     const std::shared_ptr<PchEntry> entry = pch_entry_for(header.string());
     std::lock_guard entry_lock(entry->mutex);
 
@@ -168,14 +223,33 @@ std::string ensure_pch(
         return {};
     }
 
+    try {
+        if (!reserve_profile(cache, dir)) {
+            entry->failed = true;
+            return {};
+        }
+    } catch (const fs::filesystem_error& error) {
+        log_warning(
+            tt::LogBuildKernels, "PCH: cannot reserve {}: {}; compiling without it", dir.string(), error.what());
+        entry->failed = true;
+        return {};
+    }
+    const PchFileLock process_lock(dir / "build.lock");
+    if (!process_lock) {
+        entry->failed = true;
+        return {};
+    }
+
     // Recipe keys exclude contents, so validate the dependency hashes before reuse.
-    if (entry->ok && jit_build::dependencies_up_to_date_file(dephash)) {
+    // The sidecar is published last under the process lock. A new process can reuse
+    // the files, while a crashed builder leaves an incomplete entry to rebuild.
+    if (fs::is_regular_file(gch) && fs::is_regular_file(dep) && jit_build::dependencies_up_to_date_file(dephash)) {
         return header.string();
     }
 
     const bool built = [&] {
         std::error_code ec;
-        fs::create_directories(dir, ec);
+        fs::remove(dephash, ec);
         const std::string header_tmp = tt::jit_build::utils::FileRenamer::generate_temp_path(header);
         fs::copy_file(fs::path(root) / umbrella, header_tmp, fs::copy_options::overwrite_existing, ec);
         if (!ec) {
@@ -244,7 +318,6 @@ std::string ensure_pch(
         }
         return ok;
     }();
-    entry->ok = built;
     entry->failed = !built;
     return built ? header.string() : std::string{};
 }

--- a/tt_metal/jit_build/pch.hpp
+++ b/tt_metal/jit_build/pch.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace tt::jit_build {
+
+// Internal JIT cache helpers. An empty result asks the caller to compile without a PCH.
+// Defines must match the consumer's command line, with per-kernel -include pairs removed.
+std::string ensure_pch(
+    const std::string& gpp,
+    const std::string& root,
+    const std::string& out_root,
+    const std::string& target_name,
+    std::string_view umbrella_rel,
+    const std::string& opt_level,
+    const std::string& cflags,
+    const std::string& includes,
+    const std::vector<std::string>& defines);
+
+void merge_pch_deps_into_kernel_d(
+    const std::string& kernel_d_path, const std::string& kernel_obj, const std::string& pch_d_path);
+
+void pch_cache_clear();
+
+}  // namespace tt::jit_build

--- a/tt_metal/jit_build/pch.hpp
+++ b/tt_metal/jit_build/pch.hpp
@@ -28,4 +28,7 @@ void merge_pch_deps_into_kernel_d(
 
 void pch_cache_clear();
 
+// Strict validation: require GCC's -H acceptance line for this exact header.
+void require_pch_consumed(const std::string& log_path, const std::string& header);
+
 }  // namespace tt::jit_build

--- a/tt_metal/jit_build/pch.hpp
+++ b/tt_metal/jit_build/pch.hpp
@@ -11,7 +11,8 @@
 namespace tt::jit_build {
 
 // Internal JIT cache helpers. An empty result asks the caller to compile without a PCH.
-// Defines must match the consumer's command line, with per-kernel -include pairs removed.
+// Pass only firmware profile defines and include roots, never kernel arguments or
+// source directories. out_root must include the toolchain/build identity.
 std::string ensure_pch(
     const std::string& gpp,
     const std::string& root,

--- a/tt_metal/jit_build/sources.cmake
+++ b/tt_metal/jit_build/sources.cmake
@@ -11,5 +11,6 @@ set(JIT_BUILD_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/kernel_signature_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit_build_options.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit_build_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/precompiled.cpp
 )

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -115,6 +115,8 @@ enum class EnvVarID {
     TT_METAL_DISABLE_MULTI_AERISC,                      // Disable multi-erisc mode (inverted logic, enabled by default)
     TT_METAL_USE_MGD_2_0,                               // Use mesh graph descriptor 2.0
     TT_METAL_FORCE_JIT_COMPILE,                         // Force JIT compilation
+    TT_METAL_JIT_PCH,                                   // Enable kernel precompiled headers
+    TT_METAL_JIT_PCH_STRICT,                            // Require PCH creation and consumption
     TT_METAL_DISABLE_SFPLOADMACRO,                      // Disable use of SFPLOADMACRO instructions
     TT_METAL_DRAM_BACKED_CQ,                            // Store command queues in device DRAM
     TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,            // Simulator tensor preload bypasses FD CQ copies
@@ -788,6 +790,8 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false (uses dependency tracking)
         // Usage: export TT_METAL_FORCE_JIT_COMPILE=1
         case EnvVarID::TT_METAL_FORCE_JIT_COMPILE: this->force_jit_compile = true; break;
+        case EnvVarID::TT_METAL_JIT_PCH: this->jit_pch_enabled = is_env_enabled(value); break;
+        case EnvVarID::TT_METAL_JIT_PCH_STRICT: this->jit_pch_strict = is_env_enabled(value); break;
 
         // TT_METAL_FORCE_REINIT
         // Force context reinitialization on each run.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -381,6 +381,8 @@ class RunTimeOptions {
 
     // Force JIT compile even if dependencies are up to date
     bool force_jit_compile = false;
+    bool jit_pch_enabled = false;
+    bool jit_pch_strict = false;
 
     // Store command queues in device DRAM
     bool dram_backed_cq_env_var_set = false;
@@ -930,6 +932,8 @@ public:
 
     bool get_force_jit_compile() const { return force_jit_compile; }
     void set_force_jit_compile(bool enable) { force_jit_compile = enable; }
+    bool get_jit_pch_enabled() const { return jit_pch_enabled; }
+    bool get_jit_pch_strict() const { return jit_pch_strict; }
 
     bool get_numa_based_affinity() const { return numa_based_affinity; }
 


### PR DESCRIPTION
## Summary

Reduce repeated kernel JIT header parsing with opt-in firmware PCHs (`TT_METAL_JIT_PCH=1`, off by default).

The pool test exposed excessive cache growth: kernel-specific recipes produced 2,798 PCH files (~86 GiB) and exhausted the runner's disk. PCH construction now uses shared firmware profiles; kernel argument values, defines, and source directories no longer create separate PCHs.

## Changes

- Precompile the BRISC/NCRISC/TRISC preludes. Supply positional and named arguments through generated headers after PCH loading, preserving the public APIs and Blaze argument separation.
- Key profiles by build/toolchain identity, target, compiler flags, and required NOC configuration. Revalidate dependencies, reuse valid files across processes under file locks, and merge their dependencies into kernel cache checks.
- Limit each build cache to 64 PCH profiles as a backstop. Keep ordinary compilation as the fallback for unsupported configurations or compiler rejection. Strict mode requires GCC to consume the requested PCH.

## Validation

For `8083825c`, local SFPI regressions pass, including reuse of the same five firmware PCHs across changed/empty positional arguments, kernel defines, and include paths. Named/Blaze arguments, scalar/RVV TRISC2, cache invalidation, the profile limit, and strict/fallback behavior pass. Local validation uses a Darwin overlay and SFPI 7.74.0; Linux CI uses the pinned toolchain.

[PR Gate passed](https://github.com/tenstorrent/tt-metal/actions/runs/34569749384), including ASan, full Clang Tidy, and runtime/TTNN smoke tests.

The [clean Wormhole pool A/B run passed](https://github.com/tenstorrent/tt-metal/actions/runs/34580479444) with kernel ccache disabled and a fresh JIT cache for each pass. Two runners each tested both PCH modes, in opposite orders, using the same wheel. All four passes had identical outcomes: 1,073 passed, 273 skipped, and 1 expected failure.

| Order on each runner | PCH disabled | PCH enabled | Less elapsed time |
|---|---:|---:|---:|
| Off → on | 29m 29s | 23m 59s | 18.6% |
| On → off | 28m 57s | 24m 13s | 16.3% |

Mean pool-suite time fell from 29m 13s to 24m 06s: **17.5% less elapsed time**. Artifacts confirm `TT_METAL_CCACHE_KERNEL_SUPPORT` was absent, `CCACHE_DISABLE=1`, empty starting JIT caches, and direct compiler invocations. Each PCH-enabled pass created only seven profiles (~219 MiB); the 64-profile backstop was not reached.

These are full-suite timings, including JIT compilation and test execution. The [earlier comparison with shared kernel ccache enabled](https://github.com/tenstorrent/tt-metal/actions/runs/34570696274) also passed, but its 44% timing reduction did not isolate PCH from ccache effects.

[Full sanity with PCH enabled for TTNN tests](https://github.com/tenstorrent/tt-metal/actions/runs/34569755064) passed every TTNN hardware and simulator group, including all four pool groups. A runner-disconnection failure passed on retry. The only remaining failure is the SDXL GroupNorm device-performance assertion, which the reviewer confirms also fails on main; PCH is disabled in that job. It persisted across three attempts (latest: 1,351,726 ns versus a 1,351,366.94 ns upper bound). The overall workflow is therefore red.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/jit-trisc-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/jit-trisc-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/jit-trisc-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/jit-trisc-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/jit-trisc-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/jit-trisc-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/jit-trisc-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/jit-trisc-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/jit-trisc-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/jit-trisc-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/jit-trisc-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/jit-trisc-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/jit-trisc-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/jit-trisc-pch)



