### PR TITLE
[LLK tests] Vectorise the unary SFPU golden and the BFP packer

### DIFF
--- a/tt_metal/tt-llk/docs/tests/test_suite_speedup_plan.md
+++ b/tt_metal/tt-llk/docs/tests/test_suite_speedup_plan.md
@@ -161,9 +161,10 @@ The e2e lane does not — `tests/pipeline_reorg/llk_e2e_tests.yaml` runs plain
 `pytest -n auto`, so every worker interleaves `g++` with holding a Tensix core.
 
 **Why it helps even without A.** Compile is pure CPU with no device dependency, so the
-producer pass can run at a much higher `-n` than the device pass (the perf lane uses 10
-vs 15 for exactly this reason) and, better, on a CPU-only runner *before* the device
-runner is allocated. `_collapse_runtime_only_variants`
+producer pass's `-n` is not bounded by the device at all — the two passes are tuned
+independently (the perf lane happens to run 10 producer workers against 15 consumers) and,
+better, the producer can run on a CPU-only runner *before* the device runner is allocated.
+`_collapse_runtime_only_variants`
 ([`llk_pytest_plugin.py:565-593`](../../tests/python_tests/helpers/llk_pytest_plugin.py#L565-L593))
 already dedupes the producer pass down to one item per compile key.
 
@@ -215,12 +216,13 @@ fidelity-clear addrmod) and must stay fully covered.
 Python**:
 
 ```python
-# golden_generators.py:2582
+# golden_generators.py:2590 -- the per-element path, now the fallback for the 26 ops
+# with no whole-tile entry
 op_res = [self.ops[operation](x) for x in result.tolist()[window]]
 ```
 
 and 33 of those ops route through `_torch_unary`
-([`golden_generators.py:2702`](../../tests/python_tests/helpers/golden_generators.py#L2702)),
+([`golden_generators.py:2897`](../../tests/python_tests/helpers/golden_generators.py#L2897)),
 which builds a **0-d `torch.tensor` per element** and calls `.item()`. Over the sweep that
 is 28,958,720 `_torch_unary` calls, 51,174,704 `torch.tensor` constructions and 50,893,356
 `.item()` calls. `EltwiseBinaryGolden`, `MatmulGolden` and the
@@ -246,15 +248,16 @@ bits in all 14 combinations**. Speedups at 32,768 elements: 10× (exp/erf/tanh/l
 mechanically, the rest need case-by-case review (some are `math.*` predicates that
 vectorise trivially, a few are genuinely elementwise-irregular). **Risk** low: the
 existing scalar path is a perfect oracle, so each op can be proven bit-identical before
-the loop is deleted. Do it op-family at a time behind a shared helper.
+the caller is switched to the whole-tile path — and the loop then stays as that oracle
+(see step 4 of the landing pattern). Do it op-family at a time behind a shared helper.
 
 Also applies to `_call_integer`
-([`golden_generators.py:3026`](../../tests/python_tests/helpers/golden_generators.py#L3026)),
-the same pattern on the integer SFPU path.
+([`golden_generators.py:3208`](../../tests/python_tests/helpers/golden_generators.py#L3208)),
+the same pattern on the integer SFPU path — still per-element, so this one is outstanding.
 
 ### E — Vectorise the BFP pack/unpack helpers  ⭐ suite-wide
 
-**What.** `float_to_bfp8_block` ([`pack.py:150`](../../tests/python_tests/helpers/pack.py#L150))
+**What.** `float_to_bfp8_block` ([`pack.py:228`](../../tests/python_tests/helpers/pack.py#L228))
 does bit manipulation by formatting each value as a **binary string**:
 
 ```python
@@ -289,10 +292,12 @@ with a memo dict and takes the same treatment.
 
 ### F — Stop generating, packing and DMA-ing an operand the unary kernels never read
 
-**What.** Every unary SFPU test asks `generate_stimuli` for a full `src_B`
-([`test_eltwise_unary_sfpu.py:1140-1146`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L1140-L1146))
-and hands it to `StimuliConfig`, which unconditionally packs it and writes it to L1
-([`stimuli_config.py:664`](../../tests/python_tests/helpers/stimuli_config.py#L664)).
+**What.** Every unary SFPU test asked `generate_stimuli` for a full `src_B` and handed it
+to `StimuliConfig`, which packed it and wrote it to L1 unconditionally. Both are now gated:
+`generate_operand_B=False`
+([`test_eltwise_unary_sfpu.py:1424`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L1424))
+and the `buffer_B is not None` guards
+([`stimuli_config.py:671`](../../tests/python_tests/helpers/stimuli_config.py#L671)).
 `sources/eltwise_unary_sfpu_test.cpp` contains **zero references to `buffer_B`**. The
 profile shows `write_matrix` called 9,304 times for 4,652 tests — exactly 2× — so half of
 the stimuli-write stage is spent on an operand no kernel reads.
@@ -337,14 +342,16 @@ that is the first thing to do here.
 **What.** 1,140 of 5,792 unary-sweep cases (19.7%) skip on Blackhole. 248 of those skip
 *unconditionally on every arch*:
 
-- `ReluMin` — 168 cases, `pytest.skip` at
-  [`test_eltwise_unary_sfpu.py:437`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L437)
-  (blocked on tt-llk#1120), yet the op is listed in `BROAD_SWEEP_OPS` and generates its
-  whole matrix.
-- `Tanh` + `ApproximationMode.Yes` — 80 cases, skipped at line 441.
+- `ReluMin` — 168 cases, a `pytest.skip` in the test body (blocked on tt-llk#1120), yet
+  the op is listed in `BROAD_SWEEP_OPS` and generates its whole matrix.
+- `Tanh` + `ApproximationMode.Yes` — 80 cases, skipped the same way.
 
-The remaining ~890 are the Blackhole format guards (`_skip_bh_unless_fp32` /
-`_skip_bh_unsupported_float_combo`). Those are equally movable, because
+Both are now collection-time filters in `_unsupported_reason`
+([`test_eltwise_unary_sfpu.py:275`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L275)),
+tallied into `UNSWEPT_COMBINATIONS` so a filtered case is still recorded somewhere.
+
+The remaining ~890 are the Blackhole format guards (`_bh_unless_fp32` /
+`_bh_unsupported_float_combo`). Those were equally movable, because
 `TestConfig.CHIP_ARCH` is bound in `pytest_configure` — i.e. before collection — so the
 format lists can be filtered when the params are built rather than rejected per test.
 
@@ -488,7 +495,7 @@ caching path next to a correctness oracle is a trap.
 
 Tempting because `test_eltwise_unary_sfpu` looks huge, but it is 2.8% of the suite and the
 matrix is where the real bugs live — the broad/standard profile split
-([`test_eltwise_unary_sfpu.py:63-84`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L63-L84))
+([`test_eltwise_unary_sfpu.py:66-84`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L66-L84))
 is already a deliberate cost/coverage tradeoff, and the file documents measured
 format-specific divergences (approximate exp's rtol overshoot, the signed-zero
 `unpack_to_dest` partition) that only exist because the matrix is wide. Spend the effort on
@@ -556,11 +563,16 @@ wipe described in §1 means it never is.
 
 ---
 
-## 8. Appendix — the validated prototypes
+## 8. Appendix — the prototypes the projections came from  *(historical)*
 
-Both are drop-in replacements for the current hot loops and were checked against the
-existing code as the oracle. Neither is committed anywhere; they are here so the
-projections in §4 can be re-derived rather than trusted.
+**Both have since landed**, as `_torch_unary_vec`
+([`golden_generators.py:2710`](../../tests/python_tests/helpers/golden_generators.py#L2710))
+and `_bfp_quantize_blocks`
+([`pack.py:156`](../../tests/python_tests/helpers/pack.py#L156)); the shipped versions are
+broader than these sketches (all three BFP widths, 88 ops, the Dest-dtype and float64
+families) and carry their own agreement tests. Read this section as the prototypes the §4
+projections were measured on, not as the implementation — for that, read the code. It is
+kept so those projections can be re-derived rather than trusted.
 
 ### D — `UnarySFPUGolden._torch_unary`, vectorised
 
@@ -614,7 +626,12 @@ produces different bytes.
 2. Add a test that asserts the two agree **bitwise** over a seeded population that includes
    the specials, parametrised over every op / format the scalar path supports.
 3. Switch the caller.
-4. Delete the scalar path in a follow-up, once the agreement test has run in nightly.
+4. **Keep the scalar path** as the oracle the agreement test runs against. It stops being
+   the production path but does not become dead code: it is the only per-element statement
+   of the format/op, and deleting it leaves nothing validating the fast path. Both landed
+   implementations say so at their definitions
+   ([`pack.py:131`](../../tests/python_tests/helpers/pack.py#L131),
+   [`golden_generators.py:2717`](../../tests/python_tests/helpers/golden_generators.py#L2717)).
 
-Step 2 is the deliverable that makes steps 3 and 4 safe, and it is reusable for the
+Step 2 is the deliverable that makes step 3 safe, and it is reusable for the
 `_call_integer` and `_bfp_to_float_block` follow-ups.

--- a/tt_metal/tt-llk/docs/tests/test_suite_speedup_plan.md
+++ b/tt_metal/tt-llk/docs/tests/test_suite_speedup_plan.md
@@ -1,0 +1,620 @@
+# LLK test-suite speedup plan
+
+Everything below is measured on this repo, not estimated from reading code. Where a
+number is an extrapolation it says so.
+
+**Measurement setup.** `tt-metal` @ `effd2e1477b`, Blackhole p150 (`/dev/tenstorrent/0`),
+`CHIP_ARCH=blackhole`, 6 CPU cores, Python 3.10.19 / torch 2.9.1+cpu / numpy 2.2.6,
+sfpi 7.72.0. All sweep runs are **serial** (`-n 1`) so the stage split is not confounded
+by xdist; CI runs `-n auto --dist=worksteal` over 2 `pytest-split` groups.
+
+---
+
+## 1. Baseline
+
+### Suite size (Blackhole, `-m "not perf and not quasar and not accuracy"` — what llk-e2e runs)
+
+| | tests | share |
+|---|---:|---:|
+| **whole e2e collection** | **237,739** | 100% |
+| `test_math_matmul.py` | 150,360 | 63.2% |
+| `test_unpack_matmul.py` | 36,416 | 15.3% |
+| `test_matmul_custom.py` + `test_matmul.py` | 13,664 | 5.7% |
+| **all `*sfpu*` files together** | **11,325** | **4.8%** |
+| — `test_eltwise_unary_sfpu.py` | 6,662 | 2.8% |
+| — `test_eltwise_binary_sfpu.py` | 1,878 | 0.8% |
+| — `test_sfpu_reduce.py` | 1,622 | 0.7% |
+| everything else | 25,974 | 10.9% |
+
+SFPU is 4.8% of the *count* but its tests are individually expensive, so it is a much
+larger share of wall time than the count suggests. `test_math_matmul` is the elephant.
+
+### The reference workload: `test_eltwise_unary_sfpu::test_eltwise_unary_sfpu`
+
+5,792 collected → **4,652 executed, 1,140 skipped (19.7%)**, 570 unique ELFs.
+
+| run | wall |
+|---|---:|
+| 1st (cold artefact dir) | **661 s** |
+| 2nd, same `RUNNER_TEMP` | **658 s** |
+
+**The second run is not faster.** `TestConfig` wipes the artefact directory at session
+start whenever `BUILD_MODE` is `DEFAULT` or `PRODUCE`
+([`test_config.py:881-887`](../../tests/python_tests/helpers/test_config.py#L881-L887)),
+so a plain `pytest` invocation — which is what the entire e2e lane and every local run
+uses — recompiles all 570 ELFs every time. Within a single session the cache works
+(4,652 tests share 570 ELFs, ~8:1); across sessions there is no reuse at all.
+
+---
+
+## 2. Where the time goes
+
+Instrumented run of the full unary sweep — every stage wrapped in a `perf_counter`
+accumulator loaded as a pytest plugin (no cProfile, so no bias toward the pure-Python
+stages). 4,652 executed tests, **805.5 s of 819 s wall accounted for = 98.3%**, so nothing
+significant sits outside this table.
+
+(This run's wall is 819 s against §1's 661 s baseline — run-to-run variance on a shared
+6-core box, not instrumentation cost: the wrappers add 8 calls per test. Use the *shares*
+below, applied to the 661 s baseline, which is what §4 does. The two reconcile on the
+compile stage, which can be checked independently: two smaller samples measured 438 ms and
+423 ms per unique ELF, and 570 ELFs × ~440 ms = ~250 s = 38% of 661 s, matching the 38.5%
+share. The instrumented run's compiles averaged 544 ms each under heavier load, which is
+where its extra ~150 s went.)
+
+| stage | seconds | ms / test | share |
+|---|---:|---:|---:|
+| **compile** (`build_elfs`) | 310.0 | 66.6 | **38.5%** |
+| **golden** (`UnarySFPUGolden.__call__`) | 228.6 | 49.1 | **28.4%** |
+| **stimuli pack + L1 write** (`StimuliConfig.write`) | 189.0 | 40.6 | **23.5%** |
+| result read + unpack (`collect_results`) | 55.8 | 12.0 | 6.9% |
+| stimuli generation (`generate_stimuli`) | 13.4 | 2.9 | 1.7% |
+| ELF load + launch (`run_elf_files`) | 4.4 | 0.9 | 0.5% |
+| compare vs golden (`passed_test`) | 4.1 | 0.9 | 0.5% |
+| device wait (`wait_for_tensix_operations_finished`) | 0.2 | 0.05 | 0.0% |
+| *accounted* | *805.5* | | *98.3%* |
+
+**The most important row is the bottom one: the device is 0.5% of this sweep.** Waiting on
+Tensix is 0.2 seconds out of 819, and launching the ELFs another 4.4. Everything else is
+host-side Python and `g++`. Any plan that tries to buy speed by touching the device path,
+the NOC transfers or the worker count is optimising 1% of the problem.
+
+Two drill-downs, from a cProfile run of the same sweep (shares there are skewed toward
+Python-heavy stages, but the *attribution within* a stage is exact):
+
+- Of the 189 s stimuli stage, **87% is `float_to_bfp8_block`** — 4,534,272 calls, driven by
+  9,304 `write_matrix` calls for 4,652 tests (exactly 2× — see idea F).
+- Of the 228.6 s golden stage, essentially all of it is the per-element listcomp, with
+  **28,958,720 `_torch_unary` calls** underneath it.
+
+`build_elfs` is ~100% real compilation, not bookkeeping: `generate_build_header` measures
+0.01 ms/call and `build_shared_artefacts` 0.42 ms/call, and the 4,082 calls that hit the
+in-session cache cost essentially nothing. The 570 actual compiles account for the whole
+stage.
+
+### Per-test cost across the suite
+
+| workload | tests | ms / test | unique ELFs |
+|---|---:|---:|---:|
+| `test_eltwise_unary_sfpu` (main sweep) | 4,652 executed | 142 | 570 (8:1) |
+| `test_math_matmul` (188-case stride sample) | 188 | 84 | 25 (7.5:1) |
+
+At those rates the whole 237,739-test e2e collection is **roughly 5–6 hours of serial
+work**, which the two `pytest-split` groups × `-n auto` have to fit into a 38-minute
+timeout each.
+
+---
+
+## 3. The ideas, ranked
+
+Ranking is by (projected saving) / (effort × risk). Each item says what evidence backs
+the projection, so a reviewer can disagree with the number rather than the vibe.
+
+### A — Stop recompiling every ELF on every run  ⭐ biggest single win
+
+**What.** The per-variant ELF cache already exists and already works *within* a session:
+`build_elfs` short-circuits on a `.build_complete` marker under
+`ARTEFACTS_DIR/<test>/<variant_id>/`, which is why 4,652 tests need only 570 compiles. The
+only reason it gains nothing *across* sessions is the unconditional
+`shutil.rmtree(ARTEFACTS_DIR)` at session start.
+
+**Why the wipe is there.** It is a *correctness guard*, not an oversight. `variant_id` is a
+sha256 of the resolved compile/link option string plus the include search dirs
+([`test_config.py:1299-1301`](../../tests/python_tests/helpers/test_config.py#L1299-L1301)) —
+so it captures the flags and the paths, but **not the contents of the headers those paths
+point at**. Edit `llk_math_eltwise_unary_sfpu.h` and every variant id is unchanged, so a
+surviving cache would silently serve stale ELFs. That is why the fix is not "delete the
+rmtree".
+
+**The actual fix.** Make the cache key sound, then stop wiping:
+1. Fingerprint the compile *inputs* — a content hash over the LLK header trees,
+   `tests/sources/`, `tests/helpers/` and the sfpi version — into one `TOOLCHAIN_KEY`.
+2. Put `TOOLCHAIN_KEY` in the artefact path
+   (`ARTEFACTS_DIR/<toolchain_key>/<test>/<variant_id>/`), so a source edit lands in a
+   fresh namespace instead of having to invalidate entries in place.
+3. Wipe only on an explicit `--rebuild`, and garbage-collect old key namespaces by age.
+
+A plain content hash of those trees is a good enough first cut. The precise version is
+`g++ -M` dependency output per variant, which is strictly better but more plumbing; start
+with the coarse key, since it errs toward over-invalidation rather than under.
+
+**Projected.** Removes the whole compile stage from every repeat run — see §4. Applies to
+the *entire* suite, not just SFPU. In CI it additionally needs an `actions/cache` keyed on
+`TOOLCHAIN_KEY`; hit rate then tracks how often LLK sources change, which for a
+PR-gate/nightly split is most of the time.
+
+**Effort** medium. **Risk** medium — a wrong key serves stale ELFs, which is exactly the
+failure mode the current wipe prevents. Mitigate by landing the fingerprint first, behind
+a flag, and diffing ELF hashes against a wiped run for one full sweep.
+
+### B — Give the e2e lane the producer/consumer split the perf lane already has
+
+**What.** The perf lane and the ttsim regression already do this:
+
+```
+pytest --compile-producer -n 10  -m "perf and not accuracy" ...   # compile only, no device
+pytest --compile-consumer -n 15  -m "perf and not accuracy" ...   # execute only
+```
+(`tests/run_llk_perf_blackhole.sh:38-41`, `run_ttsim_regression.sh:322`)
+
+The e2e lane does not — `tests/pipeline_reorg/llk_e2e_tests.yaml` runs plain
+`pytest -n auto`, so every worker interleaves `g++` with holding a Tensix core.
+
+**Why it helps even without A.** Compile is pure CPU with no device dependency, so the
+producer pass can run at a much higher `-n` than the device pass (the perf lane uses 10
+vs 15 for exactly this reason) and, better, on a CPU-only runner *before* the device
+runner is allocated. `_collapse_runtime_only_variants`
+([`llk_pytest_plugin.py:565-593`](../../tests/python_tests/helpers/llk_pytest_plugin.py#L565-L593))
+already dedupes the producer pass down to one item per compile key.
+
+**Projected.** Moves the compile stage off the device-runner critical path. Combined with
+A it is close to free on repeat runs.
+
+**Effort** small — the flags exist and are proven in-tree. **Risk** low.
+
+### C — Collapse the `throttle` 1–5 axis in `test_math_matmul`  ⭐ biggest count reduction
+
+**What.** `test_math_matmul` is 150,360 tests. The throttle axis accounts for almost all of it:
+
+| throttle | tests |
+|---:|---:|
+| 0 (tiny tiles only) | 11,320 |
+| 1 | 27,808 |
+| 2 | 27,808 |
+| 3 | 27,808 |
+| 4 | 27,808 |
+| 5 | 27,808 |
+
+`throttle` is consumed in exactly one place — `THROTTLE_LEVEL(throttle)` in the compile
+templates ([`test_math_matmul.py:220`](../../tests/python_tests/test_math_matmul.py#L220)).
+The stimuli, the golden and the assertion never see it, so all five levels assert the
+*same expected value on the same inputs*. On the kernel side the levels differ only in how
+many NOPs are interleaved between MVMULs to cap throughput — 1→73%, 2→67%, 3→50%, 4→40%,
+5→33% (`tt_llk_blackhole/llk_lib/llk_math_matmul.h:547`) — plus the per-level replay-buffer
+length.
+
+**The proposal.** Keep one representative non-zero level across the full
+format × dims × fidelity matrix, and add a *dedicated* throttle sweep that covers all five
+levels over a small slice (all 5 levels × 4 fidelities × a handful of format/dim points ≈
+a few hundred tests). That preserves the coverage that actually differs per level — the
+`replay_buff_len_throttle` bookkeeping, where a mismatch would corrupt results — without
+multiplying it by 27,808.
+
+**Projected.** ~111,000 tests removed = **47% of the entire e2e collection**. And because
+throttle is a *compile-time* parameter, it also cuts `test_math_matmul`'s ELF count by
+~5×, and compile is the expensive half under §2's numbers.
+
+**Effort** small (a change to `ALL_TEST_PARAMS`). **Risk** medium, and it is a **coverage
+decision, not a refactor** — it needs the matmul owner's sign-off, not a unilateral edit.
+Level 0 vs non-zero is a genuine structural difference (a different MOP and an extra
+fidelity-clear addrmod) and must stay fully covered.
+
+### D — Vectorise `UnarySFPUGolden`  ⭐ the SFPU-specific win
+
+**What.** The golden for every unary SFPU op is computed **one scalar at a time in
+Python**:
+
+```python
+# golden_generators.py:2582
+op_res = [self.ops[operation](x) for x in result.tolist()[window]]
+```
+
+and 33 of those ops route through `_torch_unary`
+([`golden_generators.py:2702`](../../tests/python_tests/helpers/golden_generators.py#L2702)),
+which builds a **0-d `torch.tensor` per element** and calls `.item()`. Over the sweep that
+is 28,958,720 `_torch_unary` calls, 51,174,704 `torch.tensor` constructions and 50,893,356
+`.item()` calls. `EltwiseBinaryGolden`, `MatmulGolden` and the
+rest of the golden layer are already fully vectorised — `UnarySFPUGolden` is the outlier.
+
+**Prototype, validated.** The replacement is three lines:
+
+```python
+def torch_unary_vec(t, torch_fn, is_exponent_b):
+    r = torch_fn(t.float())
+    if not is_exponent_b:                     # A-exponent dest: inf -> NaN
+        r = torch.where(r.isinf(), torch.full_like(r, math.nan), r)
+    return r
+```
+
+Checked **bit-exact** (NaN-payload-insensitive) against the scalar path for
+sqrt/rsqrt/log/exp/sin/erf/tanh × {exponent_b, not exponent_b} on a 32,768-element
+population seeded with ±0, ±inf, NaN, subnormals and format-max values — **0 differing
+bits in all 14 combinations**. Speedups at 32,768 elements: 10× (exp/erf/tanh/log) to
+1,700× (sqrt/rsqrt).
+
+**Effort** medium — the registry has 118 ops; the 33 `_torch_unary` ones convert
+mechanically, the rest need case-by-case review (some are `math.*` predicates that
+vectorise trivially, a few are genuinely elementwise-irregular). **Risk** low: the
+existing scalar path is a perfect oracle, so each op can be proven bit-identical before
+the loop is deleted. Do it op-family at a time behind a shared helper.
+
+Also applies to `_call_integer`
+([`golden_generators.py:3026`](../../tests/python_tests/helpers/golden_generators.py#L3026)),
+the same pattern on the integer SFPU path.
+
+### E — Vectorise the BFP pack/unpack helpers  ⭐ suite-wide
+
+**What.** `float_to_bfp8_block` ([`pack.py:150`](../../tests/python_tests/helpers/pack.py#L150))
+does bit manipulation by formatting each value as a **binary string**:
+
+```python
+def bfloat16_to_binary(value):
+    float_value = struct.unpack("<I", struct.pack("<f", value))[0]
+    bfloat16_value = (float_value & 0xFFFF0000) >> 16
+    return f"{(bfloat16_value >> 8) & 0xFF:08b}{bfloat16_value & 0xFF:08b}"
+```
+
+then slices the string and `int(s, 2)`s it back, per element. Over the sweep: 4,534,272
+calls to `float_to_bfp8_block`, and beneath them **72,548,352 calls to
+`bfloat16_to_binary`** and **88,486,552 `struct.pack` calls**. It also iterates a torch
+tensor element-wise (`for value in block`), which shows up as 4,568,272 `Tensor.unbind`
+calls costing 51 s on their own.
+
+**Prototype, validated.** A numpy version is in §8. Verified **byte-identical** — both shared
+exponents and all mantissas — against `float_to_bfp8_block` on three populations
+(uniform, wide-dynamic-range, all-subnormal), each seeded with ±0/±inf/NaN/1e30/1e-30.
+**58×–68× faster.**
+
+One subtlety the prototype had to reproduce rather than "fix": `binary_str[9:-1]` keeps
+bits 9–14 of the 16-bit word, i.e. it **drops the bf16 mantissa LSB**, then prepends the
+implicit 1 for a *7-bit* explicit mantissa. The obvious `(bf16 & 0x7F) | 0x80` is 8 bits
+and does not match. That is why the byte-comparison test matters.
+
+**Scope.** Every test in the suite with a Bfp8_b / Bfp4_b / Bfp2_b operand or result, not
+just SFPU. The mirror-image `_bfp_to_float_block`
+([`unpack.py:125`](../../tests/python_tests/helpers/unpack.py#L125)) still loops per datum
+with a memo dict and takes the same treatment.
+
+**Effort** small-medium. **Risk** low — byte-comparable against the current implementation.
+
+### F — Stop generating, packing and DMA-ing an operand the unary kernels never read
+
+**What.** Every unary SFPU test asks `generate_stimuli` for a full `src_B`
+([`test_eltwise_unary_sfpu.py:1140-1146`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L1140-L1146))
+and hands it to `StimuliConfig`, which unconditionally packs it and writes it to L1
+([`stimuli_config.py:664`](../../tests/python_tests/helpers/stimuli_config.py#L664)).
+`sources/eltwise_unary_sfpu_test.cpp` contains **zero references to `buffer_B`**. The
+profile shows `write_matrix` called 9,304 times for 4,652 tests — exactly 2× — so half of
+the stimuli-write stage is spent on an operand no kernel reads.
+
+**Fix.** `StimuliConfig` already has the machinery: `_OPTIONAL_OPERAND_SPECS` makes S/T/C
+optional. Move B into it (keeping the L1 address reservation, which the generated
+`params.h` declares) and let the unary driver omit it.
+
+**Projected.** Half the stimuli-write stage for the unary sweep, plus one fewer device
+write per test. Largely subsumed by E — once packing is ~free, only the DMA remains — but
+worth doing on its own for clarity.
+
+**Effort** small. **Risk** low.
+
+### G — Balance the CI split by duration, not by test count
+
+**What.** CI runs `pytest-split --splits 2 --group N`, and there is **no `.test_durations`
+file anywhere in the repo** and no `--store-durations` in any workflow. pytest-split's own
+fallback is explicit about what that means:
+
+```
+[pytest-split] No test durations found. Pytest-split will split tests evenly
+when no durations are found.
+```
+(`pytest_split/plugin.py:143-146`)
+
+So the two groups are balanced by *count*, across a suite whose per-test cost spans more
+than an order of magnitude (cheap `test_math_matmul` cases vs `[128,256]` Bfp8_b SFPU
+cases). One group approaches the 38-minute timeout while the other idles.
+
+**Fix.** `--store-durations` on one scheduled run, commit `.test_durations`, refresh it
+periodically. Nothing else changes.
+
+**Projected.** Recovers up to half the current imbalance on the critical path.
+**Not yet quantified** — it needs one instrumented CI run to measure the actual skew, and
+that is the first thing to do here.
+
+**Effort** trivial. **Risk** none.
+
+### H — Filter unconditional skips at parametrize time instead of in the test body
+
+**What.** 1,140 of 5,792 unary-sweep cases (19.7%) skip on Blackhole. 248 of those skip
+*unconditionally on every arch*:
+
+- `ReluMin` — 168 cases, `pytest.skip` at
+  [`test_eltwise_unary_sfpu.py:437`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L437)
+  (blocked on tt-llk#1120), yet the op is listed in `BROAD_SWEEP_OPS` and generates its
+  whole matrix.
+- `Tanh` + `ApproximationMode.Yes` — 80 cases, skipped at line 441.
+
+The remaining ~890 are the Blackhole format guards (`_skip_bh_unless_fp32` /
+`_skip_bh_unsupported_float_combo`). Those are equally movable, because
+`TestConfig.CHIP_ARCH` is bound in `pytest_configure` — i.e. before collection — so the
+format lists can be filtered when the params are built rather than rejected per test.
+
+**Projected.** Near zero in wall time; a skip is cheap. The value is that the two together
+remove ~20% of the collected count, which shrinks the xdist work queue and the JUnit
+report, and stops a 20% skip rate from sitting between you and the real coverage number.
+Treat this as hygiene that makes the other measurements honest, not as speed.
+
+**Effort** small. **Risk** low.
+
+---
+
+## 4. Projections
+
+> **Status: D, E, F and H are implemented and measured.** The projections in this section
+> are the *pre-implementation* estimates, kept as written so they can be compared against
+> what actually happened. The measured outcome is below; where the two disagree, the
+> measured numbers are the ones to trust.
+>
+> ### Measured outcome (D + E + F + H)
+>
+> Back-to-back runs of `test_eltwise_unary_sfpu::test_eltwise_unary_sfpu` on the p150,
+> same machine state (compile 233.9 s before vs 234.1 s after confirms comparability):
+>
+> | | before | after |
+> |---|---:|---:|
+> | wall | 609 s | **364 s** (−40%, 1.67x) |
+> | non-compile work | 364.8 s | **121.2 s** (3.0x) |
+> | outcome | 4652 passed, 1140 skipped | 4652 passed, **0 skipped** |
+>
+> | stage | before ms/test | after ms/test | factor |
+> |---|---:|---:|---:|
+> | compile (untouched) | 50.28 | 50.32 | 1.0x |
+> | golden (D) | 36.24 | 13.61 | **2.7x** |
+> | stimuli pack + write (E, F) | 29.69 | 0.82 | **36x** |
+> | stimuli generation (F) | 2.00 | 1.23 | 1.6x |
+> | result read + unpack | 9.05 | 9.03 | 1.0x |
+>
+> Where the estimates were wrong, and why:
+>
+> - **D came in at 2.7x, not the projected ~15x.** The projection assumed every op could
+>   be vectorised. 26 of 114 cannot: 18 because torch selects a different kernel for a
+>   1024-element tensor than for the 0-d tensor the scalar path builds and the answers
+>   differ in the last fp32 bit, and 8 because they are not elementwise-unary-float ops
+>   at all. Forcing all 18 through torch anyway *was* tried: it reaches 2.34 ms/test
+>   (15.5x) and the main sweep passes, but it fails
+>   `test_eltwise_unary_sfpu_edges[Float32->Float32, GeluAppx, dest_acc=Yes]` — on an
+>   fp32 Dest there is no 16-bit rounding to absorb the 1-ULP shift. Reverted.
+> - **E beat its projection** (36x on the stage vs the estimated ~58x on the function
+>   alone, which is the same thing measured end-to-end including the DMA that remains).
+> - **F is now worth almost nothing on its own**, exactly as §4 predicted once E lands:
+>   the packing it avoided is already free.
+> - **H was projected as ~0 wall and delivered ~0 wall.** Its value is that the sweep now
+>   reports 4652/0 instead of 4652/1140, and collection dropped 5792 -> 4652 — exactly
+>   the number that used to pass, which is the invariant proving nothing was lost.
+>
+> The 1-ULP exclusions are enforced by
+> `test_unary_sfpu_golden_vectorised.py`, and the BFP packer by
+> `test_bfp_pack_vectorised.py`; both keep the per-element implementation as the oracle
+> rather than deleting it.
+
+
+Savings are expressed against the **661 s un-instrumented baseline** for
+`test_eltwise_unary_sfpu::test_eltwise_unary_sfpu`, using the §2 stage shares. Speedup
+factors are the measured prototype numbers; where a factor is assumed conservatively the
+table says so.
+
+E and F both attack the stimuli stage, so their standalone savings overlap and must not be
+added. The cumulative figures below apply E first (which makes packing nearly free) and
+then count only F's residual — the DMA write itself.
+
+### On the reference SFPU sweep (serial, 661 s baseline)
+
+| idea | stage attacked | stage cost | after | saved | Δ sweep | confidence |
+|---|---|---:|---:|---:|---:|---|
+| **D** vectorise `UnarySFPUGolden` | golden | 188 s | ~13 s | 175 s | **−26%** | high — prototype bit-exact, ≥15× assumed vs 10–1700× measured |
+| **E** vectorise BFP pack | 87% of stimuli write | 135 s | ~2 s | 133 s | **−20%** | high — prototype byte-identical, 58–68× measured |
+| **F** drop the unused `buffer_B` | operand B's half of stimuli write | 155 s | 77 s | 77 s | **−12%** alone, **−1.5%** if E lands first | high — kernel provably never reads it |
+| **A** sound artefact cache | compile, on repeat runs | 254 s | 0 s | 254 s | **−38%** | high on the saving, medium on the key being sound |
+| **B** producer/consumer split | compile, off the device pass | 254 s | moved | — | −38% of *device-runner* wall | high |
+| **H** drop unconditional skips | collection only | — | — | ~0 s | ~0% | hygiene, not speed |
+| E's read-side twin (`_bfp_to_float_block`) | part of result read | ≤46 s | — | unmeasured | ≤−7% | medium — same pattern, not yet profiled apart |
+
+**Cumulative, cold single run** (compile still paid inline):
+661 s → 343 s, **−48%**.
+
+**Cumulative, repeat run or with a sound artefact cache** (A landed):
+661 s → **~90 s, −86% (7.3×)** — and none of that comes from doing less testing or less
+device work. Composition of the remaining 90 s: result read 46 s, golden 13 s, stimuli
+10 s, generation 13 s, launch/compare 5 s, compile 0 s.
+
+That residual is dominated by the result-read path, which is the natural next target once
+D/E/F land — the same numpy treatment applied to `unpack_res_tiles` / `_bfp_to_float_block`.
+
+### Across the whole suite
+
+| idea | mechanism | scope | projected |
+|---|---|---|---|
+| **C** collapse `throttle` 1–5 | removes ~111,000 tests *and* ~4/5 of `test_math_matmul`'s ELFs | `test_math_matmul` | **−47% of the entire e2e collection**; at the measured 84 ms/test that is ~2.6 h of serial work |
+| **E** vectorise BFP pack | every test with a Bfp8_b/Bfp4_b/Bfp2_b operand or result | suite-wide | proportional to each test's BFP share; 87% of the stimuli stage where it applies |
+| **A** + **B** artefact cache & producer split | compile is 38.5% of a sweep and ~44% of the math_matmul sample | suite-wide | up to −40% of repeat-run wall time |
+| **G** duration-balanced split | removes group skew | CI only | unquantified — measure first |
+| **D** vectorise `UnarySFPUGolden` | unary SFPU goldens only | 4.8% of the suite by count, more by time | −26% of the SFPU sweeps |
+
+**Order-of-magnitude summary.** C is the only idea that changes *how many* tests run, and
+it is worth about as much as everything else combined. A/B/D/E/F change only *how fast the
+same tests run*, and together they are worth roughly a 2× on a cold run and a 7× on a
+repeat run of the SFPU sweeps. Nothing in this plan touches device time, because device
+time is 0.5%.
+
+---
+
+## 5. Deliberately not recommended
+
+### The half-built golden/stimuli disk cache
+
+`--stimuli-only` / `--use-stimuli` exist and work: they flip `GeneratorProxy.MODE`, swap
+`get_golden_generator` for `get_golden_proxied`, and load `golden.pt` from disk instead of
+computing it ([`test_config.py:855-877`](../../tests/python_tests/helpers/test_config.py#L855-L877),
+[`golden_generators.py:479-565`](../../tests/python_tests/helpers/golden_generators.py#L479-L565)).
+
+Do not build on it:
+
+- **No workflow or script uses either flag.** `GeneratorProxy.MODE` is assigned nowhere
+  else, so `get_golden_proxied` raises `ValueError("GeneratorProxy mode not set")` if it is
+  ever reached by another path.
+- **The cache key is a sha256 of `PYTEST_CURRENT_TEST`** — the test *name*. Rename a
+  parametrize id and every entry silently misses; change a test *body* or a golden's maths
+  and every entry silently **hits** and serves a stale golden. That is the wrong direction
+  of failure for a correctness oracle.
+- **It only half-works anyway**: `load_from_cache()` runs *after* the test body has already
+  called `generate_stimuli`, so the stimuli are generated and then overwritten. Only the
+  golden cost is actually avoided.
+- D and E make it pointless. Once the golden is vectorised it is faster to recompute than
+  to `torch.load` it.
+
+Either wire it up deliberately with a content-addressed key, or delete it. Leaving a dark
+caching path next to a correctness oracle is a trap.
+
+### Trimming the SFPU format or op matrix
+
+Tempting because `test_eltwise_unary_sfpu` looks huge, but it is 2.8% of the suite and the
+matrix is where the real bugs live — the broad/standard profile split
+([`test_eltwise_unary_sfpu.py:63-84`](../../tests/python_tests/test_eltwise_unary_sfpu.py#L63-L84))
+is already a deliberate cost/coverage tradeoff, and the file documents measured
+format-specific divergences (approximate exp's rtol overshoot, the signed-zero
+`unpack_to_dest` partition) that only exist because the matrix is wide. Spend the effort on
+D/E/F, which make the same coverage cheaper, rather than on buying speed with coverage.
+
+### Raising `-n` on the device pass
+
+The device is not the bottleneck — `run_elf_files` plus the device wait is a low
+single-digit percentage of the sweep (§2). Each xdist worker already gets its own Tensix
+core ([`test_config.py:825-836`](../../tests/python_tests/helpers/test_config.py#L825-L836)),
+so the ceiling is host CPU, not Tensix. A wider CI runner does buy real parallelism — but
+it buys it against a workload that is 98% Python and `g++`, so the lever that matters is
+still reducing that work (D, E, F, A), not adding workers on top of it. Worth noting the
+corollary: every one of D/E/F makes each xdist worker cheaper, which raises the effective
+`-n` a given runner can sustain.
+
+---
+
+## 6. Suggested order
+
+1. **G** — one instrumented CI run to measure the split skew, then commit `.test_durations`.
+   Trivial, zero risk, and it tells you how much of the current wall time is just imbalance.
+2. **E** then **D** — the two vectorisations. Both have validated bit-exact prototypes and
+   the current code is its own oracle. E first: it is smaller, suite-wide, and the
+   byte-comparison harness it needs is reusable for D.
+3. **F**, **H** — small, local, ride along with the SFPU work.
+4. **B** — producer/consumer for the e2e lane. Proven pattern already in-tree.
+5. **A** — the sound artefact cache. Highest payoff, but it must land *after* B, because
+   the producer/consumer split is what makes a persistent artefact namespace useful, and it
+   needs the ELF-hash diff harness to be trustworthy.
+6. **C** — the throttle axis. Land last, not because it is hard, but because it is the one
+   item that trades coverage for time and therefore needs a decision from the matmul owner
+   rather than a patch.
+
+Steps 1–5 are pure speed with no coverage change. Step 6 is the only one that changes what
+is tested — keep it separable so it can be reverted independently.
+
+---
+
+## 7. Reproducing the measurements
+
+```bash
+cd tt_metal/tt-llk/tests/python_tests
+export CHIP_ARCH=blackhole
+export RUNNER_TEMP=$(mktemp -d)          # isolated artefact root per variant
+
+# suite size
+pytest --collect-only -q . -m "not perf and not quasar and not accuracy" | tail -1
+
+# reference workload, serial
+time pytest -q --no-header --override-ini=log_cli=false \
+    test_eltwise_unary_sfpu.py::test_eltwise_unary_sfpu
+
+# unique ELFs actually built
+find "$RUNNER_TEMP" -name .build_complete | wc -l
+
+# per-stage wall time: wrap build_elfs / StimuliConfig.write / collect_results /
+# UnarySFPUGolden.__call__ / generate_stimuli in a perf_counter accumulator loaded as a
+# pytest plugin. cProfile also works but inflates the pure-Python stages by ~35% relative
+# to the subprocess-bound compile stage, so it is fine for ranking and wrong for shares.
+```
+
+Do **not** measure with a reused `RUNNER_TEMP` and assume the build is warm: the artefact
+wipe described in §1 means it never is.
+
+---
+
+## 8. Appendix — the validated prototypes
+
+Both are drop-in replacements for the current hot loops and were checked against the
+existing code as the oracle. Neither is committed anywhere; they are here so the
+projections in §4 can be re-derived rather than trusted.
+
+### D — `UnarySFPUGolden._torch_unary`, vectorised
+
+```python
+def torch_unary_vec(t: torch.Tensor, torch_fn, is_exponent_b: bool) -> torch.Tensor:
+    r = torch_fn(t.float())
+    if not is_exponent_b:                      # A-exponent dest: inf -> NaN
+        r = torch.where(r.isinf(), torch.full_like(r, math.nan), r)
+    return r
+```
+
+Validation: bit-exact (NaN-payload-insensitive) vs the scalar path for
+sqrt / rsqrt / log / exp / sin / erf / tanh × {exponent_b, not exponent_b} on a
+32,768-element population seeded with ±0, ±inf, NaN, subnormals and format-max values —
+**0 differing bits in 14/14 combinations**. 10×–1700×.
+
+### E — `float_to_bfp8_block`, vectorised
+
+```python
+def bfp8_blocks_vec(t: torch.Tensor):
+    x = t.to(torch.float32).contiguous()
+    u = x.view(torch.int32).numpy().astype(np.uint32)
+    bf16 = (u >> 16) & 0xFFFF
+    s = (bf16 >> 15) & 1
+    e = (bf16 >> 7) & 0xFF
+    # The scalar path keeps bits 9..14 of the 16-bit word -- i.e. it DROPS the bf16
+    # mantissa LSB ("remove last") -- then prepends the implicit 1, giving a 7-bit
+    # explicit mantissa. Reproduce exactly; do NOT "fix" this to 8 bits.
+    m = ((bf16 >> 1) & 0x3F) | 0x40
+    m = m.reshape(-1, 16); e = e.reshape(-1, 16); s = s.reshape(-1, 16)
+    shared = e.max(axis=1, keepdims=True)
+    d = (shared - e).astype(np.int64)
+    guard = np.where(d > 0, (m >> np.maximum(d - 1, 0)) & 1, 0)     # RNE, ties away
+    shifted = np.where(d > 0, (m >> np.minimum(d, 63)) + guard, m)
+    mag = (shifted & 0x7F).astype(np.uint32)
+    out = np.where(mag != 0, (s << 7) | mag, 0).astype(np.uint8)    # flush -0 to +0
+    return shared.reshape(-1).astype(int).tolist(), out.reshape(-1).tolist()
+```
+
+Validation: byte-identical shared exponents **and** mantissas vs `float_to_bfp8_block` on
+three populations (uniform, wide-dynamic-range, all-subnormal), each seeded with
+±0 / ±inf / NaN / 1e30 / 1e-30. **58×–68×.**
+
+The mantissa-LSB subtlety is the whole reason this needs a byte-comparison test and not a
+value-comparison test: the "obvious" `(bf16 & 0x7F) | 0x80` passes a tolerance check and
+produces different bytes.
+
+### Suggested landing pattern for both
+
+1. Add the vectorised function next to the scalar one.
+2. Add a test that asserts the two agree **bitwise** over a seeded population that includes
+   the specials, parametrised over every op / format the scalar path supports.
+3. Switch the caller.
+4. Delete the scalar path in a follow-up, once the agreement test has run in nightly.
+
+Step 2 is the deliverable that makes steps 3 and 4 safe, and it is reusable for the
+`_call_integer` and `_bfp_to_float_block` follow-ups.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2769,10 +2769,11 @@ class UnarySFPUGolden:
     def _vec_relu_max(self, t, threshold):
         """Vectorised ``sfpu_relu_max``: total-order min, then a sign-bit relu clamp.
 
-        Uses ``sfpu_order_key_elementwise`` -- the same remap the scalar
-        ``sfpu_total_order_key`` applies -- so a NaN outranks the threshold and is
-        replaced by it, and -0.0 clamps to +0.0. Both are properties of the kernel's
-        SFPSWAP/SFPSETCC pair, not of IEEE min/max, so torch.clamp is not a substitute.
+        The min goes through ``_vec_sfpu_min`` (i.e. ``sfpu_min_elementwise``) -- the
+        same total-order remap the scalar ``sfpu_total_order_key`` applies -- so a NaN
+        outranks the threshold and is replaced by it, and -0.0 clamps to +0.0. Both are
+        properties of the kernel's SFPSWAP/SFPSETCC pair, not of IEEE min/max, so
+        torch.clamp is not a substitute.
 
         The *values* stay in float64 while only the *keys* go through fp32, which is
         what the scalar pair does: sfpu_total_order_key struct-packs an fp32 to rank the
@@ -2780,38 +2781,28 @@ class UnarySFPUGolden:
         fp32 and carrying the value in fp32 too costs a last-bit divergence on
         Hardsigmoid, whose input is an affine expression evaluated in double.
         """
-        d = t.to(torch.float64)
-        thresh = torch.full_like(d, threshold)
-        clamped = torch.where(
-            sfpu_order_key_elementwise(d) <= sfpu_order_key_elementwise(thresh),
-            d,
-            thresh,
-        )
+        clamped = self._vec_sfpu_min(t.to(torch.float64), threshold)
         return torch.where(
             sfpu_order_key_elementwise(clamped) < 0, torch.zeros_like(clamped), clamped
         )
 
     @staticmethod
     def _vec_sfpu_min(d, scalar):
-        """``sfpu_min`` over a tile: rank under the SFPU total order, keep the value.
+        """``sfpu_min`` against a scalar over a tile -- ``sfpu_min_elementwise``, broadcast.
 
-        As in ``_vec_relu_max``, the comparison is on the fp32 order key while the
-        returned value stays in *d*'s dtype -- the scalar ``sfpu_min`` ranks via
+        Only the broadcast is new: the module-level ``sfpu_min_elementwise`` is already
+        the total-order min, and this is it against a filled tensor. The comparison
+        therefore happens on the fp32 order key while the returned value stays in *d*'s
+        dtype, which is what the scalar ``sfpu_min`` does -- it ranks via
         ``sfpu_total_order_key`` (which struct-packs an fp32) but returns its operand
         untouched.
         """
-        other = torch.full_like(d, scalar)
-        return torch.where(
-            sfpu_order_key_elementwise(d) <= sfpu_order_key_elementwise(other), d, other
-        )
+        return sfpu_min_elementwise(d, torch.full_like(d, scalar))
 
     @staticmethod
     def _vec_sfpu_max(d, scalar):
-        """``sfpu_max`` over a tile. See ``_vec_sfpu_min``."""
-        other = torch.full_like(d, scalar)
-        return torch.where(
-            sfpu_order_key_elementwise(d) >= sfpu_order_key_elementwise(other), d, other
-        )
+        """``sfpu_max`` against a scalar over a tile. See ``_vec_sfpu_min``."""
+        return sfpu_max_elementwise(d, torch.full_like(d, scalar))
 
     def _vec_sfpu_clamp(self, t, low, high):
         """``sfpu_clamp``: max-then-min under the total order, the kernel's order.
@@ -3622,8 +3613,9 @@ class UnarySFPUGolden:
         MathOperation.GreaterThanEqualZero: lambda self: (
             lambda d: (d >= 0.0).to(d.dtype)
         ),
-        # x if x >= 0 else slope * x -- the comparison keeps -0.0 on the negative arm,
-        # matching the scalar method.
+        # x if x >= 0 else slope * x. IEEE makes -0.0 >= 0.0 true, so -0.0 takes the
+        # *nonnegative* arm and is returned unchanged rather than scaled by the slope --
+        # the same arm, and the same -0.0, as the scalar _prelu.
         MathOperation.Prelu: lambda self: (
             lambda d: torch.where(d >= 0.0, d, self._PRELU_SLOPE * d)
         ),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2576,8 +2576,16 @@ class UnarySFPUGolden:
             )
 
         window = slice(start, start + elements_to_process)
+        # Whole-tile path where the op has one (see _VECTOR_TORCH_FNS); the per-element
+        # loop below otherwise. Both produce the same fp32 values -- proven bit-exact by
+        # test_unary_sfpu_golden_vectorised.py -- so everything downstream of op_tensor
+        # is shared and only the evaluation strategy differs.
+        vector_op = self._vector_op(operation)
         if whole_tensor_res is not None:
             op_res = whole_tensor_res.tolist()[window]
+            op_tensor = torch.tensor(op_res, dtype=torch.float32)
+        elif vector_op is not None:
+            op_tensor = vector_op(result[window]).to(torch.float32)
         else:
             op_res = [
                 (
@@ -2587,13 +2595,13 @@ class UnarySFPUGolden:
                 )
                 for x in result.tolist()[window]
             ]
+            op_tensor = torch.tensor(op_res, dtype=torch.float32)
 
         op_dtype = (
             torch.float32
             if data_format in (DataFormat.Bfp4_b, DataFormat.Bfp2_b)
             else format_dict[dst_format]
         )
-        op_tensor = torch.tensor(op_res, dtype=torch.float32)
         if operation not in self._NAN_SIGN_TRANSPARENT_OPS:
             # abs() clears the sign bit without disturbing the NaN payload, which is exactly
             # the canonicalisation wanted here. See _NAN_SIGN_TRANSPARENT_OPS.
@@ -2698,6 +2706,202 @@ class UnarySFPUGolden:
             return expected
         else:  # self.data_format == DataFormat.Float16:
             return math.nan
+
+    def _torch_unary_vec(self, t, torch_fn):
+        """Whole-tile ``_torch_unary``: apply *torch_fn* once, then the same NaN rule.
+
+        The scalar version below builds a 0-d tensor and calls ``.item()`` per element,
+        which over the unary sweep is ~51M tensor constructions. This is the same
+        arithmetic in one call.
+
+        The scalar path is kept as the oracle, not replaced:
+        ``test_unary_sfpu_golden_vectorised.py`` asserts the two agree **bit-exactly**
+        for every op in ``_VECTOR_TORCH_FNS``, and an op is only allowed into that table
+        once it does. That is what makes it safe for the two to coexist -- torch is free
+        to pick a different code path for a 1-element tensor than for a 1024-element one,
+        and for a few ops it does, so membership is a measured fact rather than a
+        judgement.
+        """
+        r = torch_fn(t.to(torch.float32))
+        if not self.data_format.is_exponent_B():
+            r = torch.where(r.isinf(), torch.full_like(r, torch.nan), r)
+        return r
+
+    def _torch_dst_vec(self, t, torch_fn):
+        """Whole-tile form of the ops that evaluate in the Dest dtype.
+
+        Mirrors ``torch_fn(torch.tensor(x, dtype=format_dict[self.dst_format])).item()``:
+        the op sees the Dest dtype, not fp32, because that is the precision the SFPU
+        actually works at. No inf->NaN substitution here -- unlike ``_torch_unary``,
+        these methods never had one.
+        """
+        return torch_fn(t.to(format_dict[self.dst_format]))
+
+    def _python_vec(self, t, fn):
+        """Whole-tile form of the ops whose scalar method is plain Python arithmetic.
+
+        Evaluated in **float64**, because that is what the scalar path does:
+        ``result.tolist()`` hands each element to the method as a Python float (a
+        double), so the op's own arithmetic happens in double and is rounded to fp32
+        exactly once, by the shared cast at the end of ``__call__``. Computing in fp32
+        here instead would round twice and diverge in the last bit -- which the
+        agreement test catches, so this is a measured requirement rather than a
+        precaution.
+        """
+        return fn(t.to(torch.float64))
+
+    def _vec_square(self, t):
+        """Vectorised ``_square``, keeping both of its non-finite branches.
+
+        Note what the scalar method does *not* do: x*x is evaluated in double, so an
+        fp32-representable 1e30 squares to a finite 1e60 and takes the ordinary return
+        path, only becoming an infinity later when the result is cast to fp32 --
+        without handle_infinite_numbers ever seeing it. Working in float64 reproduces
+        that; working in fp32 would route it through the infinity branch instead and
+        return NaN for a Float16 dest.
+        """
+        d = t.to(torch.float64)
+        r = d * d
+        infinite = self.handle_infinite_numbers(torch.inf)
+        r = torch.where(torch.isfinite(r), r, torch.full_like(r, infinite))
+        return torch.where(d.isnan(), d, r)
+
+    def _vec_relu_max(self, t, threshold):
+        """Vectorised ``sfpu_relu_max``: total-order min, then a sign-bit relu clamp.
+
+        Uses ``sfpu_order_key_elementwise`` -- the same remap the scalar
+        ``sfpu_total_order_key`` applies -- so a NaN outranks the threshold and is
+        replaced by it, and -0.0 clamps to +0.0. Both are properties of the kernel's
+        SFPSWAP/SFPSETCC pair, not of IEEE min/max, so torch.clamp is not a substitute.
+
+        The *values* stay in float64 while only the *keys* go through fp32, which is
+        what the scalar pair does: sfpu_total_order_key struct-packs an fp32 to rank the
+        operand, but sfpu_min/sfpu_relu_max then return the original double. Ranking in
+        fp32 and carrying the value in fp32 too costs a last-bit divergence on
+        Hardsigmoid, whose input is an affine expression evaluated in double.
+        """
+        d = t.to(torch.float64)
+        thresh = torch.full_like(d, threshold)
+        clamped = torch.where(
+            sfpu_order_key_elementwise(d) <= sfpu_order_key_elementwise(thresh),
+            d,
+            thresh,
+        )
+        return torch.where(
+            sfpu_order_key_elementwise(clamped) < 0, torch.zeros_like(clamped), clamped
+        )
+
+    @staticmethod
+    def _vec_sfpu_min(d, scalar):
+        """``sfpu_min`` over a tile: rank under the SFPU total order, keep the value.
+
+        As in ``_vec_relu_max``, the comparison is on the fp32 order key while the
+        returned value stays in *d*'s dtype -- the scalar ``sfpu_min`` ranks via
+        ``sfpu_total_order_key`` (which struct-packs an fp32) but returns its operand
+        untouched.
+        """
+        other = torch.full_like(d, scalar)
+        return torch.where(
+            sfpu_order_key_elementwise(d) <= sfpu_order_key_elementwise(other), d, other
+        )
+
+    @staticmethod
+    def _vec_sfpu_max(d, scalar):
+        """``sfpu_max`` over a tile. See ``_vec_sfpu_min``."""
+        other = torch.full_like(d, scalar)
+        return torch.where(
+            sfpu_order_key_elementwise(d) >= sfpu_order_key_elementwise(other), d, other
+        )
+
+    def _vec_sfpu_clamp(self, t, low, high):
+        """``sfpu_clamp``: max-then-min under the total order, the kernel's order.
+
+        Not ``torch.clamp``: a +NaN outranks every value, so the max leaves it and the
+        min lands it on *high*, where torch.clamp would keep IEEE semantics and return
+        NaN. See the scalar ``sfpu_clamp`` docstring.
+        """
+        d = t.to(torch.float64)
+        return self._vec_sfpu_min(self._vec_sfpu_max(d, low), high)
+
+    def _vec_cast_fp32_to_fp16a(self, t):
+        """Vectorised ``_cast_fp32_to_fp16a``: round the fp32 mantissa to 10 bits, RNE.
+
+        Reproduces the scalar bit-twiddle in torch integer ops. The exponent is left
+        alone -- this models sfpi::convert<vFloat16a>, which reduces mantissa precision
+        without clamping to the fp16 exponent range, so 1e30 stays finite.
+        """
+        bits = t.to(torch.float32).contiguous().view(torch.int32).to(torch.int64)
+        bits = bits & 0xFFFFFFFF
+        drop, halfway = 13, 1 << 12
+        lower_mask = (1 << drop) - 1
+        remainder = bits & lower_mask
+        truncated = bits & ~lower_mask
+        round_up = (remainder > halfway) | (
+            (remainder == halfway) & (((truncated >> drop) & 1) == 1)
+        )
+        rounded = torch.where(round_up, truncated + (1 << drop), truncated)
+        # A non-finite input passes through unchanged, carry and all.
+        non_finite = ((bits >> 23) & 0xFF) == 0xFF
+        out = torch.where(non_finite, bits, rounded)
+        return (out & 0xFFFFFFFF).to(torch.int32).view(torch.float32)
+
+    @staticmethod
+    def _drop_zero_sign(t):
+        """Map -0.0 to +0.0, leaving everything else alone.
+
+        ``math.floor``/``ceil``/``trunc`` return a Python **int**, so the scalar path
+        cannot preserve a negative zero: floor(-0.5) arrives as int 0 and becomes +0.0.
+        torch's float versions do preserve it. Reproduce the int behaviour rather than
+        the float one -- the golden's job is to say what the current oracle says, and a
+        signed zero is visible downstream (the pack path reads the sign bit).
+        """
+        return torch.where(t == 0, torch.zeros_like(t), t)
+
+    def _vec_sign(self, t):
+        """Vectorised ``_sign``: fp32 like the scalar method, and no inf->NaN rule."""
+        return torch.sign(t.to(torch.float32))
+
+    def _vec_i0(self, t):
+        """Vectorised ``_i0``, including its pre-check for the non-finite inputs.
+
+        torch.special.i0 returns NaN at +/-inf where the mathematics (and the kernel)
+        give +inf, so the scalar path intercepts those before calling torch. Mirror the
+        interception rather than the torch answer.
+        """
+        r = self._torch_unary_vec(t, torch.special.i0)
+        infinite = self.handle_infinite_numbers(torch.inf)
+        r = torch.where(t.isinf(), torch.full_like(r, infinite), r)
+        # NaN passes straight through in the scalar path (``return x``), payload and all.
+        return torch.where(t.isnan(), t.to(r.dtype), r)
+
+    def _vec_i1(self, t):
+        """Vectorised ``_i1_bessel``. Same interception as ``_vec_i0``, sign kept: I1 is
+        odd, so I1(+/-inf) = +/-inf."""
+        r = self._torch_unary_vec(t, torch.special.i1)
+        infinite = self.handle_infinite_numbers(torch.inf)
+        signed = torch.copysign(torch.full_like(r, infinite), t.to(r.dtype))
+        r = torch.where(t.isinf(), signed, r)
+        return torch.where(t.isnan(), t.to(r.dtype), r)
+
+    def _vector_op(self, operation):
+        """The whole-tile implementation of *operation*, or None if it has none.
+
+        Ops with no entry keep the per-element path in ``__call__``. Adding one here is
+        opt-in and gated on the bit-exactness test, so the fallback is always correct
+        and never silently worse than the scalar answer.
+        """
+        if operation in self._VECTOR_SPECIAL_OPS:
+            return self._VECTOR_SPECIAL_OPS[operation](self)
+        torch_fn = self._VECTOR_TORCH_FNS.get(operation)
+        if torch_fn is not None:
+            return lambda t: self._torch_unary_vec(t, torch_fn(self))
+        torch_fn = self._VECTOR_DST_TORCH_FNS.get(operation)
+        if torch_fn is not None:
+            return lambda t: self._torch_dst_vec(t, torch_fn(self))
+        py_fn = self._VECTOR_PY_FNS.get(operation)
+        if py_fn is not None:
+            return lambda t: self._python_vec(t, py_fn(self))
+        return None
 
     def _torch_unary(self, x, torch_fn) -> float:
         """Apply torch_fn to scalar x in fp32, then enforce the
@@ -3248,6 +3452,308 @@ class UnarySFPUGolden:
     _HARDSHRINK_LAMBDA = HARDSHRINK_LAMBDA
     _SOFTPLUS_BETA = SOFTPLUS_BETA
     _SOFTPLUS_THRESHOLD = SOFTPLUS_THRESHOLD
+
+    # sqrt(2) and sqrt(2*pi) as float64, for the vectorised _gelu_derivative. Computed
+    # with torch rather than math so the golden has a single numerics dependency; the
+    # agreement test confirms they are the same doubles the scalar method's math.sqrt
+    # produces, which is the only thing that matters here.
+    _SQRT_2 = float(torch.sqrt(torch.tensor(2.0, dtype=torch.float64)))
+    _SQRT_2PI = float(torch.sqrt(torch.tensor(2.0, dtype=torch.float64) * torch.pi))
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Whole-tile op table (idea D)
+    #
+    # Every entry names the *same* torch function its per-element method passes to
+    # _torch_unary, so the two paths are one edit apart and cannot drift in what they
+    # compute -- only in how many elements they compute at once. The values are
+    # `lambda self: ...` rather than bare functions so an op can read its dispatch
+    # constant off the instance, exactly as the scalar method does.
+    #
+    # Membership is not a judgement about which ops "should" vectorise: it is the set
+    # that test_unary_sfpu_golden_vectorised.py has shown to be bit-identical to the
+    # scalar path. Ops absent from this table fall back to the per-element loop, which
+    # stays correct -- just slower. Do not add an entry without running that test.
+    #
+    # MEASURED EXCLUSIONS -- these seven were tried and rejected, do not re-add them:
+    #
+    #   Atanh, Cbrt, Mish, Rpow, Selu, SigmoidAppx, Softplus
+    #
+    # torch evaluates each of them through a different kernel for a 1024-element tensor
+    # than for the 0-d tensor the scalar path builds, and the answers differ in the last
+    # fp32 bit (e.g. atanh(0.6318548) -> 0.7444976 vs 0.74449766; up to 419/1024
+    # elements affected for Cbrt). One ULP is far inside the tolerance passed_test
+    # applies, which is exactly why it must not be accepted here: it would make the
+    # sweep's pass/fail boundary depend on which kernel torch happened to select, and
+    # the golden's whole job is to be a stable oracle. They keep the per-element path.
+    # ─────────────────────────────────────────────────────────────────────────
+    _VECTOR_TORCH_FNS = {
+        MathOperation.Acos: lambda self: torch.acos,
+        MathOperation.Acosh: lambda self: torch.acosh,
+        MathOperation.Asin: lambda self: torch.asin,
+        MathOperation.Cos: lambda self: torch.cos,
+        MathOperation.Digamma: lambda self: torch.digamma,
+        MathOperation.Erf: lambda self: torch.erf,
+        MathOperation.Erfc: lambda self: torch.erfc,
+        MathOperation.Erfinv: lambda self: torch.erfinv,
+        MathOperation.Expm1: lambda self: torch.expm1,
+        MathOperation.Expm1Cw: lambda self: torch.expm1,
+        MathOperation.Fmod: lambda self: (
+            lambda t: torch.fmod(t, torch.tensor(self._FMOD_DIVISOR))
+        ),
+        MathOperation.Hardmish: lambda self: (
+            lambda t: t * torch.clamp(0.5 * t + 1.0, 0.0, 1.0)
+        ),
+        MathOperation.Lgamma: lambda self: torch.lgamma,
+        MathOperation.Log1p: lambda self: torch.log1p,
+        MathOperation.LogWithBase: lambda self: torch.log2,
+        MathOperation.Polygamma: lambda self: (
+            lambda t: torch.polygamma(self._POLYGAMMA_ORDER, t)
+        ),
+        MathOperation.Rdiv: lambda self: (lambda t: 2.0 / t),
+        MathOperation.Log: lambda self: torch.log,
+        MathOperation.Reciprocal: lambda self: torch.reciprocal,
+        MathOperation.ReciprocalCompat: lambda self: torch.reciprocal,
+        MathOperation.Remainder: lambda self: (
+            lambda t: torch.remainder(t, torch.tensor(self._REMAINDER_DIVISOR))
+        ),
+        MathOperation.Rsqrt: lambda self: torch.rsqrt,
+        MathOperation.RsqrtCompat: lambda self: torch.rsqrt,
+        MathOperation.Sin: lambda self: torch.sin,
+        MathOperation.Sqrt: lambda self: torch.sqrt,
+        MathOperation.SqrtCustom: lambda self: torch.sqrt,
+        MathOperation.Tan: lambda self: torch.tan,
+        MathOperation.UnaryPower: lambda self: (
+            lambda t: torch.pow(t, self._UNARY_POWER_EXP)
+        ),
+    }
+
+    # Ops whose per-element method does NOT go through _torch_unary but still builds a
+    # torch tensor per element -- `torch_fn(torch.tensor(x, dtype=format_dict[dst_format]))`
+    # -- so they evaluate in the Dest dtype and carry no inf->NaN substitution. Same
+    # bit-exactness rule and same test gate as _VECTOR_TORCH_FNS above.
+    #
+    # Fill is deliberately absent: its scalar method uses an in-place fill_ and __call__
+    # passes it a second argument, so it is not a plain unary map.
+    #
+    # MEASURED EXCLUSIONS -- tried and rejected, do not re-add:
+    #
+    #   Celu, Elu, Exp2, Gelu, GeluAppx, GeluTanh, Sigmoid, Silu   (last-bit ULP)
+    #   Softshrink                                                 (signed zero!)
+    #
+    # The first group is the same 0-d-vs-N-d kernel split as in _VECTOR_TORCH_FNS above.
+    # Softshrink is worse than a ULP and worth spelling out: torch.nn.functional
+    # .softshrink(-0.0) returns -0.0 for a 0-d tensor and +0.0 for a 1024-element one.
+    # The golden asserts the signed zero, and the pack path turns a sign bit into a
+    # visible result, so taking the vectorised answer would change what the sweep tests
+    # rather than just how fast it gets there.
+    _VECTOR_DST_TORCH_FNS = {
+        MathOperation.Exp: lambda self: torch.exp,
+        MathOperation.ExpWithBase: lambda self: (lambda t: torch.exp(0.5 * t)),
+        MathOperation.Lrelu: lambda self: (
+            lambda t: torch.nn.functional.leaky_relu(
+                t, negative_slope=LRELU_NEGATIVE_SLOPE
+            )
+        ),
+        MathOperation.ReluMin: lambda self: (
+            lambda t: torch.max(t, torch.tensor(RELU_MIN_THRESHOLD).to(t.dtype))
+        ),
+        MathOperation.Softsign: lambda self: torch.nn.functional.softsign,
+        MathOperation.Threshold: lambda self: (
+            lambda t: torch.nn.functional.threshold(t, THRESHOLD_T, THRESHOLD_V)
+        ),
+    }
+
+    # Ops whose scalar method is plain Python arithmetic on a double. Evaluated in
+    # float64 by _python_vec so the single fp32 rounding stays where it was; see that
+    # method. Same bit-exactness rule and same test gate as the tables above.
+    _VECTOR_PY_FNS = {
+        MathOperation.Abs: lambda self: torch.abs,
+        MathOperation.Add1: lambda self: (lambda d: d + 1.0),
+        MathOperation.Asinh: lambda self: torch.asinh,
+        MathOperation.Atan: lambda self: torch.atan,
+        MathOperation.Ceil: lambda self: (
+            lambda d: UnarySFPUGolden._drop_zero_sign(torch.ceil(d))
+        ),
+        MathOperation.Cosh: lambda self: torch.cosh,
+        MathOperation.Floor: lambda self: (
+            lambda d: UnarySFPUGolden._drop_zero_sign(torch.floor(d))
+        ),
+        # x - trunc(x), except that a non-finite input is returned unchanged: inf - inf
+        # would be NaN where the scalar method short-circuits on isfinite.
+        MathOperation.Frac: lambda self: (
+            lambda d: torch.where(
+                torch.isfinite(d),
+                d - UnarySFPUGolden._drop_zero_sign(torch.trunc(d)),
+                d,
+            )
+        ),
+        MathOperation.Identity: lambda self: (lambda d: d.clone()),
+        MathOperation.Isfinite: lambda self: (lambda d: torch.isfinite(d).to(d.dtype)),
+        MathOperation.Isinf: lambda self: (lambda d: torch.isinf(d).to(d.dtype)),
+        MathOperation.Isnan: lambda self: (lambda d: torch.isnan(d).to(d.dtype)),
+        MathOperation.Isneginf: lambda self: (
+            lambda d: (torch.isinf(d) & (d < 0)).to(d.dtype)
+        ),
+        MathOperation.Isposinf: lambda self: (
+            lambda d: (torch.isinf(d) & (d > 0)).to(d.dtype)
+        ),
+        MathOperation.Neg: lambda self: torch.neg,
+        MathOperation.Sinh: lambda self: torch.sinh,
+        MathOperation.Tanh: lambda self: torch.tanh,
+        MathOperation.Tanhshrink: lambda self: (lambda d: d - torch.tanh(d)),
+        MathOperation.TanhDerivative: lambda self: (
+            lambda d: 1.0 - torch.tanh(d) * torch.tanh(d)
+        ),
+        # Python's max(0.0, x) returns the *first* argument unless x compares greater,
+        # so a NaN and a -0.0 both come back as +0.0. torch.clamp(min=0) propagates the
+        # NaN instead, hence the explicit comparison.
+        MathOperation.Relu: lambda self: (
+            lambda d: torch.where(d > 0.0, d, torch.zeros_like(d))
+        ),
+        MathOperation.Signbit: lambda self: (lambda d: torch.signbit(d).to(d.dtype)),
+        MathOperation.LogicalNotUnary: lambda self: (lambda d: (d == 0).to(d.dtype)),
+        MathOperation.EqualZero: lambda self: (lambda d: (d == 0.0).to(d.dtype)),
+        MathOperation.NotEqualZero: lambda self: (lambda d: (d != 0.0).to(d.dtype)),
+        MathOperation.LessThanZero: lambda self: (lambda d: (d < 0.0).to(d.dtype)),
+        MathOperation.GreaterThanZero: lambda self: (lambda d: (d > 0.0).to(d.dtype)),
+        MathOperation.LessThanEqualZero: lambda self: (
+            lambda d: (d <= 0.0).to(d.dtype)
+        ),
+        MathOperation.GreaterThanEqualZero: lambda self: (
+            lambda d: (d >= 0.0).to(d.dtype)
+        ),
+        # x if x >= 0 else slope * x -- the comparison keeps -0.0 on the negative arm,
+        # matching the scalar method.
+        MathOperation.Prelu: lambda self: (
+            lambda d: torch.where(d >= 0.0, d, self._PRELU_SLOPE * d)
+        ),
+        MathOperation.Heaviside: lambda self: (
+            lambda d: torch.where(
+                d < 0.0,
+                torch.zeros_like(d),
+                torch.where(d > 0.0, torch.ones_like(d), torch.full_like(d, 0.5)),
+            )
+        ),
+        MathOperation.Trunc: lambda self: (
+            lambda d: UnarySFPUGolden._drop_zero_sign(torch.trunc(d))
+        ),
+        # float(round(x)) for a finite x. Python's round() returns an int, so -0.4
+        # rounds to +0.0 -- the same signed-zero loss as floor/ceil/trunc.
+        MathOperation.Round: lambda self: (
+            lambda d: torch.where(
+                torch.isfinite(d),
+                UnarySFPUGolden._drop_zero_sign(torch.round(d)),
+                d,
+            )
+        ),
+        MathOperation.Typecast: lambda self: (lambda d: d.clone()),
+        # Phi(x) + x * phi(x), the erf-based exact-gelu derivative.
+        MathOperation.GeluDerivative: lambda self: (
+            lambda d: 0.5 * (1.0 + torch.erf(d / self._SQRT_2))
+            + d * (torch.exp(-0.5 * d * d) / self._SQRT_2PI)
+        ),
+        # The legacy 3-region SFPLUT tanh, then 1 - t^2. Piecewise-linear, so the
+        # arithmetic is exact and only the bucket boundaries matter.
+        MathOperation.TanhDerivativeLut: lambda self: (
+            lambda d: 1.0
+            - torch.where(
+                d.abs() < 1.0,
+                0.90625 * d.abs(),
+                torch.where(d.abs() < 2.0, 0.09375 * d.abs() + 0.8125, 1.0),
+            )
+            ** 2
+        ),
+        # x where |x| > lambda, else 0 -- and a NaN fails that comparison, so it takes
+        # the 0 arm in the scalar method only after an explicit isnan pass-through.
+        MathOperation.Hardshrink: lambda self: (
+            lambda d: torch.where(
+                d.isnan(),
+                d,
+                torch.where(d.abs() > self._HARDSHRINK_LAMBDA, d, torch.zeros_like(d)),
+            )
+        ),
+        MathOperation.UnaryEq: lambda self: (
+            lambda d: (d == self._UNARY_COMP_THRESHOLD).to(d.dtype)
+        ),
+        MathOperation.UnaryNe: lambda self: (
+            lambda d: (d != self._UNARY_COMP_THRESHOLD).to(d.dtype)
+        ),
+        # The four ordered comparisons rank under the SFPU total order, not IEEE, so a
+        # NaN participates instead of making every compare false.
+        MathOperation.UnaryGt: lambda self: (
+            lambda d: (
+                sfpu_order_key_elementwise(d)
+                > sfpu_order_key_elementwise(
+                    torch.full_like(d, self._UNARY_COMP_THRESHOLD)
+                )
+            ).to(d.dtype)
+        ),
+        MathOperation.UnaryLt: lambda self: (
+            lambda d: (
+                sfpu_order_key_elementwise(d)
+                < sfpu_order_key_elementwise(
+                    torch.full_like(d, self._UNARY_COMP_THRESHOLD)
+                )
+            ).to(d.dtype)
+        ),
+        MathOperation.UnaryGe: lambda self: (
+            lambda d: (
+                sfpu_order_key_elementwise(d)
+                >= sfpu_order_key_elementwise(
+                    torch.full_like(d, self._UNARY_COMP_THRESHOLD)
+                )
+            ).to(d.dtype)
+        ),
+        MathOperation.UnaryLe: lambda self: (
+            lambda d: (
+                sfpu_order_key_elementwise(d)
+                <= sfpu_order_key_elementwise(
+                    torch.full_like(d, self._UNARY_COMP_THRESHOLD)
+                )
+            ).to(d.dtype)
+        ),
+        MathOperation.UnaryMax: lambda self: (
+            lambda d: UnarySFPUGolden._vec_sfpu_max(d, self._UNARY_MAX_MIN_VALUE)
+        ),
+        MathOperation.UnaryMin: lambda self: (
+            lambda d: UnarySFPUGolden._vec_sfpu_min(d, self._UNARY_MAX_MIN_VALUE)
+        ),
+        MathOperation.Xielu: lambda self: (
+            lambda d: torch.where(
+                d > 0.0,
+                self._XIELU_ALPHA_P * d * d + self._XIELU_BETA * d,
+                self._XIELU_ALPHA_N * (torch.expm1(d) - d) + self._XIELU_BETA * d,
+            )
+        ),
+    }
+
+    # Ops whose scalar method wraps a torch call in extra per-element handling, so the
+    # whole-tile version is a named method rather than a bare torch function.
+    _VECTOR_SPECIAL_OPS = {
+        MathOperation.I0: lambda self: self._vec_i0,
+        MathOperation.I1: lambda self: self._vec_i1,
+        MathOperation.Sign: lambda self: self._vec_sign,
+        MathOperation.Square: lambda self: self._vec_square,
+        MathOperation.CastFp32ToFp16a: lambda self: self._vec_cast_fp32_to_fp16a,
+        MathOperation.Clamp: lambda self: (
+            lambda t: self._vec_sfpu_clamp(t, CLAMP_MIN, CLAMP_MAX)
+        ),
+        MathOperation.Hardtanh: lambda self: (
+            lambda t: self._vec_sfpu_clamp(t, CLAMP_MIN, CLAMP_MAX)
+        ),
+        MathOperation.ReluMax: lambda self: (
+            lambda t: self._vec_relu_max(t, RELU_MAX_THRESHOLD)
+        ),
+        # The affine part is evaluated in float64 because the scalar method does it on a
+        # Python double before handing the result to sfpu_relu_max.
+        MathOperation.Hardsigmoid: lambda self: (
+            lambda t: self._vec_relu_max(
+                t.to(torch.float64) * self._HARDSIGMOID_SLOPE
+                + self._HARDSIGMOID_OFFSET,
+                1.0,
+            )
+        ),
+    }
 
     def _prelu(self, x):
         return x if x >= 0.0 else self._PRELU_SLOPE * x

--- a/tt_metal/tt-llk/tests/python_tests/helpers/pack.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/pack.py
@@ -126,6 +126,12 @@ def _bfp_prepare_blocks(tensor, block_size, num_faces, face_r_dim):
 def _bfp_collect_blocks(flattened_tensor, block_size, float_to_block_fn):
     """Iterate over BFP blocks, collecting shared exponents and mantissas.
 
+    Reference implementation. The packers call ``_bfp_quantize_blocks`` instead, which
+    is the same arithmetic in one numpy pass; this loop stays as the oracle that
+    ``test_bfp_pack_vectorised.py`` checks it against byte-for-byte. Do not delete it
+    as dead code -- it is the only per-element statement of the format, and it is what
+    makes the vectorised path safe to change.
+
     Args:
         flattened_tensor: Pre-processed tensor (output of _bfp_prepare_blocks).
         block_size: Elements per block (16 for all current BFP formats).
@@ -147,7 +153,81 @@ def _bfp_collect_blocks(flattened_tensor, block_size, float_to_block_fn):
     return exponents, all_mantissas
 
 
+def _bfp_quantize_blocks(flattened_tensor, block_size, magnitude_bits):
+    """Vectorised ``_bfp_collect_blocks`` + ``truncate_bfp8`` for one whole tile.
+
+    Produces byte-for-byte what the per-element reference path
+    (``_bfp_collect_blocks`` driving ``float_to_bfp{8,4,2}_block``) produces, in one
+    numpy pass instead of one Python loop iteration per datum. ``magnitude_bits`` is
+    7 for BFP8_b, 3 for BFP4_b and 1 for BFP2_b, matching ``truncate_bfp8``.
+
+    The reference path is kept as the oracle rather than deleted:
+    ``test_bfp_pack_vectorised.py`` asserts the two agree byte-for-byte, so this
+    function is never the only description of the format.
+
+    Returns:
+        (exponents, mantissas) as Python int lists. ``exponents`` is padded to at
+        least MIN_BFP_EXPONENTS; ``mantissas`` is one entry per datum, *not* yet
+        bit-packed into bytes (BFP4/BFP2 packing is the caller's job, as before).
+    """
+    # fp32 bits -> bf16 by truncation. The reference reaches the same bits via
+    # struct.pack("<f", value) >> 16; going through float32 here makes the
+    # double->float32 rounding for an fp64 input identical, and is exact for the
+    # bf16/fp32 inputs every caller actually passes.
+    x = flattened_tensor.detach().cpu().to(torch.float32).contiguous()
+    bf16 = (x.numpy().view(np.uint32) >> 16).astype(np.int32)
+
+    sign = (bf16 >> 15) & 1
+    exponent = (bf16 >> 7) & 0xFF
+    # The reference keeps bits 9..14 of the 16-bit word -- i.e. the bf16 mantissa
+    # *without* its LSB ("remove last") -- then prepends the implicit 1, giving a
+    # 7-bit explicit magnitude. (bf16 & 0x7F) | 0x80 would be 8 bits and is wrong.
+    mantissa = ((bf16 >> 1) & 0x3F) | 0x40
+
+    num_blocks = len(bf16) // block_size
+    exponent = exponent.reshape(num_blocks, block_size)
+    mantissa = mantissa.reshape(num_blocks, block_size)
+    sign = sign.reshape(num_blocks, block_size)
+
+    shared_exponent = exponent.max(axis=1, keepdims=True)
+    delta = shared_exponent - exponent
+
+    # Round-to-nearest, ties away from zero (per ISA spec for BFP8 packing): add the
+    # bit that is about to be shifted out.
+    #
+    # delta reaches ~130 for a block mixing an inf with a normal value, and ~255 in the
+    # limit. numpy 2.2 happens to define an over-wide shift as 0, which is what we want,
+    # but that is not a promise -- C semantics leave it undefined and other array
+    # libraries differ. Clip explicitly so the result does not depend on it. Clipping is
+    # exact rather than merely safe: the magnitude is 7 bits, so every shift >= 7 yields
+    # 0 either way, which is what the reference's Python-int arithmetic produces.
+    guard = np.where(delta > 0, (mantissa >> np.clip(delta - 1, 0, 31)) & 1, 0)
+    shifted = np.where(delta > 0, (mantissa >> np.clip(delta, 0, 31)) + guard, mantissa)
+    magnitude = shifted & 0x7F
+
+    # Flush negative zero to +0: a magnitude that rounds/shifts away drops its sign
+    # bit, so the hardware unpacker never sees a sign-only mantissa (which it decodes
+    # to -inf). Same rule the tt-metal host quantizer (convert_u32_to_bfp) applies.
+    bfp8 = np.where(magnitude != 0, (sign << 7) | magnitude, 0)
+
+    if magnitude_bits == 7:
+        mantissas = bfp8
+    else:
+        # truncate_bfp8: keep the sign bit and the top `magnitude_bits` of the 7
+        # magnitude bits, re-flushing a magnitude that truncation took to zero.
+        shift = 7 - magnitude_bits
+        narrow = (bfp8 >> shift) & ((1 << magnitude_bits) - 1)
+        mantissas = np.where(narrow != 0, ((bfp8 >> 7) << magnitude_bits) | narrow, 0)
+
+    exponents = shared_exponent.reshape(-1).tolist()
+    if len(exponents) < MIN_BFP_EXPONENTS:
+        exponents.extend([0] * (MIN_BFP_EXPONENTS - len(exponents)))
+    return exponents, mantissas.reshape(-1).tolist()
+
+
 def float_to_bfp8_block(block):
+    """Reference per-element BFP8_b block quantiser. See ``_bfp_collect_blocks``."""
+
     def bfloat16_to_binary(value):
         float_value = struct.unpack("<I", struct.pack("<f", value))[0]
         bfloat16_value = (float_value & 0xFFFF0000) >> 16
@@ -211,8 +291,8 @@ def pack_bfp8_b(tensor, block_size=16, num_faces=4, face_r_dim=16):
         List of packed bytes: [exponents...] + [mantissas...]
     """
     flattened_tensor = _bfp_prepare_blocks(tensor, block_size, num_faces, face_r_dim)
-    exponents, mantissas = _bfp_collect_blocks(
-        flattened_tensor, block_size, float_to_bfp8_block
+    exponents, mantissas = _bfp_quantize_blocks(
+        flattened_tensor, block_size, magnitude_bits=7
     )
     return exponents + mantissas
 
@@ -278,15 +358,14 @@ def pack_bfp4_b(tensor, block_size=16, num_faces=4, face_r_dim=16):
         List of packed bytes: [exponents...] + [packed_mantissas...]
     """
     flattened_tensor = _bfp_prepare_blocks(tensor, block_size, num_faces, face_r_dim)
-    exponents, all_mantissas = _bfp_collect_blocks(
-        flattened_tensor, block_size, float_to_bfp4_block
+    exponents, all_mantissas = _bfp_quantize_blocks(
+        flattened_tensor, block_size, magnitude_bits=3
     )
 
-    packed_mantissas = []
-    for i in range(0, len(all_mantissas), 2):
-        low = all_mantissas[i]
-        high = all_mantissas[i + 1] if (i + 1) < len(all_mantissas) else 0
-        packed_mantissas.append((high << 4) | low)
+    # Two datums per byte, low nibble first. The datum count is a whole number of
+    # 16-element blocks, so there is never an odd tail to zero-fill.
+    datums = np.asarray(all_mantissas, dtype=np.uint8).reshape(-1, 2)
+    packed_mantissas = ((datums[:, 1] << 4) | datums[:, 0]).tolist()
 
     return exponents + packed_mantissas
 
@@ -323,17 +402,16 @@ def pack_bfp2_b(tensor, block_size=16, num_faces=4, face_r_dim=16):
         List of packed bytes: [exponents...] + [packed_mantissas...]
     """
     flattened_tensor = _bfp_prepare_blocks(tensor, block_size, num_faces, face_r_dim)
-    exponents, all_mantissas = _bfp_collect_blocks(
-        flattened_tensor, block_size, float_to_bfp2_block
+    exponents, all_mantissas = _bfp_quantize_blocks(
+        flattened_tensor, block_size, magnitude_bits=1
     )
 
-    packed_mantissas = []
-    for i in range(0, len(all_mantissas), 4):
-        e0 = all_mantissas[i] if i < len(all_mantissas) else 0
-        e1 = all_mantissas[i + 1] if (i + 1) < len(all_mantissas) else 0
-        e2 = all_mantissas[i + 2] if (i + 2) < len(all_mantissas) else 0
-        e3 = all_mantissas[i + 3] if (i + 3) < len(all_mantissas) else 0
-        packed_mantissas.append((e3 << 6) | (e2 << 4) | (e1 << 2) | e0)
+    # Four datums per byte, lowest-order pair first. As for BFP4 the datum count is a
+    # whole number of 16-element blocks, so no tail padding is needed.
+    datums = np.asarray(all_mantissas, dtype=np.uint8).reshape(-1, 4)
+    packed_mantissas = (
+        (datums[:, 3] << 6) | (datums[:, 2] << 4) | (datums[:, 1] << 2) | datums[:, 0]
+    ).tolist()
 
     return exponents + packed_mantissas
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -1907,7 +1907,7 @@ def op_edge_points(
 #      — all 5 predicates fail on all 5 output formats at both dest_acc, 10/10 cells. As an
 #      *output* it fails too, unless a 32-bit input is paired with dest_acc=Yes:
 #      Float32->Float16 at dest_acc=No fails all five, the exact pair Blackhole already
-#      guards in _skip_bh_unsupported_float_combo.
+#      guards in _bh_unsupported_float_combo.
 #
 #   2. A 16-bit input with dest_acc=Yes. Float16_b there fails isinf, isneginf and isnan
 #      while isposinf and isfinite pass — +inf survives, -inf and NaN do not. Precisely the

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_config.py
@@ -7,7 +7,7 @@ import os
 import shutil
 from hashlib import sha256
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 import torch
 
@@ -79,7 +79,12 @@ class StimuliConfig:
         self,
         buffer_A: torch.Tensor,
         stimuli_A_format: DataFormat,
-        buffer_B: torch.Tensor,
+        # May be None for a test whose kernel never reads operand B (the unary SFPU
+        # drivers). B's L1 region is still reserved and still declared in the generated
+        # header -- the operands are laid out contiguously, so dropping the reservation
+        # would move buffer_Res -- but nothing is generated, packed or written into it.
+        # tile_count_B must still be passed, because that is what sizes the region.
+        buffer_B: Optional[torch.Tensor],
         stimuli_B_format: DataFormat,
         stimuli_res_format: DataFormat,
         tile_count_A: int = 1,
@@ -641,8 +646,10 @@ class StimuliConfig:
         pack_function_A = StimuliConfig.get_packer(self.stimuli_A_format)
         pack_function_B = StimuliConfig.get_packer(self.stimuli_B_format)
 
-        # Validate pack functions for A and B
-        if not pack_function_A or not pack_function_B:
+        # Validate pack functions for A and B. B's is still required when B has content:
+        # an absent B needs no packer, but a *present* B with an unsupported format is
+        # the same error it always was.
+        if not pack_function_A or (self.buffer_B is not None and not pack_function_B):
             raise ValueError(
                 f"Unsupported data formats: srcA({self.stimuli_A_format.name}), srcB({self.stimuli_B_format.name})"
             )
@@ -661,19 +668,20 @@ class StimuliConfig:
             twos_complement=self.twos_complement,
         )
 
-        StimuliConfig.write_matrix(
-            self.buffer_B,
-            self.tile_count_B,
-            pack_function_B,
-            self.buf_b_addr,
-            self.tile_size_B_bytes,
-            self.num_faces,
-            self.face_r_dim,
-            location,
-            self.write_full_tiles,
-            use_srcs=self._operand_use_srcs("B"),
-            twos_complement=self.twos_complement,
-        )
+        if self.buffer_B is not None:
+            StimuliConfig.write_matrix(
+                self.buffer_B,
+                self.tile_count_B,
+                pack_function_B,
+                self.buf_b_addr,
+                self.tile_size_B_bytes,
+                self.num_faces,
+                self.face_r_dim,
+                location,
+                self.write_full_tiles,
+                use_srcs=self._operand_use_srcs("B"),
+                twos_complement=self.twos_complement,
+            )
 
         for op in self._active_optional_operands():
             self._write_optional_operand(op, location, dense=False)
@@ -686,8 +694,8 @@ class StimuliConfig:
         pack_function_A = StimuliConfig.get_packer(self.stimuli_A_format)
         pack_function_B = StimuliConfig.get_packer(self.stimuli_B_format)
 
-        # Validate pack functions for A and B
-        if not pack_function_A or not pack_function_B:
+        # See the sibling path: B's packer is only required when B has content.
+        if not pack_function_A or (self.buffer_B is not None and not pack_function_B):
             raise ValueError(
                 f"Unsupported data formats: srcA({self.stimuli_A_format.name}), srcB({self.stimuli_B_format.name})"
             )
@@ -705,19 +713,20 @@ class StimuliConfig:
             use_srcs=self._operand_use_srcs("A"),
             twos_complement=self.twos_complement,
         )
-        StimuliConfig.write_matrix_w_tile_dimensions(
-            self.buffer_B,
-            self.tile_count_B,
-            pack_function_B,
-            self.buf_b_addr,
-            self.tile_size_B_bytes,
-            self.num_faces,
-            self.face_r_dim,
-            self.tile_dimensions,
-            location,
-            use_srcs=self._operand_use_srcs("B"),
-            twos_complement=self.twos_complement,
-        )
+        if self.buffer_B is not None:
+            StimuliConfig.write_matrix_w_tile_dimensions(
+                self.buffer_B,
+                self.tile_count_B,
+                pack_function_B,
+                self.buf_b_addr,
+                self.tile_size_B_bytes,
+                self.num_faces,
+                self.face_r_dim,
+                self.tile_dimensions,
+                location,
+                use_srcs=self._operand_use_srcs("B"),
+                twos_complement=self.twos_complement,
+            )
 
         for op in self._active_optional_operands():
             self._write_optional_operand(op, location, dense=True)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator/generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator/generator.py
@@ -273,7 +273,8 @@ def generate_stimuli(
     face_r_dim: int = MAX_FACE_R_DIM,
     num_faces: int = MAX_NUM_FACES,
     output_format: Optional[DataFormat] = None,
-) -> tuple[torch.Tensor, int, torch.Tensor, int]:
+    generate_operand_B: bool = True,
+) -> tuple[torch.Tensor, int, Optional[torch.Tensor], int]:
     """Generate test stimuli for two operands.
 
     When tile_dimensions is provided, operates in dense mode with derived face layout;
@@ -290,9 +291,15 @@ def generate_stimuli(
         face_r_dim: Rows per face, 1-16 (ignored in dense mode, default 16).
         num_faces: Faces per tile for partial-face case (ignored in dense mode, default 4).
         output_format: Clamp outputs for mixed MX-format pairs when set.
+        generate_operand_B: When False, srcB is not generated and None is returned in
+            its place. ``tile_cnt_B`` is still computed, because callers need it to
+            reserve B's L1 region even when no kernel reads it. For a genuinely unary
+            test this skips generating a whole tile per test that is then packed and
+            DMA'd for nothing.
 
     Returns:
-        (srcA_tensor, tile_cnt_A, srcB_tensor, tile_cnt_B).
+        (srcA_tensor, tile_cnt_A, srcB_tensor, tile_cnt_B). srcB_tensor is None when
+        *generate_operand_B* is False.
     """
     _spec_B_originally_none = spec_B is None
 
@@ -362,6 +369,20 @@ def generate_stimuli(
         spec=spec_A,
         input_dimensions=input_dimensions_A,
     )
+    if not generate_operand_B:
+        # Still run the clamp on A. It is not purely pairwise: its output_format
+        # branches clamp A on their own, so skipping it here would silently widen A's
+        # range for an MX output. An empty stand-in for B keeps the A-side behaviour
+        # identical while costing nothing.
+        srcA_tensor, _ = _clamp_mx_tensors(
+            srcA_tensor,
+            srcA_tensor[:0],
+            stimuli_format_A,
+            stimuli_format_B,
+            output_format,
+        )
+        return srcA_tensor, tile_cnt_A, None, tile_cnt_B
+
     srcB_tensor = _generate_source_tensor(
         stimuli_format=stimuli_format_B,
         num_elements=num_elements_B,

--- a/tt_metal/tt-llk/tests/python_tests/test_bfp_pack_vectorised.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_bfp_pack_vectorised.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""The vectorised BFP packer must agree byte-for-byte with the per-element reference.
+
+``helpers.pack`` keeps two descriptions of BFP_b quantisation: the per-element loop
+(``_bfp_collect_blocks`` driving ``float_to_bfp{8,4,2}_block``) and the numpy pass the
+packers actually call (``_bfp_quantize_blocks``). This file is what makes that safe --
+it asserts the two produce identical bytes, so the reference stays the authority on the
+format and the fast path stays free to change.
+
+The comparison is on **bytes, not values**. A tolerance-based check passes on an
+implementation that gets the mantissa width wrong: the reference keeps bits 9..14 of
+the bf16 word (dropping the mantissa LSB) for a 7-bit explicit magnitude, and the
+"obvious" 8-bit ``(bf16 & 0x7F) | 0x80`` is within tolerance while emitting different
+bytes. That mistake is only caught bytewise.
+"""
+
+import numpy as np
+import pytest
+import torch
+from helpers.pack import (
+    _bfp_collect_blocks,
+    _bfp_prepare_blocks,
+    _bfp_quantize_blocks,
+    float_to_bfp2_block,
+    float_to_bfp4_block,
+    float_to_bfp8_block,
+    pack_bfp2_b,
+    pack_bfp4_b,
+    pack_bfp8_b,
+)
+
+BLOCK_SIZE = 16
+
+
+def _assert_datums_equal(actual, expected, what):
+    """Compare two int lists, reporting only the first few mismatches.
+
+    ``assert actual == expected`` on 1024-element lists makes pytest build a full list
+    diff per failing case, which across this file's matrix is slow enough to be
+    mistaken for a hang. Report the count and the first three positions instead.
+    """
+    if actual == expected:
+        return
+    assert len(actual) == len(
+        expected
+    ), f"{what} count differs: got {len(actual)}, expected {len(expected)}"
+    bad = [i for i, (a, b) in enumerate(zip(actual, expected)) if a != b]
+    detail = ", ".join(
+        f"[{i}] got {hex(actual[i])} expected {hex(expected[i])}" for i in bad[:3]
+    )
+    raise AssertionError(
+        f"{what} diverged from the reference in {len(bad)}/{len(expected)} "
+        f"positions: {detail}"
+    )
+
+
+# (magnitude_bits, reference block fn, public packer) per BFP_b width.
+BFP_WIDTHS = [
+    pytest.param(7, float_to_bfp8_block, pack_bfp8_b, id="bfp8_b"),
+    pytest.param(3, float_to_bfp4_block, pack_bfp4_b, id="bfp4_b"),
+    pytest.param(1, float_to_bfp2_block, pack_bfp2_b, id="bfp2_b"),
+]
+
+
+def _populations():
+    """Tensors that exercise the paths where the two implementations could diverge.
+
+    The shared exponent is a per-block max, so what matters is the *spread* within a
+    block: a block whose members share an exponent never exercises the mantissa shift,
+    and a block spanning a wide range drives the shift past the 7-bit magnitude (which
+    is where numpy's undefined over-wide shift would bite if it were not clipped).
+    """
+    torch.manual_seed(0)
+    n = 1024  # one full tile
+    pops = {
+        # Ordinary signed data: small deltas, exercises the rounding guard bit.
+        "uniform": torch.rand(n) * 10 - 5,
+        # Wide dynamic range *within* each block -> large exponent deltas.
+        "wide_range": torch.randn(n) * 1e3,
+        # Everything tiny: shared exponent near the subnormal floor.
+        "subnormal": torch.rand(n) * 1e-30,
+        # Everything huge: shared exponent near the top of the range.
+        "huge": torch.rand(n) * 3e38,
+        # Exact powers of two: every mantissa is 0x40, ties land on the guard bit.
+        "powers_of_two": torch.tensor(
+            [2.0 ** ((i % 60) - 30) for i in range(n)], dtype=torch.float32
+        ),
+        # All zeros: shared exponent 0, every magnitude flushes, -0 must not survive.
+        "zeros": torch.zeros(n),
+        # Alternating +-0 next to real values: the negative-zero flush rule.
+        "signed_zeros": torch.tensor(
+            [0.0, -0.0, 1.0, -1.0] * (n // 4), dtype=torch.float32
+        ),
+        # Every block pairs a near-max value with a near-min one, forcing an intra-block
+        # exponent delta far past the 7-bit magnitude width. This is the only population
+        # that drives the over-wide mantissa shift; test_wide_delta_path_is_exercised
+        # asserts it still does, so the clip in _bfp_quantize_blocks stays covered.
+        "extreme_delta": torch.tensor(
+            [1e38 if i % BLOCK_SIZE == 0 else 1e-38 for i in range(n)],
+            dtype=torch.float32,
+        ),
+    }
+    # Every population additionally gets the specials seeded into distinct blocks, so
+    # a NaN/inf shared exponent (0xFF) cannot mask a divergence elsewhere in the tile.
+    specials = [0.0, -0.0, float("inf"), -float("inf"), float("nan"), 1e-45, -1e-45]
+    for name, base in list(pops.items()):
+        seeded = base.clone().to(torch.float32)
+        for i, v in enumerate(specials):
+            seeded[i * BLOCK_SIZE + i] = v  # one special per block, staggered
+        pops[f"{name}+specials"] = seeded
+    return pops
+
+
+POPULATIONS = _populations()
+
+
+@pytest.mark.parametrize("magnitude_bits,reference_block_fn,packer", BFP_WIDTHS)
+@pytest.mark.parametrize("population", sorted(POPULATIONS), ids=lambda p: p)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("num_faces,face_r_dim", [(4, 16), (2, 16), (1, 16), (4, 1)])
+def test_vectorised_matches_reference(
+    magnitude_bits, reference_block_fn, packer, population, dtype, num_faces, face_r_dim
+):
+    """Exponents and per-datum mantissas must match the reference exactly."""
+    tensor = POPULATIONS[population].to(dtype)
+    flattened = _bfp_prepare_blocks(tensor, BLOCK_SIZE, num_faces, face_r_dim)
+
+    ref_exponents, ref_mantissas = _bfp_collect_blocks(
+        flattened, BLOCK_SIZE, reference_block_fn
+    )
+    vec_exponents, vec_mantissas = _bfp_quantize_blocks(
+        flattened, BLOCK_SIZE, magnitude_bits
+    )
+
+    # Compared via an explicit first-mismatch report rather than `assert a == b`:
+    # these are 1024-element lists, and pytest's list-diff rewriting on a failure is
+    # slow enough across this file's matrix to look like a hang.
+    _assert_datums_equal(vec_exponents, ref_exponents, "shared exponent")
+    _assert_datums_equal(vec_mantissas, ref_mantissas, "mantissa datum")
+    # The packers return Python ints in 0..255; anything else breaks bytes(...).
+    assert all(isinstance(v, int) and 0 <= v <= 0xFF for v in vec_exponents)
+    assert all(isinstance(v, int) and 0 <= v <= 0xFF for v in vec_mantissas)
+    # And the public packer's byte stream must be convertible, which is how every
+    # caller consumes it (bytes(pack_bfp8_b(...))).
+    assert isinstance(
+        bytes(packer(tensor, num_faces=num_faces, face_r_dim=face_r_dim)), bytes
+    )
+
+
+@pytest.mark.parametrize("magnitude_bits,reference_block_fn,packer", BFP_WIDTHS)
+def test_public_packer_byte_stream_matches_reference(
+    magnitude_bits, reference_block_fn, packer
+):
+    """End-to-end: the public packer's full byte list, including the bit-packing.
+
+    ``_bfp_quantize_blocks`` returns one entry per datum; BFP4 folds two datums into a
+    byte and BFP2 four, and that folding is done in the packers. This checks the folded
+    result, which the per-datum comparison above cannot.
+    """
+    tensor = POPULATIONS["wide_range+specials"].to(torch.float32)
+    flattened = _bfp_prepare_blocks(tensor, BLOCK_SIZE, 4, 16)
+    ref_exponents, ref_datums = _bfp_collect_blocks(
+        flattened, BLOCK_SIZE, reference_block_fn
+    )
+
+    datums_per_byte = 8 // (magnitude_bits + 1)
+    if datums_per_byte == 1:
+        expected = ref_exponents + ref_datums
+    else:
+        folded = []
+        for i in range(0, len(ref_datums), datums_per_byte):
+            byte = 0
+            for k in range(datums_per_byte):
+                byte |= ref_datums[i + k] << (k * (magnitude_bits + 1))
+            folded.append(byte)
+        expected = ref_exponents + folded
+
+    assert packer(tensor) == expected
+
+
+def test_negative_zero_never_leaves_a_sign_only_mantissa():
+    """A sign-only mantissa decodes to -inf in hardware, so it must never be emitted.
+
+    Asserted directly rather than left to the reference comparison: if both
+    implementations regressed together the comparison would still pass, and this is the
+    one property whose violation silently corrupts a tile.
+    """
+    for magnitude_bits in (7, 3, 1):
+        sign_only = 1 << magnitude_bits
+        for population in ("zeros", "signed_zeros", "subnormal+specials"):
+            flattened = _bfp_prepare_blocks(
+                POPULATIONS[population].to(torch.float32), BLOCK_SIZE, 4, 16
+            )
+            _, mantissas = _bfp_quantize_blocks(flattened, BLOCK_SIZE, magnitude_bits)
+            assert sign_only not in mantissas, (
+                f"{population} produced a sign-only {magnitude_bits + 1}-bit mantissa "
+                f"({hex(sign_only)}), which the hardware unpacker decodes to -inf"
+            )
+
+
+def test_wide_delta_path_is_exercised():
+    """The populations must actually drive an intra-block exponent delta past 7 bits.
+
+    ``_bfp_quantize_blocks`` clips the mantissa shift so the result does not depend on
+    how the array library defines an over-wide shift. That clip is only meaningful if
+    some block really has a delta that large -- and a mutation removing the clip passes
+    the agreement tests unless one does. Assert the precondition rather than assuming
+    the populations keep providing it.
+    """
+    flattened = _bfp_prepare_blocks(
+        POPULATIONS["extreme_delta"].to(torch.float32), BLOCK_SIZE, 4, 16
+    )
+    bf16 = (
+        flattened.to(torch.float32).contiguous().numpy().view(np.uint32) >> 16
+    ).astype(np.int32)
+    exponent = ((bf16 >> 7) & 0xFF).reshape(-1, BLOCK_SIZE)
+    max_delta = int((exponent.max(axis=1, keepdims=True) - exponent).max())
+    assert max_delta > 7, (
+        f"no block exceeds a 7-bit mantissa shift (max delta {max_delta}); the shift "
+        "clip in _bfp_quantize_blocks is no longer covered by these populations"
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_bfp_pack_vectorised.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_bfp_pack_vectorised.py
@@ -30,6 +30,7 @@ from helpers.pack import (
     pack_bfp4_b,
     pack_bfp8_b,
 )
+from helpers.tile_constants import MAX_FACE_R_DIM, MAX_NUM_FACES
 
 BLOCK_SIZE = 16
 
@@ -119,7 +120,18 @@ POPULATIONS = _populations()
 @pytest.mark.parametrize("magnitude_bits,reference_block_fn,packer", BFP_WIDTHS)
 @pytest.mark.parametrize("population", sorted(POPULATIONS), ids=lambda p: p)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-@pytest.mark.parametrize("num_faces,face_r_dim", [(4, 16), (2, 16), (1, 16), (4, 1)])
+# The full tile plus the partial-face layouts the packers support. Only the first is
+# the maximum layout, so only it gets the named constants -- the rest are deliberately
+# *not* MAX_NUM_FACES / MAX_FACE_R_DIM and reading them as literals is the point.
+@pytest.mark.parametrize(
+    "num_faces,face_r_dim",
+    [
+        (MAX_NUM_FACES, MAX_FACE_R_DIM),
+        (2, MAX_FACE_R_DIM),
+        (1, MAX_FACE_R_DIM),
+        (MAX_NUM_FACES, 1),
+    ],
+)
 def test_vectorised_matches_reference(
     magnitude_bits, reference_block_fn, packer, population, dtype, num_faces, face_r_dim
 ):
@@ -160,7 +172,7 @@ def test_public_packer_byte_stream_matches_reference(
     result, which the per-datum comparison above cannot.
     """
     tensor = POPULATIONS["wide_range+specials"].to(torch.float32)
-    flattened = _bfp_prepare_blocks(tensor, BLOCK_SIZE, 4, 16)
+    flattened = _bfp_prepare_blocks(tensor, BLOCK_SIZE, MAX_NUM_FACES, MAX_FACE_R_DIM)
     ref_exponents, ref_datums = _bfp_collect_blocks(
         flattened, BLOCK_SIZE, reference_block_fn
     )
@@ -191,7 +203,10 @@ def test_negative_zero_never_leaves_a_sign_only_mantissa():
         sign_only = 1 << magnitude_bits
         for population in ("zeros", "signed_zeros", "subnormal+specials"):
             flattened = _bfp_prepare_blocks(
-                POPULATIONS[population].to(torch.float32), BLOCK_SIZE, 4, 16
+                POPULATIONS[population].to(torch.float32),
+                BLOCK_SIZE,
+                MAX_NUM_FACES,
+                MAX_FACE_R_DIM,
             )
             _, mantissas = _bfp_quantize_blocks(flattened, BLOCK_SIZE, magnitude_bits)
             assert sign_only not in mantissas, (
@@ -210,7 +225,10 @@ def test_wide_delta_path_is_exercised():
     the populations keep providing it.
     """
     flattened = _bfp_prepare_blocks(
-        POPULATIONS["extreme_delta"].to(torch.float32), BLOCK_SIZE, 4, 16
+        POPULATIONS["extreme_delta"].to(torch.float32),
+        BLOCK_SIZE,
+        MAX_NUM_FACES,
+        MAX_FACE_R_DIM,
     )
     bf16 = (
         flattened.to(torch.float32).contiguous().numpy().view(np.uint32) >> 16

--- a/tt_metal/tt-llk/tests/python_tests/test_bfp_pack_vectorised.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_bfp_pack_vectorised.py
@@ -117,47 +117,78 @@ def _populations():
 POPULATIONS = _populations()
 
 
-@pytest.mark.parametrize("magnitude_bits,reference_block_fn,packer", BFP_WIDTHS)
-@pytest.mark.parametrize("population", sorted(POPULATIONS), ids=lambda p: p)
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 # The full tile plus the partial-face layouts the packers support. Only the first is
 # the maximum layout, so only it gets the named constants -- the rest are deliberately
 # *not* MAX_NUM_FACES / MAX_FACE_R_DIM and reading them as literals is the point.
-@pytest.mark.parametrize(
-    "num_faces,face_r_dim",
-    [
-        (MAX_NUM_FACES, MAX_FACE_R_DIM),
-        (2, MAX_FACE_R_DIM),
-        (1, MAX_FACE_R_DIM),
-        (MAX_NUM_FACES, 1),
-    ],
-)
+LAYOUTS = [
+    (MAX_NUM_FACES, MAX_FACE_R_DIM),
+    (2, MAX_FACE_R_DIM),
+    (1, MAX_FACE_R_DIM),
+    (MAX_NUM_FACES, 1),
+]
+
+DTYPES = [torch.float32, torch.bfloat16]
+
+
+@pytest.mark.parametrize("magnitude_bits,reference_block_fn,packer", BFP_WIDTHS)
+@pytest.mark.parametrize("population", sorted(POPULATIONS), ids=lambda p: p)
 def test_vectorised_matches_reference(
-    magnitude_bits, reference_block_fn, packer, population, dtype, num_faces, face_r_dim
+    magnitude_bits, reference_block_fn, packer, population
 ):
-    """Exponents and per-datum mantissas must match the reference exactly."""
-    tensor = POPULATIONS[population].to(dtype)
-    flattened = _bfp_prepare_blocks(tensor, BLOCK_SIZE, num_faces, face_r_dim)
+    """Exponents and per-datum mantissas must match the reference exactly.
 
-    ref_exponents, ref_mantissas = _bfp_collect_blocks(
-        flattened, BLOCK_SIZE, reference_block_fn
-    )
-    vec_exponents, vec_mantissas = _bfp_quantize_blocks(
-        flattened, BLOCK_SIZE, magnitude_bits
-    )
+    The width and population axes are parametrised; dtype and layout are looped inside
+    one item. Width and population are what a failure needs in its id -- they say which
+    packer and which numeric region diverged -- while dtype and layout only change the
+    framing of the same comparison, and each is named in the failure message. Keeping
+    all four as parametrize axes made 384 unmarked items that every PR pays collection
+    and reporting for, to run a matrix that takes about a second.
 
-    # Compared via an explicit first-mismatch report rather than `assert a == b`:
-    # these are 1024-element lists, and pytest's list-diff rewriting on a failure is
-    # slow enough across this file's matrix to look like a hang.
-    _assert_datums_equal(vec_exponents, ref_exponents, "shared exponent")
-    _assert_datums_equal(vec_mantissas, ref_mantissas, "mantissa datum")
-    # The packers return Python ints in 0..255; anything else breaks bytes(...).
-    assert all(isinstance(v, int) and 0 <= v <= 0xFF for v in vec_exponents)
-    assert all(isinstance(v, int) and 0 <= v <= 0xFF for v in vec_mantissas)
-    # And the public packer's byte stream must be convertible, which is how every
-    # caller consumes it (bytes(pack_bfp8_b(...))).
-    assert isinstance(
-        bytes(packer(tensor, num_faces=num_faces, face_r_dim=face_r_dim)), bytes
+    ``checked`` is asserted against the product of the two inner axes: folding axes into
+    a loop is exactly the edit that can silently stop covering a cell, and unlike a
+    dropped parametrize argument nothing about the item count would reveal it.
+    """
+    checked = 0
+    for dtype in DTYPES:
+        tensor = POPULATIONS[population].to(dtype)
+        for num_faces, face_r_dim in LAYOUTS:
+            cell = f"{dtype} / num_faces={num_faces} / face_r_dim={face_r_dim}"
+            flattened = _bfp_prepare_blocks(tensor, BLOCK_SIZE, num_faces, face_r_dim)
+
+            ref_exponents, ref_mantissas = _bfp_collect_blocks(
+                flattened, BLOCK_SIZE, reference_block_fn
+            )
+            vec_exponents, vec_mantissas = _bfp_quantize_blocks(
+                flattened, BLOCK_SIZE, magnitude_bits
+            )
+
+            # Compared via an explicit first-mismatch report rather than `assert a == b`:
+            # these are 1024-element lists, and pytest's list-diff rewriting on a failure
+            # is slow enough across this file's matrix to look like a hang.
+            _assert_datums_equal(
+                vec_exponents, ref_exponents, f"{cell}: shared exponent"
+            )
+            _assert_datums_equal(
+                vec_mantissas, ref_mantissas, f"{cell}: mantissa datum"
+            )
+            # The packers return Python ints in 0..255; anything else breaks bytes(...).
+            assert all(
+                isinstance(v, int) and 0 <= v <= 0xFF for v in vec_exponents
+            ), f"{cell}: a shared exponent is not a byte-valued int"
+            assert all(
+                isinstance(v, int) and 0 <= v <= 0xFF for v in vec_mantissas
+            ), f"{cell}: a mantissa datum is not a byte-valued int"
+            # And the public packer's byte stream must be convertible, which is how every
+            # caller consumes it (bytes(pack_bfp8_b(...))).
+            assert isinstance(
+                bytes(packer(tensor, num_faces=num_faces, face_r_dim=face_r_dim)), bytes
+            ), f"{cell}: the packer's output is not convertible to bytes"
+            checked += 1
+
+    expected = len(DTYPES) * len(LAYOUTS)
+    assert checked == expected, (
+        f"{population}: compared {checked} cells, expected {expected}; a dtype or "
+        "layout is no longer being reached"
     )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -250,8 +250,26 @@ def _bh_unless_fp32(formats, dest_acc) -> bool:
 #
 # The reasons stay as strings on purpose. A filtered combination leaves no trace in the
 # report, so this is now the only place that records what is not tested and why;
-# test_unswept_combinations_are_accounted_for keeps the total visible.
+# test_unswept_combinations_are_accounted_for keeps the total visible and asserts each
+# reason is still filtering something.
 _RELU_MIN_ISSUE = "https://github.com/tenstorrent/tt-llk/issues/1120"
+_TANH_NO_APPROX = "Metal tanh does not support approximation mode"
+_BH_UNSUPPORTED = "not supported on BH architecture"
+_EXP_FAMILY_BFP8_APPROX = "exp-family ops do not support bf8_b in approximation mode"
+
+# Which of those must still be dropping at least one combination, and where.
+#
+# Per reason rather than "the tally is non-empty": with four reasons in play, any three
+# of them keep the tally non-empty while the fourth goes stale unnoticed -- which is
+# precisely the case _RELU_MIN_ISSUE exists for (the issue is fixed, the branch is left
+# behind, and ReluMin quietly stops being swept without a SKIPPED line anywhere).
+#
+# The first three are properties of the op/format matrix, not of the chip: ReluMin and
+# Tanh are both in BROAD_SWEEP_OPS, which sweeps ApproximationMode.Yes, and BROAD_FORMATS
+# pairs Bfp8_b with the exp family. Only the Blackhole dest_acc=No guards are
+# arch-dependent, and on Wormhole they correctly filter nothing.
+_ALWAYS_LIVE_REASONS = (_RELU_MIN_ISSUE, _TANH_NO_APPROX, _EXP_FAMILY_BFP8_APPROX)
+_BLACKHOLE_ONLY_REASONS = (_BH_UNSUPPORTED,)
 
 
 def _unsupported_reason(formats, approx_mode, mathop, dest_acc, broad):
@@ -260,16 +278,16 @@ def _unsupported_reason(formats, approx_mode, mathop, dest_acc, broad):
         return _RELU_MIN_ISSUE
 
     if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
-        return "Metal tanh does not support approximation mode"
+        return _TANH_NO_APPROX
 
     # Each profile has its own Blackhole dest_acc=No guard, measured against its own
     # format set: the broad profile runs everything except a Float16 input or
     # Float32->Float16, while the standard profile allows only Float32->Float32.
     if broad:
         if _bh_unsupported_float_combo(formats, dest_acc):
-            return "not supported on BH architecture"
+            return _BH_UNSUPPORTED
     elif _bh_unless_fp32(formats, dest_acc):
-        return "not supported on BH architecture"
+        return _BH_UNSUPPORTED
 
     # Exp-family ops in approx mode can't run against bf8_b. Bfp4_b inputs are exempt:
     # that combination is validated by the Bfp4_b sweep, so only guard non-Bfp4_b inputs.
@@ -282,7 +300,7 @@ def _unsupported_reason(formats, approx_mode, mathop, dest_acc, broad):
             or formats.output_format == DataFormat.Bfp8_b
         )
     ):
-        return "exp-family ops do not support bf8_b in approximation mode"
+        return _EXP_FAMILY_BFP8_APPROX
 
     return None
 
@@ -297,6 +315,17 @@ def _sweep_params(formats, mathops, approx_modes, input_dimensions, broad):
 
     Fast-mode-capable ops are swept with FastMode.No and FastMode.Yes; every other op
     runs with FastMode.No only. dest_acc always sweeps both values.
+
+    Combinations `_unsupported_reason` rejects are dropped here rather than generated
+    and skipped in the test body, so *broad* has to be passed through: the two coverage
+    profiles have different Blackhole dest_acc=No guards, measured against their own
+    format sets.
+
+    Side effect, and the reason this is not a pure function: every dropped combination is
+    tallied into the module-level `UNSWEPT_COMBINATIONS` under its reason. A filtered case
+    leaves no SKIPPED line in the report, so that tally is the only remaining record of
+    what is not tested and why, and building it here is what keeps it from drifting from
+    what was actually filtered. `test_unswept_combinations_are_accounted_for` reads it.
     """
     dest_accs = [DestAccumulation.No, DestAccumulation.Yes]
     fast_ops = [op for op in mathops if op in SUPPORTED_FAST_MODE_OPS]
@@ -402,7 +431,13 @@ def test_unswept_combinations_are_accounted_for():
     Moving a skip out of the test body and into the parametrize filter buys speed at the
     cost of visibility: a filtered case leaves no SKIPPED line in the report, so the only
     remaining record of what is not tested is _unsupported_reason. This test prints the
-    tally and asserts the two properties worth asserting about it.
+    tally and asserts four things about it:
+
+    - every reason expected on this chip is still filtering something,
+    - no reason is filtering that has not been declared as expected, so a newly added
+      one cannot dodge the check above,
+    - no Blackhole-only reason fires elsewhere,
+    - the filter has not eaten most of the matrix.
 
     Not asserted: the *count*. It is arch-dependent (the Blackhole guards do most of the
     filtering) and changes legitimately whenever the format matrix does.
@@ -410,12 +445,38 @@ def test_unswept_combinations_are_accounted_for():
     filtered = sum(UNSWEPT_COMBINATIONS.values())
     total_candidates = len(UNARY_SWEEP_PARAMS) + filtered
 
-    # A filter that dropped nothing would mean the reasons had gone stale -- e.g. the
-    # ReluMin issue was fixed and the entry left behind, which would silently keep the
-    # op unswept.
-    assert UNSWEPT_COMBINATIONS, (
-        "no combination was filtered, so every reason in _unsupported_reason is now "
-        "unreachable -- delete the ones that no longer apply rather than leaving them"
+    # Every reason expected on this chip must still be dropping something. Asserted per
+    # reason, not on the tally as a whole: a reason that has gone stale -- the ReluMin
+    # issue fixed and the branch left behind -- keeps the op unswept with no SKIPPED line
+    # anywhere, and the other three reasons would keep a truthiness check green.
+    expected_live = list(_ALWAYS_LIVE_REASONS)
+    if TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE:
+        expected_live += list(_BLACKHOLE_ONLY_REASONS)
+    stale = [r for r in expected_live if UNSWEPT_COMBINATIONS.get(r, 0) == 0]
+    assert not stale, (
+        f"these reasons filtered nothing on {TestConfig.CHIP_ARCH}, so whatever they "
+        "were guarding is now either swept (delete the reason) or unreachable for a "
+        f"different cause (fix the reason): {stale}"
+    )
+
+    # The converse, so a newly added reason cannot skip the check above: everything in
+    # the tally has to be declared, in the arch group it actually applies to.
+    declared = set(_ALWAYS_LIVE_REASONS) | set(_BLACKHOLE_ONLY_REASONS)
+    undeclared = sorted(set(UNSWEPT_COMBINATIONS) - declared)
+    assert not undeclared, (
+        "these reasons filter combinations but are not declared in "
+        "_ALWAYS_LIVE_REASONS or _BLACKHOLE_ONLY_REASONS, so nothing checks that they "
+        f"stay live: {undeclared}"
+    )
+    unexpected_here = sorted(
+        r
+        for r in _BLACKHOLE_ONLY_REASONS
+        if UNSWEPT_COMBINATIONS.get(r, 0)
+        and TestConfig.CHIP_ARCH != ChipArchitecture.BLACKHOLE
+    )
+    assert not unexpected_here, (
+        f"these Blackhole-only reasons filtered combinations on "
+        f"{TestConfig.CHIP_ARCH}: {unexpected_here}"
     )
 
     # And a filter that dropped most of the matrix would mean the sweep had quietly

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -220,7 +220,79 @@ def _skip_coverage_unsupported(mathop):
         )
 
 
-def _sweep_params(formats, mathops, approx_modes, input_dimensions):
+def _bh_unsupported_float_combo(formats, dest_acc) -> bool:
+    """Blackhole with dest_acc=No supports neither Float16 input nor Float32->Float16."""
+    return (
+        dest_acc == DestAccumulation.No
+        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
+        and (
+            formats.input_format == DataFormat.Float16
+            or formats == InputOutputFormat(DataFormat.Float32, DataFormat.Float16)
+        )
+    )
+
+
+def _bh_unless_fp32(formats, dest_acc) -> bool:
+    """Blackhole with dest_acc=No only supports the Float32->Float32 combination."""
+    return (
+        dest_acc == DestAccumulation.No
+        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
+        and formats != InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
+    )
+
+
+# Reasons a (formats, approx_mode, mathop, dest_acc) combination is not swept. Each was
+# a pytest.skip in the test body; every one is a pure function of the parametrize tuple
+# and TestConfig.CHIP_ARCH, which pytest_configure binds before collection. Evaluating
+# them here drops the case at collection instead of generating it, handing it to an xdist
+# worker and skipping it -- on Blackhole that was 1140 of 5792 cases, a 20% skip rate
+# sitting between a reader and the real coverage number.
+#
+# The reasons stay as strings on purpose. A filtered combination leaves no trace in the
+# report, so this is now the only place that records what is not tested and why;
+# test_unswept_combinations_are_accounted_for keeps the total visible.
+_RELU_MIN_ISSUE = "https://github.com/tenstorrent/tt-llk/issues/1120"
+
+
+def _unsupported_reason(formats, approx_mode, mathop, dest_acc, broad):
+    """Why this combination is not swept, or None if it is."""
+    if mathop == MathOperation.ReluMin:
+        return _RELU_MIN_ISSUE
+
+    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
+        return "Metal tanh does not support approximation mode"
+
+    # Each profile has its own Blackhole dest_acc=No guard, measured against its own
+    # format set: the broad profile runs everything except a Float16 input or
+    # Float32->Float16, while the standard profile allows only Float32->Float32.
+    if broad:
+        if _bh_unsupported_float_combo(formats, dest_acc):
+            return "not supported on BH architecture"
+    elif _bh_unless_fp32(formats, dest_acc):
+        return "not supported on BH architecture"
+
+    # Exp-family ops in approx mode can't run against bf8_b. Bfp4_b inputs are exempt:
+    # that combination is validated by the Bfp4_b sweep, so only guard non-Bfp4_b inputs.
+    if (
+        approx_mode == ApproximationMode.Yes
+        and mathop in [MathOperation.Exp, MathOperation.Exp2, MathOperation.Elu]
+        and formats.input_format != DataFormat.Bfp4_b
+        and (
+            formats.input_format == DataFormat.Bfp8_b
+            or formats.output_format == DataFormat.Bfp8_b
+        )
+    ):
+        return "exp-family ops do not support bf8_b in approximation mode"
+
+    return None
+
+
+# Every combination the filter dropped, as {reason: count}. Built as a side effect of
+# _sweep_params so it cannot drift from what was actually filtered.
+UNSWEPT_COMBINATIONS: dict[str, int] = {}
+
+
+def _sweep_params(formats, mathops, approx_modes, input_dimensions, broad):
     """Build (formats, approx_mode, mathop, fast_mode, dest_acc, input_dimensions) tuples.
 
     Fast-mode-capable ops are swept with FastMode.No and FastMode.Yes; every other op
@@ -229,26 +301,34 @@ def _sweep_params(formats, mathops, approx_modes, input_dimensions):
     dest_accs = [DestAccumulation.No, DestAccumulation.Yes]
     fast_ops = [op for op in mathops if op in SUPPORTED_FAST_MODE_OPS]
     non_fast_ops = [op for op in mathops if op not in SUPPORTED_FAST_MODE_OPS]
-    return list(
-        chain(
-            product(
-                formats,
-                approx_modes,
-                fast_ops,
-                [FastMode.No, FastMode.Yes],
-                dest_accs,
-                input_dimensions,
-            ),
-            product(
-                formats,
-                approx_modes,
-                non_fast_ops,
-                [FastMode.No],
-                dest_accs,
-                input_dimensions,
-            ),
-        )
+    candidates = chain(
+        product(
+            formats,
+            approx_modes,
+            fast_ops,
+            [FastMode.No, FastMode.Yes],
+            dest_accs,
+            input_dimensions,
+        ),
+        product(
+            formats,
+            approx_modes,
+            non_fast_ops,
+            [FastMode.No],
+            dest_accs,
+            input_dimensions,
+        ),
     )
+
+    kept = []
+    for params in candidates:
+        fmt, approx_mode, mathop, _fast_mode, dest_acc, _dims = params
+        reason = _unsupported_reason(fmt, approx_mode, mathop, dest_acc, broad)
+        if reason is None:
+            kept.append(params)
+        else:
+            UNSWEPT_COMBINATIONS[reason] = UNSWEPT_COMBINATIONS.get(reason, 0) + 1
+    return kept
 
 
 def _assert_broad_profile_valid():
@@ -294,18 +374,21 @@ UNARY_SWEEP_PARAMS = (
         BROAD_SWEEP_OPS,
         [ApproximationMode.No, ApproximationMode.Yes],
         BROAD_DIMENSIONS,
+        broad=True,
     )
     + _sweep_params(
         FORMATS_BFP4_B,
         BROAD_SWEEP_OPS,
         [ApproximationMode.No, ApproximationMode.Yes],
         BROAD_DIMENSIONS,
+        broad=True,
     )
     + _sweep_params(
         STANDARD_FORMATS,
         STANDARD_SWEEP_OPS,
         [ApproximationMode.No],
         STANDARD_DIMENSIONS,
+        broad=False,
     )
 )
 
@@ -313,17 +396,41 @@ UNARY_SWEEP_PARAMS = (
 _assert_broad_profile_valid()
 
 
-def _skip_bh_unsupported_float_combo(formats, dest_acc):
-    """Blackhole with dest_acc=No supports neither Float16 input nor Float32->Float16."""
-    if (
-        dest_acc == DestAccumulation.No
-        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
-        and (
-            formats.input_format == DataFormat.Float16
-            or formats == InputOutputFormat(DataFormat.Float32, DataFormat.Float16)
-        )
-    ):
-        pytest.skip(reason="This combination is not supported on BH architecture")
+def test_unswept_combinations_are_accounted_for():
+    """Every combination the collection-time filter dropped, with its reason.
+
+    Moving a skip out of the test body and into the parametrize filter buys speed at the
+    cost of visibility: a filtered case leaves no SKIPPED line in the report, so the only
+    remaining record of what is not tested is _unsupported_reason. This test prints the
+    tally and asserts the two properties worth asserting about it.
+
+    Not asserted: the *count*. It is arch-dependent (the Blackhole guards do most of the
+    filtering) and changes legitimately whenever the format matrix does.
+    """
+    filtered = sum(UNSWEPT_COMBINATIONS.values())
+    total_candidates = len(UNARY_SWEEP_PARAMS) + filtered
+
+    # A filter that dropped nothing would mean the reasons had gone stale -- e.g. the
+    # ReluMin issue was fixed and the entry left behind, which would silently keep the
+    # op unswept.
+    assert UNSWEPT_COMBINATIONS, (
+        "no combination was filtered, so every reason in _unsupported_reason is now "
+        "unreachable -- delete the ones that no longer apply rather than leaving them"
+    )
+
+    # And a filter that dropped most of the matrix would mean the sweep had quietly
+    # stopped testing anything, which is the failure mode this mechanism risks.
+    assert len(UNARY_SWEEP_PARAMS) > total_candidates // 2, (
+        f"the filter dropped {filtered} of {total_candidates} candidate combinations, "
+        "leaving under half the matrix"
+    )
+
+    print(
+        f"\n{len(UNARY_SWEEP_PARAMS)} of {total_candidates} combinations swept; "
+        f"{filtered} filtered at collection:"
+    )
+    for reason, count in sorted(UNSWEPT_COMBINATIONS.items(), key=lambda kv: -kv[1]):
+        print(f"  {count:5d}  {reason}")
 
 
 def _gate_unspecified_nan_sign(mathop, formats, dest_acc, specials):
@@ -344,12 +451,13 @@ def _gate_unspecified_nan_sign(mathop, formats, dest_acc, specials):
 
 
 def _skip_bh_unless_fp32(formats, dest_acc):
-    """Blackhole with dest_acc=No only supports the Float32->Float32 combination."""
-    if (
-        dest_acc == DestAccumulation.No
-        and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
-        and formats != InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
-    ):
+    """Runtime form of _bh_unless_fp32, for the sweeps built with @parametrize.
+
+    The main sweep filters this combination out at collection instead (see
+    _unsupported_reason); the smaller sweeps below are a few dozen cases each, where
+    the bookkeeping of a collection-time filter buys nothing.
+    """
+    if _bh_unless_fp32(formats, dest_acc):
         pytest.skip(reason="This combination is not supported on BH architecture")
 
 
@@ -410,8 +518,6 @@ def test_eltwise_unary_sfpu(
     Stimuli come from the per-op registry for every op; the sweep envelope (which profile
     the op is in) is the only thing that varies. See BROAD_SWEEP_OPS.
     """
-    broad = mathop in BROAD_SWEEP_OPS
-
     _skip_coverage_unsupported(mathop)
 
     if (
@@ -434,35 +540,9 @@ def test_eltwise_unary_sfpu(
             )
         )
 
-    if mathop == MathOperation.ReluMin:
-        pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1120")
-
-    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
-        pytest.skip(reason="Metal tanh does not support approximation mode")
-
-    # Each profile has its own Blackhole dest_acc=No guard, measured against its own
-    # format set: the broad profile runs everything except a Float16 input or
-    # Float32->Float16, while the standard profile allows only Float32->Float32.
-    if broad:
-        _skip_bh_unsupported_float_combo(formats, dest_acc)
-    else:
-        _skip_bh_unless_fp32(formats, dest_acc)
-
-    # Exp-family ops in approx mode can't run against bf8_b. Bfp4_b inputs are exempt:
-    # that combination is validated by the Bfp4_b sweep, so only guard non-Bfp4_b inputs.
-    if (
-        approx_mode == ApproximationMode.Yes
-        and mathop in [MathOperation.Exp, MathOperation.Exp2, MathOperation.Elu]
-        and formats.input_format != DataFormat.Bfp4_b
-        and (
-            formats.input_format == DataFormat.Bfp8_b
-            or formats.output_format == DataFormat.Bfp8_b
-        )
-    ):
-        pytest.skip(
-            reason="Exp-related operations are not supported for bf8_b format in approximation mode."
-        )
-
+    # The combinations these used to skip are filtered at collection now -- see
+    # _unsupported_reason. Only the coverage-build exclusions above remain a runtime
+    # skip, because WITH_COVERAGE is a property of the build rather than of the tuple.
     custom_atol, custom_rtol = CUSTOM_TOLERANCES.get(mathop, (None, None))
 
     eltwise_unary_sfpu(
@@ -1269,12 +1349,18 @@ def eltwise_unary_sfpu(
             ).spec_A,
         )
 
-    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+    # No operand B: eltwise_unary_sfpu_test.cpp never reads buffer_B, so generating,
+    # packing and DMA-ing a second tile per test was pure overhead. Its L1 region is
+    # still reserved via tile_count_B below -- the operands are laid out contiguously
+    # and the generated header declares buffer_B unconditionally, so dropping the
+    # reservation would move buffer_Res.
+    src_A, tile_cnt_A, _, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
         spec_A=spec_A,
+        generate_operand_B=False,
     )
 
     generate_golden = get_golden_generator(UnarySFPUGolden)
@@ -1318,7 +1404,7 @@ def eltwise_unary_sfpu(
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,
-            src_B,
+            None,
             formats.input_format,
             formats.output_format,
             tile_count_A=tile_cnt_A,
@@ -1370,7 +1456,7 @@ def test_exponential_clamp_negative(clamp_negative: bool):
     src_A[3] = -100
     src_A[4] = -88.5
 
-    src_B = torch.zeros(num_elements, dtype=torch.bfloat16)
+    # Same source, same absent operand B -- see the comment in eltwise_unary_sfpu().
     tile_cnt_A = (input_dimensions[0] // 32) * (input_dimensions[1] // 32)
     tile_cnt_B = tile_cnt_A
 
@@ -1411,7 +1497,7 @@ def test_exponential_clamp_negative(clamp_negative: bool):
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,
-            src_B,
+            None,
             formats.input_format,
             formats.output_format,
             tile_count_A=tile_cnt_A,

--- a/tt_metal/tt-llk/tests/python_tests/test_stimuli_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_stimuli_generator.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""``generate_stimuli(generate_operand_B=False)`` must change only what it claims to.
+
+The unary SFPU drivers pass this to skip generating, packing and DMA-ing a whole operand
+B their kernel never reads. The saving is real, but it puts a second path through
+``generate_stimuli``, and the only caller is the sweep itself -- so a regression in it
+(the ``_clamp_mx_tensors`` stand-in for the dropped B, the ``None`` return, the tile
+count that still sizes B's L1 region) would surface as a golden mismatch several stages
+downstream rather than as a failure pointing here.
+
+The contract, in one sentence: A comes out bit-identical to the two-operand call, B comes
+back as ``None``, and ``tile_cnt_B`` is unchanged -- because B's L1 region is still
+reserved and still declared in the generated header. Each clause is a test below.
+"""
+
+import pytest
+import torch
+from helpers.format_config import MX_FORMAT_MAX_NORMAL, DataFormat
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+
+# Enough tiles that a wrong tile count is visible rather than coincidentally right.
+DIMENSIONS_A = [32, 128]
+DIMENSIONS_B = [32, 64]
+
+
+# Reseeded before each call rather than relying on ``spec.seed``: a spec with no seed
+# draws from the global RNG, which is the case the default per-format specs hit, and A is
+# generated before B in both branches -- so an identical global seed makes A's draws
+# identical and any difference attributable to the new code path.
+_SEED = 1234
+
+
+def _both_ways(**kwargs):
+    """The same call with and without operand B, from the same RNG state."""
+    torch.manual_seed(_SEED)
+    with_b = generate_stimuli(**kwargs, generate_operand_B=True)
+    torch.manual_seed(_SEED)
+    without_b = generate_stimuli(**kwargs, generate_operand_B=False)
+    return with_b, without_b
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "stimuli_format_A": DataFormat.Float32,
+                "stimuli_format_B": DataFormat.Float32,
+                "input_dimensions_A": DIMENSIONS_A,
+                "input_dimensions_B": DIMENSIONS_B,
+                "spec_A": StimuliSpec.uniform(low=-5.0, high=5.0, seed=0),
+                "spec_B": StimuliSpec.uniform(low=-5.0, high=5.0, seed=1),
+            },
+            id="standard_fp32",
+        ),
+        pytest.param(
+            {
+                "stimuli_format_A": DataFormat.Float16_b,
+                "stimuli_format_B": DataFormat.Bfp8_b,
+                "input_dimensions_A": DIMENSIONS_A,
+                "input_dimensions_B": DIMENSIONS_B,
+            },
+            id="mixed_formats_default_specs",
+        ),
+        pytest.param(
+            {
+                "stimuli_format_A": DataFormat.Float16_b,
+                "stimuli_format_B": DataFormat.Float16_b,
+                "input_dimensions_A": DIMENSIONS_A,
+                "input_dimensions_B": DIMENSIONS_B,
+                "tile_dimensions": [16, 32],
+            },
+            id="dense_mode",
+        ),
+        pytest.param(
+            {
+                "stimuli_format_A": DataFormat.Float16_b,
+                "stimuli_format_B": DataFormat.Float16_b,
+                # face_r_dim < 16 is the partial single-tile case, so it has to
+                # equal input_dimensions_A[0].
+                "input_dimensions_A": [8, 32],
+                "input_dimensions_B": [8, 32],
+                "face_r_dim": 8,
+                "num_faces": 2,
+            },
+            id="partial_faces",
+        ),
+    ],
+)
+def test_dropping_operand_b_leaves_a_and_the_tile_counts_alone(kwargs):
+    """A is bit-identical, B is None, and both tile counts are unchanged."""
+    (a_ref, cnt_a_ref, b_ref, cnt_b_ref), (a, cnt_a, b, cnt_b) = _both_ways(**kwargs)
+
+    assert b_ref is not None, "the two-operand call should still produce a B"
+    assert b is None, "generate_operand_B=False must return None in B's place"
+
+    # B's L1 region is still reserved from this count -- the operands are laid out
+    # contiguously, so a count that changed here would move buffer_Res.
+    assert cnt_b == cnt_b_ref
+    assert cnt_a == cnt_a_ref
+
+    assert a.dtype == a_ref.dtype
+    assert a.shape == a_ref.shape
+    assert torch.equal(a, a_ref), "A must not depend on whether B was generated"
+
+
+@pytest.mark.parametrize(
+    "output_format", [DataFormat.MxFp8P, DataFormat.MxFp8R], ids=lambda f: f.name
+)
+def test_the_mx_output_clamp_still_applies_to_a(output_format):
+    """The clamp is not purely pairwise, so dropping B must not drop it.
+
+    ``_clamp_mx_tensors`` has two independent halves: one fires when A and B are
+    *different* MX formats, the other when the **output** format is an MX one -- and the
+    second clamps A on its own account. Skipping the call for a missing B would silently
+    widen A's range for an MX output; the empty stand-in (``srcA_tensor[:0]``) is what
+    keeps the A-side behaviour identical, and this is the test that says so.
+
+    The population deliberately exceeds the format's max normal, so an unclamped A is a
+    visible failure rather than a no-op.
+    """
+    limit = MX_FORMAT_MAX_NORMAL[output_format]
+    kwargs = {
+        "stimuli_format_A": DataFormat.Float32,
+        "stimuli_format_B": DataFormat.Float32,
+        "input_dimensions_A": DIMENSIONS_A,
+        "input_dimensions_B": DIMENSIONS_B,
+        "spec_A": StimuliSpec.uniform(low=-4 * limit, high=4 * limit, seed=0),
+        "spec_B": StimuliSpec.uniform(low=-4 * limit, high=4 * limit, seed=1),
+        "output_format": output_format,
+    }
+    (a_ref, _, _, _), (a, _, b, _) = _both_ways(**kwargs)
+
+    assert b is None
+    assert torch.equal(a, a_ref)
+    assert a.abs().max().item() <= limit, (
+        f"A was not clamped to the {output_format.name} max normal ({limit}); the "
+        "output-format half of _clamp_mx_tensors was skipped along with operand B"
+    )
+    # And the clamp actually bit, so this is not passing on an already-in-range
+    # population.
+    assert (a.abs() == limit).any(), (
+        "no element reached the clamp bound, so this population no longer exercises "
+        "the output-format clamp"
+    )
+
+
+def test_mixed_mx_input_formats_still_clamp_a():
+    """The other half of the clamp: A and B being different MX formats clamps A too."""
+    limit = MX_FORMAT_MAX_NORMAL[DataFormat.MxFp8P]
+    kwargs = {
+        "stimuli_format_A": DataFormat.MxFp8R,
+        "stimuli_format_B": DataFormat.MxFp8P,
+        "input_dimensions_A": DIMENSIONS_A,
+        "input_dimensions_B": DIMENSIONS_B,
+        "spec_A": StimuliSpec.uniform(low=-4 * limit, high=4 * limit, seed=0),
+        "spec_B": StimuliSpec.uniform(low=-4 * limit, high=4 * limit, seed=1),
+    }
+    (a_ref, _, _, _), (a, _, b, _) = _both_ways(**kwargs)
+
+    assert b is None
+    assert torch.equal(a, a_ref)
+    assert a.abs().max().item() <= limit
+    assert (a.abs() == limit).any(), (
+        "no element reached the MxFp8P bound, so this population no longer exercises "
+        "the mixed-MX-input clamp"
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""The whole-tile unary SFPU golden must agree bit-exactly with the per-element one.
+
+``UnarySFPUGolden`` keeps two ways to evaluate an op: the per-element method registered
+in ``self.ops`` (the oracle, and the only place each op's semantics are written out) and
+the whole-tile entry in ``_VECTOR_TORCH_FNS`` / ``_VECTOR_SPECIAL_OPS`` that ``__call__``
+prefers when one exists. This file is the contract between them.
+
+Bit-exactness, not tolerance, is the bar. The golden is what every SFPU test asserts
+against, so a vectorised op that is merely *close* to the scalar one silently moves the
+pass/fail boundary of the whole sweep. torch is entitled to pick a different code path
+for a 1-element tensor than for a 1024-element one -- and for some ops it does -- which
+is exactly why membership of the table has to be measured rather than assumed.
+
+An op with no table entry is not a failure; it falls back to the per-element loop.
+``test_no_unlisted_op_is_silently_bit_exact_capable`` reports the fallback set so the
+coverage stays visible instead of quietly shrinking.
+"""
+
+import pytest
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation
+
+# One tile. The window __call__ evaluates is a whole number of tiles, so this is the
+# smallest input that exercises the real code path.
+TILE = 1024
+
+# Both formats matter: _torch_unary's inf->NaN substitution fires only for an
+# A-exponent (Float16) format, so an op is only proven equivalent if it agrees under
+# both branches of that rule.
+# Float32 is in the list because the Dest-dtype family (_VECTOR_DST_TORCH_FNS)
+# evaluates *in* dst_format, so each of the three Dest dtypes is a different
+# computation and has to be compared separately.
+FORMATS = [DataFormat.Float16_b, DataFormat.Float16, DataFormat.Float32]
+
+
+def _population(name):
+    """Inputs chosen to reach each op's interesting region *and* its specials.
+
+    A single uniform population would leave most of these ops evaluated only in their
+    smooth interior, where scalar and vectorised torch trivially agree; the divergences
+    worth catching live at poles, branch cuts and non-finite inputs.
+    """
+    torch.manual_seed(0)
+    if name == "unit_interval":
+        # (-1, 1): the domain of asin/acos/atanh/erfinv.
+        return torch.rand(TILE) * 1.98 - 0.99
+    if name == "positive":
+        # (0, 100]: log/sqrt/rsqrt/lgamma/digamma/reciprocal.
+        return torch.rand(TILE) * 100 + 1e-3
+    if name == "signed_wide":
+        # Straddles zero with a wide range: sign-sensitive and saturating ops.
+        return torch.randn(TILE) * 20
+    if name == "above_one":
+        # [1, 50]: acosh's domain.
+        return torch.rand(TILE) * 49 + 1.0
+    if name == "specials":
+        # Every special the pipeline can carry, padded with ordinary values so the
+        # comparison is not dominated by NaN-vs-NaN cases.
+        base = torch.rand(TILE) * 4 - 2
+        specials = [
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            torch.inf,
+            -torch.inf,
+            torch.nan,
+            -torch.nan,
+            1e-45,
+            -1e-45,
+            3.4e38,
+            -3.4e38,
+            65504.0,
+            -65504.0,
+        ]
+        for i, v in enumerate(specials):
+            base[i] = v
+        return base
+    raise AssertionError(f"unknown population {name}")
+
+
+POPULATIONS = ["unit_interval", "positive", "signed_wide", "above_one", "specials"]
+
+
+def _vector_ops():
+    golden = get_golden_generator(UnarySFPUGolden)
+    return sorted(
+        set(golden._VECTOR_TORCH_FNS)
+        | set(golden._VECTOR_DST_TORCH_FNS)
+        | set(golden._VECTOR_PY_FNS)
+        | set(golden._VECTOR_SPECIAL_OPS),
+        key=lambda o: o.name,
+    )
+
+
+VECTOR_OPS = _vector_ops()
+
+
+def _scalar_reference(golden, operation, values):
+    """Evaluate the per-element oracle, flagging the inputs it cannot handle.
+
+    Returns ``(results, evaluable)``, where *evaluable* is False wherever the scalar
+    method raised. Only the ``math``-backed methods do this, and only for inputs outside
+    the domain the op is ever swept over -- see the caller.
+    """
+    out, ok = [], []
+    for x in values.tolist():
+        try:
+            out.append(float(golden.ops[operation](x)))
+            ok.append(True)
+        except (OverflowError, ValueError):
+            out.append(torch.nan)
+            ok.append(False)
+    return torch.tensor(out, dtype=torch.float32), torch.tensor(ok)
+
+
+def _bitwise_equal(a, b):
+    """Bitwise equality on fp32, treating any-NaN as equal to any-NaN.
+
+    NaN *payloads* are not part of what the golden asserts: ``__call__`` canonicalises
+    the sign of every NaN it did not itself create (see _NAN_SIGN_TRANSPARENT_OPS), and
+    the payload never survives the cast to Dest. Everything else -- including the
+    distinction between NaN and infinity, which is the one the pack path turns into a
+    visible +inf/-inf disagreement -- is compared exactly.
+    """
+    both_nan = a.isnan() & b.isnan()
+    return ((a.view(torch.int32) == b.view(torch.int32)) | both_nan).all()
+
+
+def _first_difference(a, b, values):
+    both_nan = a.isnan() & b.isnan()
+    bad = (
+        (~((a.view(torch.int32) == b.view(torch.int32)) | both_nan)).nonzero().flatten()
+    )
+    i = int(bad[0])
+    return (
+        f"{len(bad)}/{a.numel()} elements differ; first at [{i}]: "
+        f"input {values[i]!r} -> vector {a[i].item()!r} vs scalar {b[i].item()!r}"
+    )
+
+
+@pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
+@pytest.mark.parametrize("population", POPULATIONS)
+@pytest.mark.parametrize("data_format", FORMATS, ids=lambda f: f.name)
+def test_vector_op_matches_scalar_op(operation, population, data_format):
+    """Every table entry, over every population, under both NaN-rule branches."""
+    golden = get_golden_generator(UnarySFPUGolden)
+    values = _population(population).to(torch.float32)
+
+    # __call__ sets these before dispatching; _torch_unary and handle_infinite_numbers
+    # both read them, so they have to be bound the same way for a fair comparison.
+    golden.data_format = data_format
+    golden.dst_format = data_format
+    golden.dest_acc = DestAccumulation.No
+
+    vector_op = golden._vector_op(operation)
+    assert vector_op is not None, f"{operation.name} is in the table but has no impl"
+
+    vector = vector_op(values).to(torch.float32)
+    scalar, evaluable = _scalar_reference(golden, operation, values)
+
+    # Some scalar methods cannot evaluate every input: _cosh/_sinh go through
+    # math.cosh/sinh, which raise OverflowError near the fp32 maximum instead of
+    # returning an infinity (torch returns inf there, so the vectorised path is
+    # strictly more total). Those elements drop out of the comparison rather than being
+    # papered over -- the oracle has no answer to compare against. The sweep never
+    # reaches them, because each op's stimuli come from its registered domain; this file
+    # is the only thing that feeds an op its format limits.
+    if not bool(evaluable.all()):
+        excluded = int((~evaluable).sum())
+        assert excluded < values.numel() // 2, (
+            f"{operation.name}: the scalar oracle could not evaluate {excluded} of "
+            f"{values.numel()} inputs, too many for the comparison to mean anything"
+        )
+        vector = vector[evaluable]
+        scalar = scalar[evaluable]
+
+    # raise rather than `assert cond, msg`: pytest's assertion rewriting renders both
+    # 1024-element tensors into the failure report, which buries the one line that says
+    # what actually differs.
+    if not _bitwise_equal(vector, scalar):
+        raise AssertionError(
+            f"{operation.name} / {population} / {data_format.name}: "
+            + _first_difference(vector, scalar, values[evaluable].tolist())
+        )
+
+
+@pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
+def test_vector_op_preserves_shape_and_dtype(operation):
+    """The whole-tile result must be a same-length fp32 tensor.
+
+    ``__call__`` writes it straight into a slice of ``result``, so a shape or dtype
+    surprise corrupts the tile rather than raising.
+    """
+    golden = get_golden_generator(UnarySFPUGolden)
+    golden.data_format = DataFormat.Float16_b
+    golden.dst_format = DataFormat.Float16_b
+    golden.dest_acc = DestAccumulation.No
+    values = _population("signed_wide").to(torch.float32)
+    out = golden._vector_op(operation)(values).to(torch.float32)
+    assert out.shape == values.shape
+    assert out.dtype == torch.float32
+
+
+def test_every_table_entry_is_a_registered_op():
+    """A table entry for an unregistered op would never be reached.
+
+    ``_vector_op`` is consulted with whatever ``__call__`` was handed, so an entry whose
+    MathOperation is not in ``self.ops`` is dead weight that reads as coverage.
+    """
+    golden = get_golden_generator(UnarySFPUGolden)
+    unreachable = sorted(op.name for op in VECTOR_OPS if op not in golden.ops)
+    assert not unreachable, f"vector table entries with no registered op: {unreachable}"
+
+
+def test_no_unlisted_op_is_silently_bit_exact_capable():
+    """Report which ops still take the per-element path.
+
+    Not an assertion about the size of the table -- ops legitimately stay scalar. This
+    exists so the fallback set is written down somewhere a reader will see it, and so a
+    regression that empties the table shows up as a diff here rather than only as a
+    slower nightly.
+    """
+    golden = get_golden_generator(UnarySFPUGolden)
+    scalar_only = sorted(op.name for op in golden.ops if op not in set(VECTOR_OPS))
+    # The count is asserted loosely on purpose: it should only ever go down.
+    assert len(scalar_only) <= len(golden.ops), "impossible"
+    print(f"\n{len(VECTOR_OPS)} vectorised, {len(scalar_only)} still per-element:")
+    print("  " + ", ".join(scalar_only))
+
+
+def test_nan_rule_branch_is_actually_exercised():
+    """The Float16 population must really produce an infinity for some op.
+
+    ``_torch_unary``'s inf->NaN substitution is the one behaviour that differs between
+    the two FORMATS. If no op/population combination ever produces an infinity, the
+    Float16 half of this file's matrix proves nothing, and a vectorised path that
+    dropped the rule would still pass.
+    """
+    golden = get_golden_generator(UnarySFPUGolden)
+    golden.data_format = DataFormat.Float16_b  # exponent-B: infinities survive
+    golden.dst_format = DataFormat.Float16_b
+    golden.dest_acc = DestAccumulation.No
+    values = _population("specials").to(torch.float32)
+    produced_inf = False
+    for operation in VECTOR_OPS:
+        out = golden._vector_op(operation)(values)
+        if bool(out.isinf().any()):
+            produced_inf = True
+            break
+    assert produced_inf, (
+        "no vectorised op produces an infinity on the specials population, so the "
+        "Float16 inf->NaN branch of _torch_unary is untested"
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
@@ -24,7 +24,7 @@ coverage stays visible instead of quietly shrinking.
 import pytest
 import torch
 from helpers.format_config import DataFormat
-from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
+from helpers.golden_generators import UnarySFPUGolden
 from helpers.llk_params import DestAccumulation, MathOperation, format_dict
 
 # One tile: the base population size, and the smallest window __call__ can produce.
@@ -105,13 +105,33 @@ def _population(name):
 POPULATIONS = ["unit_interval", "positive", "signed_wide", "above_one", "specials"]
 
 
+# One instance for the file, built directly rather than fetched with
+# ``get_golden_generator``.
+#
+# The registry is what the device tests use, but it is not usable here: the harness
+# replaces ``get_golden_generator`` with one that hands back a ``DummyGoldenGenerator``
+# under ``--compile-producer`` -- which is how the Quasar compile lane runs the whole
+# suite -- and that stub has none of the vector tables, so consulting the registry turns
+# this file's *collection* into an error there rather than into a test result. Same fix,
+# and same reason, as ``test_eltwise_binary_sfpu.py``'s ``_classify_edge_result`` and
+# ``helpers/compressed_utils.py``'s matmul golden.
+#
+# Shared across the file rather than built per test, which is also what the registry did
+# before, so the change is only in where the instance comes from. Safe because the only
+# state the vector paths read is ``data_format`` / ``dst_format`` / ``dest_acc``, and every
+# test binds all three through ``_bind_formats`` before dispatching. (``__init__``
+# assembles a 114-entry dispatch dict; per-test instantiation measured ~0.5 s slower over
+# the file -- small, but there is no reason to pay it.)
+_GOLDEN = UnarySFPUGolden()
+
+
 def _by_name(ops):
     """Sorted so the parametrize ids are stable across runs."""
     return sorted(ops, key=lambda o: o.name)
 
 
 def _vector_ops():
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     return _by_name(
         set(golden._VECTOR_TORCH_FNS)
         | set(golden._VECTOR_DST_TORCH_FNS)
@@ -144,7 +164,7 @@ def _nan_rule_partition():
     Float16 and Float16_b are two different computations there and nothing can be said
     about the pair.
     """
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     rule = {
         "_VECTOR_TORCH_FNS": _by_name(golden._VECTOR_TORCH_FNS),
         "_VECTOR_SPECIAL_OPS": _by_name(
@@ -270,7 +290,7 @@ def _compare(golden, operation, vector, scalar, evaluable, values, label):
 @pytest.mark.parametrize("data_format", FORMATS, ids=lambda f: f.name)
 def test_vector_op_matches_scalar_op(operation, population, data_format):
     """Every table entry, over every population, at every window, under both NaN rules."""
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     _bind_formats(golden, data_format)
     base = _population(population).to(torch.float32)
 
@@ -309,7 +329,7 @@ def test_vector_op_matches_scalar_op_in_the_tile_dtype(operation, data_format):
     and what is being pinned here is the dtype the window arrives in, so the specials
     are the population that matters.
     """
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     _bind_formats(golden, data_format)
     values = _population("specials").to(format_dict[data_format])
 
@@ -337,7 +357,7 @@ def test_vector_op_preserves_shape_and_dtype(operation, window):
     int-returning table entry (several entries end in ``.to(d.dtype)`` for exactly that
     reason) into a passing float.
     """
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     _bind_formats(golden, DataFormat.Float16_b)
     values = _population("signed_wide").to(torch.float32).repeat(window // TILE)
     raw = golden._vector_op(operation)(values)
@@ -351,7 +371,7 @@ def test_every_table_entry_is_a_registered_op():
     ``_vector_op`` is consulted with whatever ``__call__`` was handed, so an entry whose
     MathOperation is not in ``self.ops`` is dead weight that reads as coverage.
     """
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     unreachable = sorted(op.name for op in VECTOR_OPS if op not in golden.ops)
     assert not unreachable, f"vector table entries with no registered op: {unreachable}"
 
@@ -367,7 +387,7 @@ def test_no_unlisted_op_is_silently_bit_exact_capable():
     ``golden.ops`` by construction, so any bound against ``len(golden.ops)`` holds even
     with every vector table emptied -- which is the regression the test exists for.
     """
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     scalar_only = sorted(op.name for op in golden.ops if op not in set(VECTOR_OPS))
     print(f"\n{len(VECTOR_OPS)} vectorised, {len(scalar_only)} still per-element:")
     print("  " + ", ".join(scalar_only))
@@ -412,7 +432,7 @@ def test_nan_rule_holds_for_every_op_that_carries_it(table):
     so keeps the rule even if ``_torch_unary_vec`` drops it -- stand in for the whole
     ``_VECTOR_TORCH_FNS`` table.
     """
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     values = _population("specials").to(torch.float32)
 
     exercised = []
@@ -458,7 +478,7 @@ def test_ops_without_the_nan_rule_are_format_invariant(operation):
     here (invariance broken) or in the sibling test (rule never exercised), rather than
     silently narrowing what the rule is checked against.
     """
-    golden = get_golden_generator(UnarySFPUGolden)
+    golden = _GOLDEN
     values = _population("specials").to(torch.float32)
     exponent_b = _eval_under(golden, operation, values, DataFormat.Float16_b)
     exponent_a = _eval_under(golden, operation, values, DataFormat.Float16)

--- a/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
@@ -12,7 +12,9 @@ Bit-exactness, not tolerance, is the bar. The golden is what every SFPU test ass
 against, so a vectorised op that is merely *close* to the scalar one silently moves the
 pass/fail boundary of the whole sweep. torch is entitled to pick a different code path
 for a 1-element tensor than for a 1024-element one -- and for some ops it does -- which
-is exactly why membership of the table has to be measured rather than assumed.
+is exactly why membership of the table has to be measured rather than assumed. For the
+same reason the comparison is repeated at every window size the sweep dispatches (see
+``WINDOWS``) rather than at one tile.
 
 An op with no table entry is not a failure; it falls back to the per-element loop.
 ``test_no_unlisted_op_is_silently_bit_exact_capable`` reports the fallback set so the
@@ -23,11 +25,27 @@ import pytest
 import torch
 from helpers.format_config import DataFormat
 from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
-from helpers.llk_params import DestAccumulation
+from helpers.llk_params import DestAccumulation, MathOperation, format_dict
 
-# One tile. The window __call__ evaluates is a whole number of tiles, so this is the
-# smallest input that exercises the real code path.
+# One tile: the base population size, and the smallest window __call__ can produce.
 TILE = 1024
+
+# The window sizes __call__ actually hands to a vector op. It evaluates the whole
+# ``TILE_SIZE * iterations`` slice at once, and the sweep's input shapes are 64x64 and
+# 128x256, so in production that slice is 4,096 or 32,768 elements -- not one tile.
+# torch selects its kernel on numel, which is the very reason several ops had to be kept
+# off the table, so agreement has to be *measured* at each dispatched size rather than
+# inferred from the smallest one.
+#
+# The larger windows are the base population tiled. That keeps the scalar oracle at
+# 1,024 evaluations without weakening the check: every op on the table is a pure
+# elementwise map, so the per-element answer for a repeated input is the repeated
+# answer, and what the larger window changes is the shape torch dispatches on.
+#
+# Measured on torch 2.9: no op on the table is shape-sensitive across these three
+# windows -- the 0-d-vs-N-d split that kept 18 ops off it is a boundary at N == 1, not a
+# threshold further up. The check is here so that stays a measured fact; it costs ~1.3 s.
+WINDOWS = [1024, 4096, 32768]
 
 # Both formats matter: _torch_unary's inf->NaN substitution fires only for an
 # A-exponent (Float16) format, so an op is only proven equivalent if it agrees under
@@ -87,18 +105,78 @@ def _population(name):
 POPULATIONS = ["unit_interval", "positive", "signed_wide", "above_one", "specials"]
 
 
+def _by_name(ops):
+    """Sorted so the parametrize ids are stable across runs."""
+    return sorted(ops, key=lambda o: o.name)
+
+
 def _vector_ops():
     golden = get_golden_generator(UnarySFPUGolden)
-    return sorted(
+    return _by_name(
         set(golden._VECTOR_TORCH_FNS)
         | set(golden._VECTOR_DST_TORCH_FNS)
         | set(golden._VECTOR_PY_FNS)
-        | set(golden._VECTOR_SPECIAL_OPS),
-        key=lambda o: o.name,
+        | set(golden._VECTOR_SPECIAL_OPS)
     )
 
 
 VECTOR_OPS = _vector_ops()
+
+# _VECTOR_SPECIAL_OPS entries whose method routes through ``_torch_unary_vec`` or calls
+# ``handle_infinite_numbers`` itself, so the NaN rule reaches them as well. The rest of
+# that table (_vec_sign, _vec_cast_fp32_to_fp16a, the clamp/relu/Hardsigmoid family) has
+# no such rule and neither do their scalar twins, so requiring it of them would assert a
+# behaviour the golden does not have -- they are checked for format *invariance*
+# instead. See test_nan_rule_holds_for_every_op_that_carries_it.
+_NAN_RULE_SPECIAL_OPS = frozenset(
+    {
+        MathOperation.I0,
+        MathOperation.I1,
+        MathOperation.Square,
+    }
+)
+
+
+def _nan_rule_partition():
+    """Split the vector tables into the ops the NaN rule applies to and the rest.
+
+    ``_VECTOR_DST_TORCH_FNS`` is in neither group: it evaluates *in* dst_format, so
+    Float16 and Float16_b are two different computations there and nothing can be said
+    about the pair.
+    """
+    golden = get_golden_generator(UnarySFPUGolden)
+    rule = {
+        "_VECTOR_TORCH_FNS": _by_name(golden._VECTOR_TORCH_FNS),
+        "_VECTOR_SPECIAL_OPS": _by_name(
+            set(golden._VECTOR_SPECIAL_OPS) & _NAN_RULE_SPECIAL_OPS
+        ),
+    }
+    invariant = _by_name(
+        (set(golden._VECTOR_SPECIAL_OPS) - _NAN_RULE_SPECIAL_OPS)
+        | set(golden._VECTOR_PY_FNS)
+    )
+    return rule, invariant
+
+
+_NAN_RULE_TABLES, _FORMAT_INVARIANT_OPS = _nan_rule_partition()
+
+# The floor this file guards against a regression that quietly empties the vector
+# tables: 88 of the 114 registered ops were measured bit-exact and are on the table.
+# Asserted as a floor, not an equality -- adding an op is the intended direction, and
+# only a *drop* means the optimisation has silently gone away.
+MIN_VECTORISED_OPS = 88
+
+
+def _bind_formats(golden, data_format):
+    """Bind the fields ``__call__`` sets before dispatching.
+
+    ``_torch_unary_vec`` and ``handle_infinite_numbers`` read ``data_format`` and
+    ``_torch_dst_vec`` reads ``dst_format``, so they have to be bound the same way on
+    both sides for the comparison to be fair.
+    """
+    golden.data_format = data_format
+    golden.dst_format = data_format
+    golden.dest_acc = DestAccumulation.No
 
 
 def _scalar_reference(golden, operation, values):
@@ -119,24 +197,34 @@ def _scalar_reference(golden, operation, values):
     return torch.tensor(out, dtype=torch.float32), torch.tensor(ok)
 
 
-def _bitwise_equal(a, b):
-    """Bitwise equality on fp32, treating any-NaN as equal to any-NaN.
+def _bits_agree(a, b, nan_sign_matters=False):
+    """Elementwise bitwise equality on fp32, treating any-NaN as equal to any-NaN.
 
-    NaN *payloads* are not part of what the golden asserts: ``__call__`` canonicalises
-    the sign of every NaN it did not itself create (see _NAN_SIGN_TRANSPARENT_OPS), and
-    the payload never survives the cast to Dest. Everything else -- including the
-    distinction between NaN and infinity, which is the one the pack path turns into a
-    visible +inf/-inf disagreement -- is compared exactly.
+    NaN *payloads* are not part of what the golden asserts: the payload never survives
+    the cast to Dest. Everything else -- including the distinction between NaN and
+    infinity, which is the one the pack path turns into a visible +inf/-inf disagreement
+    -- is compared exactly.
+
+    The NaN *sign* is a different matter, and *nan_sign_matters* is the caller's way of
+    saying so. ``__call__`` canonicalises the sign of every NaN except for the three ops
+    in ``_NAN_SIGN_TRANSPARENT_OPS`` (Neg, Abs, Identity) -- precisely the ops whose NaN
+    sign is meaningful, and all three are on the vector path. For them a sign
+    disagreement becomes a visible +inf vs -inf once ``convert_nan_to_inf`` runs, so
+    folding it into "both NaN" would hide the one property ``cast_to_dest_dtype`` is
+    there to preserve.
     """
     both_nan = a.isnan() & b.isnan()
-    return ((a.view(torch.int32) == b.view(torch.int32)) | both_nan).all()
+    if nan_sign_matters:
+        both_nan &= torch.signbit(a) == torch.signbit(b)
+    # `a == b` plus matching sign bits *is* bitwise equality for floats: the only two
+    # distinct patterns that compare equal are +0.0 and -0.0. Written this way rather
+    # than as an int32 bit view so it also applies to the float64 and 16-bit tensors the
+    # tables produce before __call__'s cast.
+    return ((a == b) & (torch.signbit(a) == torch.signbit(b))) | both_nan
 
 
-def _first_difference(a, b, values):
-    both_nan = a.isnan() & b.isnan()
-    bad = (
-        (~((a.view(torch.int32) == b.view(torch.int32)) | both_nan)).nonzero().flatten()
-    )
+def _first_difference(a, b, values, nan_sign_matters=False):
+    bad = (~_bits_agree(a, b, nan_sign_matters)).nonzero().flatten()
     i = int(bad[0])
     return (
         f"{len(bad)}/{a.numel()} elements differ; first at [{i}]: "
@@ -144,33 +232,17 @@ def _first_difference(a, b, values):
     )
 
 
-@pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
-@pytest.mark.parametrize("population", POPULATIONS)
-@pytest.mark.parametrize("data_format", FORMATS, ids=lambda f: f.name)
-def test_vector_op_matches_scalar_op(operation, population, data_format):
-    """Every table entry, over every population, under both NaN-rule branches."""
-    golden = get_golden_generator(UnarySFPUGolden)
-    values = _population(population).to(torch.float32)
+def _compare(golden, operation, vector, scalar, evaluable, values, label):
+    """Assert bit-exact agreement, dropping the inputs the oracle could not evaluate.
 
-    # __call__ sets these before dispatching; _torch_unary and handle_infinite_numbers
-    # both read them, so they have to be bound the same way for a fair comparison.
-    golden.data_format = data_format
-    golden.dst_format = data_format
-    golden.dest_acc = DestAccumulation.No
-
-    vector_op = golden._vector_op(operation)
-    assert vector_op is not None, f"{operation.name} is in the table but has no impl"
-
-    vector = vector_op(values).to(torch.float32)
-    scalar, evaluable = _scalar_reference(golden, operation, values)
-
-    # Some scalar methods cannot evaluate every input: _cosh/_sinh go through
-    # math.cosh/sinh, which raise OverflowError near the fp32 maximum instead of
-    # returning an infinity (torch returns inf there, so the vectorised path is
-    # strictly more total). Those elements drop out of the comparison rather than being
-    # papered over -- the oracle has no answer to compare against. The sweep never
-    # reaches them, because each op's stimuli come from its registered domain; this file
-    # is the only thing that feeds an op its format limits.
+    Some scalar methods cannot evaluate every input: _cosh/_sinh go through
+    math.cosh/sinh, which raise OverflowError near the fp32 maximum instead of returning
+    an infinity (torch returns inf there, so the vectorised path is strictly more
+    total). Those elements drop out of the comparison rather than being papered over --
+    the oracle has no answer to compare against. The sweep never reaches them, because
+    each op's stimuli come from its registered domain; this file is the only thing that
+    feeds an op its format limits.
+    """
     if not bool(evaluable.all()):
         excluded = int((~evaluable).sum())
         assert excluded < values.numel() // 2, (
@@ -180,31 +252,97 @@ def test_vector_op_matches_scalar_op(operation, population, data_format):
         vector = vector[evaluable]
         scalar = scalar[evaluable]
 
+    nan_sign_matters = operation in golden._NAN_SIGN_TRANSPARENT_OPS
     # raise rather than `assert cond, msg`: pytest's assertion rewriting renders both
-    # 1024-element tensors into the failure report, which buries the one line that says
-    # what actually differs.
-    if not _bitwise_equal(vector, scalar):
+    # tensors into the failure report, which buries the one line that says what
+    # actually differs.
+    if not _bits_agree(vector, scalar, nan_sign_matters).all():
         raise AssertionError(
-            f"{operation.name} / {population} / {data_format.name}: "
-            + _first_difference(vector, scalar, values[evaluable].tolist())
+            f"{operation.name} / {label}: "
+            + _first_difference(
+                vector, scalar, values[evaluable].tolist(), nan_sign_matters
+            )
         )
 
 
 @pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
-def test_vector_op_preserves_shape_and_dtype(operation):
-    """The whole-tile result must be a same-length fp32 tensor.
+@pytest.mark.parametrize("population", POPULATIONS)
+@pytest.mark.parametrize("data_format", FORMATS, ids=lambda f: f.name)
+def test_vector_op_matches_scalar_op(operation, population, data_format):
+    """Every table entry, over every population, at every window, under both NaN rules."""
+    golden = get_golden_generator(UnarySFPUGolden)
+    _bind_formats(golden, data_format)
+    base = _population(population).to(torch.float32)
 
-    ``__call__`` writes it straight into a slice of ``result``, so a shape or dtype
-    surprise corrupts the tile rather than raising.
+    vector_op = golden._vector_op(operation)
+    assert vector_op is not None, f"{operation.name} is in the table but has no impl"
+
+    scalar, evaluable = _scalar_reference(golden, operation, base)
+
+    for window in WINDOWS:
+        repeats = window // TILE
+        values = base.repeat(repeats)
+        _compare(
+            golden,
+            operation,
+            vector_op(values).to(torch.float32),
+            scalar.repeat(repeats),
+            evaluable.repeat(repeats),
+            values,
+            f"{population} / {data_format.name} / window {window}",
+        )
+
+
+@pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
+@pytest.mark.parametrize("data_format", FORMATS, ids=lambda f: f.name)
+def test_vector_op_matches_scalar_op_in_the_tile_dtype(operation, data_format):
+    """The same agreement with the window arriving in the tile's own dtype.
+
+    ``__call__`` does not hand ``vector_op`` an fp32 tensor: ``result`` follows
+    *input_format* through ``tilize_block``, so for a 16-bit format the window is
+    bfloat16 or float16 while the scalar path sees the Python doubles that
+    ``result.tolist()`` widens the same elements to. Every other check here feeds fp32,
+    the one dtype where that narrowing cannot lose anything -- a NaN sign included, which
+    is exactly what ``cast_to_dest_dtype`` exists to preserve.
+
+    One cell rather than the full matrix: the populations are already covered in fp32,
+    and what is being pinned here is the dtype the window arrives in, so the specials
+    are the population that matters.
     """
     golden = get_golden_generator(UnarySFPUGolden)
-    golden.data_format = DataFormat.Float16_b
-    golden.dst_format = DataFormat.Float16_b
-    golden.dest_acc = DestAccumulation.No
-    values = _population("signed_wide").to(torch.float32)
-    out = golden._vector_op(operation)(values).to(torch.float32)
-    assert out.shape == values.shape
-    assert out.dtype == torch.float32
+    _bind_formats(golden, data_format)
+    values = _population("specials").to(format_dict[data_format])
+
+    vector_op = golden._vector_op(operation)
+    scalar, evaluable = _scalar_reference(golden, operation, values)
+    _compare(
+        golden,
+        operation,
+        vector_op(values).to(torch.float32),
+        scalar,
+        evaluable,
+        values,
+        f"specials in {format_dict[data_format]} / {data_format.name}",
+    )
+
+
+@pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
+@pytest.mark.parametrize("window", WINDOWS)
+def test_vector_op_preserves_shape_and_dtype(operation, window):
+    """The whole-tile result must be a same-length float tensor.
+
+    ``__call__`` writes it straight into a slice of ``result``, so a shape or dtype
+    surprise corrupts the tile rather than raising. Asserted on the *pre-cast* tensor:
+    the ``.to(torch.float32)`` every other test applies would launder a bool- or
+    int-returning table entry (several entries end in ``.to(d.dtype)`` for exactly that
+    reason) into a passing float.
+    """
+    golden = get_golden_generator(UnarySFPUGolden)
+    _bind_formats(golden, DataFormat.Float16_b)
+    values = _population("signed_wide").to(torch.float32).repeat(window // TILE)
+    raw = golden._vector_op(operation)(values)
+    assert raw.shape == values.shape
+    assert raw.dtype.is_floating_point, f"{operation.name} returned {raw.dtype}"
 
 
 def test_every_table_entry_is_a_registered_op():
@@ -219,41 +357,114 @@ def test_every_table_entry_is_a_registered_op():
 
 
 def test_no_unlisted_op_is_silently_bit_exact_capable():
-    """Report which ops still take the per-element path.
+    """Report which ops still take the per-element path, and hold the table's floor.
 
-    Not an assertion about the size of the table -- ops legitimately stay scalar. This
-    exists so the fallback set is written down somewhere a reader will see it, and so a
-    regression that empties the table shows up as a diff here rather than only as a
-    slower nightly.
+    The report is the point: ops legitimately stay scalar, and this is the only place
+    the fallback set is written down where a reader will see it.
+
+    The assertion is on the size of the *vector* table, not the fallback set. Asserting
+    the fallback set instead is what makes this test vacuous: it is a subset of
+    ``golden.ops`` by construction, so any bound against ``len(golden.ops)`` holds even
+    with every vector table emptied -- which is the regression the test exists for.
     """
     golden = get_golden_generator(UnarySFPUGolden)
     scalar_only = sorted(op.name for op in golden.ops if op not in set(VECTOR_OPS))
-    # The count is asserted loosely on purpose: it should only ever go down.
-    assert len(scalar_only) <= len(golden.ops), "impossible"
     print(f"\n{len(VECTOR_OPS)} vectorised, {len(scalar_only)} still per-element:")
     print("  " + ", ".join(scalar_only))
+    assert len(VECTOR_OPS) >= MIN_VECTORISED_OPS, (
+        f"only {len(VECTOR_OPS)} ops are on the vector tables, down from the measured "
+        f"{MIN_VECTORISED_OPS}; the sweep has silently gone back to the per-element "
+        f"golden for {MIN_VECTORISED_OPS - len(VECTOR_OPS)} op(s)"
+    )
 
 
-def test_nan_rule_branch_is_actually_exercised():
-    """The Float16 population must really produce an infinity for some op.
+def _eval_under(golden, operation, values, data_format):
+    """Evaluate *operation* with *data_format* bound, in the table's own precision.
 
-    ``_torch_unary``'s inf->NaN substitution is the one behaviour that differs between
-    the two FORMATS. If no op/population combination ever produces an infinity, the
-    Float16 half of this file's matrix proves nothing, and a vectorised path that
-    dropped the rule would still pass.
+    Deliberately **not** cast to fp32. The NaN rule is about the infinities the op
+    itself produces, and an fp32 cast manufactures others: ``_vec_square`` works in
+    float64, where 3.4e38 squares to a finite 1.16e77 and never reaches
+    ``handle_infinite_numbers`` -- it only becomes an infinity in the later cast, under
+    both formats alike. Comparing after the cast would read that as the rule having been
+    dropped.
+    """
+    _bind_formats(golden, data_format)
+    return golden._vector_op(operation)(values)
+
+
+@pytest.mark.parametrize("table", sorted(_NAN_RULE_TABLES))
+def test_nan_rule_holds_for_every_op_that_carries_it(table):
+    """``+/-inf`` under exponent-B must be NaN under an A-exponent format. Per op.
+
+    ``_torch_unary_vec``'s inf->NaN substitution is the one behaviour that differs
+    between the ``FORMATS`` entries, and the Float16 half of this file's matrix rests on
+    it. Asserted as the rule itself, for every op that carries it, rather than by proxy:
+    "some op produced an infinity" is satisfied by ``Abs`` -- a ``_VECTOR_PY_FNS`` entry
+    with no such rule -- and stays green with the substitution deleted outright.
+
+    Both directions are needed. Wherever exponent-B kept an infinity the A-exponent
+    format must hold a NaN, *and* nothing may differ between the two formats anywhere
+    else; either half alone passes on an implementation that has stopped applying the
+    rule and started doing something else with the format.
+
+    Parametrised per table so each one has to exercise the rule on its own. Rolling them
+    together lets ``_vec_square`` -- which calls ``handle_infinite_numbers`` directly and
+    so keeps the rule even if ``_torch_unary_vec`` drops it -- stand in for the whole
+    ``_VECTOR_TORCH_FNS`` table.
     """
     golden = get_golden_generator(UnarySFPUGolden)
-    golden.data_format = DataFormat.Float16_b  # exponent-B: infinities survive
-    golden.dst_format = DataFormat.Float16_b
-    golden.dest_acc = DestAccumulation.No
     values = _population("specials").to(torch.float32)
-    produced_inf = False
-    for operation in VECTOR_OPS:
-        out = golden._vector_op(operation)(values)
-        if bool(out.isinf().any()):
-            produced_inf = True
-            break
-    assert produced_inf, (
-        "no vectorised op produces an infinity on the specials population, so the "
-        "Float16 inf->NaN branch of _torch_unary is untested"
+
+    exercised = []
+    for operation in _NAN_RULE_TABLES[table]:
+        exponent_b = _eval_under(golden, operation, values, DataFormat.Float16_b)
+        exponent_a = _eval_under(golden, operation, values, DataFormat.Float16)
+
+        infinite = exponent_b.isinf()
+        if bool(infinite.any()):
+            exercised.append(operation.name)
+            kept = infinite & ~exponent_a.isnan()
+            assert not bool(kept.any()), (
+                f"{operation.name}: {int(kept.sum())} of {int(infinite.sum())} "
+                "infinities under Float16_b were not substituted with NaN under "
+                "Float16, so the inf->NaN rule is no longer applied"
+            )
+
+        # NaN sign is compared here: the substitution's output is what the pack path
+        # later turns into a visible +inf/-inf, so a sign that varies with the format is
+        # a real disagreement.
+        differs = ~_bits_agree(exponent_a, exponent_b, nan_sign_matters=True)
+        elsewhere = differs & ~infinite
+        assert not bool(elsewhere.any()), (
+            f"{operation.name}: Float16_b and Float16 differ in "
+            f"{int(elsewhere.sum())} elements where Float16_b held no infinity, so "
+            "something other than the inf->NaN rule varies with the format"
+        )
+
+    assert exercised, (
+        f"no op in {table} produced an infinity under Float16_b on the specials "
+        "population, so the inf->NaN substitution is untested from this table and the "
+        "Float16 half of this file's matrix proves nothing about it"
+    )
+
+
+@pytest.mark.parametrize("operation", _FORMAT_INVARIANT_OPS, ids=lambda o: o.name)
+def test_ops_without_the_nan_rule_are_format_invariant(operation):
+    """The complement of the rule, pinned so a new op cannot land on the wrong side.
+
+    ``_VECTOR_PY_FNS`` and the non-``_torch_unary_vec`` half of ``_VECTOR_SPECIAL_OPS``
+    carry no format-dependent behaviour -- their scalar twins do not either. Asserting
+    that keeps ``_NAN_RULE_SPECIAL_OPS`` honest: an op added to the wrong table fails
+    here (invariance broken) or in the sibling test (rule never exercised), rather than
+    silently narrowing what the rule is checked against.
+    """
+    golden = get_golden_generator(UnarySFPUGolden)
+    values = _population("specials").to(torch.float32)
+    exponent_b = _eval_under(golden, operation, values, DataFormat.Float16_b)
+    exponent_a = _eval_under(golden, operation, values, DataFormat.Float16)
+    differs = ~_bits_agree(exponent_a, exponent_b, nan_sign_matters=True)
+    assert not bool(differs.any()), (
+        f"{operation.name} changes with the data format in {int(differs.sum())} "
+        "elements but is not listed as carrying the inf->NaN rule; if it does carry "
+        "it, add it to _NAN_RULE_SPECIAL_OPS"
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unary_sfpu_golden_vectorised.py
@@ -17,8 +17,9 @@ same reason the comparison is repeated at every window size the sweep dispatches
 ``WINDOWS``) rather than at one tile.
 
 An op with no table entry is not a failure; it falls back to the per-element loop.
-``test_no_unlisted_op_is_silently_bit_exact_capable`` reports the fallback set so the
-coverage stays visible instead of quietly shrinking.
+``test_vector_table_holds_its_floor_and_reports_the_fallback_set`` prints that fallback
+set and holds the vector table to a floor, so the coverage stays visible instead of
+quietly shrinking.
 """
 
 import pytest
@@ -286,36 +287,57 @@ def _compare(golden, operation, vector, scalar, evaluable, values, label):
 
 
 @pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
-@pytest.mark.parametrize("population", POPULATIONS)
-@pytest.mark.parametrize("data_format", FORMATS, ids=lambda f: f.name)
-def test_vector_op_matches_scalar_op(operation, population, data_format):
-    """Every table entry, over every population, at every window, under both NaN rules."""
-    golden = _GOLDEN
-    _bind_formats(golden, data_format)
-    base = _population(population).to(torch.float32)
+def test_vector_op_matches_scalar_op(operation):
+    """Every table entry, over every population, at every window, under both NaN rules.
 
+    Only *operation* is parametrised. The population, format and window axes are looped
+    inside one item because they are cheap and the op axis is the one that carries the
+    diagnostic value: a failure names the op in its id and the cell in its message, and
+    88 items still spread across xdist workers, whereas 1,320 make every PR pay
+    collection and reporting for a matrix that runs in a couple of seconds.
+
+    ``checked`` is not decoration. Folding axes into a loop is exactly the edit that can
+    silently stop covering a cell -- a mis-scoped ``continue``, a loop nested one level
+    too deep -- and unlike a dropped parametrize argument nothing about the item count
+    would show it. The count is asserted against the product of the three axes.
+    """
+    golden = _GOLDEN
     vector_op = golden._vector_op(operation)
     assert vector_op is not None, f"{operation.name} is in the table but has no impl"
 
-    scalar, evaluable = _scalar_reference(golden, operation, base)
+    checked = 0
+    for population in POPULATIONS:
+        base = _population(population).to(torch.float32)
+        for data_format in FORMATS:
+            # Rebound per cell: the scalar oracle reads ``data_format`` too (the
+            # inf->NaN rule is applied on both sides), so it has to be re-evaluated per
+            # format rather than hoisted out with the population.
+            _bind_formats(golden, data_format)
+            scalar, evaluable = _scalar_reference(golden, operation, base)
 
-    for window in WINDOWS:
-        repeats = window // TILE
-        values = base.repeat(repeats)
-        _compare(
-            golden,
-            operation,
-            vector_op(values).to(torch.float32),
-            scalar.repeat(repeats),
-            evaluable.repeat(repeats),
-            values,
-            f"{population} / {data_format.name} / window {window}",
-        )
+            for window in WINDOWS:
+                repeats = window // TILE
+                values = base.repeat(repeats)
+                _compare(
+                    golden,
+                    operation,
+                    vector_op(values).to(torch.float32),
+                    scalar.repeat(repeats),
+                    evaluable.repeat(repeats),
+                    values,
+                    f"{population} / {data_format.name} / window {window}",
+                )
+                checked += 1
+
+    expected = len(POPULATIONS) * len(FORMATS) * len(WINDOWS)
+    assert checked == expected, (
+        f"{operation.name}: compared {checked} cells, expected {expected}; a "
+        "population, format or window is no longer being reached"
+    )
 
 
 @pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
-@pytest.mark.parametrize("data_format", FORMATS, ids=lambda f: f.name)
-def test_vector_op_matches_scalar_op_in_the_tile_dtype(operation, data_format):
+def test_vector_op_matches_scalar_op_in_the_tile_dtype(operation):
     """The same agreement with the window arriving in the tile's own dtype.
 
     ``__call__`` does not hand ``vector_op`` an fp32 tensor: ``result`` follows
@@ -325,31 +347,40 @@ def test_vector_op_matches_scalar_op_in_the_tile_dtype(operation, data_format):
     the one dtype where that narrowing cannot lose anything -- a NaN sign included, which
     is exactly what ``cast_to_dest_dtype`` exists to preserve.
 
-    One cell rather than the full matrix: the populations are already covered in fp32,
-    and what is being pinned here is the dtype the window arrives in, so the specials
-    are the population that matters.
+    One population rather than the full matrix: the populations are already covered in
+    fp32, and what is being pinned here is the dtype the window arrives in, so the
+    specials are the population that matters. The format axis is looped in-item for the
+    reason given on ``test_vector_op_matches_scalar_op``, with the same count assertion.
     """
     golden = _GOLDEN
-    _bind_formats(golden, data_format)
-    values = _population("specials").to(format_dict[data_format])
-
     vector_op = golden._vector_op(operation)
-    scalar, evaluable = _scalar_reference(golden, operation, values)
-    _compare(
-        golden,
-        operation,
-        vector_op(values).to(torch.float32),
-        scalar,
-        evaluable,
-        values,
-        f"specials in {format_dict[data_format]} / {data_format.name}",
-    )
+
+    checked = 0
+    for data_format in FORMATS:
+        _bind_formats(golden, data_format)
+        values = _population("specials").to(format_dict[data_format])
+
+        scalar, evaluable = _scalar_reference(golden, operation, values)
+        _compare(
+            golden,
+            operation,
+            vector_op(values).to(torch.float32),
+            scalar,
+            evaluable,
+            values,
+            f"specials in {format_dict[data_format]} / {data_format.name}",
+        )
+        checked += 1
+
+    expected = len(FORMATS)
+    assert (
+        checked == expected
+    ), f"{operation.name}: compared {checked} formats, expected {expected}"
 
 
 @pytest.mark.parametrize("operation", VECTOR_OPS, ids=lambda o: o.name)
-@pytest.mark.parametrize("window", WINDOWS)
-def test_vector_op_preserves_shape_and_dtype(operation, window):
-    """The whole-tile result must be a same-length float tensor.
+def test_vector_op_preserves_shape_and_dtype(operation):
+    """The whole-tile result must be a same-length float tensor, at every window.
 
     ``__call__`` writes it straight into a slice of ``result``, so a shape or dtype
     surprise corrupts the tile rather than raising. Asserted on the *pre-cast* tensor:
@@ -359,10 +390,25 @@ def test_vector_op_preserves_shape_and_dtype(operation, window):
     """
     golden = _GOLDEN
     _bind_formats(golden, DataFormat.Float16_b)
-    values = _population("signed_wide").to(torch.float32).repeat(window // TILE)
-    raw = golden._vector_op(operation)(values)
-    assert raw.shape == values.shape
-    assert raw.dtype.is_floating_point, f"{operation.name} returned {raw.dtype}"
+    vector_op = golden._vector_op(operation)
+
+    checked = 0
+    for window in WINDOWS:
+        values = _population("signed_wide").to(torch.float32).repeat(window // TILE)
+        raw = vector_op(values)
+        assert raw.shape == values.shape, (
+            f"{operation.name} at window {window}: returned {tuple(raw.shape)}, "
+            f"expected {tuple(values.shape)}"
+        )
+        assert (
+            raw.dtype.is_floating_point
+        ), f"{operation.name} at window {window} returned {raw.dtype}"
+        checked += 1
+
+    expected = len(WINDOWS)
+    assert (
+        checked == expected
+    ), f"{operation.name}: checked {checked} windows, expected {expected}"
 
 
 def test_every_table_entry_is_a_registered_op():
@@ -376,7 +422,7 @@ def test_every_table_entry_is_a_registered_op():
     assert not unreachable, f"vector table entries with no registered op: {unreachable}"
 
 
-def test_no_unlisted_op_is_silently_bit_exact_capable():
+def test_vector_table_holds_its_floor_and_reports_the_fallback_set():
     """Report which ops still take the per-element path, and hold the table's floor.
 
     The report is the point: ops legitimately stay scalar, and this is the only place


### PR DESCRIPTION
Cuts the unary SFPU sweep by **243 s of host-side CPU work** with no change in coverage:
`4652 passed / 1140 skipped` becomes `4652 passed / 0 skipped`.

What that is worth in wall time depends on the worker count, so both measurements are
below rather than one headline number:

| configuration | before | after | |
|---|---:|---:|---|
| serial, `-n 1`, p150 | 609 s | **364 s** | **−40%** (1.67×) |
| `-n 6`, p300a | 170.6 s | **132.2 s** | **−22.5%** (1.29×) |

Same change, same 243 s of CPU work removed; parallelism divides the cost *and* the
saving, so the percentage shrinks as `-n` rises. **The −40% figure is contingent on the
serial run** — do not read it as what a parallel CI lane will see.

## Measured end to end

Back-to-back runs of `test_eltwise_unary_sfpu::test_eltwise_unary_sfpu` on a Blackhole
p150, serial (`-n 1`). Compile time is 233.9 s before vs 234.1 s after — the same 570
ELFs, untouched by this PR — which is what confirms the two runs are comparable rather
than one just landing on a quieter machine.

| | before | after | |
|---|---:|---:|---|
| wall | 609 s | **364 s** | −40% (1.67×) |
| non-compile work | 364.8 s | **121.2 s** | **3.0×** |
| outcome | 4652 passed, 1140 skipped | 4652 passed, **0 skipped** | same coverage |

Per stage, per test:

| stage | before | after | factor | saved |
|---|---:|---:|---:|---:|
| compile (untouched) | 50.28 ms | 50.32 ms | 1.0× | — |
| **golden** | 36.24 ms | 13.61 ms | **2.7×** | 105.3 s |
| **stimuli pack + L1 write** | 29.69 ms | 0.82 ms | **36×** | 134.3 s |
| **stimuli generation** | 2.00 ms | 1.23 ms | **1.6×** | 3.6 s |
| result read + unpack | 9.05 ms | 9.03 ms | 1.0× | — |
| ELF load + launch | 0.75 ms | 0.73 ms | 1.0× | — |
| compare vs golden | 0.64 ms | 0.60 ms | 1.1× | — |
| device wait | 0.04 ms | 0.04 ms | 1.0× | — |
| **accounted** | **598.7 s** | **355.3 s** | **1.69×** | **243.4 s** |

Stage timings come from wrapping each stage in a `perf_counter` accumulator loaded as a
pytest plugin — not cProfile, which inflates the pure-Python stages by ~35% relative to
the subprocess-bound compile stage and would overstate exactly the thing this PR changes.
98.3% of wall time is accounted for, so nothing significant sits outside the table.

Worth noting from the table: **device wait is 0.04 ms/test.** Effectively all of this
suite's cost is host-side Python and `g++`, which is why the work is where it is.

### Rebase note

The table above is the original p150 measurement and has **not** been re-run since the
rebases onto `main`. It does not need to be: across both of them — 50 commits then a
further 96, so 146 in total — none touches any file on the measured path.
`golden_generators.py`, `pack.py`, `stimuli_config.py` and
`stimuli_generator/generator.py` are byte-identical between the original parent
`a831f597669` and the current base `7f2ea65cea2`, checked file by file. Re-running
on the p300a that is available now would swap a like-for-like p150 comparison for a
non-comparable one, so the honest thing is to leave it and say so.

**The sweep was, though — as a controlled A/B rather than a re-run of the table.** Base
`a831f597669` (this PR's exact parent, verified to contain none of the change: 5792
collected vs 4652) against the PR head, same p300a, same flags, a fresh `RUNNER_TEMP` per
side, two iterations each, back to back:

| | iter 1 | iter 2 | mean | spread |
|---|---:|---:|---:|---:|
| base | 169.08 s | 172.17 s | **170.62 s** | 3.09 s |
| PR | 131.95 s | 132.38 s | **132.16 s** | 0.43 s |

**−38.5 s, −22.5%, 1.29×**; worst case (fastest base vs slowest PR) is still −21.7%, so
it clears the noise. Both sides: 4652 passed and **exactly 570 ELFs** — coverage and
compile work identical, only the 1140 skips gone.

That result also independently validates the per-stage table above. Its three changed
stages sum to 52.27 ms/test × 4652 = **243 s of CPU work**; at `-n 6` that spreads over
six workers, predicting a 40.5 s wall saving. Observed: **38.5 s, 95% of predicted** — on
different silicon from the original measurement.

What else was re-verified on hardware after the rebase (Blackhole p300a, `-n 6`):

| claim | re-measured |
|---|---|
| `4652 passed, 0 skipped` | ✅ 4652 passed, 0 skipped |
| 570 ELFs | ✅ exactly 570, on both sides of the A/B |
| collection 5792 → 4652, tally 822/160/80/78 | ✅ unchanged, and 5468/324 on Wormhole |
| 88 vectorised / 26 fallback ops | ✅ unchanged |
| the host-side agreement cases | ✅ pass on all three `CHIP_ARCH` values |

**The second rebase (96 commits, onto `7f2ea65cea2`) was verified host-side only** — no
device was used for it. Re-checked: collection 5792 → 4652 on Blackhole and 5468 on
Wormhole with the tallies unchanged (822/160/80/78 and 160/84/80), the agreement suites
green on all three `CHIP_ARCH` values, and the Quasar compile lane's exact invocation
collecting clean. The hardware figures above are the p300a measurements from the first
rebase and are not re-claimed for this base; nothing in the 96 commits touches this PR's
files, in either direction.

One figure did move: the other sweeps' xfail count is **14, was 13**. That is main's
sqrt_custom(+inf) fix ([#53757](https://github.com/tenstorrent/tt-metal/pull/53757)),
which retired the two `Erfinv` entries in `_EDGE_KNOWN_DIVERGENCES` and added
`SqrtCustom` to the cat-B set. Nothing to do with this PR — the number is corrected
below.

## Where the gain lands — and where it does not

Worth stating plainly, because it is easy to look for this saving in the wrong place:
`test_eltwise_unary_sfpu` is **`@pytest.mark.nightly`**.

- The **PR gate** runs `-m "not perf and not nightly and not quasar and not accuracy"`
  (`.github/workflows/pr-gate.yaml`), so it never executes the swept test.
  **None of this PR's sweep saving is visible on a PR.**
- The lane that does run it is **`llk-e2e`**, a 1AM cron against `main`
  (`.github/workflows/llk-e2e.yaml`) — that is where the 243 s lands.

What the PR gate *does* see are the two parts of this PR that are not marked, pulling in
opposite directions:

- **+379 new tests** — the agreement suites are unmarked, so they run on every PR
  (~4.3 s host-side). They make **2,299 comparisons**; the item count is 379 because the
  population, format, window, dtype and layout axes are looped in-item rather than
  parametrised. That is the second review round below — it was 2,299 items.
- **the vectorised BFP packer** — `pack.py` is on the path of every test with a Bfp8_b /
  Bfp4_b / Bfp2_b operand or result, which is a large share of the non-nightly suite.

I have not isolated the packer's PR-gate contribution with a controlled A/B, so I am not
putting a number on it. Comparing this PR's gate run against another LLK PR's is
suggestive in the right direction, but not evidence: any two PRs differ in base `main`,
in their own added tests, and in kernel changes, so at least three things vary besides the
packer.

## The changes

Four, each keeping the previous per-element implementation as the oracle rather than
replacing it.

### 1. `helpers/pack.py` — vectorised BFP_b packer

`_bfp_quantize_blocks` replaces the per-element path, which did bit manipulation by
formatting each value as a **binary string**: 4.5 M calls to `float_to_bfp8_block` per
sweep, 72 M to `bfloat16_to_binary` and 88 M `struct.pack` beneath it.

The scalar loop stays as the reference. `test_bfp_pack_vectorised.py` asserts
byte-identical shared exponents *and* mantissas across 389 cases. Bytewise, not
value-wise, and that distinction matters: the reference keeps only 6 of the 7 bf16
mantissa bits (`binary_str[9:-1]`, "remove last"), so the obvious
`(bf16 & 0x7F) | 0x80` passes a tolerance check while emitting different bytes.

Mutation-tested: 5 of 6 deliberate breakages are caught (negative-zero flush, rounding
guard bit, shared-exponent min/max, narrow-truncation reflush, guard shift). The 6th —
removing the over-wide shift clip — is behaviour-neutral because numpy 2.2 defines that
shift as 0; the comment says so, and the clip stays as version insurance.

### 2. `helpers/golden_generators.py` — whole-tile unary SFPU golden

88 of 114 ops now evaluate a whole tile instead of building a 0-d `torch.tensor` per
element — 51 M tensor constructions and 50 M `.item()` calls per sweep.

`test_unary_sfpu_golden_vectorised.py` gates every table entry on **bit-exactness**
against the per-element method, across 5 populations × 3 Dest dtypes. That gate rejected
26 ops, and the reasons are recorded next to the tables:

- **18 diverge in the last fp32 bit** because torch selects a different kernel for a
  1024-element tensor than for the 0-d tensor the scalar path builds.
- `softshrink(-0.0)` returns `-0.0` scalar but `+0.0` vectorised — a signed zero, not a
  ULP.
- The remaining 8 are not elementwise-unary-float ops (`Cumsum`, `Fill`, the reduces, the
  integer shift/max/min ops, which go through `_call_integer`).

Forcing all 18 through torch anyway **was tried**: golden drops to 2.34 ms/test (15.5× vs
baseline) and the main sweep passes all 4652 — but it fails
`test_eltwise_unary_sfpu_edges[Float32->Float32, GeluAppx, dest_acc=Yes]`. On an fp32
Dest there is no 16-bit rounding to absorb the shift, so it reaches the comparator.
Reverted; the extra ~52 s is available if that one case is ever deemed acceptable.

Reproducing the oracle exactly required modelling three things it does by accident:

| oracle behaviour | why it matters |
|---|---|
| `math.floor`/`ceil`/`trunc`/`round` return Python **ints** | a negative zero cannot survive, and the pack path reads the sign bit |
| `sfpu_relu_max` keys in fp32 but carries its value in **double** | ranking the value in fp32 too costs a ULP on `Hardsigmoid` |
| `x * x` is evaluated in **double** | an fp32-representable `1e30` squares to a finite `1e60` and never reaches the infinity branch |

`math.cosh`/`sinh` also *raise* `OverflowError` near the fp32 max where torch returns
`inf`; the test compares only where the oracle can be evaluated and records why the rest
cannot, rather than hiding it.

### 3. `test_eltwise_unary_sfpu.py` + `helpers/stimuli_{config,generator}` — drop operand B

The unary kernels never read `buffer_B` — `eltwise_unary_sfpu_test.cpp` contains no
reference to it — yet every test generated, packed and DMA'd a second tile.
`write_matrix` was called 9,304 times for 4,652 tests, exactly 2×.

`generate_stimuli` gains `generate_operand_B`, and `StimuliConfig` accepts
`buffer_B=None`, keeping B's L1 reservation (the operands are laid out contiguously and
the generated header declares `buffer_B` unconditionally, so dropping the reservation
would move `buffer_Res`). The A-side of `_clamp_mx_tensors` still runs — it clamps A on
its own for an MX output format — verified byte-identical either way.

### 4. `test_eltwise_unary_sfpu.py` — filter deterministic skips at collection

All four `pytest.skip` families were pure functions of the parametrize tuple and
`TestConfig.CHIP_ARCH`, which `pytest_configure` binds before collection, so
`_unsupported_reason` now filters them when the params are built.

Collection goes **5792 → 4652, exactly the number that used to pass** — the invariant
showing nothing was dropped. Because a filtered case leaves no `SKIPPED` line,
`test_unswept_combinations_are_accounted_for` prints the tally and fails if the filter
ever empties the matrix:

| filtered | reason |
|---:|---|
| 822 | not supported on BH architecture |
| 160 | [tt-llk#1120](https://github.com/tenstorrent/tt-llk/issues/1120) (`ReluMin`) |
| 80 | Metal tanh does not support approximation mode |
| 78 | exp-family ops do not support bf8_b in approximation mode |
| **1140** | reconciling exactly against 4652 + 1140 = 5792 |

## Verification beyond the sweep

- 2,299 agreement comparisons across the three new test files, collected as **379
  pytest items** (319 golden + 53 BFP packer + 7 stimuli generator), all host-side,
  4.3 s total.
- The file's other sweeps (including `_edges`, where specials are injected):
  391 passed / 467 skipped / 14 xfailed.
- Stratified hardware samples of `test_eltwise_binary`, `test_pack`, `test_reduce`,
  `test_eltwise_unary_datacopy`, `test_matmul`, `test_fused`, the three
  compressed-matmul suites and the other SFPU files — covering the remaining consumers
  of `pack_bfp*` and `StimuliConfig`.

## Review round

All 15 review comments are addressed in the second commit, and each fix is
mutation-tested rather than assumed — three of them turned out to be right in a stronger form than reported:

| flagged | what it actually was |
|---|---|
| bit-exactness only checked at 1,024 elements | now measured at all three dispatched windows (1,024 / 4,096 / 32,768), with the larger ones as the tiled base population so the oracle stays at 1,024 evaluations. **No op on the table is shape-sensitive across the three** on torch 2.9 — the 0-d-vs-N-d split is a boundary at N == 1, not a threshold further up. Measured now, not assumed. +1.3 s |
| the inf→NaN meta-test passes for the wrong reason (`Abs`) | worse: a global "some op produced an infinity" is *also* satisfied by `_vec_square`, which calls `handle_infinite_numbers` itself — my first rewrite still passed with the substitution deleted. Now asserted per op, per table, in both directions, with the complement pinned |
| `\| both_nan` hides a NaN *sign* disagreement | correct, and the justification was backwards: `_NAN_SIGN_TRANSPARENT_OPS` is the set `__call__` *skips* canonicalising. Now sign-sensitive for those three; mutating `Neg` to canonicalise fails 5 cases |
| no direct test of `generate_operand_B=False` | new `test_stimuli_generator.py`; 4 mutations of the branch all fail it |
| `UNSWEPT_COMBINATIONS` truthiness passes on any one reason | per-reason liveness, BH gated on `CHIP_ARCH`, plus the converse. "ReluMin fixed, branch left behind" now fails on **both** arches |

Plus: two tautological asserts replaced, three open-coded copies of `sfpu_min_elementwise`
folded into it, the backwards Prelu signed-zero comment, the tile constants, a dangling
`_skip_bh_unsupported_float_combo` reference in `sfpu_domains.py` (not in the diff), and
every `#L` reference in the plan doc this PR moved — not just the one flagged.

## Second review round

Three more comments, all on the two new host-side files, all addressed in the fourth
commit. Same rule as the first round: each fix is mutation-tested rather than assumed.

**Two on the parametrization explosion.** The agreement suites collected 2,299 unmarked
items, every one of them on the PR gate, which pays collection, xdist scheduling and
reporting per item. Four tests were the whole of it:

| test | before | after |
|---|---:|---:|
| `test_vector_op_matches_scalar_op` | 1320 = 88 ops × 5 pops × 3 formats | **88** |
| `test_vector_op_matches_scalar_op_in_the_tile_dtype` | 264 = 88 × 3 formats | **88** |
| `test_vector_op_preserves_shape_and_dtype` | 264 = 88 × 3 windows | **88** |
| `test_vectorised_matches_reference` | 384 = 3 widths × 16 pops × 2 dtypes × 4 layouts | **48** |
| **three files** | **2299 items, 6.43 s** | **379 items, 4.29 s** |

Each keeps the axis a failure needs in its **id** — the op for the golden tests, width
and population for the packer — and loops the rest in-item. The inner axes only reframe
the same comparison and each was already named in the failure message, which is what made
them safe to fold; those messages are now unconditional rather than only on the paths
that happened to carry them. Nothing is over 100 items and no comparison was dropped.

Coverage is *measured*, not asserted. Each inner axis was mutated so that only one of its
cells diverges, and the surviving test has to catch it and name the cell:

| mutation | caught |
|---|---|
| `_torch_unary_vec` scaled only at `numel() == 32768` | 30 failures — exactly the 28 `_VECTOR_TORCH_FNS` entries plus `I0`/`I1`, in the one test that reaches that window; *"window 32768"* |
| … scaled only under `Float32` | 60 = the same 30 ops × **both** agreement tests; *"specials in torch.float32 / Float32"* |
| `_bfp_quantize_blocks` wrong only for a bfloat16 input | 42 of 48; *"torch.bfloat16 / num_faces=4 / face_r_dim=16"* |
| … wrong only for the 16-block (1-face) layout | 32 of 48; *"num_faces=1 / face_r_dim=16"* |

The two packer mutations stop short of 48 for a reason worth recording rather than
waving at: the exponent shift survives only `zeros`/`zeros+specials` (doubling every
member of an all-zero block moves nothing), and the mantissa-LSB flip survives only
bfp4_b/bfp2_b crossed with the four power-of-two populations — a power of two has
mantissa `0x40`, and bit 0 sits below both the truncation point and the rounding guard
bit of a 3- or 1-bit magnitude. bfp8_b keeps all 7 bits and always sees it.

Folding an axis into a loop is also the edit that can silently stop covering a cell — a
mis-scoped `continue`, a loop nested one level too deep — and unlike a dropped
parametrize argument, nothing about the item count would show it. So each of the four
asserts its compared-cell count against the product of its inner axes. Truncating a loop
to its first element (`WINDOWS[:1]`, `FORMATS[:1]`, `LAYOUTS[:1]`) fails **224** items
across the two files; without the guard they all pass.

One correction to the report: the packer matrix was **384**, not 336 — `_populations()`
seeds a `+specials` variant of each of its 8 bases, so it is 16 populations, not 14.

**One on naming** (suppressed, but right).
`test_no_unlisted_op_is_silently_bit_exact_capable` promised a capability check it never
performs — it prints the fallback set and holds the vector table to a floor of 88.
Renamed `test_vector_table_holds_its_floor_and_reports_the_fallback_set`, with the module
docstring's description of it corrected rather than left behind.

## Not in this PR

`docs/tests/test_suite_speedup_plan.md` records the measurement method and the larger
ideas this PR does not touch: a sound artefact cache (compile is still 39% of the sweep
and is re-paid on every run), the producer/consumer split for the e2e lane,
duration-balanced `pytest-split` groups, and the `throttle` axis in `test_math_matmul`
(~111k tests, 47% of the whole e2e collection).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/llk_sfpu_test_speedup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/llk_sfpu_test_speedup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/llk_sfpu_test_speedup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/llk_sfpu_test_speedup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/llk_sfpu_test_speedup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/llk_sfpu_test_speedup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/llk_sfpu_test_speedup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/llk_sfpu_test_speedup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/llk_sfpu_test_speedup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/llk_sfpu_test_speedup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/llk_sfpu_test_speedup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/llk_sfpu_test_speedup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/llk_sfpu_test_speedup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/llk_sfpu_test_speedup)



