### PR TITLE
rgb_to_yuv: drop the Blackhole DEST-remap disable in typecast_and_pack

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/rgb_to_yuv/device/kernels/compute/yuv_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/rgb_to_yuv/device/kernels/compute/yuv_compute.cpp
@@ -96,11 +96,13 @@ FORCE_INLINE void offset_clamp_pack(uint32_t cb_in, uint32_t cb_off, uint32_t cb
 }
 
 // SFPU typecast: bf16 -> uint8 on a row-major page (32x32 elements).
+// The Blackhole DEST remap (remap_addrs + swizzle_32b) that tilize/untilize enable is left
+// enabled here: BH LLKs address DEST by logical tile index across copy_tile, the SFPU typecast
+// and pack_tile, so the datacopy below reads the same rows either way (see the "no uninit --
+// leaving the bits set is benign for subsequent ops" note in _llk_math_fast_tilize_init_).
+// Toggling it back off cost a full tensix_sync + pack drain per output tile for no effect.
 FORCE_INLINE void typecast_and_pack(uint32_t cb_bf16, uint32_t cb_u8) {
     CircularBuffer bf16(cb_bf16), u8(cb_u8);
-#ifdef ARCH_BLACKHOLE
-    MATH((llk_math_reconfig_remap(false)));
-#endif
     // Mid-kernel re-init (startup already done in kernel_main): datacopy unpack+math via copy_init,
     // pack format via pack_reconfig -- the call-once init_sfpu was migrated off.
     copy_init(cb_bf16);


### PR DESCRIPTION
## Summary
Follow-up to #54776, addressing the second paragraph of [this review comment](https://github.com/tenstorrent/tt-metal/pull/54776#issuecomment-5492324198): remove the Blackhole DEST-remap disable from `rgb_to_yuv::typecast_and_pack`, the same way 9ba0ccd removed the disable/restore pairs from conv3d's fp32-exact reduction and bias helpers.

One-line kernel change: `typecast_and_pack` no longer calls `llk_math_reconfig_remap(false)` before the datacopy + SFPU typecast.

## Why it is safe
- The remap (`remap_addrs` + `swizzle_32b`) is enabled by the tilize/untilize inits on BH as the tt-metal#17132 / tt-llk#989 workaround, and `pack_untilize_uninit` does not undo it. The `false` toggle in `typecast_and_pack` was the only thing turning it back off — as a precaution, not because a defect was observed.
- BH LLKs address DEST by logical tile index across `copy_tile`, the SFPU typecast and `pack_tile`, so the single-tile datacopy in this helper reads the same rows with remap on or off. `_llk_math_fast_tilize_init_` already states this explicitly: *"No uninit - leaving the bits set is benign for subsequent ops."*
- conv3d took the same step in #54776 and is remap-enabled for its whole kernel (matmul, `copy_tile`, `unary_bcast<ROW>`, SFPU adds, pack), verified bit-identical on BH silicon.

## Why it is worth doing
`_llk_math_reconfig_remap_` unconditionally does a `tensix_sync()` plus a wait on the `MATH_PACK` semaphore before touching the config bits — a full Tensix serialization point with no early-out when the bit already holds the requested value. This kernel called it once per output tile (every Y tile and every Cb/Cr tile), and the next tilize/untilize init turned remap straight back on, so the toggle was pure overhead.

## Verified so far
The A/B result already reported on #54776: the RGB-to-YUV Y and UV correctness cases pass on Blackhole with and without the toggle, unchanged.

## Remaining before this leaves draft
- [ ] `TestYUVSweep::test_sweep_correctness` — the 441-case (H, W, T) grid in `tests/ttnn/nightly/unit_tests/operations/experimental/test_rgb_to_yuv.py`. It is `skipif(CI == "true")`, so it has to be run on a BH machine locally; this is the gate the review comment asked for.
- [ ] `TestYUVPerformance::test_performance_720p` before/after, to record the win rather than just assert there is no loss.

## Possible next step (not in this PR)
The remaining per-tile remap traffic is the `true` toggle inside each tilize/untilize init — 13 tilizes + 1 untilize per Cb/Cr tile. `tilize_config::RemapMode::AssumeConfigured` / `untilize_config::RemapMode::AssumeConfigured` exist for exactly this: enable remap once after `compute_kernel_hw_startup` and skip it in the inits, which is the shape conv3d ended up in. Happy to do that here as a separate change if it looks right to you — it is a larger behavioural change than what the review comment asked for, so I kept it out.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rouzbeh/yuv-drop-bh-remap-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rouzbeh/yuv-drop-bh-remap-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rouzbeh/yuv-drop-bh-remap-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rouzbeh/yuv-drop-bh-remap-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rouzbeh/yuv-drop-bh-remap-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rouzbeh/yuv-drop-bh-remap-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rouzbeh/yuv-drop-bh-remap-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rouzbeh/yuv-drop-bh-remap-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rouzbeh/yuv-drop-bh-remap-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rouzbeh/yuv-drop-bh-remap-toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
