### PR TITLE
[Bug Fix] Prepare Slice for Metal 2.0 Port

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
@@ -983,6 +983,46 @@ def test_slice_rm_bw_sharded_nonzero_width_begin(shard_factory, device):
     )
 
 
+def test_slice_rm_bw_sharded_subaligned_shard_row_in(device):
+    """RM WIDTH-sharded input whose shard row is 12 bf16 elems = 24B, not a multiple of any buffer
+    alignment. W=96 is tile-aligned and width-begin is 0, so only the shard-row check routes this
+    through L1 interleaved; natively the accessor strides pages by the aligned page size while
+    `noc_async_read_sharded` reuses that same value as the per-page payload."""
+    in_shape = (1, 1, 64, 96)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        (1, 1, 32, 96),
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        _width_sharded(in_shape, device, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+    )
+
+
+def test_slice_rm_bw_sharded_subaligned_shard_row_out(device):
+    """Mirror of the input-side case on the writer: RM interleaved → WIDTH-sharded output with a
+    24B shard row. Input W is tile-aligned, so needs_rm_composite_output must fire on the shard row
+    alone."""
+    in_shape = (1, 1, 64, 96)
+    out_shape = (1, 1, 32, 96)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        out_shape,
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        L1_INTERLEAVED,
+        _width_sharded(out_shape, device, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+    )
+
+
 # Focused dtype spot-checks on representative paths. The core suites above run bf16 only to keep
 # the file under budget; this hits f32 across TILE+RM paths and bf8b on the TILE-only path.
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
@@ -1003,6 +1003,26 @@ def test_slice_rm_bw_sharded_subaligned_shard_row_in(device):
     )
 
 
+def test_slice_rm_bw_sharded_rescaled_subaligned_shard_row(device):
+    """Implicit output spec (no memory_config): the output inherits the input's shard spec and then has
+    it rescaled to the sliced width, after the composite decision. The inherited row is 16 bf16 elems
+    = 32B and aligned, but the rescale yields div_up(96, 8) = 12 elems = 24B, which is not — so the
+    guard has to test the rescaled width rather than the inherited one."""
+    in_shape = (1, 1, 64, 128)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        (1, 1, 64, 96),
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        _width_sharded(in_shape, device, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+        None,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+    )
+
+
 def test_slice_rm_bw_sharded_subaligned_shard_row_out(device):
     """Mirror of the input-side case on the writer: RM interleaved → WIDTH-sharded output with a
     24B shard row. Input W is tile-aligned, so needs_rm_composite_output must fire on the shard row

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
@@ -1003,6 +1003,25 @@ def test_slice_rm_bw_sharded_subaligned_shard_row_in(device):
     )
 
 
+def test_slice_rm_block_sharded_subaligned_shard_row_in(device):
+    """BLOCK-sharded counterpart of the input-side case. `_block_sharded`'s 2x2 grid can't reach it —
+    any tile-aligned W halved is still a multiple of 8 bf16 elems — so use an explicit 2x8 grid:
+    a (32, 12) shard on (1, 1, 64, 96) gives a 24B row while W stays tile-aligned."""
+    in_shape = (1, 1, 64, 96)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        (1, 1, 32, 96),
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        _explicit_block_shard_config(device, 2, 8, 32, 12),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+    )
+
+
 def test_slice_rm_bw_sharded_rescaled_subaligned_shard_row(device):
     """Implicit output spec (no memory_config): the output inherits the input's shard spec and then has
     it rescaled to the sliced width, after the composite decision. The inherited row is 16 bf16 elems

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -25,8 +25,11 @@ void kernel_main() {
     const uint32_t chunk_size = get_arg_val<uint32_t>(10);
     const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(11);
     const uint32_t last_chunk_size = get_arg_val<uint32_t>(12);
+    // Byte offset of the slice's W-begin within a row, rounded down to the source buffer's alignment;
+    // the leftover `misalignment` bytes are trimmed on-device by the tt_memmove below.
+    const uint32_t src_offset_bytes = get_arg_val<uint32_t>(13);
 
-    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(13));
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(14));
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
@@ -35,6 +38,8 @@ void kernel_main() {
 
     // padded_stick_size = per-shard page size (shard_W on B/W-sharded, full row otherwise);
     // feeds `noc_async_read_sharded`'s multi-shard split via `get_aligned_page_size()`.
+    // The accessor base stays the unshifted buffer base: Metal 2.0 supplies it from the tensor binding
+    // and offers no seam for a pre-offset base. The W-begin shift rides each read as `src_offset_bytes`.
     const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
 
     constexpr uint32_t dfb_id_in0 = 0;
@@ -59,7 +64,7 @@ void kernel_main() {
                 uint32_t src_buffer_l1_addr = dfb_in0.get_write_ptr();
                 for (uint32_t k = 0; k < batch; ++k) {
                     const uint32_t cur = c + k;
-                    const uint32_t offset = cur * chunk_size;
+                    const uint32_t offset = src_offset_bytes + cur * chunk_size;
                     const uint32_t sz = (cur == num_chunks_per_stick - 1) ? last_chunk_size : chunk_size;
                     tt::data_movement::common::noc_async_read_sharded(
                         noc, src_buffer_l1_addr, s0, src_stick_id, offset, sz);
@@ -93,7 +98,7 @@ void kernel_main() {
             // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
             // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
             tt::data_movement::common::noc_async_read_sharded(
-                noc, src_buffer_l1_addr, s0, src_stick_id, /*offset=*/0, /*size=*/read_size);
+                noc, src_buffer_l1_addr, s0, src_stick_id, /*offset=*/src_offset_bytes, /*size=*/read_size);
             if (misalignment != 0) {
                 noc.async_read_barrier();
                 tt::data_movement::common::tt_memmove<false, false, false, 0>(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -33,22 +33,6 @@ struct ChunkingParams {
     uint32_t last_chunk_size;
 };
 
-// Aligned source base address the reader kernel reads from: the input buffer base advanced to the
-// nearest aligned address at/below the slice's byte offset (begins_bytes - misalignment). begins_bytes
-// and misalignment are hash-constant per cache entry (slice_start, dtype, input memory_config are all
-// folded into compute_program_hash), so only the buffer address changes between dispatches. A plain
-// Buffer* binding can only re-emit the bare base, not base+offset, so this value instead rides on
-// SliceDeviceOperation::get_dynamic_runtime_args (re-emitted on every cache hit). create_descriptor and
-// get_dynamic_runtime_args both call this helper so the emitted value can never drift.
-inline uint32_t slice_rm_reader_base_address(const Tensor& input, const ttnn::Shape& slice_start) {
-    const uint32_t begins_bytes = slice_start[-1] * input.element_size();
-    const auto src_buffer_alignment = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                          ? ::hal::get_dram_alignment()
-                                          : ::hal::get_l1_alignment();
-    const uint32_t misalignment = begins_bytes % src_buffer_alignment;
-    return input.buffer()->address() + begins_bytes - misalignment;
-}
-
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
     const Tensor& input_tensor,
     Tensor& output_tensor,
@@ -101,10 +85,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     const uint32_t reader_page_size = per_shard_page_size_bytes(input_tensor, padded_row_size_bytes);
 
+    // Reader arg 0 is the plain input buffer base address; it is emitted as a Buffer* binding in
+    // create_descriptor (not here), so the args returned here start at arg 1.
     std::vector<uint32_t> common_reader_kernel_args = {
-        // Aligned source base; re-emitted on every cache hit by get_dynamic_runtime_args (base+offset
-        // cannot be a plain Buffer* binding). Same helper as get_dynamic_runtime_args so it can't drift.
-        slice_rm_reader_base_address(input_tensor, output_tensor_start),
         reader_page_size,
         unpadded_row_size_bytes,
         unpadded_row_size_bytes_offset,
@@ -116,7 +99,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         0,
         chunking.chunk_size,
         chunking.num_chunks_per_stick,
-        chunking.last_chunk_size};
+        chunking.last_chunk_size,
+        begins_bytes - misalignment};
     common_reader_kernel_args.insert(
         common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
     common_reader_kernel_args.insert(
@@ -161,7 +145,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
         }
         std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        uint32_t addr_offset = 6;
+        uint32_t addr_offset = 5;
         reader_kernel_args[addr_offset++] = start_id;
         reader_kernel_args[addr_offset++] = num_sticks_per_core;
         reader_kernel_args[addr_offset++] = num_sticks_per_core_read;
@@ -386,7 +370,14 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
     reader_desc.runtime_args.reserve(all_cores_vec.size());
     writer_desc.runtime_args.reserve(all_cores_vec.size());
     for (size_t i = 0; i < all_cores_vec.size(); ++i) {
-        reader_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].first));
+        // Reader arg 0 = input buffer base address, declared as a Buffer* binding so the framework
+        // patches it on cache hits instead of rebuilding the descriptor; args 1.. follow unchanged.
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.reserve(1 + all_runtime_args[i].first.size());
+        reader_args.push_back(src0_buffer);
+        reader_args.append(all_runtime_args[i].first);
+        reader_desc.emplace_runtime_args(all_cores_vec[i], reader_args);
+
         // Writer arg 0 = output buffer base address, declared as a Buffer* binding so the framework
         // patches it on cache hits instead of rebuilding the descriptor; args 1.. follow unchanged.
         KernelDescriptor::RTArgList writer_args;
@@ -400,36 +391,6 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
     desc.kernels.push_back(std::move(writer_desc));
 
     return desc;
-}
-
-std::vector<tt::tt_metal::DynamicRuntimeArg> slice_rm_reader_dynamic_args(
-    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
-    // Reader arg 0 holds the aligned source base (input buffer address + a hash-constant byte offset).
-    // The offset is baked into the cached descriptor; only the buffer address changes per dispatch, so
-    // re-emit the full value on every cache hit. The work-split (and thus the active-core set) derives
-    // only from hashed shapes/grids, so it is identical on every hit — no freeze from a growing set.
-    const auto& input = tensor_args.input;
-    tt::tt_metal::IDevice* device = input.device();
-
-    uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    // Same work-split create_descriptor uses; only the core set (element 1) is needed here.
-    const auto work_split =
-        args.sub_core_grids.has_value()
-            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_sticks)
-            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
-    const CoreRangeSet& all_cores = std::get<1>(work_split);
-
-    const uint32_t reader_base = ttnn::operations::data_movement::slice_rm_reader_base_address(input, args.slice_start);
-    const auto cores = corerange_to_cores(all_cores);
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size());
-    for (const auto& core : cores) {
-        // kernel 0 (reader, pushed first in create_descriptor), arg 0.
-        dynamic_args.push_back(tt::tt_metal::DynamicRuntimeArg{0, core, 0, reader_base});
-    }
-    return dynamic_args;
 }
 
 void SliceRmProgramFactory::override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
@@ -34,11 +34,4 @@ struct SliceRmProgramFactory {
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
-// Per-dispatch dynamic runtime args for SliceRmProgramFactory: re-emits the reader's aligned source
-// base address (input buffer address + hash-constant offset) on every active core, since a base+offset
-// value cannot be represented by a plain Buffer* binding. Shared by SliceDeviceOperation::
-// get_dynamic_runtime_args so the emitted value matches create_descriptor exactly.
-std::vector<tt::tt_metal::DynamicRuntimeArg> slice_rm_reader_dynamic_args(
-    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output);
-
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -383,12 +383,9 @@ void patch_slice_program_addresses(
     std::visit(
         [&](auto&& f) {
             using Factory = std::decay_t<decltype(f)>;
-            if constexpr (std::is_same_v<Factory, SliceRmProgramFactory>) {
-                // The reader reads from base+offset, which no Buffer* binding can express; reuse the
-                // helper create_descriptor calls so the emitted value cannot drift.
-                const auto dynamic_args = slice_rm_reader_dynamic_args(operation_attributes, tensor_args, output);
-                tt::tt_metal::apply_dynamic_runtime_args(program, dynamic_args);
-            } else if constexpr (std::is_same_v<Factory, SliceRmStrideProgramFactory>) {
+            if constexpr (
+                std::is_same_v<Factory, SliceRmProgramFactory> ||
+                std::is_same_v<Factory, SliceRmStrideProgramFactory>) {
                 patch_slot0(kReaderKernelIdx, tensor_args.input.buffer()->address());
             } else if constexpr (
                 std::is_same_v<Factory, SliceTileProgramFactory> ||

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -13,6 +13,7 @@
 #include "ttnn/operations/core/core.hpp"
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
 
 namespace ttnn {
 
@@ -40,8 +41,22 @@ inline bool has_nontile_w(const ttnn::Tensor& input) {
     return s.rank() >= 1 && s[-1] % tt::constants::TILE_WIDTH != 0;
 }
 
-// Route RM sharded input through composite when native isn't safe: nontile-aligned B/W,
-// B/W with non-zero width-begin, or nontile-aligned HEIGHT outside the sharded fast path.
+// TensorAccessor strides pages by the buffer's *aligned* page size, but `noc_async_*_sharded` reads
+// that same value back as the per-page *payload*. For a B/W-sharded RM buffer the page is the shard
+// row, so the two only agree when the row is already a multiple of the buffer's alignment.
+inline bool has_subaligned_shard_row(const tt::tt_metal::MemoryConfig& mc, uint32_t element_size) {
+    if (!mc.shard_spec().has_value()) {
+        return false;
+    }
+    const uint32_t alignment = mc.buffer_type() == tt::tt_metal::BufferType::DRAM
+                                   ? tt::tt_metal::hal::get_dram_alignment()
+                                   : tt::tt_metal::hal::get_l1_alignment();
+    return (mc.shard_spec()->shape[1] * element_size) % alignment != 0;
+}
+
+// Route RM sharded input through composite when native isn't safe: nontile-aligned B/W, B/W with a
+// sub-aligned shard row or non-zero width-begin, or nontile-aligned HEIGHT outside the sharded fast
+// path.
 inline bool needs_rm_composite_input(
     const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc, bool no_step, bool width_begin_nonzero) {
     if (input.layout() != Layout::ROW_MAJOR || !input.is_sharded()) {
@@ -49,7 +64,8 @@ inline bool needs_rm_composite_input(
     }
     if (is_rm_bw_sharded(input.memory_config())) {
         // Only W misalignment breaks the per-shard page split; irregular H is fine.
-        return has_nontile_w(input) || width_begin_nonzero;
+        return has_nontile_w(input) || width_begin_nonzero ||
+               has_subaligned_shard_row(input.memory_config(), input.element_size());
     }
     // Require a spec: no-spec HEIGHT output triggers needs_sharded_output_reshard → composite anyway.
     const bool stays_on_sharded_fast_path =
@@ -58,12 +74,14 @@ inline bool needs_rm_composite_input(
     return has_nontile_hw(input) && !stays_on_sharded_fast_path;
 }
 
-// Compose RM B/W-sharded output only on nontile-aligned W (irregular H is fine natively).
+// Compose RM B/W-sharded output on nontile-aligned W or a sub-aligned shard row (irregular H is
+// fine natively). A spec-less output inherits the input's shard spec, which the input-side check
+// already covers.
 inline bool needs_rm_composite_output(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc) {
     if (input.layout() != Layout::ROW_MAJOR || !is_rm_bw_sharded(output_mc)) {
         return false;
     }
-    return has_nontile_w(input);
+    return has_nontile_w(input) || has_subaligned_shard_row(output_mc, input.element_size());
 }
 
 // Sharded-no-spec output that can't seed from the input (not sharded, or layout differs);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -44,14 +44,41 @@ inline bool has_nontile_w(const ttnn::Tensor& input) {
 // TensorAccessor strides pages by the buffer's *aligned* page size, but `noc_async_*_sharded` reads
 // that same value back as the per-page *payload*. For a B/W-sharded RM buffer the page is the shard
 // row, so the two only agree when the row is already a multiple of the buffer's alignment.
+inline bool is_subaligned_shard_row(
+    tt::tt_metal::BufferType buffer_type, uint32_t shard_row_elems, uint32_t element_size) {
+    const uint32_t alignment = buffer_type == tt::tt_metal::BufferType::DRAM ? tt::tt_metal::hal::get_dram_alignment()
+                                                                             : tt::tt_metal::hal::get_l1_alignment();
+    return (shard_row_elems * element_size) % alignment != 0;
+}
+
 inline bool has_subaligned_shard_row(const tt::tt_metal::MemoryConfig& mc, uint32_t element_size) {
     if (!mc.shard_spec().has_value()) {
         return false;
     }
-    const uint32_t alignment = mc.buffer_type() == tt::tt_metal::BufferType::DRAM
-                                   ? tt::tt_metal::hal::get_dram_alignment()
-                                   : tt::tt_metal::hal::get_l1_alignment();
-    return (mc.shard_spec()->shape[1] * element_size) % alignment != 0;
+    return is_subaligned_shard_row(mc.buffer_type(), mc.shard_spec()->shape[1], element_size);
+}
+
+// Shard width that `slice`'s implicit-inheritance rescale (issue #38016) will give a sharded output
+// that inherited its spec from the input. Sole owner of this formula: the rescale itself calls this
+// too, so the composite guards can test the spec the op will actually run with rather than the
+// pre-rescale one. Caller applies tile rounding when the output isn't row-major. nullopt means the
+// width isn't split across cores (HEIGHT) or the BLOCK grid isn't rectangular, which the rescale
+// rejects with its own TT_FATAL.
+inline std::optional<uint32_t> rescaled_inherited_shard_width(
+    const tt::tt_metal::ShardSpec& spec, tt::tt_metal::TensorMemoryLayout layout, uint32_t output_width) {
+    if (layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+        return tt::div_up(output_width, spec.num_cores());
+    }
+    if (layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
+        const auto bbox = spec.grid.bounding_box();
+        const uint32_t grid_h = bbox.end_coord.y - bbox.start_coord.y + 1;
+        const uint32_t grid_w = bbox.end_coord.x - bbox.start_coord.x + 1;
+        if (spec.num_cores() != grid_h * grid_w) {
+            return std::nullopt;
+        }
+        return tt::div_up(output_width, grid_w);
+    }
+    return std::nullopt;
 }
 
 // Route RM sharded input through composite when native isn't safe: nontile-aligned B/W, B/W with a
@@ -75,13 +102,22 @@ inline bool needs_rm_composite_input(
 }
 
 // Compose RM B/W-sharded output on nontile-aligned W or a sub-aligned shard row (irregular H is
-// fine natively). A spec-less output inherits the input's shard spec, which the input-side check
-// already covers.
-inline bool needs_rm_composite_output(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc) {
+// fine natively). `rescaled_shard_width`, when set, is the width the implicit-inheritance rescale
+// will install after this decision point; it supersedes output_mc's own, which is still the input's.
+inline bool needs_rm_composite_output(
+    const ttnn::Tensor& input,
+    const tt::tt_metal::MemoryConfig& output_mc,
+    std::optional<uint32_t> rescaled_shard_width = std::nullopt) {
     if (input.layout() != Layout::ROW_MAJOR || !is_rm_bw_sharded(output_mc)) {
         return false;
     }
-    return has_nontile_w(input) || has_subaligned_shard_row(output_mc, input.element_size());
+    if (has_nontile_w(input)) {
+        return true;
+    }
+    if (rescaled_shard_width.has_value()) {
+        return is_subaligned_shard_row(output_mc.buffer_type(), *rescaled_shard_width, input.element_size());
+    }
+    return has_subaligned_shard_row(output_mc, input.element_size());
 }
 
 // Sharded-no-spec output that can't seed from the input (not sharded, or layout differs);
@@ -201,11 +237,44 @@ ttnn::Tensor slice(
         return finalize_into_preallocated(ret_adjustment(input_tensor));
     }
 
+    // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
+    ttsl::SmallVector<uint32_t> modified_begins(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_ends(input_rank, 0);
+    ttsl::SmallVector<uint32_t> modified_step(input_rank, 1);
+
+    // Wrap indices and adjust begins, ends, and step
+    for (size_t i = 0; i < begins.size(); ++i) {
+        if constexpr (std::is_signed_v<T>) {
+            modified_begins[i] = operations::data_movement::wrap_index(begins[i], input_shape[i]);
+            modified_ends[i] = operations::data_movement::wrap_index(ends[i], input_shape[i]);
+            modified_step[i] = static_cast<uint32_t>(step[i]);
+        } else {
+            modified_begins[i] = begins[i];
+            modified_ends[i] = ends[i];
+            modified_step[i] = step[i];
+        }
+    }
+
+    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttsl::SmallVector<uint32_t>& modified_ends) {
+        return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
+    };
+
     // Composite hop: unshard to L1 interleaved if needed, slice, then convert to the requested mc.
     const bool width_begin_nonzero = !begins.empty() && begins.back() != 0;
+    // A sharded output with no explicit config inherits the input's shard spec and then has it
+    // rescaled to the sliced shape further down, i.e. after this decision. Test the width that
+    // rescale will produce. RM only, so there is no tile rounding to mirror.
+    std::optional<uint32_t> rescaled_out_shard_w;
+    if (input_layout == Layout::ROW_MAJOR && !memory_config_arg.has_value() && !optional_output_tensor.has_value() &&
+        input_tensor.is_sharded() && input_rank >= 2 && output_memory_config.shard_spec().has_value()) {
+        rescaled_out_shard_w = detail::rescaled_inherited_shard_width(
+            output_memory_config.shard_spec().value(),
+            output_memory_config.memory_layout(),
+            output_dim_i(input_rank - 1, modified_ends));
+    }
     const bool rm_in_bad =
         detail::needs_rm_composite_input(input_tensor, output_memory_config, no_step, width_begin_nonzero);
-    const bool rm_out_bad = detail::needs_rm_composite_output(input_tensor, output_memory_config);
+    const bool rm_out_bad = detail::needs_rm_composite_output(input_tensor, output_memory_config, rescaled_out_shard_w);
     const bool out_no_spec = detail::needs_sharded_output_reshard(input_tensor, output_memory_config);
     if (rm_in_bad || rm_out_bad || out_no_spec) {
         // Snapshot orientation before the L1-interleaved staging hop strips it.
@@ -228,28 +297,6 @@ ttnn::Tensor slice(
         const auto target = can_land_in_preallocated(sliced) ? optional_output_tensor : std::nullopt;
         return finalize_into_preallocated(ttnn::to_memory_config(sliced, final_mc, std::nullopt, target));
     }
-
-    // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
-    ttsl::SmallVector<uint32_t> modified_begins(input_rank, 0);
-    ttsl::SmallVector<uint32_t> modified_ends(input_rank, 0);
-    ttsl::SmallVector<uint32_t> modified_step(input_rank, 1);
-
-    // Wrap indices and adjust begins, ends, and step
-    for (size_t i = 0; i < begins.size(); ++i) {
-        if constexpr (std::is_signed_v<T>) {
-            modified_begins[i] = operations::data_movement::wrap_index(begins[i], input_shape[i]);
-            modified_ends[i] = operations::data_movement::wrap_index(ends[i], input_shape[i]);
-            modified_step[i] = static_cast<uint32_t>(step[i]);
-        } else {
-            modified_begins[i] = begins[i];
-            modified_ends[i] = ends[i];
-            modified_step[i] = step[i];
-        }
-    }
-
-    auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttsl::SmallVector<uint32_t>& modified_ends) {
-        return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
-    };
 
     auto check_handled_tile_alignment = [&modified_begins, &input_rank, &tile_shape]() -> bool {
         return (
@@ -304,8 +351,8 @@ ttnn::Tensor slice(
                 }
                 new_shard_shape = {new_shard_h, output_width};
             } else if (mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
-                uint32_t num_cores = shard_spec_val.num_cores();
-                uint32_t new_shard_w = tt::div_up(output_width, num_cores);
+                uint32_t new_shard_w =
+                    detail::rescaled_inherited_shard_width(shard_spec_val, mem_layout, output_width).value();
                 if (!rm_only) {
                     new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
                 }
@@ -322,7 +369,8 @@ ttnn::Tensor slice(
                     grid_h,
                     grid_w);
                 uint32_t new_shard_h = tt::div_up(output_height, grid_h);
-                uint32_t new_shard_w = tt::div_up(output_width, grid_w);
+                uint32_t new_shard_w =
+                    detail::rescaled_inherited_shard_width(shard_spec_val, mem_layout, output_width).value();
                 if (!rm_only) {
                     new_shard_h = std::max(tt::round_up(new_shard_h, tile_shape[0]), tile_shape[0]);
                     new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -44,41 +44,14 @@ inline bool has_nontile_w(const ttnn::Tensor& input) {
 // TensorAccessor strides pages by the buffer's *aligned* page size, but `noc_async_*_sharded` reads
 // that same value back as the per-page *payload*. For a B/W-sharded RM buffer the page is the shard
 // row, so the two only agree when the row is already a multiple of the buffer's alignment.
-inline bool is_subaligned_shard_row(
-    tt::tt_metal::BufferType buffer_type, uint32_t shard_row_elems, uint32_t element_size) {
-    const uint32_t alignment = buffer_type == tt::tt_metal::BufferType::DRAM ? tt::tt_metal::hal::get_dram_alignment()
-                                                                             : tt::tt_metal::hal::get_l1_alignment();
-    return (shard_row_elems * element_size) % alignment != 0;
-}
-
 inline bool has_subaligned_shard_row(const tt::tt_metal::MemoryConfig& mc, uint32_t element_size) {
     if (!mc.shard_spec().has_value()) {
         return false;
     }
-    return is_subaligned_shard_row(mc.buffer_type(), mc.shard_spec()->shape[1], element_size);
-}
-
-// Shard width that `slice`'s implicit-inheritance rescale (issue #38016) will give a sharded output
-// that inherited its spec from the input. Sole owner of this formula: the rescale itself calls this
-// too, so the composite guards can test the spec the op will actually run with rather than the
-// pre-rescale one. Caller applies tile rounding when the output isn't row-major. nullopt means the
-// width isn't split across cores (HEIGHT) or the BLOCK grid isn't rectangular, which the rescale
-// rejects with its own TT_FATAL.
-inline std::optional<uint32_t> rescaled_inherited_shard_width(
-    const tt::tt_metal::ShardSpec& spec, tt::tt_metal::TensorMemoryLayout layout, uint32_t output_width) {
-    if (layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
-        return tt::div_up(output_width, spec.num_cores());
-    }
-    if (layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
-        const auto bbox = spec.grid.bounding_box();
-        const uint32_t grid_h = bbox.end_coord.y - bbox.start_coord.y + 1;
-        const uint32_t grid_w = bbox.end_coord.x - bbox.start_coord.x + 1;
-        if (spec.num_cores() != grid_h * grid_w) {
-            return std::nullopt;
-        }
-        return tt::div_up(output_width, grid_w);
-    }
-    return std::nullopt;
+    const uint32_t alignment = mc.buffer_type() == tt::tt_metal::BufferType::DRAM
+                                   ? tt::tt_metal::hal::get_dram_alignment()
+                                   : tt::tt_metal::hal::get_l1_alignment();
+    return (mc.shard_spec()->shape[1] * element_size) % alignment != 0;
 }
 
 // Route RM sharded input through composite when native isn't safe: nontile-aligned B/W, B/W with a
@@ -102,22 +75,13 @@ inline bool needs_rm_composite_input(
 }
 
 // Compose RM B/W-sharded output on nontile-aligned W or a sub-aligned shard row (irregular H is
-// fine natively). `rescaled_shard_width`, when set, is the width the implicit-inheritance rescale
-// will install after this decision point; it supersedes output_mc's own, which is still the input's.
-inline bool needs_rm_composite_output(
-    const ttnn::Tensor& input,
-    const tt::tt_metal::MemoryConfig& output_mc,
-    std::optional<uint32_t> rescaled_shard_width = std::nullopt) {
+// fine natively). Callers must pass the post-rescale config, since the implicit-inheritance rescale
+// can turn an aligned inherited shard row into a sub-aligned one.
+inline bool needs_rm_composite_output(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc) {
     if (input.layout() != Layout::ROW_MAJOR || !is_rm_bw_sharded(output_mc)) {
         return false;
     }
-    if (has_nontile_w(input)) {
-        return true;
-    }
-    if (rescaled_shard_width.has_value()) {
-        return is_subaligned_shard_row(output_mc.buffer_type(), *rescaled_shard_width, input.element_size());
-    }
-    return has_subaligned_shard_row(output_mc, input.element_size());
+    return has_nontile_w(input) || has_subaligned_shard_row(output_mc, input.element_size());
 }
 
 // Sharded-no-spec output that can't seed from the input (not sharded, or layout differs);
@@ -259,62 +223,23 @@ ttnn::Tensor slice(
         return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
     };
 
-    // Composite hop: unshard to L1 interleaved if needed, slice, then convert to the requested mc.
-    const bool width_begin_nonzero = !begins.empty() && begins.back() != 0;
-    // A sharded output with no explicit config inherits the input's shard spec and then has it
-    // rescaled to the sliced shape further down, i.e. after this decision. Test the width that
-    // rescale will produce. RM only, so there is no tile rounding to mirror.
-    std::optional<uint32_t> rescaled_out_shard_w;
-    if (input_layout == Layout::ROW_MAJOR && !memory_config_arg.has_value() && !optional_output_tensor.has_value() &&
-        input_tensor.is_sharded() && input_rank >= 2 && output_memory_config.shard_spec().has_value()) {
-        rescaled_out_shard_w = detail::rescaled_inherited_shard_width(
-            output_memory_config.shard_spec().value(),
-            output_memory_config.memory_layout(),
-            output_dim_i(input_rank - 1, modified_ends));
-    }
-    const bool rm_in_bad =
-        detail::needs_rm_composite_input(input_tensor, output_memory_config, no_step, width_begin_nonzero);
-    const bool rm_out_bad = detail::needs_rm_composite_output(input_tensor, output_memory_config, rescaled_out_shard_w);
-    const bool out_no_spec = detail::needs_sharded_output_reshard(input_tensor, output_memory_config);
-    if (rm_in_bad || rm_out_bad || out_no_spec) {
-        // Snapshot orientation before the L1-interleaved staging hop strips it.
-        std::optional<tt::tt_metal::ShardOrientation> input_orientation_hint;
-        if (input_tensor.shard_spec().has_value()) {
-            input_orientation_hint = input_tensor.shard_spec()->orientation;
-        }
-        const auto interleaved_l1 =
-            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
-        Tensor x = rm_in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
-        // Intermediate lives in L1 interleaved; to_memory_config lands the result in the caller's
-        // buffer. sub_core_grids is threaded through to bound the recursive slice's work split.
-        auto sliced = ttnn::slice<T>(x, begins, ends, step, interleaved_l1, std::nullopt, pad_value, sub_core_grids);
-        // slice preserves layout and to_memory_config doesn't change it — no trailing to_layout needed.
-        // sliced is L1-interleaved so resolve_mc falls through to generate_transpose_shard_spec.
-        const auto final_mc = resolve_mc(sliced, input_orientation_hint);
-        if (sliced.memory_config() == final_mc) {
-            return finalize_into_preallocated(sliced);
-        }
-        const auto target = can_land_in_preallocated(sliced) ? optional_output_tensor : std::nullopt;
-        return finalize_into_preallocated(ttnn::to_memory_config(sliced, final_mc, std::nullopt, target));
-    }
-
     auto check_handled_tile_alignment = [&modified_begins, &input_rank, &tile_shape]() -> bool {
         return (
             modified_begins[input_rank - 1] % tile_shape[1] == 0 &&
             modified_begins[input_rank - 2] % tile_shape[0] == 0);
     };
 
-    bool rm_only = false;
     bool one_dimensional = input_rank == 1;
     bool handled_tile_alignment = one_dimensional ? true : check_handled_tile_alignment();
 
-    Tensor input = input_tensor;
     // Use the RM path when input isn't TILE, or TILE input has strided/1D/non-tile-aligned begins
     // (ends are padded downstream, so only begin alignment matters).
-    rm_only = (input_tensor.layout() != Layout::TILE) || (!no_step || one_dimensional || !handled_tile_alignment);
+    bool rm_only = (input_tensor.layout() != Layout::TILE) || (!no_step || one_dimensional || !handled_tile_alignment);
 
     // Implicit inheritance from a sharded input: rescale the shard spec to the sliced shape so the
     // output doesn't reuse the input's (oversized) spec. Covers HEIGHT/WIDTH/BLOCK. (Issue #38016)
+    // Runs before the composite decision below so both that decision and the composite path's own
+    // resolve_mc see the final spec — rescaling can turn an aligned shard row into a sub-aligned one.
     if (!memory_config_arg.has_value() && !optional_output_tensor.has_value() && input_tensor.is_sharded() &&
         input_rank >= 2) {
         const auto& mem_layout = output_memory_config.memory_layout();
@@ -351,8 +276,8 @@ ttnn::Tensor slice(
                 }
                 new_shard_shape = {new_shard_h, output_width};
             } else if (mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
-                uint32_t new_shard_w =
-                    detail::rescaled_inherited_shard_width(shard_spec_val, mem_layout, output_width).value();
+                uint32_t num_cores = shard_spec_val.num_cores();
+                uint32_t new_shard_w = tt::div_up(output_width, num_cores);
                 if (!rm_only) {
                     new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
                 }
@@ -369,8 +294,7 @@ ttnn::Tensor slice(
                     grid_h,
                     grid_w);
                 uint32_t new_shard_h = tt::div_up(output_height, grid_h);
-                uint32_t new_shard_w =
-                    detail::rescaled_inherited_shard_width(shard_spec_val, mem_layout, output_width).value();
+                uint32_t new_shard_w = tt::div_up(output_width, grid_w);
                 if (!rm_only) {
                     new_shard_h = std::max(tt::round_up(new_shard_h, tile_shape[0]), tile_shape[0]);
                     new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
@@ -387,6 +311,35 @@ ttnn::Tensor slice(
         }
     }
 
+    // Composite hop: unshard to L1 interleaved if needed, slice, then convert to the requested mc.
+    const bool width_begin_nonzero = !begins.empty() && begins.back() != 0;
+    const bool rm_in_bad =
+        detail::needs_rm_composite_input(input_tensor, output_memory_config, no_step, width_begin_nonzero);
+    const bool rm_out_bad = detail::needs_rm_composite_output(input_tensor, output_memory_config);
+    const bool out_no_spec = detail::needs_sharded_output_reshard(input_tensor, output_memory_config);
+    if (rm_in_bad || rm_out_bad || out_no_spec) {
+        // Snapshot orientation before the L1-interleaved staging hop strips it.
+        std::optional<tt::tt_metal::ShardOrientation> input_orientation_hint;
+        if (input_tensor.shard_spec().has_value()) {
+            input_orientation_hint = input_tensor.shard_spec()->orientation;
+        }
+        const auto interleaved_l1 =
+            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+        Tensor x = rm_in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
+        // Intermediate lives in L1 interleaved; to_memory_config lands the result in the caller's
+        // buffer. sub_core_grids is threaded through to bound the recursive slice's work split.
+        auto sliced = ttnn::slice<T>(x, begins, ends, step, interleaved_l1, std::nullopt, pad_value, sub_core_grids);
+        // slice preserves layout and to_memory_config doesn't change it — no trailing to_layout needed.
+        // sliced is L1-interleaved so resolve_mc falls through to generate_transpose_shard_spec.
+        const auto final_mc = resolve_mc(sliced, input_orientation_hint);
+        if (sliced.memory_config() == final_mc) {
+            return finalize_into_preallocated(sliced);
+        }
+        const auto target = can_land_in_preallocated(sliced) ? optional_output_tensor : std::nullopt;
+        return finalize_into_preallocated(ttnn::to_memory_config(sliced, final_mc, std::nullopt, target));
+    }
+
+    Tensor input = input_tensor;
     if (rm_only) {
         if (!no_step) {
             TT_FATAL(input.dtype() != DataType::BFLOAT8_B, "Strided slice is not supported for BFLOAT8 tensors");


### PR DESCRIPTION
### Summary
This PR prepares the Slice op for porting to Metal 2.0, resolving two blockers.

The first issue is that the `TensorAccessor` strides pages by the buffer's *aligned* page size, but
`noc_async_*_sharded` reads that same value back as the per-page *payload*. For a
block/width-sharded row-major buffer these two only agree when the row is a multiple of the buffer alignment — otherwise every row after the first is mis-addressed and slice silently returns wrong data. This is fixed by changing `needs_rm_composite_input` / `needs_rm_composite_output` to test the shard row
directly, which is the same guard `fold` already applies. 

A new pytest was added to exercise this situation. Without the fix `slice` silently fails (i.e. just returns bad data), and with this fix it passes.

With the sub-aligned rows routed away, `per_shard_page_size_bytes` returns exactly the aligned page size on every config. This means the the reader/writer's third `TensorAccessor`argument is redundant and can be dropped during the port, removing this blocker.

The second issue is a much simpler mechanical offset pointers fix that needs addressing similar to past ports e.g. https://github.com/tenstorrent/tt-metal/pull/51747

Sanity and L2 are running.

Sanity failure (reduce group has unsupposed shard spec for transpose) showed up in [main](https://github.com/tenstorrent/tt-metal/actions/runs/33654399838/job/100363555126) too and isn't related to this PR

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/Slice_Port_Fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/Slice_Port_Fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/Slice_Port_Fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/Slice_Port_Fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/Slice_Port_Fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/Slice_Port_Fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/Slice_Port_Fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/Slice_Port_Fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/Slice_Port_Fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/Slice_Port_Fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/Slice_Port_Fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/Slice_Port_Fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/Slice_Port_Fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/Slice_Port_Fixes)