### PR TITLE
[Bug fix] Revert "neighbor-pad: skip the fabric startup barrier on persistent output (#55008)"

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
@@ -241,8 +241,8 @@ void kernel_main() {
                 noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), w_barrier_wait);
             }
         }
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
-    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
 
     // Corners-only optimization for 2D H writers:
     // Only W-boundary sticks (corners) go to neighbor L1; non-corner sticks go directly to DRAM.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
@@ -98,7 +98,6 @@ struct NeighborPadAsyncParams {
         "pad2_right",
         "pad2_cluster_axis",
         "pad2_num_links",
-        "using_persistent_buffers",
         "logical_h",
         "t_front_pad");
 
@@ -118,7 +117,6 @@ struct NeighborPadAsyncParams {
             this->pad2_right,
             this->pad2_cluster_axis,
             this->pad2_num_links,
-            this->using_persistent_buffers,
             this->logical_h,
             this->t_front_pad);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -178,8 +178,6 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
         outer_dim_size *= input_tensor_shape[d];
     }
 
-    const bool use_barrier_sem = !operation_attributes.using_persistent_buffers;
-
     bool is_first_device = true;
     bool is_last_device = true;
     uint32_t forward_device_offset = 0;
@@ -526,7 +524,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 h_writer_num_sticks_per_halo_dim,  // num_sticks_per_halo_dim
                 virtual_core.x,                    // neighbor_sem_noc0_x
                 virtual_core.y,                    // neighbor_sem_noc0_y
-                use_barrier_sem,                   // use_barrier_semaphore
+                true,                              // use_barrier_semaphore
                 virtual_opposite_core.x,           // barrier_sem_noc0_x
                 virtual_opposite_core.y};          // barrier_sem_noc0_y
             // Phase 2 signal targets (W fabric reader cores for 2D padding)
@@ -840,7 +838,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                     1,                               // num_sticks_per_halo_dim
                     w_virtual_core.x,                // neighbor_sem_noc0_x
                     w_virtual_core.y,                // neighbor_sem_noc0_y
-                    use_barrier_sem,                 // use_barrier_semaphore (W-axis startup barrier)
+                    true,                            // use_barrier_semaphore (W-axis startup barrier)
                     w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].x,   // barrier_sem_noc0_x (opp dir)
                     w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].y};  // barrier_sem_noc0_y
                 // No Phase 2 signal targets (W writers don't signal further)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Reverts #55008 ("neighbor-pad: skip the fabric startup barrier on persistent output", 78b76a5680).

That change made the neighbor_pad_async Phase 0 startup barrier conditional on `!using_persistent_buffers`. The Wan2.2 VAE decoder calls neighbor_pad through `CCLManager.neighbor_pad_persistent_buffer` (ping-pong persistent outputs) on every conv3d halo exchange, so every VAE halo exchange lost its cross-device startup sync. Result: nondeterministic corruption of the decoded video, which tripped the VBench gate in the 2026-09-02 "Package and release" nightly (`TT-DiT Wan2.2-T2V-A14B multihost quad e2e tests [bh_sc4]`, subject_consistency 0.9070 < 0.9100, run 33576308912) and is very likely also behind the Wormhole 4x8 `test_vae_wan2_1.py` mid_block / decoder PCC failures seen in Tier 1 Models Unit Tests since Aug 31.

Why the persistent output buffer does not make the barrier redundant: the sender also writes corner / W-axis halo sticks into the **neighbor's L1 receive CB** (address taken from its own program, assuming the neighbor is running the same program right now) and increments the neighbor's data-ready semaphores, which are zeroed with a wait-then-reset pattern. The startup barrier is what guaranteed the neighbor had entered the op before any of that traffic arrived. Without it a fast device can (a) write into L1 that still belongs to the neighbor's previous op (conv3d), (b) land call k+1 sticks/increments while the neighbor's reader is still finishing call k, and (c) have those increments swallowed by the reset, which hangs the next call.

### Evidence (Blackhole quietbox, 2x2, 480p pipeline test, seed 42; all comparisons are exact tensor equality)
| run | commit | text-encoder + 40 denoise latents vs good | VAE video vs good |
|---|---|---|---|
| good | 047ec3ccf965 | reference | reference |
| bad, run 1 | b87f41486a9b | bit-identical | 10.8% of elements differ (mostly 1-2 LSB, max 253) |
| bad, run 2 | b87f41486a9b | bit-identical | differs from good **and** from run 1 (nondeterministic) |
| bad + this revert | | bit-identical | **bit-identical**; CLIP and VBench match the pre-regression CI baseline exactly |

A VAE-only repro (decode fixed latents 3x on a 2x2 mesh) fails on b87f414 with three different outputs and passes bit-exactly with this revert, in ~25 s per run.

### Notes for reviewers
- Pure `git revert` of 78b76a5680; applies cleanly on main, no other neighbor_pad changes since.
- The perf motivation of #55008 is real, but a safe version needs the neighbor to signal "entered the op / receive buffer free" (or route all halo traffic into persistent DRAM with per-call semaphore slots) rather than assuming persistent buffers make the L1 landing zone and semaphores safe to write.
- Suggested follow-up: the release-test quietbox job's pipeline filter selects a 4x8 variant that always skips on 4 devices; pointing it at `2x2sp0tp1nl2_linear_is_fsdp1 and resolution_480p` would have caught this on a QB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wan-vbench-regression-78b76a5680)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wan-vbench-regression-78b76a5680)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wan-vbench-regression-78b76a5680)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wan-vbench-regression-78b76a5680)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wan-vbench-regression-78b76a5680)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wan-vbench-regression-78b76a5680)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wan-vbench-regression-78b76a5680)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wan-vbench-regression-78b76a5680)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wan-vbench-regression-78b76a5680)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wan-vbench-regression-78b76a5680)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wan-vbench-regression-78b76a5680)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wan-vbench-regression-78b76a5680)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wan-vbench-regression-78b76a5680)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wan-vbench-regression-78b76a5680)