### PR TITLE
[LLK][BH] Drop three Wormhole-packed constants from p_unpacr_nop

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_instr_params.h
@@ -85,21 +85,19 @@ struct p_unpacr
     constexpr static std::uint32_t UNP_CLRSRC_ONE_INT8        = 0x2;
 };
 
-// TODO: RT Review this struct, bits do not match for UNPACR_NOP
+// Values here are PER-OPERAND: Blackhole's UNPACR_NOP takes each control as its own
+// operand, unlike Wormhole's single packed NoOp immediate. See TT_OP_UNPACR_NOP.
 struct p_unpacr_nop
 {
     constexpr static std::uint32_t UNP_POP = 0b000;
     constexpr static std::uint32_t CLR_SRC = 0b01;
     constexpr static std::uint32_t UNP_NOP = 0b010;
 
-    constexpr static std::uint32_t UNP_ZEROSRC   = 0b001;
+    constexpr static std::uint32_t UNP_ZEROSRC = 0b001;
+    // Spans Src_ClrVal_Ctrl|Unpack_Pop; equals CLR_SRC_NEGINF|CLR_SRC.
     constexpr static std::uint32_t UNP_NEGINFSRC = 0b101;
 
     constexpr static std::uint32_t SET_DVALID = 0x1;
-
-    constexpr static std::uint32_t UNP_ZEROSRC_RESET_ALL_BANKS    = 0b1001; // default is clear current bank
-    constexpr static std::uint32_t UNP_ZEROSRC_STALL_RESET_WR_RDY = 0b10001;
-    constexpr static std::uint32_t UNP_ZEROSRC_SET_DVALID         = 0b1000001;
 
     constexpr static std::uint32_t UNP0 = 0x0;
     constexpr static std::uint32_t UNP1 = 0x1;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_instr_params.h
@@ -94,8 +94,6 @@ struct p_unpacr_nop
     constexpr static std::uint32_t UNP_NOP = 0b010;
 
     constexpr static std::uint32_t UNP_ZEROSRC = 0b001;
-    // Spans Src_ClrVal_Ctrl|Unpack_Pop; equals CLR_SRC_NEGINF|CLR_SRC.
-    constexpr static std::uint32_t UNP_NEGINFSRC = 0b101;
 
     constexpr static std::uint32_t SET_DVALID = 0x1;
 


### PR DESCRIPTION
### PR Category

Bug fix (latent) / cleanup

### Summary

Fixes #55269.

Blackhole's `UNPACR_NOP` takes each control as a **separate operand**; Wormhole packs them into one `NoOp` immediate. Blackhole's `p_unpacr_nop` nevertheless carried three constants at their Wormhole packed values, byte-identical to the Wormhole header. Passed to Blackhole's 2-bit `Unpack_Pop` — the natural slot, since the legitimate `UNP_ZEROSRC` lives there — each overflows into its neighbours and encodes something other than its name:

| removed constant | value | name says | Blackhole actually encodes |
|---|---|---|---|
| `UNP_ZEROSRC_RESET_ALL_BANKS` | `0b1001` | reset all banks | `Src_ClrVal_Ctrl=0b10` → **clear to ONE**. Both-banks is `Bank_Clr_Ctrl` (bit 4), which stays clear. |
| `UNP_ZEROSRC_STALL_RESET_WR_RDY` | `0b10001` | wait like `UNPACR` | `Bank_Clr_Ctrl=1` → **clear BOTH banks**. The wait bit is bit 5, which stays clear. |
| `UNP_ZEROSRC_SET_DVALID` | `0b1000001` | clear + set DVALID | `Clr_to1_fmt_Ctrl=0b01`, and `Set_Dvalid` (at `<<8`) stays **0** — the **DVALID is never published**. |
| `UNP_NEGINFSRC` | `0b101` | clear SrcA to −inf | spans `Src_ClrVal_Ctrl`+`Unpack_Pop`; **encodes correctly**, but unused and confusing — see below. |

`TTI_UNPACR_NOP` never calls `TT_UNPACR_NOP_VALID`, so the 2-bit operand overflow is not diagnosed. Deleting them turns a silent mis-encoding into a compile error.

This is the review the struct's `// TODO: RT Review this struct, bits do not match for UNPACR_NOP` was asking for, so that TODO is replaced by a statement of the actual per-operand contract.

### Scope

- **Wormhole is untouched** — all three are correct there, and `UNP_ZEROSRC_STALL_RESET_WR_RDY` is used on that side in #54683.
- **`UNP_NEGINFSRC` (`0b101`) is also removed** — reversing the first commit, after review feedback. It is the one value that *does* encode correctly on Blackhole, because `(CLR_SRC_NEGINF << 2) + CLR_SRC` happens to equal `0b101`. But it is **unused on Blackhole too** (only its definition; nothing in `tt_llk_blackhole/`, `ttnn/`, `models/` or `tt_metal/hw/`), and Blackhole already has the per-operand form it actually uses — `p_unpacr::UNP_CLRSRC_NEGINF` with `p_unpacr::UNP_CLRSRC`, in `ckernel_template.h` and `llk_unpack_tilize.h`. "Correct but unused and confusing" is a weaker argument for keeping it than "unused" is for dropping it. Wormhole keeps it; it is used in three files there.
- With it gone, **every remaining constant fits the operand it is passed to** (max value 3, every target field ≥2 bits), so the struct's per-operand comment is unqualified and true with no exception to carry.
- No behaviour change: none of the three is referenced anywhere in the repo, on `main` or on any open branch, including the vendored LLK trees under `models/` and `ttnn/` (which carry no second copy of this header — there are exactly three `ckernel_instr_params.h` in the tree, one per arch).

### Why now

The exposure is a porting substitution, not a copy-the-call-site one: Wormhole's two-argument `TTI_UNPACR_NOP(SrcA, <packed const>)` does not compile on Blackhole. It fires when someone writes Blackhole's 9-operand form and reaches for the same-named constant. That is live risk today — dest-reuse work is adding Wormhole and Blackhole publications side by side (#54683, #55107), and a shared helper is planned once #54731 lands.

#55123 adds an audit-tool check (`DUMMY_PUBLISH_PACKED_WAIT_WRONG_ARCH`) for the same misuse; after this PR the compiler catches it on Blackhole directly, and that check remains as cover for Quasar and for re-introduction.

### Testing

Removing unused `constexpr static` members cannot affect emitted code, so the checks are the reference audit plus compile behaviour:

- **No references anywhere** — `git grep` over all tracked files (any extension) on `main` and on every open branch: the only hits are the definitions, and after this change only the Wormhole ones remain.
- **Header compiles clean** after the removal (`-fsyntax-only`, TU also referencing the kept `UNP_NEGINFSRC` / `SET_DVALID` so they still resolve).
- **The misuse is now a compile error on Blackhole** — a TU naming any of the four removed constants fails, e.g. `'UNP_ZEROSRC_STALL_RESET_WR_RDY' is not a member of 'ckernel::p_unpacr_nop'`. Checked for all four.
- **The same TUs still compile against Wormhole**, confirming that side is unaffected.
- **Every remaining constant fits its operand**, checked mechanically against the widths in `TT_UNPACR_NOP_VALID` — this is what makes the unqualified per-operand comment correct.

### Note for reviewers

`p_zeroacc`'s `CLR_HALF_32B` / `CLR_ALL_32B` look like the same class and are **not** touched here. They encode 32-bit mode inside `clear_mode` the Wormhole way, while Blackhole's `TT_OP_ZEROACC` exposes a dedicated `use_32_bit_mode` operand at a different bit; both cannot be the control the hardware reads. They fit Blackhole's 5-bit `clear_mode` so nothing spills, Blackhole code never uses them, and there is no public Blackhole `ZEROACC` ISA page to settle it. Flagged in #55269 rather than guessed at — happy to follow up if someone can confirm the hardware definition.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/bh-drop-wh-packed-unpacr-nop-consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/bh-drop-wh-packed-unpacr-nop-consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/bh-drop-wh-packed-unpacr-nop-consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/bh-drop-wh-packed-unpacr-nop-consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/bh-drop-wh-packed-unpacr-nop-consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/bh-drop-wh-packed-unpacr-nop-consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/bh-drop-wh-packed-unpacr-nop-consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/bh-drop-wh-packed-unpacr-nop-consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/bh-drop-wh-packed-unpacr-nop-consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/bh-drop-wh-packed-unpacr-nop-consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/bh-drop-wh-packed-unpacr-nop-consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/bh-drop-wh-packed-unpacr-nop-consts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/bh-drop-wh-packed-unpacr-nop-consts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/bh-drop-wh-packed-unpacr-nop-consts)


---

### Review response

Both points from the Copilot review were correct and are fixed in `576bd58`:

1. **False numeric equality.** The inline note said `UNP_NEGINFSRC` "equals `CLR_SRC_NEGINF|CLR_SRC`". As an expression that is false — both are `0b01` unshifted, so the OR is `0b01`, not `0b101`. The value only appears after the encoder shifts: `(CLR_SRC_NEGINF << 2) + CLR_SRC`.
2. **Blanket per-operand claim contradicted by the kept composite.** Also correct. Rather than qualify the contract with a legacy exception, the exception is gone: `UNP_NEGINFSRC` is unused on Blackhole, so it is removed too and the statement is now unqualified and provably true.
