### PR TITLE
[Bug fix] Make div_up overflow-safe

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -41,6 +41,7 @@ set(UNIT_TESTS_API_SOURCES
     test_kernel_thread_sync.cpp
     test_banked.cpp
     test_bit_utils.cpp
+    test_math.cpp
     test_filesystem_utils.cpp
     test_tt_memory.cpp
     test_graph_tracking.cpp

--- a/tests/tt_metal/tt_metal/api/test_math.cpp
+++ b/tests/tt_metal/tt_metal/api/test_math.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/math.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Math, DivUp) {
+    EXPECT_EQ(tt::div_up(0, 3), 0);
+    EXPECT_EQ(tt::div_up(6, 3), 2);
+    EXPECT_EQ(tt::div_up(7, 3), 3);
+
+    EXPECT_EQ(tt::div_up(-6, 3), -2);
+    EXPECT_EQ(tt::div_up(-7, 3), -2);
+    EXPECT_EQ(tt::div_up(7, -3), -2);
+    EXPECT_EQ(tt::div_up(-7, -3), 3);
+}
+
+TEST(Math, DivUpNoOverflow) {
+    constexpr auto int32_max = std::numeric_limits<std::int32_t>::max();
+    constexpr auto int64_max = std::numeric_limits<std::int64_t>::max();
+    constexpr auto uint32_max = std::numeric_limits<std::uint32_t>::max();
+    constexpr auto uint64_max = std::numeric_limits<std::uint64_t>::max();
+    constexpr auto size_max = std::numeric_limits<std::size_t>::max();
+
+    static_assert(tt::div_up(int32_max, std::int32_t{2}) == int32_max / 2 + 1);
+    static_assert(tt::div_up(int64_max, std::int64_t{2}) == int64_max / 2 + 1);
+    static_assert(tt::div_up(uint32_max, std::uint32_t{2}) == uint32_max / 2 + 1);
+    static_assert(tt::div_up(uint64_max, std::uint64_t{2}) == uint64_max / 2 + 1);
+    static_assert(tt::div_up(size_max, size_max) == 1);
+
+    EXPECT_EQ(tt::div_up(uint32_max - 1, uint32_max), 1U);
+    EXPECT_EQ(tt::div_up(uint64_max - 1, uint64_max), 1U);
+    EXPECT_EQ(tt::div_up(size_max - 1, size_max), 1U);
+}
+
+TEST(Math, DivUpCommonType) {
+    static_assert(std::is_same_v<decltype(tt::div_up(std::uint32_t{1}, std::uint64_t{1})), std::uint64_t>);
+    EXPECT_EQ(tt::div_up(std::uint32_t{7}, std::uint64_t{3}), 3U);
+}
+
+}  // namespace

--- a/tt_metal/api/tt-metalium/math.hpp
+++ b/tt_metal/api/tt-metalium/math.hpp
@@ -17,15 +17,22 @@ namespace tt {
  *
  * @param a The numerator.
  * @param b The denominator. Must be non-zero.
- * @return The result of ceiling division (a + b - 1) / b.
+ * @return The result of ceiling division.
  *
  * @note If b is zero, this results in undefined behavior.
  */
 template <typename A, typename B>
 constexpr auto div_up(A a, B b) noexcept -> std::common_type_t<A, B> {
     using T = std::common_type_t<A, B>;
-    assert(b != 0 && "Divide by zero error in div_up");
-    return static_cast<T>((static_cast<T>(a) + static_cast<T>(b) - 1) / static_cast<T>(b));
+    const T numerator = static_cast<T>(a);
+    const T denominator = static_cast<T>(b);
+    assert(denominator != 0 && "Divide by zero error in div_up");
+    const T quotient = numerator / denominator;
+    const T remainder = numerator % denominator;
+    if constexpr (std::is_signed_v<T>) {
+        return quotient + static_cast<T>(remainder != 0 && (remainder > 0) == (denominator > 0));
+    }
+    return quotient + static_cast<T>(remainder != 0);
 }
 
 /**


### PR DESCRIPTION
# PR description

### PR Category

Bug fix

### Summary

Fixes integer overflow in `tt::div_up` and adds coverage for ordinary, signed, mixed-width, and boundary-value inputs.

Fixes #55268


#### Problem

`div_up` currently uses:

```cpp
(a + b - 1) / b
```

The addition can overflow before the division even when the correct quotient
fits in the return type. For example:

```cpp
tt::div_up(UINT64_MAX, UINT64_C(2))
```

returns `0` instead of `2^63` after the intermediate sum wraps.

The old expression also does not implement mathematical ceiling division
consistently for signed inputs. For example, `div_up(-6, 3)` returns `-1`
instead of `-2` because C++ integer division truncates toward zero.

#### Fix

The implementation computes the quotient and remainder without adding to the
numerator:

```cpp
const T quotient = numerator / denominator;
const T remainder = numerator % denominator;
```

Unsigned results are incremented when the remainder is non-zero. Signed results are incremented only when the remainder and denominator have the same sign. The existing `std::common_type_t<A, B>` return type is preserved.

### Notes for reviewers

#### Related integer-rounding contracts

While reviewing this helper, I found several related edge cases in `round_up` and `round_down`. They are not changed in this focused PR because they require an explicit API contract rather than a mechanical replacement.

##### Zero denominator

`round_up` reaches the `assert` in `div_up`, but that check disappears in a Release build. `round_down` has no denominator check. Both paths can therefore reach integer division by zero in Release.

##### Negative inputs

`round_down` uses C++ division, which truncates toward zero:

```cpp
tt::round_down(-7, 3)  // currently -6 mathematical result is -9
```

The documentation permits any non-zero `b`, but the current formulas do not provide the stated round-up/round-down semantics for a negative `b`.

##### Unrepresentable rounded results

Some mathematical results cannot be represented by the selected common type:

```cpp
tt::round_up(UINT32_MAX, 2U)  // mathematical result is 2^32
tt::div_up(INT_MIN, -1)       // quotient is not representable
tt::round_up(INT_MAX, 2)      // rounded multiple is not representable
```

Handling these cases requires deciding whether the helpers should use a Release-active `TT_FATAL`, expose a checked API, or retain a documented precondition. That decision is intentionally left out of this PR so the `div_up` overflow fix remains small and reviewable.