### PR TITLE
perf fast tilize/untilize: measure zones with START_PERF_MEASURE

### DIFF
--- a/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "params.h"
 #include "perf.h"
@@ -83,7 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if (BLOCK_CT_DIM == 1)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
                 formats.unpack_A_src,
                 formats.unpack_B_src,
@@ -96,7 +97,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_unpack_tilize_(
@@ -111,7 +112,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         // Fast-tilize uses compat 16-bit DEST. When dest_acc=Yes, format inference
         // may derive a 32-bit unpack_A_dst (e.g. Tf32). Override to Float16_b so the
         // unpack produces 16-bit SrcA data and CH1_Z stride is correct.
@@ -146,7 +147,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // via _llk_unpack_configure_single_address_ (respects current cfg context).
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
@@ -210,14 +211,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if (BLOCK_CT_DIM == 1)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
             _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Tilize>(
                 4 /* num_faces */, formats.math);
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
@@ -233,13 +234,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
         _llk_math_fast_tilize_init_<is_fp32_dest_acc_en>(formats.math);
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
             // Intentionally empty: MATH_PACK SEMINITs to max 2, so posting one credit per unit hangs pack
@@ -319,7 +320,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if (BLOCK_CT_DIM == 1)
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
                 formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
@@ -327,7 +328,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 formats.pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_packer_wait_for_math_done_();
@@ -343,7 +344,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     else
     {
         {
-            ZONE_SCOPED("INIT")
+            START_PERF_MEASURE("INIT")
             _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
                 formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
@@ -351,7 +352,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 0 /* use_32bit_dest */, formats.pack_dst, unit_dims[0], 4 /* num_faces */, formats.pack_src);
         }
         {
-            ZONE_SCOPED("TILE_LOOP")
+            START_PERF_MEASURE("TILE_LOOP")
             if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
             {
             }

--- a/tt_metal/tt-llk/tests/sources/fast_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "llk_defs.h"
 #include "params.h"
 #include "profiler.h"
@@ -67,7 +68,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src,
             formats.unpack_B_src,
@@ -81,7 +82,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         for (std::uint32_t loop = 0; loop < static_cast<std::uint32_t>(LOOP_FACTOR); loop++)
         {
             for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)
@@ -163,14 +164,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
         _llk_math_fast_tilize_init_(formats.math, BLOCK_CT_DIM == 1 ? 1 : 2);
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         for (std::uint32_t loop = 0; loop < static_cast<std::uint32_t>(LOOP_FACTOR); loop++)
         {
             for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)
@@ -254,7 +255,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     std::uint32_t use_32bit_dest = formats.unpack_A_dst == ckernel::to_underlying(DataFormat::Tf32);
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>();
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
             formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
@@ -262,7 +263,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         for (std::uint32_t loop = 0; loop < static_cast<std::uint32_t>(LOOP_FACTOR); loop++)
         {
             for (std::uint32_t i = 0; i < BLOCK_RT_DIM; i++)

--- a/tt_metal/tt-llk/tests/sources/fast_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_untilize_test.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 
 #include "ckernel.h"
+#include "counters.h"
 #include "experimental/llk_fast_untilize_common.h"
 #include "llk_defs.h"
 #include "params.h"
@@ -52,7 +53,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
         ckernel::_llk_unpack_fast_untilize_init_<DST_ACCUM_MODE>(
@@ -60,7 +61,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
             return;
@@ -147,14 +148,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_math_pack_sync_init_<FAST_UNTILIZE_INTERNAL_DEST_SYNC, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
         llk_math_fast_untilize_init();
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
             return;
@@ -254,7 +255,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     {
-        ZONE_SCOPED("INIT")
+        START_PERF_MEASURE("INIT")
         _llk_pack_dest_init_<FAST_UNTILIZE_INTERNAL_DEST_SYNC, is_fp32_dest_acc_en>();
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
             formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
@@ -262,7 +263,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
     {
-        ZONE_SCOPED("TILE_LOOP")
+        START_PERF_MEASURE("TILE_LOOP")
         if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
             return;
@@ -294,8 +295,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         else
         {
             std::uint32_t unit_dims[MAX_UNITS_PER_ROW];
-            const std::uint32_t units_per_row = ckernel::fast_untilize_decompose_row(FULL_CT_DIM, unit_dims);
-            std::uint32_t prev_pack_unit_dim  = 0;
+            const std::uint32_t units_per_row         = ckernel::fast_untilize_decompose_row(FULL_CT_DIM, unit_dims);
+            std::uint32_t prev_pack_unit_dim          = 0;
             const std::uint32_t output_row_stride_16B = SCALE_DATUM_SIZE(formats.pack_dst, FULL_CT_DIM * TILE_C_DIM) / 16;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {


### PR DESCRIPTION
## What

`fast_tilize_test.cpp`, `fast_tilize_bh_test.cpp` and `fast_untilize_test.cpp` opened INIT and TILE_LOOP with bare `ZONE_SCOPED`. That records timestamps but supplies no cross-thread rendezvous, so nothing stopped one thread entering TILE_LOOP while another was still initialising.

Between 51 and 59 percent of the pack thread's INIT window overlapped TILE_LOOP. Both windows were then reported as if each measured the phase it names.

This never surfaced as a with-counters versus no-counters difference because both builds were wrong in the same way, so the number the suite watches stayed at zero while both underlying figures were wrong.

18 overlapping zone pairs across the three kernels, now 0.

## Why UNINIT stays on bare ZONE_SCOPED

UNINIT is not reported, and some run types skip it on some threads. A barrier there would have to be reached by every thread or it would hang, so it must stay as it is.

## Testing

Blackhole, speed of light. `perf_fast_untilize` with counters: 1620 variants passed, producer and consumer.

## Note

Replaces #52443, which GitHub's stack machinery closed when the merged barrier branch was deleted and would not let retarget to main. Same single commit, rebased onto main after #52442 merged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-tilize-start-measure)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf-tilize-start-measure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-tilize-start-measure)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf-tilize-start-measure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf-tilize-start-measure)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf-tilize-start-measure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf-tilize-start-measure)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf-tilize-start-measure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf-tilize-start-measure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf-tilize-start-measure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf-tilize-start-measure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf-tilize-start-measure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf-tilize-start-measure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf-tilize-start-measure)