### PR TITLE
Fix byte/word overcopy in active_erisc.cc with enum class

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -110,9 +110,7 @@ inline void initialize_local_memory() {
     uint32_t* data_image = (uint32_t*)MEM_AERISC_INIT_LOCAL_L1_BASE_SCRATCH;
     extern uint32_t __ldm_data_start[];
     extern uint32_t __ldm_data_end[];
-    const uint32_t ldm_data_size = (uint32_t)__ldm_data_end - (uint32_t)__ldm_data_start;
-    // Copy data from data_image in __ldm_data_start for ldm_data_size bytes
-    l1_to_local_mem_copy(__ldm_data_start, data_image, ldm_data_size);
+    l1_to_local_mem_copy(__ldm_data_start, data_image, l1_word_count_from_range(__ldm_data_start, __ldm_data_end));
 }
 
 #define STR(x) #x

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -49,7 +49,7 @@ extern int32_t bank_to_l1_offset[NUM_L1_BANKS];
 extern uint8_t worker_logical_col_to_virtual_col[round_up_to_mult_of_4(noc_size_x)];
 extern uint8_t worker_logical_row_to_virtual_row[round_up_to_mult_of_4(noc_size_y)];
 
-void l1_to_local_mem_copy(uint32_t* dst, uint32_t tt_l1_ptr* src, int32_t len);
+void l1_to_local_mem_copy(uint32_t* dst, uint32_t tt_l1_ptr* src, L1WordCount len);
 
 inline void do_crt1(uint32_t tt_l1_ptr* data_image) {
     // Clear bss.
@@ -61,7 +61,7 @@ inline void do_crt1(uint32_t tt_l1_ptr* data_image) {
     extern uint32_t __ldm_data_start[];
     extern uint32_t __ldm_data_end[];
     if (__ldm_data_start != data_image) {
-        l1_to_local_mem_copy(__ldm_data_start, data_image, __ldm_data_end - __ldm_data_start);
+        l1_to_local_mem_copy(__ldm_data_start, data_image, l1_word_count_from_range(__ldm_data_start, __ldm_data_end));
     }
 }
 
@@ -74,7 +74,7 @@ inline void do_thread_crt1(uint32_t tt_l1_ptr* data_image) {
     // Copy thread initialized data.
     extern thread_local uint32_t __ldm_tdata_start[];
     extern thread_local uint32_t __ldm_tdata_end[];
-    l1_to_local_mem_copy(__ldm_tdata_start, data_image, __ldm_tdata_end - __ldm_tdata_start);
+    l1_to_local_mem_copy(__ldm_tdata_start, data_image, l1_word_count_from_range(__ldm_tdata_start, __ldm_tdata_end));
 }
 
 inline void noc_bank_table_init(uint64_t mem_bank_to_noc_addr) {
@@ -85,37 +85,49 @@ inline void noc_bank_table_init(uint64_t mem_bank_to_noc_addr) {
     static_assert(
         l1_to_noc_size_bytes % 4 == 0, "l1_bank_to_noc_xy size must be 4-byte aligned for l1_to_local_mem_copy");
     l1_to_local_mem_copy(
-        (uint*)dram_bank_to_noc_xy, (uint tt_l1_ptr*)mem_bank_to_noc_addr, dram_to_noc_size_bytes >> 2);
+        (uint*)dram_bank_to_noc_xy,
+        (uint tt_l1_ptr*)mem_bank_to_noc_addr,
+        l1_word_count_from_bytes(dram_to_noc_size_bytes));
     l1_to_local_mem_copy(
         (uint*)l1_bank_to_noc_xy,
         (uint tt_l1_ptr*)(mem_bank_to_noc_addr + dram_to_noc_size_bytes),
-        l1_to_noc_size_bytes >> 2);
+        l1_word_count_from_bytes(l1_to_noc_size_bytes));
 
-    int32_t dram_offsets_size_bytes = sizeof(bank_to_dram_offset);
+    constexpr int32_t dram_offsets_size_bytes = sizeof(bank_to_dram_offset);
+    static_assert(
+        dram_offsets_size_bytes % 4 == 0, "bank_to_dram_offset size must be 4-byte aligned for l1_to_local_mem_copy");
     l1_to_local_mem_copy(
         (uint*)bank_to_dram_offset,
         (uint tt_l1_ptr*)(mem_bank_to_noc_addr + dram_to_noc_size_bytes + l1_to_noc_size_bytes),
-        dram_offsets_size_bytes >> 2);
-    int32_t l1_offsets_size_bytes = sizeof(bank_to_l1_offset);
+        l1_word_count_from_bytes(dram_offsets_size_bytes));
+    constexpr int32_t l1_offsets_size_bytes = sizeof(bank_to_l1_offset);
+    static_assert(
+        l1_offsets_size_bytes % 4 == 0, "bank_to_l1_offset size must be 4-byte aligned for l1_to_local_mem_copy");
     l1_to_local_mem_copy(
         (uint*)bank_to_l1_offset,
         (uint tt_l1_ptr*)(mem_bank_to_noc_addr + dram_to_noc_size_bytes + l1_to_noc_size_bytes +
                           dram_offsets_size_bytes),
-        l1_offsets_size_bytes >> 2);
+        l1_word_count_from_bytes(l1_offsets_size_bytes));
 }
 
 inline void noc_worker_logical_to_virtual_map_init(uint64_t worker_logical_to_virtual_map_addr) {
-    int32_t worker_logical_col_to_virtual_col_size_bytes = sizeof(worker_logical_col_to_virtual_col);
+    constexpr int32_t worker_logical_col_to_virtual_col_size_bytes = sizeof(worker_logical_col_to_virtual_col);
+    static_assert(
+        worker_logical_col_to_virtual_col_size_bytes % 4 == 0,
+        "worker_logical_col_to_virtual_col size must be 4-byte aligned for l1_to_local_mem_copy");
     l1_to_local_mem_copy(
         (uint*)worker_logical_col_to_virtual_col,
         (uint tt_l1_ptr*)(worker_logical_to_virtual_map_addr),
-        worker_logical_col_to_virtual_col_size_bytes >> 2);
+        l1_word_count_from_bytes(worker_logical_col_to_virtual_col_size_bytes));
 
-    int32_t worker_logical_row_to_virtual_row_size_bytes = sizeof(worker_logical_row_to_virtual_row);
+    constexpr int32_t worker_logical_row_to_virtual_row_size_bytes = sizeof(worker_logical_row_to_virtual_row);
+    static_assert(
+        worker_logical_row_to_virtual_row_size_bytes % 4 == 0,
+        "worker_logical_row_to_virtual_row size must be 4-byte aligned for l1_to_local_mem_copy");
     l1_to_local_mem_copy(
         (uint*)worker_logical_row_to_virtual_row,
         (uint tt_l1_ptr*)(worker_logical_to_virtual_map_addr + worker_logical_col_to_virtual_col_size_bytes),
-        worker_logical_row_to_virtual_row_size_bytes >> 2);
+        l1_word_count_from_bytes(worker_logical_row_to_virtual_row_size_bytes));
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/internal/risc_attribs.h
+++ b/tt_metal/hw/inc/internal/risc_attribs.h
@@ -5,6 +5,7 @@
 #ifndef _RISC_ATTRIBS_H_
 #define _RISC_ATTRIBS_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 union tt_uint64_t {
@@ -17,6 +18,19 @@ union tt_uint64_t {
 
 #define tt_l1_ptr __attribute__((rvtt_l1_ptr))
 #define tt_reg_ptr __attribute__((rvtt_reg_ptr))
+
+// Distinguishes a count of 32-bit words from a byte count at the type level, so a byte count can't be
+// passed where l1_to_local_mem_copy expects words. This is an enum rather than a wrapper struct so it
+// stays zero-cost even when the compiler can't inline the call: an enum with a fixed underlying type
+// has no aggregate representation to materialize separately from the int32_t it already is.
+enum class L1WordCount : int32_t {};
+
+constexpr L1WordCount l1_word_count_from_bytes(size_t bytes) { return static_cast<L1WordCount>(bytes / 4); }
+template <typename T>
+constexpr L1WordCount l1_word_count_from_range(T* start, T* end) {
+    static_assert(sizeof(T) == sizeof(uint32_t), "L1WordCount ranges must use 32-bit elements");
+    return static_cast<L1WordCount>(end - start);
+}
 
 // This enum is used to specify the dest location type for inline writes.
 // It is needed because inline writes use all 4 memory ports and may hang on Blackhole when there is back-pressure.

--- a/tt_metal/hw/toolchain/substitutes.cpp
+++ b/tt_metal/hw/toolchain/substitutes.cpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <cstddef>
 
+#include "internal/risc_attribs.h"
+
 using namespace std;
 
 extern "C" int atexit(void (*f)(void)) { return 0; }
@@ -39,7 +41,8 @@ extern "C" void wzerorange(uint32_t* start, uint32_t* end) {
 }
 
 // Let the LTO decide if this needs to be inline.
-void l1_to_local_mem_copy(uint32_t* dst, uint32_t __attribute__((rvtt_l1_ptr))* src, int32_t len) {
+void l1_to_local_mem_copy(uint32_t* dst, uint32_t __attribute__((rvtt_l1_ptr)) * src, L1WordCount len_) {
+    int32_t len = static_cast<int32_t>(len_);
 #pragma GCC unroll 0
     while (len >= 3) {
         auto v0 = src[0], v1 = src[1], v2 = src[2];


### PR DESCRIPTION
### PR Category
Bug Fix

### Problem
Fixes #51238 
`initialize_local_memory()` in active_erisc.cc computed the size of the
firmware's .data section as a byte count, then passed it straight to
l1_to_local_mem_copy(), whose `len` is actually consumed as a word count.
This resulted in a 4x overcopy currupting memory next to .data.

### Notes for reviewers
We fixed this in #54487 by giving l1_to_local_mem_copy() a distinct
`L1WordCount` type instead of a bare int32_t, so a byte count can no
longer be passed where a word count is expected. This got
reverted in #55229 likey because the wrapper struct added a small but
real overhead once the compiler couldn't fully inline the call. This caused
`models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py` to
fail in the sanity tests.

### Fix
This redoes the same fix using `enum class L1WordCount : int32_t {}`
instead of a struct. However, there is zero runtime cost even when the
function call isn't inlined as there is no aggregate to construct. Should
result in the same codegen to the previous version while being more
type safe.

Will run the sanity tests to make sure this change passes the sdxl perf tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anirudhsathiyaTT/l1wordcount-enum-perf-fix-v2)