### PR TITLE
(perf) Add structured layer-completion protocol; unify per-protocol plumbing

### DIFF
--- a/models/demos/common/prefill/runners/layer_completion_drainer.py
+++ b/models/demos/common/prefill/runners/layer_completion_drainer.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Consumer side of the layer-completion protocols (issue #54632).
+
+Channel entry points for any consumer-side tool (prefill_producer, migration
+drivers, verifiers) — dispatch on PREFILL_LAYER_COMPLETION_PROTOCOL under the
+hood, so callers hold one `completion_channel` and never branch:
+
+    channel = connect_layer_completion_channel(timeout_s)
+    drain_layer_completions(channel, expected_layers)   # NUM_LAYERS per chunk
+
+  Both protocols share the ONE scheduler-facing shm name
+  (/tt_prefill_layer_acks_<service_id>); the protocol decides the segment's
+  layout:
+  protocol 1 (default): a counter channel — a bare count; the consumer
+      correlates ticks with its own in-order chunk FIFO.
+  protocol 2: a structured completion ring — self-describing messages
+      drained work-conservingly by LayerCompletionDrainer.
+
+LayerCompletionDrainer (v2):
+
+* WORK-CONSERVING: a completion that is not yet actionable (the embedder's
+  `can_process` predicate, e.g. "migration context for this slot exists") goes
+  to a per-request SIDE QUEUE and never stalls the input ring — later requests'
+  completions keep advancing. Side queues are retried after every processed
+  message and whenever the ring runs dry.
+
+* PER-REQUEST COVERAGE: tracks each request's completed layer spans. A request
+  is fully covered when its spans total `num_layers` — with overlap enforced
+  as an error at insert, that implies an exact tiling of [0, num_layers).
+
+* EXPECTATION HOOK (future error detection): `on_first_completion` fires once
+  per request with the first message seen. The embedder may use it to register
+  a coverage rule on `RequestCoverage.expectation` — e.g. for pipelined
+  prefill, "every layer eventually spans for the position range of the first
+  completion received" — evaluated by a future checker. Nothing is enforced
+  yet; this is the seam.
+
+* TEARDOWN INVARIANT: finish() requires every side queue to be empty and
+  raises listing the stranded (never-actionable) messages otherwise — a lost
+  dependency surfaces as a precise, attributed error, not a silent stall.
+
+Kept dependency-light at import (stdlib + loguru — ttnn and the
+layer_completion bindings are imported lazily inside the connect helpers) so
+the drainer is unit testable without the device stack. The v2 ring is any
+object with `try_pop() -> tuple | None` in the v2 wire order
+(seq, source_rank, request_id, slot_id, pos_start, pos_end, layer_start,
+layer_end) — the ttnn._experimental.layer_completion.LayerCompletionQueueV2 binding qualifies.
+"""
+
+import os
+import time
+from collections import deque, namedtuple
+
+from loguru import logger
+
+# Wire order of LayerCompletionQueueV2.try_pop() (ttnn/cpp/ttnn-nanobind/layer_completion.cpp).
+Completion = namedtuple(
+    "Completion", "seq source_rank request_id slot_id pos_start pos_end layer_start layer_end"
+)
+
+
+def current_protocol() -> int:
+    """The job's completion protocol: PREFILL_LAYER_COMPLETION_PROTOCOL, 1 (default) or 2.
+
+    Mirrors prefill_runner's read (kept separate so consumer-side tools need not import the
+    device-heavy runner module).
+    """
+    try:
+        protocol = int(os.environ.get("PREFILL_LAYER_COMPLETION_PROTOCOL", "1").strip())
+    except ValueError:
+        protocol = -1
+    if protocol not in (1, 2):
+        raise ValueError(
+            f"PREFILL_LAYER_COMPLETION_PROTOCOL must be 1 or 2, got "
+            f"{os.environ.get('PREFILL_LAYER_COMPLETION_PROTOCOL')!r}"
+        )
+    return protocol
+
+
+class RequestCoverage:
+    """Per-request layer-coverage bookkeeping: disjoint spans seen so far, the chunk's
+    slot/position identity (cross-checked on every message), and the side queue of
+    not-yet-actionable completions for this request."""
+
+    __slots__ = ("request_id", "slot_id", "pos_start", "pos_end", "intervals", "layers_accounted", "side_queue", "expectation")
+
+    def __init__(self, request_id: int):
+        self.request_id = request_id
+        self.slot_id = None
+        self.pos_start = None
+        self.pos_end = None
+        self.intervals = []  # sorted, disjoint [start, end) — overlap is a producer bug
+        self.layers_accounted = 0
+        self.side_queue = deque()
+        # Registered by the embedder's on_first_completion hook; evaluated by future
+        # error-detection rules. Shape for pipelined prefill: "layers eventually tile
+        # [0, num_layers) for THIS request's position range".
+        self.expectation = None
+
+    def record_identity(self, c: Completion) -> None:
+        """Bind slot/pos from the first message of the request; cross-check afterwards."""
+        if self.slot_id is None:
+            self.slot_id, self.pos_start, self.pos_end = c.slot_id, c.pos_start, c.pos_end
+        elif (self.slot_id, self.pos_start, self.pos_end) != (c.slot_id, c.pos_start, c.pos_end):
+            raise ValueError(
+                f"[drainer] request {self.request_id}: inconsistent identity — first message had "
+                f"slot={self.slot_id} pos=[{self.pos_start},{self.pos_end}), now {c}: "
+                "producer-side correlation bug"
+            )
+
+    def add_span(self, c: Completion, num_layers: int) -> None:
+        """Record [c.layer_start, c.layer_end). Raises on overlap or out-of-bounds — both
+        are producer bugs, and the self-describing payload makes them attributable."""
+        start, end = c.layer_start, c.layer_end
+        if not (0 <= start < end <= num_layers):
+            raise ValueError(
+                f"[drainer] request {c.request_id}: layer span [{start},{end}) out of bounds "
+                f"[0,{num_layers}): {c}"
+            )
+        for iv_start, iv_end in self.intervals:
+            if start < iv_end and iv_start < end:
+                raise ValueError(
+                    f"[drainer] request {c.request_id}: layer span [{start},{end}) overlaps "
+                    f"already-covered [{iv_start},{iv_end}): {c}"
+                )
+        self.intervals.append((start, end))
+        self.intervals.sort()
+        self.layers_accounted += end - start
+
+    def is_complete(self, num_layers: int) -> bool:
+        # Disjointness is enforced at insert, so reaching the full layer count within
+        # [0, num_layers) implies an exact tiling.
+        return self.layers_accounted == num_layers
+
+
+class LayerCompletionDrainer:
+    """Work-conserving drainer for a v2 structured completion ring.
+
+    Args:
+        ring: anything with try_pop() -> tuple | None in the v2 wire order.
+        num_layers: GLOBAL model layer count (coverage bound per request).
+        can_process(completion) -> bool: readiness predicate; blocked messages are
+            side-queued (per request) instead of stalling the ring. Default: always ready.
+        on_completion(completion): action for each processed message (e.g. issue a
+            migration). Default: coverage accounting only.
+        on_first_completion(request_id, completion, coverage): expectation hook, fired
+            once per request (see RequestCoverage.expectation). Default: no-op.
+        on_request_complete(request_id, coverage): notification when a request tiles
+            [0, num_layers). Default: no-op.
+        poll_idle_s: sleep quantum for drain_blocking when nothing is actionable.
+    """
+
+    def __init__(
+        self,
+        ring,
+        *,
+        num_layers: int,
+        can_process=None,
+        on_completion=None,
+        on_first_completion=None,
+        on_request_complete=None,
+        poll_idle_s: float = 0.001,
+    ):
+        self._ring = ring
+        self._num_layers = num_layers
+        self._can_process = can_process or (lambda c: True)
+        self._on_completion = on_completion or (lambda c: None)
+        self._on_first_completion = on_first_completion or (lambda rid, c, cov: None)
+        self._on_request_complete = on_request_complete or (lambda rid, cov: None)
+        self._poll_idle_s = poll_idle_s
+        self._requests = {}  # request_id -> RequestCoverage
+        self.total_layers = 0  # span-summed layers processed (NOT message count)
+        self.processed = 0
+        self.side_queued = 0
+
+    @property
+    def requests(self):
+        return self._requests
+
+    def _coverage(self, request_id: int) -> RequestCoverage:
+        cov = self._requests.get(request_id)
+        if cov is None:
+            cov = self._requests[request_id] = RequestCoverage(request_id)
+        return cov
+
+    def _process(self, c: Completion) -> None:
+        cov = self._coverage(c.request_id)
+        first = cov.layers_accounted == 0 and not cov.intervals and cov.slot_id is None
+        cov.record_identity(c)
+        cov.add_span(c, self._num_layers)
+        if first:
+            self._on_first_completion(c.request_id, c, cov)
+        self._on_completion(c)
+        self.total_layers += c.layer_end - c.layer_start
+        self.processed += 1
+        if cov.is_complete(self._num_layers):
+            self._on_request_complete(c.request_id, cov)
+
+    def _retry_side_queues(self) -> bool:
+        """Re-test side-queued messages (oldest request first — the only ordering
+        preference the consumer keeps). Returns True if any became actionable."""
+        progressed = False
+        for request_id in sorted(self._requests):
+            sq = self._requests[request_id].side_queue
+            while sq and self._can_process(sq[0]):
+                self._process(sq.popleft())
+                progressed = True
+        return progressed
+
+    def step(self) -> bool:
+        """One work-conserving iteration. Returns True if anything moved (popped,
+        processed, or unblocked); False means idle-safe to sleep."""
+        msg = self._ring.try_pop()
+        if msg is None:
+            return self._retry_side_queues()
+        c = Completion._make(msg)
+        if self._can_process(c):
+            self._process(c)
+            # Processing may have unblocked side-queued messages (embedder state change).
+            self._retry_side_queues()
+        else:
+            cov = self._coverage(c.request_id)
+            cov.record_identity(c)  # identity is known (and checked) even while blocked
+            cov.side_queue.append(c)
+            self.side_queued += 1
+        return True
+
+    def finish(self) -> int:
+        """Teardown invariant: every side queue must be empty — a stranded message is a
+        lost dependency, reported with its full payload. Returns total layers drained."""
+        stranded = [
+            (request_id, list(cov.side_queue))
+            for request_id, cov in self._requests.items()
+            if cov.side_queue
+        ]
+        if stranded:
+            detail = "; ".join(f"request {rid}: {msgs}" for rid, msgs in stranded)
+            raise RuntimeError(f"[drainer] finish() with side-queued (never-actionable) completions: {detail}")
+        return self.total_layers
+
+    def drain_blocking(self, expected_total_layers: int, timeout_s: float = 600.0) -> int:
+        """Work-conserving loop until `expected_total_layers` (span-summed) have been
+        processed, then finish(). Raises TimeoutError with a coverage snapshot."""
+        deadline = time.perf_counter() + timeout_s
+        while self.total_layers < expected_total_layers:
+            if not self.step():
+                if time.perf_counter() > deadline:
+                    snapshot = ", ".join(
+                        f"req {rid}: {cov.layers_accounted}/{self._num_layers} layers"
+                        + (f" (+{len(cov.side_queue)} blocked)" if cov.side_queue else "")
+                        for rid, cov in sorted(self._requests.items())
+                    )
+                    raise TimeoutError(
+                        f"[drainer] timed out at {self.total_layers}/{expected_total_layers} layers "
+                        f"after {timeout_s}s; coverage: [{snapshot}]"
+                    )
+                time.sleep(self._poll_idle_s)
+        return self.finish()
+
+
+# ---------------------------------------------------------------------------
+# Channel connect/drain — protocol dispatch under the hood, so consumers hold one
+# `completion_channel` and never branch on PREFILL_LAYER_COMPLETION_PROTOCOL.
+# ---------------------------------------------------------------------------
+
+
+def _connect_layer_ack_channel(timeout_s: int):
+    """v1: attach (consumer side) to the scheduler-facing counter channel
+    (/tt_prefill_layer_acks_<service_id>). None if unavailable."""
+    import ttnn
+
+    service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
+    shm_name = f"/tt_prefill_layer_acks_{service_id}"
+    try:
+        channel = ttnn.InterProcessCounterChannel.connect(shm_name, connect_timeout_ms=timeout_s * 1000)
+    except Exception as e:
+        logger.warning(f"[layer-completion] could not connect counter channel {shm_name}: {e}; skipping drain.")
+        return None
+    logger.info(f"[layer-completion] connected counter channel {shm_name}")
+    return channel
+
+
+def _connect_layer_completion_ring(timeout_s: int):
+    """v2: attach (consumer side) to the master router's structured completion ring
+    (/tt_prefill_layer_acks_<service_id> — one name for both protocols). None if unavailable."""
+    from ttnn._experimental.layer_completion import LayerCompletionQueueV2
+
+    service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
+    shm_name = f"/tt_prefill_layer_acks_{service_id}"
+    try:
+        ring = LayerCompletionQueueV2.connect(shm_name, connect_timeout_ms=timeout_s * 1000)
+    except Exception as e:
+        logger.warning(f"[layer-completion] could not connect completion ring {shm_name}: {e}; skipping drain.")
+        return None
+    logger.info(f"[layer-completion] connected completion ring {shm_name}")
+    return ring
+
+
+def connect_layer_completion_channel(timeout_s: int):
+    """Attach (consumer side) to this job's layer-completion channel: protocol 1 → the
+    counter channel; 2 → the structured ring. None if unavailable."""
+    if current_protocol() == 2:
+        return _connect_layer_completion_ring(timeout_s)
+    return _connect_layer_ack_channel(timeout_s)
+
+
+def _drain_layer_acks(ack_channel, expected: int, timeout_s: float = 600.0) -> int:
+    """v1: block until `expected` per-layer acks (a bare count) are drained, or timeout.
+    Returns the count actually drained."""
+    if ack_channel is None:
+        return 0
+    drained = 0
+    last_logged = -1
+    start = time.perf_counter()
+    while drained < expected:
+        drained += ack_channel.try_consume_all()
+        if drained != last_logged:
+            logger.info(f"[layer-completion] layer acks {drained}/{expected}")
+            last_logged = drained
+        if drained >= expected:
+            break
+        if time.perf_counter() - start > timeout_s:
+            logger.warning(f"[layer-completion] timed out at {drained}/{expected} acks after {timeout_s}s")
+            break
+        time.sleep(0.01)
+    logger.info(f"[layer-completion] drained {drained}/{expected} layer acks in {(time.perf_counter() - start):.2f}s")
+    return drained
+
+
+def _drain_layer_completion_ring(completion_ring, expected_layers: int, timeout_s: float = 600.0) -> int:
+    """v2: work-conserving drain of the structured ring until `expected_layers` (span-summed)
+    are accounted, validating per-request coverage along the way."""
+    if completion_ring is None:
+        return 0
+    num_layers = int(os.environ.get("PREFILL_NUM_LAYERS", 61))
+    drainer = LayerCompletionDrainer(completion_ring, num_layers=num_layers)
+    try:
+        drainer.drain_blocking(expected_layers, timeout_s=timeout_s)
+    except TimeoutError as e:
+        logger.warning(f"[layer-completion] {e}")
+    logger.info(
+        f"[layer-completion] v2 drain: {drainer.total_layers}/{expected_layers} layers across "
+        f"{len(drainer.requests)} request(s), {drainer.processed} messages"
+    )
+    return drainer.total_layers
+
+
+def drain_layer_completions(completion_channel, expected_layers: int, timeout_s: float = 600.0) -> int:
+    """Drain `expected_layers` (num_layers per chunk) of per-layer completions from the
+    channel connect_layer_completion_channel() returned."""
+    if current_protocol() == 2:
+        return _drain_layer_completion_ring(completion_channel, expected_layers, timeout_s)
+    return _drain_layer_acks(completion_channel, expected_layers, timeout_s)

--- a/models/demos/common/prefill/runners/layer_completion_sink.py
+++ b/models/demos/common/prefill/runners/layer_completion_sink.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Layer-completion sinks for pipelined prefill.
+
+The runtime binds one per-chunk closure in prefill_chunk() which fires the
+registered sink once per completion EVENT inside model.forward. The sink
+interface is range-native and protocol-polymorphic:
+
+    sink.layers_completed(layer_start, layer_end, request_id, slot_id,
+                          actual_start, actual_end)
+
+— a half-open GLOBAL layer range at the model's natural completion
+granularity (per-layer runtimes fire [l, l+1); a stage-level runtime fires
+[first, end)) plus the chunk's request id, cache user slot, and absolute
+KV-position range. Each protocol implementation maps the span onto its wire
+format:
+
+* v1 (CountedLayerCompletionSink) — the frozen count protocol: ONE message
+  per covered layer, {seq, source_rank, layer_idx, request_id}, dense
+  seq = request_id*num_layers + layer_idx. The master router reorders by seq
+  and emits only a COUNT to the scheduler. (Lives here, not inline in
+  prefill_runner.py, so both implementations share the backpressure policy;
+  the wire format is unchanged.)
+
+* v2 (StructuredLayerCompletionSink) — the structured protocol (issue
+  #54632): ONE self-describing message per span, {seq, source_rank,
+  request_id, slot_id, pos_start, pos_end, layer_start, layer_end}, which the
+  master forwards as-arrived (no reorder → no per-request head-of-line
+  blocking). seq is diagnostic only in v2.
+
+Selected per job by PREFILL_LAYER_COMPLETION_PROTOCOL (1 | 2) in
+prefill_runner.py. Kept dependency-light (stdlib + loguru — no ttnn) so the
+sinks are unit testable without importing the device stack.
+"""
+
+import os
+import time
+from abc import ABC, abstractmethod
+
+from loguru import logger
+
+# When the completion ring is full, spin waiting for the router to drain rather than
+# dropping/failing immediately. Bounded so a genuinely stalled router still surfaces.
+LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S = float(os.environ.get("PREFILL_LAYER_COMPLETION_PUSH_TIMEOUT_S", 30.0))
+LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S = 10.0
+LAYER_COMPLETION_PUSH_SPIN_SLEEP_S = 0.001  # tiny yield so the spin doesn't peg a core
+
+
+def _push_with_spin(try_push, *, seq: int, is_shutdown) -> None:
+    """Push with bounded full-ring backpressure.
+
+    try_push() is a zero-arg callable returning bool. The ring is sized well
+    above in-flight depth; a full ring means the router thread is momentarily
+    behind. Spin (don't drop) for up to the timeout, logging on entry, every
+    LOG_EVERY_S while waiting, and on exit. Raises if the router never catches
+    up, or immediately if is_shutdown() reports an operator stop (SIGTERM).
+    """
+    start = time.monotonic()
+    next_log = start + LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S
+    logger.warning(
+        f"[layer-completion] ring full (seq={seq}); spinning up to "
+        f"{LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S:.0f}s for router to drain"
+    )
+    while True:
+        if try_push():
+            logger.info(f"[layer-completion] ring drained after {time.monotonic() - start:.1f}s; pushed seq={seq}")
+            return
+        if is_shutdown():
+            raise RuntimeError(f"layer-completion ring full (seq={seq}); shutdown requested while spinning")
+        now = time.monotonic()
+        if now - start >= LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S:
+            logger.error(f"[layer-completion] gave up after {now - start:.1f}s spinning on full ring (seq={seq})")
+            raise RuntimeError(
+                f"layer-completion ring full (seq={seq}); router not draining after "
+                f"{LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S:.0f}s"
+            )
+        if now >= next_log:
+            logger.warning(f"[layer-completion] still spinning on full ring (seq={seq}) after {now - start:.0f}s")
+            next_log += LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S
+        time.sleep(LAYER_COMPLETION_PUSH_SPIN_SLEEP_S)
+
+
+class LayerCompletionSink(ABC):
+    """Polymorphic completion sink; the runtime binds per-chunk fields and fires
+    layers_completed() once per completion event inside model.forward."""
+
+    @abstractmethod
+    def layers_completed(
+        self,
+        layer_start: int,
+        layer_end: int,
+        request_id: int,
+        slot_id: int,
+        actual_start: int,
+        actual_end: int,
+    ) -> None:
+        """One completion event covering global layers [layer_start, layer_end)
+        for the chunk (request_id, slot_id, KV positions [actual_start, actual_end))."""
+
+
+class CountedLayerCompletionSink(LayerCompletionSink):
+    """v1 — count protocol (frozen wire format): one 24B message PER COVERED LAYER,
+    {seq, source_rank, layer_idx, request_id}; the master reorders by the dense seq
+    and emits only a count to the scheduler. A multi-layer span is split into
+    per-layer messages because that is all the v1 wire can express. The slot and
+    position fields are accepted by the interface and intentionally unused."""
+
+    def __init__(self, producer, *, source_rank: int, num_layers: int, is_shutdown=lambda: False):
+        self._producer = producer
+        self._source_rank = source_rank
+        self._num_layers = num_layers  # GLOBAL total (seq stride), NOT this rank's slice
+        self._is_shutdown = is_shutdown
+
+    def layers_completed(self, layer_start, layer_end, request_id, slot_id, actual_start, actual_end) -> None:
+        for layer_idx in range(layer_start, layer_end):
+            seq = request_id * self._num_layers + layer_idx
+            if self._producer.try_push(
+                seq=seq, source_rank=self._source_rank, layer_idx=layer_idx, request_id=request_id
+            ):
+                continue
+            _push_with_spin(
+                lambda seq=seq, layer_idx=layer_idx: self._producer.try_push(
+                    seq=seq, source_rank=self._source_rank, layer_idx=layer_idx, request_id=request_id
+                ),
+                seq=seq,
+                is_shutdown=self._is_shutdown,
+            )
+
+
+class StructuredLayerCompletionSink(LayerCompletionSink):
+    """v2 — structured protocol: ONE self-describing 40B message per span, carrying
+    the chunk's slot and position range alongside the layer range, forwarded
+    as-arrived to the scheduler-facing ring. seq is diagnostic only."""
+
+    def __init__(self, producer, *, source_rank: int, num_layers: int, is_shutdown=lambda: False):
+        self._producer = producer
+        self._source_rank = source_rank
+        self._num_layers = num_layers  # GLOBAL total (diagnostic seq stride)
+        self._is_shutdown = is_shutdown
+
+    def layers_completed(self, layer_start, layer_end, request_id, slot_id, actual_start, actual_end) -> None:
+        # Diagnostic-only ordering key (v2 forwards as-arrived); keyed on the first
+        # covered layer so multi-layer events stay monotonic within a request.
+        seq = request_id * self._num_layers + layer_start
+        fields = dict(
+            seq=seq,
+            source_rank=self._source_rank,
+            request_id=request_id,
+            slot_id=slot_id,
+            pos_start=actual_start,
+            pos_end=actual_end,
+            layer_start=layer_start,
+            layer_end=layer_end,
+        )
+        if self._producer.try_push(**fields):
+            return
+        _push_with_spin(lambda: self._producer.try_push(**fields), seq=seq, is_shutdown=self._is_shutdown)
+
+
+def build_layer_completion_sink(producer, *, source_rank: int, num_layers: int, is_shutdown=lambda: False):
+    """v1 sink factory — count protocol (frozen wire format)."""
+    return CountedLayerCompletionSink(
+        producer, source_rank=source_rank, num_layers=num_layers, is_shutdown=is_shutdown
+    )
+
+
+def build_layer_completion_sink_v2(producer, *, source_rank: int, num_layers: int, is_shutdown=lambda: False):
+    """v2 sink factory — structured protocol (issue #54632)."""
+    return StructuredLayerCompletionSink(
+        producer, source_rank=source_rank, num_layers=num_layers, is_shutdown=is_shutdown
+    )

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -99,6 +99,10 @@ from loguru import logger
 
 import ttnn
 from models.demos.common.prefill.adapter import DEFAULT_MODEL, get_adapter
+from models.demos.common.prefill.runners.layer_completion_drainer import (
+    connect_layer_completion_channel,
+    drain_layer_completions,
+)
 from models.demos.common.prefill.runners.runner_utils import load_trace_token_ids, resolve_trace_dir
 
 
@@ -324,44 +328,6 @@ def _read_device_map(timeout_s: int) -> dict:
     if len(files) > 1:
         logger.info(f"[producer] merged {len(files)} device maps: {len(device_map)} chips total")
     return device_map
-
-
-def _connect_layer_ack_channel(timeout_s: int):
-    """Attach (consumer side) to the runner's per-layer LayerAck channel
-    (/tt_prefill_layer_acks_<service_id>). Returns the channel, or None if it isn't available (only the
-    single-rank runner creates it)."""
-    service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
-    shm_name = f"/tt_prefill_layer_acks_{service_id}"
-    try:
-        channel = ttnn.InterProcessCounterChannel.connect(shm_name, connect_timeout_ms=timeout_s * 1000)
-    except Exception as e:
-        logger.warning(f"[producer] could not connect LayerAck channel {shm_name}: {e}; skipping ack wait.")
-        return None
-    logger.info(f"[producer] connected LayerAck channel {shm_name}")
-    return channel
-
-
-def _drain_layer_acks(ack_channel, expected: int, timeout_s: float = 600.0) -> int:
-    """Block until `expected` per-layer acks (NUM_LAYERS per chunk) have been drained, or timeout.
-    Returns the count actually drained."""
-    if ack_channel is None:
-        return 0
-    drained = 0
-    last_logged = -1
-    start = time.perf_counter()
-    while drained < expected:
-        drained += ack_channel.try_consume_all()
-        if drained != last_logged:
-            logger.info(f"[producer] layer acks {drained}/{expected}")
-            last_logged = drained
-        if drained >= expected:
-            break
-        if time.perf_counter() - start > timeout_s:
-            logger.warning(f"[producer] timed out at {drained}/{expected} acks after {timeout_s}s")
-            break
-        time.sleep(0.01)
-    logger.info(f"[producer] drained {drained}/{expected} layer acks in {(time.perf_counter() - start):.2f}s")
-    return drained
 
 
 def _decode_bfp8_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
@@ -1431,7 +1397,7 @@ def main() -> None:
 
     # If we're not performing golden trace PCC-validation, then don't consume these and allow loopback
     # migration test in prefill_runner.py to consume acks and perform the testing of loopback migration
-    ack_channel = _connect_layer_ack_channel(timeout_s) if cfg.verify else None
+    completion_channel = connect_layer_completion_channel(timeout_s)
     if cfg.verify and ack_channel is None:
         logger.error(
             "[producer] CHECK_PCC=1 but LayerAck channel missing — UMD read would race the runner's "
@@ -1473,10 +1439,8 @@ def main() -> None:
         f"p99={_percentile(sorted_ms, 0.99):.1f}"
     )
 
-    # Wait for the runner's per-layer LayerAcks: NUM_LAYERS per chunk, for every chunk pushed. With a
-    # pipeline runner (num_ranks>1) the branch's LayerCompletionRouter funnels every rank's completions
-    # into this master channel, so this waits for ALL ranks' layers, not just the first stage's.
-    _drain_layer_acks(ack_channel, NUM_LAYERS * stats.total_pushes)
+    # Wait for the runner's per-layer completions: NUM_LAYERS per chunk, for every chunk pushed.
+    drain_layer_completions(completion_channel, NUM_LAYERS * stats.total_pushes)
 
     # Multi-rank: all layers of all chunks are now written across every stage's DRAM. Release the
     # validators (they PCC their own host's layers) by broadcasting the resident-slot map. Do it BEFORE

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -177,74 +177,30 @@ def _handle_sigterm(signum, frame):
 # Layer-completion routing (pipeline / num_ranks > 1)
 # ---------------------------------------------------------------------------
 
-# When the completion ring is full, spin waiting for the router to drain rather than
-# dropping/failing immediately. Bounded so a genuinely stalled router still surfaces.
-LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S = float(os.environ.get("PREFILL_LAYER_COMPLETION_PUSH_TIMEOUT_S", 30.0))
-LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S = 10.0
-LAYER_COMPLETION_PUSH_SPIN_SLEEP_S = 0.001  # tiny yield so the spin doesn't peg a core
+# The sink implementations (polymorphic LayerCompletionSink: v1 count protocol and v2
+# structured protocol) and the shared full-ring backpressure policy live in
+# layer_completion_sink.py — dependency-light so they are unit testable without ttnn.
+from models.demos.common.prefill.runners.layer_completion_sink import (
+    build_layer_completion_sink,
+    build_layer_completion_sink_v2,
+)
 
-
-def build_layer_completion_sink(producer, *, source_rank, num_layers):
-    """Build the per-layer completion sink the runtime fires once per layer.
-
-    Computes a globally-dense ordering key and pushes a full completion
-    into `producer` (a ttnn._experimental.layer_completion.LayerCompletionQueue). The
-    master router re-emits completions strictly in ascending `seq`.
-
-    seq = request_id * num_layers + layer_idx — dense across all (request,
-    layer) pairs. For pipelined prefill each rank owns a disjoint set of
-    global layer indices per request, so the union of every rank's seqs
-    tiles [0, num_requests*num_layers) with no gaps or collisions.
-
-    The runtime calls the returned sink as `sink(layer_idx, request_id)`,
-    binding the current chunk's request_id per prefill() call — so this
-    builder needs no request-id accessor and reads no shared mutable state.
-
-    Args:
-        producer: connected LayerCompletionQueue (the host-local ring).
-        source_rank: this rank's world rank (diagnostic in the payload).
-        num_layers: total GLOBAL layers (the seq stride per request), NOT this rank's slice.
-    """
-
-    def on_layer_complete(layer_idx: int, request_id: int) -> None:
-        # Hot path: fired once per layer inside model.forward. Push directly (no per-call closure)
-        # and return on the common success; only the rare full-ring case falls into the spin below.
-        seq = request_id * num_layers + layer_idx
-        if producer.try_push(seq=seq, source_rank=source_rank, layer_idx=layer_idx, request_id=request_id):
-            return
-
-        # Ring is sized well above in-flight depth; a full ring means the router
-        # thread is momentarily behind. Spin (don't drop) for up to PUSH_SPIN_TIMEOUT_S
-        # waiting for it to drain; log on entry, every PUSH_SPIN_LOG_EVERY_S while waiting,
-        # and on exit. Only surface an error if it never catches up.
-        start = time.monotonic()
-        next_log = start + LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S
-        logger.warning(
-            f"[layer-completion] ring full (seq={seq}); spinning up to "
-            f"{LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S:.0f}s for router to drain"
-        )
-        while True:
-            if producer.try_push(seq=seq, source_rank=source_rank, layer_idx=layer_idx, request_id=request_id):
-                logger.info(f"[layer-completion] ring drained after {time.monotonic() - start:.1f}s; pushed seq={seq}")
-                return
-            if _shutdown:
-                # Operator asked to stop (SIGTERM/SIGINT). Abort the spin immediately instead of
-                # ignoring the signal for up to the full timeout; teardown runs via run_request_loop's
-                # finally. Raising (vs. silently dropping) keeps the failure visible.
-                raise RuntimeError(f"layer-completion ring full (seq={seq}); shutdown requested while spinning")
-            now = time.monotonic()
-            if now - start >= LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S:
-                logger.error(f"[layer-completion] gave up after {now - start:.1f}s spinning on full ring (seq={seq})")
-                raise RuntimeError(
-                    f"layer-completion ring full (seq={seq}); router not draining after "
-                    f"{LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S:.0f}s"
-                )
-            if now >= next_log:
-                logger.warning(f"[layer-completion] still spinning on full ring (seq={seq}) after {now - start:.0f}s")
-                next_log += LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S
-            time.sleep(LAYER_COMPLETION_PUSH_SPIN_SLEEP_S)
-
-    return on_layer_complete
+# Completion protocol (issue #54632), selected once per job — never mixed within a run.
+# Both protocols use the SAME scheduler-facing shm name (/tt_prefill_layer_acks_<service_id>);
+# the protocol decides what the master router creates there:
+#   1 (default): a counter channel — the master reorders by seq and emits only a COUNT. The
+#       scheduler correlates ticks with its in-order chunk FIFO (per-request HoL blocking).
+#   2: a structured ring — every completion is self-describing (request/slot/position range/
+#       layer range); the master forwards as-arrived (no HoL). See layer_completion_sink.py.
+try:
+    LAYER_COMPLETION_PROTOCOL = int(os.environ.get("PREFILL_LAYER_COMPLETION_PROTOCOL", "1").strip())
+except ValueError:
+    LAYER_COMPLETION_PROTOCOL = -1
+if LAYER_COMPLETION_PROTOCOL not in (1, 2):
+    raise ValueError(
+        f"PREFILL_LAYER_COMPLETION_PROTOCOL must be 1 or 2, got "
+        f"{os.environ.get('PREFILL_LAYER_COMPLETION_PROTOCOL')!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1037,6 +993,14 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             "per-chunk socket tensor whose address cannot be captured, so the replay would emit no acks. "
             "Run untraced for the D2H backend, or leave PREFILL_LAYER_ACK_D2H unset to ack under trace."
         )
+    # D2H + protocol 2: LayerAckService emits v1 (count-protocol) messages only; the v2 router's
+    # structured ring would reject its attach with a confusing magic error. Fail clearly at wiring.
+    if use_d2h and LAYER_COMPLETION_PROTOCOL == 2:
+        raise ValueError(
+            "PREFILL_LAYER_ACK_D2H=1 with PREFILL_LAYER_COMPLETION_PROTOCOL=2: the D2H ack backend "
+            "emits v1 count-protocol messages only (LayerAckService has no v2 mode yet). Unset "
+            "PREFILL_LAYER_ACK_D2H to use the host-callback backend, or run protocol 1."
+        )
     # The router path covers: (a) any multi-rank run (each rank owns only a layer slice, so it can't
     # inject the scheduler channel directly and must route to the master), and (b) the D2H backend on
     # any rank count (its LayerAckService is a pure producer into the ring). The single-rank non-D2H
@@ -1045,8 +1009,12 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
 
     if use_router:
         # Imported here (not at module top) so single-rank / no-extension builds never need the
-        # standalone _layer_completion .so (built only with WITH_PYTHON_BINDINGS).
-        from ttnn._experimental.layer_completion import LayerCompletionQueue, LayerCompletionRouter
+        # layer_completion bindings.
+        from ttnn._experimental.layer_completion import (
+            LayerCompletionQueue,
+            LayerCompletionQueueV2,
+            LayerCompletionRouter,
+        )
 
         # Each rank's router OWNS its own ring, so the name must be per-rank — append _{rank} even to
         # the env override (a single literal would make colocated ranks unlink each other's live ring
@@ -1056,15 +1024,18 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         _unlink_stale_shm(ring_shm_name)
         if rank == master_rank:
             _unlink_stale_shm(ack_shm_name)
-        # The router owns the host-local ring (and, on the master, the scheduler counter channel,
-        # which it inject()s in order). Subordinate ranks MPI-forward completions to the master.
+        # The router owns the host-local ring (and, on the master, the scheduler-facing segment,
+        # which it inject()s/forwards into). Subordinate ranks MPI-forward completions to the
+        # master. Both protocols share the scheduler shm NAME (ack_shm_name) — the protocol arg
+        # decides what the master creates there (v1 counter channel vs v2 structured ring).
         # Constructed BEFORE the ring source below: the router creates the ring, the source connects.
         router = LayerCompletionRouter(
             rank=rank,
             world_size=num_ranks,
             master_rank=master_rank,
             ring_shm_name=ring_shm_name,
-            scheduler_channel_shm_name=ack_shm_name if rank == master_rank else "",
+            scheduler_shm_name=ack_shm_name if rank == master_rank else "",
+            protocol=LAYER_COMPLETION_PROTOCOL,
         )
         if use_d2h:
             # Device-record source. The reader thread reconstructs (chunk, global-layer) from a per-rank
@@ -1078,6 +1049,8 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             # are None and this equals the even split; for a DSA/cross-layer-reuse model (GLM) the snapped
             # split differs, and an unsnapped one here would hand the router overlapping/gapped seqs, which
             # its reorder buffer cannot sequence — it would stall head-of-line instead of failing loudly.
+            #
+            # v1-count-protocol only (LayerAckService has no v2 mode; guarded at wiring).
             first_layer_idx, num_my_layers = compute_layer_split(
                 NUM_LAYERS, num_ranks, ADAPTER.layer_split_boundaries(NUM_LAYERS)
             )[rank]
@@ -1099,24 +1072,24 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             layer_ack_service.start()  # connects to the router-owned ring (created above)
             source_desc = "D2H device records"
         else:
-            # Host-callback source: the runtime fires on_layer_complete(layer_idx, request_id) per layer
-            # and the sink pushes into the ring (no device D2H). seq stride is the GLOBAL layer total
-            # (NUM_LAYERS), NOT this rank's slice; layer_idx arriving at the sink is already global; the
-            # chunk index is bound per prefill() call as request_id (passed by _compute_and_send), so the
-            # sink reads no shared mutable state.
-            producer = LayerCompletionQueue.connect(ring_shm_name, connect_timeout_ms=30000)
+            # Host-callback source: the runtime fires the polymorphic sink per layer and it pushes
+            # into the ring (no device D2H). The only protocol-conditional construction is the
+            # queue/sink message type. seq stride is the GLOBAL layer total (NUM_LAYERS), NOT this
+            # rank's slice; the per-chunk fields are bound per prefill_chunk() call, so the sink
+            # reads no shared mutable state.
+            queue_cls = LayerCompletionQueueV2 if LAYER_COMPLETION_PROTOCOL == 2 else LayerCompletionQueue
+            sink_factory = (
+                build_layer_completion_sink_v2 if LAYER_COMPLETION_PROTOCOL == 2 else build_layer_completion_sink
+            )
+            producer = queue_cls.connect(ring_shm_name, connect_timeout_ms=30000)
             runtime.set_layer_completion_sink(
-                build_layer_completion_sink(
-                    producer,
-                    source_rank=rank,
-                    num_layers=NUM_LAYERS,
-                )
+                sink_factory(producer, source_rank=rank, num_layers=NUM_LAYERS, is_shutdown=lambda: _shutdown)
             )
             source_desc = "host on_layer_complete callback"
         logger.info(
-            f"[migration] layer-completion routing up: rank={rank}/{num_ranks} master={master_rank} "
-            f"ring={ring_shm_name} source={source_desc} "
-            + (f"(owns scheduler channel {ack_shm_name})" if rank == master_rank else "(subordinate -> master)")
+            f"[migration] layer-completion routing up (v{LAYER_COMPLETION_PROTOCOL}): "
+            f"rank={rank}/{num_ranks} master={master_rank} ring={ring_shm_name} source={source_desc} "
+            + (f"(owns scheduler shm {ack_shm_name})" if rank == master_rank else "(subordinate -> master)")
         )
     elif single_rank and enable_layer_ack:
         # Single-rank non-D2H direct path: the runtime owns + inject()s the scheduler counter channel
@@ -1125,6 +1098,12 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         ack_channel = ttnn.InterProcessCounterChannel(ack_shm_name)
         runtime.set_layer_ack_channel(ack_channel)
         logger.info(f"[migration] LayerAck channel ready at {ack_shm_name}; runner emits one ack per layer")
+        if LAYER_COMPLETION_PROTOCOL == 2:
+            logger.warning(
+                "[migration] PREFILL_LAYER_COMPLETION_PROTOCOL=2 only rewires the ROUTER completion "
+                "path; single-rank non-D2H still uses the direct counter channel above (no router, "
+                "no HoL blocking to remove)"
+            )
     elif single_rank:
         logger.info("[migration] LayerAck channel disabled (set PREFILL_ENABLE_LAYER_ACK=1 to enable)")
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -118,10 +118,8 @@ class TtPrefillRuntime:
         assert config.model_cfg is not None, "TtPrefillRuntimeConfig.model_cfg must be set by the model adapter"
         # Per-layer LayerAck callback, built once in set_layer_ack_channel() after compile.
         self._on_layer_complete = None
-        # Per-layer completion sink (pipelined mode), set by set_layer_completion_sink().
-        # Signature: sink(layer_idx, request_id). prefill() binds the current request_id into
-        # a fresh per-call closure, so there is no shared mutable chunk-index for the callback
-        # to race on (immune even if the threading model changes).
+        # Completion sink (pipelined mode), set by set_layer_completion_sink() — a polymorphic
+        # LayerCompletionSink fired per completion event from prefill_chunk's per-call closure.
         self._layer_completion_sink = None
         # DFlash drafter, built in _build_model when config.dflash_enabled (else all None and prefill_chunk's
         # dflash branches are inert). Its tap closure + last-rank K/V caches are set there.
@@ -148,9 +146,10 @@ class TtPrefillRuntime:
         #   _trace_captured   — flips True once capture_trace() records the segmented capture (single-shot)
         #   _kv_cache         — the engine cache handle from compile(), used by capture_trace()
         #   _trace_request_id — the request/chunk id of the replay in flight. The controller's per-layer
-        #                       callback is fixed at capture time, so a traced run cannot bind request_id
-        #                       into a fresh closure per call (the eager path does); prefill_chunk()
-        #                       publishes it here and set_layer_completion_sink()'s callback reads it.
+        #                       callback is fixed at capture time, so a traced run cannot bind the
+        #                       per-chunk fields into a fresh closure per call (the eager path does);
+        #                       prefill_chunk() publishes them here and set_layer_completion_sink()'s
+        #                       callback reads them at replay. Same for _trace_slot_id/_trace_pos_*.
         self._controller = None
         self._trace_input = None
         self._trace_metadata = None
@@ -158,6 +157,9 @@ class TtPrefillRuntime:
         self._trace_captured = False
         self._kv_cache = None
         self._trace_request_id = 0
+        self._trace_slot_id = 0
+        self._trace_pos_start = 0
+        self._trace_pos_end = 0
 
         self._build_model(state_dict)
 
@@ -620,10 +622,13 @@ class TtPrefillRuntime:
             )
             # Per-layer completion callbacks live on the CONTROLLER, registered once at capture time (a
             # host-side callback cannot execute inside a trace, so the capture splits at each ack point).
-            # That means the pipelined sink's request_id cannot be re-bound per call the way the eager
-            # path does below — publish this chunk's id instead; the captured callback built by
-            # set_layer_completion_sink() reads it at replay time.
+            # That means the per-chunk fields cannot be re-bound per call the way the eager path does
+            # below — publish them instead; the captured callback built by set_layer_completion_sink()
+            # reads them at replay time.
             self._trace_request_id = request_id
+            self._trace_slot_id = slot_id
+            self._trace_pos_start = actual_start
+            self._trace_pos_end = actual_end
             ttnn.copy(input_tensor, self._trace_input)
             for dst, val in zip(self._trace_metadata, (slot_id, actual_start, actual_end)):
                 ttnn.copy_host_to_device_tensor(self._meta1_host(val), dst)
@@ -633,15 +638,13 @@ class TtPrefillRuntime:
             # driver to forward downstream over D2D. Last/single rank: the populated KV cache is the output.
             return None if self.config.is_last_rank else self._trace_output
 
-        # Bind this chunk's request_id into a fresh per-call callback. The pipelined sink needs it to
-        # build a globally-dense key (seq = request_id*num_layers + layer_idx); capturing by value per
-        # call means there is no shared mutable chunk-index for the synchronously-fired callback to race
-        # on. Single-host layer-ack mode ignores request_id.
+        # Fresh per-call closure: no shared mutable state for the synchronously-fired sink.
+        # The polymorphic sink maps the span to its wire format; this model fires per layer.
         if self._layer_completion_sink is not None:
             sink = self._layer_completion_sink
 
             def on_layer_complete(layer_idx: int) -> None:
-                sink(layer_idx, request_id)
+                sink.layers_completed(layer_idx, layer_idx + 1, request_id, slot_id, actual_start, actual_end)
 
         else:
             on_layer_complete = self._on_layer_complete
@@ -983,23 +986,27 @@ class TtPrefillRuntime:
         )
 
     def set_layer_completion_sink(self, sink) -> None:
-        """Register a per-layer completion sink for pipelined prefill.
+        """Register the completion sink for pipelined prefill.
 
-        `sink` is called once per layer as `sink(layer_idx, request_id)` — the
-        global layer index plus the current request/chunk id, which prefill()
-        binds per call (so the sink need not read any mutable runtime state). It
-        replaces the direct counter-channel inject used in single-host mode:
-        instead of bumping a counter, the runner pushes a full completion
-        {seq, source_rank, layer_idx, request_id} into the host-local
-        LayerCompletionQueue, and the LayerCompletionRouter routes it to the
-        master host and re-emits it (in seq order) into the scheduler-facing
-        counter channel (see ttnn._experimental.layer_completion).
+        `sink` is a LayerCompletionSink (runners/layer_completion_sink.py) —
+        protocol-polymorphic: once per completion event the runtime fires
+        `sink.layers_completed(layer_start, layer_end, request_id, slot_id,
+        actual_start, actual_end)` with the span at this model's natural
+        granularity (per layer here, so [layer_idx, layer_idx+1)) and the
+        chunk's request id / cache slot / KV-position range bound per
+        prefill_chunk() call (so the sink need not read any mutable runtime
+        state). The v1 implementation maps the span to one ring message per
+        covered layer ({seq, source_rank, layer_idx, request_id}, reordered by
+        the master into a bare scheduler count); the v2 implementation emits
+        one self-describing message per span, forwarded as-arrived to the
+        scheduler-facing structured ring (issue #54632). Both replace the
+        direct counter-channel inject used in single-host mode.
 
         use_trace: same constraint as set_layer_ack_channel — the callback must be known at CAPTURE
         time (a host push cannot live inside a trace), so it is registered on the controller and the
-        eager capture is re-recorded to split at each ack point. The per-call request_id closure the
-        eager path uses is not available there, so the captured callback reads _trace_request_id,
-        which prefill_chunk() publishes before each replay.
+        eager capture is re-recorded to split at each ack point. The per-call closure the eager path
+        uses is not available there, so the captured callback reads the per-chunk fields
+        (_trace_request_id/_trace_slot_id/_trace_pos_*) that prefill_chunk() publishes before replay.
         """
         assert self.compiled or self.config.use_trace, "Call compile() before set_layer_completion_sink()"
         self._layer_completion_sink = sink
@@ -1007,7 +1014,14 @@ class TtPrefillRuntime:
             return
 
         def on_layer_complete(layer_idx: int) -> None:
-            sink(layer_idx, self._trace_request_id)
+            sink.layers_completed(
+                layer_idx,
+                layer_idx + 1,
+                self._trace_request_id,
+                self._trace_slot_id,
+                self._trace_pos_start,
+                self._trace_pos_end,
+            )
 
         # Route the traced path through the same controller hook the LayerAck channel uses, so the
         # capture is segmented at every completion point.

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -341,16 +341,18 @@ class TtPrefillRuntime:
         # per-chunk host reshard, and the tensors are persistent (do NOT deallocate them here). The KV
         # cache is engine-owned and passed in. If a LayerAck channel is registered, the model bumps it
         # once per layer via on_layer_complete.
-        # Pipelined mode registers a completion sink keyed by (global_layer_idx, request_id); bind request_id
-        # per call so the synchronous per-layer callback reads no mutable state. Single-host mode uses the ack.
+        # Pipelined mode registers a polymorphic completion sink; bind the per-chunk fields per call so
+        # the synchronous per-layer callback reads no mutable state. Single-host mode uses the ack.
         if self._layer_completion_sink is not None:
             sink = self._layer_completion_sink
 
             def on_layer_complete(layer_idx: int) -> None:
-                # The model reports a rank-local index; the sink's seq = request_id * total_layers +
-                # layer_idx needs the GLOBAL index, else every rank's local layer k collides at one seq
-                # and all but the first rank's completion is dropped.
-                sink(self.config.first_layer_idx + layer_idx, request_id)
+                # The model reports a rank-local index; globalize it (every rank's local layer k would
+                # otherwise collide across ranks).
+                global_layer = self.config.first_layer_idx + layer_idx
+                sink.layers_completed(
+                    global_layer, global_layer + 1, request_id, slot_id, actual_start, actual_end
+                )
 
         else:
             on_layer_complete = self._on_layer_complete
@@ -391,11 +393,11 @@ class TtPrefillRuntime:
         self._on_layer_complete = on_layer_complete
 
     def set_layer_completion_sink(self, sink) -> None:
-        """Register a per-layer completion sink for pipelined (multi-rank) prefill. ``sink`` is called once
-        per layer as ``sink(layer_idx, request_id)`` — the global layer index plus the current request/chunk
-        id (bound per ``prefill_chunk`` call, so the sink reads no mutable runtime state). Replaces the
-        single-host ack-counter inject: the runner pushes a full completion into the host-local
-        LayerCompletionQueue and the LayerCompletionRouter re-emits it in seq order to the scheduler channel."""
+        """Register the completion sink for pipelined (multi-rank) prefill: a polymorphic
+        LayerCompletionSink (runners/layer_completion_sink.py) fired per layer as
+        ``sink.layers_completed(layer_start, layer_end, request_id, slot_id, actual_start,
+        actual_end)`` with the per-chunk fields bound per ``prefill_chunk`` call. Replaces the
+        single-host ack-counter inject."""
         assert self.compiled, "Call compile() before set_layer_completion_sink()"
         self._layer_completion_sink = sink
 

--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -19,6 +19,8 @@ set(DISTRIBUTED_UNIT_TEST_SOURCES
     test_mesh_trace.cpp
     test_thread_pool.cpp
     test_dispatch_context.cpp
+    test_layer_completion_ring.cpp
+    test_layer_completion_router.cpp
     utils.cpp
 )
 # MPI sub-context tests require the MPI distributed build (matches tt_metal/distributed USE_MPI).

--- a/tests/tt_metal/distributed/test_layer_completion_ring.cpp
+++ b/tests/tt_metal/distributed/test_layer_completion_ring.cpp
@@ -1,0 +1,321 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Host-only tests for the layer-completion SHM ring, covering both protocol
+// versions: v1 (LayerCompletionMessage, 24B packed cells, magic 'LCQ1') and
+// v2 (LayerCompletionMessageV2, 40B self-describing messages, cache-line
+// cells, magic 'LCQ2'). No device or MPI needed — owner and connector are
+// two LayerCompletionQueueT objects in this process sharing /dev/shm.
+
+#include <gtest/gtest.h>
+
+#include <fmt/format.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include <internal/disaggregation/layer_completion_message.hpp>
+#include <internal/disaggregation/layer_completion_queue.hpp>
+#include "tt_metal/distributed/layer_completion/layer_completion_ring_layout.hpp"
+
+namespace tt::tt_metal::internal {
+
+namespace {
+
+template <typename MsgT>
+MsgT make_msg(uint64_t seq);
+
+template <>
+LayerCompletionMessage make_msg<LayerCompletionMessage>(uint64_t seq) {
+    return LayerCompletionMessage{
+        seq,
+        /*source_rank=*/1u,
+        /*layer_idx=*/static_cast<uint32_t>(seq % 61),
+        /*request_id=*/static_cast<uint32_t>(seq / 61),
+        /*reserved=*/0u};
+}
+
+template <>
+LayerCompletionMessageV2 make_msg<LayerCompletionMessageV2>(uint64_t seq) {
+    return LayerCompletionMessageV2{
+        seq,
+        /*source_rank=*/1u,
+        /*request_id=*/static_cast<uint32_t>(seq / 61),
+        /*slot_id=*/3u,
+        /*pos_start=*/5120u,
+        /*pos_end=*/10240u,
+        /*layer_start=*/static_cast<uint32_t>(seq % 61),
+        /*layer_end=*/static_cast<uint32_t>(seq % 61) + 1u,
+        /*flags=*/0u};
+}
+
+void unlink_if_exists(const std::string& shm_name) { std::remove(("/dev/shm" + shm_name).c_str()); }
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Wire geometry (the compile-time contract lives beside the layouts in the
+// headers; these EXPECTs surface a drift as a test failure too).
+// ---------------------------------------------------------------------------
+
+TEST(LayerCompletionLayout, V1GeometryIsFrozen) {
+    EXPECT_EQ(sizeof(LayerCompletionMessage), 24u);
+    EXPECT_EQ(alignof(LayerCompletionMessage), 8u);
+    EXPECT_TRUE(std::is_trivially_copyable_v<LayerCompletionMessage>);
+    EXPECT_EQ(sizeof(LayerCompletionCell), 32u);  // packed, two cells per cache line
+    EXPECT_EQ(alignof(LayerCompletionCell), 8u);
+    EXPECT_EQ(layer_completion_cells_offset<LayerCompletionMessage>(), 128u);
+    EXPECT_EQ(kLayerCompletionRingBytes<LayerCompletionMessage>, 32896u);
+    EXPECT_EQ(LayerCompletionRingTraits<LayerCompletionMessage>::magic, 0x4C435131u);
+}
+
+TEST(LayerCompletionLayout, V2Geometry) {
+    EXPECT_EQ(sizeof(LayerCompletionMessageV2), 40u);
+    EXPECT_EQ(alignof(LayerCompletionMessageV2), 8u);
+    EXPECT_TRUE(std::is_trivially_copyable_v<LayerCompletionMessageV2>);
+    // One cache line per cell — a packed 48B cell would straddle lines.
+    EXPECT_EQ(sizeof(LayerCompletionCellV2), kLayerCompletionCacheLine);
+    EXPECT_EQ(alignof(LayerCompletionCellV2), kLayerCompletionCacheLine);
+    EXPECT_EQ(layer_completion_cells_offset<LayerCompletionMessageV2>() % kLayerCompletionCacheLine, 0u);
+    EXPECT_EQ(kLayerCompletionRingBytes<LayerCompletionMessageV2> % kLayerCompletionCacheLine, 0u);
+    EXPECT_EQ(LayerCompletionRingTraits<LayerCompletionMessageV2>::magic, 0x4C435132u);
+    // The version key is what keeps a cross-protocol attach from corrupting.
+    EXPECT_NE(
+        LayerCompletionRingTraits<LayerCompletionMessage>::magic,
+        LayerCompletionRingTraits<LayerCompletionMessageV2>::magic);
+}
+
+TEST(LayerCompletionLayout, HeaderIsSharedAcrossVersions) {
+    EXPECT_EQ(offsetof(LayerCompletionRingHeader, enqueue_pos), 0u);
+    EXPECT_EQ(offsetof(LayerCompletionRingHeader, dequeue_pos), kLayerCompletionCacheLine);
+    EXPECT_EQ(sizeof(LayerCompletionRingHeader), 2 * kLayerCompletionCacheLine);
+}
+
+TEST(LayerCompletionLayout, CapacityIsPowerOfTwo) {
+    EXPECT_NE(kLayerCompletionRingCapacity, 0u);
+    EXPECT_EQ(kLayerCompletionRingCapacity & (kLayerCompletionRingCapacity - 1), 0u);
+    EXPECT_EQ(kLayerCompletionRingMask, kLayerCompletionRingCapacity - 1);
+}
+
+TEST(LayerCompletionLayout, Sentinels) {
+    LayerCompletionMessage v1{};
+    LayerCompletionMessageV2 v2{};
+    EXPECT_FALSE(is_layer_completion_sentinel(v1));
+    EXPECT_FALSE(is_layer_completion_sentinel(v2));
+    v1.reserved = kLayerCompletionSentinel;
+    v2.flags = kLayerCompletionSentinel;
+    EXPECT_TRUE(is_layer_completion_sentinel(v1));
+    EXPECT_TRUE(is_layer_completion_sentinel(v2));
+}
+
+// ---------------------------------------------------------------------------
+// Ring behaviour, both instantiations
+// ---------------------------------------------------------------------------
+
+template <typename MsgT>
+class LayerCompletionRingTest : public ::testing::Test {
+protected:
+    using Queue = LayerCompletionQueueT<MsgT>;
+
+    void SetUp() override { ring_names_.clear(); }
+
+    // Unique SHM names per case so parallel/repeated runs never collide.
+    std::string fresh_name(const char* tag) {
+        std::string name = fmt::format("/tt_lcq_test_{}_{}_{}", tag, ::getpid(), ring_names_.size());
+        ring_names_.push_back(name);
+        return name;
+    }
+
+private:
+    std::vector<std::string> ring_names_;
+};
+
+using RingTypes = ::testing::Types<LayerCompletionMessage, LayerCompletionMessageV2>;
+TYPED_TEST_SUITE(LayerCompletionRingTest, RingTypes);
+
+TYPED_TEST(LayerCompletionRingTest, FifoRoundtrip) {
+    using MsgT = TypeParam;
+    using Queue = LayerCompletionQueueT<MsgT>;
+    const std::string name = this->fresh_name("fifo");
+    unlink_if_exists(name);
+    auto owner = Queue::create(name);
+    auto conn = Queue::connect(name, 5'000);
+
+    for (uint64_t i = 0; i < 8; ++i) {
+        EXPECT_TRUE(owner->try_push(make_msg<MsgT>(i)));
+    }
+    MsgT out{};
+    for (uint64_t i = 0; i < 8; ++i) {
+        ASSERT_TRUE(conn->try_pop(out));
+        EXPECT_EQ(out.seq, i);  // FIFO
+    }
+    EXPECT_FALSE(conn->try_pop(out));  // empty
+    owner->shutdown();
+}
+
+TYPED_TEST(LayerCompletionRingTest, RejectsPushWhenFull) {
+    using MsgT = TypeParam;
+    using Queue = LayerCompletionQueueT<MsgT>;
+    const std::string name = this->fresh_name("full");
+    unlink_if_exists(name);
+    auto owner = Queue::create(name);
+    for (uint32_t i = 0; i < Queue::capacity(); ++i) {
+        ASSERT_TRUE(owner->try_push(make_msg<MsgT>(i)));
+    }
+    EXPECT_FALSE(owner->try_push(make_msg<MsgT>(9999)));  // full → reject, no overwrite
+    owner->shutdown();
+}
+
+TYPED_TEST(LayerCompletionRingTest, WrapsAroundPastCapacity) {
+    using MsgT = TypeParam;
+    using Queue = LayerCompletionQueueT<MsgT>;
+    const std::string name = this->fresh_name("wrap");
+    unlink_if_exists(name);
+    auto owner = Queue::create(name);
+    auto conn = Queue::connect(name, 5'000);
+
+    MsgT out{};
+    const uint64_t total = static_cast<uint64_t>(Queue::capacity()) * 3 + 7;
+    uint64_t pushed = 0, popped = 0;
+    while (popped < total) {
+        while (pushed < total && owner->try_push(make_msg<MsgT>(pushed))) {
+            ++pushed;
+        }
+        while (conn->try_pop(out)) {
+            EXPECT_EQ(out.seq, popped);
+            ++popped;
+        }
+    }
+    EXPECT_EQ(popped, total);
+    owner->shutdown();
+}
+
+// Multiple producer threads, single consumer — the prefill topology.
+TYPED_TEST(LayerCompletionRingTest, MpscProducersAllDelivered) {
+    using MsgT = TypeParam;
+    using Queue = LayerCompletionQueueT<MsgT>;
+    const std::string name = this->fresh_name("mpsc");
+    unlink_if_exists(name);
+    auto owner = Queue::create(name);
+    auto conn = Queue::connect(name, 5'000);
+
+    constexpr uint32_t kProducers = 4;
+    constexpr uint64_t kPerProducer = 500;
+    constexpr uint64_t kTotal = kProducers * kPerProducer;
+
+    std::vector<std::thread> producers;
+    for (uint32_t p = 0; p < kProducers; ++p) {
+        producers.emplace_back([&owner, p] {
+            for (uint64_t i = 0; i < kPerProducer; ++i) {
+                const uint64_t seq = p * kPerProducer + i;
+                while (!owner->try_push(make_msg<MsgT>(seq))) {
+                    std::this_thread::yield();
+                }
+            }
+        });
+    }
+
+    std::vector<char> seen(kTotal, 0);
+    MsgT out{};
+    uint64_t popped = 0;
+    while (popped < kTotal) {
+        if (conn->try_pop(out)) {
+            ASSERT_LT(out.seq, kTotal);
+            seen[out.seq] = 1;
+            ++popped;
+        } else {
+            std::this_thread::yield();
+        }
+    }
+    for (auto& t : producers) {
+        t.join();
+    }
+    for (uint64_t i = 0; i < kTotal; ++i) {
+        EXPECT_TRUE(seen[i]) << "seq " << i << " lost";
+    }
+    owner->shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// V2-specific: full field round-trip, and the cross-version guard.
+// ---------------------------------------------------------------------------
+
+TEST(LayerCompletionQueueV2, AllFieldsRoundTrip) {
+    const std::string name = "/tt_lcq_test_v2_fields";
+    unlink_if_exists(name);
+    auto owner = LayerCompletionQueueV2::create(name);
+    auto conn = LayerCompletionQueueV2::connect(name, 5'000);
+
+    const LayerCompletionMessageV2 in{
+        /*seq=*/7u * 61 + 14,
+        /*source_rank=*/2u,
+        /*request_id=*/7u,
+        /*slot_id=*/5u,
+        /*pos_start=*/5120u,
+        /*pos_end=*/10213u,
+        /*layer_start=*/14u,
+        /*layer_end=*/15u,
+        /*flags=*/0u};
+    ASSERT_TRUE(owner->try_push(in));
+
+    LayerCompletionMessageV2 out{};
+    ASSERT_TRUE(conn->try_pop(out));
+    EXPECT_EQ(out.seq, in.seq);
+    EXPECT_EQ(out.source_rank, in.source_rank);
+    EXPECT_EQ(out.request_id, in.request_id);
+    EXPECT_EQ(out.slot_id, in.slot_id);
+    EXPECT_EQ(out.pos_start, in.pos_start);
+    EXPECT_EQ(out.pos_end, in.pos_end);
+    EXPECT_EQ(out.layer_start, in.layer_start);
+    EXPECT_EQ(out.layer_end, in.layer_end);
+    EXPECT_EQ(out.flags, in.flags);
+    owner->shutdown();
+}
+
+// A range message (stage-level completion) travels as one slot, unsplit.
+TEST(LayerCompletionQueueV2, RangeMessageRoundTrip) {
+    const std::string name = "/tt_lcq_test_v2_range";
+    unlink_if_exists(name);
+    auto owner = LayerCompletionQueueV2::create(name);
+    auto conn = LayerCompletionQueueV2::connect(name, 5'000);
+
+    ASSERT_TRUE(owner->try_push(LayerCompletionMessageV2{
+        /*seq=*/3u * 61,
+        /*source_rank=*/0u,
+        /*request_id=*/3u,
+        /*slot_id=*/1u,
+        /*pos_start=*/0u,
+        /*pos_end=*/5120u,
+        /*layer_start=*/0u,
+        /*layer_end=*/14u,  // 14 layers, one message
+        /*flags=*/0u}));
+
+    LayerCompletionMessageV2 out{};
+    ASSERT_TRUE(conn->try_pop(out));
+    EXPECT_EQ(out.layer_end - out.layer_start, 14u);
+    EXPECT_FALSE(conn->try_pop(out));
+    owner->shutdown();
+}
+
+TEST(LayerCompletionQueue, CrossVersionConnectFails) {
+    const std::string name = "/tt_lcq_test_xver";
+    unlink_if_exists(name);
+    auto owner = LayerCompletionQueue::create(name);  // v1 segment ('LCQ1')
+    // A v2 connector must be rejected by the magic check, not map and corrupt.
+    EXPECT_THROW(LayerCompletionQueueV2::connect(name, 5'000), std::runtime_error);
+    owner->shutdown();
+
+    unlink_if_exists(name);
+    auto owner2 = LayerCompletionQueueV2::create(name);  // v2 segment ('LCQ2')
+    EXPECT_THROW(LayerCompletionQueue::connect(name, 5'000), std::runtime_error);
+    owner2->shutdown();
+}
+
+}  // namespace tt::tt_metal::internal

--- a/tests/tt_metal/distributed/test_layer_completion_router.cpp
+++ b/tests/tt_metal/distributed/test_layer_completion_router.cpp
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Host-only tests for LayerCompletionRouter protocol behaviour, world_size=1
+// (the master path with no MPI — subordinate MPI forwarding is covered by the
+// multihost tests). Verifies:
+//   * v1: the master reorders by seq and emits only a COUNT (withholding an
+//     out-of-order completion — the head-of-line semantics of #54632);
+//   * v2: the master forwards self-describing messages AS ARRIVED into the
+//     scheduler-facing ring (no reorder, no withholding), with backpressure
+//     when that ring is full and a bounded drop path at teardown.
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <thread>
+
+#include <internal/disaggregation/layer_completion_message.hpp>
+#include <internal/disaggregation/layer_completion_queue.hpp>
+#include <internal/disaggregation/layer_completion_router.hpp>
+#include <internal/service/inter_process_counter_channel.hpp>
+
+namespace tt::tt_metal::internal {
+
+namespace {
+
+using tt::tt_metal::distributed::InterProcessCounterChannel;
+
+void unlink_if_exists(const std::string& shm_name) { std::remove(("/dev/shm" + shm_name).c_str()); }
+
+std::string fresh_name(const char* tag) {
+    static std::atomic<uint32_t> counter{0};
+    return "/tt_lcr_test_" + std::string(tag) + "_" + std::to_string(::getpid()) + "_" +
+           std::to_string(counter.fetch_add(1));
+}
+
+// Poll `f` until it holds or the deadline passes. The router runs on its own
+// thread, so every observable effect is eventually-consistent.
+template <typename F>
+bool wait_until(F&& f, int timeout_ms = 10'000) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (f()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+    return f();
+}
+
+LayerCompletionMessage v1_msg(uint64_t seq) {
+    return LayerCompletionMessage{seq, /*source_rank=*/0u, /*layer_idx=*/static_cast<uint32_t>(seq),
+                                  /*request_id=*/0u, /*reserved=*/0u};
+}
+
+LayerCompletionMessageV2 v2_msg(uint64_t seq, uint32_t request_id, uint32_t layer_start, uint32_t layer_end) {
+    return LayerCompletionMessageV2{
+        seq,
+        /*source_rank=*/0u,
+        request_id,
+        /*slot_id=*/2u,
+        /*pos_start=*/100u * request_id,
+        /*pos_end=*/100u * request_id + 50u,
+        layer_start,
+        layer_end,
+        /*flags=*/0u};
+}
+
+}  // namespace
+
+// v1 regression: an out-of-order completion is WITHHELD until the gap fills —
+// the exact HoL semantics v2 removes. Also covers count-only delivery.
+TEST(LayerCompletionRouter, V1MasterReordersAndCounts) {
+    const std::string ring = fresh_name("v1_ring");
+    const std::string channel = fresh_name("v1_chan");
+    unlink_if_exists(ring);
+    unlink_if_exists(channel);
+
+    LayerCompletionRouterConfig cfg;
+    cfg.rank = 0;
+    cfg.world_size = 1;
+    cfg.master_rank = 0;
+    cfg.ring_shm_name = ring;
+    cfg.protocol = LayerCompletionProtocol::kCountOnlyV1;
+    cfg.scheduler_shm_name = channel;
+    auto router = std::make_unique<LayerCompletionRouter>(std::move(cfg));
+
+    auto producer = LayerCompletionQueue::connect(ring, 5'000);
+    auto consumer = InterProcessCounterChannel::connect(channel, 5'000);
+
+    ASSERT_TRUE(producer->try_push(v1_msg(1)));  // gap at 0 → must be withheld
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    EXPECT_EQ(consumer->pending(), 0u);
+
+    ASSERT_TRUE(producer->try_push(v1_msg(0)));  // fills the gap → both become countable
+    ASSERT_TRUE(wait_until([&] { return consumer->try_consume_all() == 2; }));
+    EXPECT_EQ(router->processed(), 2u);
+
+    producer->shutdown();
+    consumer->shutdown();
+    router->stop();
+}
+
+// v2: a completion that would be withheld by v1 (seq gap) is forwarded
+// immediately — no reorder buffer on the master.
+TEST(LayerCompletionRouter, V2MasterForwardsAsArrived) {
+    const std::string ring = fresh_name("v2_ring");
+    const std::string sched = fresh_name("v2_sched");
+    unlink_if_exists(ring);
+    unlink_if_exists(sched);
+
+    LayerCompletionRouterConfig cfg;
+    cfg.rank = 0;
+    cfg.world_size = 1;
+    cfg.master_rank = 0;
+    cfg.ring_shm_name = ring;
+    cfg.protocol = LayerCompletionProtocol::kStructuredV2;
+    cfg.scheduler_shm_name = sched;
+    auto router = std::make_unique<LayerCompletionRouter>(std::move(cfg));
+
+    auto producer = LayerCompletionQueueV2::connect(ring, 5'000);
+    auto scheduler = LayerCompletionQueueV2::connect(sched, 5'000);
+
+    // seq=1 first (gap at 0): v1 would withhold; v2 must deliver promptly.
+    ASSERT_TRUE(producer->try_push(v2_msg(/*seq=*/1, /*request_id=*/0, 5, 6)));
+    LayerCompletionMessageV2 out{};
+    ASSERT_TRUE(wait_until([&] { return scheduler->try_pop(out); }));
+    EXPECT_EQ(out.seq, 1u);
+    EXPECT_EQ(out.layer_start, 5u);
+    EXPECT_EQ(out.layer_end, 6u);
+
+    // Interleaved requests, out of order: arrival order is preserved end to end.
+    ASSERT_TRUE(producer->try_push(v2_msg(7, /*request_id=*/3, 0, 1)));
+    ASSERT_TRUE(producer->try_push(v2_msg(0, /*request_id=*/0, 0, 1)));
+    ASSERT_TRUE(producer->try_push(v2_msg(3, /*request_id=*/1, 0, 14)));  // one message, 14 layers
+    const uint64_t want_order[] = {7, 0, 3};
+    for (uint64_t want : want_order) {
+        ASSERT_TRUE(wait_until([&] { return scheduler->try_pop(out); }));
+        EXPECT_EQ(out.seq, want);
+    }
+    EXPECT_EQ(out.layer_end - out.layer_start, 14u);
+    ASSERT_TRUE(wait_until([&] { return router->processed() == 4; }));
+
+    producer->shutdown();
+    scheduler->shutdown();
+    router->stop();
+}
+
+// v2: full scheduler ring applies backpressure (forward stalls), and draining
+// resumes it — no loss, no reorder.
+TEST(LayerCompletionRouter, V2SchedulerRingBackpressure) {
+    const std::string ring = fresh_name("v2bp_ring");
+    const std::string sched = fresh_name("v2bp_sched");
+    unlink_if_exists(ring);
+    unlink_if_exists(sched);
+
+    LayerCompletionRouterConfig cfg;
+    cfg.rank = 0;
+    cfg.world_size = 1;
+    cfg.master_rank = 0;
+    cfg.ring_shm_name = ring;
+    cfg.protocol = LayerCompletionProtocol::kStructuredV2;
+    cfg.scheduler_shm_name = sched;
+    auto router = std::make_unique<LayerCompletionRouter>(std::move(cfg));
+
+    auto producer = LayerCompletionQueueV2::connect(ring, 5'000);
+    auto scheduler = LayerCompletionQueueV2::connect(sched, 5'000);
+
+    const uint64_t total = LayerCompletionQueueV2::capacity() + 17;
+    for (uint64_t i = 0; i < total; ++i) {
+        // The input ring itself provides backpressure once the master stalls.
+        while (!producer->try_push(v2_msg(i, /*request_id=*/0, static_cast<uint32_t>(i % 61),
+                                        static_cast<uint32_t>(i % 61) + 1))) {
+            std::this_thread::yield();
+        }
+    }
+
+    // Master can only have forwarded capacity() messages — the scheduler ring is full.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    EXPECT_EQ(router->processed(), LayerCompletionQueueV2::capacity());
+
+    // Drain everything; the master must resume and deliver the rest in order.
+    LayerCompletionMessageV2 out{};
+    for (uint64_t i = 0; i < total; ++i) {
+        ASSERT_TRUE(wait_until([&] { return scheduler->try_pop(out); })) << "stuck at " << i;
+        EXPECT_EQ(out.seq, i);
+    }
+    ASSERT_TRUE(wait_until([&] { return router->processed() == total; }));
+
+    producer->shutdown();
+    scheduler->shutdown();
+    router->stop();
+}
+
+// v2 teardown with a full scheduler ring and a gone scheduler: the listener
+// must exit within the teardown bound instead of wedging stop() forever.
+TEST(LayerCompletionRouter, V2TeardownDropsWhenSchedulerGone) {
+    const std::string ring = fresh_name("v2td_ring");
+    const std::string sched = fresh_name("v2td_sched");
+    unlink_if_exists(ring);
+    unlink_if_exists(sched);
+
+    LayerCompletionRouterConfig cfg;
+    cfg.rank = 0;
+    cfg.world_size = 1;
+    cfg.master_rank = 0;
+    cfg.ring_shm_name = ring;
+    cfg.protocol = LayerCompletionProtocol::kStructuredV2;
+    cfg.scheduler_shm_name = sched;
+    cfg.teardown_timeout_ms = 500;  // keep the test fast
+    auto router = std::make_unique<LayerCompletionRouter>(std::move(cfg));
+
+    auto producer = LayerCompletionQueueV2::connect(ring, 5'000);
+    // No scheduler connector: fill the scheduler ring and overflow into the input ring.
+    for (uint64_t i = 0; i < LayerCompletionQueueV2::capacity() + 64; ++i) {
+        while (!producer->try_push(v2_msg(i, 0, 0, 1))) {
+            std::this_thread::yield();
+        }
+    }
+    ASSERT_TRUE(wait_until([&] { return router->processed() == LayerCompletionQueueV2::capacity(); }));
+
+    const auto t0 = std::chrono::steady_clock::now();
+    router->stop();  // must not wedge: bounded by teardown_timeout_ms per blocked push
+    const auto elapsed = std::chrono::steady_clock::now() - t0;
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 30'000);
+    producer->shutdown();
+}
+
+// Both protocols require the (shared) scheduler shm name — misconfiguration
+// fails loudly at construction.
+TEST(LayerCompletionRouter, ConfigValidation) {
+    LayerCompletionRouterConfig cfg;
+    cfg.rank = 0;
+    cfg.world_size = 1;
+    cfg.master_rank = 0;
+    cfg.ring_shm_name = fresh_name("cfg_ring");
+
+    cfg.protocol = LayerCompletionProtocol::kCountOnlyV1;  // missing scheduler_shm_name
+    EXPECT_THROW(std::make_unique<LayerCompletionRouter>(cfg), std::exception);
+
+    cfg.protocol = LayerCompletionProtocol::kStructuredV2;  // missing scheduler_shm_name
+    EXPECT_THROW(std::make_unique<LayerCompletionRouter>(cfg), std::exception);
+
+    unlink_if_exists(cfg.ring_shm_name);
+}
+
+}  // namespace tt::tt_metal::internal

--- a/tests/ttnn/unit_tests/base_functionality/test_layer_completion_drainer.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_layer_completion_drainer.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the v2 layer-completion drainer (work-conserving consumer).
+
+Host-only: a list-backed fake ring, no ttnn, no device. Covers the protocol
+semantics: per-request coverage, span summing (a wide span is one message),
+side-queue work conservation, producer-bug detection, the expectation hook,
+and the teardown invariant.
+"""
+
+from collections import deque
+
+import pytest
+
+from models.demos.common.prefill.runners.layer_completion_drainer import (
+    Completion,
+    LayerCompletionDrainer,
+    current_protocol,
+)
+
+NUM_LAYERS = 4  # small model for tests
+
+
+class FakeRing:
+    def __init__(self, messages=()):
+        self._q = deque(messages)
+
+    def try_pop(self):
+        return self._q.popleft() if self._q else None
+
+
+def msg(request_id, layer_start, layer_end, *, seq=None, slot_id=0, pos_start=0, pos_end=128, rank=0):
+    """A v2 wire-order tuple, as LayerCompletionQueueV2.try_pop() returns."""
+    if seq is None:
+        seq = request_id * NUM_LAYERS + layer_start
+    return (seq, rank, request_id, slot_id, pos_start, pos_end, layer_start, layer_end)
+
+
+def per_layer(request_id, layers=range(NUM_LAYERS), **kw):
+    return [msg(request_id, l, l + 1, **kw) for l in layers]
+
+
+def test_single_request_per_layer_completes():
+    completed = []
+    d = LayerCompletionDrainer(
+        FakeRing(per_layer(0)), num_layers=NUM_LAYERS,
+        on_request_complete=lambda rid, cov: completed.append(rid),
+    )
+    assert d.drain_blocking(NUM_LAYERS, timeout_s=5) == NUM_LAYERS
+    assert completed == [0]
+    assert d.processed == NUM_LAYERS  # per-layer: one message per layer
+    assert d.requests[0].is_complete(NUM_LAYERS)
+
+
+def test_interleaved_requests_advance_independently():
+    completed = []
+    ring = FakeRing(
+        per_layer(0, layers=[0, 1]) + per_layer(1, layers=[0, 1, 2, 3], slot_id=1) + per_layer(0, layers=[2, 3])
+    )
+    d = LayerCompletionDrainer(ring, num_layers=NUM_LAYERS,
+                               on_request_complete=lambda rid, cov: completed.append(rid))
+    assert d.drain_blocking(2 * NUM_LAYERS, timeout_s=5) == 2 * NUM_LAYERS
+    # request 1 finished before request 0 — no head-of-line coupling
+    assert completed == [1, 0]
+
+
+def test_out_of_order_spans_tile():
+    ring = FakeRing([msg(0, 2, 4), msg(0, 0, 2)])  # two halves, reversed
+    d = LayerCompletionDrainer(ring, num_layers=NUM_LAYERS)
+    assert d.drain_blocking(NUM_LAYERS, timeout_s=5) == NUM_LAYERS
+
+
+def test_wide_span_counts_full_width_as_one_message():
+    ring = FakeRing([msg(0, 0, NUM_LAYERS)])  # whole stage in one message
+    d = LayerCompletionDrainer(ring, num_layers=NUM_LAYERS)
+    assert d.drain_blocking(NUM_LAYERS, timeout_s=5) == NUM_LAYERS
+    assert d.processed == 1
+
+
+def test_blocked_message_side_queues_without_stalling_others():
+    """Request 0's completion is blocked; request 1 must still advance (no HoL)."""
+    seen = []
+    blocked_once = {0: True}  # request 0 blocked on first sight, ready on retry
+
+    def can_process(c):
+        if c.request_id == 0 and blocked_once[0]:
+            return False
+        return True
+
+    def on_completion(c):
+        seen.append((c.request_id, c.layer_start))
+        if c.request_id == 1:
+            blocked_once[0] = False  # embedder state change unblocks request 0
+
+    ring = FakeRing([msg(0, 0, 2), *per_layer(1, slot_id=1), msg(0, 2, 4)])
+    d = LayerCompletionDrainer(ring, num_layers=NUM_LAYERS, can_process=can_process, on_completion=on_completion)
+    assert d.drain_blocking(2 * NUM_LAYERS, timeout_s=5) == 2 * NUM_LAYERS
+    # request 1 fully processed BEFORE request 0's second half, despite arriving later
+    r1_done = max(i for i, (rid, _) in enumerate(seen) if rid == 1)
+    r0_first = min(i for i, (rid, _) in enumerate(seen) if rid == 0)
+    assert r1_done < len(seen) - 1 or seen[r1_done:] == []
+    assert seen[r0_first][0] == 0 and r0_first > 0  # request 0 processed after some request-1 work
+    assert d.side_queued == 1
+
+
+def test_side_queue_retried_in_request_order():
+    """Two blocked requests: when both become ready, retries run oldest-request-first."""
+    order = []
+    ready = {"go": False}
+    # Each request contributes two half-spans: [0,2) and [2,4) — 4 messages total.
+    d = LayerCompletionDrainer(
+        FakeRing([msg(5, 0, 2), msg(2, 0, 2), msg(5, 2, 4), msg(2, 2, 4)]),
+        num_layers=NUM_LAYERS,
+        can_process=lambda c: ready["go"],
+        on_completion=lambda c: order.append(c.request_id),
+    )
+    # Nothing actionable: drain would idle — drive steps manually until everything is side-queued.
+    while d.step():
+        pass
+    assert d.side_queued == 4 and d.processed == 0
+    ready["go"] = True
+    assert d.step() is True  # ring empty → retry pass
+    # request 2's messages processed before request 5's
+    assert order == [2, 2, 5, 5]
+
+
+def test_overlap_span_raises():
+    d = LayerCompletionDrainer(FakeRing([msg(0, 0, 3), msg(0, 2, 4)]), num_layers=NUM_LAYERS)
+    with pytest.raises(ValueError, match="overlaps"):
+        while d.step():
+            pass
+
+
+def test_out_of_bounds_span_raises():
+    d = LayerCompletionDrainer(FakeRing([msg(0, 2, NUM_LAYERS + 1)]), num_layers=NUM_LAYERS)
+    with pytest.raises(ValueError, match="out of bounds"):
+        d.step()
+
+
+def test_inconsistent_identity_raises():
+    d = LayerCompletionDrainer(
+        FakeRing([msg(0, 0, 2, slot_id=0, pos_start=0, pos_end=128), msg(0, 2, 4, slot_id=1)]),
+        num_layers=NUM_LAYERS,
+    )
+    with pytest.raises(ValueError, match="inconsistent identity"):
+        while d.step():
+            pass
+
+
+def test_expectation_hook_fires_once_per_request():
+    registered = {}
+
+    def on_first(request_id, completion, coverage):
+        # The pipelined-prefill rule shape: every layer eventually spans for this
+        # request's position range. Recorded, not enforced (future error detection).
+        coverage.expectation = ("tile", 0, NUM_LAYERS, completion.pos_start, completion.pos_end)
+        registered[request_id] = coverage.expectation
+
+    ring = FakeRing(per_layer(0, layers=[0, 1]) + per_layer(1, layers=[0], slot_id=1) + per_layer(0, layers=[2, 3]))
+    d = LayerCompletionDrainer(ring, num_layers=NUM_LAYERS, on_first_completion=on_first)
+    while d.step():
+        pass
+    assert set(registered) == {0, 1}
+    assert registered[1] == ("tile", 0, NUM_LAYERS, 0, 128)
+
+
+def test_finish_raises_on_stranded_side_queue():
+    d = LayerCompletionDrainer(
+        FakeRing([msg(0, 0, 2)]), num_layers=NUM_LAYERS, can_process=lambda c: False  # never actionable
+    )
+    while d.step():
+        pass
+    with pytest.raises(RuntimeError, match="never-actionable"):
+        d.finish()
+
+
+def test_drain_blocking_timeout_reports_coverage_snapshot():
+    d = LayerCompletionDrainer(FakeRing(per_layer(0, layers=[0, 1])), num_layers=NUM_LAYERS)
+    with pytest.raises(TimeoutError, match="req 0: 2/4 layers"):
+        d.drain_blocking(NUM_LAYERS, timeout_s=0.2)
+
+
+def test_current_protocol(monkeypatch):
+    monkeypatch.delenv("PREFILL_LAYER_COMPLETION_PROTOCOL", raising=False)
+    assert current_protocol() == 1
+    monkeypatch.setenv("PREFILL_LAYER_COMPLETION_PROTOCOL", "2")
+    assert current_protocol() == 2
+    monkeypatch.setenv("PREFILL_LAYER_COMPLETION_PROTOCOL", "banana")
+    with pytest.raises(ValueError):
+        current_protocol()
+
+
+class FakeCounterChannel:
+    """v1 scheduler channel stand-in: try_consume_all() destructively drains a count."""
+
+    def __init__(self, count: int):
+        self._count = count
+
+    def try_consume_all(self) -> int:
+        n, self._count = self._count, 0
+        return n
+
+
+def test_drain_layer_completions_dispatches_v1_count(monkeypatch):
+    """v1: the dispatcher drains the bare counter channel (no ring, no coverage)."""
+    import models.demos.common.prefill.runners.layer_completion_drainer as lcd
+
+    monkeypatch.setenv("PREFILL_LAYER_COMPLETION_PROTOCOL", "1")
+    channel = FakeCounterChannel(3 * NUM_LAYERS)
+    assert lcd.drain_layer_completions(channel, 3 * NUM_LAYERS, timeout_s=5) == 3 * NUM_LAYERS
+
+
+def test_drain_layer_completions_dispatches_v2_ring(monkeypatch):
+    """v2: the dispatcher routes the ring through the work-conserving drainer."""
+    import models.demos.common.prefill.runners.layer_completion_drainer as lcd
+
+    monkeypatch.setenv("PREFILL_LAYER_COMPLETION_PROTOCOL", "2")
+    monkeypatch.setenv("PREFILL_NUM_LAYERS", str(NUM_LAYERS))
+    ring = FakeRing(per_layer(0, layers=[0, 1]) + per_layer(1, slot_id=1) + per_layer(0, layers=[2, 3]))
+    assert lcd.drain_layer_completions(ring, 2 * NUM_LAYERS, timeout_s=5) == 2 * NUM_LAYERS
+
+
+def test_drain_layer_completions_none_channel_is_noop(monkeypatch):
+    import models.demos.common.prefill.runners.layer_completion_drainer as lcd
+
+    monkeypatch.setenv("PREFILL_LAYER_COMPLETION_PROTOCOL", "2")
+    assert lcd.drain_layer_completions(None, NUM_LAYERS, timeout_s=1) == 0

--- a/tests/ttnn/unit_tests/base_functionality/test_layer_completion_sink.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_layer_completion_sink.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the layer-completion sinks (v1 count / v2 structured).
+
+Host-only: exercises models.demos.common.prefill.runners.layer_completion_sink
+with a fake producer — no ttnn import, no device. Both sinks share the
+range-native polymorphic interface
+
+    sink.layers_completed(layer_start, layer_end, request_id, slot_id,
+                          actual_start, actual_end)
+
+and map the span onto their protocol's wire format (v1: one message per
+covered layer; v2: one self-describing message per span).
+"""
+
+import pytest
+
+from models.demos.common.prefill.runners import layer_completion_sink as lcs
+
+
+class FakeProducer:
+    """LayerCompletionQueue/V2 stand-in: records every try_push attempt; can be
+    told to report a full ring for the first `fail_first` attempts."""
+
+    def __init__(self, fail_first: int = 0):
+        self.fail_first = fail_first
+        self.attempts = []  # every try_push payload, accepted or not
+
+    def try_push(self, **fields) -> bool:
+        self.attempts.append(fields)
+        return len(self.attempts) > self.fail_first
+
+
+NUM_LAYERS = 61
+RANK = 2
+
+# One completion event as fired by the runtime's per-chunk closure:
+# (layer_start, layer_end, request_id, slot_id, actual_start, actual_end)
+EVENT = dict(layer_start=14, layer_end=15, request_id=7, slot_id=5, actual_start=5120, actual_end=10213)
+
+
+def test_sinks_are_polymorphic():
+    v1 = lcs.build_layer_completion_sink(FakeProducer(), source_rank=RANK, num_layers=NUM_LAYERS)
+    v2 = lcs.build_layer_completion_sink_v2(FakeProducer(), source_rank=RANK, num_layers=NUM_LAYERS)
+    assert isinstance(v1, lcs.LayerCompletionSink)
+    assert isinstance(v2, lcs.LayerCompletionSink)
+
+
+def test_v1_sink_one_message_per_layer_frozen_fields():
+    producer = FakeProducer()
+    sink = lcs.build_layer_completion_sink(producer, source_rank=RANK, num_layers=NUM_LAYERS)
+
+    sink.layers_completed(**EVENT)
+
+    assert producer.attempts == [
+        dict(seq=7 * NUM_LAYERS + 14, source_rank=RANK, layer_idx=14, request_id=7)  # no slot/pos on v1 wire
+    ]
+
+
+def test_v1_sink_splits_span_into_dense_per_layer_messages():
+    producer = FakeProducer()
+    sink = lcs.build_layer_completion_sink(producer, source_rank=RANK, num_layers=NUM_LAYERS)
+
+    sink.layers_completed(layer_start=14, layer_end=17, request_id=7, slot_id=5, actual_start=5120,
+                          actual_end=10213)
+
+    assert producer.attempts == [
+        dict(seq=7 * NUM_LAYERS + layer, source_rank=RANK, layer_idx=layer, request_id=7)
+        for layer in (14, 15, 16)
+    ]
+
+
+def test_v2_sink_pushes_full_fields():
+    producer = FakeProducer()
+    sink = lcs.build_layer_completion_sink_v2(producer, source_rank=RANK, num_layers=NUM_LAYERS)
+
+    sink.layers_completed(**EVENT)
+
+    assert producer.attempts == [
+        dict(
+            seq=7 * NUM_LAYERS + 14,  # request_id * num_layers + layer_start
+            source_rank=RANK,
+            request_id=7,
+            slot_id=5,
+            pos_start=5120,
+            pos_end=10213,
+            layer_start=14,
+            layer_end=15,
+        )
+    ]
+
+
+def test_v2_sink_range_passthrough_single_message():
+    """A stage-level completion (3 layers at once) is pushed as ONE message — never split."""
+    producer = FakeProducer()
+    sink = lcs.build_layer_completion_sink_v2(producer, source_rank=RANK, num_layers=NUM_LAYERS)
+
+    sink.layers_completed(layer_start=0, layer_end=14, request_id=3, slot_id=1, actual_start=0, actual_end=5120)
+
+    assert len(producer.attempts) == 1
+    fields = producer.attempts[0]
+    assert fields["layer_start"] == 0
+    assert fields["layer_end"] == 14
+    assert fields["seq"] == 3 * NUM_LAYERS + 0  # keyed on the first covered layer
+
+
+@pytest.mark.parametrize("builder", [lcs.build_layer_completion_sink, lcs.build_layer_completion_sink_v2])
+def test_sink_spins_until_ring_drains(builder):
+    """Full ring → spin (identical payload every retry) until the router drains."""
+    producer = FakeProducer(fail_first=5)
+    sink = builder(producer, source_rank=RANK, num_layers=NUM_LAYERS)
+
+    sink.layers_completed(**EVENT)
+
+    assert len(producer.attempts) == 6  # 5 full-ring refusals, then success
+    first = producer.attempts[0]
+    assert all(a == first for a in producer.attempts)
+
+
+@pytest.mark.parametrize("builder", [lcs.build_layer_completion_sink, lcs.build_layer_completion_sink_v2])
+def test_sink_timeout_raises(monkeypatch, builder):
+    monkeypatch.setattr(lcs, "LAYER_COMPLETION_PUSH_SPIN_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(lcs, "LAYER_COMPLETION_PUSH_SPIN_LOG_EVERY_S", 0.02)
+    producer = FakeProducer(fail_first=10**9)  # never drains
+    sink = builder(producer, source_rank=RANK, num_layers=NUM_LAYERS)
+
+    with pytest.raises(RuntimeError, match="router not draining"):
+        sink.layers_completed(**EVENT)
+
+
+@pytest.mark.parametrize("builder", [lcs.build_layer_completion_sink, lcs.build_layer_completion_sink_v2])
+def test_sink_shutdown_aborts_spin(builder):
+    producer = FakeProducer(fail_first=10**9)
+    sink = builder(
+        producer, source_rank=RANK, num_layers=NUM_LAYERS, is_shutdown=lambda: len(producer.attempts) >= 3
+    )
+
+    with pytest.raises(RuntimeError, match="shutdown requested"):
+        sink.layers_completed(**EVENT)
+    assert len(producer.attempts) == 3  # aborted promptly, not at the timeout

--- a/tt_metal/api/internal/disaggregation/layer_completion_message.hpp
+++ b/tt_metal/api/internal/disaggregation/layer_completion_message.hpp
@@ -2,16 +2,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// Wire payload for a single prefill layer-completion event. Trivially
-// copyable, standard-layout — byte-copied verbatim through the host-local SHM
-// ring and across MPI to the master rank. The transport is agnostic to
-// the fields' meaning; `seq` is a producer-supplied, globally-dense
-// ordering key the master sequences on before re-emitting completions
-// into the scheduler-facing counter channel.
+// Wire payloads for prefill layer-completion events. Trivially copyable,
+// standard-layout — byte-copied verbatim through the host-local SHM ring and
+// across MPI to the master rank. The transport is agnostic to the fields'
+// meaning.
+//
+// Two protocol versions coexist; the version is selected once per job
+// (PREFILL_LAYER_COMPLETION_PROTOCOL) and keyed by the ring magic, so a
+// mismatched peer fails at connect() rather than corrupting:
+//
+//   V1 (LayerCompletionMessage, 24B, magic 'LCQ1'): the master reorders by
+//   the globally-dense `seq` and injects a bare COUNT into the
+//   scheduler-facing InterProcessCounterChannel. The scheduler correlates
+//   ticks with its own in-order chunk FIFO, which forces per-request
+//   in-order consumption (head-of-line blocking — issue #54632). This
+//   format is FROZEN: the static asserts below make byte-compat executable.
+//
+//   V2 (LayerCompletionMessageV2, 40B, magic 'LCQ2'): each completion is
+//   fully self-describing — (request_id, slot_id, position range, layer
+//   range) — so the master forwards as-arrived (no reorder) into a
+//   scheduler-facing structured ring and the consumer keys work on content,
+//   not arrival order. One message per completion EVENT at whatever span
+//   the model reports: per-layer hooks emit [l, l+1); a whole-stage
+//   completion emits one [first, end) message — never split, never
+//   coalesced.
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace tt::tt_metal::internal {
 
@@ -38,16 +58,95 @@ struct LayerCompletionMessage {
     uint32_t reserved = 0;
 };
 
+// V1 wire contract — frozen. Offset drift between producer/router/scheduler
+// builds would silently corrupt SHM and MPI traffic, so it is a compile error.
 static_assert(sizeof(LayerCompletionMessage) == 24, "LayerCompletionMessage wire size changed");
+static_assert(alignof(LayerCompletionMessage) == 8, "LayerCompletionMessage alignment changed");
+static_assert(std::is_trivially_copyable_v<LayerCompletionMessage>);
+static_assert(std::is_standard_layout_v<LayerCompletionMessage>);
+static_assert(offsetof(LayerCompletionMessage, seq) == 0);
+static_assert(offsetof(LayerCompletionMessage, source_rank) == 8);
+static_assert(offsetof(LayerCompletionMessage, layer_idx) == 12);
+static_assert(offsetof(LayerCompletionMessage, request_id) == 16);
+static_assert(offsetof(LayerCompletionMessage, reserved) == 20);
+static_assert(
+    offsetof(LayerCompletionMessage, reserved) + sizeof(uint32_t) == sizeof(LayerCompletionMessage),
+    "LayerCompletionMessage grew tail padding");
 
-// A message whose `reserved` field equals this is an end-of-stream SENTINEL, not a real completion:
+struct LayerCompletionMessageV2 {
+    // Producer-supplied ordering key, request_id*num_layers + layer_start.
+    // DIAGNOSTIC ONLY in v2: the master forwards as-arrived and never
+    // reorders on it; consumers must not assume density (a multi-layer
+    // completion skips the seqs of the layers it covers).
+    uint64_t seq = 0;
+    // World rank of the host whose runner produced this completion.
+    uint32_t source_rank = 0;
+    // Request/chunk ordinal this completion belongs to.
+    uint32_t request_id = 0;
+    // Cache user slot the KV was written into.
+    uint32_t slot_id = 0;
+    // Absolute KV-position range [pos_start, pos_end) this completion covers.
+    uint32_t pos_start = 0;
+    uint32_t pos_end = 0;
+    // Global layer range [layer_start, layer_end) this completion covers.
+    // Per-layer emission is the degenerate case [l, l+1); a stage-level
+    // event covers [first_layer_idx, first_layer_idx + stage_layers).
+    uint32_t layer_start = 0;
+    uint32_t layer_end = 0;
+    // 0 for real completions; kLayerCompletionSentinel marks end-of-stream.
+    uint32_t flags = 0;
+};
+
+// V2 wire contract — pinned for the same reason as v1.
+static_assert(sizeof(LayerCompletionMessageV2) == 40, "LayerCompletionMessageV2 wire size changed");
+static_assert(alignof(LayerCompletionMessageV2) == 8, "LayerCompletionMessageV2 alignment changed");
+static_assert(std::is_trivially_copyable_v<LayerCompletionMessageV2>);
+static_assert(std::is_standard_layout_v<LayerCompletionMessageV2>);
+static_assert(offsetof(LayerCompletionMessageV2, seq) == 0);
+static_assert(offsetof(LayerCompletionMessageV2, source_rank) == 8);
+static_assert(offsetof(LayerCompletionMessageV2, request_id) == 12);
+static_assert(offsetof(LayerCompletionMessageV2, slot_id) == 16);
+static_assert(offsetof(LayerCompletionMessageV2, pos_start) == 20);
+static_assert(offsetof(LayerCompletionMessageV2, pos_end) == 24);
+static_assert(offsetof(LayerCompletionMessageV2, layer_start) == 28);
+static_assert(offsetof(LayerCompletionMessageV2, layer_end) == 32);
+static_assert(offsetof(LayerCompletionMessageV2, flags) == 36);
+static_assert(
+    offsetof(LayerCompletionMessageV2, flags) + sizeof(uint32_t) == sizeof(LayerCompletionMessageV2),
+    "LayerCompletionMessageV2 has tail padding");
+
+// A message whose sentinel slot equals this is an end-of-stream SENTINEL, not a real completion:
 // a subordinate router sends exactly one as its final message at teardown so the master knows no more
 // completions will arrive from that rank and can stop without cancelling a live receive (coordinated
-// teardown — see LayerCompletionRouter). Real completions always carry reserved == 0.
+// teardown — see LayerCompletionRouter). Real completions always carry 0 there.
 inline constexpr uint32_t kLayerCompletionSentinel = 0xFFFFFFFFu;
 
 inline bool is_layer_completion_sentinel(const LayerCompletionMessage& m) noexcept {
     return m.reserved == kLayerCompletionSentinel;
+}
+
+inline bool is_layer_completion_sentinel(const LayerCompletionMessageV2& m) noexcept {
+    return m.flags == kLayerCompletionSentinel;
+}
+
+// Build the end-of-stream sentinel for the message version in use.
+template <typename MsgT>
+MsgT layer_completion_sentinel(uint32_t source_rank);
+
+template <>
+inline LayerCompletionMessage layer_completion_sentinel<LayerCompletionMessage>(uint32_t source_rank) {
+    LayerCompletionMessage m{};
+    m.source_rank = source_rank;
+    m.reserved = kLayerCompletionSentinel;
+    return m;
+}
+
+template <>
+inline LayerCompletionMessageV2 layer_completion_sentinel<LayerCompletionMessageV2>(uint32_t source_rank) {
+    LayerCompletionMessageV2 m{};
+    m.source_rank = source_rank;
+    m.flags = kLayerCompletionSentinel;
+    return m;
 }
 
 }  // namespace tt::tt_metal::internal

--- a/tt_metal/api/internal/disaggregation/layer_completion_queue.hpp
+++ b/tt_metal/api/internal/disaggregation/layer_completion_queue.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// LayerCompletionQueue — POSIX-SHM-backed bounded MPSC ring carrying
-// LayerCompletionMessages. Dual role, modelled on
+// LayerCompletionQueueT — POSIX-SHM-backed bounded MPSC ring carrying
+// layer-completion messages. Dual role, modelled on
 // InterProcessCounterChannel:
 //   * create(name)  → owner. Creates /dev/shm/<name>, initialises the
 //                     ring, owns its lifetime, unlinks on shutdown.
@@ -11,8 +11,18 @@
 //                     segment by name (polls until present or timeout).
 //
 // The ring itself is symmetric (any attached process may push and/or
-// pop). In the prefill topology the router owns it and is the sole
-// consumer; the prefill runner(s) connect and push.
+// pop). In the prefill topology the router owns the host-local ring and
+// is the sole consumer; the prefill runner(s) connect and push. The v2
+// scheduler-facing ring inverts the roles: the master router owns and
+// pushes, the scheduler connects and pops.
+//
+// Templated on the message version (see layer_completion_message.hpp):
+//   LayerCompletionQueue   — v1 (24B messages, magic 'LCQ1'), the frozen
+//                            count-protocol format.
+//   LayerCompletionQueueV2 — v2 (40B self-describing messages, magic
+//                            'LCQ2'), the structured protocol.
+// Only these two instantiations exist (extern template below); the magic
+// check in connect() rejects a cross-version attach.
 
 #pragma once
 
@@ -31,51 +41,71 @@ namespace tt::tt_metal::internal {
 
 using tt::tt_metal::distributed::NamedShm;  // tt_metal/distributed/named_shm.hpp
 
-struct LayerCompletionRingHeader;  // fwd — defined in layer_completion_ring_layout.hpp
-struct LayerCompletionCell;        // fwd — defined in layer_completion_ring_layout.hpp
+struct LayerCompletionRingHeader;           // fwd — defined in layer_completion_ring_layout.hpp
+template <typename MsgT>
+struct LayerCompletionCellT;                // fwd — defined in layer_completion_ring_layout.hpp
 
-class LayerCompletionQueue {
+// Protocol-agnostic base for the two typed rings below, so an owner that is
+// protocol-polymorphic (the router) holds EITHER message version through one
+// member. Only the protocol-neutral ops are virtual; typed use is recovered by
+// static_cast at sites where the protocol (hence the dynamic type) is known.
+class LayerCompletionQueueBase {
+public:
+    virtual ~LayerCompletionQueueBase() = default;
+    virtual void shutdown() = 0;
+    virtual const std::string& shm_name() const = 0;
+};
+
+template <typename MsgT>
+class LayerCompletionQueueT : public LayerCompletionQueueBase {
 public:
     // Owner: shm_open(O_CREAT|O_EXCL) the segment at /dev/shm/<shm_name>,
     // initialise the ring header + cell sequences, mmap. Throws
     // std::runtime_error if the segment already exists (caller unlinks a
     // stale segment first). shm_name: leading '/', no other slashes.
-    static std::unique_ptr<LayerCompletionQueue> create(const std::string& shm_name);
+    static std::unique_ptr<LayerCompletionQueueT> create(const std::string& shm_name);
 
     // Connector: poll for /dev/shm/<shm_name> up to connect_timeout_ms,
     // mmap, validate magic + capacity. Throws on timeout / mismatch.
-    static std::unique_ptr<LayerCompletionQueue> connect(
+    static std::unique_ptr<LayerCompletionQueueT> connect(
         const std::string& shm_name, uint32_t connect_timeout_ms = 30'000);
 
-    ~LayerCompletionQueue();
-    LayerCompletionQueue(const LayerCompletionQueue&) = delete;
-    LayerCompletionQueue& operator=(const LayerCompletionQueue&) = delete;
-    LayerCompletionQueue(LayerCompletionQueue&&) = delete;
-    LayerCompletionQueue& operator=(LayerCompletionQueue&&) = delete;
+    ~LayerCompletionQueueT() override;
+    LayerCompletionQueueT(const LayerCompletionQueueT&) = delete;
+    LayerCompletionQueueT& operator=(const LayerCompletionQueueT&) = delete;
+    LayerCompletionQueueT(LayerCompletionQueueT&&) = delete;
+    LayerCompletionQueueT& operator=(LayerCompletionQueueT&&) = delete;
 
     // Producer. Returns false (no write) when the ring is full.
-    bool try_push(const LayerCompletionMessage& msg);
+    bool try_push(const MsgT& msg);
 
     // Consumer. Returns false (out untouched) when the ring is empty.
-    bool try_pop(LayerCompletionMessage& out);
+    bool try_pop(MsgT& out);
 
     // Idempotent. Owner: munmap + shm_unlink. Connector: munmap only.
-    void shutdown();
+    void shutdown() override;
 
-    const std::string& shm_name() const noexcept { return shm_name_; }
+    const std::string& shm_name() const noexcept override { return shm_name_; }
     static constexpr uint32_t capacity() noexcept { return kLayerCompletionRingCapacity; }
 
 private:
     enum class Role : uint8_t { Owner, Connector };
-    LayerCompletionQueue(std::unique_ptr<NamedShm> shm, std::string shm_name, Role role);
+    LayerCompletionQueueT(std::unique_ptr<NamedShm> shm, std::string shm_name, Role role);
 
     LayerCompletionRingHeader* header() const noexcept;
-    LayerCompletionCell* cells() const noexcept;
+    LayerCompletionCellT<MsgT>* cells() const noexcept;
 
     std::unique_ptr<NamedShm> shm_;
     std::string shm_name_;
     Role role_;
     std::atomic<bool> shutdown_called_{false};
 };
+
+using LayerCompletionQueue = LayerCompletionQueueT<LayerCompletionMessage>;      // v1
+using LayerCompletionQueueV2 = LayerCompletionQueueT<LayerCompletionMessageV2>;  // v2
+
+// The only two instantiations — defined in layer_completion_queue.cpp.
+extern template class LayerCompletionQueueT<LayerCompletionMessage>;
+extern template class LayerCompletionQueueT<LayerCompletionMessageV2>;
 
 }  // namespace tt::tt_metal::internal

--- a/tt_metal/api/internal/disaggregation/layer_completion_router.hpp
+++ b/tt_metal/api/internal/disaggregation/layer_completion_router.hpp
@@ -3,16 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // LayerCompletionRouter — one per host in a pipelined-prefill MPI job.
-// Owns the host-local LayerCompletionQueue (the prefill runner connects
-// and pushes into it) and runs a background listener thread:
+// Owns the host-local completion ring (the prefill runner connects and
+// pushes into it) and runs a background listener thread. Two protocol
+// versions, selected once per job via the config (never mixed in a job):
 //
-//   * Subordinate host (rank != master_rank): drain the ring, MPI-send
-//     each completion to the master rank.
-//   * Master host (rank == master_rank): drain the local ring AND poll
-//     MPI for completions from every subordinate, feed all of them
-//     through a LayerCompletionReorderBuffer, and inject(1) into the
-//     scheduler-facing InterProcessCounterChannel (which this router
-//     owns) for each completion that becomes contiguous-in-order.
+//   V1 (kCountOnlyV1, frozen): the master feeds every completion through a
+//   LayerCompletionReorderBuffer and inject(1)s into the scheduler-facing
+//   InterProcessCounterChannel (which this router owns) for each completion
+//   that becomes contiguous-in-order. The scheduler receives a bare count
+//   and correlates it with its own in-order chunk FIFO — per-request
+//   in-order consumption (head-of-line blocking, issue #54632).
+//
+//   V2 (kStructuredV2): completions are self-describing
+//   (LayerCompletionMessageV2: request/slot/position range/layer range), so
+//   the master FORWARDS AS ARRIVED — no reorder buffer, no head-of-line
+//   blocking — into a scheduler-facing v2 ring (which this router owns and
+//   the scheduler connects to). Subordinates MPI-forward verbatim, as in v1.
 //
 // world_size == 1 ⇒ master path uses no MPI (local ring only).
 //
@@ -40,18 +46,46 @@ namespace tt::tt_metal::internal {
 
 using tt::tt_metal::distributed::InterProcessCounterChannel;  // api/internal/service/
 
-class LayerCompletionQueue;  // fwd — defined in layer_completion_queue.hpp
+struct LayerCompletionMessage;    // fwd — defined in layer_completion_message.hpp
+struct LayerCompletionMessageV2;  // fwd — defined in layer_completion_message.hpp
+template <typename MsgT>
+class LayerCompletionQueueT;     // fwd — defined in layer_completion_queue.hpp
+class LayerCompletionQueueBase;  // fwd — defined in layer_completion_queue.hpp
+using LayerCompletionQueue = LayerCompletionQueueT<LayerCompletionMessage>;
+using LayerCompletionQueueV2 = LayerCompletionQueueT<LayerCompletionMessageV2>;
+
+// SchedulerEgress — the master rank's scheduler-facing output. The router owns
+// exactly one; cfg.protocol fixes the concrete type at construction (see the
+// .cpp): v1 wraps an InterProcessCounterChannel (inject the reordered count),
+// v2 wraps a LayerCompletionQueueV2 (forward self-describing messages
+// as-arrived). Only the protocol-neutral teardown is on the interface.
+class SchedulerEgress {
+public:
+    virtual ~SchedulerEgress() = default;
+    virtual void shutdown() = 0;
+};
+
+enum class LayerCompletionProtocol : uint8_t {
+    // Values match the user-facing PREFILL_LAYER_COMPLETION_PROTOCOL / binding arg.
+    kCountOnlyV1 = 1,  // reorder → bare count into InterProcessCounterChannel (frozen default)
+    kStructuredV2 = 2,  // forward-as-arrived self-describing messages into a scheduler-facing ring
+};
 
 struct LayerCompletionRouterConfig {
     int rank = 0;
     int world_size = 1;
     int master_rank = 0;
     std::string ring_shm_name;
-    std::string scheduler_channel_shm_name;  // master-only
+    LayerCompletionProtocol protocol = LayerCompletionProtocol::kCountOnlyV1;
+    // Master-only: name of the scheduler-facing shm segment. ONE name for both protocols — the
+    // protocol decides what the master creates there (v1: InterProcessCounterChannel to inject
+    // into; v2: structured completion ring to forward into), i.e. same name, different layout/size.
+    std::string scheduler_shm_name;
     int poll_idle_us = 100;
     // Master-only safety net: max time to wait at teardown for outstanding subordinate sentinels
     // before giving up and cancelling (so a crashed/stalled rank can't hang the listener join
-    // forever). The clean path returns as soon as all sentinels arrive, well under this.
+    // forever). The clean path returns as soon as all sentinels arrive, well under this. On the
+    // v2 master it also bounds a blocked scheduler-ring push once stop_ is set.
     int teardown_timeout_ms = 5000;
 };
 
@@ -68,12 +102,23 @@ public:
     bool is_master() const noexcept { return cfg_.rank == cfg_.master_rank; }
 
 private:
-    void run_master();
-    void run_subordinate();
+    void run_master();       // master fan-in loop; the per-protocol output policy is set up inside
+    void run_subordinate();  // dispatches on cfg_.protocol
+
+    // Shared master skeleton: local-ring drain + subordinate MPI fan-in + sentinel-coordinated
+    // teardown. `forward` is the per-protocol output action (v1: reorder → count; v2: forward).
+    template <typename MsgT, typename Forward>
+    void run_master_impl(Forward&& forward);
+
+    // Identical for both protocol versions except the message type.
+    template <typename MsgT>
+    void run_subordinate_impl(LayerCompletionQueueT<MsgT>& queue);
 
     LayerCompletionRouterConfig cfg_;
-    std::unique_ptr<LayerCompletionQueue> queue_;          // owner of the host-local ring
-    std::unique_ptr<InterProcessCounterChannel> counter_;  // master-only
+    // Both polymorphic over the protocol (fixed at construction, so the master/subordinate loops
+    // recover the concrete type with a static_cast — see the .cpp):
+    std::unique_ptr<LayerCompletionQueueBase> queue_;  // owner of the host-local ring
+    std::unique_ptr<SchedulerEgress> sched_egress_;    // master-only scheduler-facing output
     std::thread listener_;
     std::atomic<bool> stop_{false};
     std::atomic<bool> stopped_{false};

--- a/tt_metal/distributed/layer_completion/layer_completion_queue.cpp
+++ b/tt_metal/distributed/layer_completion/layer_completion_queue.cpp
@@ -25,24 +25,50 @@ bool shm_path_exists(const std::string& shm_name) {
     struct stat st{};
     return ::stat(("/dev/shm" + shm_name).c_str(), &st) == 0;
 }
+
+// The cells region must land cache-line-aligned in every attached process.
+// mmap is page-aligned so this cannot fail today; the check converts
+// "impossible" into "loudly impossible" if the mapping behaviour or the
+// layout math ever changes (v2 cells are one cache line each).
+template <typename MsgT>
+void check_mapping_alignment(const void* base, const std::string& shm_name, const char* op) {
+    const auto addr = reinterpret_cast<std::uintptr_t>(base);
+    if (addr % alignof(LayerCompletionCellT<MsgT>) != 0 ||
+        (addr + layer_completion_cells_offset<MsgT>()) % alignof(LayerCompletionCellT<MsgT>) != 0) {
+        throw std::runtime_error(fmt::format(
+            "LayerCompletionQueue::{}: {} mapped at {:#x}, not aligned to {} as the ring layout requires",
+            op,
+            shm_name,
+            addr,
+            alignof(LayerCompletionCellT<MsgT>)));
+    }
+}
 }  // namespace
 
-LayerCompletionQueue::LayerCompletionQueue(std::unique_ptr<NamedShm> shm, std::string shm_name, Role role) :
+template <typename MsgT>
+LayerCompletionQueueT<MsgT>::LayerCompletionQueueT(std::unique_ptr<NamedShm> shm, std::string shm_name, Role role) :
     shm_(std::move(shm)), shm_name_(std::move(shm_name)), role_(role) {}
 
-LayerCompletionQueue::~LayerCompletionQueue() { shutdown(); }
+template <typename MsgT>
+LayerCompletionQueueT<MsgT>::~LayerCompletionQueueT() {
+    shutdown();
+}
 
-LayerCompletionRingHeader* LayerCompletionQueue::header() const noexcept {
+template <typename MsgT>
+LayerCompletionRingHeader* LayerCompletionQueueT<MsgT>::header() const noexcept {
     return static_cast<LayerCompletionRingHeader*>(shm_->ptr());
 }
 
-LayerCompletionCell* LayerCompletionQueue::cells() const noexcept {
-    return reinterpret_cast<LayerCompletionCell*>(
-        static_cast<std::byte*>(shm_->ptr()) + layer_completion_cells_offset());
+template <typename MsgT>
+LayerCompletionCellT<MsgT>* LayerCompletionQueueT<MsgT>::cells() const noexcept {
+    return reinterpret_cast<LayerCompletionCellT<MsgT>*>(
+        static_cast<std::byte*>(shm_->ptr()) + layer_completion_cells_offset<MsgT>());
 }
 
-std::unique_ptr<LayerCompletionQueue> LayerCompletionQueue::create(const std::string& shm_name) {
-    auto shm = std::make_unique<NamedShm>(NamedShm::create(shm_name, kLayerCompletionRingBytes));
+template <typename MsgT>
+std::unique_ptr<LayerCompletionQueueT<MsgT>> LayerCompletionQueueT<MsgT>::create(const std::string& shm_name) {
+    auto shm = std::make_unique<NamedShm>(NamedShm::create(shm_name, kLayerCompletionRingBytes<MsgT>));
+    check_mapping_alignment<MsgT>(shm->ptr(), shm_name, "create");
     auto* base = static_cast<std::byte*>(shm->ptr());
 
     // NamedShm zero-inits the region. Placement-construct the atomics so
@@ -51,16 +77,17 @@ std::unique_ptr<LayerCompletionQueue> LayerCompletionQueue::create(const std::st
     new (&hdr->enqueue_pos) std::atomic<uint64_t>(0);
     new (&hdr->dequeue_pos) std::atomic<uint64_t>(0);
     hdr->capacity = kLayerCompletionRingCapacity;
-    auto* cell_arr = reinterpret_cast<LayerCompletionCell*>(base + layer_completion_cells_offset());
+    auto* cell_arr = reinterpret_cast<LayerCompletionCellT<MsgT>*>(base + layer_completion_cells_offset<MsgT>());
     for (uint32_t i = 0; i < kLayerCompletionRingCapacity; ++i) {
         new (&cell_arr[i].sequence) std::atomic<uint64_t>(i);
     }
-    hdr->magic = kLayerCompletionRingMagic;
+    hdr->magic = LayerCompletionRingTraits<MsgT>::magic;
 
-    return std::unique_ptr<LayerCompletionQueue>(new LayerCompletionQueue(std::move(shm), shm_name, Role::Owner));
+    return std::unique_ptr<LayerCompletionQueueT>(new LayerCompletionQueueT(std::move(shm), shm_name, Role::Owner));
 }
 
-std::unique_ptr<LayerCompletionQueue> LayerCompletionQueue::connect(
+template <typename MsgT>
+std::unique_ptr<LayerCompletionQueueT<MsgT>> LayerCompletionQueueT<MsgT>::connect(
     const std::string& shm_name, uint32_t connect_timeout_ms) {
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(connect_timeout_ms);
     while (!shm_path_exists(shm_name)) {
@@ -71,24 +98,28 @@ std::unique_ptr<LayerCompletionQueue> LayerCompletionQueue::connect(
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
 
-    auto shm = std::make_unique<NamedShm>(NamedShm::open(shm_name, kLayerCompletionRingBytes));
+    auto shm = std::make_unique<NamedShm>(NamedShm::open(shm_name, kLayerCompletionRingBytes<MsgT>));
+    check_mapping_alignment<MsgT>(shm->ptr(), shm_name, "connect");
     auto* hdr = static_cast<LayerCompletionRingHeader*>(shm->ptr());
-    if (hdr->magic != kLayerCompletionRingMagic || hdr->capacity != kLayerCompletionRingCapacity) {
+    if (hdr->magic != LayerCompletionRingTraits<MsgT>::magic || hdr->capacity != kLayerCompletionRingCapacity) {
         throw std::runtime_error(fmt::format(
-            "LayerCompletionQueue::connect: {} is not a valid ring (magic={:#x} capacity={})",
+            "LayerCompletionQueue::connect: {} is not a valid ring for this protocol version "
+            "(magic={:#x} capacity={})",
             shm_name,
             hdr->magic,
             hdr->capacity));
     }
-    return std::unique_ptr<LayerCompletionQueue>(new LayerCompletionQueue(std::move(shm), shm_name, Role::Connector));
+    return std::unique_ptr<LayerCompletionQueueT>(
+        new LayerCompletionQueueT(std::move(shm), shm_name, Role::Connector));
 }
 
-bool LayerCompletionQueue::try_push(const LayerCompletionMessage& msg) {
+template <typename MsgT>
+bool LayerCompletionQueueT<MsgT>::try_push(const MsgT& msg) {
     auto* hdr = header();
     auto* cell_arr = cells();
     uint64_t pos = hdr->enqueue_pos.load(std::memory_order_relaxed);
     for (;;) {
-        LayerCompletionCell& cell = cell_arr[pos & kLayerCompletionRingMask];
+        LayerCompletionCellT<MsgT>& cell = cell_arr[pos & kLayerCompletionRingMask];
         const uint64_t seq = cell.sequence.load(std::memory_order_acquire);
         const int64_t diff = static_cast<int64_t>(seq) - static_cast<int64_t>(pos);
         if (diff == 0) {
@@ -105,12 +136,13 @@ bool LayerCompletionQueue::try_push(const LayerCompletionMessage& msg) {
     }
 }
 
-bool LayerCompletionQueue::try_pop(LayerCompletionMessage& out) {
+template <typename MsgT>
+bool LayerCompletionQueueT<MsgT>::try_pop(MsgT& out) {
     auto* hdr = header();
     auto* cell_arr = cells();
     uint64_t pos = hdr->dequeue_pos.load(std::memory_order_relaxed);
     for (;;) {
-        LayerCompletionCell& cell = cell_arr[pos & kLayerCompletionRingMask];
+        LayerCompletionCellT<MsgT>& cell = cell_arr[pos & kLayerCompletionRingMask];
         const uint64_t seq = cell.sequence.load(std::memory_order_acquire);
         const int64_t diff = static_cast<int64_t>(seq) - static_cast<int64_t>(pos + 1);
         if (diff == 0) {
@@ -127,7 +159,8 @@ bool LayerCompletionQueue::try_pop(LayerCompletionMessage& out) {
     }
 }
 
-void LayerCompletionQueue::shutdown() {
+template <typename MsgT>
+void LayerCompletionQueueT<MsgT>::shutdown() {
     if (shutdown_called_.exchange(true)) {
         return;
     }
@@ -139,5 +172,9 @@ void LayerCompletionQueue::shutdown() {
     }
     shm_->close();
 }
+
+// The only two instantiations (extern template declarations in the public header).
+template class LayerCompletionQueueT<LayerCompletionMessage>;
+template class LayerCompletionQueueT<LayerCompletionMessageV2>;
 
 }  // namespace tt::tt_metal::internal

--- a/tt_metal/distributed/layer_completion/layer_completion_ring_layout.hpp
+++ b/tt_metal/distributed/layer_completion/layer_completion_ring_layout.hpp
@@ -4,15 +4,24 @@
 //
 // Wire contract for the host-local layer-completion SHM ring. One POSIX
 // shared-memory region per host carries a LayerCompletionRingHeader
-// followed by kLayerCompletionRingCapacity LayerCompletionCells. The
-// ring is a Vyukov bounded MPMC queue: multiple producer processes (the
-// prefill runners) push; a single consumer (the host's
-// LayerCompletionRouter thread) pops.
+// followed by kLayerCompletionRingCapacity cells. The ring is a Vyukov
+// bounded MPMC queue: multiple producer processes (the prefill runners)
+// push; a single consumer (the host's LayerCompletionRouter thread) pops.
+// The same layout also backs the v2 scheduler-facing ring (master router
+// pushes; the scheduler process pops).
 //
 // Cross-process atomics: the segment lives in shared memory mapped into
 // every participant. std::atomic<uint64_t> is lock-free on the target
 // and usable across processes when the storage is shared — the same
 // guarantee inter_process_counter_layout.hpp relies on.
+//
+// The ring is templated on the message type; LayerCompletionRingTraits
+// binds each message version to a magic (the on-disk version key that
+// connect() validates) and a cell alignment. V1 cells stay naturally
+// packed (32B, two per cache line — frozen wire format). V2 cells are
+// padded to a full cache line: a packed 48B cell would straddle lines,
+// so every v2 push/pop would touch two lines for half the cells and
+// adjacent-cell false sharing would stop being a boundary-only case.
 
 #pragma once
 
@@ -25,15 +34,42 @@
 namespace tt::tt_metal::internal {
 
 inline constexpr std::size_t kLayerCompletionCacheLine = 64;
-inline constexpr uint32_t kLayerCompletionRingMagic = 0x4C435131u;  // 'LCQ1'
+
+// Per-message-version wire traits. No primary definition: an unregistered
+// message type is a compile error, not a silent format.
+template <typename MsgT>
+struct LayerCompletionRingTraits;
+
+template <>
+struct LayerCompletionRingTraits<LayerCompletionMessage> {
+    static constexpr uint32_t magic = 0x4C435131u;  // 'LCQ1'
+    // Natural alignment — cells stay packed 32B (frozen v1 wire format).
+    static constexpr std::size_t cell_alignment = alignof(LayerCompletionMessage);
+};
+
+template <>
+struct LayerCompletionRingTraits<LayerCompletionMessageV2> {
+    static constexpr uint32_t magic = 0x4C435132u;  // 'LCQ2'
+    // One cache line per cell (see header comment).
+    static constexpr std::size_t cell_alignment = kLayerCompletionCacheLine;
+};
+
+// v1 spelling, kept for existing references.
+inline constexpr uint32_t kLayerCompletionRingMagic = LayerCompletionRingTraits<LayerCompletionMessage>::magic;
 
 // One ring slot. `sequence` gates ownership (Vyukov): producers wait for
 // sequence==pos, consumers wait for sequence==pos+1.
-struct LayerCompletionCell {
+template <typename MsgT>
+struct alignas(LayerCompletionRingTraits<MsgT>::cell_alignment) LayerCompletionCellT {
     std::atomic<uint64_t> sequence;
-    LayerCompletionMessage msg;
+    MsgT msg;
 };
 
+using LayerCompletionCell = LayerCompletionCellT<LayerCompletionMessage>;      // v1
+using LayerCompletionCellV2 = LayerCompletionCellT<LayerCompletionMessageV2>;  // v2
+
+// Ring header — shared by both protocol versions; do not change its layout
+// (magic identifies the version, so the header can stay common).
 struct LayerCompletionRingHeader {
     // Producers CAS to claim the next enqueue slot.
     alignas(kLayerCompletionCacheLine) std::atomic<uint64_t> enqueue_pos;
@@ -45,14 +81,48 @@ struct LayerCompletionRingHeader {
     uint32_t magic;
 };
 
-// Cells start on the first LayerCompletionCell-aligned offset past the header.
+// Cells start on the first cell-aligned offset past the header.
+template <typename MsgT>
 inline constexpr std::size_t layer_completion_cells_offset() {
-    return ((sizeof(LayerCompletionRingHeader) + alignof(LayerCompletionCell) - 1) / alignof(LayerCompletionCell)) *
-           alignof(LayerCompletionCell);
+    using Cell = LayerCompletionCellT<MsgT>;
+    return ((sizeof(LayerCompletionRingHeader) + alignof(Cell) - 1) / alignof(Cell)) * alignof(Cell);
 }
 
+template <typename MsgT>
 inline constexpr std::size_t kLayerCompletionRingBytes =
-    layer_completion_cells_offset() +
-    static_cast<std::size_t>(kLayerCompletionRingCapacity) * sizeof(LayerCompletionCell);
+    layer_completion_cells_offset<MsgT>() +
+    static_cast<std::size_t>(kLayerCompletionRingCapacity) * sizeof(LayerCompletionCellT<MsgT>);
+
+// ---------------------------------------------------------------------------
+// Wire-geometry contract. These values ARE the protocol: connect() validates
+// magic+capacity, and every other byte offset follows from the layouts below.
+// A drift here means silent cross-process corruption, so it is a compile
+// error. The v1 values additionally guard the byte-compat promise — v1
+// geometry must not move while v2 is added alongside it.
+// ---------------------------------------------------------------------------
+
+// Header (shared). The alignas(64) members force alignof == 64, so sizeof
+// rounds up to a full two cache lines; capacity/magic live in the second
+// line's tail.
+static_assert(offsetof(LayerCompletionRingHeader, enqueue_pos) == 0);
+static_assert(offsetof(LayerCompletionRingHeader, dequeue_pos) == kLayerCompletionCacheLine);
+static_assert(offsetof(LayerCompletionRingHeader, capacity) == kLayerCompletionCacheLine + 8);
+static_assert(sizeof(LayerCompletionRingHeader) == 2 * kLayerCompletionCacheLine);
+
+// V1 (frozen)
+static_assert(alignof(LayerCompletionCell) == 8);
+static_assert(sizeof(LayerCompletionCell) == 32);
+static_assert(offsetof(LayerCompletionCell, msg) == 8);
+static_assert(layer_completion_cells_offset<LayerCompletionMessage>() == 128);
+static_assert(kLayerCompletionRingBytes<LayerCompletionMessage> == 32896);
+
+// V2 (one cache line per cell)
+static_assert(alignof(LayerCompletionCellV2) == kLayerCompletionCacheLine);
+static_assert(sizeof(LayerCompletionCellV2) == kLayerCompletionCacheLine);
+static_assert(offsetof(LayerCompletionCellV2, msg) == 8);
+static_assert(layer_completion_cells_offset<LayerCompletionMessageV2>() % kLayerCompletionCacheLine == 0);
+static_assert(layer_completion_cells_offset<LayerCompletionMessageV2>() == 128);
+static_assert(kLayerCompletionRingBytes<LayerCompletionMessageV2> % kLayerCompletionCacheLine == 0);
+static_assert(kLayerCompletionRingBytes<LayerCompletionMessageV2> == 65664);
 
 }  // namespace tt::tt_metal::internal

--- a/tt_metal/distributed/layer_completion/layer_completion_router.cpp
+++ b/tt_metal/distributed/layer_completion/layer_completion_router.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/distributed_context.hpp>
 
@@ -26,18 +27,62 @@ using tt::tt_metal::distributed::InterProcessCounterChannel;
 namespace {
 namespace mh = tt::tt_metal::distributed::multihost;
 // Fixed MPI tag for layer-completion traffic. Distinct from any other
-// host-to-host channel in the job.
+// host-to-host channel in the job. Shared by both protocol versions — a job
+// is homogeneous (protocol is chosen once at launch), so they never mix.
 constexpr mh::Tag kLayerCompletionTag{4242};
+
+// v1 master egress: the reordered contiguous count into the scheduler's counter channel.
+class CounterChannelEgress final : public SchedulerEgress {
+public:
+    explicit CounterChannelEgress(const std::string& shm_name) :
+        channel_(std::make_unique<InterProcessCounterChannel>(shm_name)) {}
+    void inject(uint32_t n) { channel_->inject(n); }
+    void shutdown() override { channel_->shutdown(); }
+
+private:
+    std::unique_ptr<InterProcessCounterChannel> channel_;
+};
+
+// v2 master egress: forward-as-arrived into the scheduler-facing structured ring.
+class RingEgress final : public SchedulerEgress {
+public:
+    explicit RingEgress(const std::string& shm_name) : ring_(LayerCompletionQueueV2::create(shm_name)) {}
+    bool try_push(const LayerCompletionMessageV2& m) { return ring_->try_push(m); }
+    void shutdown() override { ring_->shutdown(); }
+
+private:
+    std::unique_ptr<LayerCompletionQueueV2> ring_;
+};
 }  // namespace
 
 LayerCompletionRouter::LayerCompletionRouter(LayerCompletionRouterConfig cfg) : cfg_(std::move(cfg)) {
-    queue_ = LayerCompletionQueue::create(cfg_.ring_shm_name);
-    if (is_master()) {
-        counter_ = std::make_unique<InterProcessCounterChannel>(cfg_.scheduler_channel_shm_name);
-        listener_ = std::thread([this] { run_master(); });
-    } else {
-        listener_ = std::thread([this] { run_subordinate(); });
+    TT_FATAL(
+        !is_master() || !cfg_.scheduler_shm_name.empty(),
+        "LayerCompletionRouter: master requires scheduler_shm_name (protocol {})",
+        static_cast<int>(cfg_.protocol));
+    // The protocol is chosen once per job and fixes every dynamic type below for the
+    // process's lifetime — the master/subordinate loops recover them via static_cast.
+    switch (cfg_.protocol) {
+        case LayerCompletionProtocol::kCountOnlyV1:
+            queue_ = LayerCompletionQueue::create(cfg_.ring_shm_name);
+            if (is_master()) {
+                sched_egress_ = std::make_unique<CounterChannelEgress>(cfg_.scheduler_shm_name);
+            }
+            break;
+        case LayerCompletionProtocol::kStructuredV2:
+            queue_ = LayerCompletionQueueV2::create(cfg_.ring_shm_name);
+            if (is_master()) {
+                sched_egress_ = std::make_unique<RingEgress>(cfg_.scheduler_shm_name);
+            }
+            break;
     }
+    listener_ = std::thread([this] {
+        if (is_master()) {
+            run_master();
+        } else {
+            run_subordinate();
+        }
+    });
 }
 
 LayerCompletionRouter::~LayerCompletionRouter() { stop(); }
@@ -53,14 +98,18 @@ void LayerCompletionRouter::stop() {
     if (queue_) {
         queue_->shutdown();
     }
-    if (counter_) {
-        counter_->shutdown();
+    if (sched_egress_) {
+        sched_egress_->shutdown();
     }
 }
 
-void LayerCompletionRouter::run_master() {
-    LayerCompletionReorderBuffer reorder;
-    std::vector<LayerCompletionMessage> drained;
+// Shared master skeleton: drain the host-local ring + fan in subordinate completions over MPI,
+// with sentinel-coordinated teardown. `forward` is the per-protocol output action (v1: reorder →
+// bare count; v2: backpressured forward-as-arrived) — everything else is protocol-identical.
+template <typename MsgT, typename Forward>
+void LayerCompletionRouter::run_master_impl(Forward&& forward) {
+    // Dynamic type fixed by cfg_.protocol at construction — safe downcast.
+    auto& queue = static_cast<LayerCompletionQueueT<MsgT>&>(*queue_);
 
     // Arm one irecv per subordinate (only when there is real MPI traffic).
     std::vector<int> subs;
@@ -71,7 +120,7 @@ void LayerCompletionRouter::run_master() {
             }
         }
     }
-    using Buf = std::array<std::byte, sizeof(LayerCompletionMessage)>;
+    using Buf = std::array<std::byte, sizeof(MsgT)>;
     std::vector<Buf> bufs(subs.size());
     std::vector<mh::RequestPtr> reqs(subs.size());
     const mh::ContextPtr ctx = subs.empty() ? nullptr : mh::DistributedContext::get_current_world();
@@ -80,14 +129,6 @@ void LayerCompletionRouter::run_master() {
             ctx->irecv(ttsl::Span<std::byte>(bufs[i].data(), bufs[i].size()), mh::Rank(subs[i]), kLayerCompletionTag);
     }
 
-    auto ingest = [&](const LayerCompletionMessage& m) {
-        const uint32_t n = reorder.insert(m, drained);
-        if (n > 0) {
-            counter_->inject(n);
-            processed_.fetch_add(n, std::memory_order_relaxed);
-        }
-    };
-
     // Coordinated teardown: keep draining the local ring and receiving subordinate messages until
     // this rank is done producing (stop_) AND its ring is empty AND every subordinate has sent its
     // end-of-stream sentinel. Then no blocking subordinate send is ever left without a receiver, and
@@ -95,18 +136,18 @@ void LayerCompletionRouter::run_master() {
     // case a rank crashed without sending its sentinel.
     std::size_t sentinels_remaining = subs.size();
     std::optional<std::chrono::steady_clock::time_point> deadline;
-    LayerCompletionMessage m{};
+    MsgT m{};
     while (true) {
         bool progressed = false;
 
-        while (queue_->try_pop(m)) {
-            ingest(m);
+        while (queue.try_pop(m)) {
+            forward(m);
             progressed = true;
         }
 
         for (std::size_t i = 0; i < subs.size(); ++i) {
             if (reqs[i] && reqs[i]->test().has_value()) {
-                LayerCompletionMessage recv{};
+                MsgT recv{};
                 std::memcpy(&recv, bufs[i].data(), sizeof(recv));
                 progressed = true;
                 if (is_layer_completion_sentinel(recv)) {
@@ -114,7 +155,7 @@ void LayerCompletionRouter::run_master() {
                     reqs[i].reset();
                     --sentinels_remaining;
                 } else {
-                    ingest(recv);
+                    forward(recv);
                     reqs[i] = ctx->irecv(
                         ttsl::Span<std::byte>(bufs[i].data(), bufs[i].size()), mh::Rank(subs[i]), kLayerCompletionTag);
                 }
@@ -132,8 +173,10 @@ void LayerCompletionRouter::run_master() {
             } else if (std::chrono::steady_clock::now() >= *deadline) {
                 log_warning(
                     LogMetal,
-                    "LayerCompletionRouter master: teardown timed out after {} ms with {} subordinate "
-                    "sentinel(s) outstanding; cancelling — a stalled/crashed rank's tail completions may be lost",
+                    "LayerCompletionRouter master (protocol {}): teardown timed out after {} ms with {} "
+                    "subordinate sentinel(s) outstanding; cancelling — a stalled/crashed rank's tail "
+                    "completions may be lost",
+                    static_cast<int>(cfg_.protocol),
                     cfg_.teardown_timeout_ms,
                     sentinels_remaining);
                 break;
@@ -154,9 +197,85 @@ void LayerCompletionRouter::run_master() {
     }
 }
 
+void LayerCompletionRouter::run_master() {
+    switch (cfg_.protocol) {
+        case LayerCompletionProtocol::kCountOnlyV1: {
+            // v1 output policy: reorder by seq, inject the newly-contiguous COUNT. Dynamic type
+            // fixed by cfg_.protocol at construction — safe downcast.
+            auto& egress = static_cast<CounterChannelEgress&>(*sched_egress_);
+            LayerCompletionReorderBuffer reorder;
+            std::vector<LayerCompletionMessage> drained;
+            run_master_impl<LayerCompletionMessage>([&](const LayerCompletionMessage& m) {
+                const uint32_t n = reorder.insert(m, drained);
+                if (n > 0) {
+                    egress.inject(n);
+                    processed_.fetch_add(n, std::memory_order_relaxed);
+                }
+            });
+            break;
+        }
+        case LayerCompletionProtocol::kStructuredV2: {
+            // v2 output policy: forward as-arrived — every completion is self-describing (request,
+            // slot, position range, layer range), so the scheduler keys work on content, not arrival
+            // order; no reorder buffer, no per-request head-of-line blocking. A full scheduler ring
+            // means the scheduler is behind: spin (backpressure propagates to the producers via their
+            // own full rings) — but bounded once stop_ is set, so a dead scheduler can't wedge
+            // teardown; the drops are logged after the loop. After the first timed-out push the
+            // scheduler is known-gone: fail fast so the remaining backlog drops without paying one
+            // full timeout per message.
+            auto& egress = static_cast<RingEgress&>(*sched_egress_);
+            uint64_t dropped = 0;
+            bool scheduler_gone = false;
+            run_master_impl<LayerCompletionMessageV2>([&](const LayerCompletionMessageV2& m) {
+                if (scheduler_gone) {
+                    ++dropped;
+                    return;
+                }
+                std::optional<std::chrono::steady_clock::time_point> blocked_since;
+                while (!egress.try_push(m)) {
+                    const auto now = std::chrono::steady_clock::now();
+                    if (!blocked_since) {
+                        blocked_since = now;
+                    } else if (
+                        stop_.load(std::memory_order_acquire) &&
+                        now - *blocked_since >= std::chrono::milliseconds(cfg_.teardown_timeout_ms)) {
+                        scheduler_gone = true;
+                        ++dropped;
+                        return;
+                    }
+                    std::this_thread::sleep_for(std::chrono::microseconds(cfg_.poll_idle_us));
+                }
+                processed_.fetch_add(1, std::memory_order_relaxed);
+            });
+            if (dropped > 0) {
+                log_warning(
+                    LogMetal,
+                    "LayerCompletionRouter master (v2): dropped {} completion(s) — scheduler ring still full "
+                    "{} ms after stop (scheduler wedged or gone)",
+                    dropped,
+                    cfg_.teardown_timeout_ms);
+            }
+            break;
+        }
+    }
+}
+
 void LayerCompletionRouter::run_subordinate() {
+    // Dynamic type fixed by cfg_.protocol at construction — safe downcasts.
+    switch (cfg_.protocol) {
+        case LayerCompletionProtocol::kCountOnlyV1:
+            run_subordinate_impl(static_cast<LayerCompletionQueue&>(*queue_));
+            break;
+        case LayerCompletionProtocol::kStructuredV2:
+            run_subordinate_impl(static_cast<LayerCompletionQueueV2&>(*queue_));
+            break;
+    }
+}
+
+template <typename MsgT>
+void LayerCompletionRouter::run_subordinate_impl(LayerCompletionQueueT<MsgT>& queue) {
     const mh::ContextPtr& ctx = mh::DistributedContext::get_current_world();
-    auto send_blocking = [&](const LayerCompletionMessage& msg) {
+    auto send_blocking = [&](const MsgT& msg) {
         std::array<std::byte, sizeof(msg)> buf{};
         std::memcpy(buf.data(), &msg, sizeof(msg));
         ctx->send(ttsl::Span<std::byte>(buf.data(), buf.size()), mh::Rank(cfg_.master_rank), kLayerCompletionTag);
@@ -165,7 +284,7 @@ void LayerCompletionRouter::run_subordinate() {
     // the dtor join — if the master already hit its own teardown_timeout_ms, stopped receiving, and
     // cancelled. Returns false when the send didn't complete in time (master gone). Symmetric with the
     // master's bound; the clean path never trips it.
-    auto send_bounded = [&](const LayerCompletionMessage& msg) -> bool {
+    auto send_bounded = [&](const MsgT& msg) -> bool {
         std::array<std::byte, sizeof(msg)> buf{};
         std::memcpy(buf.data(), &msg, sizeof(msg));
         auto req =
@@ -181,9 +300,9 @@ void LayerCompletionRouter::run_subordinate() {
         return true;
     };
 
-    LayerCompletionMessage m{};
+    MsgT m{};
     while (!stop_.load(std::memory_order_acquire)) {
-        if (queue_->try_pop(m)) {
+        if (queue.try_pop(m)) {
             send_blocking(m);  // steady state: the master is actively receiving
             processed_.fetch_add(1, std::memory_order_relaxed);
         } else {
@@ -195,21 +314,19 @@ void LayerCompletionRouter::run_subordinate() {
     // (run_master), so in the clean path every send completes promptly; if a send times out the master
     // has already given up, so abandon the rest (those completions are unrecoverable either way).
     bool master_alive = true;
-    while (master_alive && queue_->try_pop(m)) {
+    while (master_alive && queue.try_pop(m)) {
         master_alive = send_bounded(m);
         if (master_alive) {
             processed_.fetch_add(1, std::memory_order_relaxed);
         }
     }
     if (master_alive) {
-        LayerCompletionMessage sentinel{};
-        sentinel.source_rank = static_cast<uint32_t>(cfg_.rank);
-        sentinel.reserved = kLayerCompletionSentinel;
+        const MsgT sentinel = layer_completion_sentinel<MsgT>(static_cast<uint32_t>(cfg_.rank));
         master_alive = send_bounded(sentinel);
     }
     if (!master_alive) {
         std::size_t lost = 1;  // the send that timed out (a completion or the sentinel)
-        while (queue_->try_pop(m)) {
+        while (queue.try_pop(m)) {
             ++lost;
         }
         log_warning(

--- a/ttnn/api/ttnn/services/layer_ack_service.hpp
+++ b/ttnn/api/ttnn/services/layer_ack_service.hpp
@@ -15,7 +15,10 @@ class D2HStreamService;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal::internal {
-class LayerCompletionQueue;
+struct LayerCompletionMessage;  // fwd — defined in internal/disaggregation/layer_completion_message.hpp
+template <typename MsgT>
+class LayerCompletionQueueT;  // fwd — defined in internal/disaggregation/layer_completion_queue.hpp
+using LayerCompletionQueue = LayerCompletionQueueT<LayerCompletionMessage>;
 }  // namespace tt::tt_metal::internal
 
 namespace tt::tt_metal {

--- a/ttnn/cpp/ttnn-nanobind/layer_completion.cpp
+++ b/ttnn/cpp/ttnn-nanobind/layer_completion.cpp
@@ -40,13 +40,28 @@ namespace nb = nanobind;
 
 void bind_layer_completion_api(nb::module_& mod) {
     using tt::tt_metal::internal::LayerCompletionMessage;
+    using tt::tt_metal::internal::LayerCompletionMessageV2;
+    using tt::tt_metal::internal::LayerCompletionProtocol;
     using tt::tt_metal::internal::LayerCompletionQueue;
+    using tt::tt_metal::internal::LayerCompletionQueueBase;
+    using tt::tt_metal::internal::LayerCompletionQueueV2;
     using tt::tt_metal::internal::LayerCompletionRouter;
     using tt::tt_metal::internal::LayerCompletionRouterConfig;
 
     mod.doc() = "Pipelined-prefill layer-completion ring/router/consumer.";
 
-    nb::class_<LayerCompletionQueue>(mod, "LayerCompletionQueue")
+    // Protocol-neutral surface, shared by both ring versions. Everything a constructed ring
+    // supports regardless of message version lives here; the versioned classes below add only
+    // their create/connect factories and their message-typed try_push/try_pop.
+    nb::class_<LayerCompletionQueueBase>(mod, "LayerCompletionQueueBase")
+        .def(
+            "shutdown",
+            &LayerCompletionQueueBase::shutdown,
+            "Idempotent teardown. Owner unlinks; connector unmaps.")
+        .def_prop_ro("shm_name", &LayerCompletionQueueBase::shm_name)
+        .def_prop_ro_static("capacity", [](nb::handle) { return LayerCompletionQueue::capacity(); });
+
+    nb::class_<LayerCompletionQueue, LayerCompletionQueueBase>(mod, "LayerCompletionQueue")
         .def_static(
             "create",
             &LayerCompletionQueue::create,
@@ -81,10 +96,59 @@ void bind_layer_completion_api(nb::module_& mod) {
                 }
                 return std::make_tuple(m.seq, m.source_rank, m.layer_idx, m.request_id);
             },
-            "Consumer pop. Returns (seq, source_rank, layer_idx, request_id) or None when empty.")
-        .def("shutdown", &LayerCompletionQueue::shutdown, "Idempotent teardown. Owner unlinks; connector unmaps.")
-        .def_prop_ro("shm_name", &LayerCompletionQueue::shm_name)
-        .def_prop_ro_static("capacity", [](nb::handle) { return LayerCompletionQueue::capacity(); });
+            "Consumer pop. Returns (seq, source_rank, layer_idx, request_id) or None when empty.");
+
+    nb::class_<LayerCompletionQueueV2, LayerCompletionQueueBase>(mod, "LayerCompletionQueueV2")
+        .def_static(
+            "create",
+            &LayerCompletionQueueV2::create,
+            nb::arg("shm_name"),
+            "Create the v2 SHM ring as OWNER. Throws if the segment already exists.")
+        .def_static(
+            "connect",
+            &LayerCompletionQueueV2::connect,
+            nb::arg("shm_name"),
+            nb::arg("connect_timeout_ms") = 30'000u,
+            "Attach to an owner-created v2 ring by name (polls until present or timeout).")
+        .def(
+            "try_push",
+            [](LayerCompletionQueueV2& self,
+               uint64_t seq,
+               uint32_t source_rank,
+               uint32_t request_id,
+               uint32_t slot_id,
+               uint32_t pos_start,
+               uint32_t pos_end,
+               uint32_t layer_start,
+               uint32_t layer_end) {
+                return self.try_push(LayerCompletionMessageV2{
+                    seq, source_rank, request_id, slot_id, pos_start, pos_end, layer_start, layer_end, 0u});
+            },
+            nb::arg("seq"),
+            nb::arg("source_rank"),
+            nb::arg("request_id"),
+            nb::arg("slot_id"),
+            nb::arg("pos_start"),
+            nb::arg("pos_end"),
+            nb::arg("layer_start"),
+            nb::arg("layer_end"),
+            "Producer push of a self-describing v2 completion (position + layer ranges). "
+            "Returns False (no write) when the ring is full.")
+        .def(
+            "try_pop",
+            [](LayerCompletionQueueV2& self)
+                -> std::optional<
+                    std::tuple<uint64_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t>> {
+                LayerCompletionMessageV2 m{};
+                if (!self.try_pop(m)) {
+                    return std::nullopt;
+                }
+                return std::make_tuple(
+                    m.seq, m.source_rank, m.request_id, m.slot_id, m.pos_start, m.pos_end, m.layer_start,
+                    m.layer_end);
+            },
+            "Consumer pop. Returns (seq, source_rank, request_id, slot_id, pos_start, pos_end, layer_start, "
+            "layer_end) or None when empty.");
 
     nb::class_<LayerCompletionRouter>(mod, "LayerCompletionRouter")
         .def(
@@ -94,28 +158,40 @@ void bind_layer_completion_api(nb::module_& mod) {
                int world_size,
                int master_rank,
                const std::string& ring_shm_name,
-               const std::string& scheduler_channel_shm_name,
+               const std::string& scheduler_shm_name,
                int poll_idle_us,
-               int teardown_timeout_ms) {
+               int teardown_timeout_ms,
+               int protocol) {
                 LayerCompletionRouterConfig cfg;
                 cfg.rank = rank;
                 cfg.world_size = world_size;
                 cfg.master_rank = master_rank;
                 cfg.ring_shm_name = ring_shm_name;
-                cfg.scheduler_channel_shm_name = scheduler_channel_shm_name;
+                cfg.scheduler_shm_name = scheduler_shm_name;
                 cfg.poll_idle_us = poll_idle_us;
                 cfg.teardown_timeout_ms = teardown_timeout_ms;
+                switch (protocol) {
+                    case 1: cfg.protocol = LayerCompletionProtocol::kCountOnlyV1; break;
+                    case 2: cfg.protocol = LayerCompletionProtocol::kStructuredV2; break;
+                    default:
+                        throw std::invalid_argument(
+                            "LayerCompletionRouter: protocol must be 1 or 2, got " + std::to_string(protocol));
+                }
                 new (self) LayerCompletionRouter(std::move(cfg));
             },
             nb::arg("rank"),
             nb::arg("world_size"),
             nb::arg("master_rank"),
             nb::arg("ring_shm_name"),
-            nb::arg("scheduler_channel_shm_name") = std::string{},
+            nb::arg("scheduler_shm_name") = std::string{},
             nb::arg("poll_idle_us") = 100,
             nb::arg("teardown_timeout_ms") = 5000,
+            // Appended (after every pre-existing arg) so positional callers are unaffected.
+            nb::arg("protocol") = 1,
             "Create the host's router: owns the local ring, spawns the listener thread, and on the master "
-            "rank owns the scheduler-facing counter channel.")
+            "rank owns the scheduler-facing segment at scheduler_shm_name (one name for both protocols). "
+            "protocol=1 (default): reorder to a bare count on a counter channel there. protocol=2: forward "
+            "self-describing messages as-arrived into a structured ring there.")
         .def("stop", &LayerCompletionRouter::stop, "Idempotent: stop + join the listener thread.")
         .def_prop_ro("processed", &LayerCompletionRouter::processed)
         .def_prop_ro("is_master", &LayerCompletionRouter::is_master);

--- a/ttnn/ttnn/_experimental/layer_completion.py
+++ b/ttnn/ttnn/_experimental/layer_completion.py
@@ -3,10 +3,11 @@
 
 from ttnn._ttnn.layer_completion import (
     LayerCompletionQueue,
+    LayerCompletionQueueV2,
     LayerCompletionRouter,
 )
 
-__all__ = ["LayerCompletionQueue", "LayerCompletionRouter"]
+__all__ = ["LayerCompletionQueue", "LayerCompletionQueueV2", "LayerCompletionRouter"]
 
 # Test-only scheduler stand-in: registered only in TTNN_BUILD_TESTS builds, so it is absent from a
 # shipped wheel. Importing it must not take the production ring/router down with it.


### PR DESCRIPTION
### PR Category
Performance

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
The original layer completion protocol had to drive a single monotonic counter in the prefill scheduler, so the layer completion aggregation layer was not driving the protocol. Due to the monotic counter implementation, the scheduler assumed (expected) that completions were ordered. All the pipeline stage completions for a request were expected before any complations of a follow up request - even though request were pipelined and therefore some completions could in theory land in parallel. This effectively produced head of line blocking where a subsequent request could not start migrating out until the last

This change improves the completion mechanism to include information about completed prefill task itself so that there is no concern for ordering. Slot and layer information is now added so we can perform layer-by-layer migrations without HOL blocking waiting on the previous requests.

### Key Additions
- `PREFILL_LAYER_COMPLETION_PROTOCOL=2` to specify new protocol + wire format, default is old behaviour (`PREFILL_LAYER_COMPLETION_PROTOCOL=1`)
- new wire format 
- 

###

v2 completions are self-describing (request/slot/position/layer ranges) and forwarded as-arrived — no reorder buffer, no per-request head-of-line blocking (issue #54632). v1 count protocol unchanged.

Both protocols now share one code path end to end: a single scheduler-facing shm name (the router's protocol arg decides the segment's layout — counter channel vs structured ring), a router with two polymorphic members (LayerCompletionQueueBase + SchedulerEgress) and one templated master fan-in loop with the output policy injected, and runner wiring where the only protocol-conditional is the queue/sink message type. Nanobind mirrors the hierarchy: LayerCompletionQueueBase carries shutdown/shm_name/capacity, the versioned classes add only their factories and typed push/pop.

Tests: ring (both versions), router (v1 reorder/HoL, v2 as-arrived, scheduler-ring backpressure, teardown-drop, config validation), sink + drainer unit tests.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
The change preserves old behaviour as default but adds in an option to select the new completion mode so we can ensure a smooth transition to the new completion mechanism.

`PREFILL_LAYER_COMPLETION_PROTOCOL=2` enables the new mode