### PR TITLE
ci: add /mirror PR comment trigger as a standalone dispatcher

### DIFF
--- a/.github/workflows/mirror-fork-branch-comment.yaml
+++ b/.github/workflows/mirror-fork-branch-comment.yaml
@@ -36,11 +36,18 @@ jobs:
             echo "Could not resolve fork owner/branch for PR #$PR_NUMBER"
             exit 1
           fi
-          TARGET=$(echo "$COMMENT_BODY" | sed -n 's|^/mirror[[:space:]]*||p' | xargs)
-          echo "Dispatching mirror-fork-branch.yaml for ${FORK_OWNER}:${SRC_BRANCH} (target: ${TARGET:-default})"
+          TARGET_RAW=$(echo "$COMMENT_BODY" | sed -n 's|^/mirror[[:space:]]*||p')
+          read -r TARGET <<< "$TARGET_RAW"
+          if [ -n "$TARGET" ]; then
+            case "$TARGET" in
+              mirror/*) TARGET_BRANCH="$TARGET" ;;
+              *) TARGET_BRANCH="mirror/$TARGET" ;;
+            esac
+          fi
+          echo "Dispatching mirror-fork-branch.yaml for ${FORK_OWNER}:${SRC_BRANCH} (target: ${TARGET_BRANCH:-default})"
           gh workflow run mirror-fork-branch.yaml --repo "$REPO" \
             --field source="${FORK_OWNER}:${SRC_BRANCH}" \
-            ${TARGET:+--field target_branch="$TARGET"}
+            ${TARGET_BRANCH:+--field target_branch="$TARGET_BRANCH"}
 
       - name: React to comment
         env:

--- a/.github/workflows/mirror-fork-branch-comment.yaml
+++ b/.github/workflows/mirror-fork-branch-comment.yaml
@@ -1,0 +1,50 @@
+name: Mirror Fork Branch via Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch-mirror:
+    if: >
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/mirror' || startsWith(github.event.comment.body, '/mirror '))
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    steps:
+      - name: Check requester is a member/collaborator
+        env:
+          ASSOC: ${{ github.event.comment.author_association }}
+        run: |
+          if [[ "$ASSOC" != "MEMBER" && "$ASSOC" != "OWNER" && "$ASSOC" != "COLLABORATOR" ]]; then
+            echo "Not authorized: $ASSOC"
+            exit 1
+          fi
+
+      - name: Resolve fork owner/branch and dispatch mirror workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          FORK_OWNER=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRepositoryOwner -q .headRepositoryOwner.login)
+          SRC_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName -q .headRefName)
+          if [ -z "$FORK_OWNER" ] || [ -z "$SRC_BRANCH" ]; then
+            echo "Could not resolve fork owner/branch for PR #$PR_NUMBER"
+            exit 1
+          fi
+          TARGET=$(echo "$COMMENT_BODY" | sed -n 's|^/mirror[[:space:]]*||p' | xargs)
+          echo "Dispatching mirror-fork-branch.yaml for ${FORK_OWNER}:${SRC_BRANCH} (target: ${TARGET:-default})"
+          gh workflow run mirror-fork-branch.yaml --repo "$REPO" \
+            --field source="${FORK_OWNER}:${SRC_BRANCH}" \
+            ${TARGET:+--field target_branch="$TARGET"}
+
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_URL: ${{ github.event.comment.url }}
+        run: |
+          gh api "$COMMENT_URL/reactions" -X POST -f content=rocket --silent || true


### PR DESCRIPTION
## Summary
- Adds a new, additive-only workflow (`mirror-fork-branch-comment.yaml`) that listens for `/mirror` comments on fork PRs and triggers the existing `mirror-fork-branch.yaml` via `gh workflow run` — no changes to the existing mirror workflow itself.
- Replaces org-membership API call with `github.event.comment.author_association` (MEMBER/OWNER/COLLABORATOR).
- Comment body is passed through env vars instead of being interpolated directly into `run:`, avoiding script-injection risk.
- `/mirror` match is exact or `/mirror <target>` prefixed (not a bare `startsWith`), so `/mirrorfoo` won't false-trigger.

## Usage
Comment on a fork PR:
```
/mirror                # mirrors to mirror/<fork_owner>/<branch>
/mirror custom-branch   # mirrors to custom-branch
```

Supersedes #41273, which embedded this logic into `mirror-fork-branch.yaml` directly and picked up a lot of review comments due to the larger diff and injection concerns. This version keeps the working mirror logic untouched and reuses it via dispatch instead.

## Test plan
- [ ] Open workflow file review — confirm `mirror-fork-branch.yaml` is unmodified
- [ ] Comment `/mirror` on a test fork PR and confirm the mirror workflow dispatches with the correct `source`
- [ ] Comment `/mirror <branch>` and confirm `target_branch` is honored
- [ ] Comment from a non-member/collaborator and confirm the job fails at the authorization step
- [ ] Confirm rocket reaction is added on successful dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/mirror-fork-branch-comment-trigger)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/mirror-fork-branch-comment-trigger)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/mirror-fork-branch-comment-trigger)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/mirror-fork-branch-comment-trigger)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/mirror-fork-branch-comment-trigger)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/mirror-fork-branch-comment-trigger)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/mirror-fork-branch-comment-trigger)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/mirror-fork-branch-comment-trigger)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/mirror-fork-branch-comment-trigger)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/mirror-fork-branch-comment-trigger)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/mirror-fork-branch-comment-trigger)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/mirror-fork-branch-comment-trigger)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/mirror-fork-branch-comment-trigger)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/mirror-fork-branch-comment-trigger)