### PR TITLE
[Bug fix] ttnn.div: forward the requested output dtype instead of discarding it

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -960,12 +960,17 @@ def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memo
     output = ttnn_op(input_tensor_a, input_tensor_b, dtype=ttnn.float32)
     tt_output_tensor = ttnn.to_torch(output)
 
+    assert output.dtype == ttnn.float32
+
     golden_fn = ttnn.get_golden_function(ttnn_op)
-    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
 
     if ttnn_fn == "divide":
-        assert_with_ulp(torch_output_tensor, tt_output_tensor, ulp_threshold=0)
+        # A float32 output was requested, so the reference has to be computed in float32 as well:
+        # comp_ulp measures against the golden's precision and expects it to be the higher one.
+        torch_output_tensor = golden_fn(torch_input_tensor_a.float(), torch_input_tensor_b.float())
+        assert_with_ulp(torch_output_tensor, tt_output_tensor, ulp_threshold=1)
     else:
+        torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
         assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.999)
 
 
@@ -1075,4 +1080,5 @@ def test_binary_div(
         torch_input_b, layout=input_layout, memory_config=memory_config, dtype=input_dtype, device=device
     )
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b, dtype=output_dtype)
+    assert output_tensor.dtype == output_dtype
     assert_with_ulp(torch_output, ttnn.to_torch(output_tensor), ulp_threshold=0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -458,3 +458,126 @@ def test_optional_output_tensor_remainder(device):
     optional_output_tensor = ttnn.to_torch(optional_output_tensor)
 
     assert_with_ulp(optional_output_tensor, torch_golden, ulp_threshold=0)
+
+
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("rounding_mode", [None, "floor", "trunc"])
+@pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
+@pytest.mark.parametrize("op", [ttnn.div, ttnn.divide])
+def test_div_output_dtype(device, input_dtype, rounding_mode, output_dtype, op):
+    torch_dtype = torch.bfloat16 if input_dtype == ttnn.bfloat16 else torch.float32
+    torch_input_a = torch.tensor([[7.0, -7.0, 6.0, -6.0]], dtype=torch_dtype)
+    torch_input_b = torch.full_like(torch_input_a, 2.0)
+
+    input_tensor_a = ttnn.from_torch(torch_input_a, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_b, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = op(input_tensor_a, input_tensor_b, rounding_mode=rounding_mode, dtype=output_dtype)
+
+    torch_golden = torch.div(torch_input_a.float(), torch_input_b.float(), rounding_mode=rounding_mode)
+    if output_dtype == ttnn.int32:
+        torch_golden = torch_golden.to(torch.int32)
+
+    assert output.dtype == output_dtype
+    assert torch.equal(ttnn.to_torch(output).float(), torch_golden.float())
+
+
+@pytest.mark.parametrize("rounding_mode", ["floor", "trunc"])
+def test_div_int32_output_rounds_before_narrowing(device, rounding_mode):
+    # Narrowing the quotient before rounding would truncate toward zero and give floor() the wrong
+    # answer for negatives, so the whole negative range has to agree with torch.
+    torch_input_a = torch.arange(-64, 64, dtype=torch.float32).reshape(1, 1, 8, 16)
+    torch_input_b = torch.full_like(torch_input_a, 3.0)
+
+    input_tensor_a = ttnn.from_torch(torch_input_a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.div(input_tensor_a, input_tensor_b, rounding_mode=rounding_mode, dtype=ttnn.int32)
+    torch_golden = torch.div(torch_input_a, torch_input_b, rounding_mode=rounding_mode).to(torch.int32)
+
+    assert output.dtype == ttnn.int32
+    assert torch.equal(ttnn.to_torch(output), torch_golden)
+
+
+@pytest.mark.parametrize("rounding_mode", [None, "floor", "trunc"])
+@pytest.mark.parametrize("output_dtype", [ttnn.float32, ttnn.int32])
+def test_div_int32_inputs_output_dtype(device, rounding_mode, output_dtype):
+    if rounding_mode is None and output_dtype != ttnn.float32:
+        pytest.skip("Integer division with rounding_mode=None only supports a float32 output")
+
+    torch_input_a = torch.tensor([[7, -7, 6, -6]], dtype=torch.int32)
+    torch_input_b = torch.full_like(torch_input_a, 2)
+
+    input_tensor_a = ttnn.from_torch(torch_input_a, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_b, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.div(input_tensor_a, input_tensor_b, rounding_mode=rounding_mode, dtype=output_dtype)
+    torch_golden = torch.div(torch_input_a, torch_input_b, rounding_mode=rounding_mode).float()
+
+    assert output.dtype == output_dtype
+    assert torch.equal(ttnn.to_torch(output).float(), torch_golden)
+
+
+@pytest.mark.parametrize("rounding_mode", [None, "floor", "trunc"])
+@pytest.mark.parametrize("output_dtype", [ttnn.float32, ttnn.int32])
+def test_div_scalar_output_dtype(device, rounding_mode, output_dtype):
+    torch_input = torch.tensor([[7.0, -7.0, 6.0, -6.0]], dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.div(input_tensor, 2.0, rounding_mode=rounding_mode, dtype=output_dtype)
+
+    torch_golden = torch.div(torch_input.float(), 2.0, rounding_mode=rounding_mode)
+    if output_dtype == ttnn.int32:
+        torch_golden = torch_golden.to(torch.int32)
+
+    assert output.dtype == output_dtype
+    assert torch.equal(ttnn.to_torch(output).float(), torch_golden.float())
+
+
+@pytest.mark.parametrize(
+    "dtype_a, dtype_b",
+    [
+        (ttnn.int32, ttnn.bfloat16),
+        (ttnn.bfloat16, ttnn.int32),
+        (ttnn.int32, ttnn.float32),
+        (ttnn.float32, ttnn.int32),
+        (ttnn.bfloat16, ttnn.float32),
+        (ttnn.float32, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize("rounding_mode", [None, "floor", "trunc"])
+@pytest.mark.parametrize("output_dtype", [ttnn.float32, ttnn.bfloat16, ttnn.int32])
+def test_div_mixed_input_dtypes_output_dtype(device, dtype_a, dtype_b, rounding_mode, output_dtype):
+    # A mismatched 32-bit integer operand is promoted to the floating compute dtype before the
+    # divide, so the requested output dtype has to survive that promotion rather than follow it.
+    torch_input_a = torch.tensor([[7.0, -7.0, 6.0, -6.0]])
+    torch_input_b = torch.full_like(torch_input_a, 2.0)
+
+    def to_device(torch_tensor, dtype):
+        torch_dtype = {ttnn.int32: torch.int32, ttnn.bfloat16: torch.bfloat16, ttnn.float32: torch.float32}[dtype]
+        return ttnn.from_torch(torch_tensor.to(torch_dtype), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.div(
+        to_device(torch_input_a, dtype_a),
+        to_device(torch_input_b, dtype_b),
+        rounding_mode=rounding_mode,
+        dtype=output_dtype,
+    )
+
+    torch_golden = torch.div(torch_input_a, torch_input_b, rounding_mode=rounding_mode)
+    if output_dtype == ttnn.int32:
+        torch_golden = torch_golden.to(torch.int32)
+
+    assert output.dtype == output_dtype
+    assert torch.equal(ttnn.to_torch(output).float(), torch_golden.float())
+
+
+def test_div_int32_rejects_non_float32_output_dtype(device, expect_error):
+    torch_input_a = torch.tensor([[7, 6]], dtype=torch.int32)
+    torch_input_b = torch.tensor([[2, 3]], dtype=torch.int32)
+
+    input_tensor_a = ttnn.from_torch(torch_input_a, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_b, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    with expect_error(RuntimeError, "Incorrect output_dtype value for Integer Division"):
+        ttnn.div(input_tensor_a, input_tensor_b, dtype=ttnn.int32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -534,6 +534,59 @@ def test_div_scalar_output_dtype(device, rounding_mode, output_dtype):
     assert torch.equal(ttnn.to_torch(output).float(), torch_golden.float())
 
 
+@pytest.mark.parametrize("rounding_mode", ["floor", "trunc"])
+@pytest.mark.parametrize("output_dtype", [ttnn.int32, ttnn.float32])
+def test_div_preallocated_output_rounds_before_narrowing(device, rounding_mode, output_dtype):
+    # A preallocated integer output has to reach the same value as dtype=int32, so the quotient
+    # cannot be narrowed into it before floor()/trunc() runs.
+    torch_input_a = torch.tensor([[7.0, -7.0, 6.0, -6.0]], dtype=torch.bfloat16)
+    torch_input_b = torch.full_like(torch_input_a, 2.0)
+
+    input_tensor_a = ttnn.from_torch(torch_input_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    torch_dtype = torch.int32 if output_dtype == ttnn.int32 else torch.float32
+    preallocated = ttnn.from_torch(
+        torch.zeros_like(torch_input_a, dtype=torch_dtype), dtype=output_dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    output = ttnn.div(input_tensor_a, input_tensor_b, rounding_mode=rounding_mode, output_tensor=preallocated)
+
+    torch_golden = torch.div(torch_input_a.float(), torch_input_b.float(), rounding_mode=rounding_mode)
+
+    assert output.dtype == output_dtype
+    assert torch.equal(ttnn.to_torch(output).float(), torch_golden)
+    # the caller's tensor must hold the result, not just the returned handle
+    assert torch.equal(ttnn.to_torch(preallocated).float(), torch_golden)
+
+
+@pytest.mark.parametrize("rounding_mode", [None, "floor", "trunc"])
+@pytest.mark.parametrize("output_dtype", [ttnn.int32, ttnn.float32])
+def test_div_output_dtype_with_sub_core_grids(device, rounding_mode, output_dtype):
+    # The post-rounding typecast has to keep the caller's core restriction.
+    torch_input_a = torch.tensor([[7.0, -7.0, 6.0, -6.0]], dtype=torch.bfloat16)
+    torch_input_b = torch.full_like(torch_input_a, 2.0)
+
+    input_tensor_a = ttnn.from_torch(torch_input_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    sub_core_grids = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))])
+
+    output = ttnn.div(
+        input_tensor_a,
+        input_tensor_b,
+        rounding_mode=rounding_mode,
+        dtype=output_dtype,
+        sub_core_grids=sub_core_grids,
+    )
+
+    torch_golden = torch.div(torch_input_a.float(), torch_input_b.float(), rounding_mode=rounding_mode)
+    if output_dtype == ttnn.int32:
+        torch_golden = torch_golden.to(torch.int32).float()
+
+    assert output.dtype == output_dtype
+    assert torch.equal(ttnn.to_torch(output).float(), torch_golden)
+
+
 @pytest.mark.parametrize(
     "dtype_a, dtype_b",
     [

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -1149,6 +1149,7 @@ void bind_div(
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             fast_and_approximate_mode (bool, optional): `true` if input_tensor_b is non-zero for fast approximation, else `false` for accurate division (Only if the input tensor is not ComplexTensor). Defaults to `false`.
             rounding_mode (string, optional): can be `None`, `floor` and `trunc` (only if the input tensor is not ComplexTensor). Defaults to `None`.
+            dtype (ttnn.DataType, optional): dtype of the output tensor. Integer division with `rounding_mode=None` only accepts `None` or `ttnn.float32`. Defaults to the dtype of :attr:`input_tensor_a`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -250,20 +250,28 @@ Tensor div(
     const bool suppress_fap = fast_and_approximate_mode && input.dtype() == DataType::BFLOAT16;
     const bool effective_fap = suppress_fap ? false : fast_and_approximate_mode;
 
+    // A preallocated output pins the result dtype exactly like an explicit dtype does, so the two
+    // have to agree before either can decide how the quotient is rounded.
+    TT_FATAL(
+        !output_dtype.has_value() || !output_tensor.has_value() || *output_dtype == output_tensor->dtype(),
+        "If both output dtype and output tensor are provided, their dtypes should match");
+    const std::optional<const DataType> requested_dtype =
+        output_tensor.has_value() ? std::optional<const DataType>{output_tensor->dtype()} : output_dtype;
+
     // The quotient has to stay in floating point until it is rounded: narrowing it to an integer
-    // dtype first truncates toward zero, which would turn floor(-3.5) into -3 instead of -4. Such a
-    // dtype is applied after the rounding step instead.
-    const bool cast_after_rounding =
-        output_dtype.has_value() && !output_tensor.has_value() && !tt::tt_metal::is_floating_point(*output_dtype);
+    // dtype first truncates toward zero, which would turn floor(-3.5) into -3 instead of -4. An
+    // integer destination is therefore filled by a typecast after the rounding step.
+    const bool cast_after_rounding = requested_dtype.has_value() && !tt::tt_metal::is_floating_point(*requested_dtype);
     const std::optional<const DataType> quotient_dtype =
         cast_after_rounding ? std::optional<const DataType>{} : output_dtype;
+    const std::optional<Tensor> quotient_output = cast_after_rounding ? std::optional<Tensor>{} : output_tensor;
 
     std::optional<Tensor> divided = ttnn::divide(
         input,
         value,
         quotient_dtype,
         output_mem_config,
-        output_tensor,
+        quotient_output,
         post_activations,
         lhs_activations,
         rhs_activations,
@@ -272,9 +280,12 @@ Tensor div(
         sub_device_id);
 
     Tensor rounded = (rounding_mode == "trunc")
-                         ? ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids)
-                         : ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
-    return cast_after_rounding ? ttnn::typecast(rounded, *output_dtype, output_mem_config) : rounded;
+                         ? ttnn::trunc(divided.value(), output_mem_config, quotient_output, sub_core_grids)
+                         : ttnn::floor(divided.value(), output_mem_config, quotient_output, sub_core_grids);
+    if (!cast_after_rounding) {
+        return rounded;
+    }
+    return ttnn::typecast(rounded, *requested_dtype, output_mem_config, output_tensor, sub_core_grids);
 }
 
 Tensor div(
@@ -382,20 +393,28 @@ Tensor div(
     const bool suppress_fap = fast_and_approximate_mode && input_dtype == DataType::BFLOAT16;
     const bool effective_fap = suppress_fap ? false : fast_and_approximate_mode;
 
+    // A preallocated output pins the result dtype exactly like an explicit dtype does, so the two
+    // have to agree before either can decide how the quotient is rounded.
+    TT_FATAL(
+        !output_dtype.has_value() || !output_tensor.has_value() || *output_dtype == output_tensor->dtype(),
+        "If both output dtype and output tensor are provided, their dtypes should match");
+    const std::optional<const DataType> requested_dtype =
+        output_tensor.has_value() ? std::optional<const DataType>{output_tensor->dtype()} : output_dtype;
+
     // The quotient has to stay in floating point until it is rounded: narrowing it to an integer
-    // dtype first truncates toward zero, which would turn floor(-3.5) into -3 instead of -4. Such a
-    // dtype is applied after the rounding step instead.
-    const bool cast_after_rounding =
-        output_dtype.has_value() && !output_tensor.has_value() && !tt::tt_metal::is_floating_point(*output_dtype);
+    // dtype first truncates toward zero, which would turn floor(-3.5) into -3 instead of -4. An
+    // integer destination is therefore filled by a typecast after the rounding step.
+    const bool cast_after_rounding = requested_dtype.has_value() && !tt::tt_metal::is_floating_point(*requested_dtype);
     const std::optional<const DataType> quotient_dtype =
         cast_after_rounding ? std::optional<const DataType>{} : output_dtype;
+    const std::optional<Tensor> quotient_output = cast_after_rounding ? std::optional<Tensor>{} : output_tensor;
 
     std::optional<Tensor> divided = ttnn::divide(
         input_a,
         input_b,
         quotient_dtype,
         output_mem_config,
-        output_tensor,
+        quotient_output,
         post_activations,
         lhs_activations,
         rhs_activations,
@@ -404,9 +423,12 @@ Tensor div(
         sub_device_id);
 
     Tensor rounded = (rounding_mode == "trunc")
-                         ? ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids)
-                         : ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
-    return cast_after_rounding ? ttnn::typecast(rounded, *output_dtype, output_mem_config) : rounded;
+                         ? ttnn::trunc(divided.value(), output_mem_config, quotient_output, sub_core_grids)
+                         : ttnn::floor(divided.value(), output_mem_config, quotient_output, sub_core_grids);
+    if (!cast_after_rounding) {
+        return rounded;
+    }
+    return ttnn::typecast(rounded, *requested_dtype, output_mem_config, output_tensor, sub_core_grids);
 }
 
 Tensor div_no_nan(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -173,7 +173,7 @@ Tensor div(
                 input,
                 value,
                 binary::BinaryOpType::DIV_FLOOR,
-                std::nullopt,
+                output_dtype,
                 output_mem_config,
                 output_tensor,
                 post_activations,
@@ -188,7 +188,7 @@ Tensor div(
                 input,
                 value,
                 binary::BinaryOpType::DIV_TRUNC,
-                std::nullopt,
+                output_dtype,
                 output_mem_config,
                 output_tensor,
                 post_activations,
@@ -207,7 +207,7 @@ Tensor div(
             input,
             value,
             binary::BinaryOpType::DIV,
-            std::nullopt,
+            output_dtype,
             output_mem_config,
             output_tensor,
             post_activations,
@@ -225,7 +225,7 @@ Tensor div(
             input,
             value,
             binary::BinaryOpType::DIV,
-            std::nullopt,
+            output_dtype,
             output_mem_config,
             output_tensor,
             post_activations,
@@ -250,10 +250,18 @@ Tensor div(
     const bool suppress_fap = fast_and_approximate_mode && input.dtype() == DataType::BFLOAT16;
     const bool effective_fap = suppress_fap ? false : fast_and_approximate_mode;
 
+    // The quotient has to stay in floating point until it is rounded: narrowing it to an integer
+    // dtype first truncates toward zero, which would turn floor(-3.5) into -3 instead of -4. Such a
+    // dtype is applied after the rounding step instead.
+    const bool cast_after_rounding =
+        output_dtype.has_value() && !output_tensor.has_value() && !tt::tt_metal::is_floating_point(*output_dtype);
+    const std::optional<const DataType> quotient_dtype =
+        cast_after_rounding ? std::optional<const DataType>{} : output_dtype;
+
     std::optional<Tensor> divided = ttnn::divide(
         input,
         value,
-        std::nullopt,
+        quotient_dtype,
         output_mem_config,
         output_tensor,
         post_activations,
@@ -263,10 +271,10 @@ Tensor div(
         sub_core_grids,
         sub_device_id);
 
-    if (rounding_mode == "trunc") {
-        return ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids);
-    }
-    return ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+    Tensor rounded = (rounding_mode == "trunc")
+                         ? ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids)
+                         : ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+    return cast_after_rounding ? ttnn::typecast(rounded, *output_dtype, output_mem_config) : rounded;
 }
 
 Tensor div(
@@ -297,7 +305,7 @@ Tensor div(
                 input_a,
                 input_b,
                 binary::BinaryOpType::DIV_FLOOR,
-                std::nullopt,
+                output_dtype,
                 output_mem_config,
                 output_tensor,
                 post_activations,
@@ -312,7 +320,7 @@ Tensor div(
                 input_a,
                 input_b,
                 binary::BinaryOpType::DIV_TRUNC,
-                std::nullopt,
+                output_dtype,
                 output_mem_config,
                 output_tensor,
                 post_activations,
@@ -331,7 +339,7 @@ Tensor div(
             input_a,
             input_b,
             binary::BinaryOpType::DIV,
-            std::nullopt,
+            output_dtype,
             output_mem_config,
             output_tensor,
             post_activations,
@@ -349,7 +357,7 @@ Tensor div(
             input_a,
             input_b,
             binary::BinaryOpType::DIV,
-            std::nullopt,
+            output_dtype,
             output_mem_config,
             output_tensor,
             post_activations,
@@ -374,10 +382,18 @@ Tensor div(
     const bool suppress_fap = fast_and_approximate_mode && input_dtype == DataType::BFLOAT16;
     const bool effective_fap = suppress_fap ? false : fast_and_approximate_mode;
 
+    // The quotient has to stay in floating point until it is rounded: narrowing it to an integer
+    // dtype first truncates toward zero, which would turn floor(-3.5) into -3 instead of -4. Such a
+    // dtype is applied after the rounding step instead.
+    const bool cast_after_rounding =
+        output_dtype.has_value() && !output_tensor.has_value() && !tt::tt_metal::is_floating_point(*output_dtype);
+    const std::optional<const DataType> quotient_dtype =
+        cast_after_rounding ? std::optional<const DataType>{} : output_dtype;
+
     std::optional<Tensor> divided = ttnn::divide(
         input_a,
         input_b,
-        std::nullopt,
+        quotient_dtype,
         output_mem_config,
         output_tensor,
         post_activations,
@@ -387,10 +403,10 @@ Tensor div(
         sub_core_grids,
         sub_device_id);
 
-    if (rounding_mode == "trunc") {
-        return ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids);
-    }
-    return ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+    Tensor rounded = (rounding_mode == "trunc")
+                         ? ttnn::trunc(divided.value(), output_mem_config, output_tensor, sub_core_grids)
+                         : ttnn::floor(divided.value(), output_mem_config, output_tensor, sub_core_grids);
+    return cast_after_rounding ? ttnn::typecast(rounded, *output_dtype, output_mem_config) : rounded;
 }
 
 Tensor div_no_nan(


### PR DESCRIPTION
Closes #55304

## Summary

`ttnn.div` accepts a `dtype=` argument, validates it on the integer `rounding_mode=None` path, and then never applies it. Every dispatch passed `std::nullopt` in the output-dtype slot of `invoke_binary_ng`, so the result always came back in the input's dtype with no error and no warning.

The reach is wider than the issue reports: `ttnn/ttnn/__init__.py:475` does `divide = ttnn.div`, so the Python `ttnn.divide` **is** `ttnn.div`. The C++ `ttnn::divide` (`binary.cpp:1166`) forwards `output_dtype` correctly but is shadowed and unreachable from Python, so both names were broken.

## Before / after

Measured on Wormhole B0, same binary in both columns apart from this patch (`a = 7.0`, `b = 2.0`, `bfloat16` unless stated). Rows marked · are unchanged.

| Call | Before | After |
| --- | --- | --- |
| · `div(a, b)` | `BFLOAT16 3.5` | `BFLOAT16 3.5` |
| · `div(a, b, dtype=bfloat16)` | `BFLOAT16 3.5` | `BFLOAT16 3.5` |
| `div(a, b, dtype=float32)` | `BFLOAT16 3.5` | **`FLOAT32 3.5`** |
| `div(a, 2.0, dtype=float32)` | `BFLOAT16 3.5` | **`FLOAT32 3.5`** |
| `divide(a, b, dtype=float32)` | `BFLOAT16 3.5` | **`FLOAT32 3.5`** |
| `div(a, b, rounding_mode="floor", dtype=int32)` | `BFLOAT16 3.0` | **`INT32 3`** |
| `div(-a, b, rounding_mode="floor", dtype=int32)` | `BFLOAT16 -4.0` | **`INT32 -4`** |
| `div(-a, b, rounding_mode="trunc", dtype=int32)` | `BFLOAT16 -3.0` | **`INT32 -3`** |
| `div(-a, b, rounding_mode="floor", output_tensor=int32)` | `INT32 -3` ⚠️ wrong value | **`INT32 -4`** |
| `div(int32, bf16, dtype=float32)` | `BFLOAT16 3.5` | **`FLOAT32 3.5`** |
| `div(bf16, int32, dtype=int32)` | `BFLOAT16 3.5` | **`INT32 3`** |
| `div(-int32, int32, rounding_mode="floor", dtype=float32)` | `INT32 -4` | **`FLOAT32 -4.0`** |
| · `div(int32, int32, dtype=float32)` | `FLOAT32 3.5` | `FLOAT32 3.5` |
| · `div(int32, int32, dtype=int32)` | raises `TT_FATAL` | raises `TT_FATAL` |

Apart from the preallocated-output row, every value was already correct before the fix and only the dtype was being discarded. The last row confirms the existing validation was firing all along, which is what made the silent drop so odd.

## Changes

- Forward `output_dtype` at all eight dispatch sites across both `div` overloads (`DIV_FLOOR`, `DIV_TRUNC`, and `DIV` on the int32 and non-int32 paths).
- On the floating-point rounding path, fill an **integer** destination with a typecast *after* rounding. Narrowing the quotient first truncates toward zero and turns `floor(-3.5)` into `-3` instead of `-4`. Floating dtypes still go straight into the divide, where they buy real precision.
- Treat a preallocated `output_tensor` as pinning the result dtype exactly like an explicit `dtype` does, so both spellings of the same request produce the same value. `floor(-7/2)` into an `int32` output tensor returned `-3` on `main`; it now returns `-4`. The two are required to agree, and the destination is reserved for the final cast.
- Document the `dtype` keyword, which was exposed on the binding but missing from the `div` docstring.

No new dtype validation was needed: the check in `invoke_binary_ng_impl` (`binary.cpp:617-625`) already rejects a non-`float32` output for integer division, it just never fired because the dtype arrived as `nullopt`. The "dtypes should match" check is now also asserted locally, since the deferred-cast path no longer hands both the dtype and the destination to `invoke_binary_ng_impl`.

Behaviour is unchanged when neither a dtype nor an output tensor is requested: every forwarded value is the `std::nullopt` that was there before, and the rounding branch returns the identical expression. All internal C++ callers of `ttnn::div` pass `std::nullopt` in that slot, so none of them are affected.

## Mixed dtypes

`invoke_binary_ng_impl` promotes a mismatched 32-bit integer operand to the floating compute dtype for `DIV`, and the default output dtype then follows the *promoted* lhs. The requested dtype has to survive that promotion rather than be overwritten by it, so every input-dtype pair was swept against torch goldens: 3 rounding modes × 4 output dtypes (unset, `float32`, `bfloat16`, `int32`) = 12 combinations per pair, checking both the resulting dtype and the values.

| Input dtypes (a / b) | Verified | Mismatched | Notes |
| --- | --- | --- | --- |
| `bfloat16` / `bfloat16` | 12 | 0 | |
| `float32` / `float32` | 12 | 0 | |
| `int32` / `int32` | 10 | 0 | 2 expected `TT_FATAL` (integer division, `rounding_mode=None`, non-`float32` dtype) |
| `int32` / `bfloat16` | 12 | 0 | lhs promoted |
| `bfloat16` / `int32` | 12 | 0 | rhs promoted |
| `int32` / `float32` | 12 | 0 | lhs promoted |
| `float32` / `int32` | 12 | 0 | rhs promoted |
| `uint32` / `bfloat16` | 12 | 0 | lhs promoted |
| `bfloat16` / `uint32` | 12 | 0 | rhs promoted |
| `uint32` / `float32` | 12 | 0 | lhs promoted |
| `float32` / `uint32` | 12 | 0 | rhs promoted |
| `bfloat16` / `float32` | 12 | 0 | mixed float family |
| `float32` / `bfloat16` | 12 | 0 | mixed float family |
| **Total** | **154** | **0** | 2 expected rejections |

The tensor-scalar overload was swept the same way (4 tensor dtypes × 3 scalar values × 3 rounding modes × 4 output dtypes); see "Out of scope" for the one pre-existing failure it surfaced.

## Test plan

- [x] New `test_div_output_dtype`, `test_div_scalar_output_dtype`, `test_div_int32_inputs_output_dtype` and `test_div_int32_rejects_non_float32_output_dtype` in `test_div_ops.py`, covering both overloads, `ttnn.divide`, and all three rounding modes.
- [x] New `test_div_int32_output_rounds_before_narrowing` checks `floor`/`trunc` with `dtype=int32` against torch over the whole `[-64, 64)` range, so the negative cases cannot silently regress.
- [x] New `test_div_preallocated_output_rounds_before_narrowing` asserts the preallocated path reaches the same values, and that the caller's tensor actually holds the result rather than just the returned handle.
- [x] New `test_div_output_dtype_with_sub_core_grids` covers a restricted core grid combined with an integer output dtype, so the post-rounding typecast cannot quietly drop the restriction.
- [x] New `test_div_mixed_input_dtypes_output_dtype` pins the mixed-input matrix above into CI.
- [x] Two existing tests requested a `float32` output but only asserted against a `bfloat16` golden, so they were passing *because of* the bug. `test_binary_div` now asserts the output dtype; `test_edgecase_dims_eltwise_broadcast_matrix_math` now computes its divide reference in `float32` and compares at 1 ULP, which is tighter than before. (`comp_ulp` assumes the golden is the higher-precision operand; against a genuine `float32` result it downcast the ULP scale, underflowed it to zero, and produced a `0/0` NaN.)

Suites run on Wormhole B0 against the current head of this branch, all green — 8796 passed, 0 failed:

| Suites | Result |
| --- | --- |
| `test_div_ops.py`, `test_binary_ng_typecast.py` | 1756 passed, 9 skipped, 2 xfailed |
| `test_binary_composite.py`, `test_binary_int32.py`, `test_binary_fp32.py`, `test_backward_div.py`, `test_backward_fmod.py` | 1478 passed, 35 skipped |
| `test_binary_dtype_validation.py`, `test_binary_bcast.py`, `test_binaryng_ND.py`, `test_binaryng_fp32.py`, `test_mul.py`, `test_where.py`, backward `addcdiv`/`rdiv`/`remainder`/`div_no_nan` | 5562 passed, 1 skipped, 5 xfailed |

## Out of scope

The tensor-scalar sweep surfaced a separate, pre-existing bug: when the left operand is an integer tensor and the right operand is a float **scalar**, the scalar is truncated to an integer, because it is packed as a runtime arg using `input_tensor_a.dtype()`.

```
ttnn.div(int32_tensor, 2.5)      -> 3.5   (torch: 2.8)    scalar became 2
ttnn.div(int32_tensor, 0.5)      -> inf   (torch: 14)     scalar became 0
ttnn.multiply(int32_tensor, 2.5) -> 14    (torch: 17.5)
ttnn.add(int32_tensor, 2.5)      -> 9     (torch: 9.5)
```

The tensor form is fine (`div(int32_tensor, float32_tensor_of_2.5)` gives `2.8`), because the promotion is guarded by `if constexpr (requires { rhs.dtype(); })` and never applies to scalars. This reproduces with no `dtype=` argument at all and affects `add` and `multiply` equally, so it is unrelated to this change and left untouched.
