### PR TITLE
test: lower ComputeConfig default opt_level O3 -> O1 (CI sanity check)

### DIFF
--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -462,7 +462,7 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         .compile_args = std::move(compile_args),
                         .defines = std::move(defines),
                         .named_compile_args = std::move(named_compile_args),
-                        .opt_level = kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O3),
+                        .opt_level = kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O1),
                         .compiler_include_paths = std::move(compiler_include_paths),
                     };
                 },


### PR DESCRIPTION
Draft/test PR — no functional intent. Lowering the default `ComputeConfig::opt_level` from `O3` to `O1` in `tt_metal/impl/program/program.cpp` to see how CI (sanity tests) reacts.

Not intended to merge.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano-tt/test-compute-opt-level-o1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano-tt/test-compute-opt-level-o1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano-tt/test-compute-opt-level-o1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano-tt/test-compute-opt-level-o1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-tt/test-compute-opt-level-o1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-tt/test-compute-opt-level-o1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano-tt/test-compute-opt-level-o1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano-tt/test-compute-opt-level-o1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano-tt/test-compute-opt-level-o1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano-tt/test-compute-opt-level-o1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano-tt/test-compute-opt-level-o1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano-tt/test-compute-opt-level-o1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano-tt/test-compute-opt-level-o1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano-tt/test-compute-opt-level-o1)