### PR TITLE
Deepseek V4 Functional SWA module

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -408,8 +408,8 @@ models:
     bh_quietbox_2: 80
   demo:
     bh_galaxy: 470
-    bh_sc1: 536
-    bh_sc1_high_power: 191
+    bh_sc1: 541
+    bh_sc1_high_power: 194
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -408,7 +408,7 @@ models:
     bh_quietbox_2: 80
   demo:
     bh_galaxy: 470
-    bh_sc1: 541
+    bh_sc1: 540
     bh_sc1_high_power: 194
     wh_n150: 500
     wh_n150_civ2: 300

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -12,8 +12,8 @@ on:
           Empty or "all" runs every stage. Groups: "module" runs every stage,
           "sdpa_perf" runs ring-joint SDPA and high-bandwidth all-gather,
           "disagg_prefill" runs the disaggregated-prefill runner+producer legs on SC1 and SC4.
-          Valid stages: dsa_mla_glm, glm_chunked, glm_chunked_accuracy, glm_moe, glm_prefill_block, hca_chunked, hca_perf, high_bw_all_gather_perf, k3_kda, k3_kda_perf, k3_mla, k3_mla_perf, k3_mla_trace, kimi_chunked, kimi_chunked_padded, kimi_dflash, kimi_k3_moe, kimi_moe, kimi_moe_perf, kv_cache_table, minimax_prefill_kv_pcc, minimax_prefill_perf, mistral4_chunked_padded, mistral4_mla, mistral4_mla_chunked, mistral4_moe, mistral4_prefill_block, mistral4_prefill_transformer, mla_chunked, moe_gate, prefill_block_determinism, prefill_runner, prefill_runner_kv_pcc, prefill_transformer_determinism, ring_joint_sdpa_perf.
-          Tags (each runs every matching stage): block, ccl, determinism, dflash, dsv4_flash, gate, glm_5_2, hca, kda, kimi_k2_7, kimi_k3, kv_cache, minimax_m3, mistral4, mla, moe, runner, sdpa, transformer.
+          Valid stages: dsa_mla_glm, glm_chunked, glm_chunked_accuracy, glm_moe, glm_prefill_block, hca_chunked, hca_perf, high_bw_all_gather_perf, k3_kda, k3_kda_perf, k3_mla, k3_mla_perf, k3_mla_trace, kimi_chunked, kimi_chunked_padded, kimi_dflash, kimi_k3_moe, kimi_moe, kimi_moe_perf, kv_cache_table, minimax_prefill_kv_pcc, minimax_prefill_perf, mistral4_chunked_padded, mistral4_mla, mistral4_mla_chunked, mistral4_moe, mistral4_prefill_block, mistral4_prefill_transformer, mla_chunked, moe_gate, prefill_block_determinism, prefill_runner, prefill_runner_kv_pcc, prefill_transformer_determinism, ring_joint_sdpa_perf, swa_mixed, swa_perf.
+          Tags (each runs every matching stage): block, ccl, determinism, dflash, dsv4_flash, gate, glm_5_2, hca, kda, kimi_k2_7, kimi_k3, kv_cache, minimax_m3, mistral4, mla, moe, runner, sdpa, swa, transformer.
         required: false
         type: string
         default: "all"

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -1,0 +1,399 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC tests for the DeepSeek-V4 sliding-only attention layer (prefill), against the reference
+modeling_deepseek_v4.py.
+
+Every test drives a public forward -- no TtSWA private method is called directly:
+  - TtSWA.forward, single-shot     4 prompt lengths
+  - TtSWA.forward, chunked         TtSWAState across chunks, 4 scenarios + two 56K runs
+
+Both V4 variants run, flash and pro. Pro has no sliding layer in the real checkpoint, but its
+dimensions are what stress the reductions, so it is kept as a width test.
+
+Prompt lengths are multiples of the 128-token window: the next chunk's first query needs the 128 keys
+before it, so a chunk that ended mid-window would leave the carry unable to name them.
+
+Device-perf for the same layer lives in tests/perf/test_ttnn_swa_perf.py.
+"""
+
+import pytest
+import torch
+from loguru import logger
+from tracy import signpost
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4.configuration_deepseek_v4 import DeepseekV4Config
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4.modeling_deepseek_v4 import (
+    DeepseekV4Attention,
+    DeepseekV4HCACache,
+    DeepseekV4RotaryEmbedding,
+)
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tt.mla.sliding_window_attention import TtSWA
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+_SEED = 42
+# One shape per behaviour: 128 is the shortest legal prompt, 1024 the pad granularity (window * sp),
+# 2048 needs no padding, 5120 is the chunk width.
+_SHAPES = [128, 1024, 2048, 5120]
+# One program must serve every chunk; a sliding layer has no cache write, so nothing may compile after
+# the first chunk at all.
+_WRITE_COMPILES_PER_CHUNK = 0
+
+
+def _config(model_config, num_hidden_layers=4):
+    """Reference config from one variant's dimension constants, with layer 0 forced to sliding.
+
+    ``compress_ratios=[0, ...]`` is the legacy per-layer form the config folds into ``layer_types``;
+    0 maps to "sliding_attention", which is what makes ``DeepseekV4Attention.compressor`` None.
+    ``q_lora_rank`` / ``o_groups`` are explicit for the reason the HCA test gives: their defaults are
+    Flash's values, so a Pro config that omitted them would silently build a hybrid."""
+    m = model_config
+    cfg = DeepseekV4Config(
+        hidden_size=m.EMB_SIZE,
+        head_dim=m.HEAD_DIM,
+        num_attention_heads=m.NUM_ATTENTION_HEADS,
+        q_lora_rank=m.Q_LORA_RANK,
+        o_groups=m.O_GROUPS,
+        num_hidden_layers=num_hidden_layers,
+        compress_ratios=[0] * num_hidden_layers,
+        compress_rates=dict(m.COMPRESS_RATES),
+        compress_rope_theta=m.COMPRESS_ROPE_THETA,
+        rms_norm_eps=m.RMS_NORM_EPS,
+    )
+    cfg._attn_implementation = "eager"  # V4 is eager-only: the sdpa interface silently drops the sinks
+    return cfg
+
+
+# (id, dimension constants, per-chunk floor, long-run floor, single-shot floor).
+#
+# All three floors are measured worst case minus 1e-3, not guessed. Unlike HCA, PCC does not decay with
+# depth here: the only state crossing a chunk boundary is 128 rows, so nothing accumulates and the
+# softmax never widens. Over 56K the worst chunk lands where the shortest scenario does -- flash
+# 0.99913, pro 0.99900, every one of the 20 runs inside 3.4e-4 -- which is why the long floor is the
+# chunked one and not looser.
+_VARIANTS = [
+    ("flash", DeepSeekV4FlashConfig, 0.998, 0.998, 0.998),
+    ("pro", DeepSeekV4ProConfig, 0.998, 0.998, 0.998),
+]
+_MODEL_CONFIGS_CHUNKED = [pytest.param(cfg, chunked, id=name) for name, cfg, chunked, _, _ in _VARIANTS]
+_MODEL_CONFIGS_LONG = [pytest.param(cfg, long, id=name) for name, cfg, _, long, _ in _VARIANTS]
+_MODEL_CONFIGS_FORWARD = [pytest.param(cfg, fwd, id=name) for name, cfg, _, _, fwd in _VARIANTS]
+
+# Blackhole runs a mesh config only when it uses every chip, so one shape per box class.
+_MESH_CONFIGS = [
+    pytest.param(
+        (2, 2),
+        fabric2d_device_params(),
+        ttnn.Topology.Linear,
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+        id="fabric2d-mesh-2x2",
+    ),
+    pytest.param(
+        (4, 2),
+        fabric2d_device_params(),
+        ttnn.Topology.Linear,
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
+        id="fabric2d-mesh-4x2",
+    ),
+    pytest.param(
+        (8, 4),
+        torus_xy_device_params(),
+        ttnn.Topology.Ring,
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+        id="torus-xy-8x4",
+    ),
+]
+
+_CHUNKED_SCENARIOS = [
+    ("2chunk-ragged", 4096, [4096, 3072]),  # the other chunk width, and a short final chunk
+    ("chunk5120-full", 5120, [5120, 5120]),  # what the perf gate measures
+    ("chunk5120-ragged", 5120, [5120, 5120, 3072]),  # three chunks, last one short
+    # Non-final chunks below chunk_size. Pins the place real_len and the padded slab width must not be
+    # confused: the carry, which the next chunk's first chip reads.
+    ("chunk5120-varying", 5120, [1024, 256, 5120]),
+]
+
+# The two 56,320-token scenarios are the same length by construction, so the mixed one differs only in
+# how the tokens are split -- every chunk a multiple of the window, none wider than chunk_size.
+_LONG_SCENARIOS = [
+    pytest.param("11x5120", 5120, [5120] * 11, id="11x5120"),
+    pytest.param(
+        "mixed5120",
+        5120,
+        [1024, 256, 5120, 2048, 5120, 5120, 3072, 5120, 640, 5120, 5120, 4096, 5120, 5120, 4224],
+        id="mixed5120",
+    ),
+]
+
+
+def _build_reference(config):
+    """A randomised sliding-only reference layer. Weights are perturbed the way the HCA test does, so a
+    PCC pass cannot come from near-identity norms."""
+    ref = DeepseekV4Attention(config, layer_idx=0).eval()
+    assert ref.compressor is None, "layer_idx=0 must be a sliding_attention layer for TtSWA"
+    with torch.no_grad():
+        ref.q_a_norm.weight.uniform_(0.5, 1.5)
+        ref.kv_norm.weight.uniform_(0.5, 1.5)
+        ref.sinks.normal_(0.0, 1.0)
+    # The layer itself carries none: HCA reads its compressor's, a sliding layer's comes from the model.
+    ref.rotary_emb = DeepseekV4RotaryEmbedding(config)
+    return ref
+
+
+def _reference_forward(ref, config, hidden, total, batch):
+    """One unchunked pass over the whole prompt: the ground truth every chunk is compared against.
+
+    Deliberately not chunked, so the chunked path has to reproduce plain attention rather than agree
+    with a reference that shares its assumptions."""
+    sw = config.sliding_window
+    position_ids = torch.arange(total).unsqueeze(0).expand(batch, -1)
+    with torch.no_grad():
+        cos, sin = ref.rotary_emb(hidden, position_ids=position_ids, layer_type="main")
+        i = torch.arange(total).view(total, 1)
+        j = torch.arange(total).view(1, total)
+        attn_mask = torch.zeros(total, total).masked_fill(~((j <= i) & (i - j < sw)), float("-inf"))
+        attn_mask = attn_mask.view(1, 1, total, total).expand(batch, 1, total, total)
+        out_ref, _ = ref(hidden, {"main": (cos, sin)}, position_ids, attn_mask, past_key_values=None)
+    return out_ref
+
+
+class _RefCache:
+    """Minimal ``past_key_values`` for driving the reference chunk by chunk: the attention calls
+    ``.update(k, v, layer_idx)`` on the container.
+
+    ``DeepseekV4HCACache`` is used for its update body, which is the plain shared-KV sliding-window
+    one every V4 layer shares; its compressor dicts stay untouched on a sliding-only layer."""
+
+    def __init__(self, layer):
+        self.layers = [layer]
+
+    def update(self, key_states, value_states, layer_idx, *args, **kwargs):
+        return self.layers[layer_idx].update(key_states, value_states)
+
+
+def _sliding_mask(q_pos, k_pos, sliding_window):
+    i, j = q_pos.view(-1, 1), k_pos.view(1, -1)
+    allowed = (j <= i) & (i - j < sliding_window)
+    return torch.zeros(i.shape[0], j.shape[1]).masked_fill(~allowed, float("-inf"))
+
+
+def _prepare_input(hidden, sp_factor, window):
+    """Pad the prompt up to a whole number of windows per chip, the granularity alloc_state asserts."""
+    align = window * sp_factor
+    real = hidden.shape[1]
+    padded = -(-real // align) * align
+    if padded == real:
+        return hidden, real
+    out = torch.zeros(hidden.shape[0], padded, hidden.shape[2], dtype=hidden.dtype)
+    out[:, :real] = hidden
+    return out, real
+
+
+def _to_device(chunk, mesh_device):
+    return ttnn.from_torch(
+        chunk.unsqueeze(1),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(  # seq @ SP, hidden @ TP
+            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=(2, 3)
+        ),
+    )
+
+
+def _from_device(out_tt, mesh_device):
+    return ttnn.to_torch(
+        out_tt,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=(2, 3)),
+    ).squeeze(1)
+
+
+def _report_chunk_pccs(pccs, floor):
+    """Log every chunk's PCC, then judge them together: the per-chunk numbers describe how error grows
+    with depth, and a single failing chunk is more useful reported alongside its neighbours."""
+    for it, kv_actual, valid, pcc in pccs:
+        logger.debug(f"  chunk {it}: kv_actual={kv_actual} valid={valid} PCC={pcc}")
+    worst = min(pccs, key=lambda row: row[3])
+    logger.info(f"worst chunk: iter={worst[0]} kv_actual={worst[1]} PCC={worst[3]} (floor {floor})")
+    assert worst[3] >= floor, f"chunk {worst[0]} (kv_actual={worst[1]}) PCC {worst[3]} below floor {floor}"
+
+
+def _run_chunked(mesh_device, topology, chunk_size, iters_valid, model_config, floor, label):
+    """Shared body for the chunked and the long scenarios: they differ only in the chunk list."""
+    torch.manual_seed(_SEED)
+    batch = 1
+    config = _config(model_config)
+    total = sum(iters_valid)
+
+    ref = _build_reference(config)
+    hidden = torch.randn(batch, total, config.hidden_size)
+    out_ref = _reference_forward(ref, config, hidden, total, batch)
+
+    tt_model = TtSWA.from_reference(mesh_device, ref, config, sp_axis=0, tp_axis=1, topology=topology)
+    state = tt_model.alloc_state(total, chunk_tokens=chunk_size)
+    logger.debug(f"mesh={tuple(mesh_device.shape)} {label} chunk_size={chunk_size} iters={iters_valid}")
+
+    signpost("SWA_START")
+    kv_actual = 0
+    pccs = []
+    programs = mesh_device.num_program_cache_entries()
+    for it, valid in enumerate(iters_valid):
+        # Fixed device width every chunk; a short final chunk is padded up to it.
+        chunk = torch.zeros(batch, chunk_size, config.hidden_size)
+        chunk[:, :valid] = hidden[:, kv_actual : kv_actual + valid]
+
+        out_tt = tt_model(_to_device(chunk, mesh_device), seq_len_actual=valid, state=state)
+        out = _from_device(out_tt, mesh_device)[:, :valid]
+
+        expected = out_ref[:, kv_actual : kv_actual + valid]
+        _, pcc = comp_pcc(expected.to(torch.float32), out.to(torch.float32))
+        pccs.append((it, kv_actual, valid, pcc))
+
+        # Every chunk drives identical device shapes, so one compiled program must serve them all. A new
+        # entry means some op's attributes moved with the chunk -- exactly what breaks trace later.
+        now = mesh_device.num_program_cache_entries()
+        logger.debug(f"  iter {it}: program cache {programs} -> {now} (+{now - programs})")
+        if it > 0:
+            assert now - programs == _WRITE_COMPILES_PER_CHUNK, (
+                f"chunk {it} compiled {now - programs} new program(s) ({programs} -> {now}), expected "
+                f"{_WRITE_COMPILES_PER_CHUNK}; an op attribute or a shape changed between chunks"
+            )
+        programs = now
+        kv_actual += valid
+    signpost("SWA_END")
+
+    _report_chunk_pccs(pccs, floor)
+    assert state.kv_actual == total
+
+
+@pytest.mark.parametrize("seq_len", _SHAPES, ids=[f"seq{s}" for s in _SHAPES])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, topology",
+    _MESH_CONFIGS,
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("model_config, forward_pcc", _MODEL_CONFIGS_FORWARD)
+def test_swa_forward_mesh(mesh_device, device_params, topology, seq_len, model_config, forward_pcc):
+    """Single-shot TtSWA.forward, SP+TP sharded. Proves the halo and the first-chunk mask variant: chip
+    0's history does not exist yet, and the 128 zero rows standing in for it must not reach the
+    softmax."""
+    torch.manual_seed(_SEED)
+
+    batch = 1
+    config = _config(model_config)
+    sp_factor = mesh_device.shape[0]
+
+    ref = _build_reference(config)
+    hidden = torch.randn(batch, seq_len, config.hidden_size)
+    out_ref = _reference_forward(ref, config, hidden, seq_len, batch)
+
+    tt_model = TtSWA.from_reference(mesh_device, ref, config, sp_axis=0, tp_axis=1, topology=topology)
+    hidden_padded, seq_len_actual = _prepare_input(hidden, sp_factor, config.sliding_window)
+    logger.debug(f"mesh={tuple(mesh_device.shape)} S_real={seq_len_actual} S_pad={hidden_padded.shape[1]}")
+
+    state = tt_model.alloc_state(hidden_padded.shape[1])  # a one-chunk prefill still owns its state
+    signpost("SWA_START")
+    out_tt = tt_model(_to_device(hidden_padded, mesh_device), seq_len_actual=seq_len_actual, state=state)
+    signpost("SWA_END")
+    out = _from_device(out_tt, mesh_device)[:, :seq_len_actual]
+
+    assert out.shape == out_ref.shape, f"shape mismatch: tt {tuple(out.shape)} vs ref {tuple(out_ref.shape)}"
+    passed, message = assert_with_pcc(out_ref.to(torch.float32), out.to(torch.float32), pcc=forward_pcc)
+    logger.debug(f"mesh SWA layer PCC: {message}")
+    assert passed, f"SWA mesh layer PCC test failed: {message}"
+
+
+@pytest.mark.parametrize("name, chunk_size, iters_valid", _CHUNKED_SCENARIOS, ids=[n for n, _, _ in _CHUNKED_SCENARIOS])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, topology",
+    _MESH_CONFIGS,
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("model_config, chunked_pcc", _MODEL_CONFIGS_CHUNKED)
+def test_swa_chunked_prefill_mesh(
+    mesh_device, device_params, topology, name, chunk_size, iters_valid, model_config, chunked_pcc
+):
+    """Chunked prefill with TtSWAState carried across chunks."""
+    _run_chunked(mesh_device, topology, chunk_size, iters_valid, model_config, chunked_pcc, f"scenario={name}")
+
+
+@pytest.mark.parametrize("name, chunk_size, iters_valid", _LONG_SCENARIOS)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, topology",
+    _MESH_CONFIGS,
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("model_config, long_pcc", _MODEL_CONFIGS_LONG)
+@pytest.mark.timeout(0)
+def test_swa_long_prefill_mesh(
+    mesh_device, device_params, topology, name, chunk_size, iters_valid, model_config, long_pcc
+):
+    """The demo context, 56,320 tokens, split two ways. This is where the carry crosses fifteen chunk
+    boundaries and where a ragged non-final chunk actually appears.
+
+    The reference is chunked here, unlike the short scenarios. An unchunked one is not an option at
+    this length: eager attention (forced, since sinks make V4 eager-only) materializes an [S, S] mask,
+    12.7 GB at 56K, and the scores on top of it. The short scenarios are what pin chunked == plain
+    attention; this test only shows it stays true that many chunks deep."""
+    torch.manual_seed(_SEED)
+
+    batch = 1
+    config = _config(model_config)
+    sw = config.sliding_window
+    total = sum(iters_valid)
+
+    ref = _build_reference(config)
+    hidden = torch.randn(batch, total, config.hidden_size)
+    position_ids = torch.arange(total).unsqueeze(0).expand(batch, -1)
+
+    tt_model = TtSWA.from_reference(mesh_device, ref, config, sp_axis=0, tp_axis=1, topology=topology)
+    state = tt_model.alloc_state(total, chunk_tokens=chunk_size)
+    ref_cache = _RefCache(DeepseekV4HCACache(config))
+    logger.debug(f"mesh={tuple(mesh_device.shape)} long={name} chunks={len(iters_valid)} total={total}")
+
+    signpost("SWA_START")
+    kv_actual = 0
+    pccs = []
+    programs = mesh_device.num_program_cache_entries()
+    for it, valid in enumerate(iters_valid):
+        real = hidden[:, kv_actual : kv_actual + valid]
+        chunk_pos = position_ids[:, kv_actual : kv_actual + valid]
+
+        # The reference cache returns [carry | chunk] from update(), so the mask must cover exactly
+        # those keys -- sw - 1 of history, which is what its slice keeps.
+        carry = min(sw - 1, kv_actual)
+        k_pos = torch.cat([torch.arange(kv_actual - carry, kv_actual), chunk_pos[0]])
+        ref_mask = _sliding_mask(chunk_pos[0], k_pos, sw).view(1, 1, valid, -1).expand(batch, 1, -1, -1)
+        with torch.no_grad():
+            cos, sin = ref.rotary_emb(real, position_ids=chunk_pos, layer_type="main")
+            expected, _ = ref(real, {"main": (cos, sin)}, chunk_pos, ref_mask, past_key_values=ref_cache)
+
+        # Fixed device width every chunk; a short chunk is padded up to it.
+        chunk = torch.zeros(batch, chunk_size, config.hidden_size)
+        chunk[:, :valid] = real
+        out_tt = tt_model(_to_device(chunk, mesh_device), seq_len_actual=valid, state=state)
+        out = _from_device(out_tt, mesh_device)[:, :valid]
+
+        _, pcc = comp_pcc(expected.to(torch.float32), out.to(torch.float32))
+        pccs.append((it, kv_actual, valid, pcc))
+
+        now = mesh_device.num_program_cache_entries()
+        logger.debug(f"  iter {it}: program cache {programs} -> {now} (+{now - programs})")
+        if it > 0:
+            assert now - programs == _WRITE_COMPILES_PER_CHUNK, (
+                f"chunk {it} compiled {now - programs} new program(s) ({programs} -> {now}), expected "
+                f"{_WRITE_COMPILES_PER_CHUNK}; an op attribute or a shape changed between chunks"
+            )
+        programs = now
+        kv_actual += valid
+    signpost("SWA_END")
+
+    _report_chunk_pccs(pccs, long_pcc)
+    assert state.kv_actual == total

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -98,6 +98,7 @@ _CHUNKED_SCENARIOS = [
     # Non-final chunks below chunk_size: real_len and the padded slab width must not be confused.
     ("chunk5120-varying", 5120, [1024, 256, 5120]),
     ("chunk1024-ragged", 1024, [1024, 1024, 1000]),  # a final chunk 8 tokens past a tile row
+    ("chunk1280", 1280, [1280, 1280, 1000]),  # whole tiles per chip, but not a whole number of windows
     # Non-final chunks below the window, which the carry can serve only by reaching back into itself.
     ("sub-window", 5120, [1024, 32, 96, 128, 5120, 1000]),
 ]

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -2,23 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-PCC tests for the DeepSeek-V4 sliding-only attention layer (prefill), against the reference
-modeling_deepseek_v4.py.
+"""PCC tests for the DeepSeek-V4 sliding-only attention layer (prefill), against the reference.
 
-Every test drives a public forward -- no TtSWA private method is called directly:
-  - TtSWA.forward, single-shot     4 prompt lengths
-  - TtSWA.forward, chunked         TtSWAState across chunks, 4 scenarios + two 56K runs
+Both V4 variants run. Pro has no sliding layer in the real checkpoint, but its dimensions are what
+stress the reductions, so it is kept as a width test.
 
-Both V4 variants run, flash and pro. Pro has no sliding layer in the real checkpoint, but its
-dimensions are what stress the reductions, so it is kept as a width test.
-
-Non-final chunks are multiples of the 128-token window: the next chunk's first query needs the 128
-keys before it, so a chunk that ended mid-window would leave the carry unable to name them. A FINAL
-chunk may be ragged -- nothing reads its carry -- which is what the 3000-token tails cover. Same rule
-as TtHCA's, so one chunk sequence is valid for both layers.
-
-Device-perf for the same layer lives in tests/perf/test_ttnn_swa_perf.py.
+A non-final chunk must end on a tile row; a final one may end anywhere. Device-perf for the same
+layer lives in tests/perf/test_ttnn_swa_perf.py.
 """
 
 import pytest
@@ -41,21 +31,17 @@ from models.demos.deepseek_v3_d_p.tt.mla.sliding_window_attention import TtSWA
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 _SEED = 42
-# One shape per behaviour: 128 is the shortest legal prompt, 1024 the pad granularity (window * sp),
-# 2048 needs no padding, 5120 is the chunk width.
+# Shortest legal prompt, the pad granularity, one needing no padding, and the chunk width.
 _SHAPES = [128, 1024, 2048, 5120]
-# One program must serve every chunk; a sliding layer has no cache write, so nothing may compile after
-# the first chunk at all.
+# A sliding layer has no cache write, so nothing may compile after the first chunk at all.
 _WRITE_COMPILES_PER_CHUNK = 0
 
 
 def _config(model_config, num_hidden_layers=4):
     """Reference config from one variant's dimension constants, with layer 0 forced to sliding.
 
-    ``compress_ratios=[0, ...]`` is the legacy per-layer form the config folds into ``layer_types``;
-    0 maps to "sliding_attention", which is what makes ``DeepseekV4Attention.compressor`` None.
-    ``q_lora_rank`` / ``o_groups`` are explicit for the reason the HCA test gives: their defaults are
-    Flash's values, so a Pro config that omitted them would silently build a hybrid."""
+    ``compress_ratios=[0, ...]`` folds into ``layer_types``, and 0 means "sliding_attention".
+    ``q_lora_rank`` / ``o_groups`` are explicit because their defaults are Flash's."""
     m = model_config
     cfg = DeepseekV4Config(
         hidden_size=m.EMB_SIZE,
@@ -73,13 +59,9 @@ def _config(model_config, num_hidden_layers=4):
     return cfg
 
 
-# (id, dimension constants, per-chunk floor, long-run floor, single-shot floor).
-#
-# All three floors are measured worst case minus 1e-3, not guessed. Unlike HCA, PCC does not decay with
-# depth here: the only state crossing a chunk boundary is 128 rows, so nothing accumulates and the
-# softmax never widens. Over 56K the worst chunk lands where the shortest scenario does -- flash
-# 0.99913, pro 0.99900, every one of the 20 runs inside 3.4e-4 -- which is why the long floor is the
-# chunked one and not looser.
+# (id, dimension constants, per-chunk floor, long-run floor, single-shot floor). Measured worst case
+# minus 1e-3. All three are equal because PCC does not decay with depth here: the only state crossing a
+# chunk boundary is one window, so nothing accumulates and the softmax never widens.
 _VARIANTS = [
     ("flash", DeepSeekV4FlashConfig, 0.998, 0.998, 0.998),
     ("pro", DeepSeekV4ProConfig, 0.998, 0.998, 0.998),
@@ -117,18 +99,14 @@ _CHUNKED_SCENARIOS = [
     ("2chunk-ragged", 4096, [4096, 3000]),  # the other chunk width, and a final chunk ending mid-tile
     ("chunk5120-full", 5120, [5120, 5120]),  # what the perf gate measures
     ("chunk5120-ragged", 5120, [5120, 5120, 3000]),  # three chunks, last one ragged
-    # Non-final chunks below chunk_size. Pins the place real_len and the padded slab width must not be
-    # confused: the carry, which the next chunk's first chip reads.
+    # Non-final chunks below chunk_size: real_len and the padded slab width must not be confused.
     ("chunk5120-varying", 5120, [1024, 256, 5120]),
     ("chunk1024-ragged", 1024, [1024, 1024, 1000]),  # a final chunk 8 tokens past a tile row
-    # Non-final chunks BELOW the 128-token window, which the carry can only serve by reaching back
-    # into itself: after the 32-token chunk the last 128 keys are 96 of the previous carry and 32 new.
-    # A carry cut out of the chunk alone cannot express that, so this is the case that pins it.
+    # Non-final chunks below the window, which the carry can serve only by reaching back into itself.
     ("sub-window", 5120, [1024, 32, 96, 128, 5120, 1000]),
 ]
 
-# The two 56,320-token scenarios are the same length by construction, so the mixed one differs only in
-# how the tokens are split -- every chunk a multiple of the window, none wider than chunk_size.
+# Same length by construction, so the mixed one differs only in how the tokens are split.
 _LONG_SCENARIOS = [
     pytest.param("11x5120", 5120, [5120] * 11, id="11x5120"),
     pytest.param(
@@ -141,8 +119,7 @@ _LONG_SCENARIOS = [
 
 
 def _build_reference(config):
-    """A randomised sliding-only reference layer. Weights are perturbed the way the HCA test does, so a
-    PCC pass cannot come from near-identity norms."""
+    """A randomised sliding-only reference layer, so a PCC pass cannot come from near-identity norms."""
     ref = DeepseekV4Attention(config, layer_idx=0).eval()
     assert ref.compressor is None, "layer_idx=0 must be a sliding_attention layer for TtSWA"
     with torch.no_grad():
@@ -155,10 +132,8 @@ def _build_reference(config):
 
 
 def _reference_forward(ref, config, hidden, total, batch):
-    """One unchunked pass over the whole prompt: the ground truth every chunk is compared against.
-
-    Deliberately not chunked, so the chunked path has to reproduce plain attention rather than agree
-    with a reference that shares its assumptions."""
+    """One UNCHUNKED pass over the whole prompt, so the chunked path has to reproduce plain attention
+    rather than agree with a reference sharing its assumptions."""
     sw = config.sliding_window
     position_ids = torch.arange(total).unsqueeze(0).expand(batch, -1)
     with torch.no_grad():
@@ -172,11 +147,8 @@ def _reference_forward(ref, config, hidden, total, batch):
 
 
 class _RefCache:
-    """Minimal ``past_key_values`` for driving the reference chunk by chunk: the attention calls
-    ``.update(k, v, layer_idx)`` on the container.
-
-    ``DeepseekV4HCACache`` is used for its update body, which is the plain shared-KV sliding-window
-    one every V4 layer shares; its compressor dicts stay untouched on a sliding-only layer."""
+    """Minimal ``past_key_values`` for driving the reference chunk by chunk. ``DeepseekV4HCACache`` is
+    used for its update body, the plain shared-KV sliding-window one every V4 layer shares."""
 
     def __init__(self, layer):
         self.layers = [layer]
@@ -223,8 +195,7 @@ def _from_device(out_tt, mesh_device):
 
 
 def _report_chunk_pccs(pccs, floor):
-    """Log every chunk's PCC, then judge them together: the per-chunk numbers describe how error grows
-    with depth, and a single failing chunk is more useful reported alongside its neighbours."""
+    """Log every chunk's PCC, then judge them together: a failing chunk reads better beside its neighbours."""
     for it, kv_actual, valid, pcc in pccs:
         logger.debug(f"  chunk {it}: kv_actual={kv_actual} valid={valid} PCC={pcc}")
     worst = min(pccs, key=lambda row: row[3])
@@ -263,8 +234,7 @@ def _run_chunked(mesh_device, topology, chunk_size, iters_valid, model_config, f
         _, pcc = comp_pcc(expected.to(torch.float32), out.to(torch.float32))
         pccs.append((it, kv_actual, valid, pcc))
 
-        # Every chunk drives identical device shapes, so one compiled program must serve them all. A new
-        # entry means some op's attributes moved with the chunk -- exactly what breaks trace later.
+        # Identical device shapes every chunk, so a new entry means an op attribute moved with the chunk.
         now = mesh_device.num_program_cache_entries()
         logger.debug(f"  iter {it}: program cache {programs} -> {now} (+{now - programs})")
         if it > 0:
@@ -288,9 +258,8 @@ def _run_chunked(mesh_device, topology, chunk_size, iters_valid, model_config, f
 )
 @pytest.mark.parametrize("model_config, forward_pcc", _MODEL_CONFIGS_FORWARD)
 def test_swa_forward_mesh(mesh_device, device_params, topology, seq_len, model_config, forward_pcc):
-    """Single-shot TtSWA.forward, SP+TP sharded. Proves the halo and the first-chunk mask variant: chip
-    0's history does not exist yet, and the 128 zero rows standing in for it must not reach the
-    softmax."""
+    """Single-shot TtSWA.forward, SP+TP sharded. Proves the halo and the first-chunk mask variant:
+    chip 0 has no history yet, and the zero rows standing in for it must not reach the softmax."""
     torch.manual_seed(_SEED)
 
     batch = 1
@@ -342,13 +311,11 @@ def test_swa_chunked_prefill_mesh(
 def test_swa_long_prefill_mesh(
     mesh_device, device_params, topology, name, chunk_size, iters_valid, model_config, long_pcc
 ):
-    """The demo context, 56,320 tokens, split two ways. This is where the carry crosses fifteen chunk
-    boundaries and where a ragged non-final chunk actually appears.
+    """The demo context, split two ways.
 
-    The reference is chunked here, unlike the short scenarios. An unchunked one is not an option at
-    this length: eager attention (forced, since sinks make V4 eager-only) materializes an [S, S] mask,
-    12.7 GB at 56K, and the scores on top of it. The short scenarios are what pin chunked == plain
-    attention; this test only shows it stays true that many chunks deep."""
+    The reference is CHUNKED here, unlike the short scenarios: an unchunked one would materialize an
+    [S, S] mask, which does not fit at this length. The short scenarios are what pin chunked == plain
+    attention; this only shows it stays true that many chunks deep."""
     torch.manual_seed(_SEED)
 
     batch = 1

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -34,6 +34,18 @@ _SHAPES = [128, 130, 1024, 2048, 4095, 5120]
 _WRITE_COMPILES_PER_CHUNK = 0
 
 
+def _ci_unsupported_param_combos_swa(**params):
+    """The Blackhole e2e pipeline collects this whole folder, so every leg it should not run has to
+    opt out here rather than be filtered by name in the pipeline's -k expression."""
+    return params["is_ci_env"] or params["is_ci_v2_env"]
+
+
+def _ci_unsupported_param_combos_swa_long(**params):
+    if not (params["is_ci_env"] or params["is_ci_v2_env"]):
+        return False
+    return params["name"] != "mixed5120"
+
+
 def _config(model_config, num_hidden_layers=4):
     """Reference config from one variant's dimension constants, with layer 0 forced to sliding.
 
@@ -246,6 +258,7 @@ def _run_chunked(mesh_device, topology, chunk_size, iters_valid, model_config, f
     assert state.kv_actual == total
 
 
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_swa)
 @pytest.mark.parametrize("seq_len", _SHAPES, ids=[f"seq{s}" for s in _SHAPES])
 @pytest.mark.parametrize(
     "mesh_device, device_params, topology",
@@ -282,6 +295,7 @@ def test_swa_forward_mesh(mesh_device, device_params, topology, seq_len, model_c
     assert passed, f"SWA mesh layer PCC test failed: {message}"
 
 
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_swa)
 @pytest.mark.parametrize("name, chunk_size, iters_valid", _CHUNKED_SCENARIOS, ids=[n for n, _, _ in _CHUNKED_SCENARIOS])
 @pytest.mark.parametrize(
     "mesh_device, device_params, topology",
@@ -296,6 +310,7 @@ def test_swa_chunked_prefill_mesh(
     _run_chunked(mesh_device, topology, chunk_size, iters_valid, model_config, chunked_pcc, f"scenario={name}")
 
 
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_swa_long)
 @pytest.mark.parametrize("name, chunk_size, iters_valid", _LONG_SCENARIOS)
 @pytest.mark.parametrize(
     "mesh_device, device_params, topology",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -4,11 +4,11 @@
 
 """PCC tests for the DeepSeek-V4 sliding-only attention layer (prefill), against the reference.
 
-Both V4 variants run. Pro has no sliding layer in the real checkpoint, but its dimensions are what
-stress the reductions, so it is kept as a width test.
+Both V4 variants run. Pro has no sliding layer in the real checkpoint, but its dimensions stress the
+reductions, so it is kept as a width test.
 
-A non-final chunk must end on a tile row; a final one may end anywhere. Device-perf for the same
-layer lives in tests/perf/test_ttnn_swa_perf.py.
+A non-final chunk must end on a tile row; a final one may end anywhere. Device-perf lives in
+tests/perf/test_ttnn_swa_perf.py.
 """
 
 import pytest
@@ -31,8 +31,8 @@ from models.demos.deepseek_v3_d_p.tt.mla.sliding_window_attention import TtSWA
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 _SEED = 42
-# Shortest legal prompt, the pad granularity, one needing no padding, the chunk width, and HCA's two
-# ragged lengths: a single-shot prompt is a final chunk, which may end anywhere.
+# Shortest legal prompt, the pad granularity, one needing no padding, the chunk width, and two lengths
+# that end mid-tile: a single-shot prompt is a final chunk, which may end anywhere.
 _SHAPES = [128, 130, 1024, 2048, 4095, 5120]
 # A sliding layer has no cache write, so nothing may compile after the first chunk at all.
 _WRITE_COMPILES_PER_CHUNK = 0
@@ -60,9 +60,9 @@ def _config(model_config, num_hidden_layers=4):
     return cfg
 
 
-# (id, dimension constants, per-chunk floor, long-run floor, single-shot floor). Measured worst case
-# minus 1e-3. All three are equal because PCC does not decay with depth here: the only state crossing a
-# chunk boundary is one window, so nothing accumulates and the softmax never widens.
+# (id, dimension constants, per-chunk floor, long-run floor, single-shot floor). All three are equal
+# because the only state crossing a chunk boundary is one window, so error does not accumulate with
+# depth and the softmax never widens.
 _VARIANTS = [
     ("flash", DeepSeekV4FlashConfig, 0.998, 0.998, 0.998),
     ("pro", DeepSeekV4ProConfig, 0.998, 0.998, 0.998),
@@ -127,14 +127,13 @@ def _build_reference(config):
         ref.q_a_norm.weight.uniform_(0.5, 1.5)
         ref.kv_norm.weight.uniform_(0.5, 1.5)
         ref.sinks.normal_(0.0, 1.0)
-    # The layer itself carries none: HCA reads its compressor's, a sliding layer's comes from the model.
+    # A sliding layer carries no rotary_emb of its own; the config determines it.
     ref.rotary_emb = DeepseekV4RotaryEmbedding(config)
     return ref
 
 
 def _reference_forward(ref, config, hidden, total, batch):
-    """One UNCHUNKED pass over the whole prompt, so the chunked path has to reproduce plain attention
-    rather than agree with a reference sharing its assumptions."""
+    """One unchunked pass over the whole prompt: plain attention, which the chunked path must reproduce."""
     sw = config.sliding_window
     position_ids = torch.arange(total).unsqueeze(0).expand(batch, -1)
     with torch.no_grad():
@@ -148,8 +147,8 @@ def _reference_forward(ref, config, hidden, total, batch):
 
 
 class _RefCache:
-    """Minimal ``past_key_values`` for driving the reference chunk by chunk. ``DeepseekV4HCACache`` is
-    used for its update body, the plain shared-KV sliding-window one every V4 layer shares."""
+    """Minimal ``past_key_values`` for driving the reference chunk by chunk. ``DeepseekV4HCACache``
+    supplies the shared-KV sliding-window update body every V4 layer uses."""
 
     def __init__(self, layer):
         self.layers = [layer]
@@ -314,9 +313,8 @@ def test_swa_long_prefill_mesh(
 ):
     """The demo context, split two ways.
 
-    The reference is CHUNKED here, unlike the short scenarios: an unchunked one would materialize an
-    [S, S] mask, which does not fit at this length. The short scenarios are what pin chunked == plain
-    attention; this only shows it stays true that many chunks deep."""
+    The reference runs chunked: an unchunked one would materialize an [S, S] mask, which does not fit
+    at this length. What this test shows is that the carry stays correct that many chunks deep."""
     torch.manual_seed(_SEED)
 
     batch = 1
@@ -341,8 +339,8 @@ def test_swa_long_prefill_mesh(
         real = hidden[:, kv_actual : kv_actual + valid]
         chunk_pos = position_ids[:, kv_actual : kv_actual + valid]
 
-        # The reference cache returns [carry | chunk] from update(), so the mask must cover exactly
-        # those keys -- sw - 1 of history, which is what its slice keeps.
+        # The reference cache returns [carry | chunk] from update(), so the mask covers sw - 1 of
+        # history plus the chunk.
         carry = min(sw - 1, kv_actual)
         k_pos = torch.cat([torch.arange(kv_actual - carry, kv_actual), chunk_pos[0]])
         ref_mask = _sliding_mask(chunk_pos[0], k_pos, sw).view(1, 1, valid, -1).expand(batch, 1, -1, -1)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -31,8 +31,9 @@ from models.demos.deepseek_v3_d_p.tt.mla.sliding_window_attention import TtSWA
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 _SEED = 42
-# Shortest legal prompt, the pad granularity, one needing no padding, and the chunk width.
-_SHAPES = [128, 1024, 2048, 5120]
+# Shortest legal prompt, the pad granularity, one needing no padding, the chunk width, and HCA's two
+# ragged lengths: a single-shot prompt is a final chunk, which may end anywhere.
+_SHAPES = [128, 130, 1024, 2048, 4095, 5120]
 # A sliding layer has no cache write, so nothing may compile after the first chunk at all.
 _WRITE_COMPILES_PER_CHUNK = 0
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -4,9 +4,6 @@
 
 """PCC tests for the DeepSeek-V4 sliding-only attention layer (prefill), against the reference.
 
-Both V4 variants run. Pro has no sliding layer in the real checkpoint, but its dimensions stress the
-reductions, so it is kept as a width test.
-
 A non-final chunk must end on a tile row; a final one may end anywhere. Device-perf lives in
 tests/perf/test_ttnn_swa_perf.py.
 """
@@ -25,7 +22,6 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v4.modeling_deepseek_v4 imp
     DeepseekV4RotaryEmbedding,
 )
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
-from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.sliding_window_attention import TtSWA
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -65,7 +61,6 @@ def _config(model_config, num_hidden_layers=4):
 # depth and the softmax never widens.
 _VARIANTS = [
     ("flash", DeepSeekV4FlashConfig, 0.998, 0.998, 0.998),
-    ("pro", DeepSeekV4ProConfig, 0.998, 0.998, 0.998),
 ]
 _MODEL_CONFIGS_CHUNKED = [pytest.param(cfg, chunked, id=name) for name, cfg, chunked, _, _ in _VARIANTS]
 _MODEL_CONFIGS_LONG = [pytest.param(cfg, long, id=name) for name, cfg, _, long, _ in _VARIANTS]

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py
@@ -13,8 +13,10 @@ Every test drives a public forward -- no TtSWA private method is called directly
 Both V4 variants run, flash and pro. Pro has no sliding layer in the real checkpoint, but its
 dimensions are what stress the reductions, so it is kept as a width test.
 
-Prompt lengths are multiples of the 128-token window: the next chunk's first query needs the 128 keys
-before it, so a chunk that ended mid-window would leave the carry unable to name them.
+Non-final chunks are multiples of the 128-token window: the next chunk's first query needs the 128
+keys before it, so a chunk that ended mid-window would leave the carry unable to name them. A FINAL
+chunk may be ragged -- nothing reads its carry -- which is what the 3000-token tails cover. Same rule
+as TtHCA's, so one chunk sequence is valid for both layers.
 
 Device-perf for the same layer lives in tests/perf/test_ttnn_swa_perf.py.
 """
@@ -112,12 +114,17 @@ _MESH_CONFIGS = [
 ]
 
 _CHUNKED_SCENARIOS = [
-    ("2chunk-ragged", 4096, [4096, 3072]),  # the other chunk width, and a short final chunk
+    ("2chunk-ragged", 4096, [4096, 3000]),  # the other chunk width, and a final chunk ending mid-tile
     ("chunk5120-full", 5120, [5120, 5120]),  # what the perf gate measures
-    ("chunk5120-ragged", 5120, [5120, 5120, 3072]),  # three chunks, last one short
+    ("chunk5120-ragged", 5120, [5120, 5120, 3000]),  # three chunks, last one ragged
     # Non-final chunks below chunk_size. Pins the place real_len and the padded slab width must not be
     # confused: the carry, which the next chunk's first chip reads.
     ("chunk5120-varying", 5120, [1024, 256, 5120]),
+    ("chunk1024-ragged", 1024, [1024, 1024, 1000]),  # a final chunk 8 tokens past a tile row
+    # Non-final chunks BELOW the 128-token window, which the carry can only serve by reaching back
+    # into itself: after the 32-token chunk the last 128 keys are 96 of the previous carry and 32 new.
+    # A carry cut out of the chunk alone cannot express that, so this is the case that pins it.
+    ("sub-window", 5120, [1024, 32, 96, 128, 5120, 1000]),
 ]
 
 # The two 56,320-token scenarios are the same length by construction, so the mixed one differs only in

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-perf for the V4 sliding-only attention layer over a chunked prefill at 5120 tokens a chunk,
+on 8x4.
+
+Chunked and not one shot, because the per-chunk work is what a long prefill repeats, and the only thing
+a gate on this layer can defend. The state is allocated outside the profiled region.
+
+Timed with the realtime (lightweight) profiler, like test_ttnn_hca_perf.py, and not with Tracy: the
+Blaze pipeline builds without the Tracy tools. Every program contributes its MAX duration across chips,
+so these numbers are NOT comparable to a Tracy merge, which averages collectives.
+
+Set HCA_PERF_BREAKDOWN=1 for a per-op split of one chunk. The gate only needs the total, but the
+profiler already returns per-program records and there is no Tracy here.
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
+from models.demos.deepseek_v3_d_p.tests.pcc.test_ttnn_swa import _MESH_CONFIGS, _SEED, _build_reference, _config
+from models.demos.deepseek_v3_d_p.tt.mla.sliding_window_attention import TtSWA
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program_merged
+
+_CHUNK = PREFILL_CHUNK_TOKENS
+_CHUNKS = 2
+_MAX_SEQ = 56_320  # the demo context, 11 chunks of 5120
+_MARGIN = 0.05
+
+# Baselines are what the first green run on a high-power 8x4 reported, not a target: this layer has no
+# compressor and its Sk is 768, so it should land far under HCA's 10.9 / 18.4 ms.
+_BASELINES = [
+    pytest.param("flash", DeepSeekV4FlashConfig, None, id="flash"),
+    pytest.param("pro", DeepSeekV4ProConfig, None, id="pro"),
+]
+
+# The team gates perf on the 14kW hosts. Set this to run anywhere for bring-up, where the baselines
+# describe nothing and only "does it run" is being checked.
+_IGNORE_POWER = os.environ.get("HCA_PERF_IGNORE_POWER") == "1"
+_BREAKDOWN = os.environ.get("HCA_PERF_BREAKDOWN") == "1"
+
+
+def _log_breakdown(per_program, chunk_ns, top=100):
+    """Per-op device time inside one chunk, grouped by each program's kernel set."""
+    by_kernel: dict[tuple, list] = {}
+    for entry in per_program.values():
+        key = tuple(sorted({source.rsplit("/", 1)[-1] for source in entry["kernel_sources"]}))
+        by_kernel.setdefault(key, []).append(entry["duration_ns"])
+    rows = sorted(((sum(v), len(v), k) for k, v in by_kernel.items()), reverse=True)
+    for ns, count, key in rows[:top]:
+        logger.info(f"    {ns / 1e3:9.1f} us {100 * ns / chunk_ns:5.1f}%  x{count:<3} {', '.join(key)}")
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="V4 SWA requires Blackhole")
+@pytest.mark.skipif(
+    not (is_high_power() or _IGNORE_POWER),
+    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw "
+    "label. HCA_PERF_IGNORE_POWER=1 runs it anyway, for bring-up only",
+)
+@pytest.mark.timeout(0)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, topology",
+    _MESH_CONFIGS,
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant, model_config, expected_ns", _BASELINES)
+def test_swa_layer_perf_galaxy(mesh_device, device_params, topology, variant, model_config, expected_ns):
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.fail("realtime profiler inactive (needs Blackhole, WORKER dispatch, fabric-tensix DM off)")
+
+    torch.manual_seed(_SEED)
+    config = _config(model_config)
+    ref = _build_reference(config)
+    tt_model = TtSWA.from_reference(mesh_device, ref, config, sp_axis=0, tp_axis=1, topology=topology)
+    state = tt_model.alloc_state(_MAX_SEQ, chunk_tokens=_CHUNK)
+    ms = tuple(mesh_device.shape)
+
+    total_ns = 0.0
+    for it in range(_CHUNKS):
+        tt_in = ttnn.from_torch(
+            torch.randn(1, _CHUNK, config.hidden_size).unsqueeze(1),
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=ms, dims=(2, 3)),
+        )
+        _, per_program = profile_realtime_program_merged(
+            mesh_device, lambda: tt_model(tt_in, seq_len_actual=_CHUNK, state=state)
+        )
+        chunk_ns = sum(entry["duration_ns"] for entry in per_program.values())
+        total_ns += chunk_ns
+        logger.info(f"  chunk {it}: {chunk_ns / 1e6:.3f} ms over {len(per_program)} programs")
+        if _BREAKDOWN:
+            _log_breakdown(per_program, chunk_ns)
+
+    logger.info(f"swa {variant} {_CHUNKS}x{_CHUNK} realtime perf: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms)")
+    if expected_ns is None:
+        pytest.skip(f"no baseline yet for {variant}; measured {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms)")
+
+    lower, upper = expected_ns * (1 - _MARGIN), expected_ns * (1 + _MARGIN)
+    assert lower <= total_ns <= upper, (
+        f"device time {total_ns:,.0f} ns outside band [{lower:,.0f}, {upper:,.0f}] "
+        f"(expected {expected_ns:,} ns, margin +/- {_MARGIN * 100:.1f}%)"
+    )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -37,11 +37,13 @@ _CHUNKS = 2
 _MAX_SEQ = 56_320  # the demo context, 11 chunks of 5120
 _MARGIN = 0.05
 
-# Baselines are what the first green run on a high-power 8x4 reported, not a target: this layer has no
-# compressor and its Sk is 768, so it should land far under HCA's 10.9 / 18.4 ms.
+# Measured, not targets. Roughly half of HCA's 10.9 / 18.4 ms on the same mesh: no compressor, no
+# cache write, and Sk is 768 rather than 5792. Taken on a host is_high_power() calls false, where the
+# HCA gate nonetheless lands inside its own 14kW-derived band -- so these are comparable, and the 5%
+# margin absorbs the rest.
 _BASELINES = [
-    pytest.param("flash", DeepSeekV4FlashConfig, None, id="flash"),
-    pytest.param("pro", DeepSeekV4ProConfig, None, id="pro"),
+    pytest.param("flash", DeepSeekV4FlashConfig, 5_124_000, id="flash"),  # both chunks -> 2.56 ms a chunk
+    pytest.param("pro", DeepSeekV4ProConfig, 8_192_000, id="pro"),  # both chunks -> 4.10 ms a chunk
 ]
 
 # The team gates perf on the 14kW hosts. Set this to run anywhere for bring-up, where the baselines

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -4,12 +4,11 @@
 
 """Device-perf for the V4 sliding-only attention layer over a chunked prefill, on 8x4.
 
-Chunked and not one shot: the per-chunk work is what a long prefill repeats. The state is allocated
-outside the profiled region.
+Chunked, since the per-chunk work is what a long prefill repeats. The state is allocated outside the
+profiled region.
 
-Timed with the realtime profiler, like test_ttnn_hca_perf.py, since the Blaze pipeline builds without
-Tracy. Every program contributes its MAX duration across chips, so these are NOT comparable to a Tracy
-merge, which averages collectives. HCA_PERF_BREAKDOWN=1 adds a per-op split.
+Timed with the realtime profiler, as the Blaze pipeline builds without Tracy. Every program
+contributes its MAX duration across chips. HCA_PERF_BREAKDOWN=1 adds a per-op split.
 """
 
 import os
@@ -33,14 +32,13 @@ _CHUNKS = 2
 _MAX_SEQ = 56_320  # the demo context, 11 chunks of 5120
 _MARGIN = 0.05
 
-# Measured, not targets. Taken on a host is_high_power() calls false, where the HCA gate nonetheless
-# lands inside its own 14kW-derived band, so these are comparable and the margin absorbs the rest.
+# Measured on a host is_high_power() calls false; the margin absorbs the difference.
 _BASELINES = [
-    pytest.param("flash", DeepSeekV4FlashConfig, 5_124_000, id="flash"),  # both chunks -> 2.56 ms a chunk
-    pytest.param("pro", DeepSeekV4ProConfig, 8_192_000, id="pro"),  # both chunks -> 4.10 ms a chunk
+    pytest.param("flash", DeepSeekV4FlashConfig, 5_124_000, id="flash"),
+    pytest.param("pro", DeepSeekV4ProConfig, 8_192_000, id="pro"),
 ]
 
-# Perf is gated on the 14kW hosts. Set this to run anywhere for bring-up, where only "does it run" holds.
+# Perf is gated on the 14kW hosts. Set this to run anywhere for bring-up.
 _IGNORE_POWER = os.environ.get("HCA_PERF_IGNORE_POWER") == "1"
 _BREAKDOWN = os.environ.get("HCA_PERF_BREAKDOWN") == "1"
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -20,7 +20,6 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
-from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
 from models.demos.deepseek_v3_d_p.tests.pcc.test_ttnn_swa import _MESH_CONFIGS, _SEED, _build_reference, _config
 from models.demos.deepseek_v3_d_p.tt.mla.sliding_window_attention import TtSWA
 from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
@@ -35,7 +34,6 @@ _MARGIN = 0.05
 # Measured on a host is_high_power() calls false; the margin absorbs the difference.
 _BASELINES = [
     pytest.param("flash", DeepSeekV4FlashConfig, 5_124_000, id="flash"),
-    pytest.param("pro", DeepSeekV4ProConfig, 8_192_000, id="pro"),
 ]
 
 # Perf is gated on the 14kW hosts. Set this to run anywhere for bring-up.

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -95,9 +95,6 @@ def test_swa_layer_perf_galaxy(mesh_device, device_params, topology, variant, mo
             _log_breakdown(per_program, chunk_ns)
 
     logger.info(f"swa {variant} {_CHUNKS}x{_CHUNK} realtime perf: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms)")
-    if expected_ns is None:
-        pytest.skip(f"no baseline yet for {variant}; measured {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms)")
-
     lower, upper = expected_ns * (1 - _MARGIN), expected_ns * (1 + _MARGIN)
     assert lower <= total_ns <= upper, (
         f"device time {total_ns:,.0f} ns outside band [{lower:,.0f}, {upper:,.0f}] "

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -2,18 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""Device-perf for the V4 sliding-only attention layer over a chunked prefill at 5120 tokens a chunk,
-on 8x4.
+"""Device-perf for the V4 sliding-only attention layer over a chunked prefill, on 8x4.
 
-Chunked and not one shot, because the per-chunk work is what a long prefill repeats, and the only thing
-a gate on this layer can defend. The state is allocated outside the profiled region.
+Chunked and not one shot: the per-chunk work is what a long prefill repeats. The state is allocated
+outside the profiled region.
 
-Timed with the realtime (lightweight) profiler, like test_ttnn_hca_perf.py, and not with Tracy: the
-Blaze pipeline builds without the Tracy tools. Every program contributes its MAX duration across chips,
-so these numbers are NOT comparable to a Tracy merge, which averages collectives.
-
-Set HCA_PERF_BREAKDOWN=1 for a per-op split of one chunk. The gate only needs the total, but the
-profiler already returns per-program records and there is no Tracy here.
+Timed with the realtime profiler, like test_ttnn_hca_perf.py, since the Blaze pipeline builds without
+Tracy. Every program contributes its MAX duration across chips, so these are NOT comparable to a Tracy
+merge, which averages collectives. HCA_PERF_BREAKDOWN=1 adds a per-op split.
 """
 
 import os
@@ -37,17 +33,14 @@ _CHUNKS = 2
 _MAX_SEQ = 56_320  # the demo context, 11 chunks of 5120
 _MARGIN = 0.05
 
-# Measured, not targets. Roughly half of HCA's 10.9 / 18.4 ms on the same mesh: no compressor, no
-# cache write, and Sk is 768 rather than 5792. Taken on a host is_high_power() calls false, where the
-# HCA gate nonetheless lands inside its own 14kW-derived band -- so these are comparable, and the 5%
-# margin absorbs the rest.
+# Measured, not targets. Taken on a host is_high_power() calls false, where the HCA gate nonetheless
+# lands inside its own 14kW-derived band, so these are comparable and the margin absorbs the rest.
 _BASELINES = [
     pytest.param("flash", DeepSeekV4FlashConfig, 5_124_000, id="flash"),  # both chunks -> 2.56 ms a chunk
     pytest.param("pro", DeepSeekV4ProConfig, 8_192_000, id="pro"),  # both chunks -> 4.10 ms a chunk
 ]
 
-# The team gates perf on the 14kW hosts. Set this to run anywhere for bring-up, where the baselines
-# describe nothing and only "does it run" is being checked.
+# Perf is gated on the 14kW hosts. Set this to run anywhere for bring-up, where only "does it run" holds.
 _IGNORE_POWER = os.environ.get("HCA_PERF_IGNORE_POWER") == "1"
 _BREAKDOWN = os.environ.get("HCA_PERF_BREAKDOWN") == "1"
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -33,7 +33,7 @@ _MARGIN = 0.05
 
 # Measured on the gated high-power host.
 _BASELINES = [
-    pytest.param("flash", DeepSeekV4FlashConfig, 5_300_000, id="flash"),
+    pytest.param("flash", DeepSeekV4FlashConfig, 5_175_000, id="flash"),
 ]
 
 # Perf is gated on the 14kW hosts. Set this to run anywhere for bring-up.

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py
@@ -8,7 +8,7 @@ Chunked, since the per-chunk work is what a long prefill repeats. The state is a
 profiled region.
 
 Timed with the realtime profiler, as the Blaze pipeline builds without Tracy. Every program
-contributes its MAX duration across chips. HCA_PERF_BREAKDOWN=1 adds a per-op split.
+contributes its MAX duration across chips. SWA_PERF_BREAKDOWN=1 adds a per-op split.
 """
 
 import os
@@ -31,14 +31,14 @@ _CHUNKS = 2
 _MAX_SEQ = 56_320  # the demo context, 11 chunks of 5120
 _MARGIN = 0.05
 
-# Measured on a host is_high_power() calls false; the margin absorbs the difference.
+# Measured on the gated high-power host.
 _BASELINES = [
-    pytest.param("flash", DeepSeekV4FlashConfig, 5_124_000, id="flash"),
+    pytest.param("flash", DeepSeekV4FlashConfig, 5_300_000, id="flash"),
 ]
 
 # Perf is gated on the 14kW hosts. Set this to run anywhere for bring-up.
-_IGNORE_POWER = os.environ.get("HCA_PERF_IGNORE_POWER") == "1"
-_BREAKDOWN = os.environ.get("HCA_PERF_BREAKDOWN") == "1"
+_IGNORE_POWER = os.environ.get("SWA_PERF_IGNORE_POWER") == "1"
+_BREAKDOWN = os.environ.get("SWA_PERF_BREAKDOWN") == "1"
 
 
 def _log_breakdown(per_program, chunk_ns, top=100):
@@ -56,7 +56,7 @@ def _log_breakdown(per_program, chunk_ns, top=100):
 @pytest.mark.skipif(
     not (is_high_power() or _IGNORE_POWER),
     reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw "
-    "label. HCA_PERF_IGNORE_POWER=1 runs it anyway, for bring-up only",
+    "label. SWA_PERF_IGNORE_POWER=1 runs it anyway, for bring-up only",
 )
 @pytest.mark.timeout(0)
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tt/mla/compressor.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/compressor.py
@@ -92,10 +92,14 @@ class TtCompressorUtils:
         ttnn.copy_host_to_device_tensor(host, buf)
         return buf
 
-    def build_rope_table(self, count: int, stride: int):
-        """Build replicated cos/sin tables for compressed or token positions."""
+    def build_rope_table(self, count: int, stride: int, layer_type: str = "compress"):
+        """Build replicated cos/sin tables for compressed or token positions.
+
+        ``layer_type`` picks the reference's rope variant: "compress" is the YaRN-scaled table the
+        HCA/CSA layers share with their compressor, "main" the plain theta=10000 one a sliding-only
+        layer uses (``DeepseekV4Attention.rope_layer_type``)."""
         positions = (torch.arange(count) * stride).unsqueeze(0)
-        cos, sin = self.rotary_emb(torch.zeros(1), position_ids=positions.to(torch.long), layer_type="compress")
+        cos, sin = self.rotary_emb(torch.zeros(1), position_ids=positions.to(torch.long), layer_type=layer_type)
         return tuple(self.from_torch(t.repeat_interleave(2, dim=-1)) for t in (cos, sin))
 
     def rope_index_base(self, rows: int):

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -305,6 +305,10 @@ class TtSWA(LightweightModule):
             is_causal=False,
             scale=self.scaling,
             attention_sink=self._hca.sinks_sdpa,
+            # 128/128 is not inherited from HCA, it is the only good split here: a provided mask makes
+            # the reader stream a [q_chunk, k_chunk] tile per iteration, so anything wider blows L1
+            # (k_chunk=256 asks 1.93 MB of a 1.57 MB budget). Swept on 8x4 -- 96/128 costs 5% and
+            # 64/128 costs 38% on this op, everything above 128 fails to allocate.
             program_config=ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=self.device.compute_with_storage_grid_size(),
                 q_chunk_size=128,

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek-V4 sliding-only attention (``layer_types[i] == "sliding_attention"``), chunked prefill.
+
+The reference builds all three attention kinds from one class: a sliding layer is
+``DeepseekV4Attention`` with ``compressor = None`` and ``rope_layer_type = "main"`` (plain theta=10000
+instead of the YaRN-scaled table HCA/CSA share with their compressor). Everything else -- the Q/KV
+stems, the per-head sink, the grouped output projection -- is identical, so those come from
+:class:`TtHCA` unchanged and only the attention core differs. Flash has two such layers (0 and 1); Pro
+has none.
+
+The attention core is where a sliding layer stops looking like HCA. HCA all-gathers the K/V and then
+attends over ``[carry | chunk | compressed]``, so every chip sees ``Sk`` = the whole slab. A 128-token
+window never reaches further back than the 128 rows before a chip's own first query, so each chip
+attends over ``[halo | its own rows]`` instead -- ``Sk`` drops from 5248 to 768 and the SDPA walks 6
+K-chunks per Q-chunk instead of 41.
+
+``halo`` is the 128 rows preceding this chip's block, which is a DIFFERENT global offset per chip. That
+comes from ``ttnn.slice`` with sequence-parallel-sharded index tensors: the bounds live in device
+tensors, so only their shape is in the program and each chip reads its own offset -- verified on 8x4 as
+one program serving all eight offsets.
+
+Two things this deliberately does NOT do, both measured or reasoned rather than assumed:
+
+* It keeps HCA's full K/V all-gather. The attention only needs each chip's own rows plus a 128-row
+  halo, so gathering just the per-chip tails would cut that CCL ~5x. But a ragged chunk's carry is the
+  global ``[real_len - 128, real_len)`` block, which a tails-only gather does not contain, and the
+  gathered slab is what makes ``_carry_index`` work. The compute win is independent of this and is the
+  larger one.
+* It masks rather than passing ``sliding_window_size``. The op's band comes from LOCAL Q/K indices, so
+  it needs Q front-padded by the window to line up, and then chunk 0's chip 0 has no real halo -- 128
+  zero KEY rows, which a zero-value key still adds to the softmax denominator, and
+  ``compute_streaming.hpp``'s ``static_assert`` forbids combining a mask with the window to -inf them.
+  A mask handles that as data (one SP-sharded tensor, chip 0 differing only on the first chunk) and
+  keeps one program. It costs the loop narrowing: 6 K-chunks instead of 2, ~150 us per chunk per layer
+  against a ~200 ms whole-model chunk.
+"""
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4.modeling_deepseek_v4 import DeepseekV4RotaryEmbedding
+from models.demos.deepseek_v3_d_p.tt.mla.compressor import TtCompressorUtils
+from models.demos.deepseek_v3_d_p.tt.mla.heavily_compressed_attention import TtHCA
+
+
+class TtSWAState:
+    """Chunked-prefill state, owned by the caller and passed to ``TtSWA.forward``.
+
+    One tensor, and it never grows: a sliding layer's whole history is the 128 tokens before the next
+    chunk starts. ``kv_actual`` says how many real tokens precede this chunk, which is what selects the
+    first-chunk mask variant and the rotary offset."""
+
+    def __init__(self, carry, max_seq_len):
+        self.carry = carry  # [B, 1, sliding_window, head_dim]
+        self.max_seq_len = int(max_seq_len)
+        self.kv_actual = 0
+
+
+class TtSWA(LightweightModule):
+    def __init__(
+        self,
+        device,
+        *,
+        q_a_proj_weight: torch.Tensor,
+        q_a_norm_weight: torch.Tensor,
+        q_b_proj_weight: torch.Tensor,
+        kv_proj_weight: torch.Tensor,
+        kv_norm_weight: torch.Tensor,
+        sinks: torch.Tensor,
+        o_a_proj_weight: torch.Tensor,
+        o_b_proj_weight: torch.Tensor,
+        rotary_emb,
+        num_heads: int,
+        head_dim: int,
+        rope_head_dim: int,
+        sliding_window: int,
+        o_groups: int,
+        rms_norm_eps: float = 1e-6,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
+        topology=ttnn.Topology.Linear,
+        dtype=ttnn.bfloat16,
+        weights_dtype=ttnn.bfloat8_b,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    ):
+        # The stems, the sink packing and the grouped o_proj are the reference's shared half, so they
+        # come from a TtHCA built with compressor=None rather than copied. Only _attention and the
+        # state differ, and both live here.
+        self._hca = TtHCA(
+            device,
+            compressor=None,
+            q_a_proj_weight=q_a_proj_weight,
+            q_a_norm_weight=q_a_norm_weight,
+            q_b_proj_weight=q_b_proj_weight,
+            kv_proj_weight=kv_proj_weight,
+            kv_norm_weight=kv_norm_weight,
+            sinks=sinks,
+            o_a_proj_weight=o_a_proj_weight,
+            o_b_proj_weight=o_b_proj_weight,
+            rotary_emb=rotary_emb,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            rope_head_dim=rope_head_dim,
+            sliding_window=sliding_window,
+            o_groups=o_groups,
+            rms_norm_eps=rms_norm_eps,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            topology=topology,
+            dtype=dtype,
+            weights_dtype=weights_dtype,
+            memory_config=memory_config,
+        )
+        self.device = device
+        self.dtype = dtype
+        self.memory_config = memory_config
+        self.head_dim = int(head_dim)
+        self.rope_head_dim = int(rope_head_dim)
+        self.sliding_window = int(sliding_window)
+        self.scaling = self.head_dim**-0.5
+        self.sp_axis, self.tp_axis = sp_axis, tp_axis
+        self.sp_factor = self._hca.sp_factor
+        self.tp_factor = self._hca.tp_factor
+        self.ops: TtCompressorUtils = self._hca.ops
+
+        # Everything below comes from alloc_state, which every caller has to run before forward.
+        self._mask = None  # persistent additive mask; forward overwrites only the halo columns
+        self._head_cols = None  # the halo columns, in a normal and a first-chunk variant
+        self._halo_bounds = None  # SP-sharded slice bounds: this chip's 128 rows of history
+        self._slab_rope = None
+        self._slab_index = None
+        self._carry_index = None
+
+    @classmethod
+    def from_reference(cls, device, reference, config, **kwargs) -> "TtSWA":
+        assert getattr(reference, "compressor", None) is None, (
+            "TtSWA expects a sliding-only reference layer (compressor is None); a layer with a "
+            "compressor is HCA or CSA"
+        )
+        # A sliding layer has no compressor to borrow a rotary_emb from -- and unlike HCA it does not
+        # need one, since its rope is the plain theta=10000 variant the config alone determines.
+        rotary_emb = getattr(reference, "rotary_emb", None) or DeepseekV4RotaryEmbedding(config)
+        return cls(
+            device,
+            q_a_proj_weight=reference.q_a_proj.weight,
+            q_a_norm_weight=reference.q_a_norm.weight,
+            q_b_proj_weight=reference.q_b_proj.weight,
+            kv_proj_weight=reference.kv_proj.weight,
+            kv_norm_weight=reference.kv_norm.weight,
+            sinks=reference.sinks,
+            o_a_proj_weight=reference.o_a_proj.weight,
+            o_b_proj_weight=reference.o_b_proj.weight,
+            rotary_emb=rotary_emb,
+            num_heads=config.num_attention_heads,
+            head_dim=config.head_dim,
+            rope_head_dim=config.qk_rope_head_dim,
+            sliding_window=config.sliding_window,
+            o_groups=config.o_groups,
+            rms_norm_eps=config.rms_norm_eps,
+            **kwargs,
+        )
+
+    def alloc_state(self, max_seq_len: int, batch: int = 1, chunk_tokens: int | None = None) -> TtSWAState:
+        """Size the state and build every host tensor forward will need, so forward builds none.
+
+        ``chunk_tokens`` is the slab width forward will be called with; the mask and the slice bounds
+        are sized from it and are the same for every chunk."""
+        assert batch == 1, f"SWA state is single-user for now, got batch={batch}"
+        chunk = int(chunk_tokens or max_seq_len)
+        sw, sp = self.sliding_window, self.sp_factor
+        assert chunk % (sw * sp) == 0, (
+            f"the slab is {chunk} wide, which is not a multiple of sliding_window * sp_factor "
+            f"({sw} * {sp} = {sw * sp}); every chip's share has to be a whole number of windows"
+        )
+        seq_local = chunk // sp
+
+        self._build_masks(seq_local)
+        self._build_halo_bounds(chunk, seq_local)
+        self._build_carry_index(chunk)
+        # A row per TOKEN, and the "main" rope variant: a sliding layer does not share the compressor's
+        # YaRN-scaled table (reference DeepseekV4Attention.rope_layer_type).
+        self._slab_rope = self.ops.build_rope_table(int(max_seq_len) + chunk, 1, layer_type="main")
+        self._slab_index = self.ops.rope_index_base(seq_local)
+        return TtSWAState(
+            carry=self.ops.from_torch(torch.zeros(batch, 1, sw, self.head_dim)),
+            max_seq_len=max_seq_len,
+        )
+
+    def _build_masks(self, seq_local: int):
+        """The additive mask over the key layout ``[halo | own rows]``, both chip-local.
+
+        Key column ``j`` holds the token at global position ``base - sw + j`` and query row ``i`` the one
+        at ``base + i``, where ``base`` is this chip's first token. The causal window
+        ``base + i - sw < pos <= base + i`` then reduces to ``i < j <= i + sw`` -- the chip offset
+        cancels, so ONE replicated mask serves every chip.
+
+        The halo columns need a second version for the first chunk, where the carry holds no tokens yet.
+        Only chip 0 reads the carry -- chips 1..sp-1 take their halo from a predecessor inside this same
+        chunk -- so that version differs per chip, and ``log(nez(chip_index))`` turns the chip index into
+        the 0 / -inf it needs without a host tensor.
+
+        Built from index vectors so no large host tensor is created. They are float32 because
+        bfloat16 stops being exact above 256, and the column index runs to 768."""
+        sw = self.sliding_window
+        width = sw + seq_local
+
+        ic = self.ops.from_torch(torch.arange(seq_local).float().view(1, 1, seq_local, 1), dtype=ttnn.float32)
+        jc = self.ops.from_torch(torch.arange(width).float().view(1, 1, 1, width), dtype=ttnn.float32)
+        band = ttnn.typecast(ttnn.log(ttnn.multiply(ttnn.gt(jc, ic), ttnn.le(jc, ttnn.add(ic, float(sw))))), self.dtype)
+        self._mask = band
+
+        head = ttnn.slice(band, [0, 0, 0, 0], [1, 1, seq_local, sw])
+        chip = self.ops.from_torch(
+            torch.arange(self.sp_factor).float().view(1, 1, self.sp_factor, 1),
+            self.ops.mesh_mapper(sp_dim=2),
+            dtype=ttnn.float32,
+        )
+        not_chip_0 = ttnn.typecast(ttnn.log(ttnn.nez(chip)), self.dtype)  # 0 on chips 1.., -inf on chip 0
+        self._head_cols = {False: head, True: ttnn.add(head, not_chip_0)}
+
+    def _build_halo_bounds(self, chunk: int, seq_local: int):
+        """Slice bounds for this chip's halo: rows ``[d*seq_local, d*seq_local + sw)`` of
+        ``[carry | gathered chunk]``.
+
+        The offset differs per chip, so the bounds are SP-sharded device tensors -- ``ttnn.slice`` reads
+        them at runtime, which keeps only their shape in the program and lets one program serve all
+        ``sp`` offsets. They must be 1-D, hence the flat layout."""
+        sw, sp = self.sliding_window, self.sp_factor
+        starts = torch.tensor([v for d in range(sp) for v in (0, 0, d * seq_local, 0)], dtype=torch.int32)
+        ends = torch.tensor(
+            [v for d in range(sp) for v in (1, 1, d * seq_local + sw, self.head_dim)], dtype=torch.int32
+        )
+        mapper = self.ops.mesh_mapper(sp_dim=0)
+        self._halo_bounds = tuple(
+            self.ops.from_torch(t, mapper, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT) for t in (starts, ends)
+        )
+        # ttnn.slice sizes its output as in_rows / num_devices, so this is a divisor and not a mesh size.
+        self._halo_num_devices = (sw + chunk) // sw
+
+    def _build_carry_index(self, chunk: int):
+        """start/end index tensors for the carry slice, one pair per real_len a chunk can have.
+
+        The carry is the GLOBAL ``[real_len - sw, real_len)`` block, not the last rows of the padded
+        slab, and those differ as soon as ``real_len < chunk``. The bounds are the same on every chip
+        (the gathered slab is replicated), so unlike the halo these are not sharded."""
+        sw = self.sliding_window
+
+        def idx(vals):
+            return self.ops.from_torch(
+                torch.tensor(vals, dtype=torch.int32), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
+            )
+
+        self._carry_index = {
+            real_len: (idx([0, 0, real_len - sw, 0]), idx([1, 1, real_len, self.head_dim]))
+            for real_len in range(sw, int(chunk) + 1, sw)
+        }
+
+    def _attention(self, q, sliding_kv, cos, sin, carry, kv_actual: int, real_len: int):
+        """``q`` [B, H/tp, S/sp, head_dim] and this chip's own ``sliding_kv`` [B, 1, S/sp, head_dim]
+        -> ``(attn, next_carry)``.
+
+        The gather is over the WHOLE chunk even though attention reads 768 rows of it, because the
+        carry slice needs the global slab; see the module docstring."""
+        batch, num_heads_local, seq_local, _ = q.shape
+        sw = self.sliding_window
+
+        if self.sp_factor > 1:
+            gathered = ttnn.experimental.all_gather_async(
+                sliding_kv,
+                dim=2,
+                multi_device_global_semaphore=self._hca.tt_ccl.get_and_cycle_ag_semaphore_handles(
+                    cluster_axis=self.sp_axis
+                ),
+                barrier_semaphore=self._hca.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
+                num_links=self._hca.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self._hca.tp_ccl_topology,
+                cluster_axis=self.sp_axis,
+            )
+        else:
+            gathered = sliding_kv
+
+        # [carry | chunk] is the global key sequence this chunk can see; each chip takes the 128 rows
+        # that precede its own block out of it.
+        hist = ttnn.concat([carry, gathered], dim=2)
+        start, end = self._halo_bounds
+        halo = ttnn.slice(hist, start, end, slice_dim=2, num_devices=self._halo_num_devices)
+        kv = ttnn.concat([halo, sliding_kv], dim=2)
+
+        # Only the halo columns move between chunks, and always over the same range, so the mask is
+        # built once and this overwrites that range in place.
+        head_cols = self._head_cols[kv_actual == 0]
+        ttnn.experimental.slice_write(
+            head_cols, self._mask, start=[0, 0, 0, 0], end=[1, 1, seq_local, sw], step=[1, 1, 1, 1]
+        )
+
+        attn = ttnn.transformer.scaled_dot_product_attention(
+            q,
+            kv,
+            kv,
+            attn_mask=self._mask,
+            is_causal=False,
+            scale=self.scaling,
+            attention_sink=self._hca.sinks_sdpa,
+            program_config=ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=self.device.compute_with_storage_grid_size(),
+                q_chunk_size=128,
+                k_chunk_size=128,
+                exp_approx_mode=False,
+            ),
+        )
+
+        # The next chunk's window reaches back into this one, so the carry is this chunk's last REAL
+        # keys. Taking the start from a device tensor keeps only its shape in the program, so one
+        # program serves every real_len.
+        c_start, c_end = self._carry_index[real_len]
+        next_carry = ttnn.slice(gathered, c_start, c_end, slice_dim=2, num_devices=gathered.shape[2] // sw)
+
+        nope_dim = self.head_dim - self.rope_head_dim
+        nope = ttnn.slice(attn, [0, 0, 0, 0], [batch, num_heads_local, seq_local, nope_dim])
+        rope = ttnn.slice(attn, [0, 0, 0, nope_dim], [batch, num_heads_local, seq_local, self.head_dim])
+        # Undoing V's RoPE is the same rotation with the sign of sin flipped, so cos is reused.
+        rope = ttnn.experimental.rotary_embedding_llama(
+            rope, cos, ttnn.neg(sin), self._hca.trans_mat, is_decode_mode=False
+        )
+        return ttnn.concat([nope, rope], dim=-1), next_carry
+
+    def forward(self, hidden_states, seq_len_actual: int | None = None, state: TtSWAState = None):
+        """[B, 1, S/sp, hidden/tp] -> the same, one chunk. ``seq_len_actual`` is the chunk's real token
+        count; the rest of the slab is padding the mask never lets a real query read."""
+        assert state is not None, "TtSWA.forward needs the state alloc_state returned"
+        seq_len = hidden_states.shape[2] * self.sp_factor
+        real_len = int(seq_len if seq_len_actual is None else seq_len_actual)
+        sw = self.sliding_window
+        assert real_len % sw == 0, (
+            f"a chunk must end on a window boundary, got {real_len} with sliding_window {sw}: the next "
+            f"chunk's first query needs the {sw} tokens before it, which is what the carry holds"
+        )
+
+        slab_index = self.ops.rope_index(self._slab_index, state.kv_actual)
+        cos, sin = self.ops.rope_gather(self._slab_rope, slab_index)
+        q = self._hca._q_stem(hidden_states, cos, sin)
+        sliding_kv = self._hca._kv_stem(hidden_states, cos, sin)
+
+        attn, next_carry = self._attention(
+            q, sliding_kv, cos, sin, carry=state.carry, kv_actual=state.kv_actual, real_len=real_len
+        )
+
+        state.kv_actual += real_len
+        state.carry = next_carry
+        return self._hca._o_proj(attn)

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -47,6 +47,10 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
+#: Slice bounds on a tiled tensor move a tile row at a time, which is what sets the
+#: granularity a chunk may end on.
+TILE_HEIGHT = 32
+
 
 class TtSWAState:
     """Chunked-prefill state, owned by the caller and passed to ``TtSWA.forward``.
@@ -280,12 +284,31 @@ class TtSWA(LightweightModule):
         # ttnn.slice sizes its output as in_rows / num_devices, so this is a divisor and not a mesh size.
         self._halo_num_devices = (sw + chunk) // sw
 
+    def _carry_key(self, real_len: int):
+        """The carry index is tabulated per tile row, the granularity a slice start can take. A chunk
+        ending mid-tile rounds down, which only the final chunk may do.
+
+        Invisible to prefill, which never reads that last carry, but NOT invisible to migration: decode
+        picks the carry up from the address table and would be short by up to 31 positions after a
+        final chunk that ended mid-tile. Deciding that is a decode-interface question, not a local one
+        -- see "the final chunk's carry is not migration-correct" in V4_HCA_next_steps.MD. TtHCA rounds
+        the same way at 128, so it is off by up to 127."""
+        return (int(real_len) // TILE_HEIGHT) * TILE_HEIGHT
+
     def _build_carry_index(self, chunk: int):
         """start/end index tensors for the carry slice, one pair per real_len a chunk can have.
 
-        The carry is the GLOBAL ``[real_len - sw, real_len)`` block, not the last rows of the padded
-        slab, and those differ as soon as ``real_len < chunk``. The bounds are the same on every chip
-        (the gathered slab is replicated), so unlike the halo these are not sharded."""
+        The carry is the last ``sw`` keys of the ACCUMULATED prefix, not the last rows of the padded
+        slab, and those differ as soon as ``real_len < chunk``. It is cut out of ``[carry | chunk]``
+        rather than out of the chunk alone, which is what lets a chunk be shorter than the window:
+        the real tokens of this chunk sit at ``[sw, sw + real_len)`` there, so the last ``sw`` of the
+        prefix are ``[real_len, real_len + sw)`` -- for ``real_len`` below ``sw`` that range walks
+        back into the previous carry on its own, and for ``real_len == 0`` it reproduces it exactly.
+        Out of the chunk alone no such range exists, since the chunk holds no history.
+
+        Tabulated per tile row: the start is a slice bound on a tiled tensor, so it moves a tile at a
+        time. The bounds are the same on every chip (the gathered slab is replicated), so unlike the
+        halo these are not sharded."""
         sw = self.sliding_window
 
         def idx(vals):
@@ -294,8 +317,8 @@ class TtSWA(LightweightModule):
             )
 
         self._carry_index = {
-            real_len: (idx([0, 0, real_len - sw, 0]), idx([1, 1, real_len, self.head_dim]))
-            for real_len in range(sw, int(chunk) + 1, sw)
+            real_len: (idx([0, 0, real_len, 0]), idx([1, 1, real_len + sw, self.head_dim]))
+            for real_len in range(0, int(chunk) + 1, TILE_HEIGHT)
         }
 
     def _attention(self, q, sliding_kv, cos, sin, carry, kv_actual: int, real_len: int):
@@ -360,8 +383,8 @@ class TtSWA(LightweightModule):
         # The next chunk's window reaches back into this one, so the carry is this chunk's last REAL
         # keys. Taking the start from a device tensor keeps only its shape in the program, so one
         # program serves every real_len.
-        c_start, c_end = self._carry_index[real_len]
-        next_carry = ttnn.slice(gathered, c_start, c_end, slice_dim=2, num_devices=gathered.shape[2] // sw)
+        c_start, c_end = self._carry_index[self._carry_key(real_len)]
+        next_carry = ttnn.slice(hist, c_start, c_end, slice_dim=2, num_devices=self._halo_num_devices)
 
         nope_dim = self.head_dim - self.rope_head_dim
         nope = ttnn.slice(attn, [0, 0, 0, 0], [batch, num_heads_local, seq_local, nope_dim])
@@ -509,9 +532,15 @@ class TtSWA(LightweightModule):
         seq_len = hidden_states.shape[2] * self.sp_factor
         real_len = int(seq_len if seq_len_actual is None else seq_len_actual)
         sw = self.sliding_window
-        assert real_len % sw == 0, (
-            f"a chunk must end on a window boundary, got {real_len} with sliding_window {sw}: the next "
-            f"chunk's first query needs the {sw} tokens before it, which is what the carry holds"
+        # Checked on the ACCUMULATED length, not this chunk's, and against a tile row rather than the
+        # window: the carry is cut out of [carry | chunk], so a chunk may be SHORTER than the window
+        # and still leave a correct carry -- the only real constraint is that its end be a slice bound
+        # a tiled tensor can take. A final chunk may end anywhere, since nothing reads its carry.
+        # Looser than TtHCA, which is tied to its compressor's 128-token windows; a chunk sequence
+        # valid there is therefore valid here too.
+        assert state.kv_actual % TILE_HEIGHT == 0, (
+            f"cannot append after a chunk with {state.kv_actual % TILE_HEIGHT} leftover tokens; only "
+            f"the final chunk may end mid-tile, non-final chunks must be a multiple of {TILE_HEIGHT}"
         )
 
         slab_index = self.ops.rope_index(self._slab_index, state.kv_actual)

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -200,8 +200,7 @@ class TtSWA(LightweightModule):
         )
         keep = ttnn.nez(ttnn.add(ttnn.nez(chip), ttnn.ge(jc, float(sw))))
         empty_carry = ttnn.typecast(ttnn.log(keep), self.dtype)
-        # Only chunk 0 differs: there chip 0's halo is the zeroed carry, and a zero key still
-        # counts in the softmax denominator.
+        # Only chunk 0 differs: chip 0's halo is the zeroed carry, and a zero key still counts in softmax.
         self._masks = {False: band, True: ttnn.add(band, empty_carry)}
 
     def _build_halo_bounds(self, chunk: int, seq_local: int):
@@ -278,8 +277,7 @@ class TtSWA(LightweightModule):
             ),
         )
 
-        # Device-tensor bounds keep only their shape in the program, so one program serves every
-        # real_len.
+        # Device-tensor bounds keep only their shape in the program, so one program serves every real_len.
         c_start, c_end = self._carry_index[self._carry_key(real_len)]
         next_carry = ttnn.slice(hist, c_start, c_end, slice_dim=2, num_devices=self._halo_num_devices)
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -150,9 +150,13 @@ class TtSWA(LightweightModule):
         assert batch == 1, f"SWA state is single-user for now, got batch={batch}"
         chunk = int(chunk_tokens or max_seq_len)
         sw, sp = self.sliding_window, self.sp_factor
-        assert chunk % (sw * sp) == 0, (
-            f"the slab is {chunk} wide, which is not a multiple of sliding_window * sp_factor "
-            f"({sw} * {sp} = {sw * sp}); every chip's share has to be a whole number of windows"
+        assert chunk % (TILE_HEIGHT * sp) == 0, (
+            f"the slab is {chunk} wide, which is not a multiple of tile height * sp_factor "
+            f"({TILE_HEIGHT} * {sp} = {TILE_HEIGHT * sp}); a chip's share must be whole tiles"
+        )
+        assert chunk % sw == 0, (
+            f"the slab is {chunk} wide, which is not a multiple of sliding_window {sw}; the halo and "
+            f"carry slices size their output as (sw + chunk) / num_devices"
         )
         seq_local = chunk // sp
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -3,37 +3,13 @@
 
 """DeepSeek-V4 sliding-only attention (``layer_types[i] == "sliding_attention"``), chunked prefill.
 
-The reference builds all three attention kinds from one class: a sliding layer is
-``DeepseekV4Attention`` with ``compressor = None`` and ``rope_layer_type = "main"`` (plain theta=10000
-instead of the YaRN-scaled table HCA/CSA share with their compressor). Everything else -- the Q/KV
-stems, the per-head sink, the grouped output projection -- is identical, and is duplicated here rather
-than shared; see the note in ``__init__``. Flash has two such layers (0 and 1); Pro has none.
+A sliding layer is the reference's ``DeepseekV4Attention`` with ``compressor = None`` and the plain
+theta=10000 rope. Flash has two (layers 0 and 1); Pro has none.
 
-The attention core is where a sliding layer stops looking like HCA. HCA all-gathers the K/V and then
-attends over ``[carry | chunk | compressed]``, so every chip sees ``Sk`` = the whole slab. A 128-token
-window never reaches further back than the 128 rows before a chip's own first query, so each chip
-attends over ``[halo | its own rows]`` instead -- ``Sk`` drops from 5248 to 768 and the SDPA walks 6
-K-chunks per Q-chunk instead of 41.
-
-``halo`` is the 128 rows preceding this chip's block, which is a DIFFERENT global offset per chip. That
-comes from ``ttnn.slice`` with sequence-parallel-sharded index tensors: the bounds live in device
-tensors, so only their shape is in the program and each chip reads its own offset -- verified on 8x4 as
-one program serving all eight offsets.
-
-Two things this deliberately does NOT do, both measured or reasoned rather than assumed:
-
-* It keeps HCA's full K/V all-gather. The attention only needs each chip's own rows plus a 128-row
-  halo, so gathering just the per-chip tails would cut that CCL ~5x. But a ragged chunk's carry is the
-  global ``[real_len - 128, real_len)`` block, which a tails-only gather does not contain, and the
-  gathered slab is what makes ``_carry_index`` work. The compute win is independent of this and is the
-  larger one.
-* It masks rather than passing ``sliding_window_size``. The op's band comes from LOCAL Q/K indices, so
-  it needs Q front-padded by the window to line up, and then chunk 0's chip 0 has no real halo -- 128
-  zero KEY rows, which a zero-value key still adds to the softmax denominator, and
-  ``compute_streaming.hpp``'s ``static_assert`` forbids combining a mask with the window to -inf them.
-  A mask handles that as data (one SP-sharded tensor, chip 0 differing only on the first chunk) and
-  keeps one program. It costs the loop narrowing: 6 K-chunks instead of 2, ~150 us per chunk per layer
-  against a ~200 ms whole-model chunk.
+The window never reaches past the ``sliding_window`` rows before a chip's own first query, so each
+chip attends over ``[halo | its own rows]`` rather than over the whole slab like HCA. Rationale for
+the choices here -- the mask instead of ``sliding_window_size``, the full K/V gather, the SDPA chunk
+sizes -- is in ``V4_HCA_next_steps.MD``.
 """
 
 import torch
@@ -47,20 +23,16 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
-#: Slice bounds on a tiled tensor move a tile row at a time, which is what sets the
-#: granularity a chunk may end on.
+#: A slice bound on a tiled tensor moves a tile row at a time.
 TILE_HEIGHT = 32
 
 
 class TtSWAState:
-    """Chunked-prefill state, owned by the caller and passed to ``TtSWA.forward``.
-
-    One tensor, and it never grows: a sliding layer's whole history is the 128 tokens before the next
-    chunk starts. ``kv_actual`` says how many real tokens precede this chunk, which is what selects the
-    first-chunk mask variant and the rotary offset."""
+    """Chunked-prefill state. One tensor, and it never grows: the whole history a sliding layer needs
+    is the ``sliding_window`` tokens before the next chunk starts."""
 
     def __init__(self, carry, max_seq_len):
-        self.carry = carry  # [B, 1, sliding_window, head_dim]
+        self.carry = carry
         self.max_seq_len = int(max_seq_len)
         self.kv_actual = 0
 
@@ -92,13 +64,7 @@ class TtSWA(LightweightModule):
         weights_dtype=ttnn.bfloat8_b,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     ):
-        # TODO: q_stem / kv_stem / o_proj below are byte-identical to TtHCA's, and to whatever TtCSA's
-        # will be -- the reference builds all eight projections unconditionally for every layer_type and
-        # runs them identically (modeling_deepseek_v4.py:786-800); only the key assembly in the middle
-        # differs. They belong in one TtV4Attention.forward that runs the shared pipeline
-        # (q_stem -> kv_stem -> per-type core -> o_proj) and injects the core, rather than in a base
-        # class each type re-derives a forward from. Duplicated here on purpose so this layer lands
-        # without touching heavily_compressed_attention.py; unify once TtCSA's core exists.
+        # TODO: share the stems with TtHCA/TtCSA once TtCSA lands; see V4_HCA_next_steps.MD.
         self.device = device
         self.dtype = dtype
         self.weights_dtype = weights_dtype
@@ -128,8 +94,7 @@ class TtSWA(LightweightModule):
             memory_config=memory_config,
         )
 
-        # Pre-divided by scale: SDPA scales BOTH QK and the sink internally, the reference scales only
-        # QK -- dividing here cancels the kernel's extra multiply. TP-sharded to match the query heads.
+        # Pre-divided: SDPA scales the sink as well as QK, the reference scales only QK.
         sinks_host = sinks.detach().reshape(1, self.num_heads, 1, 1) / self.scaling
         self.sinks_sdpa = self.ops.from_torch(sinks_host, mesh_mapper=self.ops.mesh_mapper(tp_dim=1))
 
@@ -140,9 +105,8 @@ class TtSWA(LightweightModule):
         self.wkv = self.ops.to_tt_linear_weight(kv_proj_weight, tp_shard_dim=2)
         self.kv_norm_weight = self.ops.from_torch(kv_norm_weight.detach().reshape(1, 1, 1, self.head_dim))
 
-        # o_a_proj is block-diagonal over o_groups. Groups partition the heads, so a TP chip owns whole
-        # groups: keep it as ONE batched weight sharded on the group axis and run a single batched
-        # matmul -- each chip applies only its own groups, no collective.
+        # o_a_proj is block-diagonal over o_groups and a TP chip owns whole groups, so this stays one
+        # batched weight and one batched matmul, no collective.
         in_per_group = self.num_heads * self.head_dim // self.o_groups
         o_a_grouped = o_a_proj_weight.detach().view(self.o_groups, -1, in_per_group).transpose(1, 2).unsqueeze(0)
         self.wo_a = self.ops.from_torch(
@@ -152,10 +116,10 @@ class TtSWA(LightweightModule):
 
         self.trans_mat = self.ops.from_torch(get_rot_transformation_mat())
 
-        # Everything below comes from alloc_state, which every caller has to run before forward.
-        self._mask = None  # persistent additive mask; forward overwrites only the halo columns
-        self._head_cols = None  # the halo columns, in a normal and a first-chunk variant
-        self._halo_bounds = None  # SP-sharded slice bounds: this chip's 128 rows of history
+        # Built by alloc_state, which every caller runs before forward.
+        self._mask = None
+        self._head_cols = None
+        self._halo_bounds = None
         self._halo_num_devices = None
         self._slab_rope = None
         self._slab_index = None
@@ -167,8 +131,6 @@ class TtSWA(LightweightModule):
             "TtSWA expects a sliding-only reference layer (compressor is None); a layer with a "
             "compressor is HCA or CSA"
         )
-        # A sliding layer has no compressor to borrow a rotary_emb from -- and unlike HCA it does not
-        # need one, since its rope is the plain theta=10000 variant the config alone determines.
         rotary_emb = getattr(reference, "rotary_emb", None) or DeepseekV4RotaryEmbedding(config)
         return cls(
             device,
@@ -191,10 +153,7 @@ class TtSWA(LightweightModule):
         )
 
     def alloc_state(self, max_seq_len: int, batch: int = 1, chunk_tokens: int | None = None) -> TtSWAState:
-        """Size the state and build every host tensor forward will need, so forward builds none.
-
-        ``chunk_tokens`` is the slab width forward will be called with; the mask and the slice bounds
-        are sized from it and are the same for every chunk."""
+        """Build every host tensor forward will need, so forward builds none."""
         assert batch == 1, f"SWA state is single-user for now, got batch={batch}"
         chunk = int(chunk_tokens or max_seq_len)
         sw, sp = self.sliding_window, self.sp_factor
@@ -207,8 +166,6 @@ class TtSWA(LightweightModule):
         self._build_masks(seq_local)
         self._build_halo_bounds(chunk, seq_local)
         self._build_carry_index(chunk)
-        # A row per TOKEN, and the "main" rope variant: a sliding layer does not share the compressor's
-        # YaRN-scaled table (reference DeepseekV4Attention.rope_layer_type).
         self._slab_rope = self.ops.build_rope_table(int(max_seq_len) + chunk, 1, layer_type="main")
         self._slab_index = self.ops.rope_index_base(seq_local)
         return TtSWAState(
@@ -217,10 +174,8 @@ class TtSWA(LightweightModule):
         )
 
     def _alloc_carry(self, batch: int, rows: int):
-        """``[batch, 1, rows, head_dim]``, ND-sharded so the migration address table can name it.
-
-        ``seq_len`` is pre-multiplied by sp_factor to cancel the division init_kvpe_cache does for its
-        own SP-sharded cache: the carry is replicated, so every chip holds all ``rows``."""
+        """ND-sharded so the migration address table can name it. ``seq_len`` is pre-multiplied by
+        sp_factor to cancel the division init_kvpe_cache does: the carry is replicated."""
         return init_kvpe_cache(
             kvpe_cache_head_dim=self.head_dim,
             mesh_device=self.device,
@@ -234,20 +189,9 @@ class TtSWA(LightweightModule):
         )
 
     def _build_masks(self, seq_local: int):
-        """The additive mask over the key layout ``[halo | own rows]``, both chip-local.
-
-        Key column ``j`` holds the token at global position ``base - sw + j`` and query row ``i`` the one
-        at ``base + i``, where ``base`` is this chip's first token. The causal window
-        ``base + i - sw < pos <= base + i`` then reduces to ``i < j <= i + sw`` -- the chip offset
-        cancels, so ONE replicated mask serves every chip.
-
-        The halo columns need a second version for the first chunk, where the carry holds no tokens yet.
-        Only chip 0 reads the carry -- chips 1..sp-1 take their halo from a predecessor inside this same
-        chunk -- so that version differs per chip, and ``log(nez(chip_index))`` turns the chip index into
-        the 0 / -inf it needs without a host tensor.
-
-        Built from index vectors so no large host tensor is created. They are float32 because
-        bfloat16 stops being exact above 256, and the column index runs to 768."""
+        """Additive mask over the key layout ``[halo | own rows]``. Both are chip-local and the chip
+        offset cancels, so ``i < j <= i + sw`` is the whole band and one replicated mask serves every
+        chip. float32 because bfloat16 cannot hold the column index exactly."""
         sw = self.sliding_window
         width = sw + seq_local
 
@@ -262,16 +206,14 @@ class TtSWA(LightweightModule):
             self.ops.mesh_mapper(sp_dim=2),
             dtype=ttnn.float32,
         )
-        not_chip_0 = ttnn.typecast(ttnn.log(ttnn.nez(chip)), self.dtype)  # 0 on chips 1.., -inf on chip 0
+        not_chip_0 = ttnn.typecast(ttnn.log(ttnn.nez(chip)), self.dtype)
+        # Second variant for the first chunk, where the carry is empty: only chip 0 reads it.
         self._head_cols = {False: head, True: ttnn.add(head, not_chip_0)}
 
     def _build_halo_bounds(self, chunk: int, seq_local: int):
-        """Slice bounds for this chip's halo: rows ``[d*seq_local, d*seq_local + sw)`` of
-        ``[carry | gathered chunk]``.
-
-        The offset differs per chip, so the bounds are SP-sharded device tensors -- ``ttnn.slice`` reads
-        them at runtime, which keeps only their shape in the program and lets one program serve all
-        ``sp`` offsets. They must be 1-D, hence the flat layout."""
+        """This chip's halo: rows ``[d*seq_local, d*seq_local + sw)`` of ``[carry | gathered chunk]``.
+        SP-sharded bound tensors, so only their shape is in the program and one program serves all
+        ``sp`` offsets. They must be 1-D."""
         sw, sp = self.sliding_window, self.sp_factor
         starts = torch.tensor([v for d in range(sp) for v in (0, 0, d * seq_local, 0)], dtype=torch.int32)
         ends = torch.tensor(
@@ -281,34 +223,20 @@ class TtSWA(LightweightModule):
         self._halo_bounds = tuple(
             self.ops.from_torch(t, mapper, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT) for t in (starts, ends)
         )
-        # ttnn.slice sizes its output as in_rows / num_devices, so this is a divisor and not a mesh size.
+        # ttnn.slice sizes its output as in_rows / num_devices: a divisor, not a mesh size.
         self._halo_num_devices = (sw + chunk) // sw
 
     def _carry_key(self, real_len: int):
-        """The carry index is tabulated per tile row, the granularity a slice start can take. A chunk
-        ending mid-tile rounds down, which only the final chunk may do.
-
-        Invisible to prefill, which never reads that last carry, but NOT invisible to migration: decode
-        picks the carry up from the address table and would be short by up to 31 positions after a
-        final chunk that ended mid-tile. Deciding that is a decode-interface question, not a local one
-        -- see "the final chunk's carry is not migration-correct" in V4_HCA_next_steps.MD. TtHCA rounds
-        the same way at 128, so it is off by up to 127."""
+        """Rounds down, which only the final chunk may do. Fine for prefill, which never reads that
+        carry, but not for migration -- see V4_HCA_next_steps.MD."""
         return (int(real_len) // TILE_HEIGHT) * TILE_HEIGHT
 
     def _build_carry_index(self, chunk: int):
-        """start/end index tensors for the carry slice, one pair per real_len a chunk can have.
+        """Bounds for the carry slice, one pair per real_len a chunk can have.
 
-        The carry is the last ``sw`` keys of the ACCUMULATED prefix, not the last rows of the padded
-        slab, and those differ as soon as ``real_len < chunk``. It is cut out of ``[carry | chunk]``
-        rather than out of the chunk alone, which is what lets a chunk be shorter than the window:
-        the real tokens of this chunk sit at ``[sw, sw + real_len)`` there, so the last ``sw`` of the
-        prefix are ``[real_len, real_len + sw)`` -- for ``real_len`` below ``sw`` that range walks
-        back into the previous carry on its own, and for ``real_len == 0`` it reproduces it exactly.
-        Out of the chunk alone no such range exists, since the chunk holds no history.
-
-        Tabulated per tile row: the start is a slice bound on a tiled tensor, so it moves a tile at a
-        time. The bounds are the same on every chip (the gathered slab is replicated), so unlike the
-        halo these are not sharded."""
+        The carry is the last ``sw`` keys of the ACCUMULATED prefix, cut out of ``[carry | chunk]``
+        as ``[real_len, real_len + sw)``. Out of the chunk alone that range would not exist for a
+        chunk shorter than the window; here it walks back into the previous carry by itself."""
         sw = self.sliding_window
 
         def idx(vals):
@@ -322,11 +250,10 @@ class TtSWA(LightweightModule):
         }
 
     def _attention(self, q, sliding_kv, cos, sin, carry, kv_actual: int, real_len: int):
-        """``q`` [B, H/tp, S/sp, head_dim] and this chip's own ``sliding_kv`` [B, 1, S/sp, head_dim]
-        -> ``(attn, next_carry)``.
+        """``q`` [B, H/tp, S/sp, head_dim] + this chip's ``sliding_kv`` -> ``(attn, next_carry)``.
 
-        The gather is over the WHOLE chunk even though attention reads 768 rows of it, because the
-        carry slice needs the global slab; see the module docstring."""
+        The gather covers the whole chunk though attention reads 768 rows of it, because the carry
+        slice needs the global slab."""
         batch, num_heads_local, seq_local, _ = q.shape
         sw = self.sliding_window
 
@@ -344,17 +271,13 @@ class TtSWA(LightweightModule):
         else:
             gathered = sliding_kv
 
-        # [carry | chunk] is the global key sequence this chunk can see; each chip takes the 128 rows
-        # that precede its own block out of it.
-        # The carry is ND-sharded so the migration table can name it, and concat refuses a mix of
-        # sharded and interleaved inputs.
+        # The carry is ND-sharded and concat will not mix sharded with interleaved.
         hist = ttnn.concat([ttnn.to_memory_config(carry, ttnn.DRAM_MEMORY_CONFIG), gathered], dim=2)
         start, end = self._halo_bounds
         halo = ttnn.slice(hist, start, end, slice_dim=2, num_devices=self._halo_num_devices)
         kv = ttnn.concat([halo, sliding_kv], dim=2)
 
-        # Only the halo columns move between chunks, and always over the same range, so the mask is
-        # built once and this overwrites that range in place.
+        # Only the halo columns move between chunks, over a fixed range, so this patches in place.
         head_cols = self._head_cols[kv_actual == 0]
         ttnn.experimental.slice_write(
             head_cols, self._mask, start=[0, 0, 0, 0], end=[1, 1, seq_local, sw], step=[1, 1, 1, 1]
@@ -368,10 +291,7 @@ class TtSWA(LightweightModule):
             is_causal=False,
             scale=self.scaling,
             attention_sink=self.sinks_sdpa,
-            # 128/128 is not inherited from HCA, it is the only good split here: a provided mask makes
-            # the reader stream a [q_chunk, k_chunk] tile per iteration, so anything wider blows L1
-            # (k_chunk=256 asks 1.93 MB of a 1.57 MB budget). Swept on 8x4 -- 96/128 costs 5% and
-            # 64/128 costs 38% on this op, everything above 128 fails to allocate.
+            # A provided mask makes the reader stream a [q_chunk, k_chunk] tile, so wider blows L1.
             program_config=ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=self.device.compute_with_storage_grid_size(),
                 q_chunk_size=128,
@@ -380,23 +300,20 @@ class TtSWA(LightweightModule):
             ),
         )
 
-        # The next chunk's window reaches back into this one, so the carry is this chunk's last REAL
-        # keys. Taking the start from a device tensor keeps only its shape in the program, so one
-        # program serves every real_len.
+        # Device-tensor bounds keep only their shape in the program, so one program serves every
+        # real_len.
         c_start, c_end = self._carry_index[self._carry_key(real_len)]
         next_carry = ttnn.slice(hist, c_start, c_end, slice_dim=2, num_devices=self._halo_num_devices)
 
         nope_dim = self.head_dim - self.rope_head_dim
         nope = ttnn.slice(attn, [0, 0, 0, 0], [batch, num_heads_local, seq_local, nope_dim])
         rope = ttnn.slice(attn, [0, 0, 0, nope_dim], [batch, num_heads_local, seq_local, self.head_dim])
-        # Undoing V's RoPE is the same rotation with the sign of sin flipped, so cos is reused.
+        # V's rope is undone by the same rotation with sin's sign flipped, so cos is reused.
         rope = ttnn.experimental.rotary_embedding_llama(rope, cos, ttnn.neg(sin), self.trans_mat, is_decode_mode=False)
         return ttnn.concat([nope, rope], dim=-1), next_carry
 
     def _q_stem(self, hidden_states, cos, sin):
-        """[B, 1, S/sp, hidden/tp] -> q [B, num_heads/tp, S/sp, head_dim]. ``cos``/``sin`` cover the padded
-        slab and are built once per call: both stems and the output un-rope want the same rotation, and
-        building it again costs ~2.9 ms of host time."""
+        """[B, 1, S/sp, hidden/tp] -> q [B, num_heads/tp, S/sp, head_dim]."""
         input_shape = tuple(hidden_states.shape)
         if len(input_shape) != 4 or input_shape[1] != 1:
             raise ValueError(f"Expected hidden_states shape [B, 1, S, hidden], got {input_shape}")
@@ -405,7 +322,7 @@ class TtSWA(LightweightModule):
 
         q = ttnn.linear(hidden_states, self.wq_a, memory_config=self.memory_config)
 
-        # Row-parallel -> partial sums; all-reduce rebuilds the full q_lora, replicated across TP.
+        # Row-parallel, so partial sums; the all-reduce rebuilds q_lora replicated across TP.
         if self.tp_factor > 1:
             q = ttnn.experimental.reduce_scatter_minimal_async(
                 q,
@@ -449,7 +366,7 @@ class TtSWA(LightweightModule):
 
     def _kv_stem(self, hidden_states, cos, sin):
         """[B, 1, S/sp, hidden/tp] -> single-head sliding_kv [B, 1, S/sp, head_dim], TP-replicated.
-        K == V in V4. Returns the full S; the sliding-window truncation is a chunked-prefill concern."""
+        K == V in V4, and the sliding-window truncation is the caller's concern."""
         input_shape = tuple(hidden_states.shape)
         if len(input_shape) != 4 or input_shape[1] != 1:
             raise ValueError(f"Expected hidden_states shape [B, 1, S, hidden], got {input_shape}")
@@ -457,8 +374,6 @@ class TtSWA(LightweightModule):
 
         kv = ttnn.linear(hidden_states, self.wkv, memory_config=self.memory_config)
 
-        # kv_proj is contraction(row)-parallel like wq_a -> partial-sum single-head KV; TP all-reduce
-        # (reduce_scatter + all_gather) rebuilds the full head_dim, replicated across TP.
         if self.tp_factor > 1:
             kv = ttnn.experimental.reduce_scatter_minimal_async(
                 kv,
@@ -491,7 +406,7 @@ class TtSWA(LightweightModule):
         return ttnn.concat([nope, rope], dim=-1)
 
     def _o_proj(self, attn):
-        """[B, num_heads/tp, S/sp, head_dim] -> [B, 1, S/sp, hidden/tp], the block's own input layout."""
+        """[B, num_heads/tp, S/sp, head_dim] -> [B, 1, S/sp, hidden/tp], the block's input layout."""
         batch, _, seq_len, _ = attn.shape
         in_per_group = self.num_heads * self.head_dim // self.o_groups
         groups_local = self.o_groups // self.tp_factor
@@ -500,17 +415,16 @@ class TtSWA(LightweightModule):
         x = ttnn.experimental.nlp_concat_heads(x, memory_config=self.memory_config)
         x = ttnn.reshape(x, [batch, groups_local, seq_len, in_per_group])
 
-        grouped = ttnn.linear(x, self.wo_a, memory_config=self.memory_config)  # [B, groups_local, S, o_lora_rank]
+        grouped = ttnn.linear(x, self.wo_a, memory_config=self.memory_config)
         o_lora_rank = grouped.shape[-1]
         grouped = ttnn.concat(
             [ttnn.slice(grouped, [0, g, 0, 0], [batch, g + 1, seq_len, o_lora_rank]) for g in range(groups_local)],
             dim=-1,
-        )  # [B, 1, S, groups_local*o_lora_rank]
+        )
 
-        out = ttnn.linear(grouped, self.wo_b, memory_config=self.memory_config)  # partial-sum [B,1,S,hidden]
+        out = ttnn.linear(grouped, self.wo_b, memory_config=self.memory_config)
 
-        # Reduce-scatter, not a full all-reduce: it both sums the partials and slices to hidden/tp,
-        # which is already the layout the next block wants.
+        # Reduce-scatter and not an all-reduce: it sums the partials and slices to hidden/tp at once.
         if self.tp_factor > 1:
             out = ttnn.experimental.reduce_scatter_minimal_async(
                 out,
@@ -526,18 +440,13 @@ class TtSWA(LightweightModule):
         return out
 
     def forward(self, hidden_states, seq_len_actual: int | None = None, state: TtSWAState = None):
-        """[B, 1, S/sp, hidden/tp] -> the same, one chunk. ``seq_len_actual`` is the chunk's real token
-        count; the rest of the slab is padding the mask never lets a real query read."""
+        """[B, 1, S/sp, hidden/tp] -> the same, one chunk. ``seq_len_actual`` is the real token count;
+        the rest of the slab is padding no real query reads."""
         assert state is not None, "TtSWA.forward needs the state alloc_state returned"
         seq_len = hidden_states.shape[2] * self.sp_factor
         real_len = int(seq_len if seq_len_actual is None else seq_len_actual)
         sw = self.sliding_window
-        # Checked on the ACCUMULATED length, not this chunk's, and against a tile row rather than the
-        # window: the carry is cut out of [carry | chunk], so a chunk may be SHORTER than the window
-        # and still leave a correct carry -- the only real constraint is that its end be a slice bound
-        # a tiled tensor can take. A final chunk may end anywhere, since nothing reads its carry.
-        # Looser than TtHCA, which is tied to its compressor's 128-token windows; a chunk sequence
-        # valid there is therefore valid here too.
+        # On the ACCUMULATED length: a final chunk may end mid-tile, a non-final one may not.
         assert state.kv_actual % TILE_HEIGHT == 0, (
             f"cannot append after a chunk with {state.kv_actual % TILE_HEIGHT} leftover tokens; only "
             f"the final chunk may end mid-tile, non-final chunks must be a multiple of {TILE_HEIGHT}"
@@ -553,6 +462,6 @@ class TtSWA(LightweightModule):
         )
 
         state.kv_actual += real_len
-        # In place, not a rebind: the migration table is built once from this tensor's address.
+        # In place, not a rebind: the migration table records this address once.
         ttnn.kv_cache.fill_cache_for_user_(state.carry, next_carry, 0, update_idx=0)
         return self._o_proj(attn)

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -6,9 +6,8 @@
 The reference builds all three attention kinds from one class: a sliding layer is
 ``DeepseekV4Attention`` with ``compressor = None`` and ``rope_layer_type = "main"`` (plain theta=10000
 instead of the YaRN-scaled table HCA/CSA share with their compressor). Everything else -- the Q/KV
-stems, the per-head sink, the grouped output projection -- is identical, so those come from
-:class:`TtHCA` unchanged and only the attention core differs. Flash has two such layers (0 and 1); Pro
-has none.
+stems, the per-head sink, the grouped output projection -- is identical, and is duplicated here rather
+than shared; see the note in ``__init__``. Flash has two such layers (0 and 1); Pro has none.
 
 The attention core is where a sliding layer stops looking like HCA. HCA all-gathers the K/V and then
 attends over ``[carry | chunk | compressed]``, so every chip sees ``Sk`` = the whole slab. A 128-token
@@ -41,9 +40,11 @@ import torch
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4.modeling_deepseek_v4 import DeepseekV4RotaryEmbedding
 from models.demos.deepseek_v3_d_p.tt.mla.compressor import TtCompressorUtils
-from models.demos.deepseek_v3_d_p.tt.mla.heavily_compressed_attention import TtHCA
+from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
 
 class TtSWAState:
@@ -86,50 +87,71 @@ class TtSWA(LightweightModule):
         weights_dtype=ttnn.bfloat8_b,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     ):
-        # The stems, the sink packing and the grouped o_proj are the reference's shared half, so they
-        # come from a TtHCA built with compressor=None rather than copied. Only _attention and the
-        # state differ, and both live here.
-        self._hca = TtHCA(
+        # TODO: q_stem / kv_stem / o_proj below are byte-identical to TtHCA's, and to whatever TtCSA's
+        # will be -- the reference builds all eight projections unconditionally for every layer_type and
+        # runs them identically (modeling_deepseek_v4.py:786-800); only the key assembly in the middle
+        # differs. They belong in one TtV4Attention.forward that runs the shared pipeline
+        # (q_stem -> kv_stem -> per-type core -> o_proj) and injects the core, rather than in a base
+        # class each type re-derives a forward from. Duplicated here on purpose so this layer lands
+        # without touching heavily_compressed_attention.py; unify once TtCSA's core exists.
+        self.device = device
+        self.dtype = dtype
+        self.weights_dtype = weights_dtype
+        self.memory_config = memory_config
+        self.num_heads = int(num_heads)
+        self.head_dim = int(head_dim)
+        self.rope_head_dim = int(rope_head_dim)
+        self.sliding_window = int(sliding_window)
+        self.o_groups = int(o_groups)
+        self.scaling = self.head_dim**-0.5
+        self.rotary_emb = rotary_emb
+        self.rms_norm_eps = float(rms_norm_eps)
+
+        self.sp_axis, self.tp_axis = sp_axis, tp_axis
+        self.sp_factor = device.shape[sp_axis]
+        self.tp_factor = device.shape[tp_axis]
+        self.tp_ccl_topology = topology
+        self.tt_ccl = get_tt_ccl(device) if (self.sp_factor > 1 or self.tp_factor > 1) else None
+        self.ccl_num_links = 2 if is_blackhole() else 1
+        self.ops = TtCompressorUtils(
             device,
-            compressor=None,
-            q_a_proj_weight=q_a_proj_weight,
-            q_a_norm_weight=q_a_norm_weight,
-            q_b_proj_weight=q_b_proj_weight,
-            kv_proj_weight=kv_proj_weight,
-            kv_norm_weight=kv_norm_weight,
-            sinks=sinks,
-            o_a_proj_weight=o_a_proj_weight,
-            o_b_proj_weight=o_b_proj_weight,
             rotary_emb=rotary_emb,
-            num_heads=num_heads,
-            head_dim=head_dim,
-            rope_head_dim=rope_head_dim,
-            sliding_window=sliding_window,
-            o_groups=o_groups,
-            rms_norm_eps=rms_norm_eps,
             sp_axis=sp_axis,
             tp_axis=tp_axis,
-            topology=topology,
             dtype=dtype,
             weights_dtype=weights_dtype,
             memory_config=memory_config,
         )
-        self.device = device
-        self.dtype = dtype
-        self.memory_config = memory_config
-        self.head_dim = int(head_dim)
-        self.rope_head_dim = int(rope_head_dim)
-        self.sliding_window = int(sliding_window)
-        self.scaling = self.head_dim**-0.5
-        self.sp_axis, self.tp_axis = sp_axis, tp_axis
-        self.sp_factor = self._hca.sp_factor
-        self.tp_factor = self._hca.tp_factor
-        self.ops: TtCompressorUtils = self._hca.ops
+
+        # Pre-divided by scale: SDPA scales BOTH QK and the sink internally, the reference scales only
+        # QK -- dividing here cancels the kernel's extra multiply. TP-sharded to match the query heads.
+        sinks_host = sinks.detach().reshape(1, self.num_heads, 1, 1) / self.scaling
+        self.sinks_sdpa = self.ops.from_torch(sinks_host, mesh_mapper=self.ops.mesh_mapper(tp_dim=1))
+
+        self.wq_a = self.ops.to_tt_linear_weight(q_a_proj_weight, tp_shard_dim=2)
+        self.wq_b = self.ops.to_tt_linear_weight(q_b_proj_weight, tp_shard_dim=3)
+        self.q_a_norm_weight = self.ops.from_torch(q_a_norm_weight.detach().reshape(1, 1, 1, -1))
+        self.q_b_norm_weight = self.ops.from_torch(torch.ones(1, 1, 1, self.head_dim))
+        self.wkv = self.ops.to_tt_linear_weight(kv_proj_weight, tp_shard_dim=2)
+        self.kv_norm_weight = self.ops.from_torch(kv_norm_weight.detach().reshape(1, 1, 1, self.head_dim))
+
+        # o_a_proj is block-diagonal over o_groups. Groups partition the heads, so a TP chip owns whole
+        # groups: keep it as ONE batched weight sharded on the group axis and run a single batched
+        # matmul -- each chip applies only its own groups, no collective.
+        in_per_group = self.num_heads * self.head_dim // self.o_groups
+        o_a_grouped = o_a_proj_weight.detach().view(self.o_groups, -1, in_per_group).transpose(1, 2).unsqueeze(0)
+        self.wo_a = self.ops.from_torch(
+            o_a_grouped, mesh_mapper=self.ops.mesh_mapper(tp_dim=1), dtype=self.weights_dtype
+        )
+        self.wo_b = self.ops.to_tt_linear_weight(o_b_proj_weight, tp_shard_dim=2)
+
+        self.trans_mat = self.ops.from_torch(get_rot_transformation_mat())
 
         # Everything below comes from alloc_state, which every caller has to run before forward.
         self._mask = None  # persistent additive mask; forward overwrites only the halo columns
         self._head_cols = None  # the halo columns, in a normal and a first-chunk variant
         self._halo_bounds = None  # SP-sharded slice bounds: this chip's 128 rows of history
+        self._halo_num_devices = None
         self._slab_rope = None
         self._slab_index = None
         self._carry_index = None
@@ -271,13 +293,11 @@ class TtSWA(LightweightModule):
             gathered = ttnn.experimental.all_gather_async(
                 sliding_kv,
                 dim=2,
-                multi_device_global_semaphore=self._hca.tt_ccl.get_and_cycle_ag_semaphore_handles(
-                    cluster_axis=self.sp_axis
-                ),
-                barrier_semaphore=self._hca.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
-                num_links=self._hca.ccl_num_links,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
+                num_links=self.ccl_num_links,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                topology=self._hca.tp_ccl_topology,
+                topology=self.tp_ccl_topology,
                 cluster_axis=self.sp_axis,
             )
         else:
@@ -304,7 +324,7 @@ class TtSWA(LightweightModule):
             attn_mask=self._mask,
             is_causal=False,
             scale=self.scaling,
-            attention_sink=self._hca.sinks_sdpa,
+            attention_sink=self.sinks_sdpa,
             # 128/128 is not inherited from HCA, it is the only good split here: a provided mask makes
             # the reader stream a [q_chunk, k_chunk] tile per iteration, so anything wider blows L1
             # (k_chunk=256 asks 1.93 MB of a 1.57 MB budget). Swept on 8x4 -- 96/128 costs 5% and
@@ -327,10 +347,140 @@ class TtSWA(LightweightModule):
         nope = ttnn.slice(attn, [0, 0, 0, 0], [batch, num_heads_local, seq_local, nope_dim])
         rope = ttnn.slice(attn, [0, 0, 0, nope_dim], [batch, num_heads_local, seq_local, self.head_dim])
         # Undoing V's RoPE is the same rotation with the sign of sin flipped, so cos is reused.
-        rope = ttnn.experimental.rotary_embedding_llama(
-            rope, cos, ttnn.neg(sin), self._hca.trans_mat, is_decode_mode=False
-        )
+        rope = ttnn.experimental.rotary_embedding_llama(rope, cos, ttnn.neg(sin), self.trans_mat, is_decode_mode=False)
         return ttnn.concat([nope, rope], dim=-1), next_carry
+
+    def _q_stem(self, hidden_states, cos, sin):
+        """[B, 1, S/sp, hidden/tp] -> q [B, num_heads/tp, S/sp, head_dim]. ``cos``/``sin`` cover the padded
+        slab and are built once per call: both stems and the output un-rope want the same rotation, and
+        building it again costs ~2.9 ms of host time."""
+        input_shape = tuple(hidden_states.shape)
+        if len(input_shape) != 4 or input_shape[1] != 1:
+            raise ValueError(f"Expected hidden_states shape [B, 1, S, hidden], got {input_shape}")
+        batch, seq_len = input_shape[0], input_shape[2]
+        num_heads_local = self.num_heads // self.tp_factor
+
+        q = ttnn.linear(hidden_states, self.wq_a, memory_config=self.memory_config)
+
+        # Row-parallel -> partial sums; all-reduce rebuilds the full q_lora, replicated across TP.
+        if self.tp_factor > 1:
+            q = ttnn.experimental.reduce_scatter_minimal_async(
+                q,
+                persistent_output_buffers=None,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=self.tp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                num_links=self.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.tp_ccl_topology,
+                cluster_axis=self.tp_axis,
+            )
+            q = ttnn.experimental.all_gather_async(
+                q,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                num_links=self.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.tp_ccl_topology,
+                cluster_axis=self.tp_axis,
+            )
+
+        q = ttnn.rms_norm(q, weight=self.q_a_norm_weight, epsilon=self.rms_norm_eps)
+        q = ttnn.linear(q, self.wq_b, memory_config=self.memory_config)
+
+        q, _, _ = ttnn.experimental.nlp_create_qkv_heads(
+            q,
+            num_heads=num_heads_local,
+            num_kv_heads=0,
+            transpose_k_heads=False,
+            memory_config=self.memory_config,
+        )
+        q = ttnn.rms_norm(q, weight=self.q_b_norm_weight, epsilon=self.rms_norm_eps)
+
+        nope_dim = self.head_dim - self.rope_head_dim
+        nope = ttnn.slice(q, [0, 0, 0, 0], [batch, num_heads_local, seq_len, nope_dim])
+        rope = ttnn.slice(q, [0, 0, 0, nope_dim], [batch, num_heads_local, seq_len, self.head_dim])
+        rope = ttnn.experimental.rotary_embedding_llama(rope, cos, sin, self.trans_mat, is_decode_mode=False)
+        return ttnn.concat([nope, rope], dim=-1)
+
+    def _kv_stem(self, hidden_states, cos, sin):
+        """[B, 1, S/sp, hidden/tp] -> single-head sliding_kv [B, 1, S/sp, head_dim], TP-replicated.
+        K == V in V4. Returns the full S; the sliding-window truncation is a chunked-prefill concern."""
+        input_shape = tuple(hidden_states.shape)
+        if len(input_shape) != 4 or input_shape[1] != 1:
+            raise ValueError(f"Expected hidden_states shape [B, 1, S, hidden], got {input_shape}")
+        batch, seq_len = input_shape[0], input_shape[2]
+
+        kv = ttnn.linear(hidden_states, self.wkv, memory_config=self.memory_config)
+
+        # kv_proj is contraction(row)-parallel like wq_a -> partial-sum single-head KV; TP all-reduce
+        # (reduce_scatter + all_gather) rebuilds the full head_dim, replicated across TP.
+        if self.tp_factor > 1:
+            kv = ttnn.experimental.reduce_scatter_minimal_async(
+                kv,
+                persistent_output_buffers=None,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=self.tp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                num_links=self.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.tp_ccl_topology,
+                cluster_axis=self.tp_axis,
+            )
+            kv = ttnn.experimental.all_gather_async(
+                kv,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                num_links=self.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.tp_ccl_topology,
+                cluster_axis=self.tp_axis,
+            )
+
+        kv = ttnn.rms_norm(kv, weight=self.kv_norm_weight, epsilon=self.rms_norm_eps)
+
+        nope_dim = self.head_dim - self.rope_head_dim
+        nope = ttnn.slice(kv, [0, 0, 0, 0], [batch, 1, seq_len, nope_dim])
+        rope = ttnn.slice(kv, [0, 0, 0, nope_dim], [batch, 1, seq_len, self.head_dim])
+        rope = ttnn.experimental.rotary_embedding_llama(rope, cos, sin, self.trans_mat, is_decode_mode=False)
+        return ttnn.concat([nope, rope], dim=-1)
+
+    def _o_proj(self, attn):
+        """[B, num_heads/tp, S/sp, head_dim] -> [B, 1, S/sp, hidden/tp], the block's own input layout."""
+        batch, _, seq_len, _ = attn.shape
+        in_per_group = self.num_heads * self.head_dim // self.o_groups
+        groups_local = self.o_groups // self.tp_factor
+
+        x = ttnn.reshape(attn, [groups_local, attn.shape[1] // groups_local, seq_len, self.head_dim])
+        x = ttnn.experimental.nlp_concat_heads(x, memory_config=self.memory_config)
+        x = ttnn.reshape(x, [batch, groups_local, seq_len, in_per_group])
+
+        grouped = ttnn.linear(x, self.wo_a, memory_config=self.memory_config)  # [B, groups_local, S, o_lora_rank]
+        o_lora_rank = grouped.shape[-1]
+        grouped = ttnn.concat(
+            [ttnn.slice(grouped, [0, g, 0, 0], [batch, g + 1, seq_len, o_lora_rank]) for g in range(groups_local)],
+            dim=-1,
+        )  # [B, 1, S, groups_local*o_lora_rank]
+
+        out = ttnn.linear(grouped, self.wo_b, memory_config=self.memory_config)  # partial-sum [B,1,S,hidden]
+
+        # Reduce-scatter, not a full all-reduce: it both sums the partials and slices to hidden/tp,
+        # which is already the layout the next block wants.
+        if self.tp_factor > 1:
+            out = ttnn.experimental.reduce_scatter_minimal_async(
+                out,
+                persistent_output_buffers=None,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=self.tp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                num_links=self.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.tp_ccl_topology,
+                cluster_axis=self.tp_axis,
+            )
+        return out
 
     def forward(self, hidden_states, seq_len_actual: int | None = None, state: TtSWAState = None):
         """[B, 1, S/sp, hidden/tp] -> the same, one chunk. ``seq_len_actual`` is the chunk's real token
@@ -346,8 +496,8 @@ class TtSWA(LightweightModule):
 
         slab_index = self.ops.rope_index(self._slab_index, state.kv_actual)
         cos, sin = self.ops.rope_gather(self._slab_rope, slab_index)
-        q = self._hca._q_stem(hidden_states, cos, sin)
-        sliding_kv = self._hca._kv_stem(hidden_states, cos, sin)
+        q = self._q_stem(hidden_states, cos, sin)
+        sliding_kv = self._kv_stem(hidden_states, cos, sin)
 
         attn, next_carry = self._attention(
             q, sliding_kv, cos, sin, carry=state.carry, kv_actual=state.kv_actual, real_len=real_len
@@ -355,4 +505,4 @@ class TtSWA(LightweightModule):
 
         state.kv_actual += real_len
         state.carry = next_carry
-        return self._hca._o_proj(attn)
+        return self._o_proj(attn)

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -110,8 +110,7 @@ class TtSWA(LightweightModule):
         self.trans_mat = self.ops.from_torch(get_rot_transformation_mat())
 
         # Built by alloc_state, which every caller runs before forward.
-        self._mask = None
-        self._head_cols = None
+        self._masks = None
         self._halo_bounds = None
         self._halo_num_devices = None
         self._slab_rope = None
@@ -186,26 +185,30 @@ class TtSWA(LightweightModule):
         )
 
     def _build_masks(self, seq_local: int):
-        """Additive mask over the key layout ``[halo | own rows]``. Both are chip-local and the chip
-        offset cancels, so ``i < j <= i + sw`` is the whole band and one replicated mask serves every
-        chip. float32 because bfloat16 cannot hold the column index exactly."""
+        """Additive masks over the key layout ``[halo | own rows]``, keyed on whether the carry is empty.
+
+        Both halves of the layout are chip-local and the chip offset cancels, so ``i < j <= i + sw`` is
+        the whole band and one replicated mask serves every chip. float32 because bfloat16 cannot hold
+        the column index exactly.
+
+        The empty-carry variant sends the halo columns to -inf on chip 0 only: a zero key still enters
+        the softmax denominator, and on the first chunk chip 0's halo is the zeroed carry while every
+        other chip's lies inside this same chunk."""
         sw = self.sliding_window
         width = sw + seq_local
 
         ic = self.ops.from_torch(torch.arange(seq_local).float().view(1, 1, seq_local, 1), dtype=ttnn.float32)
         jc = self.ops.from_torch(torch.arange(width).float().view(1, 1, 1, width), dtype=ttnn.float32)
         band = ttnn.typecast(ttnn.log(ttnn.multiply(ttnn.gt(jc, ic), ttnn.le(jc, ttnn.add(ic, float(sw))))), self.dtype)
-        self._mask = band
 
-        head = ttnn.slice(band, [0, 0, 0, 0], [1, 1, seq_local, sw])
         chip = self.ops.from_torch(
             torch.arange(self.sp_factor).float().view(1, 1, self.sp_factor, 1),
             self.ops.mesh_mapper(sp_dim=2),
             dtype=ttnn.float32,
         )
-        not_chip_0 = ttnn.typecast(ttnn.log(ttnn.nez(chip)), self.dtype)
-        # Second variant for the first chunk, where the carry is empty: only chip 0 reads it.
-        self._head_cols = {False: head, True: ttnn.add(head, not_chip_0)}
+        keep = ttnn.nez(ttnn.add(ttnn.nez(chip), ttnn.ge(jc, float(sw))))
+        empty_carry = ttnn.typecast(ttnn.log(keep), self.dtype)
+        self._masks = {False: band, True: ttnn.add(band, empty_carry)}
 
     def _build_halo_bounds(self, chunk: int, seq_local: int):
         """This chip's halo: rows ``[d*seq_local, d*seq_local + sw)`` of ``[carry | gathered chunk]``.
@@ -272,17 +275,11 @@ class TtSWA(LightweightModule):
         halo = ttnn.slice(hist, start, end, slice_dim=2, num_devices=self._halo_num_devices)
         kv = ttnn.concat([halo, sliding_kv], dim=2)
 
-        # Only the halo columns move between chunks, over a fixed range, so this patches in place.
-        head_cols = self._head_cols[kv_actual == 0]
-        ttnn.experimental.slice_write(
-            head_cols, self._mask, start=[0, 0, 0, 0], end=[1, 1, seq_local, sw], step=[1, 1, 1, 1]
-        )
-
         attn = ttnn.transformer.scaled_dot_product_attention(
             q,
             kv,
             kv,
-            attn_mask=self._mask,
+            attn_mask=self._masks[kv_actual == 0],
             is_causal=False,
             scale=self.scaling,
             attention_sink=self.sinks_sdpa,

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -185,15 +185,7 @@ class TtSWA(LightweightModule):
         )
 
     def _build_masks(self, seq_local: int):
-        """Additive masks over the key layout ``[halo | own rows]``, keyed on whether the carry is empty.
-
-        Both halves of the layout are chip-local and the chip offset cancels, so ``i < j <= i + sw`` is
-        the whole band and one replicated mask serves every chip. float32 because bfloat16 cannot hold
-        the column index exactly.
-
-        The empty-carry variant sends the halo columns to -inf on chip 0 only: a zero key still enters
-        the softmax denominator, and on the first chunk chip 0's halo is the zeroed carry while every
-        other chip's lies inside this same chunk."""
+        """Both masks over the key layout ``[halo | own rows]``, built here and never touched again."""
         sw = self.sliding_window
         width = sw + seq_local
 
@@ -208,12 +200,12 @@ class TtSWA(LightweightModule):
         )
         keep = ttnn.nez(ttnn.add(ttnn.nez(chip), ttnn.ge(jc, float(sw))))
         empty_carry = ttnn.typecast(ttnn.log(keep), self.dtype)
+        # Only chunk 0 differs: there chip 0's halo is the zeroed carry, and a zero key still
+        # counts in the softmax denominator.
         self._masks = {False: band, True: ttnn.add(band, empty_carry)}
 
     def _build_halo_bounds(self, chunk: int, seq_local: int):
-        """This chip's halo: rows ``[d*seq_local, d*seq_local + sw)`` of ``[carry | gathered chunk]``.
-        SP-sharded bound tensors, so only their shape is in the program and one program serves all
-        ``sp`` offsets. They must be 1-D."""
+        """Which part of the gathered KV each chip takes as its halo."""
         sw, sp = self.sliding_window, self.sp_factor
         starts = torch.tensor([v for d in range(sp) for v in (0, 0, d * seq_local, 0)], dtype=torch.int32)
         ends = torch.tensor(
@@ -223,19 +215,13 @@ class TtSWA(LightweightModule):
         self._halo_bounds = tuple(
             self.ops.from_torch(t, mapper, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT) for t in (starts, ends)
         )
-        # ttnn.slice sizes its output as in_rows / num_devices.
         self._halo_num_devices = (sw + chunk) // sw
 
     def _carry_key(self, real_len: int):
-        """Rounds down, which only the final chunk may do. See V4_HCA_next_steps.MD for migration."""
         return (int(real_len) // TILE_HEIGHT) * TILE_HEIGHT
 
     def _build_carry_index(self, chunk: int):
-        """Bounds for the carry slice, one pair per real_len a chunk can have.
-
-        The carry is the last ``sw`` keys of the accumulated prefix, which in ``[carry | chunk]`` is
-        ``[real_len, real_len + sw)``. For a chunk shorter than ``sw`` that range reaches back into the
-        previous carry."""
+        """Which part of ``[carry | chunk]`` becomes the carry for the next chunk, one pair per real_len."""
         sw = self.sliding_window
 
         def idx(vals):

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -3,13 +3,8 @@
 
 """DeepSeek-V4 sliding-only attention (``layer_types[i] == "sliding_attention"``), chunked prefill.
 
-A sliding layer is the reference's ``DeepseekV4Attention`` with ``compressor = None`` and the plain
-theta=10000 rope. Flash has two (layers 0 and 1); Pro has none.
-
-The window never reaches past the ``sliding_window`` rows before a chip's own first query, so each
-chip attends over ``[halo | its own rows]`` rather than over the whole slab like HCA. Rationale for
-the choices here -- the mask instead of ``sliding_window_size``, the full K/V gather, the SDPA chunk
-sizes -- is in ``V4_HCA_next_steps.MD``.
+Each chip attends over ``[halo | its own rows]``, where the halo is the ``sliding_window`` rows
+preceding its first query: that is as far back as the window reaches.
 """
 
 import torch
@@ -64,7 +59,6 @@ class TtSWA(LightweightModule):
         weights_dtype=ttnn.bfloat8_b,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     ):
-        # TODO: share the stems with TtHCA/TtCSA once TtCSA lands; see V4_HCA_next_steps.MD.
         self.device = device
         self.dtype = dtype
         self.weights_dtype = weights_dtype
@@ -94,7 +88,7 @@ class TtSWA(LightweightModule):
             memory_config=memory_config,
         )
 
-        # Pre-divided: SDPA scales the sink as well as QK, the reference scales only QK.
+        # SDPA scales the sink along with QK, so the division here cancels that.
         sinks_host = sinks.detach().reshape(1, self.num_heads, 1, 1) / self.scaling
         self.sinks_sdpa = self.ops.from_torch(sinks_host, mesh_mapper=self.ops.mesh_mapper(tp_dim=1))
 
@@ -105,8 +99,7 @@ class TtSWA(LightweightModule):
         self.wkv = self.ops.to_tt_linear_weight(kv_proj_weight, tp_shard_dim=2)
         self.kv_norm_weight = self.ops.from_torch(kv_norm_weight.detach().reshape(1, 1, 1, self.head_dim))
 
-        # o_a_proj is block-diagonal over o_groups and a TP chip owns whole groups, so this stays one
-        # batched weight and one batched matmul, no collective.
+        # Block-diagonal over o_groups, and a TP chip owns whole groups, so one batched matmul serves it.
         in_per_group = self.num_heads * self.head_dim // self.o_groups
         o_a_grouped = o_a_proj_weight.detach().view(self.o_groups, -1, in_per_group).transpose(1, 2).unsqueeze(0)
         self.wo_a = self.ops.from_torch(
@@ -223,20 +216,19 @@ class TtSWA(LightweightModule):
         self._halo_bounds = tuple(
             self.ops.from_torch(t, mapper, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT) for t in (starts, ends)
         )
-        # ttnn.slice sizes its output as in_rows / num_devices: a divisor, not a mesh size.
+        # ttnn.slice sizes its output as in_rows / num_devices.
         self._halo_num_devices = (sw + chunk) // sw
 
     def _carry_key(self, real_len: int):
-        """Rounds down, which only the final chunk may do. Fine for prefill, which never reads that
-        carry, but not for migration -- see V4_HCA_next_steps.MD."""
+        """Rounds down, which only the final chunk may do. See V4_HCA_next_steps.MD for migration."""
         return (int(real_len) // TILE_HEIGHT) * TILE_HEIGHT
 
     def _build_carry_index(self, chunk: int):
         """Bounds for the carry slice, one pair per real_len a chunk can have.
 
-        The carry is the last ``sw`` keys of the ACCUMULATED prefix, cut out of ``[carry | chunk]``
-        as ``[real_len, real_len + sw)``. Out of the chunk alone that range would not exist for a
-        chunk shorter than the window; here it walks back into the previous carry by itself."""
+        The carry is the last ``sw`` keys of the accumulated prefix, which in ``[carry | chunk]`` is
+        ``[real_len, real_len + sw)``. For a chunk shorter than ``sw`` that range reaches back into the
+        previous carry."""
         sw = self.sliding_window
 
         def idx(vals):
@@ -252,8 +244,7 @@ class TtSWA(LightweightModule):
     def _attention(self, q, sliding_kv, cos, sin, carry, kv_actual: int, real_len: int):
         """``q`` [B, H/tp, S/sp, head_dim] + this chip's ``sliding_kv`` -> ``(attn, next_carry)``.
 
-        The gather covers the whole chunk though attention reads 768 rows of it, because the carry
-        slice needs the global slab."""
+        The gather covers the whole chunk because the carry slice needs the global slab."""
         batch, num_heads_local, seq_local, _ = q.shape
         sw = self.sliding_window
 
@@ -291,7 +282,7 @@ class TtSWA(LightweightModule):
             is_causal=False,
             scale=self.scaling,
             attention_sink=self.sinks_sdpa,
-            # A provided mask makes the reader stream a [q_chunk, k_chunk] tile, so wider blows L1.
+            # With a mask the reader streams a [q_chunk, k_chunk] tile, so wider sizes exhaust L1.
             program_config=ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=self.device.compute_with_storage_grid_size(),
                 q_chunk_size=128,
@@ -308,7 +299,7 @@ class TtSWA(LightweightModule):
         nope_dim = self.head_dim - self.rope_head_dim
         nope = ttnn.slice(attn, [0, 0, 0, 0], [batch, num_heads_local, seq_local, nope_dim])
         rope = ttnn.slice(attn, [0, 0, 0, nope_dim], [batch, num_heads_local, seq_local, self.head_dim])
-        # V's rope is undone by the same rotation with sin's sign flipped, so cos is reused.
+        # V's rope is undone by the same rotation with sin's sign flipped.
         rope = ttnn.experimental.rotary_embedding_llama(rope, cos, ttnn.neg(sin), self.trans_mat, is_decode_mode=False)
         return ttnn.concat([nope, rope], dim=-1), next_carry
 
@@ -424,7 +415,7 @@ class TtSWA(LightweightModule):
 
         out = ttnn.linear(grouped, self.wo_b, memory_config=self.memory_config)
 
-        # Reduce-scatter and not an all-reduce: it sums the partials and slices to hidden/tp at once.
+        # Reduce-scatter sums the partials and slices to hidden/tp in one op.
         if self.tp_factor > 1:
             out = ttnn.experimental.reduce_scatter_minimal_async(
                 out,
@@ -462,6 +453,6 @@ class TtSWA(LightweightModule):
         )
 
         state.kv_actual += real_len
-        # In place, not a rebind: the migration table records this address once.
+        # The migration table records this address once, so the write is in place.
         ttnn.kv_cache.fill_cache_for_user_(state.carry, next_carry, 0, update_idx=0)
         return self._o_proj(attn)

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -45,6 +45,7 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v4.modeling_deepseek_v4 imp
 from models.demos.deepseek_v3_d_p.tt.mla.compressor import TtCompressorUtils
 from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
 
 class TtSWAState:
@@ -207,8 +208,25 @@ class TtSWA(LightweightModule):
         self._slab_rope = self.ops.build_rope_table(int(max_seq_len) + chunk, 1, layer_type="main")
         self._slab_index = self.ops.rope_index_base(seq_local)
         return TtSWAState(
-            carry=self.ops.from_torch(torch.zeros(batch, 1, sw, self.head_dim)),
+            carry=self._alloc_carry(batch, sw),
             max_seq_len=max_seq_len,
+        )
+
+    def _alloc_carry(self, batch: int, rows: int):
+        """``[batch, 1, rows, head_dim]``, ND-sharded so the migration address table can name it.
+
+        ``seq_len`` is pre-multiplied by sp_factor to cancel the division init_kvpe_cache does for its
+        own SP-sharded cache: the carry is replicated, so every chip holds all ``rows``."""
+        return init_kvpe_cache(
+            kvpe_cache_head_dim=self.head_dim,
+            mesh_device=self.device,
+            seq_len=rows * self.sp_factor,
+            mesh_shape=list(self.device.shape),
+            sp_axis=self.sp_axis,
+            num_kvpe_cache_layers=1,
+            num_users=batch,
+            dtype=self.dtype,
+            layout=ttnn.TILE_LAYOUT,
         )
 
     def _build_masks(self, seq_local: int):
@@ -305,7 +323,9 @@ class TtSWA(LightweightModule):
 
         # [carry | chunk] is the global key sequence this chunk can see; each chip takes the 128 rows
         # that precede its own block out of it.
-        hist = ttnn.concat([carry, gathered], dim=2)
+        # The carry is ND-sharded so the migration table can name it, and concat refuses a mix of
+        # sharded and interleaved inputs.
+        hist = ttnn.concat([ttnn.to_memory_config(carry, ttnn.DRAM_MEMORY_CONFIG), gathered], dim=2)
         start, end = self._halo_bounds
         halo = ttnn.slice(hist, start, end, slice_dim=2, num_devices=self._halo_num_devices)
         kv = ttnn.concat([halo, sliding_kv], dim=2)
@@ -504,5 +524,6 @@ class TtSWA(LightweightModule):
         )
 
         state.kv_actual += real_len
-        state.carry = next_carry
+        # In place, not a rebind: the migration table is built once from this tensor's address.
+        ttnn.kv_cache.fill_cache_for_user_(state.carry, next_carry, 0, update_idx=0)
         return self._o_proj(attn)

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -187,6 +187,7 @@ class TtSWA(LightweightModule):
     def _build_masks(self, seq_local: int):
         """Both masks over the key layout ``[halo | own rows]``, built here and never touched again."""
         sw = self.sliding_window
+        assert seq_local >= sw, f"seq_local ({seq_local}) must be >= sliding_window ({sw})"
         width = sw + seq_local
 
         ic = self.ops.from_torch(torch.arange(seq_local).float().view(1, 1, seq_local, 1), dtype=ttnn.float32)
@@ -238,7 +239,6 @@ class TtSWA(LightweightModule):
 
         The gather covers the whole chunk because the carry slice needs the global slab."""
         batch, num_heads_local, seq_local, _ = q.shape
-        sw = self.sliding_window
 
         if self.sp_factor > 1:
             gathered = ttnn.experimental.all_gather_async(

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -4,7 +4,7 @@
 """DeepSeek-V4 sliding-only attention (``layer_types[i] == "sliding_attention"``), chunked prefill.
 
 Each chip attends over ``[halo | its own rows]``, where the halo is the ``sliding_window`` rows
-preceding its first query: that is as far back as the window reaches.
+preceding its first query.
 """
 
 import torch

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -421,6 +421,13 @@ class TtSWA(LightweightModule):
         assert state is not None, "TtSWA.forward needs the state alloc_state returned"
         seq_len = hidden_states.shape[2] * self.sp_factor
         real_len = int(seq_len if seq_len_actual is None else seq_len_actual)
+        assert (
+            0 <= real_len <= seq_len
+        ), f"seq_len_actual must be between 0 and padded slab length {seq_len}, got {real_len}"
+        assert state.kv_actual + real_len <= state.max_seq_len, (
+            f"context longer than the state was allocated for: {state.kv_actual + real_len} tokens > "
+            f"max_seq_len {state.max_seq_len}"
+        )
         sw = self.sliding_window
         # On the ACCUMULATED length: a final chunk may end mid-tile, a non-final one may not.
         assert state.kv_actual % TILE_HEIGHT == 0, (

--- a/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/sliding_window_attention.py
@@ -429,6 +429,10 @@ class TtSWA(LightweightModule):
             f"max_seq_len {state.max_seq_len}"
         )
         sw = self.sliding_window
+        # The carry is only fully real once the prefix reaches sw; before that it still holds zeros.
+        assert (
+            state.kv_actual == 0 or state.kv_actual >= sw
+        ), f"a further chunk needs a prefix of at least {sw} tokens, got {state.kv_actual}"
         # On the ACCUMULATED length: a final chunk may end mid-tile, a non-final one may not.
         assert state.kv_actual % TILE_HEIGHT == 0, (
             f"cannot append after a chunk with {state.kv_actual % TILE_HEIGHT} leftover tokens; only "

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -36,7 +36,7 @@
 #   test_tags: Optional list of coarse selectors for workflow_dispatch, matched exactly and
 #              OR-ed with test_type / test_group. Two vocabularies in one list: the model a
 #              leg covers (kimi_k2_7, kimi_k3, glm_5_2, dsv4_flash, minimax_m3)
-#              and the unit under test (moe, gate, mla, hca, sdpa, ccl, block, transformer,
+#              and the unit under test (moe, gate, mla, hca, swa, sdpa, ccl, block, transformer,
 #              kv_cache, dflash, runner, determinism). So `moe` runs every MoE leg and `kimi_k3` every K3
 #              leg. Multiple tokens UNION, they do not intersect: `moe,kimi_k3` is every MoE
 #              leg plus every K3 leg, not the K3 MoE legs.
@@ -774,6 +774,44 @@
       timeout: 3
       tier: 2
       release_ready: false
+  owner_id: U08SXRPCTJ5  # Janko Mitrovic
+  team: models
+  sp_config: sc1
+
+
+- name: "(DeepSeek-V4-Flash) SWA chunked accuracy 55k@5k"
+  fabric_profile: torus_xy
+  cmd: |
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_swa.py::test_swa_long_prefill_mesh -k "flash and mixed5120 and torus-xy-8x4" -vvv --tb=short
+    '
+  test_type: swa_mixed
+  test_tags: [dsv4_flash, swa]
+  test_group: module
+  skus:
+    bh_sc1:
+      timeout: 5
+  owner_id: U08SXRPCTJ5  # Janko Mitrovic
+  team: models
+  sp_config: sc1
+
+
+- name: "(DeepSeek-V4-Flash) SWA chunked perf 10k@5k"
+  fabric_profile: torus_xy
+  cmd: |
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_swa_perf.py -k "flash and torus-xy-8x4" -vvv --tb=short
+    '
+  test_type: swa_perf
+  test_tags: [dsv4_flash, swa]
+  test_group: module
+  skus:
+    bh_sc1_high_power:
+      timeout: 3
   owner_id: U08SXRPCTJ5  # Janko Mitrovic
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -792,7 +792,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 5
+      timeout: 4
   owner_id: U08SXRPCTJ5  # Janko Mitrovic
   team: models
   sp_config: sc1


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adding Sliding window attention module, pcc and perf tests

### Notes for reviewers
- [x] [Blaze models SWE](https://github.com/tenstorrent/tt-metal/actions/runs/34258867448) passed✅
- [x] [E2E BH Quietbox](https://github.com/tenstorrent/tt-metal/actions/runs/34259046785) passed✅
- [x] [E2E Bh Loudbox](https://github.com/tenstorrent/tt-metal/actions/runs/34259118542) passed✅
- [Perf analysis table](https://docs.google.com/spreadsheets/d/1kOsNPe4sfXvi3NNChXN0wThTjKSrbmf3AgpR4eBKeM4/edit?gid=1866894444#gid=1866894444)

Perf Measurements, constant per chunk, total 2.6ms per 5K chunk
| component   |    us |     % |
|-------------|------:|------:|
| CCL         | 1027.7| 39.3% |
| layout / TM |  628.2| 24.0% |
| matmul      |  488.5| 18.7% |
| SDPA        |  297.6| 11.4% |
| norm        |   85.2|  3.3% |
| RoPE        |   49.6|  1.9% |
| other       |   34.8|  1.3% |


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmitrovic/swe_sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmitrovic/swe_sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmitrovic/swe_sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmitrovic/swe_sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmitrovic/swe_sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmitrovic/swe_sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmitrovic/swe_sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmitrovic/swe_sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmitrovic/swe_sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmitrovic/swe_sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmitrovic/swe_sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmitrovic/swe_sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmitrovic/swe_sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmitrovic/swe_sdpa)