### PR TITLE
[Feature] Producer support for a prebuilt test environment image

### DIFF
--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -165,6 +165,13 @@ jobs:
             echo "::error::source-ref must be a full 40-character commit sha, got '$SOURCE_REF'"
             exit 1
           fi
+          # Taking the artifact from another run says nothing about which commit
+          # built it, so defaulting the source to this workflow's sha would pair
+          # this commit's source with someone else's binaries under a valid tag.
+          if [ "$CHECKOUT_SOURCE" = "true" ] && [ -n "$ARTIFACT_RUN_ID" ] && [ -z "$SOURCE_REF" ]; then
+            echo "::error::source-ref is required when checkout-source is on and the artifact comes from another run, or src/ and artifact/ are from different commits"
+            exit 1
+          fi
           # Names end in <ref><sep><runid>, but packages joins with '-' and the
           # tarball with '_', so strip by shape rather than by position.
           CONFIG=$(printf '%s' "$ARTIFACT_NAME" | sed -E 's/[-_][0-9a-f]{7,40}[-_][0-9]+$//')

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -59,9 +59,12 @@ on:
         type: string
         default: ""
         description: >-
-          Commit to bake the source from, when checkout-source is on. Defaults to
-          this workflow's own commit. A caller testing a non-default ref must pass
-          the same one it gave build-artifact, or src/ and artifact/ disagree.
+          Commit to bake the source from, when checkout-source is on. Must be a
+          full 40-character sha, not a branch or tag: a movable ref would let a
+          re-run recompute the same tag while checking out different source, and
+          overwrite the image with it. Defaults to this workflow's own commit. A
+          caller testing a non-default ref must pass the same one it gave
+          build-artifact, or src/ and artifact/ disagree.
       runner-label:
         required: false
         type: string
@@ -114,7 +117,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "Commit to bake the source from; defaults to this workflow's commit"
+        description: "Full 40-character commit sha to bake the source from; defaults to this workflow's commit"
       runner-label:
         required: false
         type: string
@@ -154,6 +157,12 @@ jobs:
           # download-artifact fetch every artifact in the run.
           if [ -z "$ARTIFACT_NAME" ]; then
             echo "::error::artifact-name is empty; the upstream build did not produce one"
+            exit 1
+          fi
+          # A branch or tag can move, so re-running would recompute the same tag
+          # while checking out different source and overwrite the image with it.
+          if [ -n "$SOURCE_REF" ] && ! printf '%s' "$SOURCE_REF" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::source-ref must be a full 40-character commit sha, got '$SOURCE_REF'"
             exit 1
           fi
           # Names end in <ref><sep><runid>, but packages joins with '-' and the
@@ -209,13 +218,13 @@ jobs:
           path: src
           submodules: recursive
 
-      # context: is the whole workspace, so without this the source checkout
-      # ships its own .git and every submodule's - multiple GB of context.
-      - name: Exclude .git from the build context
-        if: ${{ inputs.checkout-source }}
+      # context: is the whole workspace, so every .git in it is transferred. The
+      # Dockerfile checkout puts one at the root even when no source is checked
+      # out, and a source checkout adds its own plus every submodule's.
+      - name: Exclude git metadata from the build context
         run: |
           set -euo pipefail
-          printf 'src/.git\nsrc/**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
+          printf '.git\n**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
           cat "$GITHUB_WORKSPACE/.dockerignore"
 
       - name: Download the build artifact

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -165,6 +165,12 @@ jobs:
             echo "::error::artifact-name is empty; the upstream build did not produce one"
             exit 1
           fi
+          # source-ref cannot affect the image when no source is checked out, so
+          # neither validate nor hash it there: doing so would mint a distinct tag
+          # for a byte-identical image and churn retention for nothing.
+          if [ "$CHECKOUT_SOURCE" != "true" ]; then
+            SOURCE_REF=""
+          fi
           # A branch or tag can move, so re-running would recompute the same tag
           # while checking out different source and overwrite the image with it.
           if [ -n "$SOURCE_REF" ] && ! printf '%s' "$SOURCE_REF" | grep -qE '^[0-9a-f]{40}$'; then

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -54,6 +54,14 @@ on:
           Check the source tree out to src/ for Dockerfiles that need it. Off by
           default: it is a multi-GB recursive clone that the package-based paths
           have no use for.
+      source-ref:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Commit to bake the source from, when checkout-source is on. Defaults to
+          this workflow's own commit. A caller testing a non-default ref must pass
+          the same one it gave build-artifact, or src/ and artifact/ disagree.
       runner-label:
         required: false
         type: string
@@ -102,6 +110,11 @@ on:
         type: boolean
         default: false
         description: "Check the source tree out to src/ for Dockerfiles that need it"
+      source-ref:
+        required: false
+        type: string
+        default: ""
+        description: "Commit to bake the source from; defaults to this workflow's commit"
       runner-label:
         required: false
         type: string
@@ -134,6 +147,7 @@ jobs:
           BUILD_ARGS: ${{ inputs.build-args }}
           CHECKOUT_SOURCE: ${{ inputs.checkout-source }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
+          SOURCE_REF: ${{ inputs.source-ref }}
         run: |
           set -euo pipefail
           # required: true still lets '' through, and an empty name would make
@@ -156,9 +170,11 @@ jobs:
           # is the raw input, so it is empty on the same-run path and changes
           # nothing there, but it separates two cross-run calls that share a
           # build config and would otherwise collide on different payloads.
-          RECIPE=$(printf '%s\n%s\n%s\n%s\n%s\n%s' \
+          # SOURCE_REF included, or two calls differing only in the source they
+          # bake would share a tag and the second would overwrite the first.
+          RECIPE=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s' \
             "$CONFIG" "$BASE_IMAGE" "$DOCKERFILE" "$BUILD_ARGS" "$CHECKOUT_SOURCE" \
-            "$ARTIFACT_RUN_ID" \
+            "$ARTIFACT_RUN_ID" "$SOURCE_REF" \
             | sha256sum | cut -c1-8)
           # The readable parts are truncated so the tag is bounded by construction.
           # Real configs reach 142 chars untruncated, over Docker's 128 limit, and
@@ -187,11 +203,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          # The workflow's commit: a caller baking another run's artifact must
-          # ensure it matches, or src/ and artifact/ disagree.
-          ref: ${{ github.sha }}
+          # Must match the commit the artifact was built from, or src/ and
+          # artifact/ disagree; defaults to this workflow's own commit.
+          ref: ${{ inputs.source-ref || github.sha }}
           path: src
           submodules: recursive
+
+      # context: is the whole workspace, so without this the source checkout
+      # ships its own .git and every submodule's - multiple GB of context.
+      - name: Exclude .git from the build context
+        if: ${{ inputs.checkout-source }}
+        run: |
+          set -euo pipefail
+          printf 'src/.git\nsrc/**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
+          cat "$GITHUB_WORKSPACE/.dockerignore"
 
       - name: Download the build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -62,9 +62,11 @@ on:
           Commit to bake the source from, when checkout-source is on. Must be a
           full 40-character sha, not a branch or tag: a movable ref would let a
           re-run recompute the same tag while checking out different source, and
-          overwrite the image with it. Defaults to this workflow's own commit. A
-          caller testing a non-default ref must pass the same one it gave
-          build-artifact, or src/ and artifact/ disagree.
+          overwrite the image with it. Defaults to this workflow's own commit,
+          which is only meaningful when the artifact comes from this run too.
+          Baking another run's artifact (artifact-run-id) alongside a source
+          checkout requires this, since the default would pair this commit's
+          source with someone else's binaries.
       runner-label:
         required: false
         type: string
@@ -117,7 +119,11 @@ on:
         required: false
         type: string
         default: ""
-        description: "Full 40-character commit sha to bake the source from; defaults to this workflow's commit"
+        description: >-
+          Full 40-character commit sha to bake the source from. Required whenever
+          checkout-source is on here, because a dispatched run always takes its
+          artifact from another run, so there is no commit to default to. Unused
+          when checkout-source is off.
       runner-label:
         required: false
         type: string

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -243,7 +243,11 @@ jobs:
       - name: Exclude git metadata from the build context
         run: |
           set -euo pipefail
-          printf '.git\n**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
+          # tech_reports is 69 MiB of the source tree and nothing a test leg runs
+          # reads it: the only references are a comment, an error string pointing
+          # at the docs, and a release-notes path classifier that runs elsewhere.
+          # Every consumer pulls the source layer, so this comes off every leg.
+          printf '.git\n**/.git\nsrc/tech_reports\n' > "$GITHUB_WORKSPACE/.dockerignore"
           cat "$GITHUB_WORKSPACE/.dockerignore"
 
       - name: Download the build artifact
@@ -314,7 +318,7 @@ jobs:
           # would leave behind holding the layers alive.
           provenance: false
           outputs: |
-            type=registry,push=true,compression=zstd,compression-level=3,oci-mediatypes=true
+            type=registry,push=true,compression=zstd,compression-level=7,oci-mediatypes=true
 
       # Runs only if the push succeeded, so a failed build yields an empty ref
       # and the consumer falls back to the artifact path instead of pulling a

--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -33,15 +33,16 @@ name: "Cleanup prebuilt tests images"
 # Recompute N if the push rate changes: wiring more consumers raises it, and
 # building one image per run instead of two would halve it.
 #
-# The producer also creates prebuilt-tests-env-image, whose payload is a source
-# tree plus build output rather than packages. It is swept separately because its
-# push rate is nothing like the gates': the producer test plus the nightly
-# consumers put it on the order of ten a day, so a much smaller N buys more
-# retention than 4,800 buys for the gate images. Recompute it when a high-volume
-# caller is wired, the same way the figure above is derived from a rate.
+# One matrix entry per package the producer creates, each with its own N, because
+# their push rates differ by two orders of magnitude. prebuilt-tests-env-image
+# carries a source tree plus build output rather than packages, and is pushed by
+# the producer test and the nightly consumers on the order of ten a day, so N=100
+# buys it more retention than N=4,800 buys the gate images. Recompute either when
+# a high-volume caller is wired, the same way the figure above is derived.
 #
-# This deletes irreversibly. It is scoped to the two packages the
-# build-prebuilt-tests-image producer creates, and never touches a base image.
+# This deletes irreversibly. The package list is fixed in the matrix below and
+# never derives from event context, so this cannot resolve to a package it should
+# not touch, and it never touches a base image.
 
 permissions:
   packages: write
@@ -52,66 +53,48 @@ on:
   workflow_dispatch:
     inputs:
       min-versions-to-keep:
-        description: "Newest versions to keep. Set very high for a safe no-op run."
+        description: "Override retention for every package. Set very high for a safe no-op run. Empty uses each package's own default."
         required: false
         type: string
-        default: "4800"
-      env-min-versions-to-keep:
-        description: "Newest env-image versions to keep. Set very high for a safe no-op run."
-        required: false
-        type: string
-        default: "100"
+        default: ""
 
 jobs:
   cleanup:
-    name: "Delete aged-out prebuilt tests images"
+    name: "Delete aged-out ${{ matrix.package }}"
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    strategy:
+      # One package failing must not stop the others being swept.
+      fail-fast: false
+      matrix:
+        include:
+          - package: tt-metal/prebuilt-tests-image
+            keep: "4800"
+          - package: tt-metal/prebuilt-tests-env-image
+            keep: "100"
     steps:
       - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
-          # Literal, not a context expression: this is what stops the job ever
-          # resolving to a package it should not touch.
           owner: tenstorrent
-          package-name: tt-metal/prebuilt-tests-image
+          package-name: ${{ matrix.package }}
           package-type: container
-          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '4800' }}
+          min-versions-to-keep: ${{ inputs.min-versions-to-keep || matrix.keep }}
 
       # A GC that silently falls behind looks exactly like one that is working.
       - name: Report what is left
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KEEP: ${{ inputs.min-versions-to-keep || '4800' }}
+          KEEP: ${{ inputs.min-versions-to-keep || matrix.keep }}
+          PACKAGE: ${{ matrix.package }}
         run: |
           set -euo pipefail
-          COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-image" --jq '.version_count')
-          echo "versions remaining: ${COUNT}" | tee -a "$GITHUB_STEP_SUMMARY"
+          # The API takes the package name path-encoded.
+          COUNT=$(gh api "/orgs/tenstorrent/packages/container/${PACKAGE//\//%2F}" --jq '.version_count')
+          echo "${PACKAGE}: ${COUNT} versions remaining" | tee -a "$GITHUB_STEP_SUMMARY"
           # Steady state sits near the retention value, so warn relative to it
           # rather than at a fixed number. A deliberate high-retention no-op run
           # would otherwise report falling behind.
           THRESHOLD=$(( KEEP * 2 ))
           if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
-            echo "::warning::${COUNT} versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
-          fi
-
-      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          # Literal for the same reason as above.
-          owner: tenstorrent
-          package-name: tt-metal/prebuilt-tests-env-image
-          package-type: container
-          min-versions-to-keep: ${{ inputs.env-min-versions-to-keep || '100' }}
-
-      - name: Report what is left of the env images
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KEEP: ${{ inputs.env-min-versions-to-keep || '100' }}
-        run: |
-          set -euo pipefail
-          # 404 until the first env image is pushed, which is not an error here.
-          COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-env-image" --jq '.version_count' 2>/dev/null || echo 0)
-          echo "env image versions remaining: ${COUNT}" | tee -a "$GITHUB_STEP_SUMMARY"
-          THRESHOLD=$(( KEEP * 2 ))
-          if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
-            echo "::warning::${COUNT} env image versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
+            echo "::warning::${PACKAGE}: ${COUNT} versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
           fi

--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -33,7 +33,14 @@ name: "Cleanup prebuilt tests images"
 # Recompute N if the push rate changes: wiring more consumers raises it, and
 # building one image per run instead of two would halve it.
 #
-# This deletes irreversibly. It is scoped to the one package the
+# The producer also creates prebuilt-tests-env-image, whose payload is a source
+# tree plus build output rather than packages. It is swept separately because its
+# push rate is nothing like the gates': the producer test plus the nightly
+# consumers put it on the order of ten a day, so a much smaller N buys more
+# retention than 4,800 buys for the gate images. Recompute it when a high-volume
+# caller is wired, the same way the figure above is derived from a rate.
+#
+# This deletes irreversibly. It is scoped to the two packages the
 # build-prebuilt-tests-image producer creates, and never touches a base image.
 
 permissions:
@@ -49,6 +56,11 @@ on:
         required: false
         type: string
         default: "4800"
+      env-min-versions-to-keep:
+        description: "Newest env-image versions to keep. Set very high for a safe no-op run."
+        required: false
+        type: string
+        default: "100"
 
 jobs:
   cleanup:
@@ -80,4 +92,26 @@ jobs:
           THRESHOLD=$(( KEEP * 2 ))
           if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
             echo "::warning::${COUNT} versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
+          fi
+
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          # Literal for the same reason as above.
+          owner: tenstorrent
+          package-name: tt-metal/prebuilt-tests-env-image
+          package-type: container
+          min-versions-to-keep: ${{ inputs.env-min-versions-to-keep || '100' }}
+
+      - name: Report what is left of the env images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: ${{ inputs.env-min-versions-to-keep || '100' }}
+        run: |
+          set -euo pipefail
+          # 404 until the first env image is pushed, which is not an error here.
+          COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-env-image" --jq '.version_count' 2>/dev/null || echo 0)
+          echo "env image versions remaining: ${COUNT}" | tee -a "$GITHUB_STEP_SUMMARY"
+          THRESHOLD=$(( KEEP * 2 ))
+          if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
+            echo "::warning::${COUNT} env image versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
           fi

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -224,7 +224,9 @@ jobs:
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       build-type: "Release"
       publish-artifact: true
-      build-wheel: true
+      # In-place, not build-wheel: that one runs cibuildwheel for a second full
+      # compile, and the consumers this serves get the in-place wheel anyway.
+      build-inplace-wheel: true
       use-system-sfpi: true
 
   bake-env-full:

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/build-prebuilt-tests-image.yaml"
       - ".github/workflows/test-build-prebuilt-tests-image.yaml"
       - "dockerfile/Dockerfile.prebuilt-tests-packages"
+      - "dockerfile/Dockerfile.prebuilt-tests-env"
   workflow_dispatch:
 
 permissions:
@@ -204,3 +205,152 @@ jobs:
         run: |
           /usr/bin/tt-metalium-validation-smoke \
             --gtest_filter="MeshDispatchFixture.TensixFailOnDuplicateKernelCreationDataflow"
+
+  # The packages arm above sets publish-artifact: false, so it makes no tarball
+  # and no wheel. The env image needs both, hence a second build rather than
+  # widening the one whose inputs are already proven.
+  build-env:
+    name: "Build tarball and wheel"
+    if: ${{ github.event.pull_request.head.repo.fork != true && !github.event.pull_request.draft }}
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      # 22.04: the setup-job consumers this serves pull the 22.04 ci-test base,
+      # and the hardware leg below runs on a 22.04 runner.
+      platform: "Ubuntu 22.04"
+      toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
+      build-type: "Release"
+      publish-artifact: true
+      build-wheel: true
+      use-system-sfpi: true
+
+  bake-env-full:
+    name: "Bake env image / full"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.build-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      # Own ghcr package: the env payload is sized nothing like the packages one,
+      # so its retention must not be shared with theirs.
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+
+  bake-env-wheel:
+    name: "Bake env image / wheel"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.wheel-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=wheel
+
+  # Payload shape is what breaks silently: a wrong one still builds and publishes.
+  # Checking both costs no hardware, so only the full image needs a real leg below.
+  verify-env-payloads:
+    name: "Check both env images carry the right payload"
+    needs: [bake-env-full, bake-env-wheel]
+    if: ${{ needs.bake-env-full.outputs.image != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assert each payload
+        env:
+          FULL: ${{ needs.bake-env-full.outputs.image }}
+          WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
+        run: |
+          set -euo pipefail
+          echo "::group::${FULL}"
+          docker run --rm --entrypoint cat "$FULL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=full$'
+          docker run --rm --entrypoint sh "$FULL" -c 'test -d /work/build && test -d /work/tests'
+          # A COPYed payload would leave the tarball in a layer and eat the saving.
+          test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'find / -xdev -name "*.tar.zst" 2>/dev/null')"
+          # Proves the .dockerignore worked; otherwise .git rides along unnoticed.
+          test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'ls -d /work/.git 2>/dev/null')"
+          echo "::endgroup::"
+          echo "::group::${WHEEL}"
+          docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'
+          docker run --rm --entrypoint sh "$WHEEL" -c 'test ! -d /work/build && test -d /work/tests'
+          echo "::endgroup::"
+
+  verify-env:
+    name: "Run a test from the env image"
+    needs: bake-env-full
+    # Runs freshly built native code from the PR on hardware, and only needs to
+    # pull an image. Do not let it inherit packages: write.
+    permissions:
+      contents: read
+      packages: read
+    # Empty ref means the producer was skipped (fork); nothing to verify.
+    if: ${{ needs.bake-env-full.outputs.image != '' }}
+    runs-on: tt-ubuntu-2204-N150-viommu-stable
+    timeout-minutes: 20
+    container:
+      image: ${{ needs.bake-env-full.outputs.image }}
+      # The runner pulls before any step runs, so no login step can help here.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: wormhole_b0
+        LOGURU_LEVEL: INFO
+      # No /work volume on purpose: the image owns /work, and a bind mount would
+      # mask the payload, which is the whole point of this arm.
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    steps:
+      - name: The environment came from the image, not from a checkout
+        run: |
+          set -euo pipefail
+          test -s /etc/prebuilt-tests-env-manifest
+          cat /etc/prebuilt-tests-env-manifest
+          # Source, build output, and the .so the tarball merges into the source
+          # package dir - the three things a consumer stops fetching.
+          test -d /work/tests && test -d /work/build/lib
+          test -f /work/tools/tt-triage.py
+          ls /work/ttnn/ttnn/*.so >/dev/null
+          # .git is deliberately absent; scripts shelling out to git cannot run here.
+          test ! -d /work/.git
+          ls -la /work/build/test/tt_metal/
+
+      - name: Run a runtime test against the baked build
+        timeout-minutes: 10
+        env:
+          GTEST_COLOR: yes
+        run: |
+          # Same fixture as the runtime_sanity_api leg: DRAM R/W, L1 R/W, and a
+          # JIT kernel compile, so it exercises the baked tree end to end.
+          ./build/test/tt_metal/unit_tests_api \
+            --gtest_filter='*DRAMLoopbackSingleCore*:*TestSimpleL1*:*CompileProgram*'

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -406,7 +406,9 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
       env:
         TT_METAL_HOME: /work
-        PYTHONPATH: /work
+        # /work/ttnn as well as /work: /work/ttnn is a namespace dir and the
+        # package is /work/ttnn/ttnn. Same in-place layout as bisect-dispatch.
+        PYTHONPATH: /work:/work/ttnn
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
@@ -431,6 +433,13 @@ jobs:
           # .git is deliberately absent; scripts shelling out to git cannot run here.
           test ! -d /work/.git
           ls -la /work/build/test/tt_metal/
+
+      - name: The in-place ttnn package imports
+        run: |
+          set -euo pipefail
+          # The C++ leg below would pass even if the Python payload were unusable,
+          # so import it explicitly. This is the full profile's advertised path.
+          python3 -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
 
       - name: Run a runtime test against the baked build
         timeout-minutes: 10

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -265,12 +265,35 @@ jobs:
       checkout-source: true
       build-args: PROFILE=wheel
 
+  # source-ref would otherwise only ever be exercised through its github.sha
+  # fallback. Same commit as bake-env-full, spelled explicitly: the content must
+  # come out identical while the tag must differ, since source-ref feeds the
+  # recipe hash. A DIFFERENT ref would also work but would publish an image whose
+  # source and artifact disagree, which is the thing the input exists to prevent.
+  bake-env-source-ref:
+    name: "Bake env image / explicit source-ref"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.build-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+      source-ref: ${{ github.sha }}
+
   # Payload shape is what breaks silently: a wrong one still builds and publishes.
   # Checking both costs no hardware, so only the full image needs a real leg below.
   verify-env-payloads:
     name: "Check both env images carry the right payload"
     # build-env too: the base ref is needed to tell payload layers from base ones.
-    needs: [build-env, bake-env-full, bake-env-wheel]
+    needs: [build-env, bake-env-full, bake-env-wheel, bake-env-source-ref]
     if: ${{ needs.bake-env-full.outputs.image != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -335,6 +358,31 @@ jobs:
             [ "$n" -eq 2 ] || { echo "::error::${name} adds ${n} layers, expected 2 (source + payload); a new COPY would do this"; exit 1; }
             [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
           done
+
+      - name: Assert source-ref separates the tag without changing the content
+        env:
+          FULL: ${{ needs.bake-env-full.outputs.image }}
+          EXPLICIT: ${{ needs.bake-env-source-ref.outputs.image }}
+        run: |
+          set -euo pipefail
+          # Same commit, one defaulted and one passed explicitly.
+          [ "$FULL" != "$EXPLICIT" ] \
+            || { echo "::error::source-ref does not separate the tag: both are ${FULL}"; exit 1; }
+          # Only the recipe hash may differ; sha12, CONFIG and the base slug must not.
+          [ "${FULL%-*}" = "${EXPLICIT%-*}" ] \
+            || { echo "::error::tags differ outside the recipe hash: ${FULL} vs ${EXPLICIT}"; exit 1; }
+          # And the payload must be byte-identical, or the explicit ref checked out
+          # something other than the commit the default resolves to.
+          layers() {
+            local ref="$1" repo="${1%:*}" child
+            child=$(docker manifest inspect "$ref" \
+              | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+            [ -n "$child" ] && ref="${repo}@${child}"
+            docker manifest inspect "$ref" | jq -r '.layers[].digest'
+          }
+          diff <(layers "$FULL") <(layers "$EXPLICIT") \
+            || { echo "::error::explicit source-ref produced different layers than the default"; exit 1; }
+          echo "source-ref separates the tag (${FULL##*-} vs ${EXPLICIT##*-}) with identical layers"
 
   verify-env:
     name: "Run a test from the env image"

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -269,7 +269,8 @@ jobs:
   # Checking both costs no hardware, so only the full image needs a real leg below.
   verify-env-payloads:
     name: "Check both env images carry the right payload"
-    needs: [bake-env-full, bake-env-wheel]
+    # build-env too: the base ref is needed to tell payload layers from base ones.
+    needs: [build-env, bake-env-full, bake-env-wheel]
     if: ${{ needs.bake-env-full.outputs.image != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -286,20 +287,54 @@ jobs:
         env:
           FULL: ${{ needs.bake-env-full.outputs.image }}
           WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
+          BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
         run: |
           set -euo pipefail
           echo "::group::${FULL}"
           docker run --rm --entrypoint cat "$FULL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=full$'
           docker run --rm --entrypoint sh "$FULL" -c 'test -d /work/build && test -d /work/tests'
-          # A COPYed payload would leave the tarball in a layer and eat the saving.
-          test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'find / -xdev -name "*.tar.zst" 2>/dev/null')"
           # Proves the .dockerignore worked; otherwise .git rides along unnoticed.
           test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'ls -d /work/.git 2>/dev/null')"
           echo "::endgroup::"
           echo "::group::${WHEEL}"
           docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'
           docker run --rm --entrypoint sh "$WHEEL" -c 'test ! -d /work/build && test -d /work/tests'
+          # Directory shape says nothing about whether the wheel actually works:
+          # an ABI or missing-library problem installs fine and imports never.
+          docker run --rm --entrypoint python3 "$WHEEL" -c 'import ttnn; print("ttnn imported")'
           echo "::endgroup::"
+
+      # Layer sizes, not the merged filesystem: a COPY followed by an rm leaves the
+      # payload bytes in a lower layer while `find` sees nothing, which is exactly
+      # the regression that would silently undo the saving.
+      - name: Assert the payload rides in two layers and stays small
+        env:
+          FULL: ${{ needs.bake-env-full.outputs.image }}
+          WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
+          BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
+          # Release with system SFPI measures 296 MiB (full) and 250 MiB (wheel).
+          # Generous headroom: this guards against a COPYed payload, not drift.
+          MAX_MIB: "600"
+        run: |
+          set -euo pipefail
+          layers() {  # digest<TAB>size for the amd64 image, one per line
+            local ref="$1" repo="${1%:*}" child
+            child=$(docker manifest inspect "$ref" \
+              | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+            [ -n "$child" ] && ref="${repo}@${child}"
+            docker manifest inspect "$ref" | jq -r '.layers[] | "\(.digest)\t\(.size)"'
+          }
+          layers "$BASE" | cut -f1 | sort > /tmp/base.txt
+          for pair in "full:$FULL" "wheel:$WHEEL"; do
+            name="${pair%%:*}"; ref="${pair#*:}"
+            layers "$ref" > /tmp/img.txt
+            extra=$(join -v1 -t"$(printf '\t')" <(sort -k1,1 /tmp/img.txt) /tmp/base.txt || true)
+            n=$(printf '%s' "$extra" | grep -c . || true)
+            mib=$(printf '%s' "$extra" | awk -F'\t' '{s+=$2} END {printf "%d", s/1048576}')
+            echo "${name}: ${n} layers beyond the base, ${mib} MiB"
+            [ "$n" -eq 2 ] || { echo "::error::${name} adds ${n} layers, expected 2 (source + payload); a new COPY would do this"; exit 1; }
+            [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
+          done
 
   verify-env:
     name: "Run a test from the env image"

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -224,6 +224,9 @@ jobs:
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       build-type: "Release"
       publish-artifact: true
+      # The env images bake the tarball and the wheel; the debs would be an upload
+      # and a retention cost that nothing in this arm reads.
+      publish-package: false
       # In-place, not build-wheel: that one runs cibuildwheel for a second full
       # compile, and the consumers this serves get the in-place wheel anyway.
       build-inplace-wheel: true

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -371,18 +371,20 @@ jobs:
           # Only the recipe hash may differ; sha12, CONFIG and the base slug must not.
           [ "${FULL%-*}" = "${EXPLICIT%-*}" ] \
             || { echo "::error::tags differ outside the recipe hash: ${FULL} vs ${EXPLICIT}"; exit 1; }
-          # And the payload must be byte-identical, or the explicit ref checked out
-          # something other than the commit the default resolves to.
-          layers() {
-            local ref="$1" repo="${1%:*}" child
-            child=$(docker manifest inspect "$ref" \
-              | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
-            [ -n "$child" ] && ref="${repo}@${child}"
-            docker manifest inspect "$ref" | jq -r '.layers[].digest'
+          # The contents must match, or the explicit ref checked out something other
+          # than the commit the default resolves to. Compare paths and sizes rather
+          # than layer digests: these are independent builds, so tar header mtimes
+          # differ and the digests differ with them even when the files do not.
+          # Measured on two same-run bakes of the same commit: 211,190,989 vs
+          # 211,181,760 bytes for the same source layer.
+          tree() {
+            docker run --rm --entrypoint sh "$1" -c \
+              'find /work -type f -printf "%p %s\n" | LC_ALL=C sort | sha256sum | cut -d" " -f1'
           }
-          diff <(layers "$FULL") <(layers "$EXPLICIT") \
-            || { echo "::error::explicit source-ref produced different layers than the default"; exit 1; }
-          echo "source-ref separates the tag (${FULL##*-} vs ${EXPLICIT##*-}) with identical layers"
+          a=$(tree "$FULL"); b=$(tree "$EXPLICIT")
+          [ "$a" = "$b" ] \
+            || { echo "::error::explicit source-ref produced different /work contents (${a} vs ${b})"; exit 1; }
+          echo "source-ref separates the tag (${FULL##*-} vs ${EXPLICIT##*-}) with identical /work contents (${a})"
 
   verify-env:
     name: "Run a test from the env image"

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -223,6 +223,10 @@ jobs:
       platform: "Ubuntu 22.04"
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       build-type: "Release"
+      # Sanity builds with tracy, and a tracy-enabled _ttnn imports the `tracy`
+      # Python module during module init. Without this the import checks below
+      # pass on a payload shaped unlike the one consumers actually get.
+      tracy: true
       publish-artifact: true
       # The env images bake the tarball and the wheel; the debs would be an upload
       # and a retention cost that nothing in this arm reads.
@@ -346,7 +350,7 @@ jobs:
           # about whether in-place import works. It needs deps the base image may not
           # carry, so this fails here on a GitHub runner rather than on a hardware leg.
           docker run --rm \
-            -e PYTHONPATH=/work:/work/ttnn \
+            -e PYTHONPATH=/work:/work/ttnn:/work/tools \
             -e TT_METAL_HOME=/work \
             -e LD_LIBRARY_PATH=/work/build/lib \
             --entrypoint python3 "$FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
@@ -357,7 +361,7 @@ jobs:
           # The base a consumer actually uses. Bases differ in what their venv carries,
           # so an import that works on ci-test says nothing about this one.
           docker run --rm \
-            -e PYTHONPATH=/work:/work/ttnn \
+            -e PYTHONPATH=/work:/work/ttnn:/work/tools \
             -e TT_METAL_HOME=/work \
             -e LD_LIBRARY_PATH=/work/build/lib \
             --entrypoint python3 "$DEV_FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
@@ -451,7 +455,9 @@ jobs:
         TT_METAL_HOME: /work
         # /work/ttnn as well as /work: /work/ttnn is a namespace dir and the
         # package is /work/ttnn/ttnn. Same in-place layout as bisect-dispatch.
-        PYTHONPATH: /work:/work/ttnn
+        # /work/tools carries the `tracy` module, which a tracy-enabled _ttnn
+        # imports at init. The wheel gets it via package_dir; in place it is here.
+        PYTHONPATH: /work:/work/ttnn:/work/tools
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -386,12 +386,15 @@ jobs:
           # beyond the base. Generous headroom: this guards against a COPYed
           # payload, not drift.
           MAX_MIB: "600"
-          # One per layer-adding instruction in Dockerfile.prebuilt-tests-env:
-          # the pyproject COPY, the dependency RUN, seven churn-tier COPYs, the
-          # excluding COPY of the remainder, and the payload RUN. Bump this only
-          # when that file deliberately changes shape - it is what catches an
+          # Expected per profile, because they differ by one: the dependency RUN
+          # is guarded on PROFILE=full, so under wheel it changes nothing and
+          # BuildKit omits the empty layer entirely. full counts the pyproject
+          # COPY, the dependency RUN, the source COPY and the payload RUN; wheel
+          # is the same less the dependency RUN. Bump these only when the
+          # Dockerfile deliberately changes shape - they are what catches an
           # accidental COPY, which is the regression that would undo the saving.
-          EXPECT_LAYERS: "11"
+          EXPECT_LAYERS_FULL: "4"
+          EXPECT_LAYERS_WHEEL: "3"
         run: |
           set -euo pipefail
           layers() {  # digest<TAB>size for the amd64 image, one per line
@@ -402,14 +405,14 @@ jobs:
             docker manifest inspect "$ref" | jq -r '.layers[] | "\(.digest)\t\(.size)"'
           }
           layers "$BASE" | cut -f1 | sort > /tmp/base.txt
-          for pair in "full:$FULL" "wheel:$WHEEL"; do
-            name="${pair%%:*}"; ref="${pair#*:}"
+          for pair in "full:$FULL:$EXPECT_LAYERS_FULL" "wheel:$WHEEL:$EXPECT_LAYERS_WHEEL"; do
+            name="${pair%%:*}"; rest="${pair#*:}"; ref="${rest%:*}"; want="${rest##*:}"
             layers "$ref" > /tmp/img.txt
             extra=$(join -v1 -t"$(printf '\t')" <(sort -k1,1 /tmp/img.txt) /tmp/base.txt || true)
             n=$(printf '%s' "$extra" | grep -c . || true)
             mib=$(printf '%s' "$extra" | awk -F'\t' '{s+=$2} END {printf "%d", s/1048576}')
             echo "${name}: ${n} layers beyond the base, ${mib} MiB"
-            [ "$n" -eq "$EXPECT_LAYERS" ] || { echo "::error::${name} adds ${n} layers, expected ${EXPECT_LAYERS}; an unintended COPY would do this, and a deliberate one means updating EXPECT_LAYERS"; exit 1; }
+            [ "$n" -eq "$want" ] || { echo "::error::${name} adds ${n} layers, expected ${want}; an unintended COPY would do this, and a deliberate one means updating EXPECT_LAYERS_${name}"; exit 1; }
             [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
           done
 

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -377,14 +377,21 @@ jobs:
       # Layer sizes, not the merged filesystem: a COPY followed by an rm leaves the
       # payload bytes in a lower layer while `find` sees nothing, which is exactly
       # the regression that would silently undo the saving.
-      - name: Assert the payload rides in two layers and stays small
+      - name: Assert the payload rides in the expected layers and stays small
         env:
           FULL: ${{ needs.bake-env-full.outputs.image }}
           WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
           BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
-          # Release with system SFPI measures 296 MiB (full) and 250 MiB (wheel).
-          # Generous headroom: this guards against a COPYed payload, not drift.
+          # Release with system SFPI measures 501 MiB (full) and 250 MiB (wheel)
+          # beyond the base. Generous headroom: this guards against a COPYed
+          # payload, not drift.
           MAX_MIB: "600"
+          # One per layer-adding instruction in Dockerfile.prebuilt-tests-env:
+          # the pyproject COPY, the dependency RUN, seven churn-tier COPYs, the
+          # excluding COPY of the remainder, and the payload RUN. Bump this only
+          # when that file deliberately changes shape - it is what catches an
+          # accidental COPY, which is the regression that would undo the saving.
+          EXPECT_LAYERS: "11"
         run: |
           set -euo pipefail
           layers() {  # digest<TAB>size for the amd64 image, one per line
@@ -402,7 +409,7 @@ jobs:
             n=$(printf '%s' "$extra" | grep -c . || true)
             mib=$(printf '%s' "$extra" | awk -F'\t' '{s+=$2} END {printf "%d", s/1048576}')
             echo "${name}: ${n} layers beyond the base, ${mib} MiB"
-            [ "$n" -eq 2 ] || { echo "::error::${name} adds ${n} layers, expected 2 (source + payload); a new COPY would do this"; exit 1; }
+            [ "$n" -eq "$EXPECT_LAYERS" ] || { echo "::error::${name} adds ${n} layers, expected ${EXPECT_LAYERS}; an unintended COPY would do this, and a deliberate one means updating EXPECT_LAYERS"; exit 1; }
             [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
           done
 

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -251,6 +251,26 @@ jobs:
       checkout-source: true
       build-args: PROFILE=full
 
+  # Every Sanity impl that consumes an env image uses the dev base, so testing only
+  # ci-test leaves the wave's actual base unexercised. Full profile on dev is where
+  # in-place import has to work.
+  bake-env-dev-full:
+    name: "Bake env image / dev full"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.build-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.dev-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+
   bake-env-wheel:
     name: "Bake env image / wheel"
     needs: build-env
@@ -292,11 +312,11 @@ jobs:
       source-ref: ${{ github.sha }}
 
   # Payload shape is what breaks silently: a wrong one still builds and publishes.
-  # Checking both costs no hardware, so only the full image needs a real leg below.
+  # Checking them costs no hardware, so only the full image needs a real leg below.
   verify-env-payloads:
-    name: "Check both env images carry the right payload"
+    name: "Check the env images carry the right payload"
     # build-env too: the base ref is needed to tell payload layers from base ones.
-    needs: [build-env, bake-env-full, bake-env-wheel, bake-env-source-ref]
+    needs: [build-env, bake-env-full, bake-env-dev-full, bake-env-wheel, bake-env-source-ref]
     if: ${{ needs.bake-env-full.outputs.image != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -312,6 +332,7 @@ jobs:
       - name: Assert each payload
         env:
           FULL: ${{ needs.bake-env-full.outputs.image }}
+          DEV_FULL: ${{ needs.bake-env-dev-full.outputs.image }}
           WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
           BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
         run: |
@@ -329,6 +350,17 @@ jobs:
             -e TT_METAL_HOME=/work \
             -e LD_LIBRARY_PATH=/work/build/lib \
             --entrypoint python3 "$FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
+          echo "::endgroup::"
+          echo "::group::${DEV_FULL}"
+          docker run --rm --entrypoint cat "$DEV_FULL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=full$'
+          docker run --rm --entrypoint sh "$DEV_FULL" -c 'test -d /work/build && test -d /work/tests'
+          # The base a consumer actually uses. Bases differ in what their venv carries,
+          # so an import that works on ci-test says nothing about this one.
+          docker run --rm \
+            -e PYTHONPATH=/work:/work/ttnn \
+            -e TT_METAL_HOME=/work \
+            -e LD_LIBRARY_PATH=/work/build/lib \
+            --entrypoint python3 "$DEV_FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
           echo "::endgroup::"
           echo "::group::${WHEEL}"
           docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -321,6 +321,14 @@ jobs:
           docker run --rm --entrypoint sh "$FULL" -c 'test -d /work/build && test -d /work/tests'
           # Proves the .dockerignore worked; otherwise .git rides along unnoticed.
           test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'ls -d /work/.git 2>/dev/null')"
+          # Same reasoning as the wheel image below: the directory shape says nothing
+          # about whether in-place import works. It needs deps the base image may not
+          # carry, so this fails here on a GitHub runner rather than on a hardware leg.
+          docker run --rm \
+            -e PYTHONPATH=/work:/work/ttnn \
+            -e TT_METAL_HOME=/work \
+            -e LD_LIBRARY_PATH=/work/build/lib \
+            --entrypoint python3 "$FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
           echo "::endgroup::"
           echo "::group::${WHEEL}"
           docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -1,0 +1,48 @@
+# Test environment image: the source tree and the build output merged at /work,
+# so a hardware test job needs no /work bind mount, no artifact download and no
+# full source checkout. Built by build-prebuilt-tests-image.yaml, which puts the
+# source at src/ and the payload at artifact/ in the build context.
+
+# The producer always passes BASE; the default is only so this builds standalone.
+ARG BASE=ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-ci-test-amd64:latest
+FROM ${BASE}
+
+# full  = source tree plus the build tarball unpacked over it; tests run the C++
+#         binaries from /work/build and import ttnn in place via PYTHONPATH=/work.
+# wheel = source tree plus the wheel installed; no build tree.
+ARG PROFILE=full
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# Source first, payload second: the tarball carries ttnn/ttnn/*.so that has to
+# land inside the source's package directory.
+COPY src/ /work/
+
+# Bind-mounted, not COPYed: a COPYed payload stays in its layer forever and a
+# later rm reclaims nothing, which would eat most of the saving.
+RUN --mount=type=bind,source=artifact,target=/tmp/payload \
+    shopt -s nullglob \
+    && case "${PROFILE}" in \
+        full) \
+            tarballs=( /tmp/payload/*.tar.zst ); \
+            if [ "${#tarballs[@]}" -ne 1 ]; then \
+                echo "::error::PROFILE=full wants exactly one .tar.zst in artifact/, found ${#tarballs[@]}" >&2; \
+                exit 1; \
+            fi; \
+            tar --zstd -xf "${tarballs[0]}" -C /work; \
+            test -d /work/build \
+                || { echo "::error::the tarball produced no /work/build" >&2; exit 1; }; \
+            printf 'profile=full\npayload=%s\n' "$(basename "${tarballs[0]}")" \
+                > /etc/prebuilt-tests-env-manifest ;; \
+        wheel) \
+            wheels=( /tmp/payload/*.whl ); \
+            if [ "${#wheels[@]}" -ne 1 ]; then \
+                echo "::error::PROFILE=wheel wants exactly one .whl in artifact/, found ${#wheels[@]}" >&2; \
+                exit 1; \
+            fi; \
+            uv pip install "${wheels[0]}"; \
+            printf 'profile=wheel\npayload=%s\n' "$(basename "${wheels[0]}")" \
+                > /etc/prebuilt-tests-env-manifest ;; \
+        *) echo "::error::Unsupported PROFILE=${PROFILE}" >&2; exit 1 ;; \
+       esac \
+    && test -s /work/.github/actions/setup-job/action.yml

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -8,7 +8,9 @@ ARG BASE=ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-ci-test-amd64:lat
 FROM ${BASE}
 
 # full  = source tree plus the build tarball unpacked over it; tests run the C++
-#         binaries from /work/build and import ttnn in place via PYTHONPATH=/work.
+#         binaries from /work/build and import ttnn in place. That import needs
+#         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
+#         namespace dir and the package itself is /work/ttnn/ttnn.
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -1,3 +1,4 @@
+# syntax=ghcr.io/tenstorrent/tt-metal/tt-metalium/tools/dockerfile-frontend:1.25
 # Test environment image: the source tree and the build output merged at /work,
 # so a hardware test job needs no /work bind mount, no artifact download and no
 # full source checkout. Built by build-prebuilt-tests-image.yaml, which puts the
@@ -12,17 +13,47 @@ FROM ${BASE}
 #         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
 #         namespace dir and the package itself is /work/ttnn/ttnn. Nothing here
 #         runs pip, so ttnn's declared dependencies are installed from the tree's
-#         pyproject.toml: no base image is guaranteed to carry them already. Both
-#         ci-test and dev lack graphviz and ml_dtypes; an import error names only
-#         the first one missing, so do not read it as the whole gap.
+#         pyproject.toml, in its own layer above: no base image is guaranteed to
+#         carry them already. Both ci-test and dev lack graphviz and ml_dtypes; an
+#         import error names only the first one missing, so do not read it as the
+#         whole gap.
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# The dependency manifest alone, before the tree: installing from it here means a
+# source edit no longer re-runs the install, which it did while this lived inside
+# the payload RUN below. pyproject.toml changes far less often than the tree.
+COPY src/pyproject.toml /work/pyproject.toml
+RUN if [ "${PROFILE}" = "full" ]; then uv pip install -r /work/pyproject.toml; fi
+
 # Source first, payload second: the tarball carries ttnn/ttnn/*.so that has to
 # land inside the source's package directory.
-COPY src/ /work/
+#
+# Split by how often each path changes rather than as one COPY. Measured over 199
+# commits, these seven trees are 84 MiB that change in under 3% of commits, so
+# giving them their own layers keeps them cached on a runner across commits and
+# only the volatile remainder is re-pulled.
+COPY src/models/experimental/ /work/models/experimental/
+COPY src/infra/ /work/infra/
+COPY src/tt-train/ /work/tt-train/
+COPY src/tests/sweep_framework/ /work/tests/sweep_framework/
+COPY src/models/sample_data/ /work/models/sample_data/
+COPY src/models/tt_transformers/ /work/models/tt_transformers/
+COPY src/models/tt_dit/ /work/models/tt_dit/
+
+# Everything else. The excludes are relative to the COPIED ROOT, not the build
+# context: `--exclude=src/infra` is silently ignored and ships those bytes twice,
+# which defeats the split. Verified before writing this.
+COPY --exclude=models/experimental \
+     --exclude=infra \
+     --exclude=tt-train \
+     --exclude=tests/sweep_framework \
+     --exclude=models/sample_data \
+     --exclude=models/tt_transformers \
+     --exclude=models/tt_dit \
+     src/ /work/
 
 # Bind-mounted, not COPYed: a COPYed payload stays in its layer forever and a
 # later rm reclaims nothing, which would eat most of the saving.
@@ -38,7 +69,6 @@ RUN --mount=type=bind,source=artifact,target=/tmp/payload \
             tar --zstd -xf "${tarballs[0]}" -C /work; \
             test -d /work/build \
                 || { echo "::error::the tarball produced no /work/build" >&2; exit 1; }; \
-            uv pip install -r /work/pyproject.toml; \
             printf 'profile=full\npayload=%s\n' "$(basename "${tarballs[0]}")" \
                 > /etc/prebuilt-tests-env-manifest ;; \
         wheel) \

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -12,8 +12,9 @@ FROM ${BASE}
 #         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
 #         namespace dir and the package itself is /work/ttnn/ttnn. Nothing here
 #         runs pip, so ttnn's declared dependencies are installed from the tree's
-#         pyproject.toml: no base image is guaranteed to carry them already (the
-#         dev image lacks graphviz and ml_dtypes, and ci-test lacks graphviz).
+#         pyproject.toml: no base image is guaranteed to carry them already. Both
+#         ci-test and dev lack graphviz and ml_dtypes; an import error names only
+#         the first one missing, so do not read it as the whole gap.
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -10,7 +10,10 @@ FROM ${BASE}
 # full  = source tree plus the build tarball unpacked over it; tests run the C++
 #         binaries from /work/build and import ttnn in place. That import needs
 #         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
-#         namespace dir and the package itself is /work/ttnn/ttnn.
+#         namespace dir and the package itself is /work/ttnn/ttnn. Nothing here
+#         runs pip, so ttnn's declared dependencies are installed from the tree's
+#         pyproject.toml: no base image is guaranteed to carry them already (the
+#         dev image lacks graphviz and ml_dtypes, and ci-test lacks graphviz).
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 
@@ -34,6 +37,7 @@ RUN --mount=type=bind,source=artifact,target=/tmp/payload \
             tar --zstd -xf "${tarballs[0]}" -C /work; \
             test -d /work/build \
                 || { echo "::error::the tarball produced no /work/build" >&2; exit 1; }; \
+            uv pip install -r /work/pyproject.toml; \
             printf 'profile=full\npayload=%s\n' "$(basename "${tarballs[0]}")" \
                 > /etc/prebuilt-tests-env-manifest ;; \
         wheel) \

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -1,4 +1,3 @@
-# syntax=ghcr.io/tenstorrent/tt-metal/tt-metalium/tools/dockerfile-frontend:1.25
 # Test environment image: the source tree and the build output merged at /work,
 # so a hardware test job needs no /work bind mount, no artifact download and no
 # full source checkout. Built by build-prebuilt-tests-image.yaml, which puts the
@@ -31,29 +30,12 @@ RUN if [ "${PROFILE}" = "full" ]; then uv pip install -r /work/pyproject.toml; f
 # Source first, payload second: the tarball carries ttnn/ttnn/*.so that has to
 # land inside the source's package directory.
 #
-# Split by how often each path changes rather than as one COPY. Measured over 199
-# commits, these seven trees are 84 MiB that change in under 3% of commits, so
-# giving them their own layers keeps them cached on a runner across commits and
-# only the volatile remainder is re-pulled.
-COPY src/models/experimental/ /work/models/experimental/
-COPY src/infra/ /work/infra/
-COPY src/tt-train/ /work/tt-train/
-COPY src/tests/sweep_framework/ /work/tests/sweep_framework/
-COPY src/models/sample_data/ /work/models/sample_data/
-COPY src/models/tt_transformers/ /work/models/tt_transformers/
-COPY src/models/tt_dit/ /work/models/tt_dit/
-
-# Everything else. The excludes are relative to the COPIED ROOT, not the build
-# context: `--exclude=src/infra` is silently ignored and ships those bytes twice,
-# which defeats the split. Verified before writing this.
-COPY --exclude=models/experimental \
-     --exclude=infra \
-     --exclude=tt-train \
-     --exclude=tests/sweep_framework \
-     --exclude=models/sample_data \
-     --exclude=models/tt_transformers \
-     --exclude=models/tt_dit \
-     src/ /work/
+# One COPY, deliberately. Splitting this by how often each path changes was tried
+# and measured: across two commits the seven low-churn layers were byte-identical
+# in size yet every compressed digest differed, so consumers re-pulled all of them
+# and the split bought nothing for nine extra layers. Reproducible layer blobs
+# would be a prerequisite, not the split itself.
+COPY src/ /work/
 
 # Bind-mounted, not COPYed: a COPYed payload stays in its layer forever and a
 # later rm reclaims nothing, which would eat most of the saving.


### PR DESCRIPTION
### PR Category

Feature

### Summary

Hardware test jobs that go through `setup-job` download the build output from artifact storage and do a recursive source checkout on every leg. Measured over 14 days that is about 103 seconds per leg across roughly 8,700 legs a day. This teaches the prebuilt tests image producer from #54412 to bake a test environment image instead, with the source tree and the build output merged at `/work`, so a consumer needs no `/work` bind mount, no artifact download and no full checkout.

No production consumers here. Nothing pulls the new image in CI yet, so no test job changes behaviour, and the first consumer is a separate PR so it can be reviewed and reverted on its own.

One production workflow does change behaviour: the scheduled cleanup now sweeps a second package, `tt-metal/prebuilt-tests-env-image`, keeping its newest 100 versions and irreversibly deleting the rest on the existing 15 minute cron. That retention is sized from this package's own push rate, on the order of ten a day between the producer test and the nightly consumers, rather than the 4,800 the gate images need at ~200/hour. The sweep is now a matrix over the two packages, so each carries its own retention and one failing does not stop the other.

Measured on an N150 leg running from the image with no `/work` volume and no repository checkout at all: container init 20s, the gtest 10s, 33s for the whole job. Wiring the first consumer shows what that is worth on real legs: 86 seconds per leg, with setup falling from 213s to 128s across 21 paired legs.

What is here:

- `dockerfile/Dockerfile.prebuilt-tests-env`, the environment payload, with a `PROFILE` arg selecting `full` (source plus the build tarball unpacked over it) or `wheel` (source plus the wheel installed, no build tree)
- ttnn's declared dependencies installed from the tree's own `pyproject.toml` in the `full` profile, since nothing in the image build runs pip and no base image carries them
- three changes that cut what a consumer pulls by 23%: `tech_reports` excluded from the build context, the dependency install moved above the source copy so a source edit no longer re-runs it, and zstd raised from level 3 to 7
- `source-ref` on the producer, so a caller can bake the same commit it built the artifact from
- a build-context `.dockerignore`, without which the source checkout ships its own `.git` and every submodule's
- both profiles wired into the producer's existing hardware test, on the `ci-test` and `dev` bases, including a leg that runs a real gtest from the image and an in-place `import ttnn` checked on each base

### Notes for reviewers

- The two profiles exist because payload size decides whether a consumer gains anything at all. A leg that only takes the wheel has roughly 23 seconds of artifact time to save, so handing it a full source and build payload would cost more in image pull than it saves.
- `source-ref` has to feed the tag recipe hash. Without that, two calls differing only in the source they bake compute the same tag and the second silently overwrites the first. The tag's `sha12` prefix is the producer's own commit, so the recipe hash is the only thing separating them.
- Adding `source-ref` to the recipe hash changes the computed tag for every existing caller, so the four gate images get fresh hashes on the first run after this merges. That re-mints once and then settles.
- The `.dockerignore` is the first thing `checkout-source: true` has ever needed in production, since the gate path never used it. The build context is the whole workspace, so without it the recursive submodule clone ships multiple GB of `.git`. Confirmed by inspecting the built image rather than assumed: `/work/.git` is present when the file is missing.
- The payload is bind mounted and unpacked rather than copied in. A `COPY` of the tarball keeps those bytes in a layer permanently, and a later `rm` cannot reclaim an earlier layer.
- The image is 23% smaller than the first version of this PR, measured by digest-diff against its own base rather than against `:latest`. The source layer went from 202.0 to 134.4 MiB and the payload from 451.7 to 361.0 MiB, so 653.7 becomes 501.9 MiB beyond the base. `tech_reports` is 69 MiB of that and nothing a test leg runs reads it: the only references are a code comment, an error string pointing at the docs, and a release-notes path classifier that runs elsewhere. `docs/` is deliberately still shipped, because `ttnn_integration_tests` runs from `docs/source/ttnn/ttnn/tutorials`.
- The zstd level is worth the most of the three, because it comes off the payload layer, which is per-commit and can never be cached on a runner. Producer CPU is cheap GitHub-hosted time; pulled bytes land on the constrained hardware.
- Splitting the source copy by how often each path changes was tried and reverted. Across two commits the seven low-churn layers were byte-identical in size yet every compressed digest differed, so consumers re-pulled all of them: nine extra layers for nothing. Reproducible layer blobs are the prerequisite, not the split, and the reasoning is recorded in the Dockerfile so it is not re-attempted blind.
- The layer-count assertion is exact and per profile (`full` 4, `wheel` 3, differing because the dependency RUN is a no-op under `wheel` and BuildKit omits empty layers). Its brittleness is the point: it caught both of the layering changes above and named the cause, which is what turns a silent 150 MiB regression into a loud failure.
- Both profiles share the base layers byte for byte. Measured 1559 MiB of base against a 296 MiB payload for `full` and 250 MiB for `wheel`, so pulling the image costs a consumer only the payload beyond the base it was already pulling.
- `.git` is deliberately absent from the image, because with submodules it is multiple GB and the point is a small per-commit layer. Anything that shells out to git cannot run from this image. That is worth knowing before wiring a consumer, and the first one needed a fix for exactly this.
- The cleanup change is the only thing in this PR that touches production. It deletes irreversibly, so the package list is fixed in the matrix and never derives from event context, and the dispatch input can still be set very high for a safe no-op run. Retention is by count rather than age, which bounds storage regardless of how busy a day gets.
- The `full` profile advertises an in-place `import ttnn`, which needs the Python dependencies the wheel would otherwise have installed. Neither `ci-test` nor `dev` carries `graphviz` or `ml_dtypes`, so the profile installs the tree's `[project].dependencies` instead of naming packages in the Dockerfile, which stops the list drifting from what the wheel would have pulled. An import error names only the first missing package, so the error text understates the gap.
- The producer's test covers the `dev` base as well as `ci-test`, because every consumer of this image uses `dev` and the two bases differ in what their venv carries. A `ci-test`-only test cannot see a `dev`-only break, and the in-place import is checked on both bases from a GitHub runner, so the extra coverage costs no hardware.
- The producer's test workflow keeps its explicit `types: [opened, synchronize, reopened, ready_for_review]`. Without `ready_for_review` a PR opened as a draft is never tested, and marking it ready fires nothing.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-test-env-producer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdabasinskas/ci-test-env-producer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-test-env-producer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdabasinskas/ci-test-env-producer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdabasinskas/ci-test-env-producer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdabasinskas/ci-test-env-producer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdabasinskas/ci-test-env-producer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdabasinskas/ci-test-env-producer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdabasinskas/ci-test-env-producer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdabasinskas/ci-test-env-producer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdabasinskas/ci-test-env-producer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdabasinskas/ci-test-env-producer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdabasinskas/ci-test-env-producer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdabasinskas/ci-test-env-producer)


