### PR TITLE
[Bug fix] ring indexer tests: make ring_parent_shape total so small boxes skip instead of erroring at collection

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/ring_indexer_score_test_utils.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/ring_indexer_score_test_utils.py
@@ -25,11 +25,10 @@ RING = 4
 
 
 def ring_parent_shape():
-    """The system mesh shape, as a (rows, cols) tuple. Raises if it cannot host the ring-of-4 carve."""
+    """The system mesh shape, as a (rows, cols) tuple. Total -- a box too small for the ring reports its real
+    shape rather than raising, so this is safe in a collection-time `skipif` condition."""
     shape = ttnn._ttnn.multi_device.SystemMeshDescriptor().shape()
-    rows, cols = shape[0], shape[1]
-    assert cols >= RING, f"ring-of-4 needs a system mesh with axis-1 >= {RING}; got {rows}x{cols}"
-    return rows, cols
+    return shape[0], shape[1]
 
 
 SP_AXIS = 1  # the length-4 axis of the (1, 4) submesh
@@ -49,6 +48,8 @@ def _open_ring4_ccl():
     """Open the full system mesh with 2D fabric, carve a 1x4 submesh, load a worker sub-device, make 2 CCL
     semaphores (the two ring directions, as ring_attention_all_gather_async needs). Returns
     (submesh, parent, ccl_semaphores, worker_sub_device_id, stall_group)."""
+    rows, cols = ring_parent_shape()
+    assert cols >= RING, f"ring-of-4 needs a system mesh with axis-1 >= {RING}; got {rows}x{cols}"
     ttnn.set_fabric_config(
         ttnn.FabricConfig.FABRIC_2D,
         ttnn.FabricReliabilityMode.STRICT_INIT,
@@ -59,7 +60,7 @@ def _open_ring4_ccl():
     )
     parent = None
     try:
-        parent = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*ring_parent_shape()))
+        parent = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(rows, cols))
         submesh = parent.create_submesh(ttnn.MeshShape(1, RING))
 
         grid = submesh.compute_with_storage_grid_size()


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #55328.

The nightly `ttnn nightly experimental tests (wormhole) [wh_n150_civ2]` job aborts at collection:

```
ERROR collecting tests/.../indexer_score/test_ring_indexer_score_dsa.py
E   AssertionError: ring-of-4 needs a system mesh with axis-1 >= 4; got 1x1
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
========================= 8 warnings, 1 error in 6.47s =========================
```

The suite runs with `-x`, so this single collection error takes down all **694** collected tests
in the job after 6.47s -- none of them related to `indexer_score`.

#### Why the existing skip never fired

`test_ring_indexer_score_dsa.py` has had the correct guard since #54744:

```python
pytestmark = [
    pytest.mark.skipif(not ttnn.device.is_blackhole(), reason="indexer_score is Blackhole-only"),
    pytest.mark.skipif(
        ring_parent_shape()[1] < RING,
        reason="ring-of-4 needs a system mesh with axis-1 >= 4",
    ),
]
```

But #54744 also gave `ring_parent_shape()` an internal assert:

```python
def ring_parent_shape():
    shape = ttnn._ttnn.multi_device.SystemMeshDescriptor().shape()
    rows, cols = shape[0], shape[1]
    assert cols >= RING, f"ring-of-4 needs a system mesh with axis-1 >= {RING}; got {rows}x{cols}"
    return rows, cols
```

A `skipif` condition is an ordinary expression, evaluated at module import on **every** box in the
fleet -- and Python evaluates a call's arguments before the call itself. So on the n150, where
`SystemMeshDescriptor().shape()` is `1x1`, the sequence was:

1. Python evaluates `ring_parent_shape()` to build the argument list.
2. The internal assert fires -> `AssertionError`.
3. `pytest.mark.skipif(...)` is **never constructed**; the module body never finishes.
4. Import fails -> collection error, not a skip.

The mark could never be reached, because building it was what crashed. The preceding
`is_blackhole()` mark cannot shield it either: both conditions are computed while the list literal
is evaluated, before either mark is applied.

The guard this replaced (`ttnn.get_num_devices() < 8`) was total, which is why the problem is new.

#### The fix

`ring_parent_shape()` becomes total -- it reports the real shape and never raises -- so the
comparison in the `skipif` decides skip-vs-run. The `cols >= RING` requirement moves into
`_open_ring4_ccl()`, which only ever runs on a box that already passed the skip, so nothing is
lost: a box that somehow reaches the carve still gets the same assert with the same message.

Now the same 1x1 box runs steps 1-4 as: `ring_parent_shape()` returns `(1, 1)` -> `1 < 4` is
`True` -> `skipif(True, ...)` is built and applied -> the module's tests skip.

### Notes for reviewers

One file, tests only. No kernel, op, or host-side changes.

Verified:

| Check | Result |
| --- | --- |
| Collection on a real 2x4 LoudBox | 19 collected, no error |
| Full run with the system mesh stubbed to 1x1 | `19 skipped`, reason `ring-of-4 needs a system mesh with axis-1 >= 4` |
| Same, on `main` | `1 error`, suite aborted |
| `_open_ring4_ccl()` on hardware | carves parent 2x4 -> submesh 1x4, 2 semaphores, closes cleanly |

The 1x1 case is reproduced by stubbing `SystemMeshDescriptor` on a 2x4 LoudBox at the exact point
the code reads it, not on an actual n150.

Worth noting for scope: on a real n150 the first mark (`not is_blackhole()`) is `True` as well, so
these tests skip there regardless -- `indexer_score` is Blackhole-only. The second mark does the
real work only on Blackhole boxes narrower than 4. The n150 breakage was never about the ring
requirement being wrong; it was purely an assert running during collection on a box that should
have skipped on the Blackhole check anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix_ring_indexer_collect)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/fix_ring_indexer_collect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix_ring_indexer_collect)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/fix_ring_indexer_collect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/fix_ring_indexer_collect)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/fix_ring_indexer_collect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/fix_ring_indexer_collect)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/fix_ring_indexer_collect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/fix_ring_indexer_collect)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/fix_ring_indexer_collect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/fix_ring_indexer_collect)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/fix_ring_indexer_collect)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/fix_ring_indexer_collect)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/fix_ring_indexer_collect)