### PR TITLE
Fixes for trace allocations on Tier 1, 2 and 3 models on Galaxy machine

### DIFF
--- a/models/common/llm_runtime/prefill/postprocess.py
+++ b/models/common/llm_runtime/prefill/postprocess.py
@@ -282,16 +282,19 @@ class PrefillPostprocessor:
                 request.padded_batch_size,
                 request.padded_sequence_length,
             )
-        elif self.uses_static_q128_topk(request, prepared.sampling_path) or (
-            prepared.sampling_params is None and request.kind == "single" and not request.uses_chunked_prefill
-        ):
+        elif self.uses_static_q128_topk(request, prepared.sampling_path):
             logits = self.config.model.post_process_prefill_output(hidden, relative_last[0])
         else:
+            # Runtime last-token bounds and row index for host sampling too. The static path keyed
+            # both its 32-row tile slice and the final 1-row slice on the prompt offset, so every
+            # new offset compiled fresh programs on the first real request - after warmup had
+            # recorded the decode traces (measured: 2 buffers left live across replays per model).
+            # With the device-side row pick the logits already hold the last token in row 0.
             logits = self.config.model.post_process_prefill_output(
                 hidden,
                 relative_last[0],
                 last_token_slice=(position_inputs.slice_start, position_inputs.slice_end),
-                last_token_index=(position_inputs.row_index if prepared.sampling_params is not None else None),
+                last_token_index=position_inputs.row_index,
             )
         retain_owned(owned, logits)
         if prepared.sampling_params is not None:
@@ -306,9 +309,13 @@ class PrefillPostprocessor:
             )
         else:
             output = ttnn.untilize(logits, use_multicore=True)
-            if request.kind == "single" and not request.uses_chunked_prefill:
+            if request.kind == "single" and not request.uses_chunked_prefill and int(output.shape[2]) > 1:
+                # Only the static q128-topk family still yields a 32-row tile here; the row-picked
+                # logits are already a single row. Row 0 keeps this slice offset-independent.
                 retain_owned(owned, output)
-                row = relative_last[0] % _TILE_SIZE
+                row = (
+                    relative_last[0] % _TILE_SIZE if self.uses_static_q128_topk(request, prepared.sampling_path) else 0
+                )
                 output = ttnn.slice(output, (0, 0, row, 0), (1, 1, row + 1, int(output.shape[-1])))
         retain_owned(owned, output)
         return output

--- a/models/common/llm_runtime/prefill/postprocess.py
+++ b/models/common/llm_runtime/prefill/postprocess.py
@@ -310,13 +310,10 @@ class PrefillPostprocessor:
         else:
             output = ttnn.untilize(logits, use_multicore=True)
             if request.kind == "single" and not request.uses_chunked_prefill and int(output.shape[2]) > 1:
-                # Only the static q128-topk family still yields a 32-row tile here; the row-picked
-                # logits are already a single row. Row 0 keeps this slice offset-independent.
+                # Host sampling uses runtime row selection above. If the model returns a
+                # padded tile, the selected token is in row 0; discard the extra rows.
                 retain_owned(owned, output)
-                row = (
-                    relative_last[0] % _TILE_SIZE if self.uses_static_q128_topk(request, prepared.sampling_path) else 0
-                )
-                output = ttnn.slice(output, (0, 0, row, 0), (1, 1, row + 1, int(output.shape[-1])))
+                output = ttnn.slice(output, (0, 0, 0, 0), (1, 1, 1, int(output.shape[-1])))
         retain_owned(owned, output)
         return output
 

--- a/models/common/llm_runtime/prefill/result_collector.py
+++ b/models/common/llm_runtime/prefill/result_collector.py
@@ -114,7 +114,9 @@ class PrefillResultAssembler:
                             output_logits[source_row] = combined[0, 0, local_row, :vocab_size].float()
                 else:
                     relative_last = (request.last_token_indices[0] - request.cached_tokens[0]) % _TILE_SIZE
-                    if request.kind == "single" and not request.uses_chunked_prefill:
+                    if request.kind == "single" and (
+                        not request.uses_chunked_prefill or int(host_primary.shape[2]) == 1
+                    ):
                         relative_last = 0
                     output_logits[request.source_rows[0]] = process_output_prefill(
                         host_primary,

--- a/models/common/llm_runtime/prefill/trace.py
+++ b/models/common/llm_runtime/prefill/trace.py
@@ -157,13 +157,9 @@ class PrefillTraceLifecycle:
         # Rotary positions are fixed for regular trace families; only tokens
         # and the page table vary on every replay.
         self.hooks.input_stager.refresh_regular_device_inputs(request, persistent.device_inputs)
-        uses_static_single_logits = (
-            prepared.sampling_params is None and request.kind == "single" and not request.uses_chunked_prefill
-        )
-        if (
-            not self.hooks.postprocessor.uses_static_q128_topk(request, prepared.sampling_path)
-            and not uses_static_single_logits
-        ):
+        # Host-sampling single requests now use the runtime last-token bounds as well (see
+        # finish_regular_prefill), so their position inputs must follow the prompt on every replay.
+        if not self.hooks.postprocessor.uses_static_q128_topk(request, prepared.sampling_path):
             if state.position_signature != relative_last:
                 position_inputs = self.hooks.input_stager.prepare_position_inputs_host(
                     relative_last,

--- a/models/common/llm_runtime/trace_compiler.py
+++ b/models/common/llm_runtime/trace_compiler.py
@@ -311,22 +311,36 @@ class TraceCompiler:
                     logger.info(f"Primed {plan.operation} trace capture body: signature={plan.trace_signature!r}")
 
                 self.program_compiler.set_trace_capture_in_progress(True)
-                trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
-                outputs = None
-                try:
-                    outputs = plan.capture(persistent)
-                    ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
-                    ttnn.synchronize_device(self.mesh_device)
-                except BaseException as primary:
-                    record.artifact = TraceArtifact(
-                        trace_id=trace_id,
-                        persistent_inputs=persistent,
-                        outputs=outputs,
-                        refresh_policy=plan.refresh_policy,
-                    )
-                    captured_keys.add(trace_key)
-                    attach_cleanup_failures(primary, self._release_trace(record))
-                    raise
+                # Whatever the model allocates between begin/end_trace_capture belongs to the trace
+                # being recorded and must stay allocated for replay; recording N traces means capture
+                # N runs while 1..N-1 are live, which ordering cannot avoid. Acknowledge the window
+                # (no-op unless TT_METAL_TRACE_ALLOC_TRACKING=1), as tt_transformers' generator does.
+                with ttnn.corruptible_allocation_scope(self.mesh_device):
+                    trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+                    outputs = None
+                    capture_ended = False
+                    try:
+                        outputs = plan.capture(persistent)
+                        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+                        capture_ended = True
+                        ttnn.synchronize_device(self.mesh_device)
+                    except BaseException as primary:
+                        cleanup_failures = []
+                        if not capture_ended:
+                            try:
+                                ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+                            except BaseException as error:
+                                cleanup_failures.append(error)
+                        record.artifact = TraceArtifact(
+                            trace_id=trace_id,
+                            persistent_inputs=persistent,
+                            outputs=outputs,
+                            refresh_policy=plan.refresh_policy,
+                        )
+                        captured_keys.add(trace_key)
+                        cleanup_failures.extend(self._release_trace(record))
+                        attach_cleanup_failures(primary, cleanup_failures)
+                        raise
                 record.artifact = TraceArtifact(
                     trace_id=trace_id,
                     persistent_inputs=persistent,

--- a/models/common/models/qwen25_coder_32b/executor.py
+++ b/models/common/models/qwen25_coder_32b/executor.py
@@ -63,6 +63,7 @@ class TracedQwen25Coder32BExecutor(Qwen25Coder32BExecutor):
         mesh_device,
         ondevice_decode_loop: bool = False,
         fast_prefill_last_token: bool = False,
+        trace_mode: str = "all",
     ):
         del mesh_device, fast_prefill_last_token
         super().__init__(
@@ -70,7 +71,7 @@ class TracedQwen25Coder32BExecutor(Qwen25Coder32BExecutor):
             model.model_args,
             _compat_executor_config(
                 model,
-                trace_mode="all",
+                trace_mode=trace_mode,
                 device_sampling_enabled=bool(ondevice_decode_loop),
             ),
         )

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -442,14 +442,19 @@ class SamplingGenerator:
             if scratch is not logits:
                 ttnn.deallocate(scratch)
 
-        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=self.cq_id)
-        sampled = self._run_sampling(
-            logits,
-            penalties_on=penalties_on,
-            tt_out_tok=tt_out_tok,
-        )
-        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=self.cq_id)
-        ttnn.synchronize_device(self.mesh_device)
+        # Whatever sampling allocates inside the capture window (e.g. the argmax output when no
+        # feedback buffer is supplied) belongs to the trace being recorded and must stay allocated
+        # for replay. Acknowledge the window (no-op unless TT_METAL_TRACE_ALLOC_TRACKING=1), as the
+        # model decode capture does; measured: 1 buffer left live across every replay on Qwen2.5-VL.
+        with ttnn.corruptible_allocation_scope(self.mesh_device):
+            trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=self.cq_id)
+            sampled = self._run_sampling(
+                logits,
+                penalties_on=penalties_on,
+                tt_out_tok=tt_out_tok,
+            )
+            ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=self.cq_id)
+            ttnn.synchronize_device(self.mesh_device)
 
         if tt_out_tok is not None:
             if isinstance(sampled, tuple):

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -350,6 +350,13 @@ class SamplingGenerator:
         if self._penalties_active:
             self.tt_penalties.reset_output_tokens()
 
+    def _copy_warmup_logits(self, logits: ttnn.Tensor) -> ttnn.Tensor:
+        # clone chooses its own core grid, which can cross the prefetcher/worker
+        # sub-device boundary on Galaxy.
+        if self.sub_core_grids is not None:
+            return ttnn.identity(logits, sub_core_grids=self.sub_core_grids)
+        return ttnn.clone(logits)
+
     def precompile(
         self,
         logits: ttnn.Tensor,
@@ -372,6 +379,11 @@ class SamplingGenerator:
         callers pass ``skip_precompile=True``, executes its program for the first time inside a live
         trace capture -- TT_FATAL !is_capturing_trace, which kills the engine rather than erroring.
         """
+        # Capture's penalty precompile uses a copy because penalties rewrite
+        # logits in place. Warm that copy program before any trace is live too.
+        if all_configs or self._penalties_active:
+            logits = self._copy_warmup_logits(logits)
+
         if not all_configs:
             self._run_sampling(
                 logits,
@@ -432,7 +444,7 @@ class SamplingGenerator:
             )
             # TTPenalties.apply() rewrites its input in place, so compiling on `logits` itself would
             # leave the capture buffer already penalized and make the first replay penalize it twice.
-            scratch = ttnn.clone(logits) if penalties_on else logits
+            scratch = self._copy_warmup_logits(logits) if penalties_on else logits
             self._run_sampling(
                 scratch,
                 penalties_on=penalties_on,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -94,27 +94,30 @@ class TTSampling(LightweightModule):
 
     @staticmethod
     def _untilize_chunk_count(width):
-        """Fewest tile-aligned even chunks of at most TOPK_MAX_WIDTH each, or 1
-        when the row is narrow enough (<= 2 * TOPK_MAX_WIDTH, the widest row
-        known to untilize in one program).
+        """Fewest tile-aligned chunks of at most TOPK_MAX_WIDTH each, or 1 when
+        the row is narrow enough (<= 2 * TOPK_MAX_WIDTH, the widest row known
+        to untilize in one program).
 
-        Raise rather than fall back: a wide row that cannot be cut would either
-        recreate the full-row circular-buffer/L1 compile clash (silent return 1)
-        or explode into thousands of tiny chunks (unbounded search), and both
-        are better caught at the source. The search is bounded so chunks stay at
-        least half of TOPK_MAX_WIDTH wide.
+        Prefer an even cut so every chunk is at least half of TOPK_MAX_WIDTH
+        wide (the search is bounded to twice the minimum count).s
         """
         if width <= 2 * TOPK_MAX_WIDTH:
             return 1
-        num_chunks = -(-width // TOPK_MAX_WIDTH)
+        min_chunks = (width + TOPK_MAX_WIDTH - 1) // TOPK_MAX_WIDTH  # ceil(width / TOPK_MAX_WIDTH)
+        num_chunks = min_chunks
         max_chunks = 2 * num_chunks
         while num_chunks <= max_chunks:
             if width % num_chunks == 0 and (width // num_chunks) % ttnn.TILE_SIZE == 0:
                 return num_chunks
             num_chunks += 1
-        raise ValueError(
-            f"cannot cut an untilize row of width {width} into tile-aligned chunks of at most {TOPK_MAX_WIDTH}"
-        )
+        return min_chunks
+
+    @staticmethod
+    def _untilize_chunk_width(width, num_chunks):
+        """Tile-aligned ttnn.split size that cuts `width` into `num_chunks` pieces
+        (the last one shorter when the row does not divide evenly)."""
+        per_chunk = (width + num_chunks - 1) // num_chunks  # ceil(width / num_chunks)
+        return (per_chunk + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE * ttnn.TILE_SIZE  # round up to a tile
 
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
@@ -886,7 +889,7 @@ class TTSampling(LightweightModule):
                 # is width-based, not mesh-based: multi-device force-argmax gathers the
                 # full padded vocab onto every device and hits the same wall. Untilize
                 # in tile-aligned chunks and concat row-major instead.
-                x_chunks = ttnn.split(x, x.shape[-1] // num_untilize_chunks, dim=3)
+                x_chunks = ttnn.split(x, self._untilize_chunk_width(x.shape[-1], num_untilize_chunks), dim=3)
                 untilized_chunks = []
                 for chunk in x_chunks:
                     # Free each tiled chunk as soon as its row-major copy exists,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -795,7 +795,7 @@ class TTSampling(LightweightModule):
         """Untilize a vocabulary row in bounded chunks while preserving its exact width."""
         num_untilize_chunks = self._untilize_chunk_count(x.shape[-1])
         # DRAM-interleaved ttnn.split/slice does not honor sub_core_grids (same
-        # senders-column spill as the vocab-trim slice above). 
+        # senders-column spill as the vocab-trim slice above).
         if num_untilize_chunks > 1 and self._force_argmax_sub_core_grids is None:
             # Untilizing the full row in one program needs a static circular-buffer
             # region proportional to the row width with past  around 150K elements it clashes

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -99,8 +99,9 @@ class TTSampling(LightweightModule):
         to untilize in one program).
 
         Prefer an even cut so every chunk is at least half of TOPK_MAX_WIDTH
-        wide (the search is bounded to twice the minimum count).s
+        wide (the search is bounded to twice the minimum count).
         """
+
         if width <= 2 * TOPK_MAX_WIDTH:
             return 1
         min_chunks = (width + TOPK_MAX_WIDTH - 1) // TOPK_MAX_WIDTH  # ceil(width / TOPK_MAX_WIDTH)
@@ -110,6 +111,7 @@ class TTSampling(LightweightModule):
             if width % num_chunks == 0 and (width // num_chunks) % ttnn.TILE_SIZE == 0:
                 return num_chunks
             num_chunks += 1
+        # INFO: split accepts an uneven trailing chunk.
         return min_chunks
 
     @staticmethod
@@ -789,6 +791,40 @@ class TTSampling(LightweightModule):
         ttnn.deallocate(boost)
         return adjusted
 
+    def _untilize_for_argmax(self, x):
+        """Untilize a vocabulary row in bounded chunks while preserving its exact width."""
+        num_untilize_chunks = self._untilize_chunk_count(x.shape[-1])
+        # DRAM-interleaved ttnn.split/slice does not honor sub_core_grids (same
+        # senders-column spill as the vocab-trim slice above). 
+        if num_untilize_chunks > 1 and self._force_argmax_sub_core_grids is None:
+            # Untilizing the full row in one program needs a static circular-buffer
+            # region proportional to the row width with past  around 150K elements it clashes
+            # with the model's resident L1 buffers at compile.
+            x_chunks = ttnn.split(x, self._untilize_chunk_width(x.shape[-1], num_untilize_chunks), dim=3)
+            untilized_chunks = []
+            for chunk in x_chunks:
+                # Free each tiled chunk as soon as its row-major copy exists,
+                # so peak memory holds around 1 full-vocab buffer less than freeing
+                # after the loop.
+                untilized_chunks.append(
+                    ttnn.untilize(
+                        chunk,
+                        use_multicore=True,
+                        sub_core_grids=self._force_argmax_sub_core_grids,
+                    )
+                )
+                chunk.deallocate()
+            x_untilized = ttnn.concat(
+                untilized_chunks,
+                dim=3,
+                sub_core_grids=self._force_argmax_sub_core_grids,
+            )
+            for chunk in untilized_chunks:
+                ttnn.deallocate(chunk)
+        else:
+            x_untilized = ttnn.untilize(x, use_multicore=True, sub_core_grids=self._force_argmax_sub_core_grids)
+        return x_untilized
+
     def forward(
         self,
         x: ttnn.Tensor,
@@ -873,46 +909,7 @@ class TTSampling(LightweightModule):
                 )
             if slice_valid_vocab:
                 x = self._slice_valid_vocab_for_argmax(x)
-            num_untilize_chunks = self._untilize_chunk_count(x.shape[-1])
-            # DRAM-interleaved ttnn.split/slice does not honor sub_core_grids (same
-            # senders-column spill as the vocab-trim slice above). Qwen3-32B Galaxy
-            # pads to 155648, which _untilize_chunk_count cuts into 4 chunks, so the
-            # post-main-rebase chunked path hits that fatal on the BH prefetcher
-            # worker sub-device. A single untilize of that width compiles there
-            # (Gemma-2's 256000-wide clash is the reason the chunked path exists;
-            # it stays for unpinned Wormhole grids).
-            if num_untilize_chunks > 1 and self._force_argmax_sub_core_grids is None:
-                # Untilizing the full row in one program needs a static circular-buffer
-                # region proportional to the row width; past ~150K elements it clashes
-                # with the model's resident L1 buffers at compile (Gemma-2's 256000-wide
-                # logits throw "circular buffers ... clash with L1 buffers"). The gate
-                # is width-based, not mesh-based: multi-device force-argmax gathers the
-                # full padded vocab onto every device and hits the same wall. Untilize
-                # in tile-aligned chunks and concat row-major instead.
-                x_chunks = ttnn.split(x, self._untilize_chunk_width(x.shape[-1], num_untilize_chunks), dim=3)
-                untilized_chunks = []
-                for chunk in x_chunks:
-                    # Free each tiled chunk as soon as its row-major copy exists,
-                    # so peak memory holds ~1 full-vocab buffer less than freeing
-                    # after the loop (this runs inside the captured decode trace,
-                    # so the peak is baked into the trace region size).
-                    untilized_chunks.append(
-                        ttnn.untilize(
-                            chunk,
-                            use_multicore=True,
-                            sub_core_grids=self._force_argmax_sub_core_grids,
-                        )
-                    )
-                    chunk.deallocate()
-                x_untilized = ttnn.concat(
-                    untilized_chunks,
-                    dim=3,
-                    sub_core_grids=self._force_argmax_sub_core_grids,
-                )
-                for chunk in untilized_chunks:
-                    ttnn.deallocate(chunk)
-            else:
-                x_untilized = ttnn.untilize(x, use_multicore=True, sub_core_grids=self._force_argmax_sub_core_grids)
+            x_untilized = self._untilize_for_argmax(x)
             tt_out_tok = ttnn.argmax(
                 x_untilized,
                 dim=-1,

--- a/models/common/tests/demos/qwen25_coder_32b/demo.py
+++ b/models/common/tests/demos/qwen25_coder_32b/demo.py
@@ -290,6 +290,51 @@ def lazy_weight_cache_dir_for_demo(mesh_device: ttnn.MeshDevice, hf_model_id: st
     return root
 
 
+def _warmup_demo_executor(
+    executor,
+    *,
+    kv_cache,
+    page_table,
+    prefill_compile_case=None,
+    prefill_sampling_params=None,
+    prefill_compile_execution=None,
+):
+    """Compile eager programs and representative requests before trace activation.
+
+    Same helper as the qwen3_32b demo: prefill and decode traces are only captured by the
+    executor's warmup (``requires_prefill_trace_warmup``), never lazily on first use, so every
+    fresh traced executor has to go through this before its first request.
+    """
+    config = executor.config
+    prefill_kwargs = {
+        "kv_cache": kv_cache,
+        "can_sample_on_device": config.device_sampling_enabled,
+    }
+    decode_kwargs = {
+        "kv_cache": kv_cache,
+        "max_batch_size": int(executor.model.config.max_batch_size),
+        "num_blocks": int(page_table.shape[-1]),
+        "can_sample_on_device": config.device_sampling_enabled,
+    }
+    executor.warmup_model_decode(enable_trace=False, **decode_kwargs)
+    executor.warmup_model_prefill(enable_trace=False, **prefill_kwargs)
+    if prefill_compile_case is not None:
+        tokens, prompt_lens = prefill_compile_case
+        executor.compile_prefill(
+            tokens=tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=list(range(tokens.shape[0])),
+            sampling_params=prefill_sampling_params,
+            execution=prefill_compile_execution if prefill_compile_execution is not None else executor.eager_execution,
+        )
+    if config.trace.prefill_enabled:
+        executor.warmup_model_prefill(enable_trace=True, **prefill_kwargs)
+    if config.trace.decode_enabled:
+        executor.warmup_model_decode(enable_trace=True, **decode_kwargs)
+
+
 def ref_basename_for_hf(hf_model_id: str) -> str:
     """Match ``ModelArgs.model_name`` style used for ``.refpt`` filenames."""
     return hf_model_id.strip("/").split("/")[-1]
@@ -1163,11 +1208,13 @@ def _run_eval_repeat_batch32(model, mesh_device):
 
     # Fresh traced executor + zeroed KV cache per repeat (driver owns the lifecycle), so the rotated
     # batches are fully independent — see run_eval_repeat_batch32 for why reuse corrupts the 3rd repeat.
+    #
+    # decode_only, as in the qwen3_32b eval-32 leg: eager prefill + traced decode is enough for a
+    # determinism gate, and each fresh executor is warmed up in allocate_kv_cache below. Without that
+    # warmup the shared runner's first request fails preflight with TraceCoverageError (traces are
+    # only captured by warmup, never lazily), which is how this leg failed on main.
     def make_executor():
-        return TracedQwen25Coder32BExecutor(model, mesh_device)
-
-    def allocate_kv_cache(executor):
-        return executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+        return TracedQwen25Coder32BExecutor(model, mesh_device, trace_mode="decode_only")
 
     # TTTv1 ci-eval-32 numeric prompts (parity).
     prompts = load_eval_repeat_prompts_batch32()
@@ -1185,7 +1232,19 @@ def _run_eval_repeat_batch32(model, mesh_device):
         if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
         else None
     )
+    representative_prefill = tokenize_fn(prompts)
     logger.info(f"[eval-32] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
+
+    def allocate_kv_cache(executor):
+        kv_cache = executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+        _warmup_demo_executor(
+            executor,
+            kv_cache=kv_cache,
+            page_table=page_table,
+            prefill_compile_case=representative_prefill,
+            prefill_sampling_params=sampling_params,
+        )
+        return kv_cache
 
     run_eval_repeat_batch32(
         make_executor=make_executor,

--- a/models/common/tests/llm_runtime/test_prefill_runtime.py
+++ b/models/common/tests/llm_runtime/test_prefill_runtime.py
@@ -364,7 +364,9 @@ def test_trace_refresh_skips_unchanged_position_and_sampling_inputs(monkeypatch)
     assert copied == [("host-tokens", "tokens"), ("host-page", "page")]
 
 
-def test_trace_refresh_skips_dynamic_position_inputs_for_static_single_logits(monkeypatch):
+def test_trace_refresh_updates_runtime_position_inputs_for_single_logits(monkeypatch):
+    # Host-sampling single requests pick their last token on device from runtime bounds (no
+    # offset-keyed programs), so a replay at a new prompt offset must refresh the position inputs.
     runtime = _runtime()
     request = _plan(prompt_length=80)[0]
     prepared = SimpleNamespace(request=request, sampling_params=None, sampling_path="logits")
@@ -388,14 +390,31 @@ def test_trace_refresh_skips_dynamic_position_inputs_for_static_single_logits(mo
         "copy_host_to_device_tensor",
         lambda host, device: copied.append((host, device)),
     )
-    monkeypatch.setattr(
-        runtime.inputs,
-        "prepare_position_inputs_host",
-        lambda *args: pytest.fail("position refreshed"),
-    )
+    refreshed = []
+
+    def prepare_position_inputs_host(relative_last, sequence_length):
+        refreshed.append((relative_last, sequence_length))
+        return PrefillPositionInputs("host-start", "host-end", "host-row")
+
+    monkeypatch.setattr(runtime.inputs, "prepare_position_inputs_host", prepare_position_inputs_host)
 
     runtime.refresh_trace(prepared, persistent, workspace)
 
+    assert refreshed == [(79, request.padded_sequence_length)]
+    assert copied == [
+        ("host-tokens", "tokens"),
+        ("host-page", "page"),
+        ("host-start", "start"),
+        ("host-end", "end"),
+        ("host-row", "row"),
+    ]
+    assert workspace.position_signature == 79
+
+    refreshed.clear()
+    copied.clear()
+    runtime.refresh_trace(prepared, persistent, workspace)
+
+    assert refreshed == []
     assert copied == [("host-tokens", "tokens"), ("host-page", "page")]
 
 
@@ -1401,7 +1420,7 @@ def test_finish_trace_reports_nested_persistent_logprob_and_intermediate_ownersh
     assert result.replay_ownership.replay_local_intermediates == (logits, selected)
 
 
-def test_cached_chunk_trace_logits_preserve_tile_for_logical_last_token_assembly(monkeypatch):
+def test_cached_chunk_trace_logits_row_pick_the_logical_last_token_for_assembly(monkeypatch):
     runtime = _runtime(trace_lengths=(128, 1024, 2048))
     tokens, page_table, prompt_lens, start_pos = _inputs(prompt_length=160, cached_tokens=32)
     prepared = runtime.prepare(
@@ -1418,8 +1437,10 @@ def test_cached_chunk_trace_logits_preserve_tile_for_logical_last_token_assembly
 
     def postprocess(hidden, last_token, *, last_token_slice, last_token_index):
         seen.append((hidden, last_token, last_token_slice, last_token_index))
-        rows = 1 if last_token_index is not None else 32
-        return torch.arange(rows, dtype=torch.float32).reshape(1, 1, rows, 1).expand(-1, -1, -1, 8)
+        if last_token_index is not None:
+            # Device-side row pick: the single output row carries the logical last token (127).
+            return torch.full((1, 1, 1, 8), float(last_token))
+        return torch.arange(32, dtype=torch.float32).reshape(1, 1, 32, 1).expand(-1, -1, -1, 8)
 
     runtime.config.model.post_process_prefill_output = postprocess
     monkeypatch.setattr(postprocess_module.ttnn, "untilize", lambda logits, **kwargs: logits)
@@ -1432,8 +1453,8 @@ def test_cached_chunk_trace_logits_preserve_tile_for_logical_last_token_assembly
     result = runtime.finish_trace(prepared, "hidden", workspace)
     output = runtime.assemble([(prepared, result)], batch_size=1)
 
-    assert seen == [("hidden", 127, ("slice-start", "slice-end"), None)]
-    assert torch.equal(output[0, 0], torch.full((runtime.config.model.vocab_size,), 31.0))
+    assert seen == [("hidden", 127, ("slice-start", "slice-end"), "row-index")]
+    assert torch.equal(output[0, 0], torch.full((runtime.config.model.vocab_size,), 127.0))
 
 
 def test_static_q128_single_topk_uses_tile_output_and_exact_host_row(monkeypatch):
@@ -2691,7 +2712,7 @@ def test_assemble_restores_source_rows_and_releases_each_owned_result(monkeypatc
     assert released == ["owned-0", "owned-1"]
 
 
-def test_single_logits_prefill_uses_static_tile_then_selects_exact_row_before_readback(monkeypatch):
+def test_single_logits_prefill_uses_runtime_row_pick_and_skips_host_row_slice(monkeypatch):
     runtime = _runtime()
     request = _plan(prompt_length=80)[0]
     prepared = SimpleNamespace(request=request, sampling_params=None, sampling_path="logits")
@@ -2704,7 +2725,8 @@ def test_single_logits_prefill_uses_static_tile_then_selects_exact_row_before_re
         last_token_index=None,
     ):
         seen.append((hidden_states, last_token_idx, last_token_slice, last_token_index))
-        return torch.ones(1, 1, 32, runtime.config.model.vocab_size)
+        assert last_token_index is not None
+        return torch.ones(1, 1, 1, runtime.config.model.vocab_size)
 
     runtime.config.model.post_process_prefill_output = post_process_prefill_output
     monkeypatch.setattr(postprocess_module.ttnn, "untilize", lambda logits, **kwargs: logits)
@@ -2718,8 +2740,8 @@ def test_single_logits_prefill_uses_static_tile_then_selects_exact_row_before_re
     positions = PrefillPositionInputs("slice-start", "slice-end", "row-index")
     logits = runtime.postprocessor.finish_regular_prefill(prepared, "hidden", None, positions)
 
-    assert seen == [("hidden", 79, None, None)]
-    assert sliced == [((0, 0, 15, 0), (1, 1, 16, runtime.config.model.vocab_size))]
+    assert seen == [("hidden", 79, ("slice-start", "slice-end"), "row-index")]
+    assert sliced == []
     output = runtime.assemble([(prepared, InvocationResult(logits, "owned"))], batch_size=1)
     assert torch.equal(output, logits[:, 0])
 

--- a/models/common/tests/models/deepseek_r1_distill_qwen_14b/test_demo_contract.py
+++ b/models/common/tests/models/deepseek_r1_distill_qwen_14b/test_demo_contract.py
@@ -160,7 +160,16 @@ def test_demo_warmup_uses_lane_group_capacity_and_lane_trace_policy():
     assert all(kwargs["kv_cache"] is kv_cache for _, kwargs in calls)
 
 
-def test_eval_prefill_signature_multiset_is_rotation_invariant_and_keeps_each_bucket_as_one_wave():
+@pytest.mark.parametrize(
+    "max_prefill_batch_size,expected",
+    [
+        pytest.param(8, [(128, 1, 1)] * 30 + [(1024, 2, 2)], id="oversized-bucket-falls-back"),
+        pytest.param(32, [(128, 32, 30), (1024, 2, 2)], id="whole-bucket-pads"),
+    ],
+)
+def test_eval_prefill_signature_multiset_is_rotation_invariant_and_keeps_each_bucket_as_one_wave(
+    max_prefill_batch_size, expected
+):
     tokens = torch.zeros((32, 700), dtype=torch.long)
     prompt_lens = torch.tensor([64] * 30 + [400, 700])
     page_table = torch.zeros((32, 64), dtype=torch.int32)
@@ -178,7 +187,7 @@ def test_eval_prefill_signature_multiset_is_rotation_invariant_and_keeps_each_bu
             max_batch_size=32,
             max_prefill_chunk_size=1024,
             supports_batched_prefill=True,
-            max_prefill_batch_size=32,
+            max_prefill_batch_size=max_prefill_batch_size,
             max_actual_page_table_width=32,
             canonical_page_table_width=64,
         )
@@ -187,11 +196,8 @@ def test_eval_prefill_signature_multiset_is_rotation_invariant_and_keeps_each_bu
             for request in requests
         )
 
-    # The current planner rounds one whole length bucket to one supported
-    # physical batch. It does not split a 30-row bucket into smaller waves,
-    # which would create extra TT invocations and trace identities. The cap
-    # matches this model's shipped policy (hf_adaptor.py: max_prefill_batch_size=32).
-    expected = [(128, 32, 30), (1024, 2, 2)]
+    # Each length bucket is one wave: pad the whole bucket when it fits,
+    # otherwise fall back to single requests instead of splitting it.
     assert planned_shapes(0) == expected
     assert planned_shapes(1) == expected
     assert planned_shapes(2) == expected

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -1177,6 +1177,15 @@ def test_ttsampling_force_argmax_matches_row_max_on_wide_vocab(vocab_size, mesh_
     assert sampler.force_argmax_sampling, "greedy params must take the argmax fast path"
 
     logits_host = torch.randn(1, 1, batch_size, vocab_size)
+    # Exercise both sides of every chunk boundary, including the last element.
+    # Negative logits make accidental zero padding observable as a wrong argmax.
+    logits_host = -logits_host.abs() - 2
+    split = TTSampling._untilize_chunk_width(vocab_size, TTSampling._untilize_chunk_count(vocab_size))
+    boundary_indices = [0, vocab_size - 1]
+    for boundary in range(split, vocab_size, split):
+        boundary_indices.extend((boundary - 1, boundary))
+    for user in range(batch_size):
+        logits_host[0, 0, user, boundary_indices[user % len(boundary_indices)]] = -1
     logits_tt = ttnn.from_torch(logits_host, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
     logits_bf16 = ttnn.to_torch(logits_tt).float().reshape(batch_size, vocab_size)
 
@@ -1191,6 +1200,47 @@ def test_ttsampling_force_argmax_matches_row_max_on_wide_vocab(vocab_size, mesh_
             f"user {user}: token {token} has logit {logits_bf16[user, token].item():.6f}, "
             f"but the row maximum is {row_max[user].item():.6f}"
         )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 2_000_000}], indirect=True)
+def test_uneven_untilize_preserves_logits_and_argmax_under_trace(mesh_device):
+    # Isolate the argmax conversion: the single-device constructor also validates
+    # a top-k split, which deliberately does not support this padded width.
+    sampler = TTSampling.__new__(TTSampling)
+    sampler._force_argmax_sub_core_grids = None
+    width = 262208
+    split = sampler._untilize_chunk_width(width, sampler._untilize_chunk_count(width))
+    boundaries = [0, width - 1]
+    for boundary in range(split, width, split):
+        boundaries.extend((boundary - 1, boundary))
+    expected = torch.tensor([boundaries[row % len(boundaries)] for row in range(32)])
+    logits = torch.full((1, 1, 32, width), -2.0, dtype=torch.bfloat16)
+    logits[0, 0, torch.arange(32), expected] = -1.0
+    device_logits = ttnn.from_torch(logits, device=mesh_device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    untilized = sampler._untilize_for_argmax(device_logits)
+    assert torch.equal(ttnn.to_torch(untilized), logits)
+    tokens = ttnn.argmax(untilized, dim=-1, keepdim=False)
+    assert torch.equal(ttnn.to_torch(tokens).flatten().long(), expected)
+    ttnn.deallocate(tokens)
+    ttnn.deallocate(untilized)
+
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    untilized = sampler._untilize_for_argmax(device_logits)
+    tokens = ttnn.argmax(untilized, dim=-1, keepdim=False)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    try:
+        # Reuse the capture with different maxima to detect stale inputs/outputs.
+        for expected in (expected.flip(0), expected):
+            logits.fill_(-2)
+            logits[0, 0, torch.arange(32), expected] = -1
+            host_logits = ttnn.from_torch(logits, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+            ttnn.copy_host_to_device_tensor(host_logits, device_logits)
+            ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=True)
+            assert torch.equal(ttnn.to_torch(tokens).flatten().long(), expected)
+    finally:
+        ttnn.release_trace(mesh_device, trace_id)
 
 
 def _single_device_sampling_args(mesh_device, vocab_size, max_top_k=32, max_batch_size=32):

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -1126,10 +1126,26 @@ def test_num_single_device_vocab_splits(padded_vocab_size, expected_splits):
         (151936, 4),  # Qwen3
         (256000, 4),  # Gemma-2
         (262144, 4),  # 4*TOPK_MAX_WIDTH exactly
+        (262208, 5),  # Gemma-3: 8194 tiles has no even tile-aligned cut in 5..10 -> minimum count, uneven
     ],
 )
 def test_untilize_chunk_count(width, expected):
     assert TTSampling._untilize_chunk_count(width) == expected
+
+
+@pytest.mark.parametrize(
+    "width, num_chunks, expected_split, expected_last",
+    [
+        (151936, 4, 37984, 37984),  # even cut: split size is the exact chunk width
+        (262208, 5, 52448, 52416),  # uneven cut: tile-aligned split, shorter tile-aligned remainder
+    ],
+)
+def test_untilize_chunk_width(width, num_chunks, expected_split, expected_last):
+    split = TTSampling._untilize_chunk_width(width, num_chunks)
+    assert split == expected_split
+    assert split % 32 == 0
+    assert -(-width // split) == num_chunks
+    assert width - split * (num_chunks - 1) == expected_last
 
 
 @pytest.mark.parametrize(

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -28,6 +28,45 @@ from models.common.sampling.tt_log_probs import MAX_TOP_LOGPROBS, LogProbsResult
 from models.common.utility_functions import comp_pcc, is_blackhole
 
 
+@pytest.mark.parametrize("all_configs", [False, True])
+def test_sampling_precompile_preserves_logits_and_request_state(monkeypatch, all_configs):
+    """Compiling an in-place penalty path must not penalize the next real replay."""
+    logits = torch.tensor([1.0, 2.0, 3.0])
+    original = logits.clone()
+    monkeypatch.setattr(ttnn, "clone", torch.clone)
+    log_probs = SimpleNamespace(logprobs_enabled=[False], num_logprobs=[0], enable_log_probs=False)
+
+    def set_log_probs_mode(enabled, num_logprobs):
+        log_probs.logprobs_enabled = enabled if isinstance(enabled, list) else [enabled]
+        log_probs.num_logprobs = num_logprobs if isinstance(num_logprobs, list) else [num_logprobs]
+        log_probs.enable_log_probs = any(log_probs.logprobs_enabled)
+
+    log_probs.set_log_probs_mode = set_log_probs_mode
+    sampling = SamplingGenerator.__new__(SamplingGenerator)
+    sampling._penalties_active = True
+    sampling._trace_states = {}
+    sampling.tt_sampling = SimpleNamespace(
+        log_probs_calculator=log_probs, _force_argmax_sampling=True, _allow_force_argmax_sampling=True
+    )
+    compiled = []
+
+    def run_sampling(scratch, *, penalties_on, tt_out_tok, count_tokens):
+        assert not count_tokens, "Warmup must not add dummy samples to request history"
+        if penalties_on:
+            scratch.sub_(2.0)
+        compiled.append(penalties_on)
+
+    sampling._run_sampling = run_sampling
+    sampling.precompile(logits, all_configs=all_configs)
+
+    assert compiled
+    torch.testing.assert_close(logits, original, rtol=0, atol=0)
+    assert sampling._penalties_active is True
+    assert sampling.tt_sampling._force_argmax_sampling is True
+    assert log_probs.logprobs_enabled == [False]
+    assert log_probs.num_logprobs == [0]
+
+
 def test_sampling_trace_buffer_reuse_is_bucket_only(monkeypatch):
     marked = []
     monkeypatch.setattr(ttnn, "mark_corruptible", marked.append, raising=False)

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -43,6 +43,7 @@ def test_sampling_precompile_preserves_logits_and_request_state(monkeypatch, all
 
     log_probs.set_log_probs_mode = set_log_probs_mode
     sampling = SamplingGenerator.__new__(SamplingGenerator)
+    sampling.sub_core_grids = None
     sampling._penalties_active = True
     sampling._trace_states = {}
     sampling.tt_sampling = SimpleNamespace(

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -117,6 +117,13 @@ class WarmupForwardMixin:
         logger.info(f"Start pos shape: {start_pos.shape}")
         logger.info(f"Page table shape: {page_table.shape}")
 
+        # Record every trace variant this sweep needs before any of them is live (see
+        # Generator.precapture_decode_trace_variants); the per-param passes below then only replay.
+        precapture = getattr(self, "precapture_decode_trace_variants", None)
+        if enable_trace and not skip_trace_precompile and precapture is not None:
+            if precapture(sampling_params, tokens, start_pos, page_table, kv_cache):
+                logger.info("Pre-captured decode trace variants before the sampling sweep")
+
         for param in sampling_params:
             logger.info(f"Warming up decode for sampling params: {param}")
             decode_kwargs = dict(

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -137,6 +137,10 @@ class WarmupForwardMixin:
             )
             if skip_trace_precompile:
                 decode_kwargs["skip_trace_precompile"] = True
+            if not enable_trace and hasattr(self, "_prepare_decode_trace_variant"):
+                # Run through decode_forward so model-specific page-table routing
+                # is active while staging.
+                decode_kwargs["prepare_trace"] = True
             self.decode_forward(**decode_kwargs)
 
         logger.info("Decode warmup completed")

--- a/models/demos/gemma4/demo/text_demo.py
+++ b/models/demos/gemma4/demo/text_demo.py
@@ -981,6 +981,8 @@ def run_generation(
             tb.print_exc()
             raise
         warmup_logits.deallocate(True)
+        # Finish queued warmup work before starting the measured TTFT window.
+        ttnn.synchronize_device(mesh_device)
         profiler.end(f"compile_prefill", iteration=prompt_idx)
         logger.info(f"Prefill warmup done in {profiler.get_duration('compile_prefill', iteration=prompt_idx):.2f}s")
 

--- a/models/demos/gemma4/demo/text_demo_v2.py
+++ b/models/demos/gemma4/demo/text_demo_v2.py
@@ -629,6 +629,7 @@ def test_demo_text(
         enable_trace=prefill_enable_trace,
         can_sample_on_device=can_sample,
         greedy_only=greedy_only,
+        decode_page_table=page_table,
     )
     logger.info("Warmup complete")
 

--- a/models/demos/gemma4/tt/ccl.py
+++ b/models/demos/gemma4/tt/ccl.py
@@ -284,7 +284,8 @@ def ccl_allreduce(tensor, mesh_config, ccl_manager, memory_config=None):
             scattered,
             persistent_output_buffer=None,
             dim=3,
-            multi_device_global_semaphore=ccl_manager.get_ag_semaphore(),
+            # Default async all-gather requires only the first two pre-created semaphores.
+            multi_device_global_semaphore=ccl_manager.get_ag_semaphore()[:2],
             num_links=ccl_manager.num_links,
             cluster_axis=tp_axis,
             topology=topology,
@@ -327,7 +328,8 @@ def ccl_allgather(tensor, mesh_config, ccl_manager, dim=3, memory_config=None):
             tensor,
             persistent_output_buffer=None,
             dim=dim,
-            multi_device_global_semaphore=ccl_manager.get_ag_semaphore(),
+            # Default async all-gather requires only the first two pre-created semaphores.
+            multi_device_global_semaphore=ccl_manager.get_ag_semaphore()[:2],
             num_links=ccl_manager.num_links,
             cluster_axis=tp_axis,
             topology=topology,

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -500,7 +500,7 @@ class ChunkedPrefillPageTableGuardMixin:
         if valid_len > 0:
             update(valid_len)
 
-    def _capture_trace_prefill(
+    def _prepare_trace_prefill(
         self,
         prefill_ids,
         page_table=None,
@@ -512,99 +512,59 @@ class ChunkedPrefillPageTableGuardMixin:
         user_id=0,
         start_pos=0,
     ):
-        """Capture prefill trace; reset sliding tails between compile and capture.
-
-        The compile forward (outside begin_trace) leaves per-layer sliding K/V
-        tails on the attention modules. Without a reset, the capture forward
-        takes the middle-chunk branch and loads new programs mid-capture
-        (TT_FATAL). sp0 must compile+capture with ``sliding_tail_in is None``;
-        sp1 must start capture from the *same* tail state compile started with.
-        APC / vLLM chunked continuations often JIT-capture sp1 with no prior
-        stash — compile takes the no-tail SDPA path then stashes a tail, and
-        capture would otherwise hit ``q_pad`` concat (program not in cache).
-        """
-        import ttnn
-        from models.tt_transformers.tt.common import copy_host_to_device
-
-        if batch_size > 1:
-            return super()._capture_trace_prefill(
-                prefill_ids,
-                page_table=page_table,
-                chunk_page_table=chunk_page_table,
-                kv_cache=kv_cache,
-                model_id=model_id,
-                global_user_id=global_user_id,
-                batch_size=batch_size,
-                user_id=user_id,
-                start_pos=start_pos,
-            )
-
-        prefill_kwargs = {
-            "page_table": page_table,
-            "chunk_page_table": chunk_page_table,
-            "chunk_start_idx": start_pos,
-            "user_id": user_id,
-        }
-        if global_user_id is not None:
-            prefill_kwargs["global_user_id"] = global_user_id
-        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, **prefill_kwargs)
-        tt_rot_mats_prefill_global = host_inputs[1]
-        tt_rot_mats_prefill_local = host_inputs[2]
-        host_inputs = (host_inputs[0], host_inputs[3], host_inputs[4], host_inputs[5])
-
-        # Snapshot pre-compile sliding state so capture can restore it. Compile
-        # always mutates `_sliding_prefill_tail` (and may first-alloc or copy
-        # into `sliding_prefill_tail_persistent`).
+        """Compile on persistent trace inputs, retaining Gemma4's starting tail state."""
         had_starting_tails = self._any_sliding_prefill_tails(model_id)
         had_persistent = self._any_sliding_prefill_persistent(model_id)
-
-        # Match Python graph for both compile and capture (sp0: first-alloc,
-        # no ttnn.copy). Soft release leaves sliding_prefill_tail_persistent set
-        # after compile, so capture would take the copy path and TT_FATAL
-        # (program not in cache). Hard-clear persistent on both sides.
-        if int(start_pos) == 0:
+        if batch_size == 1 and int(start_pos) == 0:
             self._release_all_sliding_prefill_tails(model_id, clear_persistent=True)
-
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.model_args[model_id].mesh_device)
-        transformed_inputs = self.model[model_id].transform_and_embed_prefill_inputs_device(*device_inputs)
-        tt_out_trace = self.model[model_id].ttnn_prefill_forward(
-            x=transformed_inputs[0],
-            rot_mats_global=tt_rot_mats_prefill_global,
-            rot_mats_local=tt_rot_mats_prefill_local,
-            page_table=transformed_inputs[1],
-            chunk_page_table=transformed_inputs[2],
-            chunk_start_idx=transformed_inputs[3],
+        prepared = super()._prepare_trace_prefill(
+            prefill_ids,
+            page_table=page_table,
+            chunk_page_table=chunk_page_table,
             kv_cache=kv_cache,
+            model_id=model_id,
+            global_user_id=global_user_id,
+            batch_size=batch_size,
+            user_id=user_id,
+            start_pos=start_pos,
         )
-        ttnn.synchronize_device(self.model_args[model_id].mesh_device)
-        logger.info("Done Compiling Model")
+        prepared["gemma4_tail_state"] = (batch_size, int(start_pos), had_starting_tails, had_persistent)
+        # The bridge and input preparation route auxiliary inputs through model
+        # attributes. Other buckets may change them before deferred recording.
+        model = self.model[model_id]
+        prepared["gemma4_prefill_context"] = {
+            name: getattr(model, name, None)
+            for name in (
+                "_active_page_tables_per_layer",
+                "_prefill_input_ids_torch",
+                "_prefill_embeds_torch",
+                "_prefill_batch_size",
+                "_prefill_seq_len_per_user",
+            )
+        }
+        return prepared
 
-        # Restore the same starting tail state as compile before capture.
-        if int(start_pos) == 0:
-            self._release_all_sliding_prefill_tails(model_id, clear_persistent=True)
-        elif not had_starting_tails:
-            # sp1 JIT (APC / first middle chunk): compile ran no-tail SDPA then
-            # stashed a new tail. Drop that stash so capture matches. Keep
-            # persistent only when compile also started with it (end-of-forward
-            # copy path); otherwise hard-clear so both passes first-alloc.
-            self._release_all_sliding_prefill_tails(model_id, clear_persistent=not had_persistent)
-
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.model_args[model_id].mesh_device)
-        trace_id = ttnn.begin_trace_capture(self.model_args[model_id].mesh_device, cq_id=0)
-        transformed_inputs = self.model[model_id].transform_and_embed_prefill_inputs_device(*device_inputs)
-        tt_out_trace = self.model[model_id].ttnn_prefill_forward(
-            x=transformed_inputs[0],
-            rot_mats_global=tt_rot_mats_prefill_global,
-            rot_mats_local=tt_rot_mats_prefill_local,
-            page_table=transformed_inputs[1],
-            chunk_page_table=transformed_inputs[2],
-            chunk_start_idx=transformed_inputs[3],
-            kv_cache=kv_cache,
-        )
-        ttnn.end_trace_capture(self.model_args[model_id].mesh_device, trace_id, cq_id=0)
-        ttnn.synchronize_device(self.model_args[model_id].mesh_device)
-        logger.info("Done Capturing Prefill Trace")
-        return trace_id, tt_out_trace, *device_inputs
+    def _record_trace_prefill(self, prepared):
+        """Restore the compiled branch and record using the already allocated inputs."""
+        model_id = prepared["model_id"]
+        batch_size, start_pos, had_starting_tails, had_persistent = prepared["gemma4_tail_state"]
+        if batch_size == 1:
+            if start_pos == 0:
+                # sp0 must take the no-tail branch in compile and capture. A
+                # soft release would retain the ring and add an unwarmed copy.
+                self._release_all_sliding_prefill_tails(model_id, clear_persistent=True)
+            elif not had_starting_tails:
+                self._release_all_sliding_prefill_tails(model_id, clear_persistent=not had_persistent)
+        model = self.model[model_id]
+        context = {**prepared["gemma4_prefill_context"], "_prefill_trace_mode": True}
+        previous = {name: getattr(model, name, None) for name in context}
+        try:
+            for name, value in context.items():
+                setattr(model, name, value)
+            return super()._record_trace_prefill(prepared)
+        finally:
+            for name, value in previous.items():
+                setattr(model, name, value)
 
     def _capture_trace_prefill_sampling(self, model_id, sampling_batch):
         """Gemma4 override: replicate the sampling trace input, do not column-shard it.
@@ -1375,6 +1335,7 @@ class ChunkedPrefillPageTableGuardMixin:
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
+        prepare_trace: bool = False,
         **kwargs,
     ):
         """Gemma4 decode with safe async-ahead merge (no ``tt_transformers`` edits).
@@ -1478,6 +1439,8 @@ class ChunkedPrefillPageTableGuardMixin:
                 **decode_kwargs,
                 reset_batch=reset_batch or mode_switched,
             )
+        elif prepare_trace:
+            tt_decode_output = self._prepare_decode_trace_variant(**decode_kwargs)
         else:
             tt_decode_output = self._decode_forward_no_trace_text(
                 **decode_kwargs,
@@ -1501,6 +1464,26 @@ class ChunkedPrefillPageTableGuardMixin:
             return self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
         return tt_decode_output
 
+    def _decode_trace_key(self, on_device_sampling, tokens):
+        return on_device_sampling, int(tokens[0].shape[0]) if tokens else 1
+
+    def _prepare_decode_trace_text(self, *args, **kwargs):
+        prepared = super()._prepare_decode_trace_text(*args, **kwargs)
+        # The vLLM bridge routes these through model attributes. Recording may
+        # happen after another batch or prefill has changed that routing.
+        prepared["gemma4_page_tables"] = [getattr(m, "_active_page_tables_per_layer", None) for m in self.model]
+        return prepared
+
+    def _record_decode_trace_text(self, prepared):
+        previous = [getattr(m, "_active_page_tables_per_layer", None) for m in self.model]
+        try:
+            for model, tables in zip(self.model, prepared["gemma4_page_tables"]):
+                model._active_page_tables_per_layer = tables
+            return super()._record_decode_trace_text(prepared)
+        finally:
+            for model, tables in zip(self.model, previous):
+                model._active_page_tables_per_layer = tables
+
     def _decode_forward_trace_text(
         self,
         tokens,
@@ -1522,7 +1505,7 @@ class ChunkedPrefillPageTableGuardMixin:
         from models.tt_transformers.tt.generator import DECODE_PAGE_TABLE_INPUT_IDX
 
         batch = int(tokens[0].shape[0]) if tokens else 1
-        decode_trace_key = (on_device_sampling, batch)
+        decode_trace_key = self._decode_trace_key(on_device_sampling, tokens)
         if not self.trace_ids_decode[decode_trace_key]:
             trace_ids, tt_out_trace, *device_inputs = self._capture_decode_trace_text(
                 tokens,

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -1604,7 +1604,17 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
         enable_trace,
         can_sample_on_device,
         greedy_only: bool = False,
+        decode_page_table=None,
     ):
+        # The prefill sweep uses narrower tables, which are unsuitable
+        # for Gemma's batch-keyed decode traces and hybrid per-layer tables.
+        prepared_decode = None
+        if enable_trace and not self.already_warmed_up_prefill and decode_page_table is not None:
+            prepared_decode = self._prepare_decode_trace_for_warmup(
+                kv_cache=kv_cache,
+                page_table=decode_page_table,
+                on_device_sampling=can_sample_on_device,
+            )
         warmup_gemma4_model_prefill(
             self,
             kv_cache,
@@ -1612,6 +1622,21 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
             can_sample_on_device=can_sample_on_device,
             greedy_only=greedy_only,
         )
+        if prepared_decode is not None:
+            # Complete trace setup before serving real requests. The eager
+            # preparation above wrote dummy K/V; capture only records commands.
+            previous_mode = self.mode
+            self.mode = Mode.DECODE
+            for model in self.model:
+                model.switch_mode(Mode.DECODE)
+            try:
+                trace_ids, outputs, *inputs = self._record_decode_trace_text(prepared_decode)
+            finally:
+                self.mode = previous_mode
+            key = (can_sample_on_device, int(decode_page_table.shape[0]) // self.data_parallel)
+            self.trace_ids_decode[key] = trace_ids
+            self.trace_inputs_decode[key] = inputs
+            self.trace_output_decode[key] = outputs
 
     def prefill_forward_text(
         self,

--- a/models/demos/gemma4/tt/generator_trace.py
+++ b/models/demos/gemma4/tt/generator_trace.py
@@ -868,6 +868,29 @@ def warmup_gemma4_batched_prefill_traces(
     if generator.already_warmed_up_prefill:
         return
     generator.already_warmed_up_prefill = True
+    generator._defer_prefill_recording = enable_trace
+    try:
+        _warmup_gemma4_prefill_sweep(
+            generator,
+            kv_cache,
+            enable_trace=enable_trace,
+            can_sample_on_device=can_sample_on_device,
+            greedy_only=greedy_only,
+            prefill_forward_fn=prefill_forward_fn,
+        )
+        generator._defer_prefill_recording = False
+        generator._record_pending_prefill_traces()
+    except BaseException:
+        generator.already_warmed_up_prefill = False
+        raise
+    finally:
+        generator._defer_prefill_recording = False
+        generator._pending_prefill_traces.clear()
+
+
+def _warmup_gemma4_prefill_sweep(
+    generator, kv_cache, *, enable_trace, can_sample_on_device, greedy_only, prefill_forward_fn
+):
 
     prefill_forward = prefill_forward_fn if prefill_forward_fn is not None else generator.prefill_forward_text
 

--- a/models/demos/gemma4/tt/generator_trace.py
+++ b/models/demos/gemma4/tt/generator_trace.py
@@ -891,7 +891,6 @@ def warmup_gemma4_batched_prefill_traces(
 def _warmup_gemma4_prefill_sweep(
     generator, kv_cache, *, enable_trace, can_sample_on_device, greedy_only, prefill_forward_fn
 ):
-
     prefill_forward = prefill_forward_fn if prefill_forward_fn is not None else generator.prefill_forward_text
 
     model_args = generator.model_args[0]

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -15,7 +15,6 @@ Supports both prefill and decode modes with paged attention.
 Compatible with tt_transformers Generator interface.
 """
 
-
 import os
 
 import torch
@@ -266,6 +265,18 @@ class Gemma4Model:
         transformation_mats=None,
     ):
         self.mesh_device = mesh_device
+        # Keep prompt-dependent slice bounds in persistent buffers. Literal
+        # offsets compile a new program after prefill traces are already live.
+        self._tail_slice_start = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=mesh_device,
+            mesh_mapper=self._replicate_to_mesh_mapper(),
+        )
+        self._tail_slice_end = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=mesh_device,
+            mesh_mapper=self._replicate_to_mesh_mapper(),
+        )
         self.hf_config = hf_config
         self.mesh_config = mesh_config
         self.hidden_size = hf_config.hidden_size
@@ -1864,10 +1875,23 @@ class Gemma4Model:
         # decode may be the next call).
         self._g4_retire_scavenge()
         get_last_token = (last_token_idx // 32) * 32
+        for device_tensor, values in (
+            (self._tail_slice_start, [0, 0, get_last_token, 0]),
+            (self._tail_slice_end, [1, 1, get_last_token + 32, int(hidden_states.shape[-1])]),
+        ):
+            ttnn.copy_host_to_device_tensor(
+                ttnn.from_torch(
+                    torch.tensor(values, dtype=torch.int32),
+                    mesh_mapper=self._replicate_to_mesh_mapper(),
+                ),
+                device_tensor,
+            )
         sliced = ttnn.slice(
-            hidden_states,
-            (0, 0, get_last_token, 0),
-            (1, 1, get_last_token + 32, hidden_states.shape[-1]),
+            input_tensor=hidden_states,
+            starts=self._tail_slice_start,
+            ends=self._tail_slice_end,
+            slice_dim=2,
+            num_devices=int(hidden_states.shape[-2]) // 32,
         )
         if batched and hidden_states is not sliced:
             hidden_states.deallocate(True)

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -117,6 +117,18 @@ class Model:
             mesh_config: Mesh configuration for parallelization
         """
         self.mesh_device = mesh_device
+        # Runtime bounds for the post-prefill tail's slice. Allocated here, before any trace
+        # exists: created lazily on first use they would themselves be stranded across replays.
+        self._tail_slice_start = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        self._tail_slice_end = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
         self.vocab_size = hf_config.vocab_size
         self.hf_config = hf_config
         self.core_grid = ttnn.CoreCoord(8, 8)
@@ -610,6 +622,35 @@ class Model:
         applies final norm + lm_head, so this method only slices logits.
         """
         get_last_token = (last_token_idx // 32) * 32
+        seq_len = int(logits.shape[-2])
+        # Pass the offset at runtime rather than as a compile-time attribute. With literal bounds
+        # every distinct prompt offset compiles its own slice program, and this runs after the
+        # prefill traces are captured, so each one is stranded across trace replays. Warmup cannot
+        # cover it either: it only sees bucket-length mock prompts, and real prompts are shorter.
+        #
+        # The tensor-args path needs a tile-aligned slice, which this already is - 32 rows starting
+        # at a multiple of 32 - so num_devices = seq_len // 32 selects exactly that window and the
+        # program keys on the prefill bucket instead of the offset.
+        if seq_len % 32 == 0:
+            for device_tensor, values in (
+                (self._tail_slice_start, [0, 0, get_last_token, 0]),
+                (self._tail_slice_end, [1, 1, get_last_token + 32, int(logits.shape[-1])]),
+            ):
+                ttnn.copy_host_to_device_tensor(
+                    ttnn.from_torch(
+                        torch.tensor(values, dtype=torch.int32),
+                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                    ),
+                    device_tensor,
+                )
+            return ttnn.slice(
+                input_tensor=logits,
+                starts=self._tail_slice_start,
+                ends=self._tail_slice_end,
+                slice_dim=2,
+                num_devices=seq_len // 32,
+            )
+
         logits = ttnn.slice(
             logits,
             (0, 0, get_last_token, 0),

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1197,13 +1197,15 @@ def test_demo_text(
 
         profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
-        # when doing repeating batches, set kv-caches to zero, to avoid context leaking
-        if batch_idx != 0:
-            model.switch_mode("prefill")
-            for layer in model.layers:
-                k_cache, v_cache = layer.attention.layer_past
-                k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
-                v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
+        # when doing repeating batches, set kv-caches to zero, to avoid context leaking.
+        # Also run it on the first batch, where it is a no-op on freshly allocated caches: it
+        # compiles the multiply here, before any trace is captured, instead of on batch 1 when
+        # the prefill traces are already live.
+        model.switch_mode("prefill")
+        for layer in model.layers:
+            k_cache, v_cache = layer.attention.layer_past
+            k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
+            v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(batch_size, -1)
         temperature = sampling_params["temperature"]

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -14,12 +14,12 @@ from transformers import AutoTokenizer
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.llama3_70b_galaxy.demo.demo_common import load_inputs_advanced
+from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import DECODE_FABRIC_CONFIG as _FABRIC_CONFIG
 from models.demos.llama3_70b_galaxy.tt.generator import Generator, SamplingParams
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations
 
 # Qwen-specific imports
 from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
-from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import DECODE_FABRIC_CONFIG as _FABRIC_CONFIG
 from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import verify_accuracy, verify_perf
 from models.demos.utils.model_targets import resolve_accuracy_targets, resolve_perf_targets
@@ -768,8 +768,9 @@ def test_qwen_demo_text(
 
         profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
-        # when doing repeating batches, set kv-caches to zero, to avoid context leaking
-        if batch_idx != 0:
+        # Clear repeated-request KV state, warming the reset program before the
+        # first trace so later resets cannot allocate behind a live trace.
+        if repeat_batches > 1:
             model.switch_mode("prefill")
             for layer in model.layers:
                 k_cache, v_cache = layer.attention.layer_past
@@ -948,7 +949,7 @@ def test_qwen_demo_text(
                     tt_out_logits_saved_iter_0 = tt_out_logits_saved
             except Exception as e:
                 logger.error(f"Error during decoding: {str(e)}")
-                break
+                raise
 
             if iteration == 0:  # First iteration will account the compile time
                 profiler.end(f"compile_decode", iteration=batch_idx)

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
@@ -37,8 +37,9 @@ from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
 )
 @pytest.mark.parametrize(
     "seq_len",
-    (128,),
+    (128, 1024, 4096),
 )
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize(
     "batch_size",
     (1,),
@@ -48,7 +49,7 @@ from models.demos.llama3_70b_galaxy.tests.unit_tests.qwen_test_utils import (
     [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": _PREFILL_FABRIC_CONFIG}],
     indirect=True,
 )
-def test_qwen_mlp_inference_prefill(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc):
+def test_qwen_mlp_inference_prefill(seq_len, input_dtype, batch_size, mesh_device, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat8_b
     mode = "decode" if seq_len <= 32 else "prefill"
 
@@ -78,7 +79,8 @@ def test_qwen_mlp_inference_prefill(seq_len, batch_size, mesh_device, reset_seed
     # Load Qwen model
     model_args = TtQwenModelArgs(mesh_device, max_batch_size=batch_size, dummy_weights=False, max_seq_len=128)
     model_args.n_layers = 1
-    model_args.use_prefetcher = False
+    # Exercise the production Wormhole ring CCL and its persistent FF2 buffers.
+    model_args.use_prefetcher = not _IS_BLACKHOLE
     state_dict = model_args.load_state_dict()
 
     logger.info(f"Qwen Model Loaded")
@@ -119,12 +121,13 @@ def test_qwen_mlp_inference_prefill(seq_len, batch_size, mesh_device, reset_seed
                 dims=(None, 3),
                 mesh_shape=model_args.cluster_shape,
             ),  # When both dims are None, the mapper used is `ReplicateTensorToMesh`
-            dtype=ttnn.bfloat8_b,
+            dtype=input_dtype,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.TILE_LAYOUT,
         )
         logger.info("Run Qwen_MLP")
         tt_output = tt_model.forward_prefill(tt_input, batch_size)
+        assert tt_output.dtype == ttnn.bfloat16
 
         tt_output_torch = ttnn.to_torch(
             tt_output,
@@ -142,6 +145,7 @@ def test_qwen_mlp_inference_prefill(seq_len, batch_size, mesh_device, reset_seed
 
         logger.info(comp_allclose(reference_output, tt_output_torch))
         logger.info(f"PCC: {pcc_message}")
+        assert passing, f"Qwen MLP prefill output does not meet PCC requirement {pcc_required}: {pcc_message}."
     if passing:
         logger.info("Qwen_MLP Prefill Passed!")
     else:

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -231,6 +231,12 @@ class Generator(WarmupForwardMixin):
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
         self._disable_decode_tracing = False  # Whether to disable decode traces
         self._decode_inputs_need_reset = False
+        # Deferred trace recording. While set, _easy_trace_prefill compiles and stages a
+        # variant's buffers but records nothing, stashing the prepared state here. Warmup
+        # sweeps every variant first and then records them back to back, so no compile and
+        # no output-processing allocation happens while a trace is live. See prefill_warmup.
+        self._defer_trace_recording = False
+        self._pending_prefill_traces: dict = {}
 
     def _set_prefill_column_mask(self, tt_column_mask):
         # Keep mask available on whichever TT_CCL instance attention currently uses.
@@ -267,6 +273,12 @@ class Generator(WarmupForwardMixin):
         # Avoids an infinite loop
         self.already_warmed_up_prefill = True
         self.warming_up_prefill = True
+
+        # Compile every variant before recording any of them. Recording as we go means variant N's
+        # compile run, its staged inputs, and the process_output_prefill* call after it all
+        # allocate while traces 1..N-1 are live - which is the bulk of this model's
+        # "allocated while a trace is active" count. Recording happens in one block at the end.
+        self._defer_trace_recording = enable_trace
 
         # Llama70b always supports on-device sampling from metal
         on_device_sampling_enabled = True
@@ -311,8 +323,35 @@ class Generator(WarmupForwardMixin):
                         can_sample_on_device=on_device_sampling_enabled,
                         batch_size=batch,
                     )
+                    # The shared sweep never sets a seed, so explicit_seeded_prefill is False for
+                    # all of it and the slot-stable seeded path never compiles here. It then
+                    # compiles on the first seeded request instead - behind every trace this
+                    # warmup is about to record - stranding its concat program-cache entry and
+                    # the prefetcher global CBs it creates. One seeded variant compiles it now.
+                    #
+                    # Prefill-only on purpose: adding a seed to _create_sampling_params would give
+                    # the decode warmup sweep another resident trace, and that sweep is already
+                    # trace-region bound (see TT_LEAN_DECODE_WARMUP).
+                    sampling_params_list = list(sampling_params_list) + [
+                        SamplingParams(
+                            temperature=[0.0] * batch,
+                            top_k=[1] * batch,
+                            top_p=[1.0] * batch,
+                            seed=[0] * batch,
+                        )
+                    ]
                 else:
-                    sampling_params_list = [None]
+                    # Not [None]: that takes the return-logits path, which skips
+                    # process_output_prefill_logits, so the tail (its last-token slice is keyed
+                    # on the prefill bucket) never compiles here. Only the first bucket ran the
+                    # sweep, so later buckets compiled their tail on the first real request -
+                    # after warmup had recorded its traces. Use the model's own greedy-only
+                    # sweep rather than a hand-built config, which is not valid on every path.
+                    sampling_params_list = self._create_sampling_params(
+                        can_sample_on_device=on_device_sampling_enabled,
+                        batch_size=batch,
+                        greedy_only=True,
+                    )
 
                 for sampling_params in sampling_params_list:
                     logger.info(
@@ -372,6 +411,12 @@ class Generator(WarmupForwardMixin):
                 tt_out_logits_all_users,
                 start_pos=[num_cached],
             )
+
+        # Every variant has compiled and staged its buffers, and nothing is recorded yet.
+        # Record them all now, back to back, with no allocation in between.
+        if self._defer_trace_recording:
+            self._defer_trace_recording = False
+            self._record_pending_traces()
 
         # trace_id_prefill dict check
         logger.info("Prefill warmup completed")
@@ -1083,6 +1128,26 @@ class Generator(WarmupForwardMixin):
             last_token_idx_relative = last_token_idx - num_cached_tokens if use_prefix_caching else last_token_idx
 
         if self.trace_id_prefill[trace_key] is None:
+            if self._defer_trace_recording:
+                # Compile and stage only. Recording now would put a trace on device before the
+                # remaining warmup variants have compiled, and every one of those compiles - plus
+                # the process_output_prefill* call the caller makes on the value returned here -
+                # would then allocate behind it. prefill_warmup records the whole set afterwards.
+                if trace_key not in self._pending_prefill_traces:
+                    self._pending_prefill_traces[trace_key] = self._prepare_trace_prefill(
+                        tokens,
+                        last_token_idx_relative,
+                        page_table=page_table,
+                        chunk_page_table=chunk_page_table,
+                        kv_cache=kv_cache,
+                        user_id=user_id,
+                        batch_size=batch_size,
+                        start_pos=chunk_start_idx,
+                    )
+                # Hand back the compile run's own output so the caller's output processing still
+                # runs (and compiles) exactly as it would have. There is no trace to replay yet.
+                return self._pending_prefill_traces[trace_key]["compile_out"]
+
             trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
                 tokens,
                 last_token_idx_relative,
@@ -1111,6 +1176,24 @@ class Generator(WarmupForwardMixin):
         )
         return tt_out_trace
 
+    def _record_pending_traces(self):
+        """
+        Record every prefill trace prepared while recording was deferred, back to back.
+
+        Nothing between these captures allocates: each variant's program cache is warm and its
+        inputs are already staged, which is the whole point of deferring.
+        """
+        if not self._pending_prefill_traces:
+            return
+
+        logger.info(f"Recording {len(self._pending_prefill_traces)} deferred prefill trace(s)")
+        for trace_key, prepared in self._pending_prefill_traces.items():
+            trace_id, tt_out_trace = self._record_trace_prefill(prepared)
+            self.trace_id_prefill[trace_key] = trace_id
+            self.trace_inputs_prefill[trace_key] = prepared["device_inputs"]
+            self.trace_output_prefill[trace_key] = tt_out_trace
+        self._pending_prefill_traces = {}
+
     def _capture_trace_prefill(
         self,
         tokens,
@@ -1123,8 +1206,40 @@ class Generator(WarmupForwardMixin):
         start_pos=0,  # Absolute start position
     ):
         """
-        Captures a trace for the prefill_forward method with prefix caching support.
-        Uses full rot mats + chunk_start_idx device tensor; slicing inside the trace.
+        Compile and immediately record a prefill trace. Kept for callers that are not
+        driving the deferred (prepare-then-record) warmup sequence.
+        """
+        prepared = self._prepare_trace_prefill(
+            tokens,
+            last_token_idx,
+            user_id,
+            page_table=page_table,
+            chunk_page_table=chunk_page_table,
+            kv_cache=kv_cache,
+            batch_size=batch_size,
+            start_pos=start_pos,
+        )
+        trace_id, tt_out_trace = self._record_trace_prefill(prepared)
+        return trace_id, tt_out_trace, *prepared["device_inputs"]
+
+    def _prepare_trace_prefill(
+        self,
+        tokens,
+        last_token_idx,
+        user_id,
+        page_table=None,
+        chunk_page_table=None,  # For prefix caching
+        kv_cache=None,
+        batch_size=1,
+        start_pos=0,  # Absolute start position
+    ):
+        """
+        Everything a prefill trace needs before it can be recorded: host inputs, the compile
+        run that populates the program cache, and this trace's own staged device inputs.
+
+        Records nothing. Split out from recording so warmup can compile every variant while
+        no trace is live - otherwise variant N's compile, and the process_output_prefill*
+        call that follows it, allocate behind the N-1 traces already captured.
         """
         # Get host tensors (tokens, user_id, page_table, chunk_page_table, chunk_start_idx, column_mask)
         host_inputs = self.model.prepare_prefill_inputs_host(
@@ -1217,6 +1332,37 @@ class Generator(WarmupForwardMixin):
         # here), so acknowledge them the way tt_transformers does for its decode trace I/O. This
         # keeps the tracker's report limited to GENUINE survivors instead of burying them.
         _mark_trace_io_corruptible(device_inputs)
+
+        return {
+            "device_inputs": device_inputs,
+            "full_rot_mats": full_rot_mats,
+            "last_token_idx": last_token_idx,
+            "kv_cache": kv_cache,
+            "batch_size": batch_size,
+            "start_pos": start_pos,
+            "compile_out": tt_out_trace,
+        }
+
+    def _record_trace_prefill(self, prepared):
+        """
+        Record a prefill trace from state produced by _prepare_trace_prefill. Allocates nothing
+        of its own: the program cache is already warm and the inputs are already staged.
+        """
+        device_inputs = prepared["device_inputs"]
+        full_rot_mats = prepared["full_rot_mats"]
+        last_token_idx = prepared["last_token_idx"]
+        kv_cache = prepared["kv_cache"]
+        batch_size = prepared["batch_size"]
+        start_pos = prepared["start_pos"]
+
+        # Point the CCL at THIS trace's column mask before recording. Preparation may have run
+        # for several variants since this one, each of which left its own buffer here.
+        self._set_prefill_column_mask(device_inputs[5])
+        # Recording used to follow this variant's compile run directly, so capture began from
+        # whatever index state that run left. With recording deferred, other variants compile in
+        # between, so reset explicitly to keep each capture starting from the same state.
+        self.model.tt_ccl.reset_gather_and_buffer_idx()
+
         # Everything allocated between begin/end_trace_capture belongs to the trace being
         # captured: the model's prefill intermediates are bound into the recorded program and
         # must stay allocated for replay. prefill_warmup captures one trace per (seq_len,
@@ -1256,7 +1402,7 @@ class Generator(WarmupForwardMixin):
         ttnn.synchronize_device(self.mesh_device)
         logger.info("Done Capturing Prefill Trace")
 
-        return trace_id, tt_out_trace, *device_inputs
+        return trace_id, tt_out_trace
 
     def _prefill_forward_trace_text(
         self,

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -280,6 +280,33 @@ class Generator(WarmupForwardMixin):
         # "allocated while a trace is active" count. Recording happens in one block at the end.
         self._defer_trace_recording = enable_trace
 
+        try:
+            self._prefill_warmup_sweep(
+                page_table,
+                kv_cache,
+                enable_trace,
+                sampling_params,
+                tt_out_logits_all_users,
+            )
+            self._defer_trace_recording = False
+            self._record_pending_traces()
+        except BaseException:
+            self.already_warmed_up_prefill = False
+            raise
+        finally:
+            self._defer_trace_recording = False
+            self._pending_prefill_traces.clear()
+            self.warming_up_prefill = False
+        logger.info("Prefill warmup completed")
+
+    def _prefill_warmup_sweep(
+        self,
+        page_table,
+        kv_cache,
+        enable_trace,
+        sampling_params,
+        tt_out_logits_all_users,
+    ):
         # Llama70b always supports on-device sampling from metal
         on_device_sampling_enabled = True
 
@@ -411,16 +438,6 @@ class Generator(WarmupForwardMixin):
                 tt_out_logits_all_users,
                 start_pos=[num_cached],
             )
-
-        # Every variant has compiled and staged its buffers, and nothing is recorded yet.
-        # Record them all now, back to back, with no allocation in between.
-        if self._defer_trace_recording:
-            self._defer_trace_recording = False
-            self._record_pending_traces()
-
-        # trace_id_prefill dict check
-        logger.info("Prefill warmup completed")
-        self.warming_up_prefill = False
 
     def prefill_forward_text(
         self,

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -237,6 +237,8 @@ class Generator(WarmupForwardMixin):
         # no output-processing allocation happens while a trace is live. See prefill_warmup.
         self._defer_trace_recording = False
         self._pending_prefill_traces: dict = {}
+        # None means programs are warm, but L1 inputs must be recreated after prefill.
+        self._prepared_decode_traces: dict = {}
 
     def _set_prefill_column_mask(self, tt_column_mask):
         # Keep mask available on whichever TT_CCL instance attention currently uses.
@@ -457,6 +459,12 @@ class Generator(WarmupForwardMixin):
             enable_trace = False
 
         if not self.already_warmed_up_prefill:
+            if (
+                enable_trace
+                and not self._disable_decode_tracing
+                and getattr(self.model_args, "prepare_decode_before_prefill", False)
+            ):
+                self._prepare_decode_before_prefill(page_table, kv_cache, sampling_params is not None)
             self.prefill_warmup(
                 tokens,
                 page_table,
@@ -774,6 +782,9 @@ class Generator(WarmupForwardMixin):
                 else:
                     # Single user: logits list has 1 entry, copy into persistent buffer
                     ttnn.copy(input_a=tt_logits_list[0], input_b=self.tt_logits_accumulated[user_id])
+                # Copies above have consumed these temporary logits. Do not keep
+                # the previous user's output alive across the next prefill replay.
+                del tt_logits_list
         if do_device_sampling and not use_batched_prefill and empty_slots:
             active_prefill_slots = {int(slot) for slot in empty_slots}
             fill_slot = int(empty_slots[0])
@@ -1654,7 +1665,54 @@ class Generator(WarmupForwardMixin):
             return tt_tok[0], None
         return tt_tok
 
-    def _capture_trace_text(
+    @staticmethod
+    def _decode_preparation_key(page_table, on_device_logits, is_cur_pos_sharded, is_page_table_sharded):
+        return (
+            on_device_logits,
+            is_cur_pos_sharded,
+            is_page_table_sharded,
+            None if page_table is None else tuple(page_table.shape),
+        )
+
+    def _prepare_decode_before_prefill(self, page_table, kv_cache, on_device_logits):
+        """Stage the initial decode programs and inputs before prefill traces exist."""
+        if any(self.trace_id_prefill.values()) or any(self.trace_ids_decode.values()):
+            return
+        batch = self.model_args.max_batch_size
+        if page_table is not None and page_table.shape[0] < batch:
+            page_table = torch.nn.functional.pad(page_table, (0, 0, 0, batch - page_table.shape[0]))
+        input_layouts = [(False, False)]
+        if (
+            page_table is not None
+            and self.model.paged_attention_config is not None
+            and page_table.shape[1] == self.model.paged_attention_config.max_num_blocks // batch
+        ):
+            # Galaxy's throughput demo shards both inputs; the serving warmup
+            # uses the default interleaved inputs with the same page-table shape.
+            input_layouts.append((True, True))
+        self.model.switch_mode("decode")
+        logger.info("Preparing decode before prefill trace capture")
+        for is_cur_pos_sharded, is_page_table_sharded in input_layouts:
+            key = self._decode_preparation_key(page_table, on_device_logits, is_cur_pos_sharded, is_page_table_sharded)
+            if key not in self._prepared_decode_traces:
+                self._prepared_decode_traces[key] = self._prepare_trace_decode(
+                    tokens=torch.zeros(batch, 1, dtype=torch.int32),
+                    # Inactive positions compile the same programs without modifying KV
+                    # entries that may already contain a cached prefix.
+                    current_pos=torch.full((batch,), -1, dtype=torch.int32),
+                    page_table=page_table,
+                    kv_cache=kv_cache[0],
+                    is_cur_pos_sharded=is_cur_pos_sharded,
+                    is_page_table_sharded=is_page_table_sharded,
+                    on_device_logits=on_device_logits,
+                )
+                if is_cur_pos_sharded or is_page_table_sharded:
+                    # These L1 buffers collide with prefill's static circular
+                    # buffers. Keep the compiled programs, not the warmup inputs.
+                    self._prepared_decode_traces[key] = None
+        self.model.switch_mode("prefill")
+
+    def _prepare_trace_decode(
         self,
         tokens,
         current_pos,
@@ -1664,9 +1722,7 @@ class Generator(WarmupForwardMixin):
         is_page_table_sharded=False,
         on_device_logits=False,
     ):
-        """
-        Captures a trace for the decode_forward method.
-        """
+        """Compile decode and sampling, and stage the persistent trace inputs."""
 
         # Compile run
         compile_out = self._decode_forward_no_trace_text(
@@ -1705,6 +1761,40 @@ class Generator(WarmupForwardMixin):
             if compile_logits is not None:
                 logger.info("Pre-compiling sampling path before decode trace capture")
                 sampling_module.precompile(logits=compile_logits, tt_out_tok=tokens_tt, all_configs=True)
+
+        return tokens_tt, current_pos_tt, rope_idxs_tt, page_table_tt
+
+    def _capture_trace_text(
+        self,
+        tokens,
+        current_pos,
+        page_table=None,
+        kv_cache=None,
+        is_cur_pos_sharded=False,
+        is_page_table_sharded=False,
+        on_device_logits=False,
+    ):
+        key = self._decode_preparation_key(page_table, on_device_logits, is_cur_pos_sharded, is_page_table_sharded)
+        if key in self._prepared_decode_traces:
+            prepared = self._prepared_decode_traces.pop(key)
+            if prepared is None:
+                # Prefill and decode intentionally reuse this L1 space. These
+                # are trace inputs, not program-cache allocations.
+                with ttnn.corruptible_allocation_scope(self.mesh_device):
+                    prepared = self.model.prepare_inputs_decode(
+                        tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
+                    )
+        else:
+            prepared = self._prepare_trace_decode(
+                tokens,
+                current_pos,
+                page_table,
+                kv_cache,
+                is_cur_pos_sharded,
+                is_page_table_sharded,
+                on_device_logits,
+            )
+        tokens_tt, current_pos_tt, rope_idxs_tt, page_table_tt = prepared
 
         # Save the buffer addresses for preallocated tensors.
         # Same reasoning as the prefill capture: everything allocated inside the capture window

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -51,6 +51,7 @@ class TT_CCL:
     ):
         self.mode = mode
         self.is_qwen = is_qwen
+        self.prefill_mlp_output_dtype = getattr(model_args, "prefill_mlp_output_dtype", ttnn.bfloat8_b)
         # Wormhole / TG always run with the prefetcher; the Blackhole bring-up runs without it.
         # The no-prefetcher (Blackhole) buffer-sizing and stable-CCL fallbacks below are gated on
         # this so the prefetcher (Wormhole) path stays byte-for-byte identical to main.
@@ -99,6 +100,15 @@ class TT_CCL:
         self.use_ring_prefill = self.ring_topology and mode == "prefill"
         self.use_ring_ag_prefill = (self.ring_topology and not LINE_AG) and mode == "prefill"
         self.use_ring_rs_prefill = (self.ring_topology and not LINE_RS) and mode == "prefill"
+        # Keep this reduction sequence specific to Qwen3-32B on Wormhole Galaxy.
+        self.use_qwen_prefill_ff2_gather_reduce = (
+            self.is_qwen
+            and model_args.base_model_name == "Qwen3-32B"
+            and not self.is_blackhole
+            and self.use_prefetcher
+            and self.use_ring_ag_prefill
+            and self.use_ring_rs_prefill
+        )
         self.max_top_k = model_args.max_top_k
         self.max_batch_size = model_args.max_batch_size
 
@@ -642,6 +652,13 @@ class TT_CCL:
 
         return persistent_buffers
 
+    def _prefill_buffer_dtype(self, key):
+        if key in ("FF2", "FF2_batched"):
+            return self.prefill_mlp_output_dtype
+        if key == "LAYERNORM":
+            return ttnn.bfloat16
+        return ttnn.bfloat8_b
+
     def get_prefill_reduce_scatter_buffers(self):
         """
         Currently, this is hardcoded with llama specific shapes.
@@ -685,7 +702,7 @@ class TT_CCL:
                         torch.zeros(shape[1]),
                         device=self.mesh_device,
                         layout=ttnn.TILE_LAYOUT,
-                        dtype=ttnn.bfloat8_b,
+                        dtype=self._prefill_buffer_dtype(key),
                         memory_config=ttnn.DRAM_MEMORY_CONFIG,
                         mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                         cache_file_name=self.weight_cache_path / (f"pb_rs_00_{key}_{i}_{seqlen}"),
@@ -696,7 +713,7 @@ class TT_CCL:
                         torch.zeros(shape[0]),
                         device=self.mesh_device,
                         layout=ttnn.TILE_LAYOUT,
-                        dtype=ttnn.bfloat8_b,
+                        dtype=self._prefill_buffer_dtype(key),
                         memory_config=ttnn.DRAM_MEMORY_CONFIG,
                         mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                         cache_file_name=self.weight_cache_path / (f"pb_rs_01_{key}_{i}_{seqlen}"),
@@ -707,7 +724,7 @@ class TT_CCL:
                         torch.zeros(shape[1]),
                         device=self.mesh_device,
                         layout=ttnn.TILE_LAYOUT,
-                        dtype=ttnn.bfloat8_b,
+                        dtype=self._prefill_buffer_dtype(key),
                         memory_config=ttnn.DRAM_MEMORY_CONFIG,
                         mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                         cache_file_name=self.weight_cache_path / (f"pb_rs_02_{key}_{i}_{seqlen}"),
@@ -760,11 +777,13 @@ class TT_CCL:
                 }
             )
             for key, shape in buffers_dict.items():
+                if self.use_qwen_prefill_ff2_gather_reduce and key in ("FF2", "FF2_batched"):
+                    continue
                 tt_intermediate_buffer = ttnn.as_tensor(
                     torch.zeros(shape[0]),
                     device=self.mesh_device,
                     layout=ttnn.TILE_LAYOUT,
-                    dtype=ttnn.bfloat8_b,
+                    dtype=self._prefill_buffer_dtype(key),
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                     cache_file_name=self.weight_cache_path / (f"pb_rs_01_{key}_0_{seqlen}"),
@@ -774,7 +793,7 @@ class TT_CCL:
                     torch.zeros(shape[1]),
                     device=self.mesh_device,
                     layout=ttnn.TILE_LAYOUT,
-                    dtype=ttnn.bfloat8_b,
+                    dtype=self._prefill_buffer_dtype(key),
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                     cache_file_name=self.weight_cache_path / (f"pb_rs_00_{key}_0_{seqlen}"),
@@ -820,11 +839,13 @@ class TT_CCL:
                 }
             )
             for key, shape in buffers_dict.items():
+                if self.use_qwen_prefill_ff2_gather_reduce and key in ("FF2",):
+                    continue
                 tt_buffer = ttnn.as_tensor(
                     torch.zeros(shape[0]),
                     device=self.mesh_device,
                     layout=ttnn.TILE_LAYOUT,
-                    dtype=ttnn.bfloat16 if key == "LAYERNORM" else ttnn.bfloat8_b,
+                    dtype=self._prefill_buffer_dtype(key),
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                     cache_file_name=self.weight_cache_path / ("pb_ag_" + key + str(seqlen)),
@@ -910,6 +931,8 @@ class TT_CCL:
                 persistent_buffer.deallocate(True)
 
         else:
+            if self.use_qwen_prefill_ff2_gather_reduce and buffer_key == "FF2":
+                return self._prefill_ff2_gather_reduce(input_tensor_mesh, cluster_axis, memory_config)
             if buffer_key == "WO_AG" or lm_head:
                 ttnn_tensor_gathered = self.line_all_gather(
                     input_tensor_mesh,
@@ -952,6 +975,33 @@ class TT_CCL:
 
         self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
         return output_tensor_mesh
+
+    def _prefill_ff2_gather_reduce(self, input_tensor_mesh, cluster_axis, memory_config):
+        """Gather FF2 partials in rank order, then reduce locally without intermediate ring sums."""
+        assert input_tensor_mesh.shape[0] == 1, "FF2 prefill requires a leading singleton dimension"
+        gathered = ttnn.experimental.all_gather_async(
+            input_tensor=input_tensor_mesh,
+            persistent_output_buffer=None,
+            dim=0,
+            multi_device_global_semaphore=self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]],
+            num_links=4,
+            barrier_semaphore=self.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Ring,
+            subdevice_id=self.worker_sub_device_id,
+            cluster_axis=cluster_axis,
+        )
+        self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
+        output = ttnn.experimental.fast_reduce_nc(
+            gathered,
+            dims=[0],
+            output=None,
+            compute_kernel_config=None,
+            memory_config=memory_config,
+            sub_core_grids=self.sub_device_crs,
+        )
+        ttnn.deallocate(gathered)
+        return output
 
     def line_all_reduce_gather_reduce(self, input_tensor_mesh, cluster_axis, num_links, memory_config):
         # Stable all-reduce used for the wide Blackhole lm_head logits in decode. all_reduce_async's

--- a/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
@@ -45,6 +45,7 @@ class TtLlamaMLP(LightweightModule):
         self.mesh_device = mesh_device
         self.layer_num = layer_num
         self.args = args
+        self.prefill_output_dtype = getattr(args, "prefill_mlp_output_dtype", ttnn.bfloat8_b)
         self.dim = args.dim
         self.model_config = model_config
         # Single source of truth for the prefetcher gate (Wormhole/TG True, Blackhole bring-up False).
@@ -383,6 +384,8 @@ class TtLlamaMLP(LightweightModule):
             w1_out = ttnn.experimental.minimal_matmul(
                 input_tensor=x,
                 weight_tensor=self.w1_interleaved if use_w1_w3_interleaved else self.w1,
+                # Qwen's residual can be BF16; FF1/FF3 CCL buffers remain BF8.
+                dtype=ttnn.bfloat8_b if self.args.is_qwen else None,
                 config=minimal_pc_1_3,
                 compute_kernel_config=self.args.compute_kernel_config_lofi,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -417,6 +420,7 @@ class TtLlamaMLP(LightweightModule):
             w3_out = ttnn.experimental.minimal_matmul(
                 input_tensor=x,
                 weight_tensor=self.w3_interleaved if use_w1_w3_interleaved else self.w3,
+                dtype=ttnn.bfloat8_b if self.args.is_qwen else None,
                 config=minimal_pc_1_3,
                 compute_kernel_config=self.args.compute_kernel_config_lofi,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -457,11 +461,14 @@ class TtLlamaMLP(LightweightModule):
                 w2_in_gathered,
                 self.w2_interleaved,
                 compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
-                dtype=ttnn.bfloat8_b,
+                dtype=self.prefill_output_dtype,
                 program_config=short_lens_pc_2,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
         else:
+            # Match the input format before communicating its bytes.
+            if w2_in.dtype != self.prefill_output_dtype:
+                w2_in = ttnn.typecast(w2_in, self.prefill_output_dtype)
             w2_out = self.tt_ccl.line_all_gather_matmul(
                 w2_in,
                 self.w2_interleaved,
@@ -470,7 +477,7 @@ class TtLlamaMLP(LightweightModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 matmul_config=minimal_pc_2,
                 compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
-                dtype=ttnn.bfloat8_b,
+                dtype=self.prefill_output_dtype,
             )
             ttnn.deallocate(w2_in)
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -77,6 +77,10 @@ class TtTransformer(LightweightModule):
         self.is_prefill_setup = False
         self.is_decode_setup = False
         self.prefetcher_setup = None
+        # Device-side prefill inputs, reused across requests. Keyed by the host inputs' shape /
+        # dtype / layout signature, which is bounded because prompts are padded to a small set of
+        # prefill buckets. See prepare_inputs_prefill.
+        self._prefill_input_cache = {}
         self.mesh_sub_device_manager_id_decode = None
         self.mesh_sub_device_manager_id_prefill = None
         # Cached CCLs so the no-prefetcher path can reuse them across mode switches instead of
@@ -156,6 +160,25 @@ class TtTransformer(LightweightModule):
         self._tt_seq_len_buffer = ttnn.from_torch(
             torch.tensor([1, 1, self.args.max_seq_len, self.args.head_dim], dtype=torch.int32),
             device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        # Runtime bounds and row selector for the prefill tail's last-token slice; see
+        # _select_last_token_row. Allocated here, before any trace exists, and rewritten in place.
+        self._tail_slice_start = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        self._tail_slice_end = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        self._tail_row_mask = ttnn.from_torch(
+            torch.zeros(1, 1, 32, 1, dtype=torch.bfloat16),
+            device=self.mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
         # [0, 0, 0, 0] - slice to get [0,0] and [0] for building slice start [0, 0, N, 0] from chunk_start_idx [N].
@@ -478,7 +501,18 @@ class TtTransformer(LightweightModule):
         host_inputs = self.prepare_prefill_inputs_host(
             tokens, user_id, page_table, chunk_page_table, chunk_start_idx, batch_size
         )
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)  # Helper function
+        # Allocating these per call leaves one set of device buffers per request live behind the
+        # traces captured during warmup. Only the untraced prefill path comes through here (the
+        # traced path stages its inputs once at capture and copies into them), and it is what a
+        # seeded or greedy request takes, so this is every such request. The buffers depend only on
+        # the padded prefill bucket, so cache them on that signature and copy into them instead.
+        cache_key = tuple(None if t is None else (tuple(t.shape), str(t.dtype), str(t.layout)) for t in host_inputs)
+        cached_inputs = self._prefill_input_cache.get(cache_key)
+        if cached_inputs is None:
+            device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
+            self._prefill_input_cache[cache_key] = device_inputs
+        else:
+            device_inputs = copy_host_to_device(host_inputs, device_tensors=cached_inputs)
         transformed_device_inputs = self.transform_prefill_inputs_device(*device_inputs)
         return transformed_device_inputs
 
@@ -618,6 +652,62 @@ class TtTransformer(LightweightModule):
         tt_tokens = self.embd(tokens)
         return tt_tokens, current_pos, tt_rot_mats, page_table
 
+    def _select_last_token_row(self, x, last_token_idx_i):
+        """
+        Pick row ``last_token_idx_i`` out of the sequence dimension without baking the position into
+        a program.
+
+        ``x[:, :, i : i + 1, :]`` puts the bounds in the slice's compile-time attributes, so every
+        distinct prompt position compiles a new program and strands its program-cache buffer behind
+        the traces captured during warmup - and warmup cannot pre-compile them, because it only ever
+        sees bucket-length mock prompts.
+
+        The tensor-args slice takes the position at runtime but only accepts a tile-aligned window,
+        which a single row is not. So take the aligned 32-row window that contains the row (the
+        position travels in a device tensor, so this compiles once per prefill bucket), then pick the
+        row inside it with a fixed-shape one-hot mask - constant shapes, so that compiles once too.
+        """
+        seq_len = int(x.shape[-2])
+        if seq_len % 32 != 0 or seq_len < 32:
+            return x[:, :, last_token_idx_i : last_token_idx_i + 1, :]
+
+        window_start = (int(last_token_idx_i) // 32) * 32
+        row_in_window = int(last_token_idx_i) % 32
+
+        for device_tensor, values in (
+            (self._tail_slice_start, [0, 0, window_start, 0]),
+            (self._tail_slice_end, [1, 1, window_start + 32, int(x.shape[-1])]),
+        ):
+            ttnn.copy_host_to_device_tensor(
+                ttnn.from_torch(
+                    torch.tensor(values, dtype=torch.int32),
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                ),
+                device_tensor,
+            )
+        window = ttnn.slice(
+            input_tensor=x,
+            starts=self._tail_slice_start,
+            ends=self._tail_slice_end,
+            slice_dim=2,
+            num_devices=seq_len // 32,
+        )
+
+        mask_torch = torch.zeros(1, 1, 32, 1, dtype=torch.bfloat16)
+        mask_torch[0, 0, row_in_window, 0] = 1.0
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(
+                mask_torch,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            ),
+            self._tail_row_mask,
+        )
+        # Exactly one row survives the mask, so the reduction copies it rather than accumulating:
+        # every other term is a true zero.
+        return ttnn.sum(ttnn.mul(window, self._tail_row_mask), dim=2, keepdim=True)
+
     def process_output_prefill_logits(self, tt_out, last_token_idx, tt_out_logits_saved=None, user_id=0):
         """
         Process prefill output to get logits tensor for on-device sampling.
@@ -638,7 +728,7 @@ class TtTransformer(LightweightModule):
                 last_token_idx_i = last_token_idx[i]
             else:
                 last_token_idx_i = last_token_idx
-            x = x[:, :, last_token_idx_i : last_token_idx_i + 1, :]
+            x = self._select_last_token_row(x, last_token_idx_i)
             # lm_head returns logits in sharded format (same as decode before all-gather)
             tt_logits = self.lm_head(x, None, mode="prefill")
             tt_logits = tt_logits[0]
@@ -868,8 +958,19 @@ class TtTransformer(LightweightModule):
                 self.lm_head.tt_ccl = self.tt_ccl
                 if self.use_prefetcher:
                     self.tt_tensors = self.prefetcher_setup.get_input_tensors()
+                    # The global CB is rebuilt on every prefill->decode switch, which on-device
+                    # prefill sampling makes once per request. It cannot be cached: it is
+                    # top-anchored in L1 and deliberately not held across prefill (keeping it
+                    # alive there fails with "static dataflow buffers clash with L1 buffers"),
+                    # and it cannot be reordered before the traces because the switch is what
+                    # creates it. Acknowledge it: the decode trace binds this CB at capture and
+                    # replays correctly across every later rebuild, so the rebuild lands where
+                    # the trace expects. NOTE this is an acknowledgement - it tells the checker
+                    # the program is prepared for this buffer, it does not stop a replay writing
+                    # it. No-op unless TT_METAL_TRACE_ALLOC_TRACKING=1.
                     # Re-create global CB for decode (if it was not already created)
-                    self.prefetcher_setup.create_global_cb()
+                    with ttnn.corruptible_allocation_scope(self.mesh_device):
+                        self.prefetcher_setup.create_global_cb()
                 else:
                     # No-prefetcher path reuses the cached decode CCL; clear its semaphore drift.
                     self.tt_ccl.reset_global_semaphores()
@@ -910,7 +1011,9 @@ class TtTransformer(LightweightModule):
         batch_size=1,
     ):
         if mode == "decode" and self.use_prefetcher:
-            self.prefetcher_setup.create_global_cb()
+            # Same rebuild-per-switch as in switch_mode; see the note there.
+            with ttnn.corruptible_allocation_scope(self.mesh_device):
+                self.prefetcher_setup.create_global_cb()
             garbage_tensor = ttnn.dram_prefetcher(
                 self.tt_tensors,
                 num_layers=self.n_layers,

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -78,8 +78,10 @@ class TtTransformer(LightweightModule):
         self.is_decode_setup = False
         self.prefetcher_setup = None
         # Device-side prefill inputs, reused across requests. Keyed by the host inputs' shape /
-        # dtype / layout signature, which is bounded because prompts are padded to a small set of
-        # prefill buckets. See prepare_inputs_prefill.
+        # dtype / layout signature. Callers must keep page-table widths fixed at the
+        # configured block-pool size as well as padding prompts to prefill buckets.
+        # Entries live for the model lifetime; arbitrary page-table widths would add
+        # signatures beyond the warmup set. See prepare_inputs_prefill.
         self._prefill_input_cache = {}
         self.mesh_sub_device_manager_id_decode = None
         self.mesh_sub_device_manager_id_prefill = None

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -132,6 +132,12 @@ def set_tg_attention_config(
 
 
 class TtQwenModelArgs(TtModelArgs):
+    # Qwen Galaxy needs decode program buffers allocated before prefill traces.
+    prepare_decode_before_prefill = True
+
+    # Preserve FF2 partial sums through the prefill reduction across devices.
+    prefill_mlp_output_dtype = ttnn.bfloat16
+
     OP_KEYS = (
         # Embedding
         "EMB_WEIGHTS",

--- a/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
+++ b/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
@@ -591,19 +591,18 @@ class GemmaMultimodalGenerator(Generator):
 
         skip_sequence_lengths = False
 
-        # Sweep all sampling parameters for prefill warmup just once since it is sequence length agnostic
-        sampling_parameters_sweeped = False
+        # Every data-parallel lane is a separate device with its own program cache, and Gemma's prefill is
+        # never traced, so the base gate (warm lanes 1..N-1 only for traced lengths) left those lanes
+        # compiling their whole prefill graph on the first real request - behind the decode traces warmup
+        # had just recorded (measured on DP-4: ~90 stranded programs per lane). Warm every lane for every
+        # bucket, and sweep the sampling parameters once per lane rather than once overall.
+        swept_sampling_model_ids = set()
 
         if enable_trace:
             logger.info("Using batch-1-only traced prefill warmup; runtime batched prefill remains enabled")
 
         for model_id in range(self.data_parallel):
             for supported_length in sequence_lengths_to_warmup:
-                if model_id != 0 and (
-                    supported_length not in self.model_args[0].trace_prefill_supported_seq_lens or not enable_trace
-                ):
-                    continue
-
                 # Token-limit guard below skips combinations that would
                 # exceed MAX_BATCHED_PREFILL_SEQ_LEN.
                 for batch_size in warmup_batch_sizes:
@@ -626,14 +625,21 @@ class GemmaMultimodalGenerator(Generator):
                         skip_sequence_lengths = True
                         break
 
-                    if not sampling_parameters_sweeped:
+                    if model_id not in swept_sampling_model_ids:
                         sampling_params = self._create_sampling_params(
                             can_sample_on_device=can_sample_on_device,
                             batch_size=batch_size,
                             greedy_only=greedy_only,
                         )
                     else:
-                        sampling_params = [None]
+                        # Not [None]: that path skips the on-device-sampling tail, whose bucket-keyed
+                        # programs (last-token slice, untilize) would then compile on the first real
+                        # request instead. One greedy pass per bucket compiles them here.
+                        sampling_params = self._create_sampling_params(
+                            can_sample_on_device=can_sample_on_device,
+                            batch_size=batch_size,
+                            greedy_only=True,
+                        )
 
                     for param in sampling_params:
                         logger.info(
@@ -647,7 +653,7 @@ class GemmaMultimodalGenerator(Generator):
                             sampling_params=param,
                         )
 
-                    sampling_parameters_sweeped = True
+                    swept_sampling_model_ids.add(model_id)
 
                 if skip_sequence_lengths:
                     break

--- a/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
+++ b/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
@@ -589,8 +589,6 @@ class GemmaMultimodalGenerator(Generator):
         sequence_lengths_to_warmup = self.model_args[0].get_warmup_prefill_supported_seq_lens()
         warmup_batch_sizes = (1,)
 
-        skip_sequence_lengths = False
-
         # Every data-parallel lane is a separate device with its own program cache, and Gemma's prefill is
         # never traced, so the base gate (warm lanes 1..N-1 only for traced lengths) left those lanes
         # compiling their whole prefill graph on the first real request - behind the decode traces warmup
@@ -602,6 +600,7 @@ class GemmaMultimodalGenerator(Generator):
             logger.info("Using batch-1-only traced prefill warmup; runtime batched prefill remains enabled")
 
         for model_id in range(self.data_parallel):
+            skip_sequence_lengths = False
             for supported_length in sequence_lengths_to_warmup:
                 # Token-limit guard below skips combinations that would
                 # exceed MAX_BATCHED_PREFILL_SEQ_LEN.

--- a/models/demos/multimodal/gemma3/tt/model_config.py
+++ b/models/demos/multimodal/gemma3/tt/model_config.py
@@ -128,6 +128,9 @@ class ModelArgs(TTModelArgs):
 
         self.use_qk_fused = False  # For Gemma 3, we do not use qk fused ops (rotary embedding + paged cache update)
         self.model_config["LM_HEAD_OUTPUT_MEMCFG"] = ttnn.DRAM_MEMORY_CONFIG
+        if self.base_model_name == "gemma-3-4b" and self.device_name == "N150":
+            # Bound the MLP intermediates while keeping sliding-window attention unchunked.
+            self.model_config["MLP_PREFILL_CHUNK_SIZE"] = 16 * 1024
         self.padded_vocab_size = 262400
         # Raise the per-device cap so on-device sampling is enabled for Gemma3's 131200-wide shard.
         self.device_sampling_max_per_device_vocab = 192 * 1024

--- a/models/experimental/diffusion_gemma/tt/ccl.py
+++ b/models/experimental/diffusion_gemma/tt/ccl.py
@@ -61,7 +61,8 @@ def ccl_allreduce(tensor, mesh_config, ccl_manager, memory_config=None):
         mesh_device=ccl_manager.mesh_device,
         num_links=ccl_manager.num_links,
         topology=ccl_manager.topology,
-        multi_device_global_semaphore=ccl_manager.get_ag_semaphore(),
+        # Default async all-gather requires only the first two pre-created semaphores.
+        multi_device_global_semaphore=ccl_manager.get_ag_semaphore()[:2],
         barrier_semaphore=ccl_manager.get_barrier_semaphore(),
         memory_config=memory_config,
     )
@@ -110,7 +111,8 @@ def ccl_allgather(tensor, mesh_config, ccl_manager, dim=3, memory_config=None):
         mesh_device=ccl_manager.mesh_device,
         num_links=ccl_manager.num_links,
         topology=ccl_manager.topology,
-        multi_device_global_semaphore=ccl_manager.get_ag_semaphore(),
+        # Default async all-gather requires only the first two pre-created semaphores.
+        multi_device_global_semaphore=ccl_manager.get_ag_semaphore()[:2],
         barrier_semaphore=ccl_manager.get_barrier_semaphore(),
         memory_config=memory_config,
     )

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -1125,10 +1125,8 @@ targets:
           - batch_size: 32
             seq_len: 707
             status: active
-            # Re-seeded from run 27036772693 (ci eval-32); the earlier 7.63/189
-            # were the token-matching teacher-forcing artifacts, not eval perf.
             perf:
-              decode_t/s/u: 22.1
+              decode_t/s/u: 29.9
               prefill_time_to_first_token: 82
             accuracy: {}
   qwen2.5-72b:
@@ -1161,7 +1159,7 @@ targets:
             seq_len: 128
             status: active
             perf:
-              prefill_time_to_first_token: 419
+              prefill_time_to_first_token: 275
               # b1 decode is run-to-run unstable: measured ~10.9-13.2 t/s across
               # recent scheduled runs + 3 targeted reruns. The old 13.77 center
               # sat at the top of the range, so its tol-0.15 floor (11.70) tripped
@@ -1302,8 +1300,8 @@ targets:
             status: active
             perf:
               prefill_time_to_first_token: 616
-              decode_t/s/u: 17.76
-              decode_t/s: 568.19
+              decode_t/s/u: 19.5
+              decode_t/s: 624
             accuracy: {}
             owner_id: U08JFM3CFA4 # Gongyu Wang
             team: models
@@ -1352,15 +1350,14 @@ targets:
           - batch_size: 32
             seq_len: 686
             status: active
-            # Targets raised to match sustained perf on bh_quietbox_2 (p300x2):
-            # 6/6 recent scheduled runs measured decode_t/s ~680-703, t/s/u ~21.8,
-            # TTFT ~86-88ms (old targets 278 / 18.7 / 207 were stale). decode_t/s
-            # = batch_size * decode_t/s/u (32 * 21.6 ~= 691).
+            #Raised again 691 / 21.6 -> 931 / 29.1:
+            # runs 33710384109 (main) and 33967118837 both measured 931 / 29.1,
+            # above the old +15% ceiling.
             perf:
               prefill_time_to_first_token: 87
               prefill_time_to_first_token_tolerance: 0.2
-              decode_t/s/u: 21.6
-              decode_t/s: 691
+              decode_t/s/u: 29.1
+              decode_t/s: 931
             accuracy: {}
             owner_id: U03PUAKE719 # Miguel Tairum Cruz
             team: models
@@ -1424,7 +1421,7 @@ targets:
             seq_len: 128
             status: active
             perf:
-              prefill_time_to_first_token: 174.0
+              prefill_time_to_first_token: 150.0
               decode_t/s: 26.0
               decode_t/s/u: 26.0
               tolerance: 0.2

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -1350,7 +1350,7 @@ targets:
           - batch_size: 32
             seq_len: 686
             status: active
-            #Raised again 691 / 21.6 -> 931 / 29.1:
+            # Raised again 691 / 21.6 -> 931 / 29.1:
             # runs 33710384109 (main) and 33967118837 both measured 931 / 29.1,
             # above the old +15% ceiling.
             perf:

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -274,12 +274,6 @@ sizes:
       wh_n150:
         trace_region_size: 14000000
 
-  llama3.1-70b-legacy:
-    aliases: ["Llama-3.1-70B-legacy", "Llama-2-70B-legacy"]
-    skus:
-      wh_llmbox_perf:
-        trace_region_size: 14227456
-
   llama3.3-70b-galaxy:
     aliases: ["llama3.3-70b-galaxy"]
     skus:

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -16,8 +16,7 @@ sizes:
       wh_n300:
         trace_region_size: 38000000
       wh_llmbox_perf:
-        # TTTv2 batch-32 with on-device sampling captures 53764096 bytes.
-        trace_region_size: 60000000
+        trace_region_size: 65000000
       wh_galaxy_perf:
         trace_region_size: 50000000
       bh_p150:

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -5,10 +5,14 @@ sizes:
     aliases: ["Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"]
     skus:
       wh_n150:
-        # 0 = dynamic runtime allocation. The fixed 25000000 was sized for the
-        # greedy performance-ci-eval-32 path but is too small for the traced
+        # Was 0 (dynamic runtime allocation): the fixed 25000000 was sized for the
+        # greedy performance-ci-eval-32 path and is too small for the traced
         # performance-batch-32 demo (full sampling op captured). See #48636.
-        trace_region_size: 0
+        # Dynamic allocation puts trace storage in ordinary DRAM instead of the reserved
+        # TRACE region, where it shares an address space with everything else and every
+        # trace recorded after the first is allocated while the earlier ones are live
+        # (see #48869). Sized up rather than left dynamic.
+        trace_region_size: 60000000
       wh_n300:
         trace_region_size: 38000000
       wh_llmbox_perf:
@@ -238,7 +242,7 @@ sizes:
     aliases: ["Qwen2.5-7B", "Qwen/Qwen2.5-7B-Instruct"]
     skus:
       wh_n300:
-        trace_region_size: 10000000
+        trace_region_size: 16000000
 
   qwen2.5-coder-32b:
     aliases: ["Qwen2.5-Coder-32B", "Qwen/Qwen2.5-Coder-32B-Instruct"]
@@ -268,7 +272,13 @@ sizes:
     aliases: ["Phi-3-mini", "microsoft/Phi-3-mini-128k-instruct"]
     skus:
       wh_n150:
-        trace_region_size: 10000000
+        trace_region_size: 14000000
+
+  llama3.1-70b-legacy:
+    aliases: ["Llama-3.1-70B-legacy", "Llama-2-70B-legacy"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 14227456
 
   llama3.3-70b-galaxy:
     aliases: ["llama3.3-70b-galaxy"]
@@ -410,7 +420,7 @@ sizes:
       wh_n300:
         trace_region_size: 30000000
       wh_llmbox_perf:
-        trace_region_size: 30100000
+        trace_region_size: 34000000
       wh_galaxy_perf:
         trace_region_size: 30000000
       bh_p150:

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1178,9 +1178,9 @@ def test_demo_text(
             ), f"max_generated_tokens ({max_generated_tokens}) needs to be <= than paged_cache_max_seq_len ({paged_cache_max_seq_len})"
         profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
-        # when doing repeating batches, set kv-caches to zero, to avoid context leaking
-
-        if batch_idx != 0:
+        # Clear K/V between requests, and compile the in-place reset on the first
+        # batch too. Its program-cache buffers must exist before trace capture.
+        if repeat_batches > 1:
             for i in range(len(model)):
                 for layer in model[i].layers:
                     k_cache, v_cache = layer.attention.layer_past

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -401,6 +401,9 @@ def test_multimodal_demo_text(
 
     non_trace_generated_texts = []
 
+    if enable_trace and hasattr(generator, "warmup_vision_encoder"):
+        # Compile the vision encoder for every image geometry before the decode trace is recorded.
+        generator.warmup_vision_encoder()
     for iter_num in range(warmup_iters + 1):
         logger.info(f"Iteration {iter_num}")
         current_dialogs = dialogs

--- a/models/tt_transformers/tests/test_lm_head.py
+++ b/models/tt_transformers/tests/test_lm_head.py
@@ -30,6 +30,7 @@ from models.tt_transformers.tt.prefetcher import Prefetcher
     "batch_size",
     (1,),
 )
+@pytest.mark.parametrize("output_memory_config", [None, ttnn.DRAM_MEMORY_CONFIG], ids=["default", "dram-output"])
 @pytest.mark.parametrize(
     "mesh_device",
     [
@@ -40,7 +41,7 @@ from models.tt_transformers.tt.prefetcher import Prefetcher
     indirect=True,
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
-def test_lm_head_inference(seq_len, batch_size, mesh_device, use_prefetcher, reset_seeds):
+def test_lm_head_inference(seq_len, batch_size, mesh_device, use_prefetcher, output_memory_config, reset_seeds):
     dtype = ttnn.bfloat8_b
 
     prefetcher = Prefetcher(mesh_device, num_tensors=0, num_layers=1) if use_prefetcher else None
@@ -52,6 +53,8 @@ def test_lm_head_inference(seq_len, batch_size, mesh_device, use_prefetcher, res
         mesh_device, max_batch_size=batch_size, max_seq_len=seq_len, cache_hf=True, prefetcher=prefetcher
     )
     model_args.n_layers = 1
+    if output_memory_config is not None:
+        model_args.model_config["LM_HEAD_OUTPUT_MEMCFG"] = output_memory_config
 
     state_dict = model_args.load_state_dict()
 
@@ -89,6 +92,10 @@ def test_lm_head_inference(seq_len, batch_size, mesh_device, use_prefetcher, res
         layout=ttnn.TILE_LAYOUT,
     )
     tt_output = tt_model(tt_input)
+    expected_memory_config = (
+        ttnn.DRAM_MEMORY_CONFIG if use_prefetcher else output_memory_config or ttnn.L1_MEMORY_CONFIG
+    )
+    assert tt_output.memory_config() == expected_memory_config
     tt_output_torch = ttnn.to_torch(
         tt_output,
         mesh_composer=ttnn.ConcatMesh2dToTensor(

--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -33,15 +33,24 @@ from models.tt_transformers.tt.prefetcher import Prefetcher
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "seq_len",
-    (64 * 1024, 32 * 1024, 512, 128, 32),
+    "seq_len,mlp_prefill_chunk_size",
+    [
+        (64 * 1024, None),
+        (32 * 1024, None),
+        (512, None),
+        (128, None),
+        (32, None),
+        pytest.param(768, 512, id="chunked-prefill-with-tail"),
+    ],
 )
 @pytest.mark.parametrize(
     "batch_size",
     (1,),
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
-def test_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc, use_prefetcher):
+def test_mlp_inference(
+    seq_len, mlp_prefill_chunk_size, batch_size, mesh_device, reset_seeds, ensure_gc, use_prefetcher
+):
     dtype = ttnn.bfloat8_b
     mode = Mode.DECODE if seq_len <= 32 else Mode.PREFILL
 
@@ -60,6 +69,10 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc,
         prefetcher=prefetcher,
     )
     model_args.n_layers = 1
+    if mlp_prefill_chunk_size is not None:
+        if model_args.num_devices != 1:
+            pytest.skip("MLP prefill chunking is used on a single device")
+        model_args.model_config["MLP_PREFILL_CHUNK_SIZE"] = mlp_prefill_chunk_size
     state_dict = model_args.load_state_dict()
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names

--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -34,7 +34,7 @@ from models.tt_transformers.tt.prefetcher import Prefetcher
 )
 @pytest.mark.parametrize(
     "seq_len",
-    (64 * 1024, 32 * 1024, 512, 32),
+    (64 * 1024, 32 * 1024, 512, 128, 32),
 )
 @pytest.mark.parametrize(
     "batch_size",
@@ -112,6 +112,15 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc,
     )
     logger.info("Run MLP")
     tt_output = tt_model(tt_input, mode)
+
+    # Qwen3-32B/T3K keeps BF16 across the linear/minimal prefill boundary.
+    # Other models preserve the original minimal-matmul BF8 output default.
+    if not model_args.is_galaxy:
+        qwen_t3k = model_args.base_model_name == "Qwen3-32B" and model_args.device_name == "T3K"
+        expected_dtype = ttnn.bfloat16
+        if seq_len > 128 and not qwen_t3k:
+            expected_dtype = ttnn.bfloat8_b
+        assert tt_output.dtype == expected_dtype
 
     tt_output_torch = ttnn.to_torch(
         tt_output,

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import pytest
 
+import ttnn
+from models.tt_transformers.tt.common import Mode
 from models.tt_transformers.tt.model_config import (
     ModelArgs,
     TensorGroup,
@@ -15,6 +17,39 @@ from models.tt_transformers.tt.model_config import (
     create_galaxy_ff1_out_reduce_scatter_memcfg,
     should_pad_sampling_logits_to_power_of_2,
 )
+
+
+@pytest.mark.parametrize("seq_len", [128, 4096])
+def test_qwen_t3k_prefill_matmul_configs_match_across_batching(monkeypatch, seq_len):
+    args = SimpleNamespace(base_model_name="Qwen3-32B", device_name="T3K", mlp2_grid=lambda _: (8, 8))
+    args.use_minimal_prefill_matmul = MethodType(ModelArgs.use_minimal_prefill_matmul, args)
+    args.use_minimal_qkv_prefill_matmul = MethodType(ModelArgs.use_minimal_qkv_prefill_matmul, args)
+    monkeypatch.setattr("models.tt_transformers.tt.model_config.is_blackhole", lambda: False)
+
+    assert args.use_minimal_prefill_matmul(seq_len)
+    assert args.use_minimal_qkv_prefill_matmul(seq_len)
+    qkv = ModelArgs.get_attn_qkv_program_config.__wrapped__(args, Mode.PREFILL, seq_len)
+    ff2 = ModelArgs.get_mlp_ff2_prg_config.__wrapped__(args, Mode.PREFILL, seq_len)
+    assert isinstance(qkv, ttnn.MinimalMatmulConfig)
+    assert isinstance(ff2, ttnn.MinimalMatmulConfig)
+
+
+@pytest.mark.parametrize(
+    "model_name,device_name,galaxy_row,qkv_minimal",
+    [
+        ("Qwen3-32B", "TG", False, False),
+        ("Qwen3-32B", "P150x4", False, False),
+        ("Llama-3.1-8B", "T3K", False, False),
+        ("Llama-3.1-8B", "T3K", True, True),
+    ],
+)
+def test_other_short_prefill_matmul_policies_are_preserved(model_name, device_name, galaxy_row, qkv_minimal):
+    args = SimpleNamespace(
+        base_model_name=model_name, device_name=device_name, is_galaxy_8_device_row_submesh=galaxy_row
+    )
+    args.use_minimal_prefill_matmul = MethodType(ModelArgs.use_minimal_prefill_matmul, args)
+    assert not args.use_minimal_prefill_matmul(128)
+    assert ModelArgs.use_minimal_qkv_prefill_matmul(args, 128) is qkv_minimal
 
 
 @pytest.mark.parametrize(

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -81,8 +81,8 @@ def test_resolve_trace_region_size_matches_yaml(model_name, sku, expected_size):
 @pytest.mark.parametrize(
     "model_name,legacy_sku,expected_size",
     [
-        ("Llama-3.1-8B", "N150", 0),  # dynamic allocation, see #48636
-        ("Llama-3.1-8B", "T3K", 60000000),
+        ("Llama-3.1-8B", "N150", 60000000),
+        ("Llama-3.1-8B", "T3K", 65000000),
         ("Llama-3.3-70B", "P150x4", 224000000),
         ("meta-llama/Llama-3.1-8B-Instruct", "bh_quietbox_2", 52000000),
     ],
@@ -175,7 +175,7 @@ def test_resolve_gemma4_config_path_aliases(model_path, sku, expected_size):
         (
             "/mnt/MLPerf/huggingface/hub/models--google--gemma-3-27b-it/snapshots/005ad3404e59d6023443cb575daa05336842228a",
             "wh_llmbox_perf",
-            30000000,
+            34000000,
         ),
         (
             "/mnt/MLPerf/huggingface/hub/models--google--gemma-3-4b-it/snapshots/093f9f388b31de276ce2de164bdc2081324b9767",

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -945,6 +945,14 @@ def create_tt_model(
             state_dict = tt_model_args.load_state_dict()
             loaded_real_weights = bool(state_dict) and not tt_model_args.dummy_weights
 
+    # A populated state_dict handed in by the caller (DP submeshes after the first) bypasses
+    # load_state_dict(), which is the only place the cold path sets is_mixture_of_experts. Without
+    # this the later lanes build a dense MLP for an MoE checkpoint and fail on the missing
+    # feed_forward.w1 key. Derive the flag from the keys, as load_state_dict does.
+    # (The warm-cache placeholder mapping is deliberately falsy, so test for None, not truthiness.)
+    if state_dict is not None and not getattr(tt_model_args, "is_mixture_of_experts", False):
+        tt_model_args.is_mixture_of_experts = any(".experts." in k for k in state_dict.keys())
+
     model = Transformer(
         args=tt_model_args,
         mesh_device=mesh_device,

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -952,6 +952,13 @@ def create_tt_model(
     # (The warm-cache placeholder mapping is deliberately falsy, so test for None, not truthiness.)
     if state_dict is not None and not getattr(tt_model_args, "is_mixture_of_experts", False):
         tt_model_args.is_mixture_of_experts = any(".experts." in k for k in state_dict.keys())
+    if getattr(tt_model_args, "is_mixture_of_experts", False):
+        # Reused weights must initialize the same MoE configuration as load_state_dict.
+        tt_model_args.moe = True
+        expert_indices = [
+            int(k.split(".experts.")[1].split(".")[0]) + 1 for k in state_dict if "block_sparse_moe.experts." in k
+        ]
+        tt_model_args.num_experts = max(expert_indices) if expert_indices else tt_model_args.num_local_experts
 
     model = Transformer(
         args=tt_model_args,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -526,6 +526,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             and is_harmony
         )
 
+    def _overrides_prefill_capture(self):
+        """Whether a subclass replaces _capture_trace_prefill (see the warmup-less deferral gate)."""
+        return type(self)._capture_trace_prefill is not Generator._capture_trace_prefill
+
     def _uses_prefetcher(self):
         """Whether any model instance drives the DRAM prefetcher.
 
@@ -1040,6 +1044,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # compiled its MoE dispatch can no longer be trace-captured, and compiling decode before any
             # prefill deadlocks in the MoE combine. It keeps main's late decode compile.
             and not self._will_row_shard_prefill(tokens, sampling_params)
+            # Excluded: models that customise the capture step. Deferred recording prepares through the
+            # base helper and records later, which skips whatever a _capture_trace_prefill override does
+            # between its compile pass and its capture.
+            and not self._overrides_prefill_capture()
         ):
             # Models that skip prefill warmup (GPT-OSS sets warmup_prefill=False everywhere) would otherwise
             # capture their prefill trace part way through this call and then compile the whole decode graph

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -2488,6 +2488,36 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             )
 
     # Note: This function is called by vLLM
+    def warmup_vision_encoder(self):
+        """Run the vision encoder once per supported image canvas so its programs exist before any trace.
+
+        The encoder's programs are keyed on the image geometry: 1, 2 or 4 chunks through the image
+        blocks, and the tile aspect ratio through the tile position embeddings. A request with a new
+        geometry otherwise compiles the whole encoder path (image blocks, positional embeddings, pad
+        and concat, the vision projection) while the decode trace is live - measured on
+        Llama-3.2-11B-Vision T3K batch-1 as 60+ buffers alive across trace replays, arriving with
+        the second and third distinct images. One blank image per supported canvas covers every
+        geometry the transform can produce.
+        """
+        from PIL import Image as PIL_Image
+
+        for model in self.model:
+            transform = getattr(model, "image_transform", None)
+            if transform is None or not hasattr(model, "compute_vision_tokens_masks"):
+                continue
+            base_transform = getattr(transform, "func", transform)
+            resolutions = base_transform.find_supported_resolutions(
+                max_num_chunks=model.max_num_chunks, patch_size=base_transform.size
+            )
+            for height, width in dict.fromkeys(tuple(r) for r in resolutions):
+                logger.info(f"Warming up vision encoder for a {width}x{height} image")
+                model.compute_vision_tokens_masks(
+                    batch_images=[[PIL_Image.new("RGB", (width, height))]],
+                    batch_masks=[[[0, -1]]],
+                    total_len=128,
+                    prefill_len=128,
+                )
+
     def prefill_forward_llama_vision(
         self,
         vision_images,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import os
 from collections import defaultdict
 
@@ -31,6 +32,7 @@ from models.common.warmup import WarmupForwardMixin
 from models.tt_transformers.tt.common import (
     Mode,
     copy_host_to_device,
+    get_all_padded_prefill_lengths,
     get_block_size,
     get_max_prefill_chunk_size,
     get_padded_prefill_len,
@@ -175,9 +177,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self._pending_prefill_traces = {}
         self._pending_decode_trace = None
 
-    # Class-level capabilities (VLLM specific, to be overridden by subclasses)
+    # Class-level capabilities (VLLM specific, to be overridden by subclasses).
+    # A subclass dict replaces this one rather than merging into it, so a default
+    # of True would be claimed by every subclass that declares nothing at all.
     model_capabilities = {
-        "supports_prefix_caching": True,
+        "supports_prefix_caching": False,
     }
 
     def _any_trace_captured(self):
@@ -252,6 +256,78 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         finally:
             self._defer_prefill_recording = False
             self._record_pending_prefill_traces()
+
+        # Only models that accept a nonzero ``start_pos`` can ever take the
+        # resumed path, so only they should reserve trace region for it. Both
+        # prefix caching and a prompt split across engine steps produce one.
+        resumes_prefill = self.model_capabilities.get("supports_prefix_caching", False) or self.model_capabilities.get(
+            "supports_chunked_prefill", False
+        )
+        if enable_trace and resumes_prefill:
+            self._warmup_prefill_resumed_sweep(kv_cache=kv_cache)
+
+    def _warmup_prefill_resumed_sweep(self, kv_cache):
+        """Capture the resumed-prefill ("sp1") traces, batch 1, one per traced length.
+
+        The sweep above never passes ``start_pos``, so it only ever captures the
+        ``sp0`` half of the prefill trace key. A resumed prefill -- prefix caching,
+        or a prompt split across engine steps -- takes the ``sp1`` half, which
+        would otherwise be captured lazily on whichever request happens to resume
+        first, allocating trace region nobody sized for. Reserving them here makes
+        the requirement a function of configuration instead of traffic.
+
+        Mirrors the phase-2 warmup in
+        ``models/demos/llama3_70b_galaxy/tt/generator.py``.
+        """
+        if kv_cache is None or kv_cache[0] is None:
+            # Resumed prefill needs a page table, so there is nothing to capture.
+            return
+        block_size = self._paged_prefill_block_size(kv_cache[0])
+
+        for model_id in range(self.data_parallel):
+            model_args = self.model_args[model_id]
+            for prefill_seq_len in model_args.trace_prefill_supported_seq_lens:
+                # A nonzero probe: ``can_enable_trace`` reads this argument only to
+                # test it against zero, and a model that refuses a resumed prefill
+                # refuses it for every offset. The declaration alone is not enough,
+                # because the model args can reject what the capability allows.
+                if not model_args.can_enable_trace(prefill_seq_len, 1):
+                    continue
+                # The offset a real request will be floored to for this length, so
+                # the captured program config is the one those replays need.
+                num_cached = self._resume_offset_alignment(prefill_seq_len, block_size, model_id)
+                # Only the suffix after the offset is padded into the bucket, so
+                # the prompt has to clear the offset by a full bucket to land on
+                # this key. ``capped_warmup_seq_len`` is the ceiling the rest of
+                # warmup uses: past it the call would be split into chunks and
+                # capture something else.
+                total_seq_len = self._resumed_warmup_prompt_len(
+                    prefill_seq_len, num_cached, model_args.capped_warmup_seq_len
+                )
+                suffix = total_seq_len - num_cached
+                if suffix <= 0 or get_padded_prefill_len(suffix) != prefill_seq_len:
+                    logger.warning(
+                        f"Skipping resumed prefill warmup for sequence length {prefill_seq_len}: "
+                        f"offset {num_cached} leaves no suffix padding back to it within "
+                        f"{model_args.capped_warmup_seq_len} tokens. Its trace is captured on first use."
+                    )
+                    continue
+
+                num_blocks = num_blocks_in_seq(total_seq_len, block_size)
+                logger.info(
+                    f"Warming up resumed prefill for sequence length: {prefill_seq_len}, " f"num_cached: {num_cached}"
+                )
+                self.prefill_forward_text(
+                    tokens=torch.zeros(1, total_seq_len, dtype=torch.long),
+                    prompt_lens=torch.tensor([total_seq_len], dtype=torch.long),
+                    empty_slots=[0],
+                    page_table=torch.zeros(1, num_blocks, dtype=torch.int32),
+                    start_pos=[num_cached],
+                    kv_cache=kv_cache,
+                    enable_trace=True,
+                    model_id_warmup=model_id,
+                    sampling_params=None,
+                )
 
     def finalize_deferred_traces(self):
         """Record the decode trace that this call deferred.
@@ -1022,6 +1098,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         assert len(num_cached_per_user) == len(
             prompt_lens
         ), f"start_pos length {len(num_cached_per_user)} != prompt_lens length {len(prompt_lens)}"
+        if start_pos is not None:
+            num_cached_per_user = self._align_resume_offsets(num_cached_per_user, prompt_lens, kv_cache)
+            # The per-user loop below re-reads the offset from ``start_pos``, so the
+            # aligned list has to replace it: otherwise the padded length computed
+            # here would not match the token slice the kernel receives.
+            start_pos = num_cached_per_user
         for i, (seq_len, num_cached) in enumerate(zip(prompt_lens, num_cached_per_user)):
             assert 0 <= num_cached < seq_len, f"user {i}: num_cached={num_cached} must be < seq_len={seq_len}"
         prefill_seq_lens = [
@@ -1473,6 +1555,136 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             return output_tokens, reformat_logprobs(output_log_probs, batch_size)
         else:
             return output_tensor
+
+    def _traced_sdpa_q_chunk_size(self, prefill_seq_len, model_id=0):
+        """q_chunk_size a traced prefill of this length is captured with, or None.
+
+        The traced path hands the op a ``chunk_start_idx`` device tensor that is
+        refreshed per replay, so the captured program config cannot be derived
+        from the offset. It is built with ``chunk_start_idx=0`` instead, which is
+        what this reproduces.
+        """
+        get_config = getattr(self.model_args[model_id], "get_attn_sdpa_program_config", None)
+        if get_config is None:
+            return None
+        # Deliberately unguarded: a model whose program config this signature does
+        # not describe must say so by not exposing the method. Swallowing the error
+        # here would drop back to block-only alignment and reinstate the wrong
+        # prefix reads this exists to prevent.
+        return get_config(Mode.PREFILL, prefill_seq_len, 0, None).q_chunk_size
+
+    def _resume_offset_alignment(self, prefill_seq_len, block_size, model_id=0):
+        """Multiple a resume offset must land on for this padded suffix length.
+
+        The paged ops need ``block_size``; the traced SDPA needs the q_chunk_size
+        its program was captured with. Their least common multiple satisfies both.
+
+        The q_chunk_size is taken from the model's own program config where it
+        exposes one, so a short suffix keeps its smaller alignment instead of
+        being rounded away. A model without one must declare
+        ``resumed_prefill_token_alignment``: there is no safe default, and
+        guessing block_size is what produces the silent wrong prefix.
+        """
+        q_chunk = self._traced_sdpa_q_chunk_size(prefill_seq_len, model_id)
+        if q_chunk is None:
+            q_chunk = self.model_capabilities.get("resumed_prefill_token_alignment")
+        if q_chunk is None:
+            raise ValueError(
+                f"{type(self).__name__} resumes a prefill but neither exposes "
+                "`get_attn_sdpa_program_config` on its model_args nor declares "
+                "`model_capabilities['resumed_prefill_token_alignment']`, so the "
+                "alignment its chunked-SDPA program requires cannot be determined."
+            )
+        return math.lcm(block_size, int(q_chunk))
+
+    def _assert_uniform_resume_alignment(self, prefill_seq_len, block_size, expected):
+        """Replica 0's alignment stands for every replica. Fail if it stops doing so.
+
+        ``create_submeshes`` splits the mesh into submeshes of one shape, and
+        ``initialize_vllm_model`` builds every replica's ``ModelArgs`` from the same
+        arguments, so they all pin the same q_chunk_size. The per-user offsets are
+        therefore aligned once against replica 0 rather than per replica. Nothing in
+        the type system holds that, so check it instead of trusting it.
+        """
+        for model_id in range(1, self.data_parallel):
+            other = self._resume_offset_alignment(prefill_seq_len, block_size, model_id)
+            assert other == expected, (
+                f"replica {model_id} needs resume alignment {other} where replica 0 needs "
+                f"{expected} at padded length {prefill_seq_len}; offsets are aligned once "
+                "against replica 0 and would be wrong for this replica."
+            )
+
+    def _align_resume_offsets(self, num_cached_per_user, prompt_lens, kv_cache):
+        """Floor each resume offset to what the paged ops and the traced SDPA need.
+
+        ``block_size`` covers the page-table slice the chunk's K/V is written
+        through: an offset off that multiple shifts every write by
+        ``chunk_start % block_size`` positions.
+
+        ``q_chunk_size`` covers the SDPA op, which requires ``chunk_start_idx`` to
+        be a multiple of the value its program was built with and answers from the
+        wrong prefix rather than raising when it is not. Under tracing that value
+        is pinned at capture, so it has to be satisfied by the offset.
+
+        Flooring recomputes at most ``alignment - 1`` tokens whose K/V is rewritten
+        identically into the same blocks, so it is semantically a no-op. Mirrors
+        the ``SDPA_CHUNK_ALIGN`` round-down in
+        ``models/demos/llama3_70b_galaxy/tt/generator.py``.
+        """
+        if kv_cache is None or kv_cache[0] is None:
+            # Non-paged prefill: there is no page table to slice.
+            return num_cached_per_user
+        block_size = self._paged_prefill_block_size(kv_cache[0])
+        aligned = []
+        for i, (num_cached, seq_len) in enumerate(zip(num_cached_per_user, prompt_lens)):
+            if int(num_cached) == 0:
+                # Not a resume. Callers pass a zero-filled start_pos for an
+                # ordinary prefill, so this is the common path and must not
+                # require the model to describe an alignment it never uses.
+                aligned.append(0)
+                continue
+            floored = (int(num_cached) // block_size) * block_size
+            # The alignment depends on the padded suffix length, which depends on
+            # the offset, so it has to settle: flooring lengthens the suffix, a
+            # longer suffix can pin a larger q_chunk_size, and that can demand a
+            # smaller offset again.
+            #
+            # The bound is exact, not generous. A pass that does not break must
+            # lower the offset, which lengthens the suffix, which moves it to a
+            # strictly higher padded bucket: an equal bucket would give an equal
+            # alignment and the pass would have broken. So the bucket count bounds
+            # the passes. It is a loose ceiling in practice, because
+            # get_attn_sdpa_prefill_program_config pins only 64 or 256 and two
+            # passes always suffice.
+            for _ in range(len(get_all_padded_prefill_lengths(int(seq_len))) + 1):
+                padded_suffix = get_padded_prefill_len(int(seq_len) - floored)
+                alignment = self._resume_offset_alignment(padded_suffix, block_size)
+                self._assert_uniform_resume_alignment(padded_suffix, block_size, alignment)
+                settled = (int(num_cached) // alignment) * alignment
+                if settled == floored:
+                    break
+                floored = settled
+            else:
+                raise RuntimeError(
+                    f"user {i}: resume offset alignment did not settle for "
+                    f"start_pos={num_cached}, seq_len={seq_len}, block_size={block_size}"
+                )
+            if floored != num_cached:
+                logger.debug(f"Resume offset alignment: user {i} start_pos {num_cached} -> {floored}")
+            aligned.append(floored)
+        return aligned
+
+    @staticmethod
+    def _resumed_warmup_prompt_len(prefill_seq_len, num_cached, capped_warmup_seq_len):
+        """Prompt length whose suffix after ``num_cached`` pads back to this bucket.
+
+        Only the suffix reaches the kernel, so the prompt has to clear the offset by
+        a full bucket. Spanning the bucket alone leaves no suffix at all once
+        ``block_size`` reaches the smallest traced length. ``capped_warmup_seq_len``
+        is the ceiling the rest of warmup uses: past it the call is split into chunks
+        and captures a different trace.
+        """
+        return min(num_cached + prefill_seq_len, capped_warmup_seq_len)
 
     def _paged_prefill_block_size(self, kv_cache):
         """Block size for chunked-prefill page-table padding/slicing.

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -47,6 +47,17 @@ MAX_BATCHED_PREFILL_SEQ_LEN = 128 * 1024
 SUPPORTED_PREFILL_BATCH_SIZES = (1, 2, 4, 8, 16, 32)
 
 
+def batched_prefill_fits_token_budget(padded_batch, seq_len, max_prefill_chunk_size):
+    """Bound the combined activation footprint by the model/device's prefill budget.
+
+    The MLP flattens the batch and sequence dimensions. Checking each sequence
+    alone admits e.g. 32 x 1024 on Llama-8B N150, whose single-pass budget is
+    4096 tokens, and runs out of DRAM even before capturing a trace.
+    """
+    total_tokens = padded_batch * seq_len
+    return total_tokens <= max_prefill_chunk_size and total_tokens < MAX_BATCHED_PREFILL_SEQ_LEN
+
+
 def batched_prefill_padded_batch(batch_size, empty_slots, max_batch_size):
     """Rows the batched-prefill device batch needs for ``empty_slots``.
 
@@ -405,13 +416,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 ):
                     continue
 
-                # Token-limit guard below skips combinations that would
-                # exceed MAX_BATCHED_PREFILL_SEQ_LEN.
+                # Use the same combined-token budget as runtime routing. Warming
+                # larger batches would OOM on shapes runtime handles sequentially.
                 for batch_size in warmup_batch_sizes:
-                    if batch_size > 1 and batch_size * supported_length >= MAX_BATCHED_PREFILL_SEQ_LEN:
+                    if batch_size > 1 and not batched_prefill_fits_token_budget(
+                        batch_size, supported_length, self.model_args[model_id].max_prefill_chunk_size
+                    ):
                         logger.info(
                             f"Skipping batched prefill warmup for batch_size={batch_size}, "
-                            f"seq_len={supported_length}: exceeds token limit"
+                            f"seq_len={supported_length}: exceeds model/device token budget"
                         )
                         continue
 
@@ -725,6 +738,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         logger.info(f"Recording {len(self._pending_prefill_traces)} deferred prefill trace(s)")
         for trace_key, prepared in self._pending_prefill_traces.items():
             if prepared["forward_kwargs"].get("batch_size", 1) > 1:
+                # Compilation and persistent allocation have already finished.
                 # Capture this bucket only when requested so unused batch sizes
                 # do not consume the model's reserved trace region.
                 self._prepared_prefill_traces[trace_key] = prepared
@@ -1273,10 +1287,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     f"max_batch_size {self.model_args[0].max_batch_size}"
                 )
                 use_batched_prefill = False
-            elif padded_batch * prefill_seq_lens[0] >= MAX_BATCHED_PREFILL_SEQ_LEN:
+            elif not batched_prefill_fits_token_budget(
+                padded_batch, prefill_seq_lens[0], self.model_args[0].max_prefill_chunk_size
+            ):
                 logger.info(
                     f"Batched prefill disabled: {padded_batch} x {prefill_seq_lens[0]} = "
-                    f"{padded_batch * prefill_seq_lens[0]} tokens exceeds limit {MAX_BATCHED_PREFILL_SEQ_LEN}"
+                    f"{padded_batch * prefill_seq_lens[0]} tokens exceeds model/device token budget "
+                    f"{self.model_args[0].max_prefill_chunk_size} or reaches kernel limit {MAX_BATCHED_PREFILL_SEQ_LEN}"
                 )
                 use_batched_prefill = False
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import os
 from collections import defaultdict
 
@@ -32,7 +31,6 @@ from models.common.warmup import WarmupForwardMixin
 from models.tt_transformers.tt.common import (
     Mode,
     copy_host_to_device,
-    get_all_padded_prefill_lengths,
     get_block_size,
     get_max_prefill_chunk_size,
     get_padded_prefill_len,
@@ -171,13 +169,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # call's prefill captures anything, and recorded once the prefill is done. Prefill traces are
         # captured as they are prepared. See _prepare_decode_trace_text for why the decode ordering matters.
         self._defer_trace_recording = False
+        # Prefill-side deferral, kept separate from the decode latch above: warmup arms this across
+        # its whole sweep so no bucket compiles behind an earlier bucket's trace.
+        self._defer_prefill_recording = False
+        self._pending_prefill_traces = {}
         self._pending_decode_trace = None
 
-    # Class-level capabilities (VLLM specific, to be overridden by subclasses).
-    # A subclass dict replaces this one rather than merging into it, so a default
-    # of True would be claimed by every subclass that declares nothing at all.
+    # Class-level capabilities (VLLM specific, to be overridden by subclasses)
     model_capabilities = {
-        "supports_prefix_caching": False,
+        "supports_prefix_caching": True,
     }
 
     def _any_trace_captured(self):
@@ -236,88 +236,22 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if enable_trace:
             logger.info("Using batch-1-only traced prefill warmup; runtime batched prefill remains enabled")
 
-        self._warmup_prefill_sweep(
-            kv_cache=kv_cache,
-            enable_trace=enable_trace,
-            can_sample_on_device=can_sample_on_device,
-            greedy_only=greedy_only,
-            sequence_lengths_to_warmup=sequence_lengths_to_warmup,
-            warmup_batch_sizes=warmup_batch_sizes,
-            skip_sequence_lengths=skip_sequence_lengths,
-            sampling_parameters_sweeped=sampling_parameters_sweeped,
-        )
-
-        # Only models that accept a nonzero ``start_pos`` can ever take the
-        # resumed path, so only they should reserve trace region for it. Both
-        # prefix caching and a prompt split across engine steps produce one.
-        resumes_prefill = self.model_capabilities.get("supports_prefix_caching", False) or self.model_capabilities.get(
-            "supports_chunked_prefill", False
-        )
-        if enable_trace and resumes_prefill:
-            self._warmup_prefill_resumed_sweep(kv_cache=kv_cache)
-
-    def _warmup_prefill_resumed_sweep(self, kv_cache):
-        """Capture the resumed-prefill ("sp1") traces, batch 1, one per traced length.
-
-        The sweep above never passes ``start_pos``, so it only ever captures the
-        ``sp0`` half of the prefill trace key. A resumed prefill -- prefix caching,
-        or a prompt split across engine steps -- takes the ``sp1`` half, which
-        would otherwise be captured lazily on whichever request happens to resume
-        first, allocating trace region nobody sized for. Reserving them here makes
-        the requirement a function of configuration instead of traffic.
-
-        Mirrors the phase-2 warmup in
-        ``models/demos/llama3_70b_galaxy/tt/generator.py``.
-        """
-        if kv_cache is None or kv_cache[0] is None:
-            # Resumed prefill needs a page table, so there is nothing to capture.
-            return
-        block_size = self._paged_prefill_block_size(kv_cache[0])
-
-        for model_id in range(self.data_parallel):
-            model_args = self.model_args[model_id]
-            for prefill_seq_len in model_args.trace_prefill_supported_seq_lens:
-                # A nonzero probe: ``can_enable_trace`` reads this argument only to
-                # test it against zero, and a model that refuses a resumed prefill
-                # refuses it for every offset. The declaration alone is not enough,
-                # because the model args can reject what the capability allows.
-                if not model_args.can_enable_trace(prefill_seq_len, 1):
-                    continue
-                # The offset a real request will be floored to for this length, so
-                # the captured program config is the one those replays need.
-                num_cached = self._resume_offset_alignment(prefill_seq_len, block_size, model_id)
-                # Only the suffix after the offset is padded into the bucket, so
-                # the prompt has to clear the offset by a full bucket to land on
-                # this key. ``capped_warmup_seq_len`` is the ceiling the rest of
-                # warmup uses: past it the call would be split into chunks and
-                # capture something else.
-                total_seq_len = self._resumed_warmup_prompt_len(
-                    prefill_seq_len, num_cached, model_args.capped_warmup_seq_len
-                )
-                suffix = total_seq_len - num_cached
-                if suffix <= 0 or get_padded_prefill_len(suffix) != prefill_seq_len:
-                    logger.warning(
-                        f"Skipping resumed prefill warmup for sequence length {prefill_seq_len}: "
-                        f"offset {num_cached} leaves no suffix padding back to it within "
-                        f"{model_args.capped_warmup_seq_len} tokens. Its trace is captured on first use."
-                    )
-                    continue
-
-                num_blocks = num_blocks_in_seq(total_seq_len, block_size)
-                logger.info(
-                    f"Warming up resumed prefill for sequence length: {prefill_seq_len}, " f"num_cached: {num_cached}"
-                )
-                self.prefill_forward_text(
-                    tokens=torch.zeros(1, total_seq_len, dtype=torch.long),
-                    prompt_lens=torch.tensor([total_seq_len], dtype=torch.long),
-                    empty_slots=[0],
-                    page_table=torch.zeros(1, num_blocks, dtype=torch.int32),
-                    start_pos=[num_cached],
-                    kv_cache=kv_cache,
-                    enable_trace=True,
-                    model_id_warmup=model_id,
-                    sampling_params=None,
-                )
+        # Compile every bucket before recording any of them; see _easy_trace_prefill.
+        self._defer_prefill_recording = enable_trace
+        try:
+            self._warmup_prefill_sweep(
+                kv_cache=kv_cache,
+                enable_trace=enable_trace,
+                can_sample_on_device=can_sample_on_device,
+                greedy_only=greedy_only,
+                sequence_lengths_to_warmup=sequence_lengths_to_warmup,
+                warmup_batch_sizes=warmup_batch_sizes,
+                skip_sequence_lengths=skip_sequence_lengths,
+                sampling_parameters_sweeped=sampling_parameters_sweeped,
+            )
+        finally:
+            self._defer_prefill_recording = False
+            self._record_pending_prefill_traces()
 
     def finalize_deferred_traces(self):
         """Record the decode trace that this call deferred.
@@ -330,6 +264,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if not self._defer_trace_recording:
             return
         try:
+            # Prefill first: its traces were prepared during this call, and the tail that runs
+            # between preparation and here has now compiled.
+            self._defer_prefill_recording = False
+            self._record_pending_prefill_traces()
             # Deliberately no prepare fallback here: the decode trace was prepared up front by
             # _prefill_forward_text_impl, before this call's prefill filled the KV cache. Preparing at
             # this point instead would run the decode compile pass -- a real decode step at position 0
@@ -355,6 +293,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         skip_sequence_lengths,
         sampling_parameters_sweeped,
     ):
+        # Once per data-parallel group, not once overall. The sweep is sequence-length agnostic,
+        # but every group is a separate device with its own program cache, so sweeping only on the
+        # first one left groups 1..N-1 compiling the sampling path on their first real request -
+        # after warmup had recorded its traces. Measured on DP-32: 31 stranded argmax programs.
+        swept_sampling_model_ids = set(range(self.data_parallel)) if sampling_parameters_sweeped else set()
+
         for model_id in range(self.data_parallel):
             for supported_length in sequence_lengths_to_warmup:
                 if model_id != 0 and (
@@ -384,14 +328,22 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         skip_sequence_lengths = True
                         break
 
-                    if not sampling_parameters_sweeped:
+                    if model_id not in swept_sampling_model_ids:
                         sampling_params = self._create_sampling_params(
                             can_sample_on_device=can_sample_on_device,
                             batch_size=batch_size,
                             greedy_only=greedy_only,
                         )
                     else:
-                        sampling_params = [None]
+                        # Not [None]: that path skips the on-device-sampling tail, so its
+                        # programs (last-token slice, and the untilize after it - both keyed on
+                        # the prefill bucket) never compile here and land on the first real
+                        # request instead, behind the traces warmup is about to record.
+                        sampling_params = self._create_sampling_params(
+                            can_sample_on_device=can_sample_on_device,
+                            batch_size=batch_size,
+                            greedy_only=True,
+                        )
 
                     for param in sampling_params:
                         logger.info(
@@ -405,7 +357,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                             sampling_params=param,
                         )
 
-                    sampling_parameters_sweeped = True
+                    swept_sampling_model_ids.add(model_id)
 
                 if skip_sequence_lengths:
                     break
@@ -660,6 +612,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         logger.info("Done Compiling Model")
         return prepared
 
+    def _record_pending_prefill_traces(self):
+        """Record every prefill trace prepared while warmup deferred recording, back to back."""
+        if not self._pending_prefill_traces:
+            return
+        logger.info(f"Recording {len(self._pending_prefill_traces)} deferred prefill trace(s)")
+        for trace_key, prepared in self._pending_prefill_traces.items():
+            trace_id, tt_out_trace, *device_inputs = self._record_trace_prefill(prepared)
+            self.trace_id_prefill[trace_key] = trace_id
+            self.trace_inputs_prefill[trace_key] = device_inputs
+            self.trace_output_prefill[trace_key] = tt_out_trace
+        self._pending_prefill_traces = {}
+
     def _record_trace_prefill(self, prepared):
         """Phase 2 of prefill trace setup: capture the trace.
 
@@ -671,9 +635,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # Release our handle on the compile-pass output before capturing, matching the pre-split behaviour.
         # A deferred warmup caller may still be holding it; that is its own reference to keep or drop.
         prepared.pop("compile_output", None)
-        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-        tt_out_trace = self._prefill_trace_forward(prepared, device_inputs)
-        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        # Everything allocated between begin/end_trace_capture belongs to the trace being recorded -
+        # the decoder's residual add and friends - and must stay allocated for replay. Recording N
+        # traces means capture N runs while 1..N-1 are live, which reordering cannot avoid, so scope
+        # the window instead. Acknowledgement, not elimination: it tells the checker the program is
+        # prepared for these, it does not stop a replay writing them. Matches llama3_70b_galaxy.
+        # No-op unless TT_METAL_TRACE_ALLOC_TRACKING=1.
+        with ttnn.corruptible_allocation_scope(mesh_device):
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            tt_out_trace = self._prefill_trace_forward(prepared, device_inputs)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
         ttnn.synchronize_device(mesh_device)
         logger.info("Done Capturing Prefill Trace")
         return trace_id, tt_out_trace, *device_inputs
@@ -824,6 +795,27 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 chunk_page_table = _pad_or_create_page_table(chunk_page_table, chunk_blocks)
 
         if self.trace_id_prefill[trace_key] is None:
+            if self._defer_prefill_recording:
+                # Compile and stage only. Recording here would put this bucket's trace on device
+                # before the remaining warmup buckets have compiled, so every one of those compiles -
+                # and the trace inputs they stage - would land behind it. warmup_model_prefill
+                # records the whole set afterwards.
+                if trace_key not in self._pending_prefill_traces:
+                    self._pending_prefill_traces[trace_key] = self._prepare_trace_prefill(
+                        prefill_ids,
+                        page_table=page_table,
+                        chunk_page_table=chunk_page_table,
+                        kv_cache=kv_cache,
+                        model_id=model_id,
+                        global_user_id=global_user_id,
+                        batch_size=batch_size,
+                        user_id=user_id,
+                        start_pos=chunk_start_idx,
+                    )
+                # The compile pass produced a real prefill result for these ids, so the caller's
+                # output processing runs (and compiles) exactly as it would have.
+                return self._pending_prefill_traces[trace_key]["compile_output"]
+
             prepared = self._prepare_trace_prefill(
                 prefill_ids,
                 page_table=page_table,
@@ -980,6 +972,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # prefill is done. First call only: after that the ordering is fixed and re-arming would defer a
             # capture later calls expect to exist.
             self._defer_trace_recording = True
+            # Also hold this call's prefill trace back. Without a warmup sweep this call both
+            # compiles and records, so _post_prefill_tail - which runs after the prefill and
+            # compiles the tail's bucket-keyed programs - would otherwise do so behind the trace
+            # just recorded. Deferring lets the tail compile first; the wrapper records both once
+            # the prefill is done.
+            self._defer_prefill_recording = True
             # Prepare decode before this call's prefill, not at the flush: the compile pass is a real decode
             # step at position 0 with mock inputs, so it writes mock K/V that the following prefill then
             # overwrites. At the flush it would instead corrupt the prefilled cache. The position-0 write
@@ -1024,12 +1022,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         assert len(num_cached_per_user) == len(
             prompt_lens
         ), f"start_pos length {len(num_cached_per_user)} != prompt_lens length {len(prompt_lens)}"
-        if start_pos is not None:
-            num_cached_per_user = self._align_resume_offsets(num_cached_per_user, prompt_lens, kv_cache)
-            # The per-user loop below re-reads the offset from ``start_pos``, so the
-            # aligned list has to replace it: otherwise the padded length computed
-            # here would not match the token slice the kernel receives.
-            start_pos = num_cached_per_user
         for i, (seq_len, num_cached) in enumerate(zip(prompt_lens, num_cached_per_user)):
             assert 0 <= num_cached < seq_len, f"user {i}: num_cached={num_cached} must be < seq_len={seq_len}"
         prefill_seq_lens = [
@@ -1481,136 +1473,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             return output_tokens, reformat_logprobs(output_log_probs, batch_size)
         else:
             return output_tensor
-
-    def _traced_sdpa_q_chunk_size(self, prefill_seq_len, model_id=0):
-        """q_chunk_size a traced prefill of this length is captured with, or None.
-
-        The traced path hands the op a ``chunk_start_idx`` device tensor that is
-        refreshed per replay, so the captured program config cannot be derived
-        from the offset. It is built with ``chunk_start_idx=0`` instead, which is
-        what this reproduces.
-        """
-        get_config = getattr(self.model_args[model_id], "get_attn_sdpa_program_config", None)
-        if get_config is None:
-            return None
-        # Deliberately unguarded: a model whose program config this signature does
-        # not describe must say so by not exposing the method. Swallowing the error
-        # here would drop back to block-only alignment and reinstate the wrong
-        # prefix reads this exists to prevent.
-        return get_config(Mode.PREFILL, prefill_seq_len, 0, None).q_chunk_size
-
-    def _resume_offset_alignment(self, prefill_seq_len, block_size, model_id=0):
-        """Multiple a resume offset must land on for this padded suffix length.
-
-        The paged ops need ``block_size``; the traced SDPA needs the q_chunk_size
-        its program was captured with. Their least common multiple satisfies both.
-
-        The q_chunk_size is taken from the model's own program config where it
-        exposes one, so a short suffix keeps its smaller alignment instead of
-        being rounded away. A model without one must declare
-        ``resumed_prefill_token_alignment``: there is no safe default, and
-        guessing block_size is what produces the silent wrong prefix.
-        """
-        q_chunk = self._traced_sdpa_q_chunk_size(prefill_seq_len, model_id)
-        if q_chunk is None:
-            q_chunk = self.model_capabilities.get("resumed_prefill_token_alignment")
-        if q_chunk is None:
-            raise ValueError(
-                f"{type(self).__name__} resumes a prefill but neither exposes "
-                "`get_attn_sdpa_program_config` on its model_args nor declares "
-                "`model_capabilities['resumed_prefill_token_alignment']`, so the "
-                "alignment its chunked-SDPA program requires cannot be determined."
-            )
-        return math.lcm(block_size, int(q_chunk))
-
-    def _assert_uniform_resume_alignment(self, prefill_seq_len, block_size, expected):
-        """Replica 0's alignment stands for every replica. Fail if it stops doing so.
-
-        ``create_submeshes`` splits the mesh into submeshes of one shape, and
-        ``initialize_vllm_model`` builds every replica's ``ModelArgs`` from the same
-        arguments, so they all pin the same q_chunk_size. The per-user offsets are
-        therefore aligned once against replica 0 rather than per replica. Nothing in
-        the type system holds that, so check it instead of trusting it.
-        """
-        for model_id in range(1, self.data_parallel):
-            other = self._resume_offset_alignment(prefill_seq_len, block_size, model_id)
-            assert other == expected, (
-                f"replica {model_id} needs resume alignment {other} where replica 0 needs "
-                f"{expected} at padded length {prefill_seq_len}; offsets are aligned once "
-                "against replica 0 and would be wrong for this replica."
-            )
-
-    def _align_resume_offsets(self, num_cached_per_user, prompt_lens, kv_cache):
-        """Floor each resume offset to what the paged ops and the traced SDPA need.
-
-        ``block_size`` covers the page-table slice the chunk's K/V is written
-        through: an offset off that multiple shifts every write by
-        ``chunk_start % block_size`` positions.
-
-        ``q_chunk_size`` covers the SDPA op, which requires ``chunk_start_idx`` to
-        be a multiple of the value its program was built with and answers from the
-        wrong prefix rather than raising when it is not. Under tracing that value
-        is pinned at capture, so it has to be satisfied by the offset.
-
-        Flooring recomputes at most ``alignment - 1`` tokens whose K/V is rewritten
-        identically into the same blocks, so it is semantically a no-op. Mirrors
-        the ``SDPA_CHUNK_ALIGN`` round-down in
-        ``models/demos/llama3_70b_galaxy/tt/generator.py``.
-        """
-        if kv_cache is None or kv_cache[0] is None:
-            # Non-paged prefill: there is no page table to slice.
-            return num_cached_per_user
-        block_size = self._paged_prefill_block_size(kv_cache[0])
-        aligned = []
-        for i, (num_cached, seq_len) in enumerate(zip(num_cached_per_user, prompt_lens)):
-            if int(num_cached) == 0:
-                # Not a resume. Callers pass a zero-filled start_pos for an
-                # ordinary prefill, so this is the common path and must not
-                # require the model to describe an alignment it never uses.
-                aligned.append(0)
-                continue
-            floored = (int(num_cached) // block_size) * block_size
-            # The alignment depends on the padded suffix length, which depends on
-            # the offset, so it has to settle: flooring lengthens the suffix, a
-            # longer suffix can pin a larger q_chunk_size, and that can demand a
-            # smaller offset again.
-            #
-            # The bound is exact, not generous. A pass that does not break must
-            # lower the offset, which lengthens the suffix, which moves it to a
-            # strictly higher padded bucket: an equal bucket would give an equal
-            # alignment and the pass would have broken. So the bucket count bounds
-            # the passes. It is a loose ceiling in practice, because
-            # get_attn_sdpa_prefill_program_config pins only 64 or 256 and two
-            # passes always suffice.
-            for _ in range(len(get_all_padded_prefill_lengths(int(seq_len))) + 1):
-                padded_suffix = get_padded_prefill_len(int(seq_len) - floored)
-                alignment = self._resume_offset_alignment(padded_suffix, block_size)
-                self._assert_uniform_resume_alignment(padded_suffix, block_size, alignment)
-                settled = (int(num_cached) // alignment) * alignment
-                if settled == floored:
-                    break
-                floored = settled
-            else:
-                raise RuntimeError(
-                    f"user {i}: resume offset alignment did not settle for "
-                    f"start_pos={num_cached}, seq_len={seq_len}, block_size={block_size}"
-                )
-            if floored != num_cached:
-                logger.debug(f"Resume offset alignment: user {i} start_pos {num_cached} -> {floored}")
-            aligned.append(floored)
-        return aligned
-
-    @staticmethod
-    def _resumed_warmup_prompt_len(prefill_seq_len, num_cached, capped_warmup_seq_len):
-        """Prompt length whose suffix after ``num_cached`` pads back to this bucket.
-
-        Only the suffix reaches the kernel, so the prompt has to clear the offset by
-        a full bucket. Spanning the bucket alone leaves no suffix at all once
-        ``block_size`` reaches the smallest traced length. ``capped_warmup_seq_len``
-        is the ceiling the rest of warmup uses: past it the call is split into chunks
-        and captures a different trace.
-        """
-        return min(num_cached + prefill_seq_len, capped_warmup_seq_len)
 
     def _paged_prefill_block_size(self, kv_cache):
         """Block size for chunked-prefill page-table padding/slicing.
@@ -2112,31 +1974,35 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         for i in range(self.data_parallel):
             sampling_module = getattr(self.model[i], "sampling", None)
             sampling_trace_enabled = on_device_sampling and sampling_module is not None
-            trace_id = ttnn.begin_trace_capture(self.model_args[i].mesh_device, cq_id=0)
-            trace_ids[i] = trace_id
-            user_kv_cache = kv_cache[i] if kv_cache is not None else None
-            model_inputs = device_inputs[i][:4] if len(device_inputs[i]) > 4 else device_inputs[i]
-            # Models that produce extra device inputs beyond the first
-            # four (e.g. Gemma4's host-precomputed per-layer-input at
-            # index 4) feed them into ``ttnn_decode_forward`` via a
-            # model-side stash rather than through the call signature.
-            # Give the model a chance to bind that stash to the
-            # *trace-input* device tensors here, before the trace is
-            # captured — otherwise traced ops stay pointed at whatever
-            # device buffer the compile run produced, and trace replay
-            # reads stale data because ``copy_host_to_device`` only
-            # refreshes ``trace_inputs_decode``.
-            bind_trace_inputs = getattr(self.model[i], "bind_decode_trace_inputs", None)
-            if bind_trace_inputs is not None:
-                bind_trace_inputs(device_inputs[i])
-            tt_out_trace.append(
-                self.model[i].ttnn_decode_forward(
-                    *model_inputs,
-                    kv_cache=user_kv_cache,
-                    on_device_logits=on_device_sampling,
+            # Same reasoning as _record_trace_prefill: whatever the model allocates inside the capture
+            # window belongs to the trace being recorded, and recording lane/variant N necessarily runs
+            # while 1..N-1 are live. Acknowledge the window rather than flag it.
+            with ttnn.corruptible_allocation_scope(self.model_args[i].mesh_device):
+                trace_id = ttnn.begin_trace_capture(self.model_args[i].mesh_device, cq_id=0)
+                trace_ids[i] = trace_id
+                user_kv_cache = kv_cache[i] if kv_cache is not None else None
+                model_inputs = device_inputs[i][:4] if len(device_inputs[i]) > 4 else device_inputs[i]
+                # Models that produce extra device inputs beyond the first
+                # four (e.g. Gemma4's host-precomputed per-layer-input at
+                # index 4) feed them into ``ttnn_decode_forward`` via a
+                # model-side stash rather than through the call signature.
+                # Give the model a chance to bind that stash to the
+                # *trace-input* device tensors here, before the trace is
+                # captured — otherwise traced ops stay pointed at whatever
+                # device buffer the compile run produced, and trace replay
+                # reads stale data because ``copy_host_to_device`` only
+                # refreshes ``trace_inputs_decode``.
+                bind_trace_inputs = getattr(self.model[i], "bind_decode_trace_inputs", None)
+                if bind_trace_inputs is not None:
+                    bind_trace_inputs(device_inputs[i])
+                tt_out_trace.append(
+                    self.model[i].ttnn_decode_forward(
+                        *model_inputs,
+                        kv_cache=user_kv_cache,
+                        on_device_logits=on_device_sampling,
+                    )
                 )
-            )
-            ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
+                ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
             _mark_trace_buffers_corruptible(self, tt_out_trace[-1])
 
             if sampling_trace_enabled:
@@ -2158,6 +2024,46 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs
+
+    def precapture_decode_trace_variants(self, sampling_params, tokens, start_pos, page_table, kv_cache):
+        """Record every decode trace variant a warmup sweep will need, preparing all of them first.
+
+        Decode traces are keyed by on-device sampling on/off. A sweep that captures the second variant
+        lazily does so with the first variant's traces already live, so its compile pass, its persistent
+        trace inputs and its sampling pre-compile all allocate behind a live trace (measured on Gemma-3-27B
+        DP-4: 58 stranded buffers). Prepare each missing variant before recording any of them, then record
+        in one go. Returns False when nothing could be pre-captured (caller keeps its lazy path).
+        """
+        variants = []
+        for param in sampling_params:
+            variant = param is not None
+            if variant not in variants:
+                variants.append(variant)
+        variants = [v for v in variants if not self.trace_ids_decode[v]]
+        if not variants or page_table is None or self._uses_prefetcher():
+            return False
+        if self.mode != Mode.DECODE:
+            self.mode = Mode.DECODE
+        for i in range(len(self.model)):
+            self.model[i].switch_mode(Mode.DECODE)
+        tokens = torch.chunk(tokens, self.data_parallel, 0)
+        start_pos = torch.chunk(start_pos, self.data_parallel, 0)
+        page_table = torch.chunk(page_table, self.data_parallel, 0)
+        prepared = [
+            (
+                variant,
+                self._prepare_decode_trace_text(
+                    tokens, start_pos, page_table=page_table, kv_cache=kv_cache, on_device_sampling=variant
+                ),
+            )
+            for variant in variants
+        ]
+        for variant, prep in prepared:
+            trace_ids, tt_out_trace, *device_inputs = self._record_decode_trace_text(prep)
+            self.trace_ids_decode[variant] = trace_ids
+            self.trace_inputs_decode[variant] = device_inputs
+            self.trace_output_decode[variant] = tt_out_trace
+        return True
 
     def _capture_decode_trace_text(
         self,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -168,14 +168,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.already_warmed_up_prefill = False
         self.mode = None
         # Set for the duration of the first traced prefill call: its decode trace is prepared before that
-        # call's prefill captures anything, and recorded once the prefill is done. Prefill traces are
-        # captured as they are prepared. See _prepare_decode_trace_text for why the decode ordering matters.
+        # call's prefill captures anything, and recorded once the prefill is done. That call's
+        # prefill traces are also deferred until its output processing has compiled.
         self._defer_trace_recording = False
         # Prefill-side deferral, kept separate from the decode latch above: warmup arms this across
         # its whole sweep so no bucket compiles behind an earlier bucket's trace.
         self._defer_prefill_recording = False
         self._pending_prefill_traces = {}
         self._pending_decode_trace = None
+        # The eager warmup phase stages decode I/O as well as programs. Keep it
+        # until the capture phase, which may follow prefill trace recording.
+        self._prepared_decode_traces = {}
 
     # Class-level capabilities (VLLM specific, to be overridden by subclasses).
     # A subclass dict replaces this one rather than merging into it, so a default
@@ -192,12 +195,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         achievable while nothing has been captured yet.
         """
         return any(
-            any(store.values())
-            for store in (
-                self.trace_id_prefill,
-                self.trace_id_prefill_sampling,
-                self.trace_ids_decode,
-            )
+            any(getattr(self, name, {}).values())
+            for name in ("trace_id_prefill", "trace_id_prefill_sampling", "trace_ids_decode")
+        ) or any(
+            slot["id"] is not None
+            for model in self.model
+            for slot in getattr(getattr(model, "sampling", None), "_trace_states", {}).values()
         )
 
     def _get_sampling_contract(self, model_id: int):
@@ -225,9 +228,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         return ret
 
     def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False):
+        self.warmup_vision_encoder()
         if self.already_warmed_up_prefill:
             return
-        self.already_warmed_up_prefill = True
 
         sequence_lengths_to_warmup = self.model_args[0].get_warmup_prefill_supported_seq_lens()
         warmup_batch_sizes = (1,)
@@ -241,7 +244,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             logger.info("Using batch-1-only traced prefill warmup; runtime batched prefill remains enabled")
 
         # Compile every bucket before recording any of them; see _easy_trace_prefill.
-        self._defer_prefill_recording = enable_trace
+        self._defer_prefill_recording = enable_trace and not self._overrides_prefill_capture()
+        self.already_warmed_up_prefill = True
         try:
             self._warmup_prefill_sweep(
                 kv_cache=kv_cache,
@@ -253,18 +257,20 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 skip_sequence_lengths=skip_sequence_lengths,
                 sampling_parameters_sweeped=sampling_parameters_sweeped,
             )
-        finally:
+            # Resumed buckets must also compile before any sp0 or sp1 trace is live.
+            resumes_prefill = self.model_capabilities.get(
+                "supports_prefix_caching", False
+            ) or self.model_capabilities.get("supports_chunked_prefill", False)
+            if enable_trace and resumes_prefill:
+                self._warmup_prefill_resumed_sweep(kv_cache=kv_cache)
             self._defer_prefill_recording = False
             self._record_pending_prefill_traces()
-
-        # Only models that accept a nonzero ``start_pos`` can ever take the
-        # resumed path, so only they should reserve trace region for it. Both
-        # prefix caching and a prompt split across engine steps produce one.
-        resumes_prefill = self.model_capabilities.get("supports_prefix_caching", False) or self.model_capabilities.get(
-            "supports_chunked_prefill", False
-        )
-        if enable_trace and resumes_prefill:
-            self._warmup_prefill_resumed_sweep(kv_cache=kv_cache)
+        except BaseException:
+            self.already_warmed_up_prefill = False
+            raise
+        finally:
+            self._defer_prefill_recording = False
+            self._pending_prefill_traces.clear()
 
     def _warmup_prefill_resumed_sweep(self, kv_cache):
         """Capture the resumed-prefill ("sp1") traces, batch 1, one per traced length.
@@ -330,12 +336,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 )
 
     def finalize_deferred_traces(self):
-        """Record the decode trace that this call deferred.
+        """Record the prefill and decode traces that this call deferred.
 
         The first traced prefill call prepares decode (compile pass, persistent inputs, sampling
         pre-compile) before its own prefill captures anything, then records it here once that prefill is
-        done. Prefill traces are captured as they are prepared, so nothing else is pending by this point.
-        Recording binds only to what was already prepared and stashed in ``_pending_decode_trace``.
+        done. Prefill recording also waits for the call's output processing to compile.
+        Recording binds only to the already prepared inputs in the pending trace stores.
         """
         if not self._defer_trace_recording:
             return
@@ -357,6 +363,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # would make every later prefill defer a capture that nothing flushes.
             self._defer_trace_recording = False
             self._pending_decode_trace = None
+            self._defer_prefill_recording = False
+            self._pending_prefill_traces.clear()
 
     def _warmup_prefill_sweep(
         self,
@@ -611,6 +619,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.trace_ids_decode[on_device_sampling] = trace_ids
             self.trace_inputs_decode[on_device_sampling] = device_inputs
             self.trace_output_decode[on_device_sampling] = tt_out_trace
+            # A warmup-less call can hoist its own preparation after an eager
+            # warmup staged this key. The hoisted trace owns the active inputs.
+            getattr(self, "_prepared_decode_traces", {}).pop(on_device_sampling, None)
 
     def _prefill_trace_forward(self, prepared, device_inputs):
         """Run the prefill body for a prepared trace variant.
@@ -892,11 +903,37 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         user_id=user_id,
                         start_pos=chunk_start_idx,
                     )
+                else:
+                    # A pending bucket has no trace to replay yet. Refresh its inputs and
+                    # execute for this user too; the previous compile output belongs to
+                    # the previous request and did not fill this user's KV rows.
+                    prepared = self._pending_prefill_traces[trace_key]
+                    prefill_kwargs = dict(
+                        page_table=page_table,
+                        chunk_page_table=chunk_page_table,
+                        chunk_start_idx=chunk_start_idx,
+                        user_id=user_id,
+                    )
+                    if batch_size > 1:
+                        prefill_kwargs["batch_size"] = batch_size
+                        prepared["forward_kwargs"] = {"batch_size": batch_size, "user_id": user_id}
+                    if global_user_id is not None:
+                        prefill_kwargs["global_user_id"] = global_user_id
+                    host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, **prefill_kwargs)
+                    prepared["rot_mats_global"], prepared["rot_mats_local"] = host_inputs[1:3]
+                    prepared["device_inputs"] = copy_host_to_device(
+                        (host_inputs[0], host_inputs[3], host_inputs[4], host_inputs[5]),
+                        device_tensors=prepared["device_inputs"],
+                        mesh_device=self.model_args[model_id].mesh_device,
+                    )
+                    prepared["compile_output"] = self._prefill_trace_forward(prepared, prepared["device_inputs"])
                 # The compile pass produced a real prefill result for these ids, so the caller's
                 # output processing runs (and compiles) exactly as it would have.
-                return self._pending_prefill_traces[trace_key]["compile_output"]
+                # Only that caller needs the result and keeping it in the pending
+                # store would retain every bucket's activations until capture.
+                return self._pending_prefill_traces[trace_key].pop("compile_output")
 
-            prepared = self._prepare_trace_prefill(
+            trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
                 prefill_ids,
                 page_table=page_table,
                 chunk_page_table=chunk_page_table,
@@ -908,7 +945,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 start_pos=chunk_start_idx,
             )
 
-            trace_id, tt_out_trace, *device_inputs = self._record_trace_prefill(prepared)
             self.trace_id_prefill[trace_key] = trace_id
             self.trace_inputs_prefill[trace_key] = device_inputs
             self.trace_output_prefill[trace_key] = tt_out_trace
@@ -966,12 +1002,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
     # Note: This function is called by vLLM
     def prefill_forward_text(self, *args, **kwargs):
-        """Thin wrapper that flushes the deferred decode-trace capture once the prefill that armed it ends.
+        """Flush deferred trace captures once the prefill that armed them ends successfully.
 
         The first traced prefill call defers only its own decode-trace recording: it prepares decode
         (compile pass, persistent inputs, sampling pre-compile) before its prefill captures anything, then
-        records decode here once the prefill is done. Prefill traces themselves are captured immediately,
-        as on main. Only the call that armed the deferral flushes it -- nested calls must not.
+        records both prefill and decode here once output processing is done. Only the call that armed
+        the deferral flushes it -- nested calls must not.
         """
         already_pending = self._defer_trace_recording
         try:
@@ -984,6 +1020,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             if not already_pending:
                 self._defer_trace_recording = False
                 self._pending_decode_trace = None
+                self._defer_prefill_recording = False
+                self._pending_prefill_traces.clear()
             raise
         if not already_pending and self._defer_trace_recording:
             self.finalize_deferred_traces()
@@ -1028,9 +1066,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             and getattr(self.model[0], "sampling", None) is not None
         )
         if warmup_prefill:
-            # No deferral on this path: warmup captures its traces immediately, as on main. The hoist
-            # below is only for the warmup-less path, where the first traced prefill call would otherwise
-            # capture a trace part way through and then set decode up behind it.
+            # Warmup owns prefill deferral across the whole bucket sweep. The hoist below
+            # handles the first warmup-less request instead.
             self.warmup_model_prefill(
                 kv_cache=kv_cache,
                 enable_trace=enable_trace,
@@ -1039,6 +1076,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         elif (
             enable_trace
             and not self._defer_trace_recording
+            and not self._defer_prefill_recording
             and not self._any_trace_captured()
             # Excluded: the row-sharded batched path deadlocks either way round -- once a decode program is
             # compiled its MoE dispatch can no longer be trace-captured, and compiling decode before any
@@ -1896,6 +1934,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         slot_remap=None,
         defer_device_sampling: bool = False,
         skip_trace_precompile: bool = False,
+        prepare_trace: bool = False,
         **kwargs,
     ):
         mode_switched = False
@@ -2036,6 +2075,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 reload_inputs=reload_inputs,
                 skip_precompile=skip_trace_precompile,
             )
+        elif prepare_trace:
+            tt_decode_output = self._prepare_decode_trace_variant(**decode_kwargs)
         else:
             tt_decode_output = self._decode_forward_no_trace_text(
                 **decode_kwargs,
@@ -2118,6 +2159,35 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         return tt_output
 
+    def _decode_trace_key(self, on_device_sampling, tokens):
+        return on_device_sampling
+
+    def _prepare_decode_trace_variant(
+        self, tokens, current_pos, page_table=None, kv_cache=None, on_device_sampling=False
+    ):
+        """Stage a decode variant during an eager warmup call, inside the model's input routing."""
+        if self._uses_prefetcher():
+            return self._decode_forward_no_trace_text(
+                tokens, current_pos, page_table=page_table, kv_cache=kv_cache, on_device_sampling=on_device_sampling
+            )
+        key = self._decode_trace_key(on_device_sampling, tokens)
+        if not hasattr(self, "_prepared_decode_traces"):
+            self._prepared_decode_traces = {}
+        if key not in self._prepared_decode_traces and not self.trace_ids_decode[key]:
+            prepared = self._prepare_decode_trace_text(
+                tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                on_device_sampling=on_device_sampling,
+                return_compile_output=True,
+            )
+            self._prepared_decode_traces[key] = prepared
+            return prepared.pop("compile_output")
+        return self._decode_forward_no_trace_text(
+            tokens, current_pos, page_table=page_table, kv_cache=kv_cache, on_device_sampling=on_device_sampling
+        )
+
     def _prepare_decode_trace_text(
         self,
         tokens,
@@ -2126,6 +2196,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         kv_cache=None,
         on_device_sampling=False,
         skip_precompile=False,
+        return_compile_output=False,
     ):
         """Phase 1 of decode trace setup: run the compile pass and stage the persistent trace inputs.
 
@@ -2161,9 +2232,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # (only qwen36 sets _tt_allow_decode_trace_buffer_reuse today).
             _mark_trace_buffers_corruptible(self, device_inputs[i])
 
-        # SamplingGenerator normally pre-compiles just before capturing, which would allocate with the
-        # decode trace already live. Pre-compile here instead, against the compile pass' logits (same spec
-        # as the traced output), leaving only the capture for the recording phase.
+        # Eager warmup stages this variant before the first capture, including
+        # all sampling programs. Recording then consumes the staged inputs.
+        all_sampling_configs = not self._any_trace_captured()
         for i in range(self.data_parallel):
             sampling_module = getattr(self.model[i], "sampling", None)
             if not on_device_sampling or sampling_module is None or compile_output is None:
@@ -2171,13 +2242,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             sampling_module.precompile(
                 logits=compile_output[i][0],
                 tt_out_tok=self._decode_token_feedback_buffer(self.model[i], device_inputs[i]),
+                all_configs=all_sampling_configs,
             )
 
-        return {
+        prepared = {
             "device_inputs": device_inputs,
             "kv_cache": kv_cache,
             "on_device_sampling": on_device_sampling,
         }
+        if return_compile_output:
+            prepared["compile_output"] = compile_output
+        return prepared
 
     def _record_decode_trace_text(self, prepared):
         """Phase 2 of decode trace setup: capture the trace.
@@ -2186,6 +2261,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         :meth:`_prepare_decode_trace_text`.
         """
         device_inputs = prepared["device_inputs"]
+        prepared.pop("compile_output", None)
         kv_cache = prepared["kv_cache"]
         on_device_sampling = prepared["on_device_sampling"]
 
@@ -2259,7 +2335,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             variant = param is not None
             if variant not in variants:
                 variants.append(variant)
-        variants = [v for v in variants if not self.trace_ids_decode[v]]
         if not variants or page_table is None or self._uses_prefetcher():
             return False
         if self.mode != Mode.DECODE:
@@ -2269,20 +2344,25 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0)
-        prepared = [
-            (
-                variant,
-                self._prepare_decode_trace_text(
+        variants = [(v, self._decode_trace_key(v, tokens)) for v in variants]
+        variants = [(v, key) for v, key in variants if not self.trace_ids_decode[key]]
+        if not variants:
+            return False
+        staged = getattr(self, "_prepared_decode_traces", {})
+        prepared = []
+        for variant, key in variants:
+            if key in staged:
+                prep = staged.pop(key)
+            else:
+                prep = self._prepare_decode_trace_text(
                     tokens, start_pos, page_table=page_table, kv_cache=kv_cache, on_device_sampling=variant
-                ),
-            )
-            for variant in variants
-        ]
-        for variant, prep in prepared:
+                )
+            prepared.append((key, prep))
+        for key, prep in prepared:
             trace_ids, tt_out_trace, *device_inputs = self._record_decode_trace_text(prep)
-            self.trace_ids_decode[variant] = trace_ids
-            self.trace_inputs_decode[variant] = device_inputs
-            self.trace_output_decode[variant] = tt_out_trace
+            self.trace_ids_decode[key] = trace_ids
+            self.trace_inputs_decode[key] = device_inputs
+            self.trace_output_decode[key] = tt_out_trace
         return True
 
     def _capture_decode_trace_text(
@@ -2303,8 +2383,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         ``skip_precompile`` is forwarded to the prepare phase, where main's decode-bucketing callers use
         it to state that the program cache is already warm for this variant.
         """
-        return self._record_decode_trace_text(
-            self._prepare_decode_trace_text(
+        key = self._decode_trace_key(on_device_sampling, tokens)
+        staged = getattr(self, "_prepared_decode_traces", {})
+        prepared = (
+            staged.pop(key)
+            if key in staged
+            else self._prepare_decode_trace_text(
                 tokens,
                 current_pos,
                 page_table=page_table,
@@ -2313,6 +2397,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 skip_precompile=skip_precompile,
             )
         )
+        return self._record_decode_trace_text(prepared)
 
     def _decode_forward_trace_text(
         self,
@@ -2721,6 +2806,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         """
         from PIL import Image as PIL_Image
 
+        if getattr(self, "already_warmed_up_vision", False):
+            return
         for model in self.model:
             transform = getattr(model, "image_transform", None)
             if transform is None or not hasattr(model, "compute_vision_tokens_masks"):
@@ -2737,6 +2824,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     total_len=128,
                     prefill_len=128,
                 )
+        self.already_warmed_up_vision = True
 
     def prefill_forward_llama_vision(
         self,
@@ -2754,6 +2842,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         """
         Batched version of _prefill_forward_single_user for vision model.
         """
+        self.warmup_vision_encoder()
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
         if cross_page_table is not None:
@@ -2850,6 +2939,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
     ):
+        # vLLM may warm decode before the first image request. Compile every
+        # canvas before that path captures a trace as well.
+        self.warmup_vision_encoder()
         B = tokens.shape[0]
         data_parallel = min(B, self.data_parallel)
         batch_per_device = B // data_parallel

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1066,13 +1066,34 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             and getattr(self.model[0], "sampling", None) is not None
         )
         if warmup_prefill:
-            # Warmup owns prefill deferral across the whole bucket sweep. The hoist below
-            # handles the first warmup-less request instead.
+            # The prefill sweep records its traces before returning. Stage decode
+            # programs and persistent inputs first, otherwise the first decode
+            # allocates behind those traces and a later request cannot replay them.
+            prepare_decode = (
+                enable_trace
+                and not self.already_warmed_up_prefill
+                and not self._defer_trace_recording
+                and not self._defer_prefill_recording
+                and not self._any_trace_captured()
+                and not self._will_row_shard_prefill(tokens, sampling_params)
+                and not self._overrides_prefill_capture()
+                and not self._uses_prefetcher()
+            )
+            if prepare_decode:
+                self._prepare_decode_trace_once(
+                    kv_cache=kv_cache,
+                    page_table=page_table,
+                    on_device_sampling=on_device_sampling_requested and on_device_sampling_enabled,
+                )
             self.warmup_model_prefill(
                 kv_cache=kv_cache,
                 enable_trace=enable_trace,
                 can_sample_on_device=on_device_sampling_enabled,
             )
+            if prepare_decode:
+                # Capture also executes a dummy decode and writes K/V. Finish it
+                # here, before the real prefill below overwrites the warmup data.
+                self._record_pending_traces()
         elif (
             enable_trace
             and not self._defer_trace_recording
@@ -1559,6 +1580,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 self._post_prefill_tail(model_id, logits, sampling_enabled),
                 sampling_enabled,
             )
+            # Only host results are queued above. Release this user's temporary
+            # logits before the next user's prefill trace can overwrite them.
+            del logits
 
         if len(prefill_results) > 0:
             for elem_idx, res in enumerate(prefill_results):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -175,6 +175,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # its whole sweep so no bucket compiles behind an earlier bucket's trace.
         self._defer_prefill_recording = False
         self._pending_prefill_traces = {}
+        self._prepared_prefill_traces = {}
+        self._prepared_prefill_sampling_traces = {}
         self._pending_decode_trace = None
         # The eager warmup phase stages decode I/O as well as programs. Keep it
         # until the capture phase, which may follow prefill trace recording.
@@ -234,6 +236,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         sequence_lengths_to_warmup = self.model_args[0].get_warmup_prefill_supported_seq_lens()
         warmup_batch_sizes = (1,)
+        _, sampling_dp, _, _ = self._get_sampling_contract(0)
+        if (
+            self.data_parallel == 1
+            and not getattr(self.model_args[0], "disable_batched_prefill", False)
+            and (not can_sample_on_device or sampling_dp == 1)
+            and not self._overrides_prefill_capture()
+            and not self._uses_prefetcher()
+        ):
+            warmup_batch_sizes = tuple(
+                batch for batch in SUPPORTED_PREFILL_BATCH_SIZES if batch <= self.model_args[0].max_batch_size
+            )
 
         skip_sequence_lengths = False
 
@@ -241,7 +254,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         sampling_parameters_sweeped = False
 
         if enable_trace:
-            logger.info("Using batch-1-only traced prefill warmup; runtime batched prefill remains enabled")
+            logger.info("Warming traced prefill batch sizes {}", warmup_batch_sizes)
 
         # Compile every bucket before recording any of them; see _easy_trace_prefill.
         self._defer_prefill_recording = enable_trace and not self._overrides_prefill_capture()
@@ -267,6 +280,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self._record_pending_prefill_traces()
         except BaseException:
             self.already_warmed_up_prefill = False
+            self._prepared_prefill_traces.clear()
+            self._prepared_prefill_sampling_traces.clear()
             raise
         finally:
             self._defer_prefill_recording = False
@@ -704,11 +719,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         return prepared
 
     def _record_pending_prefill_traces(self):
-        """Record every prefill trace prepared while warmup deferred recording, back to back."""
+        """Record single-user traces; retain prepared batched inputs for capture on first use."""
         if not self._pending_prefill_traces:
             return
         logger.info(f"Recording {len(self._pending_prefill_traces)} deferred prefill trace(s)")
         for trace_key, prepared in self._pending_prefill_traces.items():
+            if prepared["forward_kwargs"].get("batch_size", 1) > 1:
+                # Capture this bucket only when requested so unused batch sizes
+                # do not consume the model's reserved trace region.
+                self._prepared_prefill_traces[trace_key] = prepared
+                continue
             trace_id, tt_out_trace, *device_inputs = self._record_trace_prefill(prepared)
             self.trace_id_prefill[trace_key] = trace_id
             self.trace_inputs_prefill[trace_key] = device_inputs
@@ -771,7 +791,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # count_tokens=False: this pass samples off dummy zeros. Counting it and then zeroing the
         # counters would also discard the caller's real output history, which sample() may have built up
         # before this variant was first prepared.
-        tt_tokens, tt_log_probs = self.model[model_id].sampling.sample(logits, enable_trace=False, count_tokens=False)
+        self.model[model_id].sampling.precompile(logits, all_configs=not self._any_trace_captured())
         ttnn.synchronize_device(mesh_device)
         logger.info("Done compiling prefill sampling")
 
@@ -790,14 +810,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         mesh_device = self.model_args[model_id].mesh_device
         trace_input = prepared["input"]
 
-        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-        logits = self.model[model_id]._apply_norm_and_lm_head(trace_input)
         # count_tokens stays on (the default) inside the capture window: capture only records the commands,
         # so the update runs on replays, over real sampled tokens -- exactly like SamplingGenerator's own
         # capture_trace. Only the eager compile pass in _prepare_trace_prefill_sampling passes
         # count_tokens=False, because it actually executes, over dummy logits.
-        tt_tokens, tt_log_probs = self.model[model_id].sampling.sample(logits, enable_trace=False)
-        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        # As with the prefill trace, these outputs are scratch shared with
+        # other captured graphs and are consumed immediately after replay.
+        with ttnn.corruptible_allocation_scope(mesh_device):
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            logits = self.model[model_id]._apply_norm_and_lm_head(trace_input)
+            tt_tokens, tt_log_probs = self.model[model_id].sampling.sample(logits, enable_trace=False)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
         ttnn.synchronize_device(mesh_device)
         logger.info("Done capturing prefill sampling trace")
 
@@ -933,17 +956,22 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # store would retain every bucket's activations until capture.
                 return self._pending_prefill_traces[trace_key].pop("compile_output")
 
-            trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
-                prefill_ids,
-                page_table=page_table,
-                chunk_page_table=chunk_page_table,
-                kv_cache=kv_cache,
-                model_id=model_id,
-                global_user_id=global_user_id,
-                batch_size=batch_size,
-                user_id=user_id,
-                start_pos=chunk_start_idx,
-            )
+            if trace_key in self._prepared_prefill_traces:
+                trace_id, tt_out_trace, *device_inputs = self._record_trace_prefill(
+                    self._prepared_prefill_traces.pop(trace_key)
+                )
+            else:
+                trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
+                    prefill_ids,
+                    page_table=page_table,
+                    chunk_page_table=chunk_page_table,
+                    kv_cache=kv_cache,
+                    model_id=model_id,
+                    global_user_id=global_user_id,
+                    batch_size=batch_size,
+                    user_id=user_id,
+                    start_pos=chunk_start_idx,
+                )
 
             self.trace_id_prefill[trace_key] = trace_id
             self.trace_inputs_prefill[trace_key] = device_inputs
@@ -1022,6 +1050,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 self._pending_decode_trace = None
                 self._defer_prefill_recording = False
                 self._pending_prefill_traces.clear()
+                if not self._any_trace_captured():
+                    self._prepared_prefill_traces.clear()
+                    self._prepared_prefill_sampling_traces.clear()
             raise
         if not already_pending and self._defer_trace_recording:
             self.finalize_deferred_traces()
@@ -1091,8 +1122,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 can_sample_on_device=on_device_sampling_enabled,
             )
             if prepare_decode:
-                # Capture also executes a dummy decode and writes K/V. Finish it
-                # here, before the real prefill below overwrites the warmup data.
+                # Finish deferred capture as part of warmup so real requests
+                # can refresh and replay the prepared decode trace directly.
                 self._record_pending_traces()
         elif (
             enable_trace
@@ -1465,21 +1496,47 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         target_batch=sampling_batch,
                     )
 
-                    sampling_trace_key = f"sampling_{prefill_seq_len}_{model_id}_{sampling_batch}_{sampling_dp}"
+                    sampling_input_key = f"sampling_{prefill_seq_len}_{model_id}_{sampling_batch}_{sampling_dp}"
+                    sampling_trace_key = (
+                        f"{sampling_input_key}_{sampling_module._penalties_active}_"
+                        f"{sampling_module.tt_sampling.log_probs_calculator.enable_log_probs}_"
+                        f"{sampling_module.tt_sampling.force_argmax_sampling}"
+                    )
 
-                    if enable_trace_current_prompt:
+                    if enable_trace_current_prompt and self._defer_prefill_recording:
+                        if sampling_input_key not in self._prepared_prefill_sampling_traces:
+                            self._prepared_prefill_sampling_traces[
+                                sampling_input_key
+                            ] = self._prepare_trace_prefill_sampling(model_id, sampling_batch)
+                        # Consume this warmup's actual hidden states. Capture
+                        # waits until every batched extraction/sampling program
+                        # has compiled and all persistent inputs exist.
+                        batched_logits = self.model[model_id]._apply_norm_and_lm_head(user_hidden)
+                        tt_tokens, tt_log_probs = self.model[model_id].sampling.sample(
+                            batched_logits, enable_trace=False
+                        )
+                    elif enable_trace_current_prompt:
                         if self.trace_id_prefill_sampling[sampling_trace_key] is None:
                             (
                                 s_trace_id,
                                 s_trace_output,
                                 s_trace_input,
-                            ) = self._capture_trace_prefill_sampling(model_id, sampling_batch)
+                            ) = (
+                                self._record_trace_prefill_sampling(
+                                    self._prepared_prefill_sampling_traces[sampling_input_key]
+                                )
+                                if sampling_input_key in self._prepared_prefill_sampling_traces
+                                else self._capture_trace_prefill_sampling(model_id, sampling_batch)
+                            )
                             self.trace_id_prefill_sampling[sampling_trace_key] = s_trace_id
                             self.trace_output_prefill_sampling[sampling_trace_key] = s_trace_output
                             self.trace_input_prefill_sampling[sampling_trace_key] = s_trace_input
 
                         s_trace_input = self.trace_input_prefill_sampling[sampling_trace_key]
                         user_hidden_host = user_hidden.cpu()
+                        # Readback is blocking; the sampling trace only needs
+                        # the host copy and its persistent input from here.
+                        del user_hidden
                         ttnn.copy_host_to_device_tensor(user_hidden_host, s_trace_input)
                         ttnn.execute_trace(
                             self.model_args[model_id].mesh_device,

--- a/models/tt_transformers/tt/lm_head.py
+++ b/models/tt_transformers/tt/lm_head.py
@@ -278,10 +278,16 @@ class LMHead(LightweightModule):
 
         # Concatenate the outputs
         # outputs shape: a list of tensors, each tensor is 1,1,32,size_per_device per device
+        # Decode traces retain these logits across requests. Honor the model's placement
+        # so large vocabularies do not occupy L1 needed by the next eager prefill.
         output = ttnn.concat(
             outputs,
             dim=-1,
-            memory_config=ttnn.L1_MEMORY_CONFIG if not use_prefetcher else ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=(
+                self.args.model_config.get("LM_HEAD_OUTPUT_MEMCFG", ttnn.L1_MEMORY_CONFIG)
+                if not use_prefetcher
+                else ttnn.DRAM_MEMORY_CONFIG
+            ),
             sub_core_grids=self.prefetcher.all_worker_cores_range_set if use_prefetcher else None,
         )
 

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -168,6 +168,19 @@ class MLP(LightweightModule):
         HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         """
         seq_len = x.shape[-2]
+        chunk_size = self.model_config.get("MLP_PREFILL_CHUNK_SIZE", seq_len)
+        if mode == Mode.PREFILL and seq_len > chunk_size:
+            # The MLP is independent across tokens. Bound its gate/up/product intermediates
+            # without splitting attention, which may require a complete sliding window.
+            outputs = [
+                self.forward(x[..., start : min(start + chunk_size, seq_len), :], mode)
+                for start in range(0, seq_len, chunk_size)
+            ]
+            ttnn.deallocate(x)
+            output = ttnn.concat(outputs, dim=-2, memory_config=outputs[0].memory_config())
+            for chunk in outputs:
+                ttnn.deallocate(chunk)
+            return output
         TG = self.args.is_galaxy
         layer_num = max(self.layer_num, 0)  # cross_block uses the configuration of the first decoder
         activation_dtype = self.decoders_optimizations.get_tensor_dtype(

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -341,19 +341,33 @@ class MLP(LightweightModule):
             decoder_id=layer_num, op=OpGroup.LI_FF2, configuration=self.args
         )
 
-        if seq_len > 128 and mode != Mode.DECODE:
+        w2_output_dtype = activation_dtype
+        if w2_output_dtype is None:
+            w2_output_dtype = ttnn.bfloat16
+
+        if mode != Mode.DECODE and self.args.use_minimal_prefill_matmul(seq_len):
+            is_qwen3_32b_t3k = self.args.base_model_name == "Qwen3-32B" and self.args.device_name == "T3K"
+            if not is_qwen3_32b_t3k:
+                # None makes minimal_matmul inherit w2_in.dtype. Only the
+                # validated Qwen3-32B/T3K path overrides that default.
+                w2_output_dtype = None
+
             w2_out = ttnn.experimental.minimal_matmul(
                 w2_in,
                 self.w2,
+                dtype=w2_output_dtype,
                 compute_kernel_config=li_ff2_compute_kernel_cfg,
                 config=pc_2,
             )
         else:
+            if TG:
+                w2_output_dtype = self.args.ccl_dtype
+
             w2_out = ttnn.linear(
                 w2_in,
                 self.w2,
                 compute_kernel_config=li_ff2_compute_kernel_cfg,
-                dtype=self.args.ccl_dtype if TG else activation_dtype or ttnn.bfloat16,
+                dtype=w2_output_dtype,
                 program_config=None if use_tg_decode_no_prefetch else pc_2,
                 memory_config=(
                     ttnn.DRAM_MEMORY_CONFIG

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -50,6 +50,9 @@ class Transformer(LightweightModule):
         self.tt_ccl = TT_CCL(self.mesh_device)
         # Runtime bounds for the post-prefill tail's slice. Allocated here, before any trace exists,
         # and rewritten in place per call - see process_logits_after_prefill_trace.
+        # These buffers belong to this model/DP lane. Calls on a lane enqueue the
+        # copy and slice on the same command queue, in order. Concurrent host
+        # calls on the same model instance are not supported.
         self._tail_slice_start = ttnn.from_torch(
             torch.zeros(4, dtype=torch.int32),
             device=self.mesh_device,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -48,6 +48,18 @@ class Transformer(LightweightModule):
         self.decoders_optimizations = args.decoders_optimizations
         self.prefetcher = prefetcher
         self.tt_ccl = TT_CCL(self.mesh_device)
+        # Runtime bounds for the post-prefill tail's slice. Allocated here, before any trace exists,
+        # and rewritten in place per call - see process_logits_after_prefill_trace.
+        self._tail_slice_start = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        self._tail_slice_end = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
 
         embd_kwargs = {
             "mesh_device": mesh_device,
@@ -246,11 +258,42 @@ class Transformer(LightweightModule):
 
     def process_logits_after_prefill_trace(self, logits, last_token_idx):
         get_last_token = (last_token_idx // 32) * 32
-        logits = ttnn.slice(
-            logits,
-            (0, 0, get_last_token, 0),
-            (1, 1, get_last_token + 32, logits.shape[-1]),
-        )
+        seq_len = int(logits.shape[-2])
+        # Pass the offset as a runtime argument rather than a compile-time attribute. With literal
+        # bounds every distinct prompt offset compiles its own slice program, and since this runs
+        # after the prefill traces are captured - once per data-parallel group - that was the single
+        # largest source of buffers left live across trace replays on a DP run. Warmup cannot cover
+        # it either: it only ever sees bucket-length mock prompts, and real prompts are shorter.
+        #
+        # The tensor-args path needs the slice tile-aligned, which this one already is: it takes 32
+        # rows starting at a multiple of 32. num_devices splits the sequence into equal parts, so
+        # seq_len // 32 gives exactly the 32-row window, and the program then keys on the padded
+        # prefill bucket instead of the offset.
+        if seq_len % 32 == 0:
+            for device_tensor, values in (
+                (self._tail_slice_start, [0, 0, get_last_token, 0]),
+                (self._tail_slice_end, [1, 1, get_last_token + 32, int(logits.shape[-1])]),
+            ):
+                ttnn.copy_host_to_device_tensor(
+                    ttnn.from_torch(
+                        torch.tensor(values, dtype=torch.int32),
+                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                    ),
+                    device_tensor,
+                )
+            logits = ttnn.slice(
+                input_tensor=logits,
+                starts=self._tail_slice_start,
+                ends=self._tail_slice_end,
+                slice_dim=2,
+                num_devices=seq_len // 32,
+            )
+        else:
+            logits = ttnn.slice(
+                logits,
+                (0, 0, get_last_token, 0),
+                (1, 1, get_last_token + 32, logits.shape[-1]),
+            )
         logits = self._apply_norm_and_lm_head(logits)
         return logits
 
@@ -1024,7 +1067,33 @@ class Transformer(LightweightModule):
 
         # Slicing the tensor to the nearest ceiling/floor multiples of 32 for the prefill_len, to get the last token
         if get_last_token != -1:
-            x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, x.shape[-1]))
+            seq_len = int(x.shape[2])
+            if seq_len % 32 == 0:
+                # Runtime bounds, as in process_logits_after_prefill_trace: with literal bounds every
+                # distinct prompt offset compiles its own slice program. Untraced-prefill models
+                # (Gemma-3) reach this slice on every real request, after warmup has recorded their
+                # decode traces, and warmup only ever sees bucket-length mock prompts - measured on
+                # Gemma-3-27B DP-4 as the last 8 buffers left live across trace replays.
+                for device_tensor, values in (
+                    (self._tail_slice_start, [0, 0, get_last_token, 0]),
+                    (self._tail_slice_end, [1, 1, get_last_token + 32, int(x.shape[-1])]),
+                ):
+                    ttnn.copy_host_to_device_tensor(
+                        ttnn.from_torch(
+                            torch.tensor(values, dtype=torch.int32),
+                            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                        ),
+                        device_tensor,
+                    )
+                x = ttnn.slice(
+                    input_tensor=x,
+                    starts=self._tail_slice_start,
+                    ends=self._tail_slice_end,
+                    slice_dim=2,
+                    num_devices=seq_len // 32,
+                )
+            else:
+                x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, x.shape[-1]))
 
         # Output norm
         x = self.norm(x, mode=mode, norm_config=self.args.get_norm_config("lm_head", mode, self.prefetcher))

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1498,7 +1498,7 @@ class ModelArgs:
                         num_workers_per_dram_bank=self.get_dram_sharded_matmul_num_workers(TensorGroup.FF2, self.dim),
                     )
         elif mode == Mode.PREFILL:
-            if seq_len > 128:
+            if self.use_minimal_prefill_matmul(seq_len):
                 grid = self.mlp2_grid(seq_len)
                 return ttnn.MinimalMatmulConfig(
                     M_block_size=8,
@@ -1848,8 +1848,13 @@ class ModelArgs:
         else:
             raise ValueError(f"Invalid mode: {mode}")
 
+    def use_minimal_prefill_matmul(self, seq_len: int) -> bool:
+        # Qwen's 128-token prompts can run singly or be flattened into a larger
+        # batched prefill.
+        return seq_len > 128 or (seq_len == 128 and self.base_model_name == "Qwen3-32B" and self.device_name == "T3K")
+
     def use_minimal_qkv_prefill_matmul(self, seq_len: int) -> bool:
-        if seq_len > 128:
+        if self.use_minimal_prefill_matmul(seq_len):
             return True
 
         # The regular 128-token QKV prefill matmul over-allocates L1 on Llama 8B

--- a/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_text.py
+++ b/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_text.py
@@ -50,6 +50,18 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
         assert self.vocab_size > 0
         self.n_layers = configuration.n_layers
         self.mesh_device = mesh_device
+        # Runtime bounds for the post-prefill last-token slice, allocated before any trace exists and
+        # rewritten in place per call (see forward).
+        self._tail_slice_start = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        self._tail_slice_end = ttnn.from_torch(
+            torch.zeros(4, dtype=torch.int32),
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
         self.tt_ccl = tt_ccl
         self.dtype = dtype
         self.model_config = configuration.get_model_config()
@@ -319,7 +331,31 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
             total_layer_idx += 1
 
         if get_last_token != -1:
-            h = ttnn.slice(h, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, h.shape[-1]))
+            seq_len = int(h.shape[2])
+            if seq_len % 32 == 0:
+                # Runtime bounds, as in tt_transformers Transformer.forward: with literal bounds every
+                # distinct prompt offset compiles its own slice program on the first real request,
+                # after the decode trace is live.
+                for device_tensor, values in (
+                    (self._tail_slice_start, [0, 0, get_last_token, 0]),
+                    (self._tail_slice_end, [1, 1, get_last_token + 32, int(h.shape[-1])]),
+                ):
+                    ttnn.copy_host_to_device_tensor(
+                        ttnn.from_torch(
+                            torch.tensor(values, dtype=torch.int32),
+                            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                        ),
+                        device_tensor,
+                    )
+                h = ttnn.slice(
+                    input_tensor=h,
+                    starts=self._tail_slice_start,
+                    ends=self._tail_slice_end,
+                    slice_dim=2,
+                    num_devices=seq_len // 32,
+                )
+            else:
+                h = ttnn.slice(h, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, h.shape[-1]))
 
         lm_head_norm_config = self.configuration.get_norm_config("lm_head", mode, None)
         h = self.norm(h, mode=mode, norm_config=lm_head_norm_config)

--- a/models/tt_transformers/tt/multimodal/llama_vision_model.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_model.py
@@ -738,10 +738,14 @@ class CrossAttentionTransformer(torch.nn.Module):
         tt_h = self.configuration.prepare_residual_tensor_prefill(
             h,
         )
+        # Build the rope matrices for the padded bucket, not the exact prompt length.
+        # Otherwise every distinct prompt length otherwise materialises its own cos/sin tensors and
+        # its own rotary_embedding_llama programs, compiled on the first real request after the decode
+        # trace is live.
         rot_mats = get_rot_mats(
             head_dim=self.configuration.head_dim,
             device=self.mesh_device,
-            seq_len=S,
+            seq_len=padded_seq_len,
             theta=self.configuration.rope_theta,
             rope_scaling=self.configuration.rope_scaling,
         )

--- a/models/tt_transformers/tt/multimodal/llama_vision_model.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_model.py
@@ -739,7 +739,7 @@ class CrossAttentionTransformer(torch.nn.Module):
             h,
         )
         # Build the rope matrices for the padded bucket, not the exact prompt length.
-        # Otherwise every distinct prompt length otherwise materialises its own cos/sin tensors and
+        # Otherwise every distinct prompt length materialises its own cos/sin tensors and
         # its own rotary_embedding_llama programs, compiled on the first real request after the decode
         # trace is live.
         rot_mats = get_rot_mats(

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1866,8 +1866,6 @@
   model_family: TTTv2
   skus:
     wh_llmbox:
-      # Passing runs take ~3:45 (main 33710384109: 3:41); 4 min left no headroom
-      # and timed out on run 33967118837 at 4:00.
       timeout: 6
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1866,7 +1866,9 @@
   model_family: TTTv2
   skus:
     wh_llmbox:
-      timeout: 4
+      # Passing runs take ~3:45 (main 33710384109: 3:41); 4 min left no headroom
+      # and timed out on run 33967118837 at 4:00.
+      timeout: 6
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -332,7 +332,7 @@
 
 - name: "Llama-3.1-8B-Instruct with sampling-tests"
   model: meta-llama/Llama-3.1-8B-Instruct
-  server-timeout: 15
+  server-timeout: 20
   benchmark-timeout: 5
   mesh-device: T3K
   arch: arch-wormhole_b0
@@ -353,7 +353,7 @@
 
 - name: "Llama-3.1-8B-Instruct (prefix caching)"
   model: meta-llama/Llama-3.1-8B-Instruct
-  server-timeout: 10
+  server-timeout: 15
   benchmark-timeout: 5
   mesh-device: T3K
   arch: arch-wormhole_b0


### PR DESCRIPTION
I’d add the recent Llama, Gemma and Wan fixes, remove the blanket “CI passed” claim, and describe the performance numbers as single-run observations. The PR also now includes a C++ device-kernel change.

Suggested replacement:

---

Fixes [#42698](https://github.com/tenstorrent/tt-metal/issues/42698).

This PR fixes allocation lifetimes around device traces. Model warmup prepares supported execution paths and persistent buffers before capture, allowing subsequent requests with different prompt lengths, batches and sampling parameters to reuse traces safely.

## Changes

- Separate trace preparation from recording across prefill buckets, decode variants, sampling paths and data-parallel groups.
- Reuse device buffers and runtime last-token indices to avoid allocations and recompilation when prompt lengths change.
- Extend vision encoder warmup to supported image geometries and explicitly mark intentional trace allocations.
- Fix Qwen warmup, repeated trace replay and prefill precision, along with Gemma sampling chunking and MoE initialization.
- Apply the same combined-token budget during batched-prefill warmup and execution, fixing Llama-3.1-8B startup OOMs on the N150 path.
- Fix Gemma-3-4B long-sequence memory failures by honoring LM-head output placement and limiting MLP intermediate sizes.
- Update trace-region sizes, selected performance targets, CI configuration and regression coverage.

## Performance

The following Galaxy measurements compare main at [b7b582a](https://github.com/tenstorrent/tt-metal/commit/b7b582aa6e07bf6437da7ac579be9fe01ca7e89a) against an earlier PR revision, [dce3c57](https://github.com/tenstorrent/tt-metal/commit/dce3c57f3a70ca68ee5002b9fb45b649c1d0f745), using fresh caches, tracing and 200 generated tokens.

| Model | Batch | Main TTFT (ms) | PR TTFT (ms) | Main tok/s | PR tok/s |
| --- | ---: | ---: | ---: | ---: | ---: |
| Llama 3.3 70B Instruct | 1 | 164.76 | 164.94 | 18.08 | 18.08 |
| Llama 3.3 70B Instruct | 32 | 60.44 | 60.34 | 533.45 | 533.53 |
| Qwen3 32B | 1 | 93.44 | 93.72 | 28.88 | 28.82 |
| Qwen3 32B | 32 | 35.70 | 35.72 | 801.86 | 803.33 |

Observed differences were within approximately **0.3%**. These are single-run comparisons; they do not establish statistical significance or validate performance of subsequent revisions.

---

Also for this PR this tool was used for trace memory allocation verification: tech_reports/AdvancedPerformanceOptimizationsForModels/TraceCorrectness.md

All models CI (all failures happen on main as well): https://github.com/tenstorrent/tt-metal/actions/runs/34027959238

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ifabijanic/42698-trace-alloc-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ifabijanic/42698-trace-alloc-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ifabijanic/42698-trace-alloc-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ifabijanic/42698-trace-alloc-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ifabijanic/42698-trace-alloc-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ifabijanic/42698-trace-alloc-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ifabijanic/42698-trace-alloc-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ifabijanic/42698-trace-alloc-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ifabijanic/42698-trace-alloc-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ifabijanic/42698-trace-alloc-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ifabijanic/42698-trace-alloc-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ifabijanic/42698-trace-alloc-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ifabijanic/42698-trace-alloc-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ifabijanic/42698-trace-alloc-fixes)