### PR TITLE
fix(ttnn): compute true RMSNorm with epsilon on rank-0 tensors (#55347)

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -143,3 +143,31 @@ def test_rms_norm_with_weight_and_residual(device, batch_size, h, w, dtype):
         atol=atol,
         frobenius_threshold=frobenius_threshold,
     )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("val", [0.0, 1e-7, -1e-7, 1e-3, -2e-3, 1.0, -1.0, 5.0, -5.0])
+@pytest.mark.parametrize("eps", [1e-5, 1e-12])
+@pytest.mark.parametrize("with_weight", [False, True])
+def test_rms_norm_rank_0(device, val, eps, dtype, with_weight):
+    torch_input = torch.tensor(val, dtype=dtype)
+    torch_weight = torch.tensor(1.5, dtype=dtype) if with_weight else None
+
+    torch_ref = torch.nn.functional.rms_norm(
+        torch_input.reshape(1),
+        (1,),
+        weight=torch_weight.reshape(1) if with_weight else None,
+        eps=eps,
+    ).reshape(())
+
+    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_weight = ttnn.from_torch(torch_weight, device=device, layout=ttnn.TILE_LAYOUT) if with_weight else None
+
+    ttnn_out = ttnn.rms_norm(ttnn_input, epsilon=eps, weight=ttnn_weight)
+    out = ttnn.to_torch(ttnn.from_device(ttnn_out))
+
+    if dtype == torch.bfloat16:
+        assert torch.allclose(torch_ref, out, atol=1e-2, rtol=1e-2)
+    else:
+        assert torch.allclose(torch_ref, out, atol=1e-4, rtol=1e-4)
+

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -149,9 +149,11 @@ def test_rms_norm_with_weight_and_residual(device, batch_size, h, w, dtype):
 @pytest.mark.parametrize("val", [0.0, 1e-7, -1e-7, 1e-3, -2e-3, 1.0, -1.0, 5.0, -5.0])
 @pytest.mark.parametrize("eps", [1e-5, 1e-12])
 @pytest.mark.parametrize("with_weight", [False, True])
-def test_rms_norm_rank_0(device, val, eps, dtype, with_weight):
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_rms_norm_rank_0(device, val, eps, dtype, with_weight, with_bias):
     torch_input = torch.tensor(val, dtype=dtype)
     torch_weight = torch.tensor(1.5, dtype=dtype) if with_weight else None
+    torch_bias = torch.tensor(0.5, dtype=dtype) if with_bias else None
 
     torch_ref = torch.nn.functional.rms_norm(
         torch_input.reshape(1),
@@ -159,11 +161,14 @@ def test_rms_norm_rank_0(device, val, eps, dtype, with_weight):
         weight=torch_weight.reshape(1) if with_weight else None,
         eps=eps,
     ).reshape(())
+    if with_bias:
+        torch_ref = torch_ref + torch_bias
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, layout=ttnn.TILE_LAYOUT)
     ttnn_weight = ttnn.from_torch(torch_weight, device=device, layout=ttnn.TILE_LAYOUT) if with_weight else None
+    ttnn_bias = ttnn.from_torch(torch_bias, device=device, layout=ttnn.TILE_LAYOUT) if with_bias else None
 
-    ttnn_out = ttnn.rms_norm(ttnn_input, epsilon=eps, weight=ttnn_weight)
+    ttnn_out = ttnn.rms_norm(ttnn_input, epsilon=eps, weight=ttnn_weight, bias=ttnn_bias)
     out = ttnn.to_torch(ttnn.from_device(ttnn_out))
 
     if dtype == torch.bfloat16:

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
@@ -42,9 +42,23 @@ Tensor rms_norm(
 
     // For 0D tensors
     if (rank == 0) [[unlikely]] {
-        auto result = ttnn::divide(
-            input_tensor,
-            ttnn::abs(input_tensor, output_memory_config),
+        auto actual_input = input_tensor;
+        if (residual_input_tensor.has_value()) {
+            actual_input = ttnn::add(actual_input, residual_input_tensor.value(), /*output_dtype=*/std::nullopt, output_memory_config);
+        }
+        auto x_squared = ttnn::square(actual_input, output_memory_config);
+        auto variance_plus_eps = ttnn::add(
+            x_squared,
+            epsilon,
+            /*output_dtype=*/std::nullopt,
+            output_memory_config);
+        auto inv_rms = ttnn::rsqrt(
+            variance_plus_eps,
+            /*fast_and_approximate_mode=*/false,
+            output_memory_config);
+        auto result = ttnn::multiply(
+            actual_input,
+            inv_rms,
             /*output_dtype=*/std::nullopt,
             output_memory_config);
 


### PR DESCRIPTION
### Description
Closes #55347

For rank-0 (0D scalar) tensors, `ttnn::rms_norm` previously computed `x / |x|` via `ttnn::divide(input_tensor, ttnn::abs(input_tensor))`, which dropped `epsilon`, yielded `NaN` at `x = 0`, and clamped values with `|x| < sqrt(eps)` to `±1`.

This PR replaces the rank-0 branch with the exact scalar formulation of RMSNorm:
```cpp
actual_input * rsqrt(actual_input^2 + epsilon)
```
matching `torch.nn.functional.rms_norm` and the registered golden reference.

### Changes
- In `ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp`:
  - Included `residual_input_tensor` addition for rank-0 if present.
  - Computed `x_squared = ttnn::square(actual_input)`.
  - Added `epsilon` to `x_squared`.
  - Computed `inv_rms = ttnn::rsqrt(variance_plus_eps, /*fast_and_approximate_mode=*/false)`.
  - Multiplied `actual_input * inv_rms`.
  - Retained `weight` and `bias` transformations.
- In `tests/ttnn/unit_tests/operations/fused/test_rms_norm.py`:
  - Added `test_rms_norm_rank_0` parameterized across `fp32` and `bfloat16`, epsilons (`1e-5`, `1e-12`), and inputs `{0, ±1e-7, ±1e-3, ±1, ±5}`, verifying parity against `torch.nn.functional.rms_norm`.

### Validation
- Validated parity with `torch.nn.functional.rms_norm` on zero and sub-sqrt(eps) values across `fp32` and `bfloat16`.
