### PR TITLE
fix(ttnn): align argmax comparators with torch NaN and signed-zero semantics (#55346)

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -394,3 +394,27 @@ def test_argmax_nan_and_signed_zero(device, dtype, row):
 
     assert actual_idx == expected_idx, f"Row {row} ({dtype}): expected {expected_idx}, got {actual_idx}"
 
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+def test_argmax_tile_layout_with_nan_and_signed_zero(device, dtype, layout):
+    """Verifies tile-layout and multicore reduction paths with NaNs and signed zeros."""
+    torch_tensor = torch.zeros((32, 64), dtype=dtype)
+    torch_tensor[0, 5] = float("nan")
+    torch_tensor[1, 0] = -0.0
+    torch_tensor[1, 1] = 0.0
+    torch_tensor[2, 10] = 3.0
+    torch_tensor[2, 20] = float("nan")
+    torch_tensor[3, 0] = 5.0
+    torch_tensor[3, 1] = 5.0
+
+    expected = torch.argmax(torch_tensor, dim=-1, keepdim=False)
+
+    ttnn_dtype = ttnn.float32 if dtype == torch.float32 else ttnn.bfloat16
+    ttnn_tensor = ttnn.from_torch(torch_tensor, ttnn_dtype, layout=layout, device=device)
+
+    out = ttnn.argmax(ttnn_tensor, dim=-1, keepdim=False)
+    actual = ttnn.to_torch(ttnn.from_device(out)).to(torch.int64)
+
+    assert torch.equal(actual, expected), f"Mismatch for dtype {dtype}, layout {layout}"
+

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -366,3 +366,31 @@ def test_argmax_reduce_all_sub_core_grids_idle_cores(device):
 
     got = int(ttnn.to_torch(ttnn.from_device(result["out"])).item())
     assert got == int(torch.argmax(t.reshape(-1))), f"reduce_all mismatch: got {got}"
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize(
+    "row",
+    [
+        [3.0, float("nan")],
+        [float("nan"), 3.0],
+        [1.0, float("nan"), 3.0],
+        [-float("inf"), float("nan")],
+        [-0.0, 0.0],
+        [-0.0, 0.0, -1.0],
+        [0.0, -0.0],
+        [2.0, 2.0],
+    ],
+)
+def test_argmax_nan_and_signed_zero(device, dtype, row):
+    torch_tensor = torch.tensor(row, dtype=dtype)
+    expected_idx = int(torch.argmax(torch_tensor).item())
+
+    ttnn_dtype = ttnn.float32 if dtype == torch.float32 else ttnn.bfloat16
+    ttnn_tensor = ttnn.from_torch(torch_tensor, ttnn_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    out = ttnn.argmax(ttnn_tensor, dim=-1, keepdim=False)
+    actual_idx = int(ttnn.to_torch(ttnn.from_device(out)).item())
+
+    assert actual_idx == expected_idx, f"Row {row} ({dtype}): expected {expected_idx}, got {actual_idx}"
+

--- a/tt_metal/hw/inc/api/numeric/bfloat16.h
+++ b/tt_metal/hw/inc/api/numeric/bfloat16.h
@@ -62,6 +62,10 @@ struct FloatBits {
     }
 };
 
+inline constexpr uint16_t BFLOAT16_EXPONENT_MASK = 0x7F80;   // Exponent mask for bfloat16
+inline constexpr uint16_t BFLOAT16_MANTISSA_MASK = 0x007F;   // Mantissa mask for bfloat16
+inline constexpr uint16_t BFLOAT16_MAGNITUDE_MASK = 0x7FFF;  // Magnitude mask for bfloat16
+
 // Optimized function to compare two bfloat16 values using integer arithmetic
 bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
     /*
@@ -70,6 +74,9 @@ bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
        bit 15         bits 14-7          bits 6-0
 
     Comparison Logic:
+    - Torch argmax semantics: NaN is greater than any non-NaN value.
+      Two NaNs are equal (neither is strictly greater, preserving the first NaN index).
+    - Handle zero cases (both +0 and -0 are equal).
     - If signs differ:
         - If bf16_a is positive (sign bit 0), it is greater.
         - If bf16_a is negative (sign bit 1), it is not greater.
@@ -77,6 +84,17 @@ bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
         - Positive numbers: higher bits mean greater value.
         - Negative numbers: higher bits mean smaller value (reverse comparison).
     */
+
+    bool is_nan_a = (bf16_a & BFLOAT16_EXPONENT_MASK) == BFLOAT16_EXPONENT_MASK && (bf16_a & BFLOAT16_MANTISSA_MASK) != 0;
+    bool is_nan_b = (bf16_b & BFLOAT16_EXPONENT_MASK) == BFLOAT16_EXPONENT_MASK && (bf16_b & BFLOAT16_MANTISSA_MASK) != 0;
+    if (is_nan_a || is_nan_b) {
+        return is_nan_a && !is_nan_b;
+    }
+
+    // Handle zero cases (both +0 and -0 are equal)
+    if ((bf16_a & BFLOAT16_MAGNITUDE_MASK) == 0 && (bf16_b & BFLOAT16_MAGNITUDE_MASK) == 0) {
+        return false;
+    }
 
     // Check if signs are different
     if ((bf16_a ^ bf16_b) & BFLOAT16_SIGN_MASK) {
@@ -92,4 +110,18 @@ bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
         // Both positive: regular comparison
         return bf16_a > bf16_b;
     }
+}
+
+inline bool bfloat16_equal(uint16_t bf16_a, uint16_t bf16_b) {
+    if (bf16_a == bf16_b) {
+        return true;
+    }
+    // ±0 equality
+    if ((bf16_a & BFLOAT16_MAGNITUDE_MASK) == 0 && (bf16_b & BFLOAT16_MAGNITUDE_MASK) == 0) {
+        return true;
+    }
+    // NaN equality (for tie-breaking/first-index consistency)
+    bool is_nan_a = (bf16_a & BFLOAT16_EXPONENT_MASK) == BFLOAT16_EXPONENT_MASK && (bf16_a & BFLOAT16_MANTISSA_MASK) != 0;
+    bool is_nan_b = (bf16_b & BFLOAT16_EXPONENT_MASK) == BFLOAT16_EXPONENT_MASK && (bf16_b & BFLOAT16_MANTISSA_MASK) != 0;
+    return is_nan_a && is_nan_b;
 }

--- a/tt_metal/hw/inc/api/numeric/float32.h
+++ b/tt_metal/hw/inc/api/numeric/float32.h
@@ -31,10 +31,11 @@ bool float32_greater(uint32_t f32_a, uint32_t f32_b) {
         - Negative numbers: higher bits mean smaller value (reverse comparison).
     */
 
-    // Handle NaN cases - NaN is never greater than anything
-    if (((f32_a & FLOAT32_EXPONENT_MASK) == FLOAT32_EXPONENT_MASK && (f32_a & FLOAT32_MANTISSA_MASK) != 0) ||
-        ((f32_b & FLOAT32_EXPONENT_MASK) == FLOAT32_EXPONENT_MASK && (f32_b & FLOAT32_MANTISSA_MASK) != 0)) {
-        return false;
+    // Handle NaN cases with torch argmax semantics (NaN beats non-NaN, NaN does not beat NaN)
+    bool is_nan_a = (f32_a & FLOAT32_EXPONENT_MASK) == FLOAT32_EXPONENT_MASK && (f32_a & FLOAT32_MANTISSA_MASK) != 0;
+    bool is_nan_b = (f32_b & FLOAT32_EXPONENT_MASK) == FLOAT32_EXPONENT_MASK && (f32_b & FLOAT32_MANTISSA_MASK) != 0;
+    if (is_nan_a || is_nan_b) {
+        return is_nan_a && !is_nan_b;
     }
 
     // Handle zero cases (both +0 and -0 are equal)
@@ -56,4 +57,18 @@ bool float32_greater(uint32_t f32_a, uint32_t f32_b) {
         // Both positive: regular comparison
         return f32_a > f32_b;
     }
+}
+
+inline bool float32_equal(uint32_t f32_a, uint32_t f32_b) {
+    if (f32_a == f32_b) {
+        return true;
+    }
+    // ±0 equality
+    if ((f32_a & FLOAT32_MAGNITUDE_MASK) == 0 && (f32_b & FLOAT32_MAGNITUDE_MASK) == 0) {
+        return true;
+    }
+    // NaN equality (for tie-breaking/first-index consistency)
+    bool is_nan_a = (f32_a & FLOAT32_EXPONENT_MASK) == FLOAT32_EXPONENT_MASK && (f32_a & FLOAT32_MANTISSA_MASK) != 0;
+    bool is_nan_b = (f32_b & FLOAT32_EXPONENT_MASK) == FLOAT32_EXPONENT_MASK && (f32_b & FLOAT32_MANTISSA_MASK) != 0;
+    return is_nan_a && is_nan_b;
 }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
@@ -211,6 +211,21 @@ void compare_values(
  * @param max_idx Reference to the current maximum index
  * @param compare_func Function to compare two values of the data format
  */
+template <typename ValueType>
+inline bool values_equal(ValueType a, ValueType b) {
+    return a == b;
+}
+
+template <>
+inline bool values_equal<uint32_t>(uint32_t a, uint32_t b) {
+    return float32_equal(a, b);
+}
+
+template <>
+inline bool values_equal<uint16_t>(uint16_t a, uint16_t b) {
+    return bfloat16_equal(a, b);
+}
+
 template <DataFormat data_format, typename ValueType, typename CompareFunc>
 inline void process_core_data(
     const uint32_t inner_idx,
@@ -224,7 +239,7 @@ inline void process_core_data(
     if (compare_func(val, max_val)) {
         max_idx = i_red_idxs[inner_idx];
         max_val = val;
-    } else if ((val == max_val) && (i_red_idxs[inner_idx] < max_idx)) {
+    } else if (values_equal(val, max_val) && (i_red_idxs[inner_idx] < max_idx)) {
         max_idx = i_red_idxs[inner_idx];
     }
 }
@@ -265,7 +280,7 @@ inline void process_value_comparison(
         auto full_idx = outer_idx * inner_dim_units * red_dim_units + j * red_dim_units + i;
         max_idx = reduce_all ? full_idx : i;
         max_val = val;
-    } else if (val == max_val) {
+    } else if (values_equal(val, max_val)) {
         auto full_idx = outer_idx * inner_dim_units * red_dim_units + j * red_dim_units + i;
         max_idx = reduce_all ? std::min(max_idx, full_idx) : std::min(max_idx, i);
     }


### PR DESCRIPTION
### Description
Closes #55346

Aligns non-SFPU `ttnn.argmax` float comparators with PyTorch reference semantics:
1. **NaN Selection**: In PyTorch (`torch.argmax`), `NaN` is treated as greater than any non-NaN value, with the first occurrence chosen among multiple NaNs. Previously, `float32_greater` rejected NaNs on either side (never selecting NaN), while `bfloat16_greater` only selected positive NaNs by bit pattern coincidence.
2. **Signed Zero Parity**: `+0.0` and `-0.0` represent identical values. Previously, `bfloat16_greater` lacked zero-magnitude handling, allowing a later `+0.0` (sign bit 0) to beat an earlier `-0.0` (sign bit 1).
3. **First-Index Tie Handling**: Tie-break checks in `argmax_common.hpp` now use value equality (`values_equal`) so that `[-0.0, 0.0]` and multiple NaNs retain the initial index.

### Changes
- In `tt_metal/hw/inc/api/numeric/float32.h`:
  - Updated `float32_greater` to return `true` when `f32_a` is NaN and `f32_b` is non-NaN, and `false` when both are NaN.
  - Added `float32_equal` accounting for `±0` and NaN equality.
- In `tt_metal/hw/inc/api/numeric/bfloat16.h`:
  - Added exponent, mantissa, and magnitude bitmasks for `bfloat16`.
  - Updated `bfloat16_greater` to match Torch NaN semantics and handle `±0` equality.
  - Added `bfloat16_equal`.
- In `ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp`:
  - Added `values_equal` template helper specializing for `uint32_t` (f32) and `uint16_t` (bf16).
  - Used `values_equal` in `process_core_data` and `process_value_comparison` instead of raw bitwise equality.
- In `tests/ttnn/unit_tests/operations/reduce/test_argmax.py`:
  - Added `test_argmax_nan_and_signed_zero` parameterized over `fp32` and `bf16` for rows with NaNs, signed zeros (`[-0.0, 0.0]`), and duplicates, validating against `torch.argmax`.
