### PR TITLE
[Bug fix] Honour the requested memory_config in eltwise ops that create their output

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_fill.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_fill.py
@@ -62,3 +62,113 @@ def test_bw_fill_opt_tensor(input_shapes, device):
     tt_output_tensor_on_device = [input_grad]
     comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=0, rtol=0)
     assert comp_pass
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+def test_bw_fill_honours_memory_config(input_shapes, device):
+    """The gradient fill_bw allocates itself must land in the requested memory config.
+
+    Regression: both `zeros_like` calls passed `std::nullopt`, so the result inherited
+    grad's config — the tensor is created from grad — and an explicitly requested config
+    was ignored. `output_memory_config` was computed one line above and never read: an
+    unused local rather than an unused parameter, so nothing warned.
+
+    grad and input are both placed in L1 with DRAM requested, so the requested config
+    differs from the inherited one; with matching configs the defect is invisible.
+    See test_bw_fill_unset_memory_config_follows_grad for the unset-config half.
+    """
+    _, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    _, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+
+    input_tensor = ttnn.to_memory_config(input_tensor, ttnn.L1_MEMORY_CONFIG)
+    grad_tensor = ttnn.to_memory_config(grad_tensor, ttnn.L1_MEMORY_CONFIG)
+
+    result = ttnn.fill_bw(grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    assert (
+        result[0].memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    ), f"requested {ttnn.DRAM_MEMORY_CONFIG} but landed in {result[0].memory_config()}"
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+def test_bw_fill_preallocated_output_wins_over_memory_config(input_shapes, device):
+    """A caller-supplied input_grad keeps its own config and is written in place."""
+    _, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    _, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+    preallocated = ttnn.full(input_shapes, 7.0, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG)
+
+    result = ttnn.fill_bw(grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG, input_grad=preallocated)
+
+    assert result[0].memory_config() == ttnn.L1_MEMORY_CONFIG, "preallocated output should win over memory_config"
+    assert torch.all(ttnn.to_torch(preallocated) == 0.0), "preallocated tensor was not written"
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize(
+    "grad_memcfg, input_memcfg",
+    (
+        (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+        (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ),
+    ids=["grad_L1_input_DRAM", "grad_DRAM_input_L1"],
+)
+def test_bw_fill_unset_memory_config_follows_grad(input_shapes, device, grad_memcfg, input_memcfg):
+    """With no memory_config, the result must follow grad's placement, not input's.
+
+    fill_bw builds its output from `grad`, so an unset config has always inherited grad's
+    config. The obvious fix -- passing the `output_mem_config.value_or(input.memory_config())`
+    local that sat unused above -- would silently change that default whenever grad and input
+    live in different spaces. grad and input are deliberately placed in opposite spaces here;
+    with both in the same space this cannot discriminate.
+    """
+    _, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    _, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+
+    grad_tensor = ttnn.to_memory_config(grad_tensor, grad_memcfg)
+    input_tensor = ttnn.to_memory_config(input_tensor, input_memcfg)
+
+    result = ttnn.fill_bw(grad_tensor, input_tensor)
+
+    assert (
+        result[0].memory_config() == grad_memcfg
+    ), f"unset memory_config should follow grad ({grad_memcfg}) but landed in {result[0].memory_config()}"
+
+
+# Zero-gradient backward ops that build their output from grad, same shape as fill_bw.
+_ZERO_GRAD_OPS = {"floor": ttnn.floor_bw, "round": ttnn.round_bw, "ceil": ttnn.ceil_bw}
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("op", sorted(_ZERO_GRAD_OPS))
+def test_bw_zero_gradient_ops_honour_memory_config(input_shapes, device, op):
+    """floor_bw, round_bw and ceil_bw are the same shape as fill_bw and dropped the config too.
+
+    Each is a bare `zeros_like(grad)` with `output_mem_config` commented out in the
+    signature, which is exactly how the fill_bw case stayed hidden.
+    """
+    _, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    _, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+
+    grad_tensor = ttnn.to_memory_config(grad_tensor, ttnn.L1_MEMORY_CONFIG)
+    input_tensor = ttnn.to_memory_config(input_tensor, ttnn.L1_MEMORY_CONFIG)
+
+    result = _ZERO_GRAD_OPS[op](grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    assert (
+        result[0].memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    ), f"{op}_bw requested DRAM but landed in {result[0].memory_config()}"
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("op", sorted(_ZERO_GRAD_OPS))
+def test_bw_zero_gradient_ops_unset_memory_config_follows_grad(input_shapes, device, op):
+    """With no memory_config these must keep inheriting grad's placement."""
+    _, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    _, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+
+    grad_tensor = ttnn.to_memory_config(grad_tensor, ttnn.L1_MEMORY_CONFIG)
+    input_tensor = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+
+    result = _ZERO_GRAD_OPS[op](grad_tensor, input_tensor)
+
+    assert result[0].memory_config() == ttnn.L1_MEMORY_CONFIG, f"{op}_bw unset config should follow grad"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -634,3 +634,45 @@ def test_div_int32_rejects_non_float32_output_dtype(device, expect_error):
 
     with expect_error(RuntimeError, "Incorrect output_dtype value for Integer Division"):
         ttnn.div(input_tensor_a, input_tensor_b, dtype=ttnn.int32)
+
+
+@pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
+@pytest.mark.parametrize("value", [0.0, 2.0], ids=["zero_divisor", "nonzero_divisor"])
+@pytest.mark.parametrize(
+    "requested_memcfg, expected_memcfg",
+    (
+        (ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+        (None, ttnn.L1_MEMORY_CONFIG),
+    ),
+    ids=["explicit_DRAM", "unset_follows_input"],
+)
+def test_div_no_nan_scalar_honours_memory_config(device, shape, value, requested_memcfg, expected_memcfg):
+    """The scalar div_no_nan overload must return in the requested memory config.
+
+    Both returns dropped it: `zeros_like(input_a)` on the zero-divisor branch and
+    `multiply(input_a, 1/value)` on the other, with `output_mem_config` commented out in
+    the signature. Both branches are covered because they are separate return statements.
+
+    The unset case is covered too, and separately per branch: the two reach their default
+    through different machinery — `zeros_like` via `fill`'s fast path, `multiply` via the
+    binary op's own `value_or(input_a.memory_config())` — so a divergence between them
+    would not show up in the explicit-request case alone.
+
+    The input is placed in L1 with DRAM requested; with matching configs the inherited
+    and requested values coincide and the defect is invisible.
+    """
+    torch.manual_seed(0)
+    torch_input = torch.rand(shape, dtype=torch.bfloat16) + 1.0
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    output = (
+        ttnn.div_no_nan(input_tensor, value)
+        if requested_memcfg is None
+        else ttnn.div_no_nan(input_tensor, value, memory_config=requested_memcfg)
+    )
+
+    assert (
+        output.memory_config() == expected_memcfg
+    ), f"divisor {value}, requested {requested_memcfg}: expected {expected_memcfg} but landed in {output.memory_config()}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_polyval.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_polyval.py
@@ -32,3 +32,34 @@ def test_polyval(device, shape, coeff):
     output_tensor = ttnn.polyval(input_tensor_a, coeff)
     output_tensor = ttnn.to_torch(output_tensor).squeeze(0)
     assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=2)
+
+
+@pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
+@pytest.mark.parametrize("coeff", [(3.0,), (3.0, 2.0)])
+def test_polyval_honours_memory_config(device, shape, coeff):
+    """polyval must return in the requested memory config, including the 1-coefficient path.
+
+    Regression: `coeffs.size() == 1` returns early via `full_like` without the memory
+    config, so the result inherited the input's. The multi-coefficient path was already
+    correct, which is why it is parametrized here alongside as a control.
+
+    The input is placed in L1 with DRAM requested; with matching configs the defect is
+    invisible.
+    """
+    torch.manual_seed(0)
+    torch_input = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    output = ttnn.polyval(input_tensor, list(coeff), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    assert (
+        output.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    ), f"{len(coeff)} coeff(s): requested {ttnn.DRAM_MEMORY_CONFIG} but landed in {output.memory_config()}"
+
+    # with no memory_config both paths must fall back the same way, to the input's config
+    default_output = ttnn.polyval(input_tensor, list(coeff))
+    assert (
+        default_output.memory_config() == ttnn.L1_MEMORY_CONFIG
+    ), f"{len(coeff)} coeff(s): unset config should follow the input but landed in {default_output.memory_config()}"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -432,12 +432,12 @@ Tensor div(
 }
 
 Tensor div_no_nan(
-    const Tensor& input_a, unary::ScalarVariant value, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    const Tensor& input_a, unary::ScalarVariant value, const std::optional<MemoryConfig>& output_mem_config) {
     float value_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, value);
     if (value_f == 0) {
-        return ttnn::zeros_like(input_a);
+        return ttnn::zeros_like(input_a, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
-    return ttnn::multiply(input_a, (1.0f / value_f));
+    return ttnn::multiply(input_a, (1.0f / value_f), std::nullopt, output_mem_config);
 }
 
 Tensor div_no_nan(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
@@ -712,7 +712,7 @@ Tensor polyval(
     const Tensor& input_a, const std::vector<float>& coeffs, const std::optional<MemoryConfig>& output_mem_config) {
     TT_ASSERT(!coeffs.empty() && "coeffs should be 1 or more coefficients");
     if (coeffs.size() == 1) {
-        return ttnn::full_like(input_a, coeffs[0]);
+        return ttnn::full_like(input_a, coeffs[0], std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
     Tensor result = ttnn::multiply(input_a, coeffs[0], std::nullopt, output_mem_config);
     for (int idx = 1; idx < coeffs.size() - 1; idx++) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -535,14 +535,16 @@ std::vector<Tensor> relu_bw(
 // result: at::fill(self_t, 0)
 std::vector<std::optional<Tensor>> fill_bw(
     const Tensor& grad,
-    const Tensor& input,
+    const Tensor& /*input*/,
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<Tensor>& input_grad) {
-    auto output_memory_config = output_mem_config.value_or(input.memory_config());
+    // The gradient of fill does not depend on the input value, only its shape, which grad
+    // already has. Pass output_mem_config rather than value_or(input.memory_config()): the
+    // tensor is created from grad, so an unset config must keep inheriting grad's placement.
     std::vector<std::optional<Tensor>> result = {std::nullopt};
     result[0] = input_grad.has_value()
-                    ? ttnn::zeros_like(grad, std::nullopt, std::nullopt, std::nullopt, std::nullopt, input_grad)
-                    : ttnn::zeros_like(grad);
+                    ? ttnn::zeros_like(grad, std::nullopt, std::nullopt, std::nullopt, output_mem_config, input_grad)
+                    : ttnn::zeros_like(grad, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     return result;
 }
 
@@ -817,17 +819,17 @@ std::vector<Tensor> rpow_bw(
 }
 
 std::vector<Tensor> floor_bw(
-    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor t_zero = ttnn::zeros_like(grad);
+    Tensor t_zero = ttnn::zeros_like(grad, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(t_zero);
     return grad_tensor;
 }
 
 std::vector<Tensor> round_bw(
-    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor t_zero = ttnn::zeros_like(grad);
+    Tensor t_zero = ttnn::zeros_like(grad, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(t_zero);
     return grad_tensor;
 }
@@ -1157,9 +1159,9 @@ std::vector<Tensor> erfc_bw(
 }
 
 std::vector<Tensor> ceil_bw(
-    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = ttnn::zeros_like(grad);
+    Tensor zero_grad = ttnn::zeros_like(grad, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(zero_grad);
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
@@ -393,12 +393,12 @@ Tensor div(
 }
 
 Tensor div_no_nan(
-    const Tensor& input_a, unary::ScalarVariant value, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    const Tensor& input_a, unary::ScalarVariant value, const std::optional<MemoryConfig>& output_mem_config) {
     float value_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, value);
     if (value_f == 0) {
-        return ttnn::zeros_like(input_a);
+        return ttnn::zeros_like(input_a, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
-    return q::multiply(input_a, (1.0f / value_f));
+    return q::multiply(input_a, (1.0f / value_f), std::nullopt, output_mem_config);
 }
 
 Tensor div_no_nan(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
@@ -602,7 +602,7 @@ Tensor polyval(
     const Tensor& input_a, const std::vector<float>& coeffs, const std::optional<MemoryConfig>& output_mem_config) {
     TT_ASSERT(!coeffs.empty() && "coeffs should be 1 or more coefficients");
     if (coeffs.size() == 1) {
-        return ttnn::full_like(input_a, coeffs[0]);
+        return ttnn::full_like(input_a, coeffs[0], std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
     Tensor result = q::multiply(input_a, coeffs[0], std::nullopt, output_mem_config);
     for (int idx = 1; idx < coeffs.size() - 1; idx++) {


### PR DESCRIPTION
Closes #55360

### What

Ops that build the tensor they **return** now pass the caller's `memory_config`. In each the parameter was already commented out as `/*output_mem_config*/`, which is how they stayed hidden.

| Op | Built from |
| --- | --- |
| `fill_bw`, `floor_bw`, `round_bw`, `ceil_bw` | `grad` |
| `polyval`, 1-coefficient early return | `input_a` |
| `div_no_nan` scalar, both returns | `input_a` |

`polyval` and `div_no_nan` have verbatim quasar copies, fixed there too.

### Measured (Wormhole, bfloat16/TILE, inputs L1, req DRAM)

- Every op above: **L1 → DRAM**
- Unchanged and pinned: `polyval` 2-coeff; unset config still follows `grad` (`fill_bw`, zero-grad ops) and `input` (`polyval`); preallocated `input_grad` keeps its config and is written

### Notes

- `fill_bw` passes the raw `output_mem_config`, **not** the `value_or(input.memory_config())` local: the tensor is built from `grad`, so that local would change the default path. Deleting it leaves `input` unused — correct, `fill`'s gradient needs only grad's shape — so its name is commented out.
- Scalar-base `pow` (`:831`, quasar twin) is **not** changed: it already returns DRAM for L1 inputs, so the change would be inert.
- Quasar changes are mirrors and **not executable on this hardware**.

### Tests

Inputs in L1, DRAM requested — with matching configs the defect is invisible.

Each fix fails its own tests when reverted:

| Reverted | Result |
| --- | --- |
| `fill_bw` explicit config | 2 failed |
| `fill_bw` unset config | 2 failed |
| `floor`/`round`/`ceil` | 3 failed |
| `div_no_nan` scalar | 2 failed |

The unset-config cases earn their place: both the fix and the old local satisfy every explicit request, so a default-path regression would otherwise pass silently.

- `fill_bw` + `polyval` + `div_ops`: **234 passed**, 9 skipped, 2 xfailed
- `floor` / `round` / `ceil` suites: **3 passed** each

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/c)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/c)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/c)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/c)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/c)


