### PR TITLE
[Quasar Resnet] Clean up fused conv compute kernel and use cfg register to tilize/untilize more than one row of tiles

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -92,14 +92,22 @@ inline void llk_pack_untilize(
 
     const std::uint32_t y_stride = full_ct_dim * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
     const LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(output_id);
-    const std::uint32_t base_l1 = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx *
-                                  tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
+
+    // Compute how many l1_index units fit in one DFB entry
+    const std::uint32_t entry_size_16B = local_dfb_interface.entry_size;  // DFB entry size in 16B
+    const std::uint32_t face_row_16B =                                    // Buffer Descriptor granularity in 16B
+        SCALE_DATUM_SIZE(pack_dst_format[output_id], ckernel::trisc::FACE_C_DIM) >> 4;
+    const std::uint32_t l1_index_per_entry =  // l1_index steps per entry
+        entry_size_16B / (face_row_16B * tensor_shape.num_faces_c_dim);
+    const std::uint32_t base_l1 =
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx * l1_index_per_entry;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         const std::uint32_t dest_idx = block_rt * block_ct_dim + tile_dst_rt_offset;
         const std::uint32_t l1_tile_idx = base_l1 + block_rt * y_stride + block_c_index * block_ct_dim;
         if (tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES) {
-            _llk_pack_untilize_(dest_idx, l1_tile_idx);
+            _llk_pack_untilize_set_dst_offset_(tensor_shape, l1_tile_idx);
+            _llk_pack_untilize_(dest_idx, 0 /*l1_tile_idx*/);
         } else {
             // Strided PACR consumes buf_desc_id as an immediate; pass the id programmed by
             // llk_pack_untilize_init (bfd_current), not the DFB output_id (which no longer doubles

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -73,21 +73,31 @@ inline void llk_unpack_tilize_block(
             (tensor_shape.total_num_faces() == 2 && (tensor_shape.face_r_dim == 1 || tensor_shape.face_r_dim == 2)),
         "only 1x32 and 2x32 tiny tiles supported for unpack tilize on Quasar");
 
-    const std::uint32_t faces_per_entry = tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
-
     const LocalDFBInterface& local_dfb = g_dfb_interface[operand_id];
     const std::uint32_t rd_entry_idx = local_dfb.tc_slots[local_dfb.tc_idx].rd_entry_idx;
+
+    // Compute how many l1_index units fit in one DFB entry.
+    const std::uint32_t entry_size_16B = local_dfb.entry_size;  // DFB entry size in 16B
+    const std::uint32_t face_row_16B =                          // Buffer Descriptor granularity in 16B
+        SCALE_DATUM_SIZE(unpack_src_format[operand_id], ckernel::trisc::FACE_C_DIM) >> 4;
+    const std::uint32_t l1_index_per_entry =  // l1_index steps per entry
+        entry_size_16B / (face_row_16B * tensor_shape.num_faces_c_dim);
 
     // TODO (SK) #42757: Remove ct_dim loop when block_ct_dim unpacking optimization implemented.
     // BLOCK_CT_DIM is currently hardcoded to 1 in tilize_init (see compute/tilize.h), so the MOP
     // emits one SrcA dvalid per invocation. Loop to match the per-tile math consumption same
     // structural pattern as BH/WH llk_unpack_tilize_block
-    const std::uint32_t l1_base_idx = (rd_entry_idx + input_tile_index) * faces_per_entry;
+    const std::uint32_t l1_base_idx = rd_entry_idx * l1_index_per_entry;
+
+    if (tensor_shape.total_num_faces() == NUM_FACES) {
+        _llk_unpack_tilize_set_src_offset_<p_unpacr::UNP_A>(tensor_shape, l1_base_idx);
+    }
+
     for (std::uint32_t t = 0; t < block_c_tiles; t++) {
         if (tensor_shape.total_num_faces() == NUM_FACES) {
-            _llk_unpack_tilize_<p_unpacr::UNP_A>(l1_base_idx + t);
+            _llk_unpack_tilize_<p_unpacr::UNP_A>(t + input_tile_index);
         } else {
-            _llk_unpack_tilize_strided_small_faces_<p_unpacr::UNP_A>(tensor_shape, l1_base_idx + t);
+            _llk_unpack_tilize_strided_small_faces_<p_unpacr::UNP_A>(tensor_shape, l1_base_idx + t + input_tile_index);
         }
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -87,7 +87,10 @@ inline void llk_unpack_tilize_block(
     // BLOCK_CT_DIM is currently hardcoded to 1 in tilize_init (see compute/tilize.h), so the MOP
     // emits one SrcA dvalid per invocation. Loop to match the per-tile math consumption same
     // structural pattern as BH/WH llk_unpack_tilize_block
-    const std::uint32_t l1_base_idx = rd_entry_idx * l1_index_per_entry;
+    const std::uint32_t block = input_tile_index / block_c_tiles;
+    const std::uint32_t offset = input_tile_index % block_c_tiles;
+    const std::uint32_t l1_base_idx =
+        rd_entry_idx * l1_index_per_entry + block * (block_c_tiles * tensor_shape.total_row_dim());
 
     if (tensor_shape.total_num_faces() == NUM_FACES) {
         _llk_unpack_tilize_set_src_offset_<p_unpacr::UNP_A>(tensor_shape, l1_base_idx);
@@ -95,9 +98,9 @@ inline void llk_unpack_tilize_block(
 
     for (std::uint32_t t = 0; t < block_c_tiles; t++) {
         if (tensor_shape.total_num_faces() == NUM_FACES) {
-            _llk_unpack_tilize_<p_unpacr::UNP_A>(t + input_tile_index);
+            _llk_unpack_tilize_<p_unpacr::UNP_A>(t + offset);
         } else {
-            _llk_unpack_tilize_strided_small_faces_<p_unpacr::UNP_A>(tensor_shape, l1_base_idx + t + input_tile_index);
+            _llk_unpack_tilize_strided_small_faces_<p_unpacr::UNP_A>(tensor_shape, l1_base_idx + t + offset);
         }
     }
 }

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/untilize.py
@@ -70,4 +70,7 @@ class PackUntilize(Packer):
         )
         l1_row_idx = f"{y_stride} * ({block.block_y} + tile_y) + {block.block_x}"
 
-        return f"_llk_pack_untilize_({block.tile_id_block}, {l1_row_idx});\n"
+        return (
+            f"_llk_pack_untilize_set_dst_offset_({tile_shape.cpp_value}, {l1_row_idx});\n"
+            f"_llk_pack_untilize_({block.tile_id_block}, 0);\n"
+        )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/tilize_a.py
@@ -83,12 +83,15 @@ class UnpackerTilizeA(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
+        tensor_shape = compute_unit.src_a.tile_shape.cpp_value
         num_faces_r_dim = compute_unit.src_a.tile_shape.num_faces_r_dim
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
+        l1_row_idx = f"{block.tile_id_global} * {num_faces_r_dim} * {face_r_dim}"
 
         return (
-            f"_llk_unpack_tilize_<p_unpacr::UNP_A>"
-            f"({block.tile_id_global} * {num_faces_r_dim} * {face_r_dim});\n"
+            f"_llk_unpack_tilize_set_src_offset_<p_unpacr::UNP_A>"
+            f"({tensor_shape}, {l1_row_idx});\n"
+            f"_llk_unpack_tilize_<p_unpacr::UNP_A>(0);\n"
         )
 
     def uninit(

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -313,7 +313,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     // and switches the packer to the other bank.
                     if (tensor_shape.total_num_faces() == NUM_FACES)
                     {
-                        _llk_pack_untilize_(0 /*dest_idx*/, y * y_stride_external);
+                        _llk_pack_untilize_set_dst_offset_(tensor_shape, y * y_stride_external);
+                        _llk_pack_untilize_(0 /*dest_idx*/, 0 /*l1_tile_idx*/);
                     }
                     else
                     {
@@ -331,7 +332,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     if (tensor_shape.total_num_faces() == NUM_FACES)
                     {
-                        _llk_pack_untilize_(0 /*dest_idx*/, y * y_stride_external);
+                        _llk_pack_untilize_set_dst_offset_(tensor_shape, y * y_stride_external);
+                        _llk_pack_untilize_(0 /*dest_idx*/, 0 /*l1_tile_idx*/);
                     }
                     else
                     {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -157,7 +157,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     for (std::uint32_t y = 0; y < BLOCK_RT_DIM; y++)
                     {
-                        _llk_unpack_tilize_block_(y * y_stride_external /*l1_face_idx*/, y * BLOCK_CT_DIM /*dest_tile_idx*/);
+                        _llk_unpack_tilize_set_src_offset_<UNPACKER_ENGINE_SEL>(tensor_shape, y * y_stride_external);
+                        _llk_unpack_tilize_block_(0 /*l1_tile_idx*/, y * BLOCK_CT_DIM /*dest_tile_idx*/);
                     }
                     if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
                     {
@@ -175,7 +176,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     for (std::uint32_t y = 0; y < BLOCK_RT_DIM; y++)
                     {
-                        _llk_unpack_tilize_<UNPACKER_ENGINE_SEL>(y * y_stride_external /*l1_tile_idx*/);
+                        _llk_unpack_tilize_set_src_offset_<UNPACKER_ENGINE_SEL>(tensor_shape, y * y_stride_external);
+                        _llk_unpack_tilize_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/);
                     }
                 }
             }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -19,17 +19,17 @@ using namespace ckernel;
  *
  * The Z counter walks tiles across a single row of tiles, but it does not advance between rows. To untilize more than
  * one row of tiles, program this register to account for the offset of every row already completed. The offset is
- * in units of datums, so it is the number of datums in a row of tiles.
+ * in units of 16 datums (one face row), so it is the number of face rows in a row of tiles.
  *
  * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
- * @param l1_base_idx: Offset of the current row of tiles, scaled to datums here.
+ * @param l1_base_idx: Offset of the current row of tiles.
  * @note Call this once per row of tiles, before the @ref _llk_pack_untilize_ call that writes that row.
  */
 inline void _llk_pack_untilize_set_dst_offset_(const TensorShape& tensor_shape, const std::uint32_t l1_base_idx)
 {
-    const std::uint32_t dst_addr_offset_datums = l1_base_idx * tensor_shape.num_faces_c_dim;
+    const std::uint32_t dst_addr_offset_face_rows = l1_base_idx * tensor_shape.num_faces_c_dim;
 
-    cfg_rmw(THCON_PACKER0_REG0_UNTILIZE_DST_ADDR_OFFSET_RMW, dst_addr_offset_datums);
+    cfg_rmw(THCON_PACKER0_REG0_UNTILIZE_DST_ADDR_OFFSET_RMW, dst_addr_offset_face_rows);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -8,10 +8,29 @@
 
 #include "ckernel_trisc_common.h"
 #include "cpack_common.h"
+#include "llk_assert.h"
 #include "llk_pack_common.h"
 #include "tensor_shape.h"
 
 using namespace ckernel;
+
+/**
+ * @brief Sets the L1 destination offset that carries untilize past each completed row of tiles.
+ *
+ * The Z counter walks tiles across a single row of tiles, but it does not advance between rows. To untilize more than
+ * one row of tiles, program this register to account for the offset of every row already completed. The offset is
+ * in units of datums, so it is the number of datums in a row of tiles.
+ *
+ * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
+ * @param l1_base_idx: Offset of the current row of tiles, scaled to datums here.
+ * @note Call this once per row of tiles, before the @ref _llk_pack_untilize_ call that writes that row.
+ */
+inline void _llk_pack_untilize_set_dst_offset_(const TensorShape& tensor_shape, const std::uint32_t l1_base_idx)
+{
+    const std::uint32_t dst_addr_offset_datums = l1_base_idx * tensor_shape.num_faces_c_dim;
+
+    cfg_rmw(THCON_PACKER0_REG0_UNTILIZE_DST_ADDR_OFFSET_RMW, dst_addr_offset_datums);
+}
 
 /**
  * @brief Builds the MOP for pack untilize of contiguous tiles; works only with Packer 0.
@@ -73,7 +92,8 @@ inline void _llk_pack_untilize_init_(const std::uint8_t buf_desc_id, const Tenso
  * @brief Packs out tiles and untilizes them; always uses Packer 0 for untilize.
  *
  * @param dest_idx: Index into the DEST register for a tile.
- * @param l1_tile_idx: Index into the L1 buffer for a tile.
+ * @param l1_tile_idx: Within-row column index into the L1 buffer. The L1 base is carried by
+ *        @ref _llk_pack_untilize_set_dst_offset_, which the caller must set for the tile row.
  * @note Call @ref _llk_pack_untilize_init_ with matching template args before this function.
  */
 inline void _llk_pack_untilize_(const std::uint32_t dest_idx, const std::uint32_t l1_tile_idx)
@@ -86,6 +106,11 @@ inline void _llk_pack_untilize_(const std::uint32_t dest_idx, const std::uint32_
         (dest_register_offset == ckernel::trisc::DEST_REGISTER_HALF_SIZE) ? ckernel::DEST_NUM_TILES_FP16_HALF : ckernel::DEST_NUM_TILES_FP16_HALF >> 1;
     const std::uint32_t dest_reg_offset_idx = (dest_register_offset == 0) ? 0 : dest_bank1_offset_idx;
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, p_pacr::PACK0, dest_reg_offset_idx + dest_idx);
+
+    // The value field of the TT_SET_DST_TILE_FACE_ROW_IDX instruction is 18 bits wide, but only values up to 11 bits are actually
+    // passed on when using FACE_SEL; anything larger is truncated and aliases back to an earlier tile.
+    LLK_ASSERT(l1_tile_idx < (1u << 11), "l1_tile_idx exceeds the 11 bits the dst face index can carry");
+
     TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, p_pacr::PACK0, l1_tile_idx);
     // Runs MOP
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -29,6 +29,8 @@ inline void _llk_pack_untilize_set_dst_offset_(const TensorShape& tensor_shape, 
 {
     const std::uint32_t dst_addr_offset_face_rows = l1_base_idx * tensor_shape.num_faces_c_dim;
 
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, 0, p_stall::PACK0);
+
     cfg_rmw(THCON_PACKER0_REG0_UNTILIZE_DST_ADDR_OFFSET_RMW, dst_addr_offset_face_rows);
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -29,8 +29,6 @@ inline void _llk_pack_untilize_set_dst_offset_(const TensorShape& tensor_shape, 
 {
     const std::uint32_t dst_addr_offset_face_rows = l1_base_idx * tensor_shape.num_faces_c_dim;
 
-    TTI_STALLWAIT(p_stall::STALL_CFG, 0, 0, p_stall::PACK0);
-
     cfg_rmw(THCON_PACKER0_REG0_UNTILIZE_DST_ADDR_OFFSET_RMW, dst_addr_offset_face_rows);
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -127,11 +127,9 @@ inline void _llk_unpack_tilize_(const std::uint32_t l1_tile_idx)
     // UNP_DEST shares UNP_A's hardware path, so use UNP_A for counter instructions
     constexpr std::uint32_t CNT_SEL = (UNP_SEL == p_unpacr::UNP_DEST) ? p_unpacr::UNP_A : UNP_SEL;
 
-    constexpr std::uint32_t STALL_UNP_RES = (CNT_SEL == p_unpacr::UNP_A) ? p_stall::UNPACK0 : p_stall::UNPACK1;
-    TTI_STALLWAIT(p_stall::STALL_CFG, 0, 0, STALL_UNP_RES);
-
     const std::uint32_t src_addr_offset_datums =
-        l1_tile_idx * (TILE_C_DIM / FACE_C_DIM); // should be tensor_shape.num_faces_c_dim, but it is not available here yet
+        l1_tile_idx *
+        (TILE_C_DIM / FACE_C_DIM); // should be tensor_shape.num_faces_c_dim, but it is not available here yet, this will work only for 32x32 tiles
     if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
     {
         cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -18,25 +18,25 @@ using namespace ckernel;
  *
  * The Z counter walks tiles across a single row of tiles, but it does not advance between rows. To tilize more than
  * one row of tiles, program this register to account for the offset of every row already completed. The offset is
- * in units of datums, so it is the number of datums in a row of tiles.
+ * in units of 16 datums (one face row), so it is the number of face rows in a row of tiles.
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
  * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
- * @param l1_base_idx: Offset of the current row of tiles, scaled to datums here.
+ * @param l1_base_idx: Offset of the current row of tiles.
  * @note Call this once per row of tiles, before the @ref _llk_unpack_tilize_ calls that tilize that row.
  */
 template <std::uint32_t UNP_SEL>
 inline void _llk_unpack_tilize_set_src_offset_(const TensorShape& tensor_shape, const std::uint32_t l1_base_idx)
 {
-    const std::uint32_t src_addr_offset_datums = l1_base_idx * tensor_shape.num_faces_c_dim;
+    const std::uint32_t src_addr_offset_face_rows = l1_base_idx * tensor_shape.num_faces_c_dim;
 
     if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
     {
-        cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
+        cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_face_rows);
     }
     else
     {
-        cfg_rmw(THCON_UNPACKER1_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
+        cfg_rmw(THCON_UNPACKER1_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_face_rows);
     }
 }
 
@@ -140,7 +140,8 @@ inline void _llk_unpack_tilize_init_(
  * @brief Unpacks and tilizes a single full 32x32 tile; works for UNP_A, UNP_B, UNP_DEST.
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
- * @param l1_tile_idx: Index into the L1 buffer for a tile.
+ * @param l1_tile_idx: Within-row column index into the L1 buffer. The L1 base is carried by
+ *        @ref _llk_unpack_tilize_set_src_offset_, which the caller must set for the tile row.
  * @note Call @ref _llk_unpack_tilize_init_ with matching template args before this function.
  */
 template <std::uint32_t UNP_SEL>
@@ -238,7 +239,8 @@ inline void _llk_unpack_tilize_block_init_(const std::uint32_t buf_desc_id, cons
  * DST_Z_STRIDE=NUM_FACES). Call once per tile row, then call @ref _llk_unpack_dest_dvalid_section_done_
  * after all rows.
  *
- * @param l1_tile_idx: Index into the L1 buffer for the start of the current tile row.
+ * @param l1_tile_idx: Within-row column index into the L1 buffer. The L1 base is carried by
+ *        @ref _llk_unpack_tilize_set_src_offset_, which the caller must set for the tile row.
  * @param dest_tile_idx: Tile index within DEST for the first tile of this row.
  * @note Call @ref _llk_unpack_tilize_block_init_ before this function to program the MOP.
  */

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -8,9 +8,37 @@
 
 #include "ckernel_trisc_common.h"
 #include "cunpack_common.h"
+#include "llk_assert.h"
 #include "llk_unpack_common.h"
 #include "tensor_shape.h"
 using namespace ckernel;
+
+/**
+ * @brief Sets the L1 source offset that carries tilize past each completed row of tiles.
+ *
+ * The Z counter walks tiles across a single row of tiles, but it does not advance between rows. To tilize more than
+ * one row of tiles, program this register to account for the offset of every row already completed. The offset is
+ * in units of datums, so it is the number of datums in a row of tiles.
+ *
+ * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
+ * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
+ * @param l1_base_idx: Offset of the current row of tiles, scaled to datums here.
+ * @note Call this once per row of tiles, before the @ref _llk_unpack_tilize_ calls that tilize that row.
+ */
+template <std::uint32_t UNP_SEL>
+inline void _llk_unpack_tilize_set_src_offset_(const TensorShape& tensor_shape, const std::uint32_t l1_base_idx)
+{
+    const std::uint32_t src_addr_offset_datums = l1_base_idx * tensor_shape.num_faces_c_dim;
+
+    if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
+    {
+        cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
+    }
+    else
+    {
+        cfg_rmw(THCON_UNPACKER1_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
+    }
+}
 
 /**
  * @brief Builds the MOP for unpack tilize of full 32x32 tiles using the fused HW instruction.
@@ -18,12 +46,12 @@ using namespace ckernel;
  * Unpacks and tilizes block_ct_dim tiles per invocation; works for SrcA/B and DEST.
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
- * @tparam IS_32b_DEST_EN: Enables using the math destination register in 32-bit mode, values = <true/false>
+ * @tparam EN_32BIT_DEST: Enables using the math destination register in 32-bit mode, values = <true/false>
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  *        stored in the buffer descriptor table, values = 0 - 16
  * @param block_ct_dim: Number of tiles unpacked per MOP invocation (MOP inner loop length).
  */
-template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
+template <std::uint32_t UNP_SEL, bool EN_32BIT_DEST>
 inline void _llk_unpack_tilize_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t block_ct_dim)
 {
     static_assert(
@@ -43,7 +71,7 @@ inline void _llk_unpack_tilize_mop_config_(const std::uint32_t buf_desc_id, cons
 
     // This path is exclusively for FP32 datacopy via math thread (ELWADD on SrcA+SrcB),
     // not for UNP_DEST where data goes directly to DEST without involving the math thread.
-    if constexpr (IS_32b_DEST_EN && (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_B))
+    if constexpr (EN_32BIT_DEST && (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_B))
     {
         // FP32 datacopy uses ELWADD, which requires dvalid from both SrcA and SrcB
         // Set dvalid for the opposite unpacker (if using UNP_A, set dvalid for UNP_B and vice versa)
@@ -69,7 +97,7 @@ inline void _llk_unpack_tilize_mop_config_(const std::uint32_t buf_desc_id, cons
  * programs the MOP.
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
- * @tparam IS_32b_DEST_EN: Enables using the math destination register in 32-bit mode, values = <true/false>
+ * @tparam EN_32BIT_DEST: Enables using the math destination register in 32-bit mode, values = <true/false>
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  *        stored in the buffer descriptor table, values = 0 - 16
  * @param full_ct_dim: Number of tiles in a row of the input tensor. Input tensor is row-major format. R_DIM not implemented yet.
@@ -79,7 +107,7 @@ inline void _llk_unpack_tilize_mop_config_(const std::uint32_t buf_desc_id, cons
  * with
  *       @ref _llk_pack_init_ (T2). @ref _llk_unpack_tilize_ is the matching execute call on this thread.
  */
-template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
+template <std::uint32_t UNP_SEL, bool EN_32BIT_DEST>
 inline void _llk_unpack_tilize_init_(
     const std::uint32_t buf_desc_id, const std::uint32_t full_ct_dim, const std::uint32_t block_ct_dim, const TensorShape& tensor_shape)
 {
@@ -105,7 +133,7 @@ inline void _llk_unpack_tilize_init_(
         cfg[THCON_UNPACKER1_REG1_UNPACK_TILIZE_SRC_Z_STRIDE_ADDR32] = unpk_cfg.val[0];
         cfg[THCON_UNPACKER1_REG2_UNPACK_STRIDE_OFFSET_0_ADDR32]     = unpk_cfg.val[2];
     }
-    _llk_unpack_tilize_mop_config_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, block_ct_dim);
+    _llk_unpack_tilize_mop_config_<UNP_SEL, EN_32BIT_DEST>(buf_desc_id, block_ct_dim);
 }
 
 /**
@@ -127,18 +155,11 @@ inline void _llk_unpack_tilize_(const std::uint32_t l1_tile_idx)
     // UNP_DEST shares UNP_A's hardware path, so use UNP_A for counter instructions
     constexpr std::uint32_t CNT_SEL = (UNP_SEL == p_unpacr::UNP_DEST) ? p_unpacr::UNP_A : UNP_SEL;
 
-    const std::uint32_t src_addr_offset_datums =
-        l1_tile_idx *
-        (TILE_C_DIM / FACE_C_DIM); // should be tensor_shape.num_faces_c_dim, but it is not available here yet, this will work only for 32x32 tiles
-    if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
-    {
-        cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
-    }
-    else
-    {
-        cfg_rmw(THCON_UNPACKER1_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
-    }
-    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, CNT_SEL, 0);
+    // The value field of the TT_SET_SRC_TILE_FACE_ROW_IDX instruction is 18 bits wide, but only values up to 11 bits are actually
+    // passed on when using FACE_SEL; anything larger is truncated and aliases back to an earlier tile.
+    LLK_ASSERT(l1_tile_idx < (1u << 11), "l1_tile_idx exceeds the 11 bits the src face index can carry");
+
+    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, CNT_SEL, l1_tile_idx);
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CNT_SEL, 0);
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, CNT_SEL, 0); // Clear face counter (block path leaves it non-zero)
 
@@ -217,14 +238,18 @@ inline void _llk_unpack_tilize_block_init_(const std::uint32_t buf_desc_id, cons
  * DST_Z_STRIDE=NUM_FACES). Call once per tile row, then call @ref _llk_unpack_dest_dvalid_section_done_
  * after all rows.
  *
- * @param l1_face_idx: Face-level index into the L1 buffer for the start of this tile row.
+ * @param l1_tile_idx: Index into the L1 buffer for the start of the current tile row.
  * @param dest_tile_idx: Tile index within DEST for the first tile of this row.
  * @note Call @ref _llk_unpack_tilize_block_init_ before this function to program the MOP.
  */
-inline void _llk_unpack_tilize_block_(const std::uint32_t l1_face_idx, const std::uint32_t dest_tile_idx)
+inline void _llk_unpack_tilize_block_(const std::uint32_t l1_tile_idx, const std::uint32_t dest_tile_idx)
 {
+    // The value field of the TT_SET_SRC_TILE_FACE_ROW_IDX instruction is 18 bits wide, but only values up to 11 bits are actually
+    // passed on when using FACE_SEL; anything larger is truncated and aliases back to an earlier tile.
+    LLK_ASSERT(l1_tile_idx < (1u << 11), "l1_tile_idx exceeds the 11 bits the src face index can carry");
+
     // UNP_DEST shares UNP_A's counter hardware.
-    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, p_unpacr::UNP_A, l1_face_idx);
+    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, p_unpacr::UNP_A, l1_tile_idx);
     // UNPACR_TILIZE Z counter controls DEST positioning; DST_Z_STRIDE=total_num_faces so each
     // Z unit = one tile.  Reset face counter to dest_tile_idx so the first tile in this row
     // lands at the correct DEST slot.
@@ -239,13 +264,13 @@ inline void _llk_unpack_tilize_block_(const std::uint32_t l1_face_idx, const std
  * Unpacks half a face with the strided instruction and increments the L1 counter.
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
- * @tparam IS_32b_DEST_EN: Enables using the math destination register in 32-bit mode, values = <true/false>
+ * @tparam EN_32BIT_DEST: Enables using the math destination register in 32-bit mode, values = <true/false>
  * @tparam FULL_CT_DIM: Number of tiles in a row of the input tensor (row-major).
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  *        stored in the buffer descriptor table, values = 0 - 16
  * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
  */
-template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN, std::uint32_t FULL_CT_DIM>
+template <std::uint32_t UNP_SEL, bool EN_32BIT_DEST, std::uint32_t FULL_CT_DIM>
 inline void _llk_unpack_tilize_strided_mop_config_(const std::uint32_t buf_desc_id, const TensorShape& tensor_shape)
 {
     static_assert(
@@ -272,14 +297,14 @@ inline void _llk_unpack_tilize_strided_mop_config_(const std::uint32_t buf_desc_
  * @brief Initializes the unpacker with stride values for strided tilize of 32x32 or 16x32 tiles.
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
- * @tparam IS_32b_DEST_EN: Enables using the math destination register in 32-bit mode, values = <true/false>
+ * @tparam EN_32BIT_DEST: Enables using the math destination register in 32-bit mode, values = <true/false>
  * @tparam FULL_CT_DIM: Number of tiles in a row of the input tensor. Input tensor is row-major format. R_DIM not implemented yet.
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  *        stored in the buffer descriptor table, values = 0 - 16
  * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
  * @note @ref _llk_unpack_tilize_strided_ is the matching execute call on this thread.
  */
-template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN, std::uint32_t FULL_CT_DIM>
+template <std::uint32_t UNP_SEL, bool EN_32BIT_DEST, std::uint32_t FULL_CT_DIM>
 inline void _llk_unpack_tilize_strided_init_(const std::uint32_t buf_desc_id, const TensorShape& tensor_shape)
 {
     if constexpr (UNP_SEL == p_unpacr::UNP_A)
@@ -296,8 +321,8 @@ inline void _llk_unpack_tilize_strided_init_(const std::uint32_t buf_desc_id, co
         cfg_rmw(THCON_UNPACKER1_REG1_UNPACK_STRIDE_VAL_SOURCE_RMW, 0);
         cfg_rmw(THCON_UNPACKER1_REG2_UNPACK_STRIDE_OFFSET_0_RMW, FULL_CT_DIM * tensor_shape.num_faces_c_dim);
     }
-    _llk_unpack_tilize_strided_mop_config_<UNP_SEL, IS_32b_DEST_EN, FULL_CT_DIM>(buf_desc_id, tensor_shape); // TODO: This throws a compile time error for UPK
-                                                                                                             // but not PCK - why?
+    _llk_unpack_tilize_strided_mop_config_<UNP_SEL, EN_32BIT_DEST, FULL_CT_DIM>(buf_desc_id, tensor_shape); // TODO: This throws a compile time error for UPK
+                                                                                                            // but not PCK - why?
 }
 
 /**
@@ -305,12 +330,12 @@ inline void _llk_unpack_tilize_strided_init_(const std::uint32_t buf_desc_id, co
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
  * @tparam FULL_CT_DIM: Number of tiles in a row of the input tensor. Input tensor is row-major format. R_DIM not implemented yet.
- * @tparam IS_32b_DEST_EN: Enables using the math destination register in 32-bit mode, values = <true/false>
+ * @tparam EN_32BIT_DEST: Enables using the math destination register in 32-bit mode, values = <true/false>
  * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
  * @param l1_tile_idx: c_dim index of the tile in L1.
  * @note Call @ref _llk_unpack_tilize_strided_init_ before this function to program the MOP.
  */
-template <std::uint32_t UNP_SEL, std::uint32_t FULL_CT_DIM, bool IS_32b_DEST_EN>
+template <std::uint32_t UNP_SEL, std::uint32_t FULL_CT_DIM, bool EN_32BIT_DEST>
 inline void _llk_unpack_tilize_strided_(const TensorShape& tensor_shape, const std::uint32_t l1_tile_idx)
 {
     const std::uint32_t f1_row_idx =
@@ -344,11 +369,11 @@ inline void _llk_unpack_tilize_strided_(const TensorShape& tensor_shape, const s
             UNP_SEL,
             l1_tile_idx * tensor_shape.num_faces_c_dim + tensor_shape.num_faces_c_dim * tensor_shape.face_r_dim * FULL_CT_DIM + 1);
     }
-    if constexpr (UNP_SEL == p_unpacr::UNP_A && IS_32b_DEST_EN)
+    if constexpr (UNP_SEL == p_unpacr::UNP_A && EN_32BIT_DEST)
     { // TODO pgardner: I don't think I'll need this for float32 dest
         TTI_UNPACR_NOP(p_unpacr::UNP_B, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*clear to 0*/);
     }
-    else if constexpr (UNP_SEL == p_unpacr::UNP_B && IS_32b_DEST_EN)
+    else if constexpr (UNP_SEL == p_unpacr::UNP_B && EN_32BIT_DEST)
     {
         TTI_UNPACR_NOP(p_unpacr::UNP_A, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*clear to 0*/);
     }
@@ -373,18 +398,18 @@ inline void _llk_unpack_tilize_strided_(const TensorShape& tensor_shape, const s
  * Unpacks half a face with the strided instruction and increments the L1 counter.
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
- * @tparam IS_32b_DEST_EN: Enables using the math destination register in 32-bit mode, values = <true/false>
+ * @tparam EN_32BIT_DEST: Enables using the math destination register in 32-bit mode, values = <true/false>
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
             stored in the buffer descriptor table, values = 0 - 16
  * @param block_ct_dim: Number of tiles in a row of a block.
  */
-template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
+template <std::uint32_t UNP_SEL, bool EN_32BIT_DEST>
 inline void _llk_unpack_tilize_strided_mop_config_small_faces_(const std::uint32_t buf_desc_id, const std::uint32_t block_ct_dim)
 {
     static_assert(
         (UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B) || (UNP_SEL == p_unpacr::UNP_DEST),
         "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B/UNP_DEST");
-    static_assert(!(IS_32b_DEST_EN && UNP_SEL != p_unpacr::UNP_A), "If IS_32b_DEST_EN then UNP_SEL should be UNP_A");
+    static_assert(!(EN_32BIT_DEST && UNP_SEL != p_unpacr::UNP_A), "If EN_32BIT_DEST then UNP_SEL should be UNP_A");
 
     constexpr std::uint32_t MOP_OUTER_LOOP = 1;
     const std::uint32_t MOP_INNER_LOOP     = block_ct_dim;
@@ -411,7 +436,7 @@ inline void _llk_unpack_tilize_strided_mop_config_small_faces_(const std::uint32
             });
     }
 
-    if constexpr (IS_32b_DEST_EN)
+    if constexpr (EN_32BIT_DEST)
     {
         constexpr std::uint32_t OPPOSITE_UNP                      = (UNP_SEL == p_unpacr::UNP_B) ? p_unpacr::UNP_A : p_unpacr::UNP_B;
         constexpr static std::uint32_t set_opposite_dvalid_instrn = TT_OP_UNPACR_NOP(OPPOSITE_UNP, 1 /*Dvalid*/, 0, 0, 0 /*clear to 0*/, 0 /*UNP_CLR_SRC*/);
@@ -429,7 +454,7 @@ inline void _llk_unpack_tilize_strided_mop_config_small_faces_(const std::uint32
  * @brief Initializes the unpacker with stride values for strided tilize of small tiles (8x32, 4x32, 2x32, 1x32).
  *
  * @tparam UNP_SEL: Selects which unpacker resource to use, values = <p_unpacr::UNP_A/UNP_B/UNP_DEST>
- * @tparam IS_32b_DEST_EN: Enables using the math destination register in 32-bit mode, values = <true/false>
+ * @tparam EN_32BIT_DEST: Enables using the math destination register in 32-bit mode, values = <true/false>
  * @param buf_desc_id: The buffer descriptor ID where the buffer information is
  *        stored in the buffer descriptor table, values = 0 - 16
  * @param tensor_shape: Tile shape info: num faces, face row/col dim, etc.
@@ -437,7 +462,7 @@ inline void _llk_unpack_tilize_strided_mop_config_small_faces_(const std::uint32
  * @param block_ct_dim: Number of tiles in a row of a block.
  * @note @ref _llk_unpack_tilize_strided_small_faces_ is the matching execute call on this thread.
  */
-template <std::uint32_t UNP_SEL, bool IS_32b_DEST_EN>
+template <std::uint32_t UNP_SEL, bool EN_32BIT_DEST>
 inline void _llk_unpack_tilize_strided_init_small_faces_(
     const std::uint32_t buf_desc_id, const TensorShape& tensor_shape, const std::uint32_t full_ct_dim, const std::uint32_t block_ct_dim)
 {
@@ -455,7 +480,7 @@ inline void _llk_unpack_tilize_strided_init_small_faces_(
         cfg_rmw(THCON_UNPACKER1_REG2_UNPACK_STRIDE_OFFSET_0_RMW, full_ct_dim * tensor_shape.num_faces_c_dim);
     }
 
-    _llk_unpack_tilize_strided_mop_config_small_faces_<UNP_SEL, IS_32b_DEST_EN>(buf_desc_id, block_ct_dim);
+    _llk_unpack_tilize_strided_mop_config_small_faces_<UNP_SEL, EN_32BIT_DEST>(buf_desc_id, block_ct_dim);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -126,7 +126,21 @@ inline void _llk_unpack_tilize_(const std::uint32_t l1_tile_idx)
     // Set Source counter to L1 base + offset
     // UNP_DEST shares UNP_A's hardware path, so use UNP_A for counter instructions
     constexpr std::uint32_t CNT_SEL = (UNP_SEL == p_unpacr::UNP_DEST) ? p_unpacr::UNP_A : UNP_SEL;
-    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, CNT_SEL, l1_tile_idx);
+
+    constexpr std::uint32_t STALL_UNP_RES = (CNT_SEL == p_unpacr::UNP_A) ? p_stall::UNPACK0 : p_stall::UNPACK1;
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, 0, STALL_UNP_RES);
+
+    const std::uint32_t src_addr_offset_datums =
+        l1_tile_idx * (TILE_C_DIM / FACE_C_DIM); // should be tensor_shape.num_faces_c_dim, but it is not available here yet
+    if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
+    {
+        cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
+    }
+    else
+    {
+        cfg_rmw(THCON_UNPACKER1_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_datums);
+    }
+    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, CNT_SEL, 0);
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CNT_SEL, 0);
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, CNT_SEL, 0); // Clear face counter (block path leaves it non-zero)
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -30,6 +30,9 @@ inline void _llk_unpack_tilize_set_src_offset_(const TensorShape& tensor_shape, 
 {
     const std::uint32_t src_addr_offset_face_rows = l1_base_idx * tensor_shape.num_faces_c_dim;
 
+    constexpr std::uint32_t WAIT_UNP_RES = (UNP_SEL == p_unpacr::UNP_B) ? p_stall::UNPACK1 : p_stall::UNPACK0;
+    TTI_STALLWAIT(p_stall::STALL_CFG, 0, 0, WAIT_UNP_RES);
+
     if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
     {
         cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_face_rows);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_tilize.h
@@ -30,9 +30,6 @@ inline void _llk_unpack_tilize_set_src_offset_(const TensorShape& tensor_shape, 
 {
     const std::uint32_t src_addr_offset_face_rows = l1_base_idx * tensor_shape.num_faces_c_dim;
 
-    constexpr std::uint32_t WAIT_UNP_RES = (UNP_SEL == p_unpacr::UNP_B) ? p_stall::UNPACK1 : p_stall::UNPACK0;
-    TTI_STALLWAIT(p_stall::STALL_CFG, 0, 0, WAIT_UNP_RES);
-
     if constexpr (UNP_SEL == p_unpacr::UNP_A || UNP_SEL == p_unpacr::UNP_DEST)
     {
         cfg_rmw(THCON_UNPACKER0_REG0_TILIZE_SRC_ADDR_OFFSET_RMW, src_addr_offset_face_rows);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -219,7 +219,8 @@ std::vector<CBInfo> get_cb_info(
     const bool depthwise_dest_reuse_scratch = is_1d_depthwise_conv &&
                                               sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED &&
                                               !coalesce_1d_depthwise_kw_reads && num_blocks_act_h > 1;
-    const bool partials_use_output_cb = !untilize_out && partial_dtype == output_datatype && !is_1d_depthwise_conv;
+    const bool partials_use_output_cb = !untilize_out && partial_dtype == output_datatype && !is_1d_depthwise_conv &&
+                                        tt::tt_metal::hal::get_arch() != tt::ARCH::QUASAR;
     // This must match the compute kernel's out_block_num_tiles. Both factories pass one full per-core output-width
     // block to compute, so dedicated partials storage is exactly one output block reused through ordinary CB FIFO
     // wraparound. When formats allow output aliasing, only the final block of the existing output allocation is used.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -610,17 +610,9 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     const uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
     const uint32_t weight_block_w_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
     const uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntile;
-    // WORKAROUND (Quasar), from sjovic/quasar-resnet 057e1792f0a: force out_subblock to 1x1. The Quasar
-    // compute dest-sync (MATH_PACK / SrcA handshake) in conv_bmm_tilize_metal2 deadlocks the three compute
-    // threads whenever the matmul_partials spill/reload handles more than one tile per subblock
-    // (out_subblock_num_tiles > 1). Constraining to 1x1 makes partials flow one tile at a time so the
-    // compute pipeline drains. Verified there: the resnet stem conv passes single-core AND full 32-core
-    // (was hanging). Applies to every conv this factory builds (stem + bottleneck 3x3), so it also covers
-    // the L1-path convs a DRAM slice_config cannot reach. Gated to Quasar; WH/BH keep the tuned subblock.
-    // Remove once the LLK dest-sync limitation is fixed (tt-metal #48679 / tt-llk #48504).
     const bool arch_is_quasar = device->arch() == tt::ARCH::QUASAR;
-    const uint32_t out_subblock_h_ntiles = arch_is_quasar ? 1 : block_config.out_subblock_h_ntiles;
-    const uint32_t out_subblock_w_ntiles = arch_is_quasar ? 1 : block_config.out_subblock_w_ntiles;
+    const uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
+    const uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
     const SkipMcast skip_mcast = conv_skip_mcast(parallelization_config, a.memory_config().memory_layout());
     const bool skip_activation_mcast = skip_mcast.skip_activation_mcast;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1135,17 +1135,7 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
 
     const uint32_t tilized_act_tile_size = tt::tile_size(tilized_act_df);
 
-    // Only enable packer l1 accumulation when there are in0_num_blocks_w > 2.
-    // QSR: the Quasar hardware packer-L1-accumulate pack path (PACR0_TILE_INC in-place accumulate combined
-    // with the QSR_RESTORE_WR / g_dfb ring rewind between K-blocks) mis-addresses the matmul_partials CB and
-    // overruns it -> OOB L1 write -> ERROR_TRISC1 fault on the pack thread (opcode 0x19 = PACR0_TILE_INC).
-    // Unlike WH/BH (address derived from fifo_wr_ptr), Quasar's packer DST_TILE_FACE_ROW_IDX counter is not
-    // resynced to the rewound descriptor. Force off so K-accumulation goes through the FPU-reload path
-    // (copy_block reload + re-accumulate), which IS ported/validated on Quasar. This only
-    // drops a perf optimization; correctness is preserved. Remove once the LLK packer-L1-acc + ring-rewind
-    // counter resync is fixed. (This factory is Quasar-only, so no arch guard is needed.)
-    const bool packer_l1_acc_en = false;
-    (void)ttnn::prim::determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
+    const bool packer_l1_acc_en = ttnn::prim::determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
     const uint32_t batch = sliding_window_config.get_output_shape()[0];
     const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
     const uint32_t output_image_height = sliding_window_config.get_output_shape()[1];
@@ -1252,8 +1242,8 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
 
     // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
     const bool partials_cb_uses_output =
-        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
-    log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
+        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated &&
+        !arch_is_quasar;
 
     const bool reader_indices_globally_allocated =
         get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).is_globally_allocated;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1242,8 +1242,8 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
 
     // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
     const bool partials_cb_uses_output =
-        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated &&
-        !arch_is_quasar;
+        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+    log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
 
     const bool reader_indices_globally_allocated =
         get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).is_globally_allocated;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -34,6 +34,7 @@
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "api/debug/dprint.h"
 
 // In-place matmul-partials accumulate: re-accumulate each inner-K block into the SAME L1 region by
 // "rewinding" the partials buffer's producer/consumer position back to the start of the output block.
@@ -428,8 +429,10 @@ void kernel_main() {
     });
 #endif
 
+    DPRINT("enter nh={} nw={} n1w={}\n", in0_num_blocks_h, in0_num_blocks_w, in1_num_blocks_w);
     compute_kernel_hw_startup<SrcOrder::Reverse>(mm_in0_cb_id, in1_cb_id, out_cb_id);
     matmul_block_init(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+    DPRINT("hwok\n");
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
@@ -440,7 +443,7 @@ void kernel_main() {
             bool enable_reload = false;
 
             if constexpr (pack_relu) {
-                PACK((llk_pack_relu_config(ReluConfig::none())));
+                pack_relu_config(ReluConfig::none());
             }
             if constexpr (partials_cb_uses_output) {
                 UNPACK(RESAVE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials);)
@@ -449,6 +452,7 @@ void kernel_main() {
             uint32_t curr_matmul_out_cb = matmul_partials_cb;
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
                 bool last_inner_dim_block = (in0_block_w_i == in0_num_blocks_w - 1);
+                DPRINT("loop h={} k={}\n", in0_block_h_i, in0_block_w_i);
                 // TRISC1) so the LAST BS* line in that file before the 0x19 pins the stall point:
                 //   BSLOOP present but no "mmin0-ok" -> stuck in cb_mm_in0.wait_front (tilized act never
                 //     delivered by the mcast reader / tilize never completed for this K-block).
@@ -459,7 +463,7 @@ void kernel_main() {
                     if (in0_block_w_i % in0_nblocks_w_tilize == 0) {
                         if constexpr (pack_relu && !fuse_bias) {
                             if (last_inner_dim_block) {
-                                PACK((llk_pack_relu_config(ReluConfig::none())));
+                                pack_relu_config(ReluConfig::none());
                             }
                         }
                         if constexpr (packer_l1_acc) {
@@ -467,14 +471,7 @@ void kernel_main() {
                             pack_reconfig_l1_acc(0);
                         }
 #ifdef ARCH_QUASAR
-                        // [#48552] Re-seed MATH/PACK sync + repoint the pack BD before the block-sharded tilize
-                        // (matmul->tilize). This fixed the tilize side (207 blocks OK). NOTE: the dvalid scrub
-                        // (llk_math_set_dvalid) was tried here AND before the matmul and did NOT help the 0x19 --
-                        // the fault is the SyncFull single-DEST-section datacopy<->pack MOP collision (see
-                        // conv2d_op_sharded_program_factory.cpp #47797 notes), not a stale dvalid.
-                        MATH((llk_math_pack_sync_init()));
-                        PACK((llk_pack_init(tilized_in0_cb_id)));
-                        PACK((llk_pack_dest_init()));
+                        pack_init(tilized_in0_cb_id);
 #endif
                         tilize_in<
                             in0_block_w,
@@ -496,7 +493,7 @@ void kernel_main() {
                 } else {
                     if constexpr (pack_relu && !fuse_bias) {
                         if (last_inner_dim_block) {
-                            PACK((llk_pack_relu_config(ReluConfig::none())));
+                            pack_relu_config(ReluConfig::none());
                         }
                     }
                     if constexpr (packer_l1_acc) {
@@ -504,73 +501,13 @@ void kernel_main() {
                         pack_reconfig_l1_acc(0);
                     }
 #ifdef ARCH_QUASAR
-                    // ROOT CAUSE (proven via MMBLK-absent + tile-index>obnt localization): on Quasar the plain
-                    // `tilize_init` (tilize.h:63-69) does ONLY unpack+math init and omits ALL pack config --
-                    // unlike the non-Quasar branch (:106-108), BH (:60-62), which all call llk_pack_hw_configure(ocb) +
-                    // llk_pack_init(ocb). So the tilize's pack BUFFER DESCRIPTOR is never pointed at
-                    // tilized_in0 -- it keeps the stale dfb::out base from compute_kernel_hw_startup, and the
-                    // tilize packs tilized_in0's tiles into the OUT L1 region -> PACR0_TILE_INC / ERROR_TRISC1
-                    // OOB (fires BEFORE the matmul pack). A prior workaround called only llk_pack_init here
-                    // (sets the MOP buf_desc_id) but NOT llk_pack_hw_configure (which programs the BD BASE),
-                    // so the BD base stayed stale. UPDATE (pool cross-check 2026-07-14): re-running
-                    // llk_pack_hw_configure PER K-block is the "hw_configure is one-time" corruption that caused
-                    // an UNPACKER fault in the Quasar pool -- and is the likely cause of the residual t=4
-                    // DEST-bank fault here (state corruption surfacing after a bank rotation, NOT an LLK bug).
-                    // The one-time pack hw_configure already ran pre-loop at compute_kernel_hw_startup. Drop the
-                    // per-block hw_configure; llk_pack_init repoints the pack BD (the per-use-safe call the pool
-                    // relies on per c-block). If this regresses to the earlier t=1 tilize OOB (stale BD base),
-                    // the proper fix is to set the pack BD base ONCE in tilize.h's Quasar tilize_init.
-                    // Quasar-only: re-seed the MATH<->PACK DEST semaphore + dest-bank phase for the tilize.
-                    // Quasar's DEST handshake is a MATH_PACK-semaphore workaround (dest-dvalid gap); the plain
-                    // Quasar tilize_init omits llk_math_pack_sync_init, so the tilize inherits the matmul's
-                    // stale semaphore count / bank phase -> MATH issues its datacopy MOP into a DEST bank out
-                    // of phase with PACK -> Risc IB interrupt (0x19) whose faulting tile/core move with DPRINT
-                    // latency (a timing race, not OOB: TZCUR showed wr_entry_idx=0/nent=448). This is the
-                    // MATH-side partner of the llk_pack_init/llk_pack_dest_init re-issued just below; runs once
-                    // per tilize group, NO per-block hw_configure.
-                    // NB: this seeds the MATH side; a RESIDUAL Quasar DEST-handshake race in the per-tile
-                    // tilize_block datacopy<->pack loop (ERROR_TRISC1 0x19, fault tile/core move with DPRINT
-                    // latency) survives even with correct init -- it is an LLK-team issue, see
-                    // ~/llk_conv_tilize_issue.md.
-                    //
-                    // ROOT CAUSE (LLK hazard audit 2026-07-15): the Quasar MATH<->PACK *semaphore* dest-sync
-                    // scheme never issues a CLEARDVALID, so the HW DEST data-valid bit SET by the preceding
-                    // matmul's terminal MVMUL is never scrubbed. The tilize's MOVA2D datacopy MOP is then
-                    // rejected at issue for targeting a bank whose dvalid is still set -> ERROR_TRISC1 (MATH)
-                    // 0x19. (Standalone tilize passes because no prior op set the dvalid.) All prior fixes
-                    // stalled on PACK, but the dvalid + ZEROACC retire on MATH/FPU, so a PACK stall can't drain
-                    // them -- the fix is a state SCRUB, not a stall. Issue the CLEARDVALID (both banks in
-                    // SyncFull, the active bank in SyncHalf) to clear the matmul's stale math dvalid before the
-                    // tilize. Cheaper than compute_kernel_hw_startup (no hw_configure).
-                    // [#48552] CLEARDVALID scrub REMOVED: llk_math_set_dvalid is static_assert-blocked on Quasar
-                    // (it belongs to the dest-dvalid sync scheme and must not mix with the semaphore scheme
-                    // tt-metal uses) AND it did not resolve the 0x19 in testing. Leaving it here was a hard
-                    // trisc1 compile error once the static_assert was restored. The MATH pack-sync re-seed +
-                    // pack init/dest_init below are the kept fix for the tilize inheriting stale matmul state.
-                    MATH((llk_math_pack_sync_init()));
-                    PACK((llk_pack_init(tilized_in0_cb_id)));
-                    // A/B RESULT: disabling this moved the tilize fault EARLIER (t=4 -> t=1), so dest_init
-                    // HELPS (sets up the packer DEST section Quasar tilize_init omits) — keep it. The residual
-                    // fault at t=4 (first DEST bank-0 reuse after a full 4-bank rotation) is the tilize's own
-                    // Quasar DEST bank rotation/release (pack_dest_section_done) not freeing banks — an LLK bug.
-                    PACK((llk_pack_dest_init()));
-                    // [DIAG cursor] Confirm the t=5 tilize pack OOB is the ring cursor: llk_pack writes
-                    // tc_slots[tc_idx].wr_entry_idx + t into ACT_TILIZED (t up to 15). If wr_entry_idx != 0
-                    // (the in-place matmul-partials ring rewind leaves ACT_TILIZED off ring-start) the +t
-                    // overshoots the ring around t=5. Gated to the first tilize so it flushes pre-fault.
-                    if (in0_block_w_i == 0 && in0_block_h_i == 0) {
-                        // [stale-pack-BD confirm] The tilize packs into act_tilized (tilized base). If the
-                        // ERROR_TRISC1 0x19 fault address (~0x37c28) lands in the OUT CB's L1 range instead of
-                        // the tilized CB's range, the packer BD is still pointed at OUT (from hw_startup) --
-                        // the Quasar tilize_init omits the pack hw_configure that would repoint it. esz = entry
-                        // size (bytes); tilized range = [tilized_base, tilized_base + nent*esz).
-                    }
+                    pack_init(tilized_in0_cb_id);
 #endif
-                    // (TZHWCFG/TZBD/TZBDTAB/TILIZEPACK probes removed — they confirmed the tilize pack BD is
-
                     if constexpr (!activation_reuse) {
+                        DPRINT("tilize in\n");
                         tilize_in<in0_block_w, in0_cb_id, tilized_in0_cb_id, true, !split_reader>(
                             in0_num_subblocks_read);
+                        DPRINT("tilize ok\n");
                     }
 
 #ifdef SPLIT_READER
@@ -607,7 +544,9 @@ void kernel_main() {
                     matmul_block_init(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
                 }
 
+                DPRINT("wait mm_in0\n");
                 cb_mm_in0.wait_front(in0_block_num_tiles);
+                DPRINT("mm_in0 ok\n");
 
                 uint32_t in0_index_subblock_offset = 0;
 #ifdef CHECK_SKIP_COMPUTE
@@ -617,12 +556,14 @@ void kernel_main() {
                 }
 #endif
 
+                DPRINT("wait in1\n");
                 cb_in1.wait_front(in1_block_num_tiles);
+                DPRINT("in1 ok\n");
 
                 if (last_inner_dim_block) {
                     if constexpr (!fuse_bias) {
                         if constexpr (pack_relu) {
-                            PACK((llk_pack_relu_config(ReluConfig::zero())));
+                            pack_relu_config(ReluConfig::zero());
                         }
                         curr_matmul_out_cb = mm_out_cb_id;
                     }
@@ -632,33 +573,7 @@ void kernel_main() {
                     pack_reconfig_data_format(curr_matmul_out_cb);
                 }
 #ifdef ARCH_QUASAR
-                // QSR quirk #1 (buffer descriptors are baked at op init, not recomputed per pack): the pack
-                // BD was last programmed for dfb::out (compute_kernel_hw_startup) and the tilize left it
-                // stale — it is NEVER repointed to the real matmul output CB. pack_block below runs the
-                // init-baked MOP applying matmul_partials' tile *offset* on top of out's L1 *base* -> OOB
-                // write -> PACR0_TILE_INC / ERROR_TRISC1 fault. Repoint the pack BD to the actual output CB
-                // here (once per K-block; the reload path at 539+ doesn't touch pack config). WH/BH don't
-                // need this (they recompute the full L1 addr from fifo_wr_ptr each pack). Mirrors
-                // compute_pool_2d.cpp's llk_pack_init re-init.
-                PACK((llk_pack_init(curr_matmul_out_cb)));
-                // [#48552] Re-seed the MATH<->PACK DEST bank-recycle handshake for the MATMUL — the exact
-                // MIRROR of the PROVEN pre-tilize re-seed (:564-570). Root cause (confirmed by removing the
-                // MVMUL entirely: the hang PERSISTS byte-identical, so it is the acquire/commit/pack/
-                // section_done/recycle HANDSHAKE, NOT compute — drop the earlier FPU-dvalid framing): a plain
-                // matmul kernel runs this identical handshake and passes; the ONLY difference here is the
-                // pretilize (datacopy->DEST->pack, 294 tiles) that ran FIRST on the SAME MATH_PACK semaphore
-                // + DEST bank-parity, then the matmul reuses that machinery. The transition (reconfig /
-                // matmul_block_init / the PACK llk_pack_init above) does NOT reset the MATH-side DEST section
-                // pointer / MATH_PACK sem / bank-parity, so the matmul inherits the pretilize's ending phase.
-                // That is self-consistent for the first two subblocks (banks 0,1 fresh) but DEADLOCKS at the
-                // FIRST bank0 REUSE (out_subblock 2) -> ERROR_TRISC1 0x0119. llk_math_pack_sync_init drains the
-                // pretilize's outstanding packs (cb_mm_in0.wait_front already guaranteed the data), resets
-                // MATH dest parity to bank0 and re-seeds MATH_PACK to its SyncHalf init (max 2); llk_pack_dest_
-                // init resets PACK parity to bank0 + re-selects the packer dest registers. Both threads restart
-                // at a clean bank0/init handshake — the same clean start the standalone matmul gets from its
-                // own init and the tilize gets from :564-570.
-                MATH((llk_math_pack_sync_init()));
-                PACK((llk_pack_dest_init()));
+                pack_init(curr_matmul_out_cb);
 #endif
                 // (flushes) so the LAST marker seen before the PACR0_TILE_INC fault tells whether the faulting
                 // pack is the MATMUL (MMBLK) or the fuse_bias->OUT pack (BIASBLK). base is the current pack
@@ -688,15 +603,8 @@ void kernel_main() {
                         uint32_t in1_index = in1_index_subblock_offset;
                         // prints for (i0,i1) but MMMVOK does NOT, the MATH 0x19 is in that subblock's matmul_block.
                         // Gated to the first height block (bsp1 faulted there, ~3 MMPACKs in).
+                        DPRINT("matmul i0={} i1={}\n", in0_subblock_i, in1_subblock_i);
                         for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; inner_dim_idx++) {
-                            // hang is at idx=0 the very first MVMUL of subblock 2 stalls (SrcA/SrcB unpack for
-                            // that DEST section never validated); if idx>0 it stalls mid-K accumulation. Prints
-                            // the mm_in0 / in1 tile indices being read (to check for an OOB read too).
-                            // NEW text => proves the JIT recompiled. On TRISC0 (UNPACK). If "UNPK i0=2 idx=0" prints
-                            // (unpacker delivered SrcA/SrcB for the stalling MVMUL) yet MATH still hangs at MMK i0=2
-                            // idx=0 => the fault is the DEST FPU-dvalid (a) and the per-subblock clear is
-                            // ineffective/misplaced. If the last UNPK is i0=1 idx=2 (unpacker stalled ENTERING
-                            // subblock 2) => it's SrcA/SrcB unpack re-arm (b), fix belongs in the unpack handshake.
                             matmul_block(
                                 mm_in0_cb_id,
                                 in1_cb_id,
@@ -739,30 +647,7 @@ void kernel_main() {
                             }
 
                             uint32_t start_dst_index = 0;
-#ifdef ARCH_QUASAR
-                            // QSR matmul-pack DST addressing fix. The Quasar SEQUENTIAL pack
-                            // (pack_block -> llk_pack_block -> get_output_tile_index<out_of_order=false>)
-                            // computes l1_tile_index = tc_slots[tc_idx].wr_entry_idx + wr_entry_ptr, where
-                            // wr_entry_idx advances per push_back (llk_push_tiles) AND wr_entry_ptr is a
-                            // monotonic per-pack counter that reserve_back/push_back never reset. Those two
-                            // DOUBLE-advance the DST address, so across the no-spill multi-height-block matmul
-                            // (in0_num_blocks_h > 1) the pack drifts ~2x and walks off the OUT/partials tile
-                            // boundary -> PACR0_TILE_INC OOB (ERROR_TRISC1). WH/BH don't hit this because their
-                            // pack recomputes the L1 addr from the CB fifo_wr_ptr each pack. Mirror the WORKING
-                            // Quasar tilize pack: out_of_order with a RELATIVE tile index (0..osnt-1). That path
-                            // (get_output_tile_index<out_of_order=true>) uses ONLY wr_entry_idx + the explicit
-                            // index and never touches wr_entry_ptr, so it single-advances and stays tile-aligned
-                            // -- the portable "reset write ptr after push_back" sequential semantics. Each
-                            // subblock reserve_back(osnt)/push_back(osnt) advances wr_entry_idx by osnt, so the
-                            // relative 0..osnt-1 lands in the correct sequential OUT/partials slot for every
-                            // (height-block, subblock), identical to the pre-Quasar pack_block behavior.
-                            for (uint32_t t = 0; t < out_subblock_num_tiles; ++t) {
-                                pack_tile<true /*out_of_order_output*/>(start_dst_index + t, curr_matmul_out_cb, t);
-                            }
-#else
                             pack_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
-#endif
-
                             tile_regs_release();
                             curr_out_cb.push_back(out_subblock_num_tiles);
                         }
@@ -771,6 +656,7 @@ void kernel_main() {
                     }  // for in1_num_subblocks
                     in0_index_subblock_offset += in0_subblock_num_tiles;
                 }
+                DPRINT("matmul ok\n");
                 if (curr_matmul_out_cb == matmul_partials_cb) {
                     if constexpr (!partials_cb_uses_output) {
                         UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials);)
@@ -872,23 +758,19 @@ void kernel_main() {
 #endif
 #ifdef FUSE_BIAS
             if constexpr (fuse_bias) {
+                DPRINT("bias\n");
                 if constexpr (pack_relu) {
-                    PACK((llk_pack_relu_config(ReluConfig::zero())));
+                    pack_relu_config(ReluConfig::zero());
                 }
                 pack_reconfig_data_format(matmul_partials_cb, untilize_mode_out_cb_id);
                 if constexpr (packer_l1_acc) {
                     pack_reconfig_l1_acc(0);
                 }
 #ifdef ARCH_QUASAR
-                // QSR quirk #1: pack_reconfig_data_format above sets only the gasket FORMAT, not the pack
-                // buffer descriptor. The pack BD is still pointed at matmul_partials (from the matmul-block
-                // pack_init); pack_tile below targets untilize_mode_out_cb_id -> stale base + new offset ->
-                // OOB PACR0_TILE_INC / ERROR_TRISC1 (this is the fault that surfaced after the matmul-pack
-                // fix, at a higher L1 addr). Repoint the pack BD to the actual pack target CB.
-                PACK((llk_pack_init(untilize_mode_out_cb_id)));
+                pack_init(untilize_mode_out_cb_id);
 #endif
                 reconfig_data_format(in1_cb_id, matmul_partials_cb, mm_in0_cb_id, bias_cb_id);
-                add_bcast_rows_init_short(matmul_partials_cb, bias_cb_id);
+                add_bcast_rows_init(matmul_partials_cb, bias_cb_id);
 
                 cb_bias.wait_front(bias_ntiles_w);
                 cb_matmul_partials.wait_front(out_block_num_tiles);
@@ -917,18 +799,7 @@ void kernel_main() {
                         cb_untilize_mode_out.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-#ifdef ARCH_QUASAR
-                            // Same Quasar sequential-pack double-advance fix as the matmul pack: the default
-                            // pack_tile (out_of_order=false) uses get_output_tile_index<false> =
-                            // wr_entry_idx (advances per push_back) + monotonic wr_entry_ptr, which DOUBLE-
-                            // advances the DST across this multi-subblock / multi-height-block bias->OUT pack
-                            // (fuse_bias, partials aliases OUT) and walks off the tile boundary. Use
-                            // out_of_order with the RELATIVE tile index i (single-advance via wr_entry_idx),
-                            // mirroring the working tilize. WH/BH keep the sequential pack (fifo_wr_ptr path).
-                            pack_tile<true /*out_of_order_output*/>(i, untilize_mode_out_cb_id, i);
-#else
                             pack_tile(i, untilize_mode_out_cb_id);
-#endif
                         }
                         tile_regs_release();
                         cb_untilize_mode_out.push_back(out_subblock_num_tiles);
@@ -948,7 +819,7 @@ void kernel_main() {
                     pack_reconfig_l1_acc(0);
                 }
                 if constexpr (pack_relu) {
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
                 }
                 if constexpr (!fuse_bias) {
                     reconfig_data_format_srca(in1_cb_id, matmul_partials_cb);
@@ -990,4 +861,5 @@ void kernel_main() {
         }
 #endif
     }  // for in1_num_blocks_w
+    DPRINT("done\n");
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -157,11 +157,7 @@ void tilize_in(
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
 inline void tilize_single_block(DataflowBuffer& in_cb) {
     in_cb.wait_front(in_block_w);
-#ifndef ARCH_QUASAR  // Quasar has no fast tilize; these helpers are only reached on the split_reader/
-                     // activation_reuse path, which the resnet conv factories force OFF. Guard the
-                     // raw fast_tilize_* names out so the template body parses on Quasar (dead there).
     fast_tilize_block(in_cb_id, in_block_w, out_cb_id);
-#endif
     in_cb.pop_front(in_block_w);
 }
 
@@ -202,9 +198,7 @@ inline void tilize_in_reuse_split_reader(
     uint32_t act_cb_start_address,
     uint32_t act_cb_second_reader_start_address) {
     out_cb.reserve_back(out_cb_tiles);
-#ifndef ARCH_QUASAR  // Quasar has no fast tilize (split_reader/activation_reuse path, off for resnet)
     fast_tilize_init_with_dt(in1_cb_id, in_block_w, out_cb_id);
-#endif
 
     uint32_t in1_cb_addr = act_cb_start_address;
     uint32_t in2_cb_addr = act_cb_second_reader_start_address;
@@ -260,9 +254,7 @@ inline void tilize_in_reuse_split_reader(
     PACK((out_cb.evil_set_write_ptr(out_cb_addr_init)));
 #endif
     out_cb.push_back(out_cb_tiles);
-#ifndef ARCH_QUASAR  // Quasar has no fast tilize (split_reader/activation_reuse path, off for resnet)
     fast_tilize_uninit(in2_cb_id, out_cb_id, in_block_w);
-#endif
 }
 
 template <uint32_t out_subblock_w, uint32_t out_block_w>
@@ -603,7 +595,6 @@ void kernel_main() {
                         uint32_t in1_index = in1_index_subblock_offset;
                         // prints for (i0,i1) but MMMVOK does NOT, the MATH 0x19 is in that subblock's matmul_block.
                         // Gated to the first height block (bsp1 faulted there, ~3 MMPACKs in).
-                        DPRINT("matmul i0={} i1={}\n", in0_subblock_i, in1_subblock_i);
                         for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; inner_dim_idx++) {
                             matmul_block(
                                 mm_in0_cb_id,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -34,7 +34,6 @@
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
-#include "api/debug/dprint.h"
 
 // In-place matmul-partials accumulate: re-accumulate each inner-K block into the SAME L1 region by
 // "rewinding" the partials buffer's producer/consumer position back to the start of the output block.
@@ -421,10 +420,8 @@ void kernel_main() {
     });
 #endif
 
-    DPRINT("enter nh={} nw={} n1w={}\n", in0_num_blocks_h, in0_num_blocks_w, in1_num_blocks_w);
     compute_kernel_hw_startup<SrcOrder::Reverse>(mm_in0_cb_id, in1_cb_id, out_cb_id);
     matmul_block_init(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
-    DPRINT("hwok\n");
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
@@ -444,13 +441,6 @@ void kernel_main() {
             uint32_t curr_matmul_out_cb = matmul_partials_cb;
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
                 bool last_inner_dim_block = (in0_block_w_i == in0_num_blocks_w - 1);
-                DPRINT("loop h={} k={}\n", in0_block_h_i, in0_block_w_i);
-                // TRISC1) so the LAST BS* line in that file before the 0x19 pins the stall point:
-                //   BSLOOP present but no "mmin0-ok" -> stuck in cb_mm_in0.wait_front (tilized act never
-                //     delivered by the mcast reader / tilize never completed for this K-block).
-                //   "mmin0-ok" but no "in1-ok"       -> stuck in cb_in1.wait_front (weights never delivered
-                //     by the DM3 weights mcast).
-                //   "in1-ok" (+ existing MMBLK/MMMV) then fault -> the matmul MVMULs read missing SrcA/SrcB.
                 if constexpr (!height_sharded) {
                     if (in0_block_w_i % in0_nblocks_w_tilize == 0) {
                         if constexpr (pack_relu && !fuse_bias) {
@@ -496,10 +486,8 @@ void kernel_main() {
                     pack_init(tilized_in0_cb_id);
 #endif
                     if constexpr (!activation_reuse) {
-                        DPRINT("tilize in\n");
                         tilize_in<in0_block_w, in0_cb_id, tilized_in0_cb_id, true, !split_reader>(
                             in0_num_subblocks_read);
-                        DPRINT("tilize ok\n");
                     }
 
 #ifdef SPLIT_READER
@@ -536,9 +524,7 @@ void kernel_main() {
                     matmul_block_init(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
                 }
 
-                DPRINT("wait mm_in0\n");
                 cb_mm_in0.wait_front(in0_block_num_tiles);
-                DPRINT("mm_in0 ok\n");
 
                 uint32_t in0_index_subblock_offset = 0;
 #ifdef CHECK_SKIP_COMPUTE
@@ -548,9 +534,7 @@ void kernel_main() {
                 }
 #endif
 
-                DPRINT("wait in1\n");
                 cb_in1.wait_front(in1_block_num_tiles);
-                DPRINT("in1 ok\n");
 
                 if (last_inner_dim_block) {
                     if constexpr (!fuse_bias) {
@@ -647,7 +631,7 @@ void kernel_main() {
                     }  // for in1_num_subblocks
                     in0_index_subblock_offset += in0_subblock_num_tiles;
                 }
-                DPRINT("matmul ok\n");
+
                 if (curr_matmul_out_cb == matmul_partials_cb) {
                     if constexpr (!partials_cb_uses_output) {
                         UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials);)
@@ -749,7 +733,6 @@ void kernel_main() {
 #endif
 #ifdef FUSE_BIAS
             if constexpr (fuse_bias) {
-                DPRINT("bias\n");
                 if constexpr (pack_relu) {
                     pack_relu_config(ReluConfig::zero());
                 }
@@ -852,5 +835,4 @@ void kernel_main() {
         }
 #endif
     }  // for in1_num_blocks_w
-    DPRINT("done\n");
 }  // void kernel_main()


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Quasar Resnet conv bring-up currently routes height-sharded conv2d through `TT_METAL_QSR_CONV_SPLIT_PROGRAM=1 `(tilize-only + standalone matmul) so e2e and layer tests stay off `ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp`.

This PR enables using the fused `conv_bmm_tilize_metal2.cpp` compute kernel.

**1. Bug fixes in `conv_bmm_tilize_metal2.cpp`:**
- Remove additional `llk_math_pack_sync_init` and `llk_pack_dest_init` which were added while debugging 0x19. These calls were causing hangs;
- Restore the original `pack_block` and `pack_tile` calls from the compute kernel, which were swapped for Quasar specific versions while debugging 0x19.

**2. Fix bug in tilize/untilize L1 addressing:**
- 18bit value fields in `SET_SRC_TILE_ROW_FACE_IDX` and `SET_DST_TILE_ROW_FACE_IDX` are truncated to 11bit when using FACE_SEL, passing in a number larger than 2047 would cause bad PCC;
- Fix by using `TILIZE_SRC_ADDR_OFFSET` and `UNTILIZE_DST_ADDR_OFFSET` cfg registers to tilize more than one row of tiles, use z_cntr inside of one tile row;
- Improve L1 index calculation for untilize/tilize LLK API to be more robust (specifically when it comes to different page sizes).

**3. Cleanup in `conv_bmm_tilize_metal2.cpp`:**
- Remove LLK API calls and use compute API instead;
- Remove calls to deprecated compute API functions;
- Remove Quasar arch guards for fast_tilize;
- Remove outdated/incorrect comments.

**4. Cleanup in `conv2d_op_sharded_program_factory.cpp`:**
- Remove Quasar specific restriction to 1x1 out_subblock_h/w_ntiles;
- Re-enable packer l1 accumulation;
- Allocate matmul_partials and output DFB to different L1 defensively;
- Remove outdated/incorrect comments.


The following tests go from hanging to passing:
```
models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d_correctness_bisect.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d_stem.py with with TT_METAL_QSR_CONV_SPLIT_PROGRAM unset
```


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/fused_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/fused_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/fused_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/fused_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/fused_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/fused_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/fused_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/fused_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/fused_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/fused_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/fused_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/fused_conv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/fused_conv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/fused_conv)