### PR TITLE
Fix the FLUX.2 transformer failures on Linear-topology meshes

### DIFF
--- a/models/tt_dit/blocks/transformer_block_opt.py
+++ b/models/tt_dit/blocks/transformer_block_opt.py
@@ -134,6 +134,10 @@ class TransformerBlock(Module):
             q_chunk_size=attention_q_chunk_size,
             is_fsdp=is_fsdp,
             shard_prompt=shard_prompt,
+            # QK-RMSNorm reduces over each head's head_dim independently, not over the whole
+            # row: the reference unflattens to heads before norm_q/norm_k. Defaulting this to
+            # False normalized across all heads and cost ~2.5% PCC on Q/K.
+            per_head_norm=True,
         )
 
         self.norm2 = DistributedLayerNorm(

--- a/models/tt_dit/blocks/transformer_block_opt.py
+++ b/models/tt_dit/blocks/transformer_block_opt.py
@@ -134,9 +134,6 @@ class TransformerBlock(Module):
             q_chunk_size=attention_q_chunk_size,
             is_fsdp=is_fsdp,
             shard_prompt=shard_prompt,
-            # QK-RMSNorm reduces over each head's head_dim independently, not over the whole
-            # row: the reference unflattens to heads before norm_q/norm_k. Defaulting this to
-            # False normalized across all heads and cost ~2.5% PCC on Q/K.
             per_head_norm=True,
         )
 

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -363,8 +363,8 @@ class ColParallelLinear(Module):
 
         `addcmul_a` / `addcmul_b` fuse a gated residual into the matmul epilogue, returning
         `addcmul_a + addcmul_scalar * matmul_result * addcmul_b`. Both must already be at the
-        per-TP-device output slice. Only the all-gather-matmul path supports it, so it requires
-        `parallel_config`; callers on the unfused path should apply the addcmul themselves.
+        per-TP-device output slice and require `parallel_config`. The Ring path fuses them into
+        the all-gather-matmul; other paths route through the addcmul-fused minimal matmul.
         """
         if addcmul_a is not None or addcmul_b is not None:
             if (addcmul_a is None) != (addcmul_b is None):
@@ -491,17 +491,41 @@ class ColParallelLinear(Module):
                     fuse_swiglu=self.fuse_swiglu,
                 )
                 return [_apply_activation_fn(o, self.activation_fn) for o in outputs]
-            matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
-            output = ttnn.experimental.minimal_matmul(
-                input_tensor=x,
-                weight_tensor=weight,
-                bias_tensor=self.bias.data if self.bias is not None else None,
-                config=matmul_config,
-                fused_activation=self.fused_activation_fn,
-                compute_kernel_config=compute_kernel_config or self.compute_config,
-                dtype=dtype,
-                fuse_swiglu=self.fuse_swiglu,
-            )
+            if addcmul_a is not None:
+                # This branch used to accept addcmul_a/addcmul_b and silently drop them:
+                # only the Ring all-gather-matmul above fused them, so on Linear topology
+                # the gated residual promised by the docstring was never added (flux2's
+                # double blocks lost their attention residual this way). Route through the
+                # addcmul-fused minimal matmul instead. That op has no fused-activation
+                # support, so reject the combination rather than compute the wrong thing.
+                if self.fused_activation_fn is not None or self.fuse_swiglu:
+                    msg = "fused addcmul is not supported alongside a fused activation on the minimal_matmul path"
+                    raise ValueError(msg)
+                # x may have been gathered above, so size the config from its current K.
+                matmul_config = get_matmul_config(M, x.padded_shape[-1], N, core_grid, default_block_size)
+                output = ttnn.experimental.dit_minimal_matmul_addcmul_fused(
+                    x,
+                    weight,
+                    addcmul_scalar,
+                    addcmul_a,
+                    addcmul_b,
+                    bias_tensor=self.bias.data if self.bias is not None else None,
+                    config=matmul_config,
+                    compute_kernel_config=compute_kernel_config or self.compute_config,
+                    dtype=dtype,
+                )
+            else:
+                matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
+                output = ttnn.experimental.minimal_matmul(
+                    input_tensor=x,
+                    weight_tensor=weight,
+                    bias_tensor=self.bias.data if self.bias is not None else None,
+                    config=matmul_config,
+                    fused_activation=self.fused_activation_fn,
+                    compute_kernel_config=compute_kernel_config or self.compute_config,
+                    dtype=dtype,
+                    fuse_swiglu=self.fuse_swiglu,
+                )
 
         return _apply_activation_fn(output, self.activation_fn)
 

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -363,8 +363,7 @@ class ColParallelLinear(Module):
 
         `addcmul_a` / `addcmul_b` fuse a gated residual into the matmul epilogue, returning
         `addcmul_a + addcmul_scalar * matmul_result * addcmul_b`. Both must already be at the
-        per-TP-device output slice and require `parallel_config`. The Ring path fuses them into
-        the all-gather-matmul; other paths route through the addcmul-fused minimal matmul.
+        per-TP-device output slice, and require `parallel_config`.
         """
         if addcmul_a is not None or addcmul_b is not None:
             if (addcmul_a is None) != (addcmul_b is None):
@@ -492,16 +491,11 @@ class ColParallelLinear(Module):
                 )
                 return [_apply_activation_fn(o, self.activation_fn) for o in outputs]
             if addcmul_a is not None:
-                # This branch used to accept addcmul_a/addcmul_b and silently drop them:
-                # only the Ring all-gather-matmul above fused them, so on Linear topology
-                # the gated residual promised by the docstring was never added (flux2's
-                # double blocks lost their attention residual this way). Route through the
-                # addcmul-fused minimal matmul instead. That op has no fused-activation
-                # support, so reject the combination rather than compute the wrong thing.
+                # This op has no fused-activation support, so reject the combination rather
+                # than compute the wrong thing.
                 if self.fused_activation_fn is not None or self.fuse_swiglu:
                     msg = "fused addcmul is not supported alongside a fused activation on the minimal_matmul path"
                     raise ValueError(msg)
-                # x may have been gathered above, so size the config from its current K.
                 matmul_config = get_matmul_config(M, x.padded_shape[-1], N, core_grid, default_block_size)
                 output = ttnn.experimental.dit_minimal_matmul_addcmul_fused(
                     x,

--- a/models/tt_dit/pipelines/flux2/pipeline_flux2.py
+++ b/models/tt_dit/pipelines/flux2/pipeline_flux2.py
@@ -36,6 +36,31 @@ if TYPE_CHECKING:
     from PIL import Image
 
 
+def _module_is_loaded(module: object | None) -> bool:
+    """Whether a submodule currently holds its weights on device.
+
+    Returns True for anything that has no load state (a torch fallback encoder, or None), so
+    callers treat it as "nothing to evict".
+    """
+    is_loaded = getattr(module, "is_loaded", None)
+    return True if is_loaded is None else bool(is_loaded())
+
+
+def _release_module_trace(module: object | None) -> None:
+    """Release the trace captured on ``module.forward``, if it has one.
+
+    ``traced_function`` keeps one ``Tracer`` per context in a ``WeakKeyDictionary`` hung off
+    the decorated function, so the module instance is the key.
+    """
+    forward = getattr(type(module), "forward", None)
+    tracers = getattr(forward, "_tracers", None)
+    if tracers is None:
+        return
+    tracer = tracers.get(module)
+    if tracer is not None:
+        tracer.release_trace()
+
+
 class Flux2TransformerState:
     def __init__(self) -> None:
         self._tt_embedded_prompt = StateTensor()
@@ -234,7 +259,31 @@ class Flux2Pipeline:
             traced=traced,
         )
 
+    def _release_denoise_trace(self) -> None:
+        """Release the captured denoise trace, if any."""
+        tracer = type(self)._step._tracers.get(self)
+        if tracer is not None:
+            logger.debug("releasing denoise trace: the transformer it captured is being evicted")
+            tracer.release_trace()
+
+    def release_traces(self) -> None:
+        """Release every trace captured by this pipeline or its submodules.
+
+        A ttnn trace bakes its inputs' *and its weights'* device addresses, so a trace must
+        never outlive an eviction of the module it captured. With ``dynamic_load`` the three
+        big modules take turns in DRAM, so each `_prepare_*` below drops the traces that
+        depend on whatever it is about to evict.
+        """
+        self._release_denoise_trace()
+        _release_module_trace(self._vae_decoder)
+        _release_module_trace(getattr(self._prompt_encoder, "_encoder", None))
+
     def _prepare_transformer(self) -> None:
+        # Loading the transformer evicts the encoder and the VAE (see the coresident
+        # exclusions registered in __init__), so their traces die with their weights.
+        if self.dynamic_load and not self.transformer.is_loaded():
+            _release_module_trace(self._vae_decoder)
+            _release_module_trace(getattr(self._prompt_encoder, "_encoder", None))
         cache.load_model(
             tt_model=self.transformer,
             get_torch_state_dict=self._torch_transformer.state_dict,
@@ -248,10 +297,17 @@ class Flux2Pipeline:
         ttnn.synchronize_device(self._mesh_device)
 
     def _prepare_prompt_encoder(self) -> None:
+        # Loading the encoder evicts the transformer, which the denoise trace captured.
+        encoder = getattr(self._prompt_encoder, "_encoder", None)
+        if self.dynamic_load and not _module_is_loaded(encoder):
+            self._release_denoise_trace()
         self._prompt_encoder.load_weights()
         ttnn.synchronize_device(self._mesh_device)
 
     def _prepare_vae(self) -> None:
+        # Loading the VAE also evicts the transformer.
+        if self.dynamic_load and not self._vae_decoder.is_loaded():
+            self._release_denoise_trace()
         cache.load_model(
             tt_model=self._vae_decoder,
             get_torch_state_dict=self._torch_vae.state_dict,

--- a/models/tt_dit/pipelines/flux2/pipeline_flux2.py
+++ b/models/tt_dit/pipelines/flux2/pipeline_flux2.py
@@ -37,21 +37,13 @@ if TYPE_CHECKING:
 
 
 def _module_is_loaded(module: object | None) -> bool:
-    """Whether a submodule currently holds its weights on device.
-
-    Returns True for anything that has no load state (a torch fallback encoder, or None), so
-    callers treat it as "nothing to evict".
-    """
+    """Whether ``module`` holds weights on device. Anything without load state counts as loaded."""
     is_loaded = getattr(module, "is_loaded", None)
     return True if is_loaded is None else bool(is_loaded())
 
 
 def _release_module_trace(module: object | None) -> None:
-    """Release the trace captured on ``module.forward``, if it has one.
-
-    ``traced_function`` keeps one ``Tracer`` per context in a ``WeakKeyDictionary`` hung off
-    the decorated function, so the module instance is the key.
-    """
+    """Release the trace captured on ``module.forward``, if it has one."""
     forward = getattr(type(module), "forward", None)
     tracers = getattr(forward, "_tracers", None)
     if tracers is None:
@@ -267,20 +259,13 @@ class Flux2Pipeline:
             tracer.release_trace()
 
     def release_traces(self) -> None:
-        """Release every trace captured by this pipeline or its submodules.
-
-        A ttnn trace bakes its inputs' *and its weights'* device addresses, so a trace must
-        never outlive an eviction of the module it captured. With ``dynamic_load`` the three
-        big modules take turns in DRAM, so each `_prepare_*` below drops the traces that
-        depend on whatever it is about to evict.
-        """
+        """Release every trace captured by this pipeline or its submodules."""
         self._release_denoise_trace()
         _release_module_trace(self._vae_decoder)
         _release_module_trace(getattr(self._prompt_encoder, "_encoder", None))
 
     def _prepare_transformer(self) -> None:
-        # Loading the transformer evicts the encoder and the VAE (see the coresident
-        # exclusions registered in __init__), so their traces die with their weights.
+        # A trace bakes its weights' addresses, so drop the traces this load will evict.
         if self.dynamic_load and not self.transformer.is_loaded():
             _release_module_trace(self._vae_decoder)
             _release_module_trace(getattr(self._prompt_encoder, "_encoder", None))
@@ -297,7 +282,6 @@ class Flux2Pipeline:
         ttnn.synchronize_device(self._mesh_device)
 
     def _prepare_prompt_encoder(self) -> None:
-        # Loading the encoder evicts the transformer, which the denoise trace captured.
         encoder = getattr(self._prompt_encoder, "_encoder", None)
         if self.dynamic_load and not _module_is_loaded(encoder):
             self._release_denoise_trace()
@@ -305,7 +289,6 @@ class Flux2Pipeline:
         ttnn.synchronize_device(self._mesh_device)
 
     def _prepare_vae(self) -> None:
-        # Loading the VAE also evicts the transformer.
         if self.dynamic_load and not self._vae_decoder.is_loaded():
             self._release_denoise_trace()
         cache.load_model(

--- a/models/tt_dit/pipelines/flux2/pipeline_flux2.py
+++ b/models/tt_dit/pipelines/flux2/pipeline_flux2.py
@@ -36,12 +36,6 @@ if TYPE_CHECKING:
     from PIL import Image
 
 
-def _module_is_loaded(module: object | None) -> bool:
-    """Whether ``module`` holds weights on device. Anything without load state counts as loaded."""
-    is_loaded = getattr(module, "is_loaded", None)
-    return True if is_loaded is None else bool(is_loaded())
-
-
 def _release_module_trace(module: object | None) -> None:
     """Release the trace captured on ``module.forward``, if it has one."""
     forward = getattr(type(module), "forward", None)
@@ -283,7 +277,8 @@ class Flux2Pipeline:
 
     def _prepare_prompt_encoder(self) -> None:
         encoder = getattr(self._prompt_encoder, "_encoder", None)
-        if self.dynamic_load and not _module_is_loaded(encoder):
+        encoder_is_loaded = getattr(encoder, "is_loaded", None)
+        if self.dynamic_load and encoder_is_loaded is not None and not encoder_is_loaded():
             self._release_denoise_trace()
         self._prompt_encoder.load_weights()
         ttnn.synchronize_device(self._mesh_device)

--- a/models/tt_dit/tests/models/flux2/test_performance_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_performance_flux2.py
@@ -60,6 +60,9 @@ _STEP_TO_METRIC = {
 }
 
 
+# pytest.ini sets a 300s default. Three timed runs of a 50-step denoise, plus first-call
+# weight conversion, exceed that on a 4-chip box even with warm caches.
+@pytest.mark.timeout(6000)
 @pytest.mark.parametrize(
     "width, height",
     [
@@ -78,7 +81,10 @@ _STEP_TO_METRIC = {
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, encoder_tp_axis, vae_tp_axis, topology, num_links, is_fsdp, dynamic_load, device_params",
     [
-        [(2, 2), 0, 1, 1, 1, ttnn.Topology.Linear, 2, True, False, line_params_flux2_perf],
+        # dynamic_load is mandatory on 4 chips: the 32B transformer, the 24B encoder and the
+        # VAE cannot be co-resident, and without it the encoder OOMs partway through its
+        # weight conversion with DRAM already ~99% full.
+        [(2, 2), 0, 1, 1, 1, ttnn.Topology.Linear, 2, True, True, line_params_flux2_perf],
         [(2, 4), 0, 1, 1, 1, ttnn.Topology.Linear, 2, False, False, line_params_flux2_perf],
         [(4, 8), 0, 1, 1, 1, ttnn.Topology.Linear, 2, False, False, line_params_8k_flux2_perf],
         [(4, 8), 0, 1, 1, 0, ttnn.Topology.Ring, 2, False, False, ring_params_8k_flux2_perf],

--- a/models/tt_dit/tests/models/flux2/test_performance_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_performance_flux2.py
@@ -60,8 +60,6 @@ _STEP_TO_METRIC = {
 }
 
 
-# pytest.ini sets a 300s default. Three timed runs of a 50-step denoise, plus first-call
-# weight conversion, exceed that on a 4-chip box even with warm caches.
 @pytest.mark.timeout(6000)
 @pytest.mark.parametrize(
     "width, height",
@@ -81,9 +79,7 @@ _STEP_TO_METRIC = {
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, encoder_tp_axis, vae_tp_axis, topology, num_links, is_fsdp, dynamic_load, device_params",
     [
-        # dynamic_load is mandatory on 4 chips: the 32B transformer, the 24B encoder and the
-        # VAE cannot be co-resident, and without it the encoder OOMs partway through its
-        # weight conversion with DRAM already ~99% full.
+        # Without dynamic_load the encoder OOMs during weight conversion on 4 chips.
         [(2, 2), 0, 1, 1, 1, ttnn.Topology.Linear, 2, True, True, line_params_flux2_perf],
         [(2, 4), 0, 1, 1, 1, ttnn.Topology.Linear, 2, False, False, line_params_flux2_perf],
         [(4, 8), 0, 1, 1, 1, ttnn.Topology.Linear, 2, False, False, line_params_8k_flux2_perf],


### PR DESCRIPTION
### What this is

#55225 registers the Flux.2-dev CI legs and says the two transformer cases stay red until commit `92919ba7f5d` lands. This is that commit, on top of that branch.

### Why the transformer was red

FLUX.2 came out as pure noise on any Linear topology mesh, which is every mesh a 4 chip QuietBox can run. Three separate bugs:

1. `ColParallelLinear.forward` accepted the gated attention residual (`addcmul_a`/`addcmul_b`) and silently dropped it unless the topology was Ring. Flux2's double blocks lost their residual entirely and returned the bare projection.
2. The double block built `Attention` without `per_head_norm`. FLUX.2 applies QK-RMSNorm per head, not across the whole row. Q/K went from 0.9738 to 0.9997.
3. Traces bake their weights' device addresses, but `dynamic_load` cycles the encoder, transformer and VAE through DRAM, so replay was reading freed memory. Traces are now released when a load will actually evict their weights, same as the wan and ltx pipelines.

2x2 transformer PCC goes from **0.3185% to 99.9972%**. Verified on hardware against the torch reference, and traced and untraced agree, both rendering correct, prompt distinct images.

### What it should do to the legs

* `test_transformer_flux2.py`: `all_blocks` (-3.7093%) and `single_blocks` (0.3185%) should both go green. Those are the two reds #55225 calls expected.
* `test_performance_flux2.py`: the `bh_qb` row also needed `dynamic_load=True`. Without it the encoder OOMs partway through weight conversion with DRAM already ~99% full, so that row could not run at all.

### What I left out on purpose

The original commit also added a 2x2 row and the `fsdp` thread to `test_transformer_flux2.py`. That is already on the base branch, and that version also sets `require_exact_physical_num_devices` so the rows self skip per SKU. I dropped my hunks and kept those, so that file is untouched here.

Base is `jlee/flux2-dev-tiered-ci` rather than `main`, so this merges into #55225 instead of racing it. Happy to retarget at `main` if you'd rather land them separately.
