### PR TITLE
[Bug fix] Rms_allgather: multicast per shard-grid rectangle, not the bounding box

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     // box. For non-rectangular shard grids this differs from num_blocks (the
     // worker count). The NoC ack counter must be credited against the
     // rectangle size or noc_async_write_barrier() will wait forever.
-    constexpr uint32_t num_mcast_dests = get_compile_time_arg_val(16);
+    [[maybe_unused]] constexpr uint32_t num_mcast_dests = get_compile_time_arg_val(16);
 
     Noc noc_obj;
     CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
@@ -47,15 +47,44 @@ void kernel_main() {
     Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
     Semaphore<> reduce_second_stage_sem(reduce_second_stage_semaphore_id);
 
-    const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(0);
-    const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(1);
-    const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(2);
-    const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(3);
-    const uint32_t start_x = get_arg_val<uint32_t>(4);
-    const uint32_t start_y = get_arg_val<uint32_t>(5);
+    // Multicast rectangles covering exactly the program's cores (see the factory).
+    // Multicasting to the grid's bounding box instead writes into foreign cores' L1.
+    constexpr uint32_t MAX_MCAST_RECTS = 8;
+    size_t arg_idx = 0;
+    const uint32_t num_mcast_rects = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mrect[MAX_MCAST_RECTS][6];  // x0, y0, x1, y1, num_cells, has_sender
+    for (uint32_t r = 0; r < num_mcast_rects; ++r) {
+        for (uint32_t k = 0; k < 6; ++k) {
+            mrect[r][k] = get_arg_val<uint32_t>(arg_idx++);
+        }
+    }
+    const uint32_t start_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_y = get_arg_val<uint32_t>(arg_idx++);
 
-    tt_l1_ptr uint32_t* in0_remote_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
-    tt_l1_ptr uint32_t* in0_remote_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + num_x));
+    tt_l1_ptr uint32_t* in0_remote_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    tt_l1_ptr uint32_t* in0_remote_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx + num_x));
+
+    // Semaphore multicast to every program core except self.
+    auto sem_mcast_excl_src = [&](Semaphore<>& sem) {
+        for (uint32_t r = 0; r < num_mcast_rects; ++r) {
+            const uint32_t dests = mrect[r][4] - mrect[r][5];
+            if (dests == 0) {
+                continue;
+            }
+            sem.set_multicast(noc_obj, mrect[r][0], mrect[r][1], mrect[r][2], mrect[r][3], dests);
+        }
+    };
+    // Semaphore multicast to every program core including self.
+    auto sem_mcast_incl_src = [&](Semaphore<>& sem) {
+        for (uint32_t r = 0; r < num_mcast_rects; ++r) {
+            if (mrect[r][5]) {
+                sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                    noc_obj, mrect[r][0], mrect[r][1], mrect[r][2], mrect[r][3], mrect[r][4]);
+            } else {
+                sem.set_multicast(noc_obj, mrect[r][0], mrect[r][1], mrect[r][2], mrect[r][3], mrect[r][4]);
+            }
+        }
+    };
 
     const DataFormat data_format = get_dataformat(cb_ex_partial2);
 
@@ -88,13 +117,7 @@ void kernel_main() {
             reduce_receiver_sem.set(0);
             // num_dests counts the multicast bounding-box cells excluding self,
             // not the worker count.
-            reduce_sender_sem.set_multicast(
-                noc_obj,
-                mcast_dest_noc_start_x,
-                mcast_dest_noc_start_y,
-                mcast_dest_noc_end_x,
-                mcast_dest_noc_end_y,
-                num_mcast_dests - 1);
+            sem_mcast_excl_src(reduce_sender_sem);
         }
 
         // read data from other cores - first stage reduce
@@ -140,13 +163,7 @@ void kernel_main() {
 
         // num_dests counts the multicast bounding-box cells (loopback includes
         // self), not the worker count.
-        post_reduce_sender_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
-            noc_obj,
-            mcast_dest_noc_start_x,
-            mcast_dest_noc_start_y,
-            mcast_dest_noc_end_x,
-            mcast_dest_noc_end_y,
-            num_mcast_dests);
+        sem_mcast_incl_src(post_reduce_sender_sem);
         noc_obj.async_write_barrier();
     };
 
@@ -156,18 +173,35 @@ void kernel_main() {
                                                     uint32_t l1_read_addr_ex_global = cb_ex_global_arg.get_read_ptr();
                                                     // num_dests counts the multicast bounding-box cells
                                                     // (loopback includes self), not the worker count.
-                                                    noc_obj.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
-                                                        CoreLocalMem<uint8_t>(l1_read_addr_ex),
-                                                        MulticastEndpoint{},
-                                                        single_tile_size_bytes,
-                                                        num_mcast_dests,
-                                                        {},
-                                                        {.noc_x_start = mcast_dest_noc_start_x,
-                                                         .noc_y_start = mcast_dest_noc_start_y,
-                                                         .noc_x_end = mcast_dest_noc_end_x,
-                                                         .noc_y_end = mcast_dest_noc_end_y,
-                                                         .addr = l1_read_addr_ex_global},
-                                                        false);
+                                                    for (uint32_t r = 0; r < num_mcast_rects; ++r) {
+                                                        if (mrect[r][5]) {
+                                                            noc_obj.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                                                                CoreLocalMem<uint8_t>(l1_read_addr_ex),
+                                                                MulticastEndpoint{},
+                                                                single_tile_size_bytes,
+                                                                mrect[r][4],
+                                                                {},
+                                                                {.noc_x_start = mrect[r][0],
+                                                                 .noc_y_start = mrect[r][1],
+                                                                 .noc_x_end = mrect[r][2],
+                                                                 .noc_y_end = mrect[r][3],
+                                                                 .addr = l1_read_addr_ex_global},
+                                                                false);
+                                                        } else {
+                                                            noc_obj.async_write_multicast(
+                                                                CoreLocalMem<uint8_t>(l1_read_addr_ex),
+                                                                MulticastEndpoint{},
+                                                                single_tile_size_bytes,
+                                                                mrect[r][4],
+                                                                {},
+                                                                {.noc_x_start = mrect[r][0],
+                                                                 .noc_y_start = mrect[r][1],
+                                                                 .noc_x_end = mrect[r][2],
+                                                                 .noc_y_end = mrect[r][3],
+                                                                 .addr = l1_read_addr_ex_global},
+                                                                false);
+                                                        }
+                                                    }
                                                     noc_obj.async_write_barrier();
                                                 };
     cb_stats_reduced_obj.wait_front(1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -56,7 +56,7 @@ void kernel_main() {
     // box. For non-rectangular shard grids this differs from num_blocks (the
     // worker count). The NoC ack counter must be credited against the
     // rectangle size or noc_async_write_barrier() will wait forever.
-    constexpr uint32_t num_mcast_dests = get_compile_time_arg_val(24);
+    [[maybe_unused]] constexpr uint32_t num_mcast_dests = get_compile_time_arg_val(24);
     constexpr auto gamma_args = TensorAccessorArgs<25>();
 
     Noc noc_obj;
@@ -70,10 +70,16 @@ void kernel_main() {
     size_t arg_idx = 0;
     const uint32_t base_post_rt =
         get_arg_val<uint32_t>(arg_idx++);  // RT 0 holds how many pre RTs there are (which can vary core by core)
-    const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(arg_idx++);
+    // Multicast rectangles which cover exactly the program's cores (see the factory)
+    // A bounding-box multicast would write into foreign cores' L1 which is bad.
+    constexpr uint32_t MAX_MCAST_RECTS = 8;
+    const uint32_t num_mcast_rects = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mrect[MAX_MCAST_RECTS][6];  // x0, y0, x1, y1, num_cells, has_sender
+    for (uint32_t r = 0; r < num_mcast_rects; ++r) {
+        for (uint32_t k = 0; k < 6; ++k) {
+            mrect[r][k] = get_arg_val<uint32_t>(arg_idx++);
+        }
+    }
     dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
         cb_in_2,
         ckernel::PoolType::AVG,
@@ -196,13 +202,14 @@ void kernel_main() {
         stats_set_sem.set(VALID);
         // num_dests counts the multicast bounding-box cells (loopback includes
         // self), not the worker count.
-        stats_set_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
-            noc_obj,
-            mcast_dest_noc_start_x,
-            mcast_dest_noc_start_y,
-            mcast_dest_noc_end_x,
-            mcast_dest_noc_end_y,
-            num_mcast_dests);
+        for (uint32_t r = 0; r < num_mcast_rects; ++r) {
+            if (mrect[r][5]) {
+                stats_set_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                    noc_obj, mrect[r][0], mrect[r][1], mrect[r][2], mrect[r][3], mrect[r][4]);
+            } else {
+                stats_set_sem.set_multicast(noc_obj, mrect[r][0], mrect[r][1], mrect[r][2], mrect[r][3], mrect[r][4]);
+            }
+        }
         noc_obj.async_write_barrier();
         fabric_connection.close_finish();  // Includes a noc async write barrier
     } else {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
@@ -373,6 +373,43 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
         all_to_all_cores = applyStartOffset(all_to_all_cores, grid_offset.value());
         all_to_all_workers_except_sender = applyStartOffset(all_to_all_workers_except_sender, grid_offset.value());
     }
+    // Multicast targets.
+    //
+    // The issue that we have is that shard grid is not always a single rectangle.
+    // On Galaxy, for example, the decode grids are split around the column reserved for the DRAM prefetcher.
+    // Multicasting over the bounding box of such a grid can hit cores that do not belong to this program.
+    // If one of those cores is running the prefetcher at the time, the multicast can overwrite its live runtime args,
+    // which has been observed to deadlock the prefetcher's global circular buffer.
+    //
+    // To avoid this, the grid can be split into exact rectangles and each one is multicast separately.
+    // The rectangles are passed to the kernels as runtime args where has_sender parameter marks the rectangle that
+    // contains the sender core. Only that rectangle needs the loopback / exclude-self handling.
+    constexpr uint32_t kMaxMcastRects = 8;
+    const CoreRangeSet mcast_ranges = all_cores.merge_ranges();
+    TT_FATAL(
+        mcast_ranges.size() <= kMaxMcastRects,
+        "rms_allgather: shard grid splits into {} rectangles, kernels support at most {}",
+        mcast_ranges.size(),
+        kMaxMcastRects);
+    const CoreCoord mcast_sender_core = sender_cores.start_coord;
+    auto mcast_rect_args = [&](NOC noc) {
+        std::vector<uint32_t> args;
+        args.push_back(static_cast<uint32_t>(mcast_ranges.size()));
+        for (const CoreRange& r : mcast_ranges.ranges()) {
+            CoreCoord s = mesh_device->worker_core_from_logical_core(r.start_coord);
+            CoreCoord e = mesh_device->worker_core_from_logical_core(r.end_coord);
+            if (noc == NOC::NOC_1) {
+                std::swap(s, e);
+            }
+            args.push_back(s.x);
+            args.push_back(s.y);
+            args.push_back(e.x);
+            args.push_back(e.y);
+            args.push_back(static_cast<uint32_t>(r.size()));
+            args.push_back(r.contains(mcast_sender_core) ? 1u : 0u);
+        }
+        return args;
+    };
     if (num_none_all_to_all_workers > 0) {
         // Workers that are not on the first all-to-all column. Computing this
         // as a bounding-box rectangle (the legacy path) silently includes
@@ -940,23 +977,7 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
         }
 
         if (width_index == 0) {
-            CoreCoord mcast_start, mcast_end;
-            CoreCoord top_left_core = {(std::size_t)start_core.x, (std::size_t)start_core.y};
-            CoreCoord bottom_right_core = {
-                (std::size_t)start_core.x + num_cores_x - 1, (std::size_t)start_core.y + num_cores_y - 1};
-            auto top_left_core_physical = mesh_device->worker_core_from_logical_core(top_left_core);
-            auto bottom_right_core_physical = mesh_device->worker_core_from_logical_core(bottom_right_core);
-            mcast_start = top_left_core_physical;
-            mcast_end = bottom_right_core_physical;
-            if (reader_noc == NOC::NOC_1) {
-                std::swap(mcast_start, mcast_end);
-            }
-            std::vector<uint32_t> mcast_sender_args;
-            mcast_sender_args.reserve(6 + in0_mcast_noc_x.size() + in0_mcast_noc_y.size());
-            mcast_sender_args.push_back(mcast_start.x);
-            mcast_sender_args.push_back(mcast_start.y);
-            mcast_sender_args.push_back(mcast_end.x);
-            mcast_sender_args.push_back(mcast_end.y);
+            std::vector<uint32_t> mcast_sender_args = mcast_rect_args(reader_noc);
             mcast_sender_args.push_back(core.x - start_core.x);
             mcast_sender_args.push_back(core.y - start_core.y);
             mcast_sender_args.insert(mcast_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
@@ -1107,21 +1128,10 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
         if ((not use_two_stage_reduce and width_index < num_cores_all_to_all) or
             (use_two_stage_reduce and width_index_two_stage < 1)) {
             std::vector<uint32_t> writer_mcast_sender_args = {0};
-            CoreCoord mcast_start, mcast_end;
-            CoreCoord top_left_core = {(std::size_t)start_core.x, (std::size_t)start_core.y};
-            CoreCoord bottom_right_core = {
-                (std::size_t)start_core.x + num_cores_x - 1, (std::size_t)start_core.y + num_cores_y - 1};
-            auto top_left_core_physical = mesh_device->worker_core_from_logical_core(top_left_core);
-            auto bottom_right_core_physical = mesh_device->worker_core_from_logical_core(bottom_right_core);
-            mcast_start = top_left_core_physical;
-            mcast_end = bottom_right_core_physical;
-            if (writer_noc == NOC::NOC_1) {
-                std::swap(mcast_start, mcast_end);
+            {
+                const std::vector<uint32_t> rects = mcast_rect_args(writer_noc);
+                writer_mcast_sender_args.insert(writer_mcast_sender_args.end(), rects.begin(), rects.end());
             }
-            writer_mcast_sender_args.push_back(mcast_start.x);
-            writer_mcast_sender_args.push_back(mcast_start.y);
-            writer_mcast_sender_args.push_back(mcast_end.x);
-            writer_mcast_sender_args.push_back(mcast_end.y);
             if (use_two_stage_reduce && (!(width_index < 1))) {
                 writer_mcast_sender_args.push_back(cinv_one_bits);
             } else {
@@ -1157,21 +1167,10 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
             writer_kernel_ids.push_back(writer_mcast_sender_kernels_id);
         } else {
             std::vector<uint32_t> writer_mcast_receiver_args = {0};
-            CoreCoord mcast_start, mcast_end;
-            CoreCoord top_left_core = {(std::size_t)start_core.x, (std::size_t)start_core.y};
-            CoreCoord bottom_right_core = {
-                (std::size_t)start_core.x + num_cores_x - 1, (std::size_t)start_core.y + num_cores_y - 1};
-            auto top_left_core_physical = mesh_device->worker_core_from_logical_core(top_left_core);
-            auto bottom_right_core_physical = mesh_device->worker_core_from_logical_core(bottom_right_core);
-            mcast_start = top_left_core_physical;
-            mcast_end = bottom_right_core_physical;
-            if (reader_noc == NOC::NOC_1) {
-                std::swap(mcast_start, mcast_end);
+            {
+                const std::vector<uint32_t> rects = mcast_rect_args(reader_noc);
+                writer_mcast_receiver_args.insert(writer_mcast_receiver_args.end(), rects.begin(), rects.end());
             }
-            writer_mcast_receiver_args.push_back(mcast_start.x);
-            writer_mcast_receiver_args.push_back(mcast_start.y);
-            writer_mcast_receiver_args.push_back(mcast_end.x);
-            writer_mcast_receiver_args.push_back(mcast_end.y);
             writer_mcast_receiver_args.push_back(cinv_pre_bits);
             writer_mcast_receiver_args.push_back(i);  // Core ID to limit number of cores to do all gather on
             writer_mcast_receiver_args.insert(
@@ -1267,14 +1266,18 @@ void RMSAllGatherMeshWorkloadFactory::override_runtime_arguments(
 
             if (writer_kernel_id == shared_vars.writer_mcast_sender_kernels_id) {
                 auto& runtime_args = writer_sender_args_by_core[core.x][core.y];
-                runtime_args[7] = operation_attributes.semaphore.address();
-                runtime_args[9] = stats_tensor.value().buffer()->address();
+                // Layout: [0]=post-arg offset, [1]=num_mcast_rects, 6 words per rect, cinv, core id,
+                // then the all-gather args (semaphore address first, stats tensor address third).
+                const uint32_t ag_base = 4 + 6 * runtime_args[1];
+                runtime_args[ag_base] = operation_attributes.semaphore.address();
+                runtime_args[ag_base + 2] = stats_tensor.value().buffer()->address();
                 // runtime_args[0] holds the start of the post arguments, apply that offset
                 runtime_args[runtime_args[0] + 2] = gamma_address;
             } else if (writer_kernel_id == shared_vars.writer_mcast_receiver_kernels_id) {
                 auto& runtime_args = writer_receiver_args_by_core[core.x][core.y];
-                runtime_args[7] = operation_attributes.semaphore.address();
-                runtime_args[9] = stats_tensor.value().buffer()->address();
+                const uint32_t ag_base = 4 + 6 * runtime_args[1];
+                runtime_args[ag_base] = operation_attributes.semaphore.address();
+                runtime_args[ag_base + 2] = stats_tensor.value().buffer()->address();
                 runtime_args[runtime_args[0] + 2] = gamma_address;
             }
         }

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -27,9 +27,16 @@ void kernel_main() {
     const uint32_t bank_id = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t vc = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t total_num_blocks_in_buffer = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t* page_sizes = (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));
-    const uint32_t* block_num_pages = (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));
-    const uint32_t* block_num_tiles = (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));
+    // Copy the per-tensor runtime args out of L1 once (reason explained in writer_l1.cpp).
+    uint32_t page_sizes[num_tensors];
+    uint32_t block_num_pages[num_tensors];
+    uint32_t block_num_tiles[num_tensors];
+    for (uint32_t t = 0; t < num_tensors; t++) {
+        page_sizes[t] = get_arg_val<uint32_t>(rt_args_idx + t);
+        block_num_pages[t] = get_arg_val<uint32_t>(rt_args_idx + num_tensors + t);
+        block_num_tiles[t] = get_arg_val<uint32_t>(rt_args_idx + 2 * num_tensors + t);
+    }
+    rt_args_idx += 3 * num_tensors;
 
     uint32_t l1_buffer_start_addr = get_write_ptr(cb_id);
     uint32_t l1_buffer_end_addr = get_write_ptr(cb_id) + read_cb_size;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
@@ -28,13 +28,26 @@ void kernel_main() {
 
     // Runtime args
     // Note: Coalesced sizes -> wrt to receiver cores, sizes -> wrt to dram reader cores
+    // FIX UPDATE
+    // We need to read all per-tensor runtime args into local variables up front, instead
+    // from L1 on every layer. Since this kernel stays resident for an entire decode step,
+    // (during which other programs run on the worker cores), if one of the other programs
+    // writes into the runtime-arg region (e.g. a multicast that overshoots its grid),
+    // the values read later can get corrupted.
     uint32_t rt_args_idx = 0;
-    const uint32_t* coalesced_page_sizes = (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));
-    const uint32_t* coalesced_num_pages = (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));
-    const uint32_t* block_num_tiles = (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));
-    const uint32_t* single_tile_sizes = (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));
-    const uint32_t* block_height_in_tiles =
-        (uint32_t*)(get_arg_addr(increment_arg_idx(rt_args_idx, num_tensors)));  // Kt / num_blocks = in_block_h;
+    uint32_t coalesced_page_sizes[num_tensors];
+    uint32_t coalesced_num_pages[num_tensors];
+    uint32_t block_num_tiles[num_tensors];
+    uint32_t single_tile_sizes[num_tensors];
+    uint32_t block_height_in_tiles[num_tensors];  // Kt / num_blocks = in_block_h;
+    for (uint32_t t = 0; t < num_tensors; t++) {
+        coalesced_page_sizes[t] = get_arg_val<uint32_t>(rt_args_idx + t);
+        coalesced_num_pages[t] = get_arg_val<uint32_t>(rt_args_idx + num_tensors + t);
+        block_num_tiles[t] = get_arg_val<uint32_t>(rt_args_idx + 2 * num_tensors + t);
+        single_tile_sizes[t] = get_arg_val<uint32_t>(rt_args_idx + 3 * num_tensors + t);
+        block_height_in_tiles[t] = get_arg_val<uint32_t>(rt_args_idx + 4 * num_tensors + t);
+    }
+    rt_args_idx += 5 * num_tensors;
 
     uint32_t noc = noc_index;
     for (uint32_t layer = 0; layer < num_layers; layer++) {


### PR DESCRIPTION
### Problem

We were having issues with Llama-3.3-70B galaxy text demo script for some time now. It deadlocks in untraced decode (ci-token-matching) at a fixed point: decode step 33, exactly after layer 77. This only happens in untraced regime, traced one never hangs. Triage with tt-triage showed the DRAM-prefetcher cores in column 4 stalled inside the global circular-buffer credit protocol, with a corrupted runtime argument: block_height_in_tiles for the w2 tensor had been overwritten from 5 to 1 while the prefetcher kernel was running.

The issue turned out to be the writer from rms_allgather. Sender kernels multicast the semaphore and the reduced-stats tile over shard_spec.grid.bounding_box(). Since galaxy decode norms have a non-rectangular shard grid split around the prefetcher column, the bounding box then includes prefetcher cores that are not part of the program. On those cores the multicast lands in the live kernel-config region. In traced decode the kernel-config ring layout is fixed at capture, so the stray write never coincides with a live arg; in untraced mode the ring drifts each step until it does.

### Fix

With the fix rms_allgather now multicasts per rectangle of all_cores.merge_ranges(). The rectangles are passed as runtime args (count, then x0, y0, x1, y1, cell count, has-sender per rectangle), so the compile-time arg layout is unchanged. Loopback multicast is used only on the rectangle that contains the sender. override_runtime_arguments derives the all-gather argument offset from the rectangle count instead of hard-coded indices.
The DRAM prefetcher kernels (writer_l1, reader_dram) copy their per-tensor runtime args into locals at kernel start instead of re-reading L1 every layer, so a long-running prefetcher is no longer so sensitive to later writes into its kernel-config slot. This is more of a defence as well since the multicast change alone fixes the hang.

### Validation

- ci-token-matching (untraced decode) on galaxy: 499 iterations complete, Top-1 95.80%, Top-5 99.80%. Previously deadlocked at iteration 31, reproducibly.

- Perf A/B on galaxy Llama-3.3-70B text_demo.py, batch-1 and batch-32 legs, fresh build and cleared kernel cache on each side:

| Leg | Fix | Base |
|----|----|------|
| batch-1 decode | 15.31 ms/tok, 65.32 tok/s | 15.60 ms/tok, 64.10 tok/s |
| batch-32 throughput | 2072 tok/s | 2038 tok/s |
| batch-32 log-probs | 1944 tok/s | 1912 tok/s |

- TTFT, all test are within 1% delta which is statistically insignificant	

This all means that we have no regression; all deltas are within run-to-run noise.

CI:
Sanity check CI: https://github.com/tenstorrent/tt-metal/actions/runs/33806963117/job/101024558617

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ifabijanic/rms-allgather-mcast-bbox-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ifabijanic/rms-allgather-mcast-bbox-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ifabijanic/rms-allgather-mcast-bbox-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ifabijanic/rms-allgather-mcast-bbox-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ifabijanic/rms-allgather-mcast-bbox-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ifabijanic/rms-allgather-mcast-bbox-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ifabijanic/rms-allgather-mcast-bbox-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ifabijanic/rms-allgather-mcast-bbox-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ifabijanic/rms-allgather-mcast-bbox-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ifabijanic/rms-allgather-mcast-bbox-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ifabijanic/rms-allgather-mcast-bbox-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ifabijanic/rms-allgather-mcast-bbox-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ifabijanic/rms-allgather-mcast-bbox-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ifabijanic/rms-allgather-mcast-bbox-fix)