### PR TITLE
[Performance] gpt_oss: take the force-argmax path for greedy decode

### DIFF
--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -92,6 +92,30 @@ class TTSampling(LightweightModule):
             return None
         return num_splits
 
+    @classmethod
+    def supports_vocab_on_device(cls, mesh_device, padded_vocab_size, num_sampling_shards):
+        """Whether TTSampling can sample this vocabulary on device.
+
+        The two cases are not the same bound, which is why callers must not
+        hardcode one:
+
+        - 1x1 mesh: ``forward`` takes the same-device split top-k
+          (``multi_step_reduction``), which cuts the padded vocab into
+          power-of-two chunks each at most TOPK_MAX_WIDTH wide. Any vocab it can
+          cut tile-aligned is supported, however wide (#53167). The mesh
+          predicate here must stay identical to ``multi_step_reduction``: a
+          single-device mesh whose shape is not [1, 1] does NOT take the split
+          path and would hand ttnn.topk a half-width row.
+        - Larger mesh: each device runs top-k on its own vocab shard and there is
+          no same-device split for shards, so the shard itself has to fit.
+
+        Callers that get False must fall back to host sampling rather than
+        constructing TTSampling.
+        """
+        if list(mesh_device.shape) == [1, 1]:
+            return cls.num_single_device_vocab_splits(padded_vocab_size) is not None
+        return padded_vocab_size // num_sampling_shards <= TOPK_MAX_WIDTH
+
     @staticmethod
     def _untilize_chunk_count(width):
         """Fewest tile-aligned even chunks of at most TOPK_MAX_WIDTH each, or 1

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -1072,6 +1072,43 @@ def test_num_single_device_vocab_splits(padded_vocab_size, expected_splits):
     assert TTSampling.num_single_device_vocab_splits(padded_vocab_size) == expected_splits
 
 
+# The parameter is "shape", not "mesh_shape": pytest_collection_modifyitems in this
+# directory's conftest deselects any item carrying a mesh_shape param whose value does
+# not equal its ttnn_mesh_device param. These cases build a stand-in object instead of
+# taking that fixture, so the name would silently drop every one of them.
+@pytest.mark.parametrize(
+    "shape, padded_vocab_size, num_sampling_shards, expected",
+    [
+        # 1x1: the same-device split path, so width alone never disqualifies a vocab
+        # it can cut tile-aligned. GPT-OSS at TP=1 is the 262144 case (4 x 65536).
+        ([1, 1], 262144, 1, True),
+        ([1, 1], 256000, 1, True),  # Gemma-2, 4 x 64000
+        ([1, 1], 131104, 1, False),  # no tile-aligned cut -> host sampling
+        # Larger meshes shard the vocab instead: each device top-ks its own shard,
+        # which has to fit on its own. The same 262144 that a 1x1 mesh splits is
+        # fine across 8 devices and not fine across 2.
+        ([1, 8], 262144, 8, True),
+        ([1, 2], 262144, 2, False),
+        ([4, 8], 262144, 8, True),
+    ],
+)
+def test_supports_vocab_on_device(shape, padded_vocab_size, num_sampling_shards, expected):
+    mesh_device = SimpleNamespace(shape=shape)
+    assert TTSampling.supports_vocab_on_device(mesh_device, padded_vocab_size, num_sampling_shards) is expected
+
+
+def test_supports_vocab_on_device_tracks_multi_step_reduction():
+    """A single-device mesh that is not [1, 1] must not claim the split path.
+
+    ``multi_step_reduction`` (and with it ``_num_vocab_splits``) keys off
+    ``list(mesh_device.shape) == [1, 1]``. If this predicate were written as
+    ``get_num_devices() == 1`` instead, a 1D single-device mesh would report
+    support, then take the non-split branch and hand ttnn.topk a 131072-wide row.
+    """
+    assert TTSampling.supports_vocab_on_device(SimpleNamespace(shape=[1, 1]), 262144, 1) is True
+    assert TTSampling.supports_vocab_on_device(SimpleNamespace(shape=[1]), 262144, 1) is False
+
+
 @pytest.mark.parametrize(
     "width, expected",
     [
@@ -1159,17 +1196,21 @@ def _single_device_sampling_args(mesh_device, vocab_size, max_top_k=32, max_batc
         # into four same-device chunks. Qwen3 has exactly this vocab size (#53064).
         pytest.param(151936, id="v151936_four_way_split"),
         # Four 64000-wide tile-aligned chunks, none a power of two. Gemma-2-2B has exactly
-        # this vocab size and is the largest vocab any tiered model runs on one device.
+        # this vocab size.
         pytest.param(256000, id="v256000_four_way_split_gemma"),
+        # Exactly four TOPK_MAX_WIDTH chunks, so every chunk is both the widest ttnn.topk
+        # accepts and a power of two. GPT-OSS at TP=1 pads to this width, and it is the
+        # widest vocab any tiered model runs on one device.
+        pytest.param(262144, id="v262144_four_way_split_gpt_oss"),
     ],
 )
 @pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
 def test_ttsampling_topk_matches_argmax_on_single_device(vocab_size, mesh_device):
     """top-k=1 through TTSampling must select the row maximum on a 1x1 mesh.
 
-    On a single device TTSampling splits the logits in half and runs ttnn.topk on each half
-    (``multi_step_reduction``), so this covers the split path end to end for both top-k program
-    factories. Regression test for the half-width local indices buffer, which made the multi-core
+    On a single device TTSampling cuts the logits into as many same-device chunks as the width
+    needs (``multi_step_reduction``) and runs ttnn.topk on each chunk, so this covers the split
+    path end to end for both top-k program factories. Regression test for the half-width local indices buffer, which made the multi-core
     factory page its index tiles past the end of that buffer and return indices that did not
     belong to the values it returned.
     """

--- a/models/demos/gpt_oss/tests/accuracy/test_model.py
+++ b/models/demos/gpt_oss/tests/accuracy/test_model.py
@@ -8,6 +8,7 @@ Full model integration test with accuracy testing
 import os
 import pickle
 
+import pytest
 import torch
 from loguru import logger
 
@@ -142,14 +143,24 @@ def run_accuracy(
 def test_full_model_accuracy(mesh_device, device_params, reset_seeds, state_dict):
     """Test full model with accuracy testing using new abstractions"""
 
-    # Cache file for reference tokens
-    cache_dir = "models/demos/gpt_oss/tests/accuracy/"
-    os.makedirs(cache_dir, exist_ok=True)
-    cache_file = os.path.join(cache_dir, "reference_tokens.pkl")
-
     setup = TestFactory.setup_test(mesh_device, use_real_weights=True)
     config = setup["config"]
     mesh_config = setup["mesh_config"]
+
+    # Reference tokens are the reference model's own continuation, so they belong to one
+    # model. Key the cache by model_name: gpt-oss-20b and gpt-oss-120b answer the same
+    # prompt differently, and a shared file would score one model against the other's
+    # tokens and still report a number.
+    cache_dir = "models/demos/gpt_oss/tests/accuracy/"
+    os.makedirs(cache_dir, exist_ok=True)
+    model_name = setup["model_args"].model_name
+    cache_file = os.path.join(cache_dir, f"reference_tokens_{model_name}.pkl")
+    legacy_cache_file = os.path.join(cache_dir, "reference_tokens.pkl")
+    if not os.path.exists(cache_file) and os.path.exists(legacy_cache_file):
+        # The original unkeyed file predates this split. Keep reading it so the model it
+        # was generated for keeps its coverage until each model has its own file.
+        logger.warning(f"Using the unkeyed reference cache {legacy_cache_file} for {model_name}")
+        cache_file = legacy_cache_file
 
     # Try to load cached reference tokens first
     reference_tokens = None
@@ -170,6 +181,12 @@ def test_full_model_accuracy(mesh_device, device_params, reset_seeds, state_dict
 
     # Generate reference tokens if not cached
     if reference_tokens is None:
+        if os.environ.get("CI") == "true":
+            pytest.skip(
+                f"No reference tokens for {model_name} at {cache_file}. Generating them loads the "
+                "reference model on the host, which does not fit in a CI job. Generate the file "
+                "on a machine that holds the weights and commit it."
+            )
         logger.info("Generating reference tokens (this may take a while)...")
 
         # Create reference model for comparison (use full model like demo)

--- a/models/demos/gpt_oss/tests/unit/test_sampling_ccl.py
+++ b/models/demos/gpt_oss/tests/unit/test_sampling_ccl.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only regressions for the GPT-OSS sampling CCL and force-argmax configuration.
+
+The force-argmax all-gather must be handed semaphores that belong to sampling alone.
+``all_gather_async`` maps its two global semaphores to the forward and backward ring
+directions, so a handle that also serves the model's own CCLs as a single leaves
+per-direction counts behind and desyncs a later gather; on Blackhole that shows up as
+argmax indices displaced by whole vocab chunks. ``SamplingCCL`` therefore hands out one
+fixed pair per axis and never rotates it. These tests pin that contract and the
+configuration that turns the path on. Neither needs a device.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import ttnn
+from models.demos.gpt_oss.tt.ccl import SamplingCCL
+from models.demos.gpt_oss.tt.model import Model
+
+GPT_OSS_VOCAB_SIZE = 201088
+
+
+def _ccl_without_device():
+    """A SamplingCCL with stand-in handles, so the accessor contract is testable on the host.
+
+    ``__init__`` allocates global semaphores and needs a mesh, but every property under
+    test here is pool selection and aliasing, which the handles' identity is enough to show.
+    """
+    ccl = object.__new__(SamplingCCL)
+    ccl.mesh_device = None
+    ccl._ag_handles = [[f"ag{pool}a", f"ag{pool}b"] for pool in range(3)]
+    ccl._barrier_handles = [f"barrier{pool}" for pool in range(3)]
+    return ccl
+
+
+@pytest.mark.parametrize(
+    "cluster_axis, expected_pool",
+    [
+        (1, 1),  # mesh_2x4, mesh_4x4 and mesh_4x8 all gather on axis 1
+        (0, 0),
+        (None, 2),  # mesh_1x8: a shape holding a 1 gathers without an axis
+    ],
+)
+def test_semaphore_pools_are_selected_by_axis(cluster_axis, expected_pool):
+    ccl = _ccl_without_device()
+    assert ccl.get_and_cycle_ag_semaphore_handles(cluster_axis) == [f"ag{expected_pool}a", f"ag{expected_pool}b"]
+    assert ccl.get_sampling_barrier_semaphore_handle(cluster_axis) == f"barrier{expected_pool}"
+
+
+def test_axis_none_does_not_collide_with_axis_zero():
+    """None must not fold into the axis-0 pool, which is a real axis with its own handles."""
+    ccl = _ccl_without_device()
+    assert ccl.get_and_cycle_ag_semaphore_handles(None) != ccl.get_and_cycle_ag_semaphore_handles(0)
+    assert ccl.get_sampling_barrier_semaphore_handle(None) != ccl.get_sampling_barrier_semaphore_handle(0)
+
+
+def test_handles_keep_a_fixed_role_across_calls():
+    """The pair must not rotate. Rotation is what corrupts the gather, so pin identity.
+
+    A handle that changes direction role between calls, or that is handed out while the
+    model's own CCLs hold it, desyncs the gather. Fixed handles are the whole reason this
+    class exists rather than a reuse of CCLManager's ping-pong banks.
+    """
+    ccl = _ccl_without_device()
+    for cluster_axis in (0, 1, None):
+        first = ccl.get_and_cycle_ag_semaphore_handles(cluster_axis)
+        second = ccl.get_and_cycle_ag_semaphore_handles(cluster_axis)
+        assert first is second, f"axis {cluster_axis}: all-gather handles rotated between calls"
+        assert ccl.get_sampling_barrier_semaphore_handle(cluster_axis) is ccl.get_sampling_barrier_semaphore_handle(
+            cluster_axis
+        ), f"axis {cluster_axis}: barrier handle rotated between calls"
+
+
+def test_barrier_default_accessor_aliases_the_sampling_one():
+    """TTSampling reads the sampling accessor through getattr with this as the default.
+
+    Python evaluates that default eagerly, so the method has to exist, and it has to give
+    back the dedicated handle rather than something shared.
+    """
+    ccl = _ccl_without_device()
+    for cluster_axis in (0, 1, None):
+        assert ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis) is ccl.get_sampling_barrier_semaphore_handle(
+            cluster_axis
+        )
+
+
+# "shape", not "mesh_shape": a mesh_shape param is what pytest_collection_modifyitems keys
+# on elsewhere in the tree to deselect items, and these cases take no device fixture.
+@pytest.mark.parametrize("shape", [(2, 4), (4, 4), (1, 8), (4, 8)])
+def test_force_argmax_is_configured_for_every_deployable_mesh(shape):
+    """Every GPT-OSS mesh configuration must switch greedy decode to the argmax path."""
+    mesh_device = SimpleNamespace(shape=list(shape), get_num_devices=lambda: shape[0] * shape[1])
+    args = Model._make_sampling_args(
+        SimpleNamespace(sampling_dp=1),
+        SimpleNamespace(vocab_size=GPT_OSS_VOCAB_SIZE),
+        mesh_device,
+    )
+    config = args.model_config["SAMPLING_AG_CONFIG"]
+    assert config["allow_force_argmax"] is True
+    assert config["topology"] is ttnn.Topology.Linear
+    assert config["num_links"] >= 1

--- a/models/demos/gpt_oss/tt/ccl.py
+++ b/models/demos/gpt_oss/tt/ccl.py
@@ -2,6 +2,70 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
+from models.common.modules.tt_ccl import get_num_links
+
+
+class SamplingCCL:
+    """Dedicated CCL handles for the TTSampling force-argmax all-gather.
+
+    TTSampling's force-argmax path needs ``get_and_cycle_ag_semaphore_handles`` and a
+    barrier accessor, neither of which CCLManager exposes.
+
+    These handles are deliberately separate from CCLManager's ping-pong banks rather
+    than borrowed from them. ``all_gather_async`` maps its two global semaphores to the
+    forward and backward ring directions, so a handle that also serves the model's own
+    CCLs as a single leaves per-direction counts behind and desyncs a later gather. On
+    Blackhole that appears as argmax indices displaced by whole vocab chunks;
+    ``models/demos/llama3_70b_galaxy/tt/llama_ccl.py`` records the same finding and
+    solves it the same way. So these are fixed-role: one pair per axis, never cycled and
+    never shared.
+
+    Index 2 is the no-axis pool. ``TTSampling._get_sampling_cluster_axis`` returns None
+    for a mesh whose shape contains a 1 (mesh_1x8) and the gather axis otherwise
+    (mesh_2x4, mesh_4x4 and mesh_4x8 all give 1), so both forms reach these accessors.
+    """
+
+    _NO_AXIS = 2
+
+    def __init__(self, mesh_device):
+        self.mesh_device = mesh_device
+        grid = mesh_device.compute_with_storage_grid_size()
+        core_range_set = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))}
+        )
+        # all_gather_async consumes two semaphores per call; the barrier consumes one.
+        self._ag_handles = [
+            [ttnn.create_global_semaphore(mesh_device, core_range_set, 0) for _ in range(2)] for _ in range(3)
+        ]
+        self._barrier_handles = [ttnn.create_global_semaphore(mesh_device, core_range_set, 0) for _ in range(3)]
+
+    def _pool_index(self, cluster_axis):
+        return self._NO_AXIS if cluster_axis is None else cluster_axis
+
+    def get_and_cycle_ag_semaphore_handles(self, cluster_axis=None):
+        """Return the fixed pair for this axis. The name matches the interface TTSampling
+        calls; the handles do not rotate, which is the point (see the class docstring)."""
+        return self._ag_handles[self._pool_index(cluster_axis)]
+
+    def get_sampling_barrier_semaphore_handle(self, cluster_axis=None):
+        return self._barrier_handles[self._pool_index(cluster_axis)]
+
+    def get_and_cycle_barrier_semaphore_handle(self, cluster_axis=None):
+        # TTSampling reads the sampling accessor above through getattr with this method as
+        # the default. Python evaluates that default eagerly, so it has to exist.
+        return self.get_sampling_barrier_semaphore_handle(cluster_axis)
+
+    def get_num_links(self, cluster_axis=None):
+        return get_num_links(self.mesh_device, cluster_axis)
+
+    def reset_global_semaphores(self):
+        """Return every handle to 0, so a reused sampler starts from the state that trace
+        capture assumes."""
+        for pair in self._ag_handles:
+            for semaphore in pair:
+                ttnn.reset_global_semaphore_value(semaphore, 0)
+        for semaphore in self._barrier_handles:
+            ttnn.reset_global_semaphore_value(semaphore, 0)
 
 
 class CCLManager:

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -229,11 +229,19 @@ class Model:
         # sampling_dp: number of independent sampling groups (one per mesh row for row-sharded users)
         self.sampling_dp = mesh_device.shape[0] if users_row_sharded else 1
         if self._supports_on_device_sampling:
-            # tt_ccl=None makes TTSampling fall back to ttnn.all_gather() which works on [4,8] meshes
+            # Greedy decode takes TTSampling's force-argmax path, which all-gathers the logits
+            # once and then argmaxes, instead of the top-k / top-p / temperature / RNG chain.
+            # That gather needs real semaphores, so hand it a SamplingCCL. Its handles are
+            # dedicated to sampling and never shared with the model's own CCLs; see that class
+            # for what sharing corrupts. SamplingCCL exposes no line_all_gather, so the regular
+            # top-k path still falls back to ttnn.all_gather() exactly as it did with tt_ccl=None.
+            from models.demos.gpt_oss.tt.ccl import SamplingCCL
+
+            self.sampling_ccl = SamplingCCL(mesh_device)
             self.sampling = SamplingGenerator(
                 args=self.args if hasattr(self, "args") else self._make_sampling_args(hf_config, mesh_device),
                 mesh_device=mesh_device,
-                tt_ccl=None,
+                tt_ccl=self.sampling_ccl,
             )
             # Hook reset_sampling_params to set prefill flag — Generator calls this
             # before prefill forward; tells _forward_layers_and_head to skip TP all-gather
@@ -263,7 +271,18 @@ class Model:
         args.sampling_all_gather_axis = 1
         args.num_devices = mesh_device.get_num_devices()
         args.is_galaxy = mesh_device.shape[0] > 1
-        args.model_config = {}  # No SAMPLING_AG_CONFIG → regular sampling path always used
+        # Greedy requests (k=1, p in {0.0, 1.0}, temp=1) take the single all-gather + argmax
+        # path; every other request still takes the regular sampling path. Topology is Linear
+        # rather than Ring: TTSampling only downgrades to Linear below 8 devices, and the gather
+        # axis here is 4 wide on mesh_2x4 and mesh_4x4, where a ring route is not available.
+        # TTSampling clamps num_links to what the submesh actually has.
+        args.model_config = {
+            "SAMPLING_AG_CONFIG": {
+                "allow_force_argmax": True,
+                "num_links": get_default_num_links(mesh_device),
+                "topology": ttnn.Topology.Linear,
+            }
+        }
         # sampling_dp: number of independent sampling groups (one per mesh row)
         # Only use row-sharded sampling when users_row_sharded is active
         args.sampling_dp = self.sampling_dp

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
 from models.common.sampling.generator import SamplingGenerator
-from models.common.sampling.tt_sampling import TOPK_MAX_WIDTH, TTSampling
+from models.common.sampling.tt_sampling import TTSampling
 from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.common import Mode, copy_host_to_device
 from models.tt_transformers.tt.decoder import TransformerBlock
@@ -152,16 +152,15 @@ class Transformer(LightweightModule):
             prefetcher=prefetcher,
         )
 
-        # Initialize on-device sampling if supported
-        # Sampling on device is supported only if each device holds at most TOPK_MAX_WIDTH logits.
-        # On a single device TTSampling cuts the padded vocab into as many same-device chunks as
-        # needed (power-of-two, each <= TOPK_MAX_WIDTH), so any vocab it can cut tile-aligned is
-        # supported (#53064); anything it cannot falls back to host sampling.
+        # Initialize on-device sampling if supported. TTSampling owns the capability
+        # rule: a single device splits the padded vocab into same-device chunks that each
+        # fit ttnn.topk, so any vocab it can cut tile-aligned works (#53064); a larger
+        # mesh needs each device's own shard to fit. Anything it cannot take falls back
+        # to host sampling.
         padded_vocab_size = getattr(self.args, "padded_vocab_size", None) or self.args.vocab_size
-        if list(self.mesh_device.shape) != [1, 1]:
-            vocab_fits_on_device = padded_vocab_size // self.args.num_devices <= TOPK_MAX_WIDTH
-        else:
-            vocab_fits_on_device = TTSampling.num_single_device_vocab_splits(padded_vocab_size) is not None
+        vocab_fits_on_device = TTSampling.supports_vocab_on_device(
+            self.mesh_device, padded_vocab_size, self.args.num_devices
+        )
         self._supports_on_device_sampling = prefetcher is None and vocab_fits_on_device
         if self._supports_on_device_sampling:
             self.sampling = SamplingGenerator(

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -830,6 +830,28 @@
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
 
+- name: GPT-OSS 120B accuracy tests
+  cmd: |
+    export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ TT_MM_THROTTLE_PERF=2
+    # Tensor cache is pre-built on the NAS — skip loading model weights by default.
+    # Check mlperf-write-access in the workflow to load weights and regenerate the cache.
+    SKIP_MODEL_LOAD="--skip-model-load"
+    [ "${MLPERF_READ_ONLY:-true}" = "false" ] && SKIP_MODEL_LOAD=""
+    pytest models/demos/gpt_oss/tests/accuracy/test_model.py --timeout 1200 $SKIP_MODEL_LOAD
+  model: gpt-oss-120b
+  model_family: GPT-OSS
+  skus:
+    wh_galaxy_perf:
+      timeout: 20
+      tier: 1
+      release_ready: false
+    bh_quietbox_2:
+      timeout: 20
+      tier: 1
+      release_ready: false
+  owner_id: U08TJ70UFRT # Harry Andrews
+  team: models
+
 # ── Whisper ────────────────────────────────────────────────────────
 
 - name: Whisper e2e tests

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1561,7 +1561,7 @@
 
 - name: On-device sampling unit tests
   cmd: |
-    pytest --timeout 300 models/common/tests/test_sampling.py -k "ttsampling or num_single_device_vocab_splits or untilize_chunk_count or seed or slot_remap or topk_authoritative_route_decision"
+    pytest --timeout 300 models/common/tests/test_sampling.py -k "ttsampling or num_single_device_vocab_splits or supports_vocab_on_device or untilize_chunk_count or seed or slot_remap or topk_authoritative_route_decision"
   model: tt-model-sampling
   skus:
     wh_n150:


### PR DESCRIPTION
## The CI runs

| Workflow | Model | SKU | Commit | Run |
| --- | --- | --- | --- | --- |
| (Tier 2) Models e2e | gpt-oss-20b | all | `f6aa1cf` | [33869372615](https://github.com/tenstorrent/tt-metal/actions/runs/33869372615) |
| (Tier 2) Models Unit | gpt-oss-20b | all | `f6aa1cf` | [33869376084](https://github.com/tenstorrent/tt-metal/actions/runs/33869376084) |
| (Tier 1) Models Unit | gpt-oss-120b | all | `f6aa1cf` | [33869379228](https://github.com/tenstorrent/tt-metal/actions/runs/33869379228) |
| (Tier 1) Models Unit | tt-transformers-common | wh_llmbox | `dc4f0bd` | [33866987868](https://github.com/tenstorrent/tt-metal/actions/runs/33866987868) |
| (Tier 3) Models Unit | tt-model-sampling | all | `dc4f0bd` | [33866991058](https://github.com/tenstorrent/tt-metal/actions/runs/33866991058) |

The e2e run is the one that matters most. It uses `pytest models/demos/gpt_oss/demo/text_demo.py` with real weights, and the demo sets `temperature: 0`, so every decode step takes the new force-argmax path. It covers wh_llmbox, bh_quietbox_2 and bh_p150.

The two GPT-OSS unit runs load no weights, but they do construct `SamplingCCL`, so they show whether the semaphore allocation succeeds on each mesh. The 120B entry reaches wh_galaxy, which is the 4x8 mesh.

The last two runs cover the shared capability rule and were dispatched before this branch gained the GPT-OSS commit. That commit touches only `models/demos/gpt_oss/`, so those two results still hold for the files they exercise.

The vLLM Galaxy run that appeared in an earlier revision of this description is not listed. `openai/gpt-oss-120b` in `tests/pipeline_reorg/vllm_model_tests.yaml` sets `tt-llama-text-ver: tt_transformers`, so it does not construct `models/demos/gpt_oss/tt/model.py` and cannot exercise this change.

### The Tier 1 tt-transformers run cannot reach a green result

That entry already fails on the main branch. Run [33718221645](https://github.com/tenstorrent/tt-metal/actions/runs/33718221645) on main reports `4 failed, 2733 passed` and names four tests in `test_demo_contract.py` and `test_hf_adaptor.py`. None of them touch sampling. An earlier run on this branch reported the same four tests and the same assertion messages. Read that run as "the same four failures and no more".

---

## Part 1: greedy decode takes the force-argmax path

`_make_sampling_args` passed an empty `model_config`, so `allow_force_argmax` stayed false and greedy decode always paid the full top-k, top-p, temperature and RNG chain. #48886 measured the single all-gather plus argmax path as a clear improvement. This turns it on for GPT-OSS.

The path needs real semaphores for its all-gather, and the call site passed `tt_ccl=None`. `SamplingCCL` in `models/demos/gpt_oss/tt/ccl.py` supplies them.

### Why SamplingCCL owns its handles

`SamplingCCL` does not borrow `CCLManager`'s ping-pong banks, and that is the whole reason it exists. `all_gather_async` maps its two global semaphores to the forward and backward ring directions. A handle that also serves the model's own CCLs as a single leaves per-direction counts behind, and that desyncs a later gather. On Blackhole the symptom is argmax indices displaced by whole vocab chunks. `models/demos/llama3_70b_galaxy/tt/llama_ccl.py` records the same problem and solves it the same way.

So the handles are fixed-role: one pair per axis, never rotated and never shared. Index 2 holds the no-axis pool, because `TTSampling._get_sampling_cluster_axis` returns `None` for a mesh whose shape holds a 1.

Two further choices:

- Topology is `Linear`, not `Ring`. TTSampling downgrades to `Linear` only below 8 devices. The gather axis is 4 wide on a 2x4 and on a 4x4 mesh, and a ring route is not available there. `num_links` comes from `get_default_num_links`, and TTSampling clamps it to what the submesh has.
- `SamplingCCL` exposes no `line_all_gather`. The regular top-k path and `LogProbsCalculator` both probe for that attribute, and both fall back to `ttnn.all_gather` when it is absent. They therefore behave exactly as they did with `tt_ccl=None`. Log-probs on 8 and on 32 devices are unaffected.

## Part 2: the vocab capability rule moves into TTSampling

Whether a vocabulary can be sampled on the device is two different bounds, and call sites wrote one of them out by hand.

- On a 1x1 mesh, `forward` takes the same-device split top-k (`multi_step_reduction`). It cuts the padded vocab into power-of-two chunks that each fit `ttnn.topk`. Any vocab it can cut tile-aligned is therefore supported, however wide it is (#53167).
- On a larger mesh, each device runs top-k on its own shard. There is no same-device split for shards, so the shard itself has to fit.

`TTSampling.supports_vocab_on_device()` holds both cases, and `models/tt_transformers/tt/model.py` now calls it. That file already had this exact branch inline, so its behavior does not change and it no longer imports `TOPK_MAX_WIDTH`.

The mesh predicate is `list(shape) == [1, 1]`, which matches `multi_step_reduction` rather than a device count. A mesh with one device can have a shape that is not `[1, 1]`. Such a mesh does not take the split path, and it would get a row of half the correct width. A test pins that distinction.

Four model files still carry a hardcoded `per_device_padded <= 64 * 1024`, and each becomes one line once it adopts this function:

- `models/demos/gpt_oss/tt/model.py:227`
- `models/demos/gpt_oss_d_p/tt/model.py:145`
- `models/demos/minimax_m3/tt/model.py:292`
- `models/experimental/ops/quasar/gpt_oss/tt/model.py:227`

## Why this replaces #52255

#52255 by @tennyfr reported that GPT-OSS never builds its sampler, because the gate reads `per_device_padded <= 64 * 1024` and TP=1 gives 262144. #52255 read that constant correctly. But no deployable GPT-OSS mesh reaches TP=1.

`models/demos/gpt_oss/tt/common.py` derives the mesh configuration from the mesh that is actually open, with `tp = mesh_device.shape[1]`, and `models/demos/gpt_oss/config.py` offers four shapes for it:

| Mesh configuration | TP | `per_device_padded` | Passes `<= 64 * 1024` |
| --- | --- | --- | --- |
| `mesh_2x4` | 4 | 65536 | yes |
| `mesh_4x4` | 4 | 65536 | yes |
| `mesh_1x8` | 8 | 32768 | yes |
| `mesh_4x8` | 8 | 32768 | yes |

Every one already passed, so nothing was disabled and no decode step read its logits back to the host. TP=1 arises only on a single-card runner, where GPT-OSS is not deployed. A change to that gate therefore alters nothing that ships, and a force-argmax path conditioned on one device never runs.

The cost #52255 aimed at is real. But it is the top-k chain on the meshes GPT-OSS does use. Part 1 addresses that instead. The gate itself is left alone here.

## The tests

- `test_supports_vocab_on_device` covers a 1x1 mesh at 262144, at 256000, and at 131104. The last width has no cut that fits the tiles. It also covers the shapes `[1,8]`, `[1,2]` and `[4,8]`.
- `test_supports_vocab_on_device_tracks_multi_step_reduction` compares `shape == [1,1]` with `num_devices == 1`.
- `test_ttsampling_topk_matches_argmax_on_single_device` gains the width 262144. That is the widest vocabulary a tiered model runs on one device, and Gemma-4 and Gemma-3 both use it. It is also the only case where every chunk is both `TOPK_MAX_WIDTH` and a power of two. It asserts `not force_argmax_sampling`, so it is the one place the split top-k path runs at that width on hardware.
- `models/demos/gpt_oss/tests/unit/test_sampling_ccl.py` pins the `SamplingCCL` contract on the host. It checks four things:
  - Each axis selects its own pool, and `None` stays apart from axis 0.
  - The handles keep the same identity across calls.
  - The default barrier accessor gives back the dedicated handle.
  - `allow_force_argmax` is set for all four mesh shapes.

The identity check is the important one. Rotation is what corrupts the gather, so a change that makes these handles cycle again must fail a test rather than produce displaced tokens.

### A parameter name that removed a test

The new parametrize in `test_sampling.py` uses `shape`, not `mesh_shape`. `pytest_collection_modifyitems` in `models/common/tests/conftest.py` removes any item whose `mesh_shape` parameter differs from its `ttnn_mesh_device` parameter. These cases build a stand-in object instead of taking that fixture. The fixture value was therefore `None`, the comparison was false, and all six cases were dropped. An earlier run showed the symptom: `6 deselected`, where main shows none.

## What is not settled

1. **No measurement.** No registry entry measures GPT-OSS throughput on any SKU, so this pull request carries no before-and-after number. `text_demo.py` prints a figure, but on one arm only. A reviewer with a QB2 or a Galaxy must compare this branch against main before it merges.
2. **The CCL wiring is unverified outside CI.** The semaphore shapes and the accessor names follow `models/tt_transformers/tt/ccl.py` and `llama_ccl.py`. A wrong gather shows up as displaced tokens rather than as a crash. The e2e run is the check, so read its output text and not only its exit status.
3. **Log-probs below 8 devices.** `LogProbsCalculator._is_supported()` needs 8 or 32 devices. Below that count, `calculate_topk_log_probs` and `calculate_log_probs` both return `None`, and neither raises. A single-card model with on-device sampling therefore answers a request for log-probs with nothing and no error. Gemma4-E2B on wh_n150 is one such configuration. This arrived with #53167 and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-sampling-vocab-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gpt-oss-sampling-vocab-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gpt-oss-sampling-vocab-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gpt-oss-sampling-vocab-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gpt-oss-sampling-vocab-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gpt-oss-sampling-vocab-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gpt-oss-sampling-vocab-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gpt-oss-sampling-vocab-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gpt-oss-sampling-vocab-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gpt-oss-sampling-vocab-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gpt-oss-sampling-vocab-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gpt-oss-sampling-vocab-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gpt-oss-sampling-vocab-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gpt-oss-sampling-vocab-gate)