### PR TITLE
[Bug fix] matmul: flush non-posted NOC atomics before in1 sender/writer exits

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -755,7 +755,11 @@ void kernel_main() {
 #endif
 #ifdef ENABLE_GLOBAL_CB
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
-    noc.async_atomic_barrier();
 #endif
+    // #53329: this kernel issues non-posted NOC atomics (multicast semaphore increments, and
+    // OpSignaler in the fused reduce-scatter path). Flushing only writes lets the kernel retire
+    // with atomics still unacknowledged -> watcher reports an inter-kernel data race under load.
+    // Barrier both, unconditionally, mirroring the CCL reader fix in #53595.
+    noc.async_atomic_barrier();
     noc.async_write_barrier();
 }


### PR DESCRIPTION
### Summary

Closes #55223. Relates to #53329 and #50886.

`reader_bmm_tile_layout_in1_sender_writer_padding.cpp` issues non-posted NOC atomics via
`OpSignaler` on the fused reduce-scatter path, but its `noc.async_atomic_barrier()` was inside
`#ifdef ENABLE_GLOBAL_CB`. That define is only ever set by the 1D mcast program factory, under
`if (use_global_cb)` (`matmul_multicore_reuse_mcast_1d_program_factory.cpp:548` and `:2462`).
The 2D mcast factory never sets it, while still wiring up the fused op signaler. The kernel
therefore retired with atomics unacknowledged, leaving `noc.async_write_barrier()` as the only
exit barrier: writes were flushed, atomics were not.

With the watcher enabled this is reported as:

```
BRISC detected an inter-kernel data race due to kernel completing with pending NOC
transactions (missing NOC non-posted atomics flushed barrier)
```

The fix barriers both writes and non-posted atomics unconditionally, mirroring the CCL reader
fix in #53595.

Plain non-fused matmuls were never affected, since `OpSignaler` only runs on the fused path.

### Verification

Run on a 4-chip Blackhole quietbox (2x P300), 1x4 mesh, FABRIC_1D, on main at `fbf7d27db93`.
Watcher enabled with the same four variables CI sets in `.github/actions/setup-job/action.yml`,
with the poll interval raised to 30s. Each run on a freshly reset board.

| Check | Without fix | With fix |
| --- | --- | --- |
| Qwen3.6 `test_gdn_tp.py -k "peruser_state and B8"` | exit 134, 1 data race | 0 data races |
| Qwen3.6 `test_gdn_tp.py -k prefill` | exit 134, 1 data race | 0 data races |
| Standalone ttnn-only repro (attached to #55223) | exit 134, 1 data race | 0 data races |
| Full `tests/ttnn/unit_tests/operations/matmul/` | n/a | 1498 passed, 368 skipped, exit 0 |
| Qwen3.6 peruser_state, watcher off | n/a | 2 passed, exit 0 |

The fix was verified across five patched runs on three tests.

### Notes for reviewers

1. Performance. This kernel is on the hot path for every mcast matmul, so the added barrier is a
fair question. An alternating A/B of 4000 dispatch iterations of a plain 1D mcast matmul showed no
measurable difference (pristine 198.9 / 142.7 / 230.6 us per iteration, patched 144.9 / 139.4 /
202.0 us per iteration). The run to run spread is larger than any difference between the two, so
this should be read as "no measurable regression in a dispatch loop" rather than as a device-side
measurement. I did not profile kernel duration on device. If you want that number, your own perf
tooling is the right instrument.

2. Was the `#ifdef` placement deliberate? `git blame` attributes those lines to #50681, which added
tensor prefetcher support with mcast-in0, and #49173, which migrated these kernels to
DataflowBuffer. If the barrier was intended to be global-CB specific, please say so and I will
narrow it, for example to the `fuse_op_reduce_scatter` case only.

3. Sibling kernel. `reader_bmm_tile_layout_in1_ring_all_gather.cpp` has the identical
`#ifdef`-guarded ending. I found no directly visible atomics in it, so I left it alone, but it is
worth your eye in the same pass.

4. No regression test in this PR, and the reason matters. With this fix applied, the Qwen3.6 suite
and the standalone repro both get further and then trip a separate device assert in
`ring_reduce_scatter_minimal_async_writer.cpp`, the reduce-scatter half of the same fused op. Any
test that exercises the fused path therefore cannot pass yet, so committing the repro would add a
permanently failing test. The repro is attached to #55223 and I will land it as a regression test
once that second fault is fixed.

### The second fault, for visibility

Investigated but not fixed, and it belongs to a different owner
(`ttnn/cpp/ttnn/operations/experimental/ccl/`, per CODEOWNERS
@tenstorrent/metalium-developers-ops-data-movement and @jonathansuTT).

Symptom: the fused `matmul_reduce_scatter_async` op launches its second reduce-scatter worker core
with zeroed runtime arguments. With fp32 tensors that core trips a device assert. With bfloat16 it
gets further and issues an illegal read, `unicast read 4 bytes to local L1[0x000000] from DRAM core
w/ virtual coords 0-0`, which the watcher reports as "NOC target address did not map to any known
Tensix/Ethernet/DRAM/PCIE core". Both the target coordinate and the destination address are zero,
which is consistent with a core that was launched but never programmed.

Deterministic, and reproducible in about 30 seconds with no model and no weights. The failing core
is always the second reduce-scatter worker, x=1 of the reduce-scatter row. Eliminated as triggers:
reduce_scatter_core_grid_offset (tried (0,8), (0,6), (0,4); the failing core simply follows the
row), num_links (1 and 2), topology (Ring and Linear), tensor dtype (changes the symptom, not the
presence), fp32_dest_acc_en (on and off), and whether a sub-device manager is created (with and
without).

Likely reason CI has not caught it: the only in-repo test of this op,
`tests/ttnn/unit_tests/operations/ccl/test_new_matmul_reduce_scatter.py`, is parametrized
`mesh_device [(1, 8)]` and therefore skips entirely on a 4-chip box. It also differs from the model
usage on every other axis, using 8 devices, bfloat16, num_links=1 and bias.

Consequence for #50886: the `unset TT_METAL_WATCHER` line on the Qwen3.6 entry in
`tests/pipeline_reorg/models_unit_tests.yaml` cannot be removed by this PR. It stays until the
reduce-scatter fault is fixed as well.

### One pre-existing CI failure to expect

If the `tm-fabric-tests` CCL nightly leg is run on this branch, expect
`test_all_gather_nightly.py::test_all_gather_linear_4D_nightly` to abort on a device assert in
`ccl/all_gather/device/kernels/multicast_reader.cpp`. This is not caused by this PR. I confirmed it
by reverting the kernel change and reproducing the identical failure, same core, same waypoint. It
matches the already filed #53035.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=53329-matmul-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:53329-matmul-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=53329-matmul-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:53329-matmul-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=53329-matmul-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:53329-matmul-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=53329-matmul-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:53329-matmul-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=53329-matmul-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:53329-matmul-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=53329-matmul-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:53329-matmul-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=53329-matmul-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:53329-matmul-atomic-barrier)