### PR TITLE
[Bug fix] Fix relu_min reading an unloaded LREG2 on Wormhole, and unskip its tests

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -39,73 +39,73 @@
 // calculate_nez_uint32, calculate_comp_unary_int + their *_init). Distinct from
 // the tt-llk sfpu/ckernel_sfpu_comp.h (_calculate_zero_comp_ etc.) included
 // below; the two share no symbol names so both can coexist.
+#include "llk_sfpu/ckernel_sfpu_binop_with_unary.h"
+#include "llk_sfpu/ckernel_sfpu_celu.h"
 #include "llk_sfpu/ckernel_sfpu_comp.h"
 #include "llk_sfpu/ckernel_sfpu_digamma.h"
 #include "llk_sfpu/ckernel_sfpu_div_int32.h"
 #include "llk_sfpu/ckernel_sfpu_div_int32_floor.h"
+#include "llk_sfpu/ckernel_sfpu_elu.h"
 #include "llk_sfpu/ckernel_sfpu_erf.h"
 #include "llk_sfpu/ckernel_sfpu_erfc.h"
+#include "llk_sfpu/ckernel_sfpu_erfinv.h"
+#include "llk_sfpu/ckernel_sfpu_exp.h"
+#include "llk_sfpu/ckernel_sfpu_exp2.h"
 #include "llk_sfpu/ckernel_sfpu_expm1.h"
 #include "llk_sfpu/ckernel_sfpu_fmod.h"
 #include "llk_sfpu/ckernel_sfpu_gcd.h"
+#include "llk_sfpu/ckernel_sfpu_gelu.h"
 #include "llk_sfpu/ckernel_sfpu_hardmish.h"
 #include "llk_sfpu/ckernel_sfpu_hardshrink.h"
 #include "llk_sfpu/ckernel_sfpu_hardtanh.h"
+#include "llk_sfpu/ckernel_sfpu_heaviside.h"
+#include "llk_sfpu/ckernel_sfpu_i0.h"
 #include "llk_sfpu/ckernel_sfpu_i1.h"
 #include "llk_sfpu/ckernel_sfpu_identity.h"
 #include "llk_sfpu/ckernel_sfpu_isclose.h"
 #include "llk_sfpu/ckernel_sfpu_lcm.h"
+#include "llk_sfpu/ckernel_sfpu_lerp.h"
 #include "llk_sfpu/ckernel_sfpu_lgamma.h"
 #include "llk_sfpu/ckernel_sfpu_log.h"
+#include "llk_sfpu/ckernel_sfpu_log1p.h"
 #include "llk_sfpu/ckernel_sfpu_logical_not.h"
 #include "llk_sfpu/ckernel_sfpu_logsigmoid.h"
 #include "llk_sfpu/ckernel_sfpu_mask.h"
+#include "llk_sfpu/ckernel_sfpu_mish.h"
 #include "llk_sfpu/ckernel_sfpu_mul_int32.h"
 #include "llk_sfpu/ckernel_sfpu_negative.h"
 #include "llk_sfpu/ckernel_sfpu_polygamma.h"
 #include "llk_sfpu/ckernel_sfpu_prelu.h"
+#include "llk_sfpu/ckernel_sfpu_rdiv.h"
+#include "llk_sfpu/ckernel_sfpu_recip.h"
 #include "llk_sfpu/ckernel_sfpu_remainder.h"
 #include "llk_sfpu/ckernel_sfpu_rpow.h"
+#include "llk_sfpu/ckernel_sfpu_rsqrt.h"
 #include "llk_sfpu/ckernel_sfpu_rsub_int32.h"
+#include "llk_sfpu/ckernel_sfpu_selu.h"
+#include "llk_sfpu/ckernel_sfpu_shift.h"
+#include "llk_sfpu/ckernel_sfpu_sigmoid.h"
 #include "llk_sfpu/ckernel_sfpu_sigmoid_appx.h"
 #include "llk_sfpu/ckernel_sfpu_sign.h"
 #include "llk_sfpu/ckernel_sfpu_signbit.h"
 #include "llk_sfpu/ckernel_sfpu_silu.h"
+#include "llk_sfpu/ckernel_sfpu_snake_beta.h"
 #include "llk_sfpu/ckernel_sfpu_softplus.h"
+#include "llk_sfpu/ckernel_sfpu_softshrink.h"
+#include "llk_sfpu/ckernel_sfpu_softsign.h"
+#include "llk_sfpu/ckernel_sfpu_sqrt.h"
 #include "llk_sfpu/ckernel_sfpu_sqrt_custom.h"
+#include "llk_sfpu/ckernel_sfpu_square.h"
+#include "llk_sfpu/ckernel_sfpu_tanh.h"
 #include "llk_sfpu/ckernel_sfpu_tanh_derivative.h"
+#include "llk_sfpu/ckernel_sfpu_tanhshrink.h"
+#include "llk_sfpu/ckernel_sfpu_trigonometry.h"
+#include "llk_sfpu/ckernel_sfpu_typecast.h"
 #include "llk_sfpu/ckernel_sfpu_unary_comp.h"
 #include "llk_sfpu/ckernel_sfpu_unary_max_min.h"
 #include "llk_sfpu/ckernel_sfpu_unary_power.h"
 #include "llk_sfpu/ckernel_sfpu_unary_shift.h"
 #include "llk_sfpu/ckernel_sfpu_xielu.h"
-#include "llk_sfpu/ckernel_sfpu_binop_with_unary.h"
-#include "llk_sfpu/ckernel_sfpu_celu.h"
-#include "llk_sfpu/ckernel_sfpu_elu.h"
-#include "llk_sfpu/ckernel_sfpu_erfinv.h"
-#include "llk_sfpu/ckernel_sfpu_exp.h"
-#include "llk_sfpu/ckernel_sfpu_exp2.h"
-#include "llk_sfpu/ckernel_sfpu_gelu.h"
-#include "llk_sfpu/ckernel_sfpu_heaviside.h"
-#include "llk_sfpu/ckernel_sfpu_i0.h"
-#include "llk_sfpu/ckernel_sfpu_lerp.h"
-#include "llk_sfpu/ckernel_sfpu_log1p.h"
-#include "llk_sfpu/ckernel_sfpu_mish.h"
-#include "llk_sfpu/ckernel_sfpu_rdiv.h"
-#include "llk_sfpu/ckernel_sfpu_recip.h"
-#include "llk_sfpu/ckernel_sfpu_rsqrt.h"
-#include "llk_sfpu/ckernel_sfpu_selu.h"
-#include "llk_sfpu/ckernel_sfpu_shift.h"
-#include "llk_sfpu/ckernel_sfpu_sigmoid.h"
-#include "llk_sfpu/ckernel_sfpu_snake_beta.h"
-#include "llk_sfpu/ckernel_sfpu_softshrink.h"
-#include "llk_sfpu/ckernel_sfpu_softsign.h"
-#include "llk_sfpu/ckernel_sfpu_sqrt.h"
-#include "llk_sfpu/ckernel_sfpu_square.h"
-#include "llk_sfpu/ckernel_sfpu_tanh.h"
-#include "llk_sfpu/ckernel_sfpu_tanhshrink.h"
-#include "llk_sfpu/ckernel_sfpu_trigonometry.h"
-#include "llk_sfpu/ckernel_sfpu_typecast.h"
 #include "sfpu/ckernel_sfpu_add_int.h"
 #include "sfpu/ckernel_sfpu_comp.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
@@ -734,6 +734,18 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
 #else
     constexpr std::uint32_t SHIFT_AMOUNT = 3u;
 #endif
+    // Integer threshold for relu_min's vInt branch, as a two's-complement uint32 (_relu_min_
+    // declares the parameter std::uint32_t and immediately static_casts it to int). Overridable
+    // via the SFPU_RELU_MIN_INT_THRESHOLD template parameter, on the same #ifdef arrangement as
+    // SHIFT_AMOUNT, so the int32 sweep can drive a *negative* threshold -- the only way to reach
+    // the sign+magnitude re-encoding branch in _relu_min_, which no production caller triggers.
+    // A test that does not set it keeps the fixed 5. The golden reads the same value through
+    // UnarySFPUGolden's relu_min_int_threshold argument, so the two sides move together.
+#ifdef SFPU_RELU_MIN_INT_THRESHOLD
+    constexpr std::uint32_t RELU_MIN_INT_THRESHOLD = SFPU_RELU_MIN_INT_THRESHOLD;
+#else
+    constexpr std::uint32_t RELU_MIN_INT_THRESHOLD = 5u;
+#endif
     // Integer scalar that unary_eq/unary_ne (Int32) compare against via metal
     // calculate_comp_unary_int. Shared with the golden (golden_generators.py:
     // _unary_comp_int_scalar); the two sides must move together.
@@ -1118,7 +1130,13 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
         if (math_format == ckernel::to_underlying(DataFormat::Int32))
         {
             SFPU_UNARY_CALL(
-                DST_SYNC_MODE, DST_ACCUM_MODE, _relu_min_, (sfpi::vInt, APPROX_MODE, ITERATIONS, std::uint32_t), dst_index, vector_mode, 5u /* threshold */);
+                DST_SYNC_MODE,
+                DST_ACCUM_MODE,
+                _relu_min_,
+                (sfpi::vInt, APPROX_MODE, ITERATIONS, std::uint32_t),
+                dst_index,
+                vector_mode,
+                RELU_MIN_INT_THRESHOLD /* threshold */);
         }
         else
         {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2428,6 +2428,11 @@ class UnarySFPUGolden:
             MathOperation.UnaryMinInt32,
             MathOperation.UnaryMaxUint32,
             MathOperation.UnaryMinUint32,
+            # relu_min is the one op here that is not integer-*only*: sfpu_operations.h
+            # picks the vInt branch of _relu_min_ at runtime on math_format == Int32 and
+            # the vFloat branch otherwise, so the same MathOperation needs an exact
+            # integer golden as well as the float one. See _relu_min.
+            MathOperation.ReluMin,
         }
         # Fixed dispatch constants shared with sfpu_operations.h: unary shift by 3
         # bits, integer unary max/min against the scalar 1000.
@@ -3141,6 +3146,13 @@ class UnarySFPUGolden:
         return sfpu_relu_max(float(x), float(threshold))
 
     def _relu_min(self, x, threshold=RELU_MIN_THRESHOLD):
+        if isinstance(x, int):
+            # Integer dst. The kernel takes the vInt branch of _relu_min_, which loads an
+            # integer threshold into LREG2 and compares under INT32_2S_COMP, so the golden
+            # is an exact integer max with no float round-trip. Deliberately independent of
+            # self.dst_format: _call_integer returns before __call__ assigns it, so reading
+            # it here would pick up whatever the previous call left behind.
+            return max(x, int(threshold))
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3164,12 +3164,23 @@ class UnarySFPUGolden:
             # int32 sweep drives negative thresholds to reach the wrapper's sign+magnitude
             # re-encoding branch, and a negative value has no float-path equivalent here.
             return max(x, int(self._relu_min_int_threshold))
-        input_tensor = (
-            x
-            if isinstance(x, torch.Tensor)
-            else torch.tensor(x, dtype=format_dict[self.dst_format])
-        )
-        return torch.max(input_tensor, torch.tensor(threshold)).item()
+        # Float dst. The kernel is a single SFPSWAP fold, so this is a max under the SFPU's
+        # total order and not IEEE's -- see sfpu_total_order_key. Measured on n150, threshold
+        # 5.0, Float32 end to end:
+        #
+        #   -NaN (0xFFC00000) -> 5.0        +NaN (0x7FC00000) -> +NaN
+        #   -inf              -> 5.0        +inf              -> +inf
+        #
+        # torch.max agrees on four of those and not on -NaN, which it propagates: -NaN ranks
+        # below -inf under the total order, so the fold discards it for the threshold exactly
+        # as it does -inf. FLOAT_SPECIALS injects only +NaN, so no sweep reaches that lane
+        # today and switching to sfpu_max changes no sweep's outcome -- but the device answer
+        # is measured, so the golden may as well be right there rather than resting on which
+        # NaN sign the specials set happens to carry.
+        #
+        # ReluMax states the same thing through sfpu_relu_max, whose first compare is this
+        # fold; relu_min is that compare with no relu clamp after it.
+        return sfpu_max(float(x), float(threshold))
 
     def _lrelu(self, x, negative_slope=LRELU_NEGATIVE_SLOPE):
         input_tensor = (

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2438,6 +2438,9 @@ class UnarySFPUGolden:
         # bits, integer unary max/min against the scalar 1000.
         self._int_shift_amount = 3
         self._int_maxmin_scalar = INT_MAXMIN_SCALAR
+        # relu_min's integer threshold, matching the kernel's RELU_MIN_INT_THRESHOLD default.
+        # Signed: the kernel carries it as a two's-complement uint32 and static_casts to int.
+        self._relu_min_int_threshold = int(RELU_MIN_THRESHOLD)
         self.data_format = None
         # Precision the SFPU actually evaluates at, which is Dest's and not the output
         # format's. The per-element ops below read this rather than data_format: no
@@ -2461,12 +2464,16 @@ class UnarySFPUGolden:
         skip_tilize: bool = False,
         unpack_to_srcs: bool = False,
         shift_amount: int = 3,
+        relu_min_int_threshold: int = int(RELU_MIN_THRESHOLD),
     ):
         self.data_format = data_format
         self.dst_format = data_format
         self.dest_acc = dest_acc
         # Mirrors the SFPU_SHIFT_AMOUNT template parameter; only the unary shift ops read it.
         self._int_shift_amount = shift_amount
+        # Mirrors the SFPU_RELU_MIN_INT_THRESHOLD template parameter; only relu_min on an
+        # integer format reads it. Signed here, two's-complement uint32 on the kernel side.
+        self._relu_min_int_threshold = relu_min_int_threshold
 
         if operation not in self.ops:
             raise ValueError(f"Unsupported operation: {operation}")
@@ -3152,7 +3159,11 @@ class UnarySFPUGolden:
             # is an exact integer max with no float round-trip. Deliberately independent of
             # self.dst_format: _call_integer returns before __call__ assigns it, so reading
             # it here would pick up whatever the previous call left behind.
-            return max(x, int(threshold))
+            #
+            # The threshold comes from _relu_min_int_threshold, not the float default: the
+            # int32 sweep drives negative thresholds to reach the wrapper's sign+magnitude
+            # re-encoding branch, and a negative value has no float-path equivalent here.
+            return max(x, int(self._relu_min_int_threshold))
         input_tensor = (
             x
             if isinstance(x, torch.Tensor)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -439,8 +439,17 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Relu: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
+    # relu_max(x) = clamp(x, 0, RELU_MAX_THRESHOLD) -- two cutoffs, and the upper one is a
+    # strict `result > threshold`, so the bound has to clear the threshold for a *finite*
+    # input to reach it. At low=-5/high=5 against a threshold of 5.0 the sampler is
+    # half-open and only the relu knee at 0 ever fired; +inf from the edge sweep was the
+    # sole thing exercising the clamp. See _OP_EDGE_POINTS for the straddled cutoffs.
     MathOperation.ReluMax: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM,
+            low=-5.0,
+            high=2.0 * RELU_MAX_THRESHOLD,
+        )
     ),
     # relu_min(x) = max(x, RELU_MIN_THRESHOLD), so the upper bound has to clear the
     # threshold or the op has no pass-through half: at low=-5/high=5 against a threshold of
@@ -1829,8 +1838,20 @@ _OP_EDGE_POINTS: Dict[MathOperation, Tuple[float, ...]] = {
     MathOperation.Hardmish: (-2.0, 0.0),
     # Below THRESHOLD_T the output jumps to THRESHOLD_V.
     MathOperation.Threshold: (THRESHOLD_T,),
-    # relu_max clamps above at its threshold, and keeps relu's own knee at 0.
-    MathOperation.ReluMax: (0.0, RELU_MAX_THRESHOLD),
+    # relu_max clamps above at its threshold, and keeps relu's own knee at 0. Both cutoffs
+    # are strict compares (`> threshold`, `< 0`), so each needs a value on either side and
+    # not just the cutoff itself: at exactly the threshold the clamp does not fire, and at
+    # exactly 0 the relu does not. -0.0 is deliberately absent -- the relu branch is
+    # SFPSETCC, whose contract holds only "provided that VC is neither negative zero nor
+    # any kind of NaN", so that input is unspecified on hardware (see sfpu_relu_max).
+    MathOperation.ReluMax: (
+        -1.0,
+        0.0,
+        1.0,
+        RELU_MAX_THRESHOLD - 1.0,
+        RELU_MAX_THRESHOLD,
+        RELU_MAX_THRESHOLD + 1.0,
+    ),
     # The threshold alone only proves the clamp branch. Straddle it so the edge face also
     # carries a value that passes through unchanged; 4.0/5.0/6.0 are exact in every format
     # this sweep runs, so the pair does not blur together in bf16.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -442,8 +442,16 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.ReluMax: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
+    # relu_min(x) = max(x, RELU_MIN_THRESHOLD), so the upper bound has to clear the
+    # threshold or the op has no pass-through half: at low=-5/high=5 against a threshold of
+    # 5.0 the sampler is half-open, every input clamps, and the golden collapses to the
+    # constant 5.0 -- a kernel that ignored x entirely would have scored a perfect PCC.
     MathOperation.ReluMin: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM,
+            low=-5.0,
+            high=2.0 * RELU_MIN_THRESHOLD,
+        )
     ),
     # lrelu: leaky ReLU with slope 0.1; span both signs so the negative
     # (scaled) branch and the positive (pass-through) branch are exercised.
@@ -1823,7 +1831,14 @@ _OP_EDGE_POINTS: Dict[MathOperation, Tuple[float, ...]] = {
     MathOperation.Threshold: (THRESHOLD_T,),
     # relu_max clamps above at its threshold, and keeps relu's own knee at 0.
     MathOperation.ReluMax: (0.0, RELU_MAX_THRESHOLD),
-    MathOperation.ReluMin: (RELU_MIN_THRESHOLD,),
+    # The threshold alone only proves the clamp branch. Straddle it so the edge face also
+    # carries a value that passes through unchanged; 4.0/5.0/6.0 are exact in every format
+    # this sweep runs, so the pair does not blur together in bf16.
+    MathOperation.ReluMin: (
+        RELU_MIN_THRESHOLD - 1.0,
+        RELU_MIN_THRESHOLD,
+        RELU_MIN_THRESHOLD + 1.0,
+    ),
     # softplus goes linear at its threshold.
     MathOperation.Softplus: (SOFTPLUS_THRESHOLD,),
     # Round-half-to-even ties, where the kernel's _round_even_ and a naive round differ.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -1811,15 +1811,22 @@ _COMPARISON_EDGE_OPS = (
 
 _OP_EDGE_POINTS: Dict[MathOperation, Tuple[float, ...]] = {
     **{op: (0.0, -0.0) for op in _ZERO_EDGE_OPS},
-    # UnaryGt/Lt/Ge/Le reach the edge sweep through edge_spec(). UnaryEq and UnaryNe do not
-    # -- they are outside _OP_DOMAIN_REGISTRY, so their consumer is
-    # test_eltwise_unary_sfpu._threshold_op_stimuli_spec, which reads op_edge_points() directly to
-    # place the exact threshold in its stimuli, as the int32 comparison ops below do.
+    # UnaryGt/Lt/Ge/Le reach the edge sweep through edge_spec(), which is what consumes these.
+    #
+    # UnaryEq, UnaryNe and LogicalNot below have no consumer today, and are listed anyway.
+    # They are outside _OP_DOMAIN_REGISTRY, so sfpu_unary_ops() never puts them in an edge
+    # sweep and edge_spec() never sees them; their one reader used to be
+    # test_eltwise_unary_sfpu._threshold_op_stimuli_spec, which took the threshold from
+    # op_edge_points(op)[0] until that positional read was replaced by op_threshold() and
+    # _OP_COMPARISON_THRESHOLD (see the table below for why). Kept as the recorded cutoff so
+    # registering any of the three later gets a correct edge sweep for free -- but treat these
+    # three entries as documentation, not as something a test is reading. The threshold the
+    # sweeps actually use lives in _OP_COMPARISON_THRESHOLD, and moving one here alone moves
+    # nothing.
     **{op: (UNARY_COMP_THRESHOLD,) for op in _COMPARISON_EDGE_OPS},
     # logical_not(x) = (x == 0). Same shape as _ZERO_EDGE_OPS but it is a threshold op
     # rather than a sign op, so keep it named. (LogicalNotUnary is an alias of this
-    # member — see the note in llk_params.py — so listing both would be one key.) Also
-    # outside the registry, and read by _threshold_op_stimuli_spec as above.
+    # member — see the note in llk_params.py — so listing both would be one key.)
     MathOperation.LogicalNot: (0.0, -0.0),
     # unary max/min compare x against UNARY_MAX_MIN_VALUE. Keyed on the constant rather
     # than folded into _ZERO_EDGE_OPS: it happens to be 0.0 today, and if it moves the
@@ -2183,6 +2190,14 @@ SPECIALS_READY_OPS.update(
         "two share one golden by construction. The identity is pinned host-side.",
         MathOperation.ReluMax: "_relu_max_body_: a total-order `> threshold` replaces a NaN "
         "with the threshold, and the relu clamp then sees a finite value.",
+        MathOperation.ReluMin: "max(x, threshold) as a single SFPSWAP fold -- the same "
+        "total-order compare _relu_max_body_ opens with, minus the relu clamp after it. A "
+        "+NaN outranks the threshold and the fold keeps it, which is what IEEE propagation "
+        "gives too, so the golden agrees at every injected special. Read the scope narrowly: "
+        "FLOAT_SPECIALS carries only a positive NaN. A *negative* one folds to the threshold, "
+        "since -NaN ranks below -inf -- measured on n150 as 0xFFC00000 -> 5.0, against IEEE's "
+        "propagation -- so _relu_min's golden models the total order rather than torch.max and "
+        "is correct there too. That lane is not swept, so enrolment rests on the +NaN result.",
         MathOperation.Hardsigmoid: "x * (1/6) + 0.5 through the same _relu_max_body_ the "
         "kernel shares with ReluMax, so a NaN clamps to 1.0.",
     }

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -1889,6 +1889,36 @@ _OP_EDGE_POINTS: Dict[MathOperation, Tuple[float, ...]] = {
 }
 
 
+# The scalar each threshold-driven op compares against, mirrored from the dispatch constants
+# the kernels read.
+#
+# Explicit rather than positional. Callers used to take the threshold as op_edge_points(op)[0],
+# which held only while an entry was exactly (threshold,). Several entries now *straddle* their
+# cutoff -- ReluMin is (4.0, 5.0, 6.0) and ReluMax leads with its relu knee -- so index 0 is a
+# probe beside the threshold rather than the threshold, and a positional read would place the
+# wrong value with nothing noticing. Consumers: test_eltwise_unary_sfpu._threshold_op_stimuli_spec.
+_OP_COMPARISON_THRESHOLD: Dict[MathOperation, float] = {
+    # logical_not(x) = (x == 0) ? 1 : 0.
+    MathOperation.LogicalNotUnary: 0.0,
+    **{op: UNARY_COMP_THRESHOLD for op in _COMPARISON_EDGE_OPS},
+    # The two clamps. relu_min clamps below at its threshold; relu_max clamps *above* at
+    # its own, and its relu knee at 0 is a second cutoff the random domain already covers.
+    MathOperation.ReluMin: RELU_MIN_THRESHOLD,
+    MathOperation.ReluMax: RELU_MAX_THRESHOLD,
+    # threshold(x) jumps to THRESHOLD_V below THRESHOLD_T.
+    MathOperation.Threshold: THRESHOLD_T,
+}
+
+
+def op_threshold(op: MathOperation) -> Optional[float]:
+    """The scalar *op* compares its input against, or None if it has no such scalar.
+
+    Use this rather than reading op_edge_points(op)[0]: the edge-point entries straddle
+    their cutoffs, so index 0 is not the threshold for every op that has one.
+    """
+    return _OP_COMPARISON_THRESHOLD.get(op)
+
+
 # Cat D for an operand other than A. _OP_EDGE_POINTS describes the op's own input, which for
 # a unary or binary op is operand A. A ternary op breaks that: lerp is a + c * (b - a), so
 # its interesting values are properties of the *weight*, operand C. pow's interesting

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -295,10 +295,13 @@ class SFPU_UNARY_THRESHOLD(TemplateParameter):
     threshold is the value relu_min is supposed to clamp to.
     """
 
-    value_bits: int = 0x40A00000  # 5.0f
+    # Field name is deliberately not `value_bits`: test_perf_header_gate requires every
+    # parameter field name in the tree to be unique, because the perf CSV takes its column
+    # headers from them and SFPU_UNARY_SCALAR already owns `value_bits`.
+    threshold_bits: int = 0x40A00000  # 5.0f
 
     def convert_to_cpp(self) -> str:
-        return f"constexpr std::uint32_t SFPU_UNARY_THRESHOLD = {self.value_bits}u;"
+        return f"constexpr std::uint32_t SFPU_UNARY_THRESHOLD = {self.threshold_bits}u;"
 
 
 @dataclass

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -302,6 +302,27 @@ class SFPU_UNARY_THRESHOLD(TemplateParameter):
 
 
 @dataclass
+class SFPU_RELU_MIN_INT_THRESHOLD(TemplateParameter):
+    """Integer threshold for relu_min's vInt branch, as a two's-complement uint32.
+
+    Emitted as a macro rather than a constexpr for the same reason as
+    :class:`SFPU_SHIFT_AMOUNT`: sfpu_operations.h selects on ``#ifdef``, the header is
+    shared by every unary test, and only the int32 relu_min sweep sets this, so the rest
+    have to keep compiling without it. Unset means the kernel's fixed 5.
+
+    Takes a *signed* Python int and emits its two's-complement pattern, because
+    ``_relu_min_`` declares the parameter ``std::uint32_t`` and immediately
+    ``static_cast<int>``s it. A negative value is the only way to reach the sign+magnitude
+    re-encoding branch inside that wrapper.
+    """
+
+    threshold: int = 5
+
+    def convert_to_cpp(self) -> str:
+        return f"#define SFPU_RELU_MIN_INT_THRESHOLD {self.threshold & 0xFFFFFFFF}u"
+
+
+@dataclass
 class SFPU_SHIFT_AMOUNT(TemplateParameter):
     """Shift amount for the *unary* shift ops (LeftShift / RightShift).
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -285,6 +285,23 @@ class SFPU_UNARY_SCALAR(TemplateParameter):
 
 
 @dataclass
+class SFPU_UNARY_THRESHOLD(TemplateParameter):
+    """Threshold operand for a unary op that clamps against a scalar, as raw fp32 bits.
+
+    Same contract as :class:`SFPU_UNARY_SCALAR` -- emit the bit pattern rather than a
+    decimal literal so the kernel and the torch golden agree exactly. Separate from
+    SFPU_UNARY_SCALAR so a driver can carry both at once, which
+    relu_min_lreg2_regression_test.cpp does: the scalar is its LREG2 poison and the
+    threshold is the value relu_min is supposed to clamp to.
+    """
+
+    value_bits: int = 0x40A00000  # 5.0f
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr std::uint32_t SFPU_UNARY_THRESHOLD = {self.value_bits}u;"
+
+
+@dataclass
 class SFPU_SHIFT_AMOUNT(TemplateParameter):
     """Shift amount for the *unary* shift ops (LeftShift / RightShift).
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -434,9 +434,6 @@ def test_eltwise_unary_sfpu(
             )
         )
 
-    if mathop == MathOperation.ReluMin:
-        pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1120")
-
     if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
         pytest.skip(reason="Metal tanh does not support approximation mode")
 
@@ -721,9 +718,6 @@ def test_eltwise_unary_sfpu_edges(
     _skip_coverage_unsupported(mathop)
 
     _skip_bh_unless_fp32(formats, dest_acc)
-
-    if mathop == MathOperation.ReluMin:
-        pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1120")
 
     # Two independent gates, and both have to pass: _SPECIALS_READY_OPS says the *golden*
     # defines a result for non-finite inputs, specials_safe() says the *pipeline* delivers

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -36,6 +36,7 @@ from helpers.sfpu_domains import (
     for_op_pipeline,
     negative_zero_delivered,
     op_edge_points,
+    op_threshold,
     sfpu_unary_ops,
     specials_after_nan_sign_gate,
     specials_safe,
@@ -899,6 +900,12 @@ _INT_UNARY_OPS = [
     MathOperation.UnaryMinInt32,
     MathOperation.UnaryMaxUint32,
     MathOperation.UnaryMinUint32,
+    # relu_min is the only entry that is not an integer-only op. sfpu_operations.h selects
+    # the vInt branch of _relu_min_ at runtime on math_format == Int32, and nothing else
+    # drives that branch -- the float sweeps all take the vFloat one -- so without this the
+    # integer half of the kernel, including its 2's-complement to sign+magnitude threshold
+    # conversion, has no coverage at all.
+    MathOperation.ReluMin,
 ]
 
 # Ops whose kernel interprets DST as unsigned; run them under UInt32.
@@ -1160,39 +1167,51 @@ def test_eltwise_unary_sfpu_isinf_isnan(
     )
 
 
-# Threshold comparison ops: each maps every element to 0/1 by comparing against a
-# fixed threshold, so a plain random float sweep never lands on the threshold and the
-# output collapses to a constant (PCC undefined). Keyed by mathop:
-#   logical_not(x) = (x == 0) ? 1 : 0   -> threshold 0.0
-#   unary_eq / unary_ne(x)  compare vs 0.5 -> threshold 0.5
+# Ops whose behaviour turns on a comparison against a fixed scalar. A plain random float
+# sweep reaches such a scalar with probability ~0, so the one input where a `>` / `>=` slip
+# or a missing branch is visible never gets driven. Keyed by mathop:
+#   logical_not(x) = (x == 0) ? 1 : 0        -> threshold 0.0
+#   unary_eq / unary_ne(x)  compare vs 0.5   -> threshold 0.5
+#   relu_min(x) = max(x, threshold)          -> threshold RELU_MIN_THRESHOLD
+#   relu_max(x) = clamp(x, 0, threshold)     -> threshold RELU_MAX_THRESHOLD
+#
+# The first three collapse to 0/1 and are here because their output would otherwise be a
+# constant. The two clamps are here for the tie itself: their random domains (widened to
+# clear the threshold) already cover both branches, but neither lands *on* the cutoff, and
+# both kernels compare strictly -- `> threshold` for relu_max, and an SFPSWAP fold for
+# relu_min -- so the boundary is exactly where an off-by-one would hide.
 _THRESHOLD_OPS = [
     MathOperation.LogicalNotUnary,
     MathOperation.UnaryEq,
     MathOperation.UnaryNe,
+    MathOperation.ReluMin,
+    MathOperation.ReluMax,
 ]
 
 
 def _threshold_op_stimuli_spec(mathop):
-    # Force a regular subset onto the op's threshold so both the equal and not-equal
-    # branches fire and the output is non-constant.
+    # Force a regular subset onto the op's threshold so the tie branch fires and, for the
+    # 0/1 ops, the output is non-constant.
     #
-    # The threshold comes from op_edge_points() rather than a local literal, which could drift
-    # from UNARY_COMP_THRESHOLD -- the value the golden reads -- with no test noticing. These
-    # three ops are outside _OP_DOMAIN_REGISTRY, so this is the only consumer of their
-    # _OP_EDGE_POINTS entry, the same arrangement the int32 comparison ops have.
-    edges = op_edge_points(mathop)
-    if not edges:
+    # The threshold comes from op_threshold() rather than a local literal, which could drift
+    # from the dispatch constant the golden reads with no test noticing. Deliberately NOT
+    # op_edge_points()[0]: that held only while every entry was exactly (threshold,), and the
+    # clamp entries now straddle their cutoff, so index 0 is a probe beside the threshold.
+    threshold = op_threshold(mathop)
+    if threshold is None:
         raise AssertionError(
-            f"{mathop.name} has no op_edge_points() entry, so the threshold sweep cannot "
-            "land on its comparison threshold — add one in sfpu_domains._OP_EDGE_POINTS"
+            f"{mathop.name} has no op_threshold() entry, so the threshold sweep cannot "
+            "land on its comparison threshold — add one in sfpu_domains._OP_COMPARISON_THRESHOLD"
         )
-    # logical_not's entry is the signed-zero pair (+0.0, -0.0); both are the same
-    # threshold, so the first element is the value to hit in every case.
-    threshold = edges[0]
 
     def dist(size, dtype, generator):
         idx = torch.arange(size, dtype=torch.float32)
-        x = (idx % 5) - 2.0  # {-2, -1, 0, 1, 2}; none equal 0.5
+        # Spread *relative to* the threshold: {t-2, t-1, t, t+1, t+2}. An absolute
+        # {-2, -1, 0, 1, 2} spread works only for a threshold near zero -- against
+        # relu_min's 5.0 every value sat on the clamped side and the golden went constant,
+        # which is the same defect the widened domains fixed. Unchanged for logical_not,
+        # whose threshold is 0.0.
+        x = threshold + ((idx % 5) - 2.0)
         x[0::3] = threshold  # guaranteed threshold hits
         return x.to(dtype)
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -996,10 +996,17 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     which is the same way the float domain used to be vacuous.
 
     Negatives are required here -- max(x, -5) only clamps for x < -5 -- so unlike
-    _int_unary_stimuli_spec this cannot stay positive-only. That is safe for this op
-    because the kernel loads and stores under InstrModLoadStore::INT32_2S_COMP, which
-    converts DEST's two's complement to sign+magnitude and back around the SFPSWAP; the
-    positive-only rule there exists for the max/min ops that are also read as unsigned.
+    _int_unary_stimuli_spec this cannot stay positive-only. (The positive-only rule over
+    there is about ops that are also read as unsigned, which is a different constraint.)
+
+    Negative *inputs* are fine on their own: SFPSWAP orders operands as sign+magnitude, and
+    for a non-negative threshold that misreading cannot change the outcome, because any
+    negative input is below the threshold under either encoding. What negative inputs do
+    expose, once the *threshold* is also negative, is that the kernel loads them under
+    InstrModLoadStore::INT32_2S_COMP, which loads **raw** rather than converting -- so the
+    compare sees a two's-complement input against a sign+magnitude threshold. That is the
+    unsupported path this sweep deliberately drives, and why the negative-threshold cases
+    below are xfailed. See https://github.com/tenstorrent/tt-metal/issues/55643.
     """
     straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
     # A decade either side, so the comparison is exercised well away from the boundary too.
@@ -1058,8 +1065,8 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
                 reason="Wormhole _relu_min_ vInt branch mishandles a negative threshold: the "
                 "sign+magnitude re-encoding wins every comparison and is stored raw "
                 "(threshold -5 returns 0x80000005). Unreached before this test; no shipping "
-                "op passes a negative integer threshold. See tt-metal issue #55643, which "
-                "carries the measurements for both encodings.",
+                "op passes a negative integer threshold. Measurements for both encodings: "
+                "https://github.com/tenstorrent/tt-metal/issues/55643",
                 strict=False,
             )
         )

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1044,6 +1044,8 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     # ISA semantics for that pair rather than a guess. Recorded as a non-strict xfail rather
     # than skipped so the case still *executes* and reports XPASS the moment it is fixed.
     #
+    # Tracked as tt-metal issue #55643. Drop this marker as part of fixing the kernel.
+    #
     # Nothing ships on this path: no Compute API entry point passes a negative integer
     # threshold (relu_tile_int32 passes 0, relu_min_tile_int32 routes to relu_clamp_int), and
     # the harness itself hard-coded 5u until this test parametrized it. Wormhole-scoped
@@ -1056,7 +1058,8 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
                 reason="Wormhole _relu_min_ vInt branch mishandles a negative threshold: the "
                 "sign+magnitude re-encoding wins every comparison and is stored raw "
                 "(threshold -5 returns 0x80000005). Unreached before this test; no shipping "
-                "op passes a negative integer threshold.",
+                "op passes a negative integer threshold. See tt-metal issue #55643, which "
+                "carries the measurements for both encodings.",
                 strict=False,
             )
         )

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -51,6 +51,7 @@ from helpers.test_variant_parameters import (
     MATH_OP,
     NUM_BLOCKS,
     NUM_TILES_IN_BLOCK,
+    SFPU_RELU_MIN_INT_THRESHOLD,
     SFPU_SHIFT_AMOUNT,
     TILE_COUNT,
     DestSync,
@@ -969,6 +970,110 @@ def test_eltwise_unary_sfpu_int(
     )
 
 
+# relu_min's integer threshold, which is the last unreached branch of that kernel.
+#
+# The vInt branch of _relu_min_ re-encodes its threshold from two's complement into the
+# sign+magnitude order SFPSWAP compares in -- but only when the threshold is negative:
+#
+#     int scalar = static_cast<int>(threshold);
+#     if (scalar < 0) { scalar = -scalar; scalar = 0x80000000 | (scalar & 0x7FFFFFFF); }
+#
+# Nothing reaches that `if`. The harness's own dispatch hard-coded 5u, and no Compute API
+# entry point passes a negative integer threshold either (relu_tile_int32 passes 0, and
+# relu_min_tile_int32 routes to a different kernel entirely). So the re-encoding shipped
+# untested. Overriding the threshold via SFPU_RELU_MIN_INT_THRESHOLD is what reaches it.
+#
+# Both signs are swept, because the negation is only meaningful against a control: the
+# non-negative thresholds take the straight-through path and must keep agreeing.
+_RELU_MIN_INT_THRESHOLDS = [-1000, -5, -1, 0, 5, 1000]
+
+
+def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
+    """Values straddling *threshold*, so both sides of the clamp fire.
+
+    Built around the threshold rather than from a fixed span: at -1000 a positive-only
+    spread would sit entirely on the pass-through side and the clamp would never fire,
+    which is the same way the float domain used to be vacuous.
+
+    Negatives are required here -- max(x, -5) only clamps for x < -5 -- so unlike
+    _int_unary_stimuli_spec this cannot stay positive-only. That is safe for this op
+    because the kernel loads and stores under InstrModLoadStore::INT32_2S_COMP, which
+    converts DEST's two's complement to sign+magnitude and back around the SFPSWAP; the
+    positive-only rule there exists for the max/min ops that are also read as unsigned.
+    """
+    straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
+    # A decade either side, so the comparison is exercised well away from the boundary too.
+    spread = [float(threshold + d) for d in (-1000, -100, -10, 10, 100, 1000)]
+    return StimuliSpec.custom(values=straddle + spread, seed=0)
+
+
+@parametrize(
+    threshold=_RELU_MIN_INT_THRESHOLDS,
+    dest_acc=[DestAccumulation.Yes],
+    input_dimensions=[[64, 64]],
+)
+def test_eltwise_unary_sfpu_relu_min_int_threshold(
+    request,
+    threshold: int,
+    dest_acc: DestAccumulation,
+    input_dimensions: list[int],
+):
+    """relu_min on Int32 against both signs of threshold.
+
+    The negative cases are the point: they are the only inputs that reach the
+    sign+magnitude re-encoding in _relu_min_'s vInt branch. Exact integer golden, so a
+    mis-encoded threshold shows up as a wrong clamp value rather than a tolerance miss.
+
+    The non-negative cases are the control and pass: they take the straight-through path
+    where sign+magnitude and two's complement coincide.
+    """
+    formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
+
+    # First execution of this branch, and it does not work. Measured on n300 at
+    # thresholds -1, -5 and -1000, against stimuli straddling each:
+    #
+    #   as shipped      the threshold wins every lane, including against inputs that are
+    #                   larger than it, and is stored as the raw re-encoding: threshold -5
+    #                   returns 0x80000005 (-2147483643) rather than -5, and -1000 returns
+    #                   0x800003E8. The magnitude is right, the representation is not.
+    #   re-encode       the opposite failure -- a plain two's-complement negative threshold
+    #     removed       never wins, so every input passes through unclamped.
+    #
+    # So it is not a matter of deleting the conversion: neither representation makes SFPSWAP
+    # and the INT32_2S_COMP store agree for a negative threshold, and settling it needs the
+    # ISA semantics for that pair rather than a guess. Recorded as a non-strict xfail rather
+    # than skipped so the case still *executes* and reports XPASS the moment it is fixed.
+    #
+    # Nothing ships on this path: no Compute API entry point passes a negative integer
+    # threshold (relu_tile_int32 passes 0, relu_min_tile_int32 routes to relu_clamp_int), and
+    # the harness itself hard-coded 5u until this test parametrized it. Wormhole-scoped
+    # because this is the raw-TTI kernel; Blackhole's _relu_min_ is plain sfpi and is
+    # expected to handle a negative threshold correctly -- if it does not, that is a real
+    # Blackhole finding and should surface as a failure rather than be pre-excused.
+    if threshold < 0 and TestConfig.CHIP_ARCH == ChipArchitecture.WORMHOLE:
+        request.node.add_marker(
+            pytest.mark.xfail(
+                reason="Wormhole _relu_min_ vInt branch mishandles a negative threshold: the "
+                "sign+magnitude re-encoding wins every comparison and is stored raw "
+                "(threshold -5 returns 0x80000005). Unreached before this test; no shipping "
+                "op passes a negative integer threshold.",
+                strict=False,
+            )
+        )
+
+    eltwise_unary_sfpu(
+        "sources/eltwise_unary_sfpu_test.cpp",
+        formats,
+        dest_acc,
+        ApproximationMode.No,
+        MathOperation.ReluMin,
+        FastMode.No,
+        input_dimensions,
+        spec_A=_relu_min_int_stimuli_spec(threshold),
+        relu_min_int_threshold=threshold,
+    )
+
+
 # Cat E: the shift amount itself, which is the last gap in that category.
 #
 # The unary shift ops take their amount as a compile-time immediate, not as an operand, so
@@ -1258,6 +1363,7 @@ def eltwise_unary_sfpu(
     custom_atol=None,
     custom_rtol=None,
     shift_amount=None,
+    relu_min_int_threshold=None,
 ):
     torch.manual_seed(0)
     torch.set_printoptions(precision=10)
@@ -1299,6 +1405,11 @@ def eltwise_unary_sfpu(
         formats.input_format,
         input_dimensions,
         **({} if shift_amount is None else {"shift_amount": shift_amount}),
+        **(
+            {}
+            if relu_min_int_threshold is None
+            else {"relu_min_int_threshold": relu_min_int_threshold}
+        ),
     )
 
     num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
@@ -1322,6 +1433,11 @@ def eltwise_unary_sfpu(
             # Only emitted when swept: sfpu_operations.h keys off #ifdef, and every other
             # unary test has to keep compiling without the macro.
             *([] if shift_amount is None else [SFPU_SHIFT_AMOUNT(shift_amount)]),
+            *(
+                []
+                if relu_min_int_threshold is None
+                else [SFPU_RELU_MIN_INT_THRESHOLD(relu_min_int_threshold)]
+            ),
         ],
         runtimes=[
             TILE_COUNT(tile_cnt_A),

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -999,14 +999,16 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     _int_unary_stimuli_spec this cannot stay positive-only. (The positive-only rule over
     there is about ops that are also read as unsigned, which is a different constraint.)
 
-    Negative *inputs* are fine on their own: SFPSWAP orders operands as sign+magnitude, and
-    for a non-negative threshold that misreading cannot change the outcome, because any
-    negative input is below the threshold under either encoding. What negative inputs do
-    expose, once the *threshold* is also negative, is that the kernel loads them under
-    InstrModLoadStore::INT32_2S_COMP, which loads **raw** rather than converting -- so the
-    compare sees a two's-complement input against a sign+magnitude threshold. That is the
-    unsupported path this sweep deliberately drives, and why the negative-threshold cases
-    below are xfailed. See https://github.com/tenstorrent/tt-metal/issues/55643.
+    Negative inputs and a negative threshold matter independently, which is worth keeping
+    straight. Negative *inputs* alone are harmless: the compare orders operands as
+    sign+magnitude, but for a non-negative threshold that ordering cannot change the
+    outcome, because a negative input loses under either encoding. Only once the *threshold*
+    is negative too does the encoding of the two operands have to actually agree.
+
+    On both arches it currently does not, which is the unsupported path this sweep
+    deliberately drives and why the negative cases below are xfailed -- the mechanism
+    differs per arch and is tabulated at that marker.
+    See https://github.com/tenstorrent/tt-metal/issues/55643.
     """
     straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
     # A decade either side, so the comparison is exercised well away from the boundary too.
@@ -1055,17 +1057,34 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     #
     # Nothing ships on this path: no Compute API entry point passes a negative integer
     # threshold (relu_tile_int32 passes 0, relu_min_tile_int32 routes to relu_clamp_int), and
-    # the harness itself hard-coded 5u until this test parametrized it. Wormhole-scoped
-    # because this is the raw-TTI kernel; Blackhole's _relu_min_ is plain sfpi and is
-    # expected to handle a negative threshold correctly -- if it does not, that is a real
-    # Blackhole finding and should surface as a failure rather than be pre-excused.
-    if threshold < 0 and TestConfig.CHIP_ARCH == ChipArchitecture.WORMHOLE:
+    # the harness itself hard-coded 5u until this test parametrized it.
+    #
+    # Both arches fail, for different reasons, and both return the *sign+magnitude* encoding
+    # of the threshold instead of its two's-complement value:
+    #
+    #   Wormhole   raw TTI. The vInt branch hand-re-encodes the threshold to sign+magnitude
+    #              for SFPSWAP, correctly, but loads the input with
+    #              InstrModLoadStore::INT32_2S_COMP, which loads raw -- so the compare comes
+    #              out against a two's-complement input. Threshold -5 returns 0x80000005.
+    #   Blackhole  plain sfpi, and no instruction mode to get wrong -- but _relu_min_impl_
+    #              reads DEST as a bare sfpi::dst_reg[0], with no .mode<DataLayout::I32>()
+    #              to request the converting layout. Dst holds int32 as sign+magnitude (see
+    #              _int_unary_stimuli_spec, which stays positive-only for exactly this
+    #              reason), so a negative threshold does not survive the round trip.
+    #              Threshold -1000 returns 0x800003E8, measured in CI on bh_p150b.
+    #
+    # Non-strict, so the case still executes and reports XPASS per arch as each is fixed.
+    if threshold < 0 and TestConfig.CHIP_ARCH in (
+        ChipArchitecture.WORMHOLE,
+        ChipArchitecture.BLACKHOLE,
+    ):
         request.node.add_marker(
             pytest.mark.xfail(
-                reason="Wormhole _relu_min_ vInt branch mishandles a negative threshold: the "
-                "sign+magnitude re-encoding wins every comparison and is stored raw "
-                "(threshold -5 returns 0x80000005). Unreached before this test; no shipping "
-                "op passes a negative integer threshold. Measurements for both encodings: "
+                reason="relu_min's vInt branch returns the sign+magnitude encoding of a "
+                "negative threshold instead of its value: Wormhole 0x80000005 for -5 "
+                "(wrong SFPLOAD instruction mode), Blackhole 0x800003E8 for -1000 (no "
+                "converting sfpi DataLayout on the DEST access). Unreached before this "
+                "test; no shipping op passes a negative integer threshold. "
                 "https://github.com/tenstorrent/tt-metal/issues/55643",
                 strict=False,
             )

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -953,6 +953,12 @@ def test_eltwise_unary_sfpu_int(
     dest_acc: DestAccumulation,
     input_dimensions: list[int],
 ):
+    # ReluMin is in both BROAD_SWEEP_OPS and COVERAGE_COMPILE_SKIP_OPS, so this sweep needs
+    # the same coverage guard the float ones use. It was unreachable before ReluMin joined
+    # _INT_UNARY_OPS -- no integer-only op is in either list -- but without it the coverage
+    # job compiles the relu_min kernel and fails at build time instead of skipping.
+    _skip_coverage_unsupported(mathop)
+
     int_format = (
         DataFormat.UInt32 if mathop in _UINT32_INT_UNARY_OPS else DataFormat.Int32
     )
@@ -1036,6 +1042,9 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     The non-negative cases are the control and pass: they take the straight-through path
     where sign+magnitude and two's complement coincide.
     """
+    # ReluMin is hardcoded here rather than parametrized, so the guard takes it directly.
+    _skip_coverage_unsupported(MathOperation.ReluMin)
+
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
 
     # First execution of this branch, and it does not work. Measured on n300 at
@@ -1366,6 +1375,9 @@ def test_eltwise_unary_sfpu_threshold(
     dest_acc: DestAccumulation,
     input_dimensions: list[int],
 ):
+    # ReluMin/ReluMax are COVERAGE_COMPILE_SKIP_OPS members, so this sweep needs the guard
+    # too now that _THRESHOLD_OPS carries them.
+    _skip_coverage_unsupported(mathop)
     _skip_bh_unless_fp32(formats, dest_acc)
 
     eltwise_unary_sfpu(

--- a/tt_metal/tt-llk/tests/python_tests/test_relu_min_lreg2_regression.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_relu_min_lreg2_regression.py
@@ -126,10 +126,12 @@ def test_relu_min_ignores_stale_lreg2():
 
     golden = torch.maximum(src_A, torch.tensor(RELU_MIN_THRESHOLD))
 
-    # Exact, not a tolerance: relu_min is an SFPSWAP, which *selects* one of its two
-    # operands rather than computing anything, and the whole path is fp32. Any deviation
-    # at all is a wrong operand, not rounding.
-    poisoned = torch.isclose(res, torch.tensor(LREG2_POISON))
+    # Both assertions below are exact rather than tolerances, and can be: relu_min is an
+    # SFPSWAP, which *selects* one of its two operands rather than computing anything, and
+    # the pipeline is Float32 end to end. Any deviation at all is a wrong operand, not
+    # rounding -- so the poison probe compares bit-for-bit too, instead of admitting a
+    # near-1024.0 result that could only come from a different defect.
+    poisoned = res == LREG2_POISON
     assert not poisoned.any(), (
         f"{poisoned.sum().item()}/{res.numel()} lanes came back as the LREG2 poison "
         f"({LREG2_POISON}), so _relu_min_ used the stale register instead of its own "

--- a/tt_metal/tt-llk/tests/python_tests/test_relu_min_lreg2_regression.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_relu_min_lreg2_regression.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic stale-LREG2 regression for relu_min (Wormhole only).
+
+tt-llk#1120: Wormhole's ``_relu_min_impl_`` reads its threshold from LREG2 as an
+*implicit input* -- the body is raw TTI (``TTI_SFPMOV(0, LREG2, LREG1, 0)`` before the
+SFPSWAP), so the register is part of the calling contract but appears nowhere in the
+signature. The ``T == float`` branch of the ``_relu_min_`` wrapper assigned a local sfpi
+vector instead of loading LREG2, which compiled clean and then ran relu_min against
+whatever the previously executed SFPU kernel had left in that register.
+
+Why this file exists rather than relying on the sweeps. The sweeps only fail when some
+*other* op runs first and dirties LREG2, so on the broken kernel ``pytest -k ReluMin``
+passes in isolation and fails only when mixed with Sqrt/Square/Log/Sign -- the failure
+is a property of test ordering, not of the kernel, and a reordered or sharded run can
+go green over a reintroduced bug. This test removes the ordering entirely: the kernel
+writes a known poison into LREG2 as the instruction immediately preceding the
+``_relu_min_`` call, inside the same SFPU block, so nothing can come between them.
+
+    fixed kernel:  _relu_min_ loads LREG2 itself  ->  result = max(x, threshold)
+    broken kernel: the poison survives            ->  result = max(x, poison)
+
+The poison is far outside the golden's range, so the two outcomes are separated by
+orders of magnitude rather than by a tolerance.
+
+Wormhole only. Blackhole's ``_relu_min_`` is a plain sfpi predicated form
+(``v_if (a < threshold)``) that genuinely consumes its parameter, so there is no
+register to poison and this test would pass vacuously there; Quasar has its own
+implementation. Both are skipped rather than silently covered.
+"""
+
+import struct
+
+import torch
+from conftest import skip_for_blackhole, skip_for_quasar
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.llk_params import (
+    ApproximationMode,
+    DestAccumulation,
+    VectorMode,
+    format_dict,
+)
+from helpers.sfpu_dispatch_constants import RELU_MIN_THRESHOLD
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    SFPU_UNARY_SCALAR,
+    SFPU_UNARY_THRESHOLD,
+    VECTOR_MODE,
+    generate_input_dim,
+)
+
+pytestmark = [skip_for_blackhole, skip_for_quasar]
+
+ELEMENTS_PER_TILE = 1024
+
+# The value written into LREG2 immediately before _relu_min_. Requirements: not the
+# threshold (or the bug is invisible), positive and large enough that `max(x, poison)`
+# is the poison for every input below (so a broken kernel returns a flat, unmistakable
+# tile), and exactly representable in every format on this path so the expected-failure
+# value is not itself approximate.
+LREG2_POISON = 1024.0
+
+
+def _bits(value: float) -> int:
+    """Raw fp32 bit pattern, the encoding both SFPU_UNARY_* parameters expect."""
+    return struct.unpack("<I", struct.pack("<f", value))[0]
+
+
+def _straddling_inputs() -> torch.Tensor:
+    """One tile straddling the threshold, so both branches of max(x, threshold) fire.
+
+    Deterministic rather than sampled: this test is about a register, not a domain, and
+    a fixed pattern makes the failure message reproducible. Half the lanes sit below the
+    threshold (where relu_min must clamp) and half above (where it must pass through) --
+    the pass-through half is what a threshold-returning kernel gets wrong, and the
+    clamped half is what a poisoned LREG2 gets wrong.
+    """
+    x = torch.empty(ELEMENTS_PER_TILE, dtype=torch.float32)
+    below = torch.linspace(-8.0, RELU_MIN_THRESHOLD - 1.0, ELEMENTS_PER_TILE // 2)
+    above = torch.linspace(RELU_MIN_THRESHOLD + 1.0, 12.0, ELEMENTS_PER_TILE // 2)
+    x[0::2] = below
+    x[1::2] = above
+    return x
+
+
+def test_relu_min_ignores_stale_lreg2():
+    formats = InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
+    dest_acc = DestAccumulation.Yes
+
+    src_A = _straddling_inputs()
+    src_B = torch.zeros(ELEMENTS_PER_TILE, dtype=torch.float32)
+
+    configuration = TestConfig(
+        "sources/relu_min_lreg2_regression_test.cpp",
+        formats,
+        templates=[
+            generate_input_dim([32, 32], [32, 32]),
+            APPROX_MODE(ApproximationMode.No),
+            SFPU_UNARY_SCALAR(_bits(LREG2_POISON)),
+            SFPU_UNARY_THRESHOLD(_bits(RELU_MIN_THRESHOLD)),
+            VECTOR_MODE(VectorMode.RC),
+        ],
+        runtimes=[],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=1,
+            tile_count_B=1,
+            tile_count_res=1,
+        ),
+        dest_acc=dest_acc,
+        unpack_to_dest=True,
+        compile_time_formats=True,
+    )
+
+    res = torch.tensor(
+        configuration.run().result[:ELEMENTS_PER_TILE],
+        dtype=format_dict[formats.output_format],
+    ).to(torch.float32)
+
+    golden = torch.maximum(src_A, torch.tensor(RELU_MIN_THRESHOLD))
+
+    # Exact, not a tolerance: relu_min is an SFPSWAP, which *selects* one of its two
+    # operands rather than computing anything, and the whole path is fp32. Any deviation
+    # at all is a wrong operand, not rounding.
+    poisoned = torch.isclose(res, torch.tensor(LREG2_POISON))
+    assert not poisoned.any(), (
+        f"{poisoned.sum().item()}/{res.numel()} lanes came back as the LREG2 poison "
+        f"({LREG2_POISON}), so _relu_min_ used the stale register instead of its own "
+        f"threshold. This is tt-llk#1120: the T == float branch of _relu_min_ must call "
+        f"_sfpu_load_imm32_(p_sfpu::LREG2, ...), because _relu_min_impl_ takes the "
+        f"threshold from LREG2 and never reads a parameter."
+    )
+    assert torch.equal(res, golden), (
+        f"relu_min(x, {RELU_MIN_THRESHOLD}) mismatched on "
+        f"{(res != golden).sum().item()}/{res.numel()} lanes "
+        f"(max deviation {(res - golden).abs().max().item():.6g}). LREG2 was not the "
+        f"poison, so the threshold load is happening -- the defect is in the clamp itself."
+    )

--- a/tt_metal/tt-llk/tests/sources/relu_min_lreg2_regression_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/relu_min_lreg2_regression_test.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Deterministic regression for tt-llk#1120: relu_min reading an unloaded LREG2.
+//
+// Wormhole's _relu_min_impl_ takes its threshold from LREG2 as an *implicit input* --
+// the body is raw TTI and copies LREG2 into LREG1 before the SFPSWAP, so the register
+// is part of the calling contract but appears nowhere in the signature. The float
+// branch of the _relu_min_ wrapper used to assign a local sfpi vector instead of
+// loading LREG2, which compiled clean and then ran relu_min against whatever the
+// previously executed SFPU kernel happened to leave in that register.
+//
+// The sweeps cannot pin this down on their own: they only fail when some *other* op
+// runs first and dirties LREG2, so the failure is a property of test ordering rather
+// than of the kernel. This driver removes the ordering: it writes a known poison value
+// into LREG2 as the instruction immediately preceding the _relu_min_ call, inside the
+// same SFPU block, so nothing can come between them.
+//
+//   fixed kernel:  _relu_min_ loads LREG2 itself   -> result = max(x, threshold)
+//   broken kernel: the poison survives             -> result = max(x, poison)
+//
+// The python side drives a poison far outside the golden's range, so the two outcomes
+// are separated by much more than any tolerance. Wormhole only -- Blackhole's
+// _relu_min_ is a plain sfpi predicated form that genuinely consumes its parameter,
+// so there is no register to poison and the test would pass vacuously.
+//
+// SFPU_UNARY_SCALAR carries the poison as raw fp32 bits; SFPU_UNARY_THRESHOLD carries
+// the threshold the same way, so the C++ and the torch golden agree bit for bit.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "params.h"
+
+// Globals required by the test framework.
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+static constexpr ckernel::DstSync DST_SYNC = ckernel::DstSync::SyncHalf;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
+
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
+
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, formats.unpack_A_dst);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "ckernel_sfpu.h"
+#include "llk_lib_math_wrappers.h"
+#include "llk_math_eltwise_unary_sfpu.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "sfpu/ckernel_sfpu_load_config.h"
+#include "sfpu/ckernel_sfpu_relu.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
+
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
+        TILE_NUM_FACES, formats.math);
+
+    // relu_min needs only the invariant SFPU config + ADDR_MOD_7 and a dest RWC reset,
+    // which is what the production relu_min_tile_init reduces to -- so the bare init is
+    // the faithful one here, exactly as sfpu_operations.h routes relu_min.
+    _llk_math_eltwise_unary_sfpu_init_<SfpuType::unused>();
+
+    _llk_math_wait_for_dest_available_<DST_SYNC>();
+
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+        0 /* dst_index */, formats.math, formats.math);
+
+    // Kept for init/uninit symmetry only -- what actually rebases DEST to the tile-0 base
+    // is _llk_math_eltwise_unary_sfpu_params_ below. Same paired call as
+    // sfpu_add_rsqrt_test.cpp and sfpu_binop_scalar_test.cpp, for the same reason.
+    _llk_math_eltwise_unary_datacopy_uninit_<BroadcastType::NONE, unpack_to_dest>();
+
+    // Both halves live in one SFPU block on purpose: the poison must be the last thing
+    // written to LREG2 before _relu_min_ runs, with no init, no sync and no other SFPU
+    // kernel in between. ITERATIONS=8 at VectorMode::RC is what relu_min_tile dispatches.
+    _llk_math_eltwise_unary_sfpu_params_(
+        []
+        {
+            ckernel::sfpu::_sfpu_load_imm32_(p_sfpu::LREG2, SFPU_UNARY_SCALAR);
+            ckernel::sfpu::_relu_min_<sfpi::vFloat, APPROX_MODE, 8 /* ITERATIONS */, float>(__builtin_bit_cast(float, SFPU_UNARY_THRESHOLD));
+        },
+        0 /* dst_index */,
+        VECTOR_MODE);
+
+    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>();
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* tile_index */, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -87,6 +87,10 @@ inline void _relu_max_(T threshold)
     VectorType v_threshold;
     if constexpr (std::is_same_v<T, float>)
     {
+        static_assert(
+            std::is_same_v<VectorType, sfpi::vFloat>,
+            "A float threshold requires VectorType == sfpi::vFloat: sfpi::vInt has no float constructor, so the assignment below would otherwise fail as an "
+            "ambiguous conversion");
         v_threshold = threshold;
     }
     else if constexpr (std::is_same_v<T, std::uint32_t>)
@@ -133,6 +137,10 @@ inline void _relu_min_(T threshold)
     VectorType v_threshold;
     if constexpr (std::is_same_v<T, float>)
     {
+        static_assert(
+            std::is_same_v<VectorType, sfpi::vFloat>,
+            "A float threshold requires VectorType == sfpi::vFloat: sfpi::vInt has no float constructor, so the assignment below would otherwise fail as an "
+            "ambiguous conversion");
         v_threshold = threshold;
     }
     else if constexpr (std::is_same_v<T, std::uint32_t>)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -103,8 +103,11 @@ inline void _relu_max_(T threshold)
     _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
-template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_min_impl_(const int iterations, [[maybe_unused]] VecType threshold, InstrModLoadStore sfpload_instr_mod)
+// The threshold is read from LREG2, NOT from a parameter: every caller must have loaded it
+// with _sfpu_load_imm32_ first. The dead `VecType threshold` argument this used to carry made
+// the dependency look satisfied when it was not -- see _relu_min_ below and tt-llk#1120.
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void _relu_min_impl_(const int iterations, InstrModLoadStore sfpload_instr_mod)
 {
     for (int d = 0; d < iterations; d++)
     {
@@ -126,23 +129,31 @@ inline void _relu_min_(T threshold)
 {
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
-    VectorType v_threshold;
-    int scalar = threshold;
-    if (scalar < 0)
-    { // To convert from 2's complement to sign+magnitude
-        scalar  = -scalar;
-        int res = 0x80000000 | (scalar & 0x7FFFFFFF);
-        scalar  = res;
-    }
+    // _relu_min_impl_ takes the threshold from LREG2, so every branch below has to load it.
+    // The T == float branch used to assign a local vector instead and leave LREG2 untouched,
+    // so relu_min ran against whatever the previously executed SFPU kernel had left there --
+    // order-dependent garbage, which is tt-llk#1120. Only the tt-llk test harness instantiates
+    // T == float; the Compute API passes uint32_t, which is why no shipping op ever saw it.
     InstrModLoadStore sfpload_instr_mod = InstrModLoadStore::DEFAULT;
     if constexpr (std::is_same_v<T, float>)
     {
-        v_threshold = threshold;
+        static_assert(std::is_same_v<VectorType, sfpi::vFloat>, "A float threshold requires VectorType == sfpi::vFloat");
+        _sfpu_load_imm32_(p_sfpu::LREG2, __builtin_bit_cast(std::uint32_t, threshold));
     }
     else if constexpr (std::is_same_v<T, std::uint32_t>)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
+            // SFPSWAP orders sign+magnitude, so a 2's complement threshold is converted here.
+            // Scoped to this branch: it is meaningless for a float threshold, where the old
+            // unconditional `int scalar = threshold` merely truncated the value.
+            int scalar = static_cast<int>(threshold);
+            if (scalar < 0)
+            {
+                scalar  = -scalar;
+                int res = 0x80000000 | (scalar & 0x7FFFFFFF);
+                scalar  = res;
+            }
             _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
             sfpload_instr_mod = InstrModLoadStore::INT32_2S_COMP;
         }
@@ -156,7 +167,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold, sfpload_instr_mod);
+    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, sfpload_instr_mod);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -82,6 +82,10 @@ inline void _relu_max_(T threshold)
     VectorType v_threshold;
     if constexpr (std::is_same_v<T, float>)
     {
+        static_assert(
+            std::is_same_v<VectorType, sfpi::vFloat>,
+            "A float threshold requires VectorType == sfpi::vFloat: sfpi::vInt has no float constructor, so the assignment below would otherwise fail as an "
+            "ambiguous conversion");
         v_threshold = threshold;
     }
     else if constexpr (std::is_same_v<T, std::uint32_t>)
@@ -103,9 +107,10 @@ inline void _relu_max_(T threshold)
     _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
-// The threshold is read from LREG2, NOT from a parameter: every caller must have loaded it
-// with _sfpu_load_imm32_ first. The dead `VecType threshold` argument this used to carry made
-// the dependency look satisfied when it was not -- see _relu_min_ below and tt-llk#1120.
+// Contract: the threshold is an *implicit input in LREG2*, not a parameter. Every caller must
+// load it with _sfpu_load_imm32_(p_sfpu::LREG2, ...) before calling. The body is raw TTI, so
+// this dependency cannot be expressed in the signature -- keep it out of the parameter list
+// rather than carrying an argument the body never reads.
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_impl_(const int iterations, InstrModLoadStore sfpload_instr_mod)
 {
@@ -129,24 +134,26 @@ inline void _relu_min_(T threshold)
 {
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
-    // _relu_min_impl_ takes the threshold from LREG2, so every branch below has to load it.
-    // The T == float branch used to assign a local vector instead and leave LREG2 untouched,
-    // so relu_min ran against whatever the previously executed SFPU kernel had left there --
-    // order-dependent garbage, which is tt-llk#1120. Only the tt-llk test harness instantiates
-    // T == float; the Compute API passes uint32_t, which is why no shipping op ever saw it.
+    // Invariant every branch below must uphold: leave the threshold in LREG2, in the encoding
+    // the matching sfpload_instr_mod selects. A branch that sets only a local vector compiles
+    // clean and then reads whatever the previously executed SFPU kernel left in LREG2, so the
+    // load is not optional on any path.
     InstrModLoadStore sfpload_instr_mod = InstrModLoadStore::DEFAULT;
     if constexpr (std::is_same_v<T, float>)
     {
-        static_assert(std::is_same_v<VectorType, sfpi::vFloat>, "A float threshold requires VectorType == sfpi::vFloat");
+        static_assert(
+            std::is_same_v<VectorType, sfpi::vFloat>,
+            "A float threshold requires VectorType == sfpi::vFloat: the LREG2 load below bit-casts the float, which is meaningless for an integer datapath");
         _sfpu_load_imm32_(p_sfpu::LREG2, __builtin_bit_cast(std::uint32_t, threshold));
     }
     else if constexpr (std::is_same_v<T, std::uint32_t>)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            // SFPSWAP orders sign+magnitude, so a 2's complement threshold is converted here.
-            // Scoped to this branch: it is meaningless for a float threshold, where the old
-            // unconditional `int scalar = threshold` merely truncated the value.
+            // SFPSWAP orders operands as sign+magnitude, so a 2's complement integer
+            // threshold has to be re-encoded before it is loaded. Scoped to this branch
+            // because it is only meaningful for an integer threshold -- applying it to a
+            // float would reinterpret the value, not convert it.
             int scalar = static_cast<int>(threshold);
             if (scalar < 0)
             {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -111,19 +111,33 @@ inline void _relu_max_(T threshold)
 // load it with _sfpu_load_imm32_(p_sfpu::LREG2, ...) before calling. The body is raw TTI, so
 // this dependency cannot be expressed in the signature -- keep it out of the parameter list
 // rather than carrying an argument the body never reads.
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_min_impl_(const int iterations, InstrModLoadStore sfpload_instr_mod)
+//
+// SFPLOAD_INSTR_MOD is a template parameter rather than a function argument because it feeds
+// the "n" (immediate) operand of TTI_SFPLOAD/TTI_SFPSTORE. Passed by value it compiles only
+// for as long as the optimiser folds the constant into the asm, which makes a hard build
+// requirement out of an optimisation. Measured on this toolchain (sfpi 7.74.0, gcc 15.1.0),
+// both instantiations in one TU: as a runtime argument -O1/-O2/-O3 fold it and -O0 fails with
+// "impossible constraint in 'asm'"; as a template parameter all four levels compile.
+// ComputeConfig::opt_level is user-settable, so that is worth not relying on. Every sibling
+// integer kernel declares the mode constexpr for the same reason (see ckernel_sfpu_add_int.h,
+// ckernel_sfpu_sub_int.h, ckernel_sfpu_topk.h).
+template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore SFPLOAD_INSTR_MOD>
+inline void _relu_min_impl_(const int iterations)
 {
+    static_assert(
+        SFPLOAD_INSTR_MOD == InstrModLoadStore::DEFAULT || SFPLOAD_INSTR_MOD == InstrModLoadStore::INT32_2S_COMP,
+        "SFPLOAD_INSTR_MOD must be DEFAULT (fp32 datapath) or INT32_2S_COMP (integer datapath)");
+
     for (int d = 0; d < iterations; d++)
     {
         // Load input tensor to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, SFPLOAD_INSTR_MOD, ADDR_MOD_3, 0);
         // Copy value param from lreg2 to lreg1
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
         // Swap and store maximum in lreg1, minimum in lreg0 (sign + magnitude format)
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         // Store the result
-        TTI_SFPSTORE(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, SFPLOAD_INSTR_MOD, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }
 }
@@ -134,11 +148,17 @@ inline void _relu_min_(T threshold)
 {
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
+    // The load/store mode the branches below encode the threshold for. Only the integer
+    // datapath needs a non-default mode, and which branch runs is fixed by <T, VectorType>,
+    // so this is a compile-time constant rather than a variable the branches assign -- see
+    // the note on _relu_min_impl_'s SFPLOAD_INSTR_MOD parameter.
+    constexpr InstrModLoadStore SFPLOAD_INSTR_MOD =
+        (std::is_same_v<T, std::uint32_t> && std::is_same_v<VectorType, sfpi::vInt>) ? InstrModLoadStore::INT32_2S_COMP : InstrModLoadStore::DEFAULT;
+
     // Invariant every branch below must uphold: leave the threshold in LREG2, in the encoding
-    // the matching sfpload_instr_mod selects. A branch that sets only a local vector compiles
-    // clean and then reads whatever the previously executed SFPU kernel left in LREG2, so the
-    // load is not optional on any path.
-    InstrModLoadStore sfpload_instr_mod = InstrModLoadStore::DEFAULT;
+    // SFPLOAD_INSTR_MOD selects. A branch that sets only a local vector compiles clean and then
+    // reads whatever the previously executed SFPU kernel left in LREG2, so the load is not
+    // optional on any path.
     if constexpr (std::is_same_v<T, float>)
     {
         static_assert(
@@ -162,7 +182,6 @@ inline void _relu_min_(T threshold)
                 scalar  = res;
             }
             _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
-            sfpload_instr_mod = InstrModLoadStore::INT32_2S_COMP;
         }
         else
         {
@@ -174,7 +193,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, sfpload_instr_mod);
+    _relu_min_impl_<APPROXIMATION_MODE, ITERATIONS, SFPLOAD_INSTR_MOD>(ITERATIONS);
 }
 
 } // namespace sfpu


### PR DESCRIPTION
### PR Category

**Bug fix** (Wormhole only; Blackhole has its own implementation and was never exposed.)

Fixes tenstorrent/tt-llk#1120.

### Summary

`_relu_min_impl_` on Wormhole takes its threshold from **LREG2**:

```cpp
TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);   // "copy value param from lreg2"
```

but the wrapper only loaded LREG2 on its two `uint32_t` branches. The `T == float` branch
assigned a local vector instead:

```cpp
if constexpr (std::is_same_v<T, float>) { v_threshold = threshold; }   // LREG2 untouched
```

and `_relu_min_impl_` never read that argument — it was declared `[[maybe_unused]]` and the
body is raw TTI. So on the float path `relu_min` ran against **whatever the previously
executed SFPU kernel had left in LREG2**.

In the file, LREG2 appeared exactly three times: read unconditionally at the `SFPMOV`,
written in the `uint32_t`+`vInt` branch, written in the `uint32_t`+`vFloat` branch. Nothing
wrote it on the float path.

That is why #1120 is order-dependent, and why it says *"when tests are randomly executed"* —
a stale-register read, not a numerical defect.

#### Evidence

The control matters more than the pass here, because the tests pass unfixed if you run them
exactly the way the issue's repro command does:

| Kernel | Session | ReluMin |
|---|---|---:|
| unfixed | `pytest -k ReluMin` alone | 168 passed |
| unfixed | ReluMin mixed with `Sqrt`/`Square`/`Log`/`Sign` | **168 failed** |
| fixed | ReluMin mixed with `Sqrt`/`Square`/`Log`/`Sign` | **all passed** |

n300, skips lifted. Running the issue's own command in isolation would have suggested the
bug was stale; it needs another op to run first and dirty LREG2.

#### Scope

- **Wormhole only.** Blackhole's `_relu_min_impl_` is a plain sfpi predicated form
  (`v_if (a < threshold)`) that genuinely consumes the parameter — no LREG2, no hidden
  dependency. Quasar has its own implementation.
- **No shipping op was affected.** Every Compute API entry point (`relu_tile`,
  `relu_min_tile`, and the int32/uint32/uint16 variants) instantiates `T == uint32_t`, which
  does load LREG2. The only `T == float` instantiation in the tree is the tt-llk harness at
  `tests/helpers/include/sfpu_operations.h`.

#### What changed

| Change | Why |
|---|---|
| Load LREG2 on the `T == float` branch | The bug. Brings the branch in line with what the two `uint32_t` branches already did. |
| Drop the dead `VecType threshold` parameter from `_relu_min_impl_` | That argument is what made the register dependency *look* satisfied when it was not — and it was being passed **uninitialised on every path**, production included. |
| Move the 2's-complement → sign+magnitude conversion into the `vInt` branch | It ran unconditionally and, for a float threshold, merely truncated the value. |
| Remove the two `pytest.skip(... issues/1120)` guards | ReluMin runs in the sweeps and the edge suite again. |

### Notes for reviewers

**Where to focus:** the `__builtin_bit_cast` on the float branch. The kernel build is
`-std=c++17`, so `std::bit_cast` is unavailable; `__builtin_bit_cast` is the idiom
`Converter::as_float` in this same directory already uses for the reverse direction.

**Verified** on n300: 368 passed across the whole Relu family (`Relu`, `ReluMin`,
`ReluMax`); 1421 passed on the mixed-op session that reproduces the failure.

**Not verified here — the ttnn/metal path.** This branch is based on today's `main` while
the local `build/` tree was built from a much older commit, so the runtime firmware build
fails for reasons unrelated to this change. The production instantiation is unaffected *by
construction* — its `_sfpu_load_imm32_` call is untouched, and the only other edit on that
path removes a dead uninitialised argument — but that is an argument, not a measurement, and
CI should be the judge.

**Upstream sync.** The issue lives in `tenstorrent/tt-llk` and this fixes the copy vendored
at `tt_metal/tt-llk/`. If tt-llk is the repo of record for these headers, this needs a
matching PR there or the change will be overwritten on the next sync.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/relu_min_wh_lreg2_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/relu_min_wh_lreg2_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/relu_min_wh_lreg2_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/relu_min_wh_lreg2_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/relu_min_wh_lreg2_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/relu_min_wh_lreg2_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/relu_min_wh_lreg2_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/relu_min_wh_lreg2_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/relu_min_wh_lreg2_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/relu_min_wh_lreg2_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/relu_min_wh_lreg2_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/relu_min_wh_lreg2_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/relu_min_wh_lreg2_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/relu_min_wh_lreg2_fix)
