### PR TITLE
#51346: Use new sfpi::lut API

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -207,24 +207,15 @@ void gelu_init() {
     if constexpr (APPROXIMATION_MODE) {
         sfpi::vConstFloatPrgm0 = 0.5f;
 
-        // LUT segments (6-entry piecewise linear, each hi/lo pair packed into one imm32):
-        // [0.0, 0.5): slope=0.1928, intercept=-0.000104  (lreg0)
-        // [0.5, 1.0): slope=0.4939, intercept=-0.1605  (lreg0 hi / lreg4 hi)
-        // [1.0, 1.5): slope=0.6189, intercept=-0.2797  (lreg1)
-        // [1.5, 2.0): slope=0.6099, intercept=-0.2635  (lreg1 hi / lreg5 hi)
-        // [2.0, 3.0): slope=0.5402, intercept=-0.1194  (lreg2)
-        // [3.0, ∞):   slope=0.5,    intercept=0.0      (lreg2 hi / lreg6 hi)
         // Load the packed 6-segment LUT coefficients directly into the LRegs via sfpi.
-        // vUInt(uint32_t) emits a full 32-bit immediate load, equivalent to the two
-        // 16-bit halves that _sfpu_load_imm32_ previously wrote.
-        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x37E7322Bu);
-        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0xB12286D8u);
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut16ss(0.1928f, 0.4939f);
+        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vLut16ii(-0.00010443f, -0.1604f);
 
-        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x38E138F3u);
-        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0xB437B479u);
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut16ss(0.6188f, 0.6099f);
+        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vLut16ii(-0.2795f, -0.2635f);
 
-        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x38003852u);
-        sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vUInt(0x7c00afa4u);
+        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut16ss(0.5402f, 0.5f);
+        sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vLut16ii(-0.1194f, 0.0f);
     } else if constexpr (is_fp32_dest_acc_en) {
         // FP32 accurate mode: rational erf evaluation requires reciprocal init
         sfpu_reciprocal_init<false>();
@@ -234,31 +225,31 @@ void gelu_init() {
 
 template <int ITERATIONS>
 inline void calculate_gelu_appx() {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
+    sfpi::vLut16ss s01 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut16ss s23 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut16ss s45 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut16ii i01 = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vLut16ii i23 = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vLut16ii i45 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat half = sfpi::vConstFloatPrgm0;
         sfpi::vFloat half_in = in * half;
-        sfpi::vFloat result = lut2_sign(in, l0, l1, l2, l4, l5, l6);
+        sfpi::vFloat result = sfpi::lut(in, s01, i01, s23, i23, s45, i45, sfpi::LutSign::Update);
         result = half_in + result;
 
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
-    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
-    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
-    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = s01;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = s23;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = s45;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = i01;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = i23;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = i45;
 }
 
 // FP32 erf: n16/d16 parity rational coefficients, MaxULP=1 vs FP64.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -9,37 +9,34 @@
 #include "ckernel_defs.h"
 #include "sfpi.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
 template <int ITERATIONS = 8>
 inline void calculate_sigmoid_appx() {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vLut8si si0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
-        dst_reg[0] = lut(val, l0, l1, l2) + 0.5f;
+        sfpi::dst_reg[0] = sfpi::lut(val, si0, si1, si2) + 0.5f;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
 }
 
 inline void sigmoid_appx_init() {
-    // Load the 3 fp16b LUT coefficients into LReg0-2 via sfpi (each imm16 is loaded
-    // as an unsigned 16-bit value, matching the original TTI_SFPLOADI mod0==2 path).
-    l_reg[LRegs::LReg0] = vUInt(static_cast<std::uint16_t>(0x3DFF));
-    l_reg[LRegs::LReg1] = vUInt(static_cast<std::uint16_t>(0x21D8));
-    l_reg[LRegs::LReg2] = vUInt(static_cast<std::uint16_t>(0xFF10));
+    // Load the 3 fp16b LUT coefficients into LReg0-2
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.22656f, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.26562f, -0.04687f);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 0.5f);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -151,22 +151,22 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_tanh() {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
-        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
-        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
-        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
+        sfpi::vLut8si si0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+        sfpi::vLut8si si1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+        sfpi::vLut8si si2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
-            val = sfpi::lut(val, l0, l1, l2);
+            val = sfpi::lut(val, si0, si1, si2);
             sfpi::dst_reg[0] = val;
 
             sfpi::dst_reg++;
         }
 
-        l_reg[sfpi::LRegs::LReg0] = l0;
-        l_reg[sfpi::LRegs::LReg1] = l1;
-        l_reg[sfpi::LRegs::LReg2] = l2;
+        sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+        sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+        sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
     } else if constexpr (is_fp32_dest_acc_en) {  // APPROXIMATION_MODE is false
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
@@ -206,12 +206,9 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanh_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
-        std::uint32_t imm0 = 0x1DFF;  // 0.90625*x
-        std::uint32_t imm1 = 0x481A;  // 0.09375*x + 0.8125
-        std::uint32_t imm2 = 0xFF00;  // 1
-        _sfpu_load_imm16_(0, imm0);
-        _sfpu_load_imm16_(1, imm1);
-        _sfpu_load_imm16_(2, imm2);
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.90625f, 0.0f);
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.09375f, 0.8125f);
+        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 1.0f);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
             sfpi::vConstFloatPrgm0 = 2.0f * 1.442695f;      // 2 * log2(e) == 2 / ln(2)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -11,8 +11,6 @@
 #include "sfpu/ckernel_sfpu_load_config.h"
 #include "cmath_common.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
@@ -21,40 +19,34 @@ namespace sfpu {
 // Kept for backward compatibility. Use calculate_tanh_derivative_sech2 instead.
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH = 0, int ITERATIONS = 8>
 inline void calculate_tanh_derivative() {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vLut8si si0 = l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         if constexpr (!WITH_PRECOMPUTED_TANH) {
-            val = lut(val, l0, l1, l2);
+            val = sfpi::lut(val, si0, si1, si2);
         }
 
         val = val * (-val) + 1.0f;
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[LRegs::LReg0] = si0;
+    sfpi::l_reg[LRegs::LReg1] = si1;
+    sfpi::l_reg[LRegs::LReg2] = si2;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void tanh_derivative_init() {
-    uint imm0;
-    uint imm1;
-    uint imm2;
-    imm0 = 0x1DFF;  // 0.90625*x
-    imm1 = 0x481A;  // 0.09375*x + 0.8125
-    imm2 = 0xFF00;  // 1
-    _sfpu_load_imm16_(0, imm0);
-    _sfpu_load_imm16_(1, imm1);
-    _sfpu_load_imm16_(2, imm2);
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.90625f, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.09375f, 0.8125f);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 1.0f);
 }
 
 // =============================================================================

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -45,18 +45,10 @@ namespace ckernel::sfpu {
 
 template <int ITERATIONS = SFPU_ITERATIONS>
 inline void calculate_gelu_appx() {
-    // Operands lut2_sign() requires; their contents are irrelevant on Quasar (see above).
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
-
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
-        sfpi::vFloat piecewise = lut2_sign(in, l0, l1, l2, l4, l5, l6);
+        sfpi::vFloat piecewise = sfpi::lut<sfpi::LutMode::Fp16x6_HWM3>(in, sfpi::LutSign::Update);
         sfpi::dst_reg[0] = in * 0.5f + piecewise;
         sfpi::dst_reg++;
     }
@@ -180,33 +172,13 @@ inline void gelu_init() {
     if constexpr (APPROXIMATION_MODE) {
         // Segment slopes/intercepts, packed hi/lo the way SFPLUTFP32's FP16 6-entry mode 1 reads
         // them. Same values as the Blackhole table (l_reg0 = 0x37E7322B, l_reg4 = 0xB12286D8, ...).
-        //
-        // 1.0 > x >= 0.5
-        // lreg9_hi  =  0.4939 (0x37E7)
-        // lreg12_hi = -0.1605 (0xB122)
-        // 0.5 > x >= 0.0
-        // lreg9_lo  =  0.1928 (0x322B)
-        // lreg12_lo = -7.4e-05 (0x86D8)
-        ckernel::math::_sfpu_load_config32_(0x9, 0x37E7, 0x322B);
-        ckernel::math::_sfpu_load_config32_(0xC, 0xB122, 0x86D8);
-
-        // 2.0 > x >= 1.5
-        // lreg10_hi =  0.6099 (0x38E1)
-        // lreg13_hi = -0.2635 (0xB437)
-        // 1.5 > x >= 1.0
-        // lreg10_lo =  0.6189 (0x38F3)
-        // lreg13_lo = -0.2797 (0xB479)
-        ckernel::math::_sfpu_load_config32_(0xA, 0x38E1, 0x38F3);
-        ckernel::math::_sfpu_load_config32_(0xD, 0xB437, 0xB479);
-
-        // x >= 3.0
-        // lreg11_hi =  0.50   (0x3800)
-        // lreg14_hi =  0.0    (0x7C00)
-        // 3.0 > x >= 2.0
-        // lreg11_lo =  0.5402 (0x3852)
-        // lreg14_lo = -0.1194 (0xAFA4)
-        ckernel::math::_sfpu_load_config32_(0xB, 0x3800, 0x3852);
-        ckernel::math::_sfpu_load_config32_(0xE, 0x7C00, 0xAFA4);
+        sfpi::lut_init(
+            sfpi::sLut16si(0.1928f, -0.00010443f),
+            sfpi::sLut16si(0.4939f, -0.1604f),
+            sfpi::sLut16si(0.6188f, -0.2795f),
+            sfpi::sLut16si(0.6099f, -0.2635f),
+            sfpi::sLut16si(0.5402f, -0.1194f),
+            sfpi::sLut16si(0.5000f, 0.0f));
     } else if constexpr (is_fp32_dest_acc_en) {
         // FP32 accurate mode: rational erf evaluation requires reciprocal init
         _init_reciprocal_<false>();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -207,21 +207,15 @@ void gelu_init() {
     if constexpr (APPROXIMATION_MODE) {
         sfpi::vConstFloatPrgm0 = 0.5f;
 
-        // LUT segments (6-entry piecewise linear, each hi/lo pair packed into one imm32):
-        // [0.0, 0.5): slope=0.1928, intercept=-0.000104  (lreg0)
-        // [0.5, 1.0): slope=0.4939, intercept=-0.1605  (lreg0 hi / lreg4 hi)
-        // [1.0, 1.5): slope=0.6189, intercept=-0.2797  (lreg1)
-        // [1.5, 2.0): slope=0.6099, intercept=-0.2635  (lreg1 hi / lreg5 hi)
-        // [2.0, 3.0): slope=0.5402, intercept=-0.1194  (lreg2)
-        // [3.0, ∞):   slope=0.5,    intercept=0.0      (lreg2 hi / lreg6 hi)
-        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x37E7322B);
-        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0xB12286D8);
+        // LUT segments (6-entry piecewise linear)
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut16ss(0.1928f, 0.4939f);
+        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vLut16ii(-0.00010443f, -0.1604f);
 
-        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x38E138F3);
-        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0xB437B479);
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut16ss(0.6188f, 0.6099f);
+        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vLut16ii(-0.2796f, -0.2635f);
 
-        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x38003852);
-        sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vUInt(0x7c00afa4);
+        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut16ss(0.5402f, 0.5f);
+        sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vLut16ii(-0.1194f, 0.0f);
     } else if constexpr (is_fp32_dest_acc_en) {
         // FP32 accurate mode: rational erf evaluation requires reciprocal init
         sfpu_reciprocal_init<false>();
@@ -231,31 +225,31 @@ void gelu_init() {
 
 template <int ITERATIONS>
 inline void calculate_gelu_appx() {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
+    sfpi::vLut16ss s01 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut16ss s23 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut16ss s45 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut16ii i01 = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vLut16ii i23 = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vLut16ii i45 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat half = sfpi::vConstFloatPrgm0;
         sfpi::vFloat half_in = in * half;
-        sfpi::vFloat result = lut2_sign(in, l0, l1, l2, l4, l5, l6);
+        sfpi::vFloat result = sfpi::lut(in, s01, i01, s23, i23, s45, i45, sfpi::LutSign::Update);
         result = half_in + result;
 
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
-    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
-    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
-    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = s01;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = s23;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = s45;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = i01;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = i23;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = i45;
 }
 
 // FP32 erf: n16/d16 parity rational coefficients, MaxULP=1 vs FP64.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -9,35 +9,33 @@
 #include "ckernel_defs.h"
 #include "sfpi.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
 template <int ITERATIONS = 8>
 inline void calculate_sigmoid_appx() {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vLut8si si0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
-        dst_reg[0] = lut(val, l0, l1, l2) + 0.5f;
+        sfpi::dst_reg[0] = sfpi::lut(val, si0, si1, si2) + 0.5f;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
 }
 
 inline void sigmoid_appx_init() {
-    l_reg[LRegs::LReg0] = vUInt(static_cast<std::uint16_t>(0x3DFF));
-    l_reg[LRegs::LReg1] = vUInt(static_cast<std::uint16_t>(0x21D8));
-    l_reg[LRegs::LReg2] = vUInt(static_cast<std::uint16_t>(0xFF10));
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.22656f, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.26562f, -0.04687f);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 0.5f);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -154,22 +154,22 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_tanh() {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
-        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
-        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
-        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
+        sfpi::vLut8si si0 = l_reg[sfpi::LRegs::LReg0];
+        sfpi::vLut8si si1 = l_reg[sfpi::LRegs::LReg1];
+        sfpi::vLut8si si2 = l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
-            val = sfpi::lut(val, l0, l1, l2);
+            val = sfpi::lut(val, si0, si1, si2);
             sfpi::dst_reg[0] = val;
 
             sfpi::dst_reg++;
         }
 
-        l_reg[sfpi::LRegs::LReg0] = l0;
-        l_reg[sfpi::LRegs::LReg1] = l1;
-        l_reg[sfpi::LRegs::LReg2] = l2;
+        l_reg[sfpi::LRegs::LReg0] = si0;
+        l_reg[sfpi::LRegs::LReg1] = si1;
+        l_reg[sfpi::LRegs::LReg2] = si2;
     } else if constexpr (is_fp32_dest_acc_en) {  // APPROXIMATION_MODE is false
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
@@ -209,9 +209,9 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanh_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
-        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x1DFF);  // 0.90625*x
-        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x481A);  // 0.09375*x + 0.8125
-        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0xFF00);  // 1
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.90625f, 0.0f);
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.09375f, 0.8125f);
+        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 1.0f);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
             sfpi::vConstFloatPrgm0 = 2.0f * 1.442695f;      // 2 * log2(e) == 2 / ln(2)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -11,8 +11,6 @@
 #include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
@@ -21,34 +19,34 @@ namespace sfpu {
 // Kept for backward compatibility. Use calculate_tanh_derivative_sech2 instead.
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH = 0, int ITERATIONS = 8>
 inline void calculate_tanh_derivative() {
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+    sfpi::vLut8si si0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
+        sfpi::vFloat val = sfpi::dst_reg[0];
 
         if constexpr (!WITH_PRECOMPUTED_TANH) {
-            val = lut(val, l0, l1, l2);
+            val = sfpi::lut(val, si0, si1, si2);
         }
 
         val = val * (-val) + 1.0f;
-        dst_reg[0] = val;
+        sfpi::dst_reg[0] = val;
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void tanh_derivative_init() {
-    l_reg[LRegs::LReg0] = vUInt(static_cast<std::uint16_t>(0x1DFF));  // 0.90625*x
-    l_reg[LRegs::LReg1] = vUInt(static_cast<std::uint16_t>(0x481A));  // 0.09375*x + 0.8125
-    l_reg[LRegs::LReg2] = vUInt(static_cast<std::uint16_t>(0xFF00));  // 1
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.90625f, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.09375f, 0.8125f);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 1.0f);
 }
 
 // =============================================================================

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -15,66 +15,42 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_sigmoid_(const int iterations)
 {
-    constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
-    sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1         = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2         = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4         = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5         = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6         = sfpi::l_reg[sfpi::LRegs::LReg6];
+    sfpi::vLut16ss s01 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut16ss s23 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut16ss s45 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut16ii i01 = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vLut16ii i23 = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vLut16ii i45 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[0] = sfpi::lut(val, s01, i01, s23, i23, s45, i45) + 0.5f;
 
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
-    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
-    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
-    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = s01;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = s23;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = s45;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = i01;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = i23;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = i45;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_sigmoid_()
 {
-    // imm0 = 0x3DFF;
-    // imm1 = 0x21D8;
-    // imm2 = 0xFF10;
-    // TTI_SFPLOADI(0, 2, imm0);
-    // TTI_SFPLOADI(1, 2, imm1);
-    // TTI_SFPLOADI(2, 2, imm2);
-    // Using a 6 piece LUT to calculate and model sigmoid  directly
-    // x <= 0.5 --> 0.2452x + (-0.0004997)
-    // x <= 1.0 --> 0.2173x + 0.0152
-    // x <= 1.5 --> 0.1731x + 0.05988
-    // x <= 2.0 --> 0.1262x + 0.1298
-    // x <= 4.0 --> 0.0485x + 0.2998
-    // x >  4.0 --> 0.4998
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut16ss(0.2452f, 0.2173f);
+    sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vLut16ii(-0.0004997f, 0.0152f);
 
-    // Load the packed 6-segment LUT coefficients directly into the LRegs via sfpi.
-    // vUInt(uint32_t) emits a full 32-bit immediate load, equivalent to the two 16-bit
-    // halves that _sfpu_load_imm32_ previously wrote, and is read back by lut2() above.
-    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x32F433D9u);
-    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-    sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x23C89018u);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut16ss(0.1731f, 0.1262f);
+    sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vLut16ii(0.05988f, 0.1298f);
 
-    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x300A318Au);
-    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-    sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x30272BAAu);
-
-    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x7C002A35u);
-    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-    sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vUInt(0x37ff34CCu);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut16ss(0.0485, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vLut16ii(0.2998f, 0.4998f);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -18,37 +18,31 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_tanh_(const int iterations)
 {
     // SFPU microcode
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut8si si0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        val              = lut(val, l0, l1, l2);
+        val              = sfpi::lut(val, si0, si1, si2);
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_tanh_()
 {
-    // Load the 3 fp16b LUT coefficients into LReg0-2 via sfpi. Each imm16 is loaded as an
-    // unsigned 16-bit value (right-justified, MSBs zeroed), matching the original
-    // _sfpu_load_imm16_ -> TT_SFPLOADI mod0==2 path that _calculate_tanh_'s lut() reads back.
-    //   imm0 = 0x1DFF -> 0.90625*x
-    //   imm1 = 0x481A -> 0.09375*x + 0.8125
-    //   imm2 = 0xFF00 -> 1
-    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(static_cast<std::uint16_t>(0x1DFF));
-    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(static_cast<std::uint16_t>(0x481A));
-    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(static_cast<std::uint16_t>(0xFF00));
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.90625f, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.09375f, 0.8125f);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 1.0f);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -14,9 +14,9 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
 inline void _calculate_tanh_derivative_(const int iterations)
 {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut8si si0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
@@ -25,7 +25,7 @@ inline void _calculate_tanh_derivative_(const int iterations)
 
         if constexpr (!WITH_PRECOMPUTED_TANH)
         {
-            val = lut(val, l0, l1, l2);
+            val = sfpi::lut(val, si0, si1, si2);
         }
 
         val              = val * (-val) + 1.0f;
@@ -34,9 +34,9 @@ inline void _calculate_tanh_derivative_(const int iterations)
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sigmoid.h
@@ -15,57 +15,43 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_sigmoid_(const int iterations)
 {
-    constexpr int lut_mode = 0; // SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1
-    sfpi::vUInt l0         = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1         = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2         = sfpi::l_reg[sfpi::LRegs::LReg2];
-    sfpi::vUInt l4         = sfpi::l_reg[sfpi::LRegs::LReg4];
-    sfpi::vUInt l5         = sfpi::l_reg[sfpi::LRegs::LReg5];
-    sfpi::vUInt l6         = sfpi::l_reg[sfpi::LRegs::LReg6];
+    sfpi::vLut16ss s01 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut16ss s23 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut16ss s45 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut16ii i01 = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vLut16ii i23 = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vLut16ii i45 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[0] = lut2(val, l0, l1, l2, l4, l5, l6, lut_mode) + 0.5f;
+        sfpi::dst_reg[0] = sfpi::lut<sfpi::LutMode::Fp16x6_HWM3>(val, s01, i01, s23, i23, s45, i45) + 0.5f;
 
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
-    sfpi::l_reg[sfpi::LRegs::LReg4] = l4;
-    sfpi::l_reg[sfpi::LRegs::LReg5] = l5;
-    sfpi::l_reg[sfpi::LRegs::LReg6] = l6;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = s01;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = s23;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = s45;
+    sfpi::l_reg[sfpi::LRegs::LReg4] = i01;
+    sfpi::l_reg[sfpi::LRegs::LReg5] = i23;
+    sfpi::l_reg[sfpi::LRegs::LReg6] = i45;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_sigmoid_()
 {
     // Using a 6 piece LUT to calculate and model sigmoid  directly
-    // x <= 0.5 --> 0.2452x + (-0.0004997)
-    // x <= 1.0 --> 0.2173x + 0.0152
-    // x <= 1.5 --> 0.1731x + 0.05988
-    // x <= 2.0 --> 0.1262x + 0.1298
-    // x <= 4.0 --> 0.0485x + 0.2998
-    // x >  4.0 --> 0.4998
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut16ss(0.2452f, 0.2173f);
+    sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vLut16ss(-0.0004997f, 0.0152);
 
-    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x32F433D9);
-    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-    sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x23C89018);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut16ss(0.1731f, 0.1262f);
+    sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vLut16ii(0.05988f, 0.1298f);
 
-    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x300A318A);
-    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-    sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x30272BAA);
-
-    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x7C002A35);
-    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-    sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vUInt(0x37ff34CC);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut16ss(0.0485f, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vLut16ii(0.2998f, 0.4998f);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh.h
@@ -18,31 +18,31 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_tanh_(const int iterations)
 {
     // SFPU microcode
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut8si si0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = sfpi::l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        val              = lut(val, l0, l1, l2);
+        val              = sfpi::lut(val, si0, si1, si2);
         sfpi::dst_reg[0] = val;
 
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void _init_tanh_()
 {
-    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(static_cast<std::uint16_t>(0x1DFF)); // 0.90625*x
-    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(static_cast<std::uint16_t>(0x481A)); // 0.09375*x + 0.8125
-    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(static_cast<std::uint16_t>(0xFF00)); // 1
+    sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vLut8si(0.90625f, 0.0f);
+    sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vLut8si(0.09375f, 0.8125f);
+    sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vLut8si(0.0f, 1.0f);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_tanh_derivative.h
@@ -14,9 +14,9 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH, int ITERATIONS>
 inline void _calculate_tanh_derivative_(const int iterations)
 {
-    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
-    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vLut8si si0 = l_reg[sfpi::LRegs::LReg0];
+    sfpi::vLut8si si1 = l_reg[sfpi::LRegs::LReg1];
+    sfpi::vLut8si si2 = l_reg[sfpi::LRegs::LReg2];
 
     // tanh'(x) = 1 - (tanh(x))^2
     for (int d = 0; d < iterations; d++)
@@ -25,7 +25,7 @@ inline void _calculate_tanh_derivative_(const int iterations)
 
         if constexpr (!WITH_PRECOMPUTED_TANH)
         {
-            val = lut(val, l0, l1, l2);
+            val = sfpi::lut(val, si0, si1, si2);
         }
 
         val              = val * (-val) + 1.0f;
@@ -34,9 +34,9 @@ inline void _calculate_tanh_derivative_(const int iterations)
         sfpi::dst_reg++;
     }
 
-    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
-    sfpi::l_reg[sfpi::LRegs::LReg1] = l1;
-    sfpi::l_reg[sfpi::LRegs::LReg2] = l2;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = si0;
+    sfpi::l_reg[sfpi::LRegs::LReg1] = si1;
+    sfpi::l_reg[sfpi::LRegs::LReg2] = si2;
 }
 
 } // namespace sfpu


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This converts all the sfpi::lut uses to the new API that landed in 7.73.0.  Also removed some `using namespace sfpi;`s that should never be in header files.

### Notes for reviewers
ETA:
the sigmoid uses all comment that the format is TABLE1, but they pass 0, which actually selects TABLE2.  I chose to believe the comment, so `Fp16x6_HWM3`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/lut-51346)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/lut-51346)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/lut-51346)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/lut-51346)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/lut-51346)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/lut-51346)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/lut-51346)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/lut-51346)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/lut-51346)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/lut-51346)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/lut-51346)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/lut-51346)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/lut-51346)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/lut-51346)