### PR TITLE
[Feature] Per-core socket config blocks under per_core_allocation

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/mesh_socket.hpp
@@ -162,6 +162,9 @@ public:
     std::shared_ptr<MeshBuffer> get_data_buffer() const;
     // Access the config buffer associated with this socket.
     std::shared_ptr<MeshBuffer> get_config_buffer() const;
+    // The config block's L1 address at this endpoint's core; valid for both
+    // lockstep and per-core config allocations.
+    DeviceAddr get_config_buffer_address() const;
     // Access the underlying configuration of the instantiated socket (connectivity of senders/receivers and the socket
     // memory config).
     const SocketConfig& get_config() const;

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -344,6 +344,8 @@ std::shared_ptr<MeshBuffer> MeshSocket::get_data_buffer() const {
 
 std::shared_ptr<MeshBuffer> MeshSocket::get_config_buffer() const { return config_buffer_; }
 
+DeviceAddr MeshSocket::get_config_buffer_address() const { return get_socket_config_buffer_address(*this); }
+
 const SocketConfig& MeshSocket::get_config() const { return config_; }
 
 tt::tt_fabric::FabricNodeId MeshSocket::get_fabric_node_id(SocketEndpoint endpoint, const MeshCoordinate& coord) const {

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/per_core_allocation/allocator_mode.hpp>
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/system_mesh.hpp>
+#include <tt-metalium/tt_metal.hpp>
 
 using namespace tt::tt_metal::distributed::multihost;
 
@@ -241,10 +242,26 @@ std::shared_ptr<MeshBuffer> create_socket_config_buffer(
     auto shard_params =
         ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {static_cast<uint32_t>(num_cores), 1});
 
+    // Per-core sockets keep their config block per-core too: the peer learns the
+    // address through the descriptor handshake, and the block stops fragmenting
+    // the lockstep book on every other core.
+    auto sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED);
+    if (socket_mem_config.per_core_allocation) {
+        TT_FATAL(
+            num_cores == 1,
+            "Per-core socket config allocation (v1) supports exactly one endpoint core per socket; got {}.",
+            num_cores);
+        TT_FATAL(
+            tt::tt_metal::MetalContext::instance().rtoptions().get_allocator_mode_hybrid(),
+            "Per-core socket allocation requires the device to be opened with AllocatorMode::HYBRID "
+            "(set TT_METAL_ALLOCATOR_MODE_HYBRID=1 before opening the device).");
+        experimental::per_core_allocation::set_per_core_allocation(sharding_args, true);
+    }
+
     DeviceLocalBufferConfig buffer_specs = {
         .page_size = config_buffer_size,
         .buffer_type = BufferType::L1,
-        .sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
+        .sharding_args = sharding_args,
         .bottom_up = std::nullopt,
         .sub_device_id = is_sender ? socket_mem_config.sender_sub_device : socket_mem_config.receiver_sub_device,
     };
@@ -335,13 +352,19 @@ void write_socket_configs(
     SocketEndpoint socket_endpoint,
     const std::shared_ptr<MeshDevice>& peer_device) {
     auto* mesh_device = config_buffer->device();
-    const auto& core_to_core_id = config_buffer->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
     bool is_sender = socket_endpoint == SocketEndpoint::SENDER;
     // The peer descriptor has already been validated to use the same socket
     // config. Keep using the local descriptor's config here so rank-scoped
     // metadata generated from the local MeshSocket stays available even though
     // the serialized peer descriptor does not carry that extra context.
     const auto& config = local_descriptor.config;
+    // Per-core buffers carry no page mapping (v1: exactly one endpoint core, so
+    // the core-to-slot index is always 0); only lockstep buffers provide one.
+    static const std::unordered_map<CoreCoord, uint32_t> kSingleCoreId;
+    const bool config_is_per_core = config.socket_mem_config.per_core_allocation;
+    const auto& core_to_core_id = config_is_per_core
+                                      ? kSingleCoreId
+                                      : config_buffer->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
     auto grouped_connections = group_socket_connections(config, socket_endpoint);
     auto peer_config_buf_addr = peer_descriptor.config_buffer_address;
     const SocketSenderSize sender_size;
@@ -397,7 +420,7 @@ void write_socket_configs(
             for (const auto& [sender_core_coord, connections] : cores_map) {
                 MeshCoreCoord sender_core = {device_coord, sender_core_coord};
 
-                uint32_t idx = core_to_core_id.at(sender_core.core_coord);
+                uint32_t idx = config_is_per_core ? 0 : core_to_core_id.at(sender_core.core_coord);
                 // write sender_socket_md (only once per sender core)
                 uint32_t md_offset = idx * sender_total_size_bytes / sizeof(uint32_t);
                 config_data[md_offset++] = 0;                                    // bytes_sent
@@ -434,7 +457,22 @@ void write_socket_configs(
                     config_data[receiver_enc_offset + 3] = recv_virtual_core.x;  // downstream_noc_x
                 }
             }
-            distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            if (config.socket_mem_config.per_core_allocation) {
+                // WriteShard resolves lockstep addresses only; per-core blocks are
+                // written straight at their per-core L1 address (h2d_socket pattern).
+                const CoreCoord core = cores_map.begin()->first;
+                std::span<const uint8_t> bytes(
+                    reinterpret_cast<const uint8_t*>(config_data.data()), config_data.size() * sizeof(config_data[0]));
+                tt::tt_metal::detail::WriteToDeviceL1(
+                    mesh_device->get_device(device_coord),
+                    core,
+                    static_cast<uint32_t>(
+                        experimental::per_core_allocation::get_per_core_address(*config_buffer, device_coord, core)),
+                    bytes);
+            } else {
+                distributed::WriteShard(
+                    mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            }
         }
     } else {
         std::vector<receiver_socket_md> config_data(
@@ -464,7 +502,7 @@ void write_socket_configs(
                     fabric_config,
                     SocketEndpoint::RECEIVER);
 
-                uint32_t idx = core_to_core_id.at(recv_core.core_coord);
+                uint32_t idx = config_is_per_core ? 0 : core_to_core_id.at(recv_core.core_coord);
                 auto& md = config_data[idx];
                 md.bytes_sent = 0;
                 md.bytes_acked = 0;
@@ -479,7 +517,21 @@ void write_socket_configs(
                 md.d2d.upstream_bytes_acked_addr = peer_config_buf_addr + sender_size.md_size_bytes +
                                                    sender_size.ack_size_bytes * receiver_ids_per_sender.at(connection);
             }
-            distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            if (config.socket_mem_config.per_core_allocation) {
+                // Same as the sender branch: per-core blocks bypass WriteShard.
+                const CoreCoord core = cores_map.begin()->first;
+                std::span<const uint8_t> bytes(
+                    reinterpret_cast<const uint8_t*>(config_data.data()), config_data.size() * sizeof(config_data[0]));
+                tt::tt_metal::detail::WriteToDeviceL1(
+                    mesh_device->get_device(device_coord),
+                    core,
+                    static_cast<uint32_t>(
+                        experimental::per_core_allocation::get_per_core_address(*config_buffer, device_coord, core)),
+                    bytes);
+            } else {
+                distributed::WriteShard(
+                    mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            }
         }
     }
 }
@@ -498,6 +550,25 @@ DeviceAddr get_receiver_data_buffer_address(const MeshSocket& receiver_socket) {
         data_buffer, receiver_core.device_coord, receiver_core.core_coord);
 }
 
+DeviceAddr get_socket_config_buffer_address(const MeshSocket& socket_endpoint) {
+    // Per-core config blocks have one valid address per endpoint core; the plain
+    // address() accessor is undefined for them. Mirrors get_receiver_data_buffer_address.
+    const auto& config = socket_endpoint.get_config();
+    const auto& config_buffer = *socket_endpoint.get_config_buffer();
+    if (!config.socket_mem_config.per_core_allocation) {
+        return config_buffer.address();
+    }
+    TT_FATAL(
+        !config.socket_connection_config.empty(),
+        "Per-core socket has no connections; cannot resolve config buffer address.");
+    const auto& connection = config.socket_connection_config.front();
+    const auto& endpoint_core = socket_endpoint.get_socket_endpoint_type() == SocketEndpoint::SENDER
+                                    ? connection.sender_core
+                                    : connection.receiver_core;
+    return experimental::per_core_allocation::get_per_core_address(
+        config_buffer, endpoint_core.device_coord, endpoint_core.core_coord);
+}
+
 SocketPeerDescriptor generate_local_endpoint_descriptor(
     const MeshSocket& socket_endpoint, std::optional<DistributedContextId> context_id) {
     const auto& config = socket_endpoint.get_config();
@@ -513,7 +584,7 @@ SocketPeerDescriptor generate_local_endpoint_descriptor(
 
     SocketPeerDescriptor local_endpoint_desc = {
         .config = config,
-        .config_buffer_address = socket_endpoint.get_config_buffer()->address(),
+        .config_buffer_address = get_socket_config_buffer_address(socket_endpoint),
         .data_buffer_address = is_sender ? 0 : get_receiver_data_buffer_address(socket_endpoint),
         .exchange_tag = tag};
     return local_endpoint_desc;

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -53,6 +53,10 @@ void write_socket_configs(
     SocketEndpoint socket_endpoint,
     const std::shared_ptr<MeshDevice>& peer_device = nullptr);
 
+// The endpoint's config-block address; per-core-aware (address() is undefined
+// for per-core buffers).
+DeviceAddr get_socket_config_buffer_address(const MeshSocket& socket_endpoint);
+
 SocketPeerDescriptor generate_local_endpoint_descriptor(
     const MeshSocket& socket_endpoint, std::optional<multihost::DistributedContextId> context_id = std::nullopt);
 

--- a/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
@@ -181,7 +181,7 @@ void py_module_types(nb::module_& mod) {
         .def(
             "get_config_buffer_address",
             [](const tt::tt_metal::distributed::MeshSocket& socket) {
-                return static_cast<uint32_t>(socket.get_config_buffer()->address());
+                return static_cast<uint32_t>(socket.get_config_buffer_address());
             },
             R"doc(
                 Returns the L1 address of the socket configuration buffer on the device.


### PR DESCRIPTION
### PR Category

Feature

### Summary

`SocketMemoryConfig::per_core_allocation` already puts a socket's **data** buffer under the per-core allocator. Its **config** buffer still went to the lockstep allocator. The lockstep allocator reserves the same address on every core in the grid, so a socket that uses one endpoint core still costs that much L1 on all of them. Kimi-K3 opens its devices in hybrid allocator mode for exactly this reason, and this was the one socket allocation left behind.

This change extends `per_core_allocation` to the config buffer, so a per-core socket keeps both of its buffers per-core.

There are three parts.

1. `create_socket_config_buffer` marks the sharding args per-core when the socket asks for it. This first version is limited to exactly one endpoint core per socket, and it requires the device to be opened with `AllocatorMode::HYBRID`. Both are `TT_FATAL` guards, so a wrong configuration fails at socket creation, not later at a bad address.

2. `write_socket_configs` needs two adjustments. First, a per-core buffer carries no page mapping, so the core-to-slot index is fixed at 0. That is safe only because of the single-core limit above. Second, `WriteShard` resolves lockstep addresses only, so the config block is written with `tt::tt_metal::detail::WriteToDeviceL1` at the per-core address instead. This is the same pattern the h2d socket path already uses.

3. `Buffer::address()` is undefined for a per-core buffer, and the peer learns the config address through the descriptor handshake, so something has to return it. This adds `MeshSocket::get_config_buffer_address()` and the free function `get_socket_config_buffer_address()`. They return the plain buffer address for a lockstep socket and the endpoint core's per-core address for a per-core socket. The Python binding `get_config_buffer_address` now calls the new accessor instead of `get_config_buffer()->address()`.

With `per_core_allocation = false` nothing changes: same `BufferShardingArgs`, same page mapping, same `WriteShard`.

### Notes for reviewers

- The single-core limit is the part worth checking. `group_socket_connections` can return more than one core per device, and the index-0 shortcut in `write_socket_configs` is correct only because `create_socket_config_buffer` rejects that case up front. If you would rather have the general form now, the change is to keep a per-core index map in place of the page mapping.

- The two `WriteToDeviceL1` branches, one for the sender and one for the receiver, are the same code twice. I left them inline next to the `WriteShard` calls they replace so the diff reads as a local change. I am happy to pull them into a helper if you prefer.

- Tested by running the Kimi-K3 four-stage single-galaxy pipeline on a Blackhole galaxy with real weights. The device-to-device sockets between the four ring stages come up and pages move through all four stages. I have not added a unit test for the new accessor; tell me if you want one and where it belongs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjameel/k3-percore-socket-blocks-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjameel/k3-percore-socket-blocks-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjameel/k3-percore-socket-blocks-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjameel/k3-percore-socket-blocks-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjameel/k3-percore-socket-blocks-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjameel/k3-percore-socket-blocks-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjameel/k3-percore-socket-blocks-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjameel/k3-percore-socket-blocks-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjameel/k3-percore-socket-blocks-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjameel/k3-percore-socket-blocks-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjameel/k3-percore-socket-blocks-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjameel/k3-percore-socket-blocks-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjameel/k3-percore-socket-blocks-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjameel/k3-percore-socket-blocks-v2)