### PR TITLE
[Feature] Bring up `tt-metal` on the Quasar 8x4 grid in `craq-sim`

### DIFF
--- a/.github/actions/setup-ttsim/action.yml
+++ b/.github/actions/setup-ttsim/action.yml
@@ -3,11 +3,12 @@ description: |
   Install the ttsim simulator binary for a given SKU from a pre-uploaded
   artifact, and export the env vars needed to run tests under the simulator
   (TT_METAL_SIMULATOR_HOME, TT_METAL_SIMULATOR, TT_METAL_SLOW_DISPATCH_MODE,
-  TT_METAL_DISABLE_SFPLOADMACRO). The caller workflow is expected to have
-  published each simulator binary as its own ttsim-lib-<library> artifact (see the
-  fetch-ttsim job pattern in ttsim-sanity-tests-impl.yaml). Which binary a SKU gets is
-  declared by that SKU's ttsim_lib in .github/sku_config.yaml, so callers pass only the
-  SKU and this action downloads the single artifact holding that library.
+  TT_METAL_DISABLE_SFPLOADMACRO, TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION). The
+  caller workflow is expected to have published each simulator binary as its own
+  ttsim-lib-<library> artifact (see the fetch-ttsim job pattern in
+  ttsim-sanity-tests-impl.yaml). Which binary a SKU gets is declared by that SKU's
+  ttsim_lib in .github/sku_config.yaml, so callers pass only the SKU and this
+  action downloads the single artifact holding that library.
 
 inputs:
   sku:
@@ -87,6 +88,7 @@ runs:
           echo "TT_METAL_SIMULATOR=${{ inputs.root }}/sim/libttsim.so"
           echo "TT_METAL_SLOW_DISPATCH_MODE=1"
           echo "TT_METAL_DISABLE_SFPLOADMACRO=1"
+          echo "TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1"
         } >> "$GITHUB_ENV"
 
     - name: Download ttsim binaries artifact

--- a/.github/actions/setup-ttsim/action.yml
+++ b/.github/actions/setup-ttsim/action.yml
@@ -68,7 +68,7 @@ runs:
         case "$asset" in
           libttsim_wh*) soc=wormhole_b0_80_arch.yaml ;;
           libttsim_bh*) soc=blackhole_140_arch.yaml ;;
-          libttsim_qsr*) soc=quasar_32_arch.yaml ;;
+          libttsim_qsr*) soc=quasar_32_arch_ttsim.yaml ;;
           *) echo "::error::Cannot derive an arch from ttsim_lib '$asset' for SKU '${{ inputs.sku }}'."; exit 1 ;;
         esac
 

--- a/.github/actions/setup-ttsim/action.yml
+++ b/.github/actions/setup-ttsim/action.yml
@@ -3,7 +3,7 @@ description: |
   Install the ttsim simulator binary for a given SKU from a pre-uploaded
   artifact, and export the env vars needed to run tests under the simulator
   (TT_METAL_SIMULATOR_HOME, TT_METAL_SIMULATOR, TT_METAL_SLOW_DISPATCH_MODE,
-  TT_METAL_DISABLE_SFPLOADMACRO, TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION). The
+  TT_METAL_DISABLE_SFPLOADMACRO, TT_METAL_QUASAR_NOC_API_VERSION). The
   caller workflow is expected to have published each simulator binary as its own
   ttsim-lib-<library> artifact (see the fetch-ttsim job pattern in
   ttsim-sanity-tests-impl.yaml). Which binary a SKU gets is declared by that SKU's
@@ -88,7 +88,7 @@ runs:
           echo "TT_METAL_SIMULATOR=${{ inputs.root }}/sim/libttsim.so"
           echo "TT_METAL_SLOW_DISPATCH_MODE=1"
           echo "TT_METAL_DISABLE_SFPLOADMACRO=1"
-          echo "TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1"
+          echo "TT_METAL_QUASAR_NOC_API_VERSION=1"
         } >> "$GITHUB_ENV"
 
     - name: Download ttsim binaries artifact

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -9,6 +9,9 @@
 #
 # Simulator mode (TT_METAL_SIMULATOR set):
 #   Exports TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_DISABLE_SFPLOADMACRO=1.
+#   Does not set TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION (default is 2).
+#   ttsim does not implement NOC API v2: for Quasar ttsim, export
+#   TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1 yourself.
 #   Skips flock, device resets, and triage (these require real hardware).
 #   No hang protection — sim runs at kHz, so wall-clock timeouts are meaningless.
 #

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -9,9 +9,9 @@
 #
 # Simulator mode (TT_METAL_SIMULATOR set):
 #   Exports TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_DISABLE_SFPLOADMACRO=1.
-#   Does not set TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION (default is 2).
+#   Does not set TT_METAL_QUASAR_NOC_API_VERSION (default is 2).
 #   ttsim does not implement NOC API v2: for Quasar ttsim, export
-#   TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1 yourself.
+#   TT_METAL_QUASAR_NOC_API_VERSION=1 yourself.
 #   Skips flock, device resets, and triage (these require real hardware).
 #   No hang protection — sim runs at kHz, so wall-clock timeouts are meaningless.
 #

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -22,16 +22,16 @@ static constexpr uint32_t default_l1_alignment = 16;
 
 TEST(DispatchSettingsTest, CPU_TestDispatchSettingsDefaultUnsupportedCoreType) {
     const auto unsupported_core = CoreType::ARC;
-    EXPECT_THROW(DispatchSettings(1, unsupported_core, false, false, default_l1_alignment, 4), std::runtime_error);
+    EXPECT_THROW(DispatchSettings(1, 1, unsupported_core, false, false, default_l1_alignment, 4), std::runtime_error);
 }
 
 TEST(DispatchSettingsTest, CPU_TestDispatchSettingsInvalidPrefetchQEntrySize) {
-    EXPECT_THROW(DispatchSettings(1, CoreType::WORKER, false, false, default_l1_alignment, 3), std::runtime_error);
+    EXPECT_THROW(DispatchSettings(1, 1, CoreType::WORKER, false, false, default_l1_alignment, 3), std::runtime_error);
 }
 
 TEST(DispatchSettingsTest, CPU_TestDispatchSettingsEq) {
     const uint32_t hw_cqs = 2;
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
+    DispatchSettings settings(hw_cqs, 1, CoreType::WORKER, false, false, default_l1_alignment, 4);
     DispatchSettings settings_2 = settings;  // Copy
     EXPECT_EQ(settings, settings_2);
     settings_2.dispatch_size_ += 1;
@@ -43,7 +43,7 @@ TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetPrefetchDBuffer) {
     const uint32_t expected_buffer_bytes = 0xcafe;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
+    DispatchSettings settings(hw_cqs, 1, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.prefetch_d_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_pages_, expected_page_count);
@@ -53,7 +53,7 @@ TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetPrefetchQBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * 4;
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
+    DispatchSettings settings(hw_cqs, 1, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_size_, expected_buffer_bytes);
@@ -64,7 +64,7 @@ TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetPrefetchQBufferWith2ByteEn
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * 2;
-    DispatchSettings settings(hw_cqs, CoreType::ETH, false, false, default_l1_alignment, 2);
+    DispatchSettings settings(hw_cqs, 1, CoreType::ETH, false, false, default_l1_alignment, 2);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_size_, expected_buffer_bytes);
@@ -75,7 +75,7 @@ TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetDispatchBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
+    DispatchSettings settings(hw_cqs, 1, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.dispatch_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_pages_, expected_page_count);
@@ -86,7 +86,7 @@ TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetDispatchSBuffer) {
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
+    DispatchSettings settings(hw_cqs, 1, CoreType::WORKER, false, false, default_l1_alignment, 4);
     settings.dispatch_s_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_pages_, expected_page_count);

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -43,7 +43,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     }
 
     constexpr CoreCoord core = {0, 0};
-    const uint32_t dram_channel = this->device().dram_channel_from_virtual_core(core);
+    constexpr uint32_t dram_channel = 0;
 
     // Initialize L1 signal so hart FIRST_USER_DM (2) can proceed first; the simple_tls_check
     // kernel chains the signal forward (signal_addr := hartid + 1) so hartids 2..7 run in order.

--- a/tt_metal/hw/inc/internal/mod_div_lib.h
+++ b/tt_metal/hw/inc/internal/mod_div_lib.h
@@ -20,6 +20,10 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_20(uint32_t n) {
     return (((uint64_t)n * 0xCCCCCCCD) >> 32) >> 4;
 }
 
+inline __attribute__((always_inline)) uint32_t fast_udiv_28(uint32_t n) {
+    return (((uint64_t)n * 0x92492493) >> 32) >> 4;
+}
+
 inline __attribute__((always_inline)) uint32_t fast_udiv_48(uint32_t n) {
     return (((uint64_t)n * 0xAAAAAAAB) >> 32) >> 5;
 }
@@ -93,6 +97,8 @@ inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
     } else if constexpr (d == 20) {
         // fast divide for 20 divisor
         return fast_udiv_20(n);
+    } else if constexpr (d == 28) {
+        return fast_udiv_28(n);
     } else if constexpr (d == 48) {
         return fast_udiv_48(n);
     } else if constexpr (d == 56) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -47,7 +47,6 @@
 #elif defined(NOC_API_V1)
 #include "noc_nonblocking_api_v1.h"
 #else
-#define NOC_API_V2
 #include "noc_nonblocking_api_v2.h"
 #endif
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -121,7 +121,7 @@ void validate_num_banks(uint32_t num_banks, const BufferType& buffer_type, bool 
     // address gen For non pow2 num banks, special cases need to be added to avoid falling back to generic
     // implementation. See https://github.com/tenstorrent/tt-metal/issues/3321
     std::unordered_set<uint32_t> acceptable_num_non_pow2_mem_banks = {
-        7, 12, 20, 48, 56, 63, 70, 72, 80, 94, 108, 110, 117, 120, 124, 126, 130, 140};
+        7, 12, 20, 28, 48, 56, 63, 70, 72, 80, 94, 108, 110, 117, 120, 124, 126, 130, 140};
     bool custom_mod_bank_id_calculation_exists = acceptable_num_non_pow2_mem_banks.contains(num_banks);
     bool valid_num_banks = (is_pow2_num_banks or custom_mod_bank_id_calculation_exists or doesnt_support_interleaved);
     if (not valid_num_banks) {

--- a/tt_metal/impl/dispatch/dispatch_engine_cores.hpp
+++ b/tt_metal/impl/dispatch/dispatch_engine_cores.hpp
@@ -32,6 +32,10 @@ namespace tt::tt_metal::detail {
 // Returns synthetic logical dispatch-engine cores CoreCoord(index, 0) from the ordered soc `dispatch:` list.
 std::vector<CoreCoord> get_quasar_soc_dispatch_engine_logical_cores(const metal_SocDescriptor& soc_desc);
 
+// Returns the dispatch core each CQ lands on from the Quasar [prefetch, dispatch] per-CQ pool; empty otherwise.
+std::vector<CoreCoord> get_quasar_dispatch_core_per_cq(
+    tt::ARCH arch, const std::vector<CoreCoord>& dispatch_core_pool, uint8_t num_hw_cqs);
+
 // Fail fast dispatch init when Quasar has no usable dispatch cores for the active path.
 void validate_quasar_dispatch_cores_for_fd(
     tt::tt_metal::MetalEnvImpl& env,

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -27,6 +27,8 @@ DispatchMemMap::DispatchMemMap(
     settings(DispatchSettings(
         num_hw_cqs,
 
+        cq_layout.num_cqs_per_core,
+
         core_type,
 
         is_galaxy_cluster,

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -15,6 +15,7 @@
 #include "core_descriptor.hpp"
 #include "dispatch/dispatch_core_manager.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
+#include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -82,11 +83,30 @@ std::vector<tt::tt_metal::CoreCoord> populate_all_logical_dispatch_cores(
     return get_consistent_logical_cores(env, num_hw_cqs, dispatch_core_config);
 }
 
-tt::tt_metal::CommandQueueDispatchLayout generate_cq_dispatch_layout(tt::ARCH arch, uint8_t num_hw_cqs) {
+tt::tt_metal::CommandQueueDispatchLayout generate_cq_dispatch_layout(
+    tt::ARCH arch, uint8_t num_hw_cqs, const std::vector<tt::tt_metal::CoreCoord>& dispatch_core_pool) {
     if (arch != tt::ARCH::QUASAR) {
         return {.fd_kernels_on_same_core = false, .num_cqs_per_core = 1};
     }
-    return {.fd_kernels_on_same_core = true, .num_cqs_per_core = num_hw_cqs};
+    const std::vector<tt::tt_metal::CoreCoord> cq_dispatch_cores =
+        tt::tt_metal::detail::get_quasar_dispatch_core_per_cq(arch, dispatch_core_pool, num_hw_cqs);
+
+    // No dispatch cores means no CQ placement, however DispatchMemMap is still built so return the default
+    // Quasar layout.
+    if (cq_dispatch_cores.empty()) {
+        return {.fd_kernels_on_same_core = true, .num_cqs_per_core = num_hw_cqs};
+    }
+
+    const bool all_cqs_on_one_core =
+        std::all_of(cq_dispatch_cores.begin(), cq_dispatch_cores.end(), [&cq_dispatch_cores](const auto& core) {
+            return core == cq_dispatch_cores.front();
+        });
+    if (all_cqs_on_one_core) {
+        return {.fd_kernels_on_same_core = true, .num_cqs_per_core = num_hw_cqs};
+    }
+
+    // The only placement remaining is one CQ per dispatch core.
+    return {.fd_kernels_on_same_core = true, .num_cqs_per_core = 1};
 }
 
 }  // namespace
@@ -126,12 +146,12 @@ void DispatchQueryManager::reset(DispatchCoreConfig& dispatch_core_config, uint8
     }
 
     go_signal_noc_ = (dispatch_s_enabled_ and arch != tt::ARCH::QUASAR) ? NOC::NOC_1 : NOC::NOC_0;
-    cq_dispatch_layout_ = generate_cq_dispatch_layout(arch, num_hw_cqs);
-    // Reset the dispatch cores reported by the manager. Will be re-populated when the associated query is made
-    dispatch_cores_ = {};
-    // Populate dispatch
+    // Populate dispatch cores first: the layout is derived from the cores this pool hands out per CQ.
     logical_dispatch_cores_on_user_chips_ =
         populate_all_logical_dispatch_cores(env_, num_hw_cqs_, dispatch_core_config_);
+    cq_dispatch_layout_ = generate_cq_dispatch_layout(arch, num_hw_cqs, logical_dispatch_cores_on_user_chips_);
+    // Reset the dispatch cores reported by the manager. Will be re-populated when the associated query is made
+    dispatch_cores_ = {};
 }
 
 const std::vector<tt::tt_metal::CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores(uint32_t device_id) const {

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -27,6 +27,7 @@ class DispatchSettings {
 public:
     explicit DispatchSettings(
         uint32_t num_hw_cqs,
+        uint32_t num_cqs_per_core,
         const CoreType& core_type,
         bool is_galaxy_cluster,
         bool are_cqs_dram_backed,
@@ -162,7 +163,8 @@ public:
 private:
     void init_worker_defaults(
         uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed, uint32_t l1_alignment);
-    void init_dispatch_defaults(uint32_t num_hw_cqs, bool are_cqs_dram_backed, uint32_t l1_alignment);
+    void init_dispatch_defaults(
+        uint32_t num_hw_cqs, uint32_t num_cqs_per_core, bool are_cqs_dram_backed, uint32_t l1_alignment);
     void init_eth_defaults(uint32_t num_hw_cqs, uint32_t l1_alignment);
     uint32_t get_prefetch_q_entries(
         CoreType core_type, uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed);

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -35,6 +35,7 @@ static_assert(
 
 DispatchSettings::DispatchSettings(
     uint32_t num_hw_cqs,
+    uint32_t num_cqs_per_core,
     const CoreType& core_type,
     bool is_galaxy_cluster,
     bool are_cqs_dram_backed,
@@ -49,7 +50,9 @@ DispatchSettings::DispatchSettings(
         case CoreType::WORKER:
             init_worker_defaults(num_hw_cqs, is_galaxy_cluster, are_cqs_dram_backed, l1_alignment);
             break;
-        case CoreType::DISPATCH: init_dispatch_defaults(num_hw_cqs, are_cqs_dram_backed, l1_alignment); break;
+        case CoreType::DISPATCH:
+            init_dispatch_defaults(num_hw_cqs, num_cqs_per_core, are_cqs_dram_backed, l1_alignment);
+            break;
         case CoreType::ETH: init_eth_defaults(num_hw_cqs, l1_alignment); break;
         default: TT_THROW("init_defaults not implemented for core type {}", enchantum::to_string(core_type));
     }
@@ -77,7 +80,8 @@ void DispatchSettings::init_worker_defaults(
         .build();
 }
 
-void DispatchSettings::init_dispatch_defaults(uint32_t num_hw_cqs, bool are_cqs_dram_backed, uint32_t l1_alignment) {
+void DispatchSettings::init_dispatch_defaults(
+    uint32_t num_hw_cqs, uint32_t num_cqs_per_core, bool are_cqs_dram_backed, uint32_t l1_alignment) {
     this->num_hw_cqs(num_hw_cqs)
         .core_type(CoreType::DISPATCH)
         .prefetch_q_entries(
@@ -85,11 +89,9 @@ void DispatchSettings::init_dispatch_defaults(uint32_t num_hw_cqs, bool are_cqs_
         .prefetch_max_cmd_size(128_KB)
         .prefetch_cmddat_q_size(256_KB)
         .prefetch_scratch_db_size(128_KB)
-        // Quasar currently only has a single dispatch engine, so if there is more than one CQ, they will be placed in
-        // the same dispatch engine. The ringbuffer size of each CQ is lowered to 864 KB so that both CQs can fit in the
-        // same dispatch engine. Once support for multiple dispatch engines is added, this will need to be updated as
-        // each CQ will be placed in a separate dispatch engine.
-        .prefetch_ringbuffer_size(num_hw_cqs > 1 ? 864_KB : 1024_KB)
+        // Multiple CQs on one dispatch engine share L1, so shrink the per-CQ ringbuffer so they fit.
+        // When each CQ has its own dispatch engine, keep the full 1024 KB ringbuffer.
+        .prefetch_ringbuffer_size(num_cqs_per_core > 1 ? 864_KB : 1024_KB)
         .prefetch_d_buffer_size(256_KB)
 
         .dispatch_size(512_KB)

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -217,9 +217,12 @@ void JitBuildEnv::init(
         this->defines_ += "-D" + device_kernel_define.first + "=" + device_kernel_define.second + " ";
     }
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
-    if (this->arch_ == tt::ARCH::QUASAR && rtoptions.get_simulator_enabled() &&
-        rtoptions.get_simulator_path().extension() == ".so") {
-        this->defines_ += "-DNOC_API_V1 ";
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        std::string qsr_noc_api_version = "NOC_API_V2";
+        if (rtoptions.get_simulator_enabled() && rtoptions.get_simulator_path().extension() == ".so") {
+            qsr_noc_api_version = "NOC_API_V" + std::to_string(rtoptions.get_simulator_quasar_noc_api_version());
+        }
+        this->defines_ += "-D" + qsr_noc_api_version + " ";
     }
 
     if (rtoptions.get_profiler_enabled()) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -217,13 +217,6 @@ void JitBuildEnv::init(
         this->defines_ += "-D" + device_kernel_define.first + "=" + device_kernel_define.second + " ";
     }
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
-    if (this->arch_ == tt::ARCH::QUASAR) {
-        std::string qsr_noc_api_version = "NOC_API_V2";
-        if (rtoptions.get_simulator_enabled() && rtoptions.get_simulator_path().extension() == ".so") {
-            qsr_noc_api_version = "NOC_API_V" + std::to_string(rtoptions.get_simulator_quasar_noc_api_version());
-        }
-        this->defines_ += "-D" + qsr_noc_api_version + " ";
-    }
 
     if (rtoptions.get_profiler_enabled()) {
         uint32_t profiler_options = 1;

--- a/tt_metal/llrt/dispatch_engine_cores.cpp
+++ b/tt_metal/llrt/dispatch_engine_cores.cpp
@@ -21,6 +21,9 @@
 
 namespace {
 
+// Two pool pops per CQ (prefetch, then dispatch) land on the same core.
+constexpr size_t num_fd_kernels_per_cq = 2;
+
 std::vector<tt::tt_metal::CoreCoord> get_quasar_tensix_fallback_dispatch_cores_from_yaml(
     tt::tt_metal::MetalEnvImpl& env,
     tt::ChipId device_id,
@@ -53,7 +56,7 @@ void expand_quasar_dispatch_engine_pool_for_fd_assignment(
     }
     const std::vector<tt::tt_metal::CoreCoord> available_des = std::move(logical_cores);
     logical_cores.clear();
-    logical_cores.reserve(static_cast<size_t>(num_hw_cqs) * 2);
+    logical_cores.reserve(static_cast<size_t>(num_hw_cqs) * num_fd_kernels_per_cq);
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; ++cq_id) {
         const size_t de_index = static_cast<size_t>(cq_id) % available_des.size();
         const auto& de = available_des[de_index];
@@ -121,6 +124,34 @@ std::vector<CoreCoord> get_quasar_soc_dispatch_engine_logical_cores(const metal_
         logical_cores.emplace_back(static_cast<uint32_t>(index), 0);
     }
     return logical_cores;
+}
+
+std::vector<CoreCoord> get_quasar_dispatch_core_per_cq(
+    tt::ARCH arch, const std::vector<CoreCoord>& dispatch_core_pool, uint8_t num_hw_cqs) {
+    if (arch != tt::ARCH::QUASAR || dispatch_core_pool.empty()) {
+        return {};
+    }
+    TT_FATAL(
+        dispatch_core_pool.size() == num_fd_kernels_per_cq * num_hw_cqs,
+        "Dispatch core pool holds {} cores, expected {} ({} FD kernels per CQ over {} CQs)",
+        dispatch_core_pool.size(),
+        num_fd_kernels_per_cq * num_hw_cqs,
+        num_fd_kernels_per_cq,
+        num_hw_cqs);
+
+    std::vector<CoreCoord> cq_dispatch_cores;
+    cq_dispatch_cores.reserve(num_hw_cqs);
+    for (uint8_t cq_id = 0; cq_id < num_hw_cqs; ++cq_id) {
+        const CoreCoord& prefetch_core = dispatch_core_pool[num_fd_kernels_per_cq * cq_id];
+        const CoreCoord& dispatch_core = dispatch_core_pool[num_fd_kernels_per_cq * cq_id + 1];
+        TT_FATAL(
+            prefetch_core == dispatch_core,
+            "Expected prefetch and dispatch cores to be the same, got prefetch core {} and dispatch core {}",
+            prefetch_core,
+            dispatch_core);
+        cq_dispatch_cores.push_back(dispatch_core);
+    }
+    return cq_dispatch_cores;
 }
 
 void validate_quasar_dispatch_cores_for_fd(

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -15,6 +15,7 @@
 #include "llrt/hal.hpp"
 #include "noc/noc_overlay_parameters.h"
 #include "noc/noc_parameters.h"
+#include "rtoptions.hpp"
 #include "tensix.h"
 #include "hal_2xx_common.hpp"
 #include "overlay/meta/registers/overlay_reg_defines_core.h"
@@ -337,6 +338,11 @@ public:
     std::vector<std::string> defines(const Params& params) const override {
         auto defines = HalJitBuildQueryBase::defines(params);
         defines.push_back("ARCH_QUASAR");
+        std::string qsr_noc_api_version = "NOC_API_V2";
+        if (params.rtoptions.get_simulator_enabled() && params.rtoptions.get_simulator_path().extension() == ".so") {
+            qsr_noc_api_version = "NOC_API_V" + std::to_string(params.rtoptions.get_simulator_quasar_noc_api_version());
+        }
+        defines.push_back(qsr_noc_api_version);
         return defines;
     }
 

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -338,11 +338,7 @@ public:
     std::vector<std::string> defines(const Params& params) const override {
         auto defines = HalJitBuildQueryBase::defines(params);
         defines.push_back("ARCH_QUASAR");
-        std::string qsr_noc_api_version = "NOC_API_V2";
-        if (params.rtoptions.get_simulator_enabled() && params.rtoptions.get_simulator_path().extension() == ".so") {
-            qsr_noc_api_version = "NOC_API_V" + std::to_string(params.rtoptions.get_simulator_quasar_noc_api_version());
-        }
-        defines.push_back(qsr_noc_api_version);
+        defines.push_back("NOC_API_V" + std::to_string(params.rtoptions.get_quasar_noc_api_version()));
         return defines;
     }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -118,7 +118,7 @@ enum class EnvVarID {
     TT_METAL_DISABLE_SFPLOADMACRO,                      // Disable use of SFPLOADMACRO instructions
     TT_METAL_DRAM_BACKED_CQ,                            // Store command queues in device DRAM
     TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,            // Simulator tensor preload bypasses FD CQ copies
-    TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION,          // Simulator Quasar NOC API version
+    TT_METAL_QUASAR_NOC_API_VERSION,                    // Quasar NOC API version
     TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES,  // Override Blackhole DRAM programmable cores
     TT_METAL_MEASURE_DFB_INIT_TIME,  // Temporary DFB init rdcycle instrumentation (deprecate once device profiler
                                      // covers this).
@@ -855,16 +855,16 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             this->simulator_direct_tensor_writes = is_env_enabled(value);
             break;
 
-        // TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION
-        // Set the NOC API version for the simulator.
+        // TT_METAL_QUASAR_NOC_API_VERSION
+        // Set the NOC API version for Quasar (simulator and silicon).
         // Default: 2 (use NOC API v2)
-        // Usage: export TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1
-        case EnvVarID::TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION:
-            this->simulator_quasar_noc_api_version = std::stoi(value);
+        // Usage: export TT_METAL_QUASAR_NOC_API_VERSION=1
+        case EnvVarID::TT_METAL_QUASAR_NOC_API_VERSION:
+            this->quasar_noc_api_version = std::stoi(value);
             TT_FATAL(
-                this->simulator_quasar_noc_api_version == 1 || this->simulator_quasar_noc_api_version == 2,
+                this->quasar_noc_api_version == 1 || this->quasar_noc_api_version == 2,
                 "Invalid NOC API version: {}",
-                this->simulator_quasar_noc_api_version);
+                this->quasar_noc_api_version);
             break;
 
         // TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -118,6 +118,7 @@ enum class EnvVarID {
     TT_METAL_DISABLE_SFPLOADMACRO,                      // Disable use of SFPLOADMACRO instructions
     TT_METAL_DRAM_BACKED_CQ,                            // Store command queues in device DRAM
     TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,            // Simulator tensor preload bypasses FD CQ copies
+    TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION,          // Simulator Quasar NOC API version
     TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES,  // Override Blackhole DRAM programmable cores
     TT_METAL_MEASURE_DFB_INIT_TIME,  // Temporary DFB init rdcycle instrumentation (deprecate once device profiler
                                      // covers this).
@@ -852,6 +853,18 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Usage: export TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1
         case EnvVarID::TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES:
             this->simulator_direct_tensor_writes = is_env_enabled(value);
+            break;
+
+        // TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION
+        // Set the NOC API version for the simulator.
+        // Default: 2 (use NOC API v2)
+        // Usage: export TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1
+        case EnvVarID::TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION:
+            this->simulator_quasar_noc_api_version = std::stoi(value);
+            TT_FATAL(
+                this->simulator_quasar_noc_api_version == 1 || this->simulator_quasar_noc_api_version == 2,
+                "Invalid NOC API version: {}",
+                this->simulator_quasar_noc_api_version);
             break;
 
         // TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -856,7 +856,7 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             break;
 
         // TT_METAL_QUASAR_NOC_API_VERSION
-        // Set the NOC API version for Quasar (simulator and silicon).
+        // Set the NOC API version for Quasar.
         // Default: 2 (use NOC API v2)
         // Usage: export TT_METAL_QUASAR_NOC_API_VERSION=1
         case EnvVarID::TT_METAL_QUASAR_NOC_API_VERSION:

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -389,8 +389,8 @@ class RunTimeOptions {
     // Bypass FD CQ payload copies for simulator tensor preloads (TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1)
     bool simulator_direct_tensor_writes = false;
 
-    // NOC API version for the Quasar simulator
-    uint32_t simulator_quasar_noc_api_version = 2;
+    // NOC API version for Quasar (simulator and silicon)
+    uint32_t quasar_noc_api_version = 2;
 
     // To be used for NUMA node based thread binding
     bool numa_based_affinity = false;
@@ -939,7 +939,7 @@ public:
 
     bool get_simulator_direct_tensor_writes() const { return simulator_direct_tensor_writes; }
 
-    uint32_t get_simulator_quasar_noc_api_version() const { return simulator_quasar_noc_api_version; }
+    uint32_t get_quasar_noc_api_version() const { return quasar_noc_api_version; }
 
     std::optional<uint32_t> get_fabric_router_sync_timeout_ms() const { return fabric_router_sync_timeout_ms; }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -389,6 +389,9 @@ class RunTimeOptions {
     // Bypass FD CQ payload copies for simulator tensor preloads (TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1)
     bool simulator_direct_tensor_writes = false;
 
+    // NOC API version for the Quasar simulator
+    uint32_t simulator_quasar_noc_api_version = 2;
+
     // To be used for NUMA node based thread binding
     bool numa_based_affinity = false;
 
@@ -935,6 +938,8 @@ public:
     void set_dram_backed_cq(bool enable) { dram_backed_cq = enable; }
 
     bool get_simulator_direct_tensor_writes() const { return simulator_direct_tensor_writes; }
+
+    uint32_t get_simulator_quasar_noc_api_version() const { return simulator_quasar_noc_api_version; }
 
     std::optional<uint32_t> get_fabric_router_sync_timeout_ms() const { return fabric_router_sync_timeout_ms; }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -389,7 +389,7 @@ class RunTimeOptions {
     // Bypass FD CQ payload copies for simulator tensor preloads (TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1)
     bool simulator_direct_tensor_writes = false;
 
-    // NOC API version for Quasar (simulator and silicon)
+    // NOC API version for Quasar
     uint32_t quasar_noc_api_version = 2;
 
     // To be used for NUMA node based thread binding

--- a/tt_metal/soc_descriptors/quasar_32_arch.yaml
+++ b/tt_metal/soc_descriptors/quasar_32_arch.yaml
@@ -1,6 +1,6 @@
 # grid is the full NOC coordinate-space extent and must contain every core's coords
 grid:
-  x_size: 10
+  x_size: 11
   y_size: 8
 
 arc:
@@ -46,6 +46,9 @@ harvested_workers:
 
 router_only:
   [0-2]
+
+dispatch:
+  [10-1, 10-6, 1-6]
 
 worker_l1_size:
   4194304

--- a/tt_metal/soc_descriptors/quasar_32_arch.yaml
+++ b/tt_metal/soc_descriptors/quasar_32_arch.yaml
@@ -1,9 +1,6 @@
-# No `dispatch:` list here on purpose. ttsim does not model the Quasar dispatch-engine tiles and
-# exits the whole process on the first access to one, so listing them breaks every ttsim leg.
-# Use quasar_32_arch_dispatch_engines.yaml on simulators that do model them (craq-sim).
 # grid is the full NOC coordinate-space extent and must contain every core's coords
 grid:
-  x_size: 10
+  x_size: 11
   y_size: 8
 
 arc:
@@ -49,6 +46,9 @@ harvested_workers:
 
 router_only:
   [0-2]
+
+dispatch:
+  [10-1, 10-6, 1-6]
 
 worker_l1_size:
   4194304

--- a/tt_metal/soc_descriptors/quasar_32_arch_dispatch_engines.yaml
+++ b/tt_metal/soc_descriptors/quasar_32_arch_dispatch_engines.yaml
@@ -1,9 +1,9 @@
-# No `dispatch:` list here on purpose. ttsim does not model the Quasar dispatch-engine tiles and
-# exits the whole process on the first access to one, so listing them breaks every ttsim leg.
-# Use quasar_32_arch_dispatch_engines.yaml on simulators that do model them (craq-sim).
+# quasar_32_arch.yaml plus the three dispatch-engine tiles. For simulators that model them
+# (craq-sim): copy this file to soc_descriptor.yaml next to the simulator. ttsim does not model
+# them and exits on first access, so ttsim keeps quasar_32_arch.yaml.
 # grid is the full NOC coordinate-space extent and must contain every core's coords
 grid:
-  x_size: 10
+  x_size: 11
   y_size: 8
 
 arc:
@@ -49,6 +49,9 @@ harvested_workers:
 
 router_only:
   [0-2]
+
+dispatch:
+  [10-1, 10-6, 1-6]
 
 worker_l1_size:
   4194304

--- a/tt_metal/soc_descriptors/quasar_32_arch_ttsim.yaml
+++ b/tt_metal/soc_descriptors/quasar_32_arch_ttsim.yaml
@@ -1,9 +1,9 @@
-# quasar_32_arch.yaml plus the three dispatch-engine tiles. For simulators that model them
-# (craq-sim): copy this file to soc_descriptor.yaml next to the simulator. ttsim does not model
-# them and exits on first access, so ttsim keeps quasar_32_arch.yaml.
+# quasar_32_arch.yaml without the three dispatch engines. ttsim does not model them and fails to run if it reads them.
+# Once ttsim models them, this file can be deleted and ttsim can use quasar_32_arch.yaml.
+
 # grid is the full NOC coordinate-space extent and must contain every core's coords
 grid:
-  x_size: 11
+  x_size: 10
   y_size: 8
 
 arc:
@@ -49,9 +49,6 @@ harvested_workers:
 
 router_only:
   [0-2]
-
-dispatch:
-  [10-1, 10-6, 1-6]
 
 worker_l1_size:
   4194304

--- a/tt_metal/tt-llk/tests/TTSIM.md
+++ b/tt_metal/tt-llk/tests/TTSIM.md
@@ -47,6 +47,9 @@ cd $TT_METAL_HOME/tt_metal/tt-llk/tests/python_tests
 pytest -v --run-simulator --timeout=600 test_eltwise_unary_datacopy.py
 ```
 
+Quasar ttsim only: ttsim does not implement NOC API v2, so also export
+`TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1` (ignored for wormhole/blackhole).
+
 `TT_METAL_SIMULATOR` is the canonical env var — the same one tt-metal
 runtime and the ttsim project docs use. `TT_UMD_SIMULATOR_PATH` is
 accepted as an alias for back-compat with the RTL-simulator flow; when
@@ -80,6 +83,9 @@ the most common format and no SFPU/tilize paths.
   `TT_METAL_SLOW_DISPATCH_MODE=1`.
 - **SFPLOADMACRO** is not implemented. Set
   `TT_METAL_DISABLE_SFPLOADMACRO=1` if your test hits the SFPU.
+- **NOC API v2 is not supported** (Quasar ttsim only). Set
+  `TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1` so Quasar kernels compile
+  against NOC API v1. Wormhole/Blackhole JIT does not use this define.
 - **Not all ISA is modeled.** Unimplemented opcodes surface as
   `UnimplementedFunctionality` errors from the simulator. See the
   [ttsim README](https://github.com/tenstorrent/ttsim) for the error

--- a/tt_metal/tt-llk/tests/TTSIM.md
+++ b/tt_metal/tt-llk/tests/TTSIM.md
@@ -48,7 +48,7 @@ pytest -v --run-simulator --timeout=600 test_eltwise_unary_datacopy.py
 ```
 
 Quasar ttsim only: ttsim does not implement NOC API v2, so also export
-`TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1` (ignored for wormhole/blackhole).
+`TT_METAL_QUASAR_NOC_API_VERSION=1` (ignored for wormhole/blackhole).
 
 `TT_METAL_SIMULATOR` is the canonical env var — the same one tt-metal
 runtime and the ttsim project docs use. `TT_UMD_SIMULATOR_PATH` is
@@ -84,7 +84,7 @@ the most common format and no SFPU/tilize paths.
 - **SFPLOADMACRO** is not implemented. Set
   `TT_METAL_DISABLE_SFPLOADMACRO=1` if your test hits the SFPU.
 - **NOC API v2 is not supported** (Quasar ttsim only). Set
-  `TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION=1` so Quasar kernels compile
+  `TT_METAL_QUASAR_NOC_API_VERSION=1` so Quasar kernels compile
   against NOC API v1. Wormhole/Blackhole JIT does not use this define.
 - **Not all ISA is modeled.** Unimplemented opcodes surface as
   `UnimplementedFunctionality` errors from the simulator. See the

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -242,6 +242,9 @@ fi
 # ttsim does not implement SFPLOADMACRO; default to disabling unless caller set it.
 export TT_METAL_DISABLE_SFPLOADMACRO="${TT_METAL_DISABLE_SFPLOADMACRO:-1}"
 
+# ttsim does not implement NOC API v2; default to using v1 unless caller set it.
+export TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION="${TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION:-1}"
+
 mkdir -p "$RESULTS_DIR"
 
 # ──────────────────────────────────────────────────────────────
@@ -356,6 +359,7 @@ echo " Marker expr    : ${MARKER_EXPR}"
 echo " Simulator      : ${TT_METAL_SIMULATOR}"
 echo " SoC descriptor : $(dirname "$TT_METAL_SIMULATOR")/soc_descriptor.yaml"
 echo " SFPLOADMACRO   : disabled=${TT_METAL_DISABLE_SFPLOADMACRO}"
+echo " NOC API version: ${TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION}"
 echo " Workers (-n)   : ${WORKERS}"
 echo " Per-test fork  : on"
 echo " Timeout        : ${TIMEOUT}s"

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -150,7 +150,7 @@ provision_ttsim() {
         quasar)
             architecture=quasar
             so_name=libttsim_qsr.so
-            soc_src="${REPO_ROOT}/tt_metal/soc_descriptors/quasar_32_arch.yaml"
+            soc_src="${REPO_ROOT}/tt_metal/soc_descriptors/quasar_32_arch_ttsim.yaml"
             hash_var=ttsim_qsr_so_hash
             ;;
         *)

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -243,7 +243,7 @@ fi
 export TT_METAL_DISABLE_SFPLOADMACRO="${TT_METAL_DISABLE_SFPLOADMACRO:-1}"
 
 # ttsim does not implement NOC API v2; default to using v1 unless caller set it.
-export TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION="${TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION:-1}"
+export TT_METAL_QUASAR_NOC_API_VERSION="${TT_METAL_QUASAR_NOC_API_VERSION:-1}"
 
 mkdir -p "$RESULTS_DIR"
 
@@ -359,7 +359,7 @@ echo " Marker expr    : ${MARKER_EXPR}"
 echo " Simulator      : ${TT_METAL_SIMULATOR}"
 echo " SoC descriptor : $(dirname "$TT_METAL_SIMULATOR")/soc_descriptor.yaml"
 echo " SFPLOADMACRO   : disabled=${TT_METAL_DISABLE_SFPLOADMACRO}"
-echo " NOC API version: ${TT_METAL_SIMULATOR_QUASAR_NOC_API_VERSION}"
+echo " NOC API version: ${TT_METAL_QUASAR_NOC_API_VERSION}"
 echo " Workers (-n)   : ${WORKERS}"
 echo " Per-test fork  : on"
 echo " Timeout        : ${TIMEOUT}s"


### PR DESCRIPTION
### PR Category
Feature

### Summary
This branch was initially merged into `main` but reverted because it caused `ttsim` tests to fail. The branch has been updated to fix two problems `ttsim` had with the original change:
 - A separate Quasar 8x4 SoC descriptor that leaves out the dispatch engines since `ttsim` doesn't currently model them.
 - A new env var that controls which NoC API version Quasar kernels use since `ttsim` only supports NoC API v1 whereas `craq-sim` and the RTL emulator support NoC API v2.

This branch adds support for running `tt-metal` on the Quasar 8x4 grid in `craq-sim`, through the following changes:
- The Quasar 8x4 SoC descriptor now lists its three dispatch engines, and its coordinate extent grows from 10 to 11 columns so the core at x=10 fits inside it.
- The CQ dispatch layout is now derived from the dispatch engines each CQ is actually assigned, instead of assuming every CQ shares a single engine.
- The prefetch ring buffer shrinks to 864 KB only when CQs genuinely share a dispatch engine, rather than whenever more than one CQ exists.
- Interleaved buffers now work with 28 memory banks: a specialized divide-by-28 was added for bank address generation, and 28 was added to the list of non-power-of-two bank counts the allocator accepts for interleaved buffers.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_craqsim_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_fd_craqsim_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_craqsim_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_fd_craqsim_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_fd_craqsim_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_fd_craqsim_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_craqsim_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_fd_craqsim_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_fd_craqsim_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_fd_craqsim_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_fd_craqsim_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_fd_craqsim_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_fd_craqsim_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_fd_craqsim_reland)