### PR TITLE
[Test Only] Qualify public TTSim pin changes

### DIFF
--- a/.github/workflows/ttsim-pin-qualification.yaml
+++ b/.github/workflows/ttsim-pin-qualification.yaml
@@ -1,0 +1,29 @@
+name: "PR - TTSim pin qualification"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - tt_metal/ttsim-version
+      - tests/pipeline_reorg/ttsim-skip-list.yaml
+      - .github/workflows/ttsim-pin-qualification.yaml
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  pages: write
+  id-token: write
+  packages: write
+  checks: write
+
+jobs:
+  qualify-public-ttsim-release:
+    uses: ./.github/workflows/sanity-tests.yaml
+    secrets: inherit
+    with:
+      build-inplace-wheel: true
+      run-wormhole: false
+      run-blackhole: false
+      run-sim: true
+      run-llk-sanity-tests: true


### PR DESCRIPTION
### Ticket

Closes #55388

### Problem description

Same-repository version-pin PRs can currently merge without running the simulator sanity matrix because the general PR sanity caller is restricted to fork PRs.

### What is being changed

Add a path-scoped PR workflow for the TTSim version pin, simulator skip list, and this workflow. It reuses the existing sanity workflow with hardware SKUs disabled, simulator SKUs enabled, and LLK sanity enabled.

This forces the existing public-release download and setup path to exercise Wormhole, Blackhole, and Quasar assets before a new TTSim pin merges.

### How has this been tested?

YAML syntax and git diff checks pass. This PR intentionally triggers the new qualification workflow, which is the end-to-end validation.

### Checklist

- [x] New test-only workflow is narrowly path-scoped
- [x] No new downloader, secret, or simulator source is introduced
- [x] Uses the existing fetch-ttsim and setup-ttsim actions
- [x] Enables LLK simulator sanity

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/ttsim-pin-qualification)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/ttsim-pin-qualification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/ttsim-pin-qualification)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/ttsim-pin-qualification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/ttsim-pin-qualification)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/ttsim-pin-qualification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/ttsim-pin-qualification)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/ttsim-pin-qualification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/ttsim-pin-qualification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/ttsim-pin-qualification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/ttsim-pin-qualification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/ttsim-pin-qualification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/ttsim-pin-qualification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/ttsim-pin-qualification)