### PR TITLE
[Test Only] Additional unit tests for moe_grouped_topk

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
@@ -27,6 +27,15 @@ def score_activation(logits: torch.Tensor, score_func: str) -> torch.Tensor:
     raise ValueError(f"Unsupported score_func '{score_func}'")
 
 
+def select_descending(scores, n, stable):
+    """Indices of the top ``n`` scores. ``stable`` breaks ties by lowest index, as torch documents
+    for ``sort(stable=True)`` and as ``moe_grouped_topk(stable_sort=True)`` promises; ``torch.topk``
+    itself is NOT stable, so the two cannot share one call."""
+    if stable:
+        return torch.argsort(scores, dim=-1, descending=True, stable=True)[..., :n]
+    return torch.topk(scores, n, dim=-1, sorted=True).indices
+
+
 def grouped_gate_golden_act(
     logits,
     bias,
@@ -37,28 +46,32 @@ def grouped_gate_golden_act(
     topk_groups,
     n_activated_experts,
     score_func="sigmoid",
+    stable=False,
 ):
     """Activation-parametrized port of MoEGate.grouped_gate_golden.
 
     Identical to the DeepSeek-V3 reference grouped gate (same top-k ordering convention as the
     moe_grouped_topk device op) except the router affinity activation is selectable. With
     ``n_groups == 1`` it collapses to a plain top-k, matching the single-group device path used by
-    Kimi and DeepSeek-V4. Returns ``(top_k_indices, scaled_weights)``.
+    Kimi and DeepSeek-V4. ``stable=True`` matches the device op's ``stable_sort=True`` contract:
+    equal keys are returned lowest-index first, in both the group and the expert selection.
+    Returns ``(top_k_indices, scaled_weights)``.
     """
     scores = score_activation(logits, score_func)
     biased_scores = scores + bias
 
     grouped_scores = biased_scores.reshape(scores.shape[:-1] + (n_groups, scores.shape[-1] // n_groups))
+    # Order-independent: only the sum of the top-p group members is used, never their order.
     top_p_experts_scores, _ = torch.topk(grouped_scores, summed_experts_per_group, dim=-1, sorted=True)
     summed_scores = top_p_experts_scores.sum(dim=-1, keepdim=False)
 
-    _, top_k_groups_indices = torch.topk(summed_scores, topk_groups, dim=-1, sorted=True)
+    top_k_groups_indices = select_descending(summed_scores, topk_groups, stable)
     group_mask = torch.ones(grouped_scores.shape[:-1], dtype=torch.bool, device=scores.device)
     group_mask.scatter_(-1, top_k_groups_indices, False)
     masked_grouped_scores = grouped_scores.masked_fill(group_mask.unsqueeze(-1), float("-inf"))
     masked_scores = masked_grouped_scores.reshape(scores.shape)
 
-    _, top_k_experts_indices = torch.topk(masked_scores, n_activated_experts, dim=-1, sorted=True)
+    top_k_experts_indices = select_descending(masked_scores, n_activated_experts, stable)
     chosen_scores = torch.gather(scores, dim=-1, index=top_k_experts_indices)
     normalized_scores = chosen_scores / (chosen_scores.sum(dim=-1, keepdim=True) + epsilon)
     scaled_scores = normalized_scores * route_scale
@@ -222,6 +235,64 @@ def assert_gate_output(
     )
     assert weights_passed, f"Weights PCC {weights_pcc:.4f} < {pcc_threshold}"
     return recall, weights_pcc
+
+
+def assert_index_domain(
+    tt_indices: torch.Tensor,
+    n_activated_experts: int,
+    total_experts: int,
+    num_real: int = 0,
+    apply_padding: bool = False,
+) -> None:
+    """Reference-free domain invariants for a gate's expert-index output.
+
+    Every real token must select ``n_activated_experts`` DISTINCT valid expert ids, and every
+    padded token must carry the out-of-range sentinel (== ``total_experts``). Unlike recall or
+    PCC this needs no golden reference, so it holds for any input.
+
+    Worth asserting separately from selection accuracy: a duplicate or out-of-range id does not
+    merely degrade the routed output, it makes the downstream dispatch address the wrong expert
+    (or nothing at all), which corrupts memory rather than the numerics.
+    """
+    idx = tt_indices.reshape(-1, n_activated_experts).long()
+
+    if apply_padding:
+        pad_rows = idx[num_real:]
+        assert torch.all(
+            pad_rows == total_experts
+        ), f"Padded rows must all be the sentinel {total_experts}; got {torch.unique(pad_rows).tolist()}"
+        idx = idx[:num_real]
+
+    out_of_range = ((idx < 0) | (idx >= total_experts)).any(dim=-1)
+    assert not out_of_range.any(), (
+        f"{int(out_of_range.sum())}/{out_of_range.numel()} tokens carry an expert id outside "
+        f"[0, {total_experts}); first at token {int(out_of_range.nonzero()[0])} -> "
+        f"{idx[out_of_range][0].tolist()}"
+    )
+
+    ordered = idx.sort(dim=-1).values
+    duplicated = (ordered[:, 1:] == ordered[:, :-1]).any(dim=-1)
+    assert not duplicated.any(), (
+        f"{int(duplicated.sum())}/{duplicated.numel()} tokens select the same expert twice; "
+        f"first at token {int(duplicated.nonzero()[0])} -> {idx[duplicated][0].tolist()}"
+    )
+
+
+def assert_indices_exact(tt_indices, ref_indices, n_activated_experts, context=""):
+    """Element-wise index parity, no tolerance. Unlike ``assert_gate_output``'s set recall this sees
+    ORDER, which is the whole content of the stable-sort contract."""
+    tt = tt_indices.reshape(-1, n_activated_experts).long()
+    ref = ref_indices.reshape(-1, n_activated_experts).long()
+    assert tt.shape == ref.shape, f"{context}shape {tuple(tt.shape)} != {tuple(ref.shape)}"
+
+    mismatched = (tt != ref).any(dim=-1)
+    if not mismatched.any():
+        return
+    first = int(mismatched.nonzero()[0])
+    raise AssertionError(
+        f"{context}{int(mismatched.sum())}/{mismatched.numel()} tokens differ; "
+        f"first at token {first}: got {tt[first].tolist()} want {ref[first].tolist()}"
+    )
 
 
 def trace_token_source(

--- a/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
@@ -248,9 +248,8 @@ def assert_index_domain(
     padded token must carry the out-of-range sentinel (== ``total_experts``). Unlike recall or
     PCC this needs no golden reference, so it holds for any input.
 
-    Worth asserting separately from selection accuracy: a duplicate or out-of-range id does not
-    merely degrade the routed output, it makes the downstream dispatch address the wrong expert
-    (or nothing at all), which corrupts memory rather than the numerics.
+    Worth asserting separately from selection accuracy: the wrong expert (or nothing at all)
+    may corrupt memory rather than the output numerics.
     """
     idx = tt_indices.reshape(-1, n_activated_experts).long()
 
@@ -278,7 +277,7 @@ def assert_index_domain(
 
 def assert_indices_exact(tt_indices, ref_indices, n_activated_experts, context=""):
     """Element-wise index parity, no tolerance. Unlike ``assert_gate_output``'s set recall this sees
-    ORDER, which is the whole content of the stable-sort contract."""
+    order, which is the whole content of the stable-sort contract."""
     tt = tt_indices.reshape(-1, n_activated_experts).long()
     ref = ref_indices.reshape(-1, n_activated_experts).long()
     assert tt.shape == ref.shape, f"{context}shape {tuple(tt.shape)} != {tuple(ref.shape)}"

--- a/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/validation_helpers.py
@@ -28,9 +28,7 @@ def score_activation(logits: torch.Tensor, score_func: str) -> torch.Tensor:
 
 
 def select_descending(scores, n, stable):
-    """Indices of the top ``n`` scores. ``stable`` breaks ties by lowest index, as torch documents
-    for ``sort(stable=True)`` and as ``moe_grouped_topk(stable_sort=True)`` promises; ``torch.topk``
-    itself is NOT stable, so the two cannot share one call."""
+    """Indices of the top ``n`` scores. ``stable`` breaks ties by lowest index``"""
     if stable:
         return torch.argsort(scores, dim=-1, descending=True, stable=True)[..., :n]
     return torch.topk(scores, n, dim=-1, sorted=True).indices

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
@@ -136,8 +136,7 @@ def test_moe_grouped_topk(
         topk_groups=topk_groups,
         n_activated_experts=n_activated_experts,
         route_scale=route_scale,
-        # Explicit: these inputs are deliberately tie-free (distinct_logits), so both settings agree
-        # and this matrix says nothing about tie order. That contract lives in the _ties suite.
+        # These inputs are tie-free (distinct_logits). Stable sort is validated in the _ties suite.
         stable_sort=False,
         epsilon=epsilon,
         score_func=score_func,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
@@ -136,6 +136,9 @@ def test_moe_grouped_topk(
         topk_groups=topk_groups,
         n_activated_experts=n_activated_experts,
         route_scale=route_scale,
+        # Explicit: these inputs are deliberately tie-free (distinct_logits), so both settings agree
+        # and this matrix says nothing about tie order. That contract lives in the _ties suite.
+        stable_sort=False,
         epsilon=epsilon,
         score_func=score_func,
         padding_config=padding_config,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_state.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_state.py
@@ -2,20 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Production-fidelity coverage for moe_grouped_topk in Kimi-K2.6's configuration.
+"""Fidelity coverage for moe_grouped_topk
 
-Every existing test runs one call on a device that has done nothing else. Production runs the op
-59 times per forward, thousands of times per chunk, on Tensix cores whose destination registers,
-SFPU configuration and constant registers hold whatever the previous operation left. uint16 indices
-travel through 32-bit DEST with an undefined high half, and nothing clears DEST between programs.
+In production, Tensix cores' destination registers, SFPU configuration and constant registers hold
+whatever the previous operation left. uint16 indices travel through 32-bit DEST with an undefined
+high half, and nothing clears DEST between programs.
 
 These tests recreate that: many distinct calls back to back, DEST deliberately polluted with
 adversarial bit patterns immediately before the gate, padding boundaries inside a tile and inside
-a face, the production token count, more height tiles than cores, a top-k straddling zero, and
-trace capture with replay. Inputs are the realistic distribution the broad matrix uses, and every
-assertion is exact element-wise index order on rows the hardware can order unambiguously -- rows
-whose top k+1 keys are separated by more than the datapath's ~8e-4 relative resolution. None of
-this depends on stable tie order, so a failure here is a new defect, not #33492.
+a face, more height tiles than cores, a top-k straddling zero, and trace capture with replay.
 """
 
 import pytest
@@ -39,10 +34,8 @@ SCORE_FUNC = "sigmoid"
 INPUT_DTYPE = ttnn.bfloat16
 
 # Relative key gap below which the sort datapath cannot separate two keys (measured ~8e-4 on
-# Blackhole by test_moe_grouped_topk_stable.py). Rows are only asserted where every gap among the
-# top k+1 exceeds this, so order is unambiguous and a mismatch is a defect rather than a rounding.
+# Blackhole).
 SORT_RESOLUTION = 2e-3
-# A test whose strict rows fall below this fraction is asserting too little to mean anything.
 MIN_STRICT_FRACTION = 0.5
 
 ENGINES = pytest.mark.parametrize("stable_sort", [True, False], ids=["stable", "unstable"])

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_state.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_state.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Production-fidelity coverage for moe_grouped_topk in Kimi-K2.6's configuration.
+
+Every existing test runs one call on a device that has done nothing else. Production runs the op
+59 times per forward, thousands of times per chunk, on Tensix cores whose destination registers,
+SFPU configuration and constant registers hold whatever the previous operation left. uint16 indices
+travel through 32-bit DEST with an undefined high half, and nothing clears DEST between programs.
+
+These tests recreate that: many distinct calls back to back, DEST deliberately polluted with
+adversarial bit patterns immediately before the gate, padding boundaries inside a tile and inside
+a face, the production token count, more height tiles than cores, a top-k straddling zero, and
+trace capture with replay. Inputs are the realistic distribution the broad matrix uses, and every
+assertion is exact element-wise index order on rows the hardware can order unambiguously -- rows
+whose top k+1 keys are separated by more than the datapath's ~8e-4 relative resolution. None of
+this depends on stable tie order, so a failure here is a new defect, not #33492.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
+    assert_index_domain,
+    assert_indices_exact,
+    build_padding_config,
+    distinct_logits,
+    grouped_gate_golden_act,
+)
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
+
+EPSILON = 1e-20
+KIMI = (1, 384, 1, 1, 8, 2.827)
+TOTAL_EXPERTS, K = KIMI[1], KIMI[4]
+SCORE_FUNC = "sigmoid"
+INPUT_DTYPE = ttnn.bfloat16
+
+# Relative key gap below which the sort datapath cannot separate two keys (measured ~8e-4 on
+# Blackhole by test_moe_grouped_topk_stable.py). Rows are only asserted where every gap among the
+# top k+1 exceeds this, so order is unambiguous and a mismatch is a defect rather than a rounding.
+SORT_RESOLUTION = 2e-3
+# A test whose strict rows fall below this fraction is asserting too little to mean anything.
+MIN_STRICT_FRACTION = 0.5
+
+ENGINES = pytest.mark.parametrize("stable_sort", [True, False], ids=["stable", "unstable"])
+
+
+def realistic_inputs(tokens, seed):
+    """The broad matrix's distribution, bf16-quantised: distinct logits plus a normal bias."""
+    torch.manual_seed(seed)
+    logits = distinct_logits((1, 1, tokens, TOTAL_EXPERTS), dtype=torch.bfloat16).float()
+    bias = torch.randn(1, 1, tokens, TOTAL_EXPERTS).to(torch.bfloat16).float()
+    return logits, bias
+
+
+def golden(logits, bias, stable_sort):
+    n_groups, _, summed, topk_groups, k, route_scale = KIMI
+    indices, _ = grouped_gate_golden_act(
+        logits, bias, route_scale, EPSILON, n_groups, summed, topk_groups, k, SCORE_FUNC, stable=stable_sort
+    )
+    return indices
+
+
+def strict_rows(biased):
+    """Rows whose top k+1 keys are pairwise separated beyond SORT_RESOLUTION, from the device's own
+    biased scores so the predicate describes what the hardware actually compared."""
+    s = biased.reshape(-1, TOTAL_EXPERTS).sort(dim=-1, descending=True).values[:, : K + 1]
+    gaps = s[:, :-1] - s[:, 1:]
+    scale = torch.maximum(s[:, :-1].abs(), s[:, 1:].abs()).clamp_min(1e-6)
+    return (gaps / scale > SORT_RESOLUTION).all(dim=-1)
+
+
+def assert_exact_where_strict(indices, ref, biased, context=""):
+    mask = strict_rows(biased)
+    frac = mask.float().mean().item()
+    logger.info(f"{context}strict rows: {int(mask.sum())}/{mask.numel()} ({frac:.1%})")
+    assert frac >= MIN_STRICT_FRACTION, f"{context}only {frac:.1%} of rows are strict; test would be vacuous"
+    assert_indices_exact(indices.reshape(-1, K)[mask], ref.reshape(-1, K)[mask], K, context=context)
+
+
+def to_device(t, dtype=INPUT_DTYPE, device=None):
+    return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+
+def run_gate(device, dev_logits, dev_bias, stable_sort, num_real=None, tokens=None):
+    """One call on already-uploaded inputs. Returns (indices, biased) trimmed to shape."""
+    n_groups, total_experts, summed, topk_groups, k, route_scale = KIMI
+    tokens = tokens or dev_logits.shape[-2]
+    dev_biased = to_device(torch.zeros(1, 1, tokens, total_experts), ttnn.float32, device)
+    padding_config = build_padding_config(device, num_real) if num_real is not None else None
+
+    _, indices = ttnn.experimental.deepseek_prefill.moe_grouped_topk(
+        dev_logits,
+        dev_bias,
+        n_groups=n_groups,
+        summed_experts_per_group=summed,
+        topk_groups=topk_groups,
+        n_activated_experts=k,
+        route_scale=route_scale,
+        stable_sort=stable_sort,
+        epsilon=EPSILON,
+        score_func=SCORE_FUNC,
+        padding_config=padding_config,
+        biased_scores=dev_biased,
+    )
+    return (
+        ttnn.to_torch(indices)[:1, :1, :tokens, :k],
+        ttnn.to_torch(dev_biased)[:1, :1, :tokens, :total_experts].float(),
+    )
+
+
+def gate_from_host(device, logits, bias, stable_sort, num_real=None):
+    return run_gate(device, to_device(logits, device=device), to_device(bias, device=device), stable_sort, num_real)
+
+
+# --------------------------------------------------------------------------------------------
+
+
+@ENGINES
+def test_sequential_distinct_inputs(device, stable_sort):
+    """Production cadence: many calls, each with new data, program cache warm, each exact."""
+    calls = 24
+    for seed in range(calls):
+        logits, bias = realistic_inputs(32, seed)
+        indices, biased = gate_from_host(device, logits, bias, stable_sort)
+        assert_exact_where_strict(indices, golden(logits, bias, stable_sort), biased, context=f"[call {seed}] ")
+
+
+# uint32 bit patterns whose HIGH half is the adversarial part: if any path reads the high half of a
+# uint16 index word in 32-bit DEST, these are the values it would see.
+POLLUTION = {
+    "all_ones": 0xFFFFFFFF,
+    "high_ones": 0xFFFF0000,
+    "neg_zero": 0x80000000,
+    "neg_one": 0xBF800000,
+    "pos_inf": 0x7F800000,
+    "low_ones": 0x0000FFFF,
+}
+
+
+def pollute_dest(device, pattern):
+    """Write `pattern` through the FPU on every core so DEST holds it when the gate starts.
+    Two tiles per core across the 11x10 grid; nothing runs between this and the gate."""
+    grid = device.compute_with_storage_grid_size()
+    tiles = 2 * grid.x * grid.y
+    signed = pattern - (1 << 32) if pattern >= (1 << 31) else pattern  # torch.int32 wants two's complement
+    raw = torch.full((1, 1, 32 * tiles, 32), signed, dtype=torch.int32).view(torch.float32)
+    t = to_device(raw, ttnn.float32, device)
+    out = ttnn.multiply(t, 1.0)
+    ttnn.synchronize_device(device)
+    ttnn.deallocate(out)
+    ttnn.deallocate(t)
+
+
+@ENGINES
+@pytest.mark.parametrize("pattern", list(POLLUTION), ids=list(POLLUTION))
+def test_dest_pollution_before_gate(device, stable_sort, pattern):
+    """Adversarial DEST residue immediately before the gate must not reach the indices.
+    Uses the production token count so 20 cores run the gate, all of them polluted."""
+    tokens = PREFILL_CHUNK_TOKENS_PER_CHIP
+    logits, bias = realistic_inputs(tokens, seed=7)
+    dev_logits, dev_bias = to_device(logits, device=device), to_device(bias, device=device)
+
+    pollute_dest(device, POLLUTION[pattern])
+    indices, biased = run_gate(device, dev_logits, dev_bias, stable_sort)
+
+    assert_index_domain(indices, K, TOTAL_EXPERTS)
+    assert_exact_where_strict(indices, golden(logits, bias, stable_sort), biased, context=f"[{pattern}] ")
+
+
+# Face boundary at row 16 and tile boundary at row 32: the writer patches sentinels with per-face
+# offset arithmetic, so a boundary that lands inside a tile or inside a face is where an off-by-one
+# would show. Existing padding coverage only ever uses tile-aligned boundaries.
+PADDING_BOUNDARIES = [1, 15, 16, 17, 31, 32, 33, 47, 48, 63]
+
+
+@pytest.mark.parametrize("num_real", PADDING_BOUNDARIES)
+def test_padding_boundary_inside_tile(device, num_real):
+    tokens = 64
+    logits, bias = realistic_inputs(tokens, seed=11)
+    indices, biased = gate_from_host(device, logits, bias, stable_sort=True, num_real=num_real)
+
+    assert_index_domain(indices, K, TOTAL_EXPERTS, num_real=num_real, apply_padding=True)
+    real = slice(0, num_real)
+    assert_exact_where_strict(
+        indices[:, :, real],
+        golden(logits, bias, True)[:, :, real],
+        biased[:, :, real],
+        context=f"[num_real={num_real}] ",
+    )
+
+
+@ENGINES
+def test_production_token_count(device, stable_sort):
+    """One chip's share of one prefill chunk: 640 tokens, 20 height tiles, one per core."""
+    tokens = PREFILL_CHUNK_TOKENS_PER_CHIP
+    logits, bias = realistic_inputs(tokens, seed=3)
+    indices, biased = gate_from_host(device, logits, bias, stable_sort)
+    assert_index_domain(indices, K, TOTAL_EXPERTS)
+    assert_exact_where_strict(indices, golden(logits, bias, stable_sort), biased, context="[640] ")
+
+
+def test_more_tiles_than_cores(device):
+    """128 height tiles on a 110-core grid forces the per-core loop to run twice on some cores,
+    reusing DEST across tiles inside one kernel. Not the production shape, but a live code path."""
+    grid = device.compute_with_storage_grid_size()
+    tokens = 32 * (grid.x * grid.y + 18)
+    logits, bias = realistic_inputs(tokens, seed=5)
+    indices, biased = gate_from_host(device, logits, bias, stable_sort=True)
+    assert_index_domain(indices, K, TOTAL_EXPERTS)
+    assert_exact_where_strict(indices, golden(logits, bias, True), biased, context=f"[{tokens} tok] ")
+
+
+def test_mixed_sign_topk(device):
+    """A top-k straddling zero. The SFPU compare-exchange orders in sign-magnitude space, so a
+    descending sort across the sign boundary is where a sign-handling defect would show."""
+    tokens = 128
+    logits, bias = realistic_inputs(tokens, seed=13)
+    # Centre each row's top-k on zero: shift by that row's k/2-th largest biased score, then
+    # re-quantise so the golden sees exactly the bf16 bias the device receives.
+    host_biased = torch.sigmoid(logits) + bias
+    shift = host_biased.topk(K, dim=-1).values[..., K // 2 - 1 : K // 2]
+    bias = (bias - shift).to(torch.bfloat16).float()
+    indices, biased = gate_from_host(device, logits, bias, stable_sort=True)
+
+    top = biased.reshape(-1, TOTAL_EXPERTS).topk(K, dim=-1).values
+    straddling = ((top < 0).any(dim=-1) & (top > 0).any(dim=-1)).float().mean().item()
+    logger.info(f"[mixed_sign] rows whose top-{K} straddles zero: {straddling:.1%}")
+    assert straddling >= 0.3, f"only {straddling:.1%} of rows straddle zero; input needs re-centring"
+
+    assert_index_domain(indices, K, TOTAL_EXPERTS)
+    assert_exact_where_strict(indices, golden(logits, bias, True), biased, context="[mixed_sign] ")
+
+
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 32 * 1024 * 1024}], indirect=True)
+def test_trace_replay(device):
+    """The traced prefill legs capture the gate once and replay it per chunk with new inputs
+    copied into persistent tensors. Replay must be exact on every input, not just the captured one."""
+    tokens = PREFILL_CHUNK_TOKENS_PER_CHIP
+    n_groups, total_experts, summed, topk_groups, k, route_scale = KIMI
+
+    logits0, bias0 = realistic_inputs(tokens, seed=100)
+    dev_logits, dev_bias = to_device(logits0, device=device), to_device(bias0, device=device)
+    dev_biased = to_device(torch.zeros(1, 1, tokens, total_experts), ttnn.float32, device)
+
+    def call():
+        return ttnn.experimental.deepseek_prefill.moe_grouped_topk(
+            dev_logits,
+            dev_bias,
+            n_groups=n_groups,
+            summed_experts_per_group=summed,
+            topk_groups=topk_groups,
+            n_activated_experts=k,
+            route_scale=route_scale,
+            stable_sort=True,
+            epsilon=EPSILON,
+            score_func=SCORE_FUNC,
+            padding_config=None,
+            biased_scores=dev_biased,
+        )
+
+    call()  # compile
+    ttnn.synchronize_device(device)
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    _, dev_indices = call()
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+    ttnn.synchronize_device(device)
+
+    try:
+        for seed in range(101, 109):
+            logits, bias = realistic_inputs(tokens, seed)
+            ttnn.copy_host_to_device_tensor(
+                ttnn.from_torch(logits, dtype=INPUT_DTYPE, layout=ttnn.TILE_LAYOUT), dev_logits
+            )
+            ttnn.copy_host_to_device_tensor(ttnn.from_torch(bias, dtype=INPUT_DTYPE, layout=ttnn.TILE_LAYOUT), dev_bias)
+            ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+
+            indices = ttnn.to_torch(dev_indices)[:1, :1, :tokens, :k]
+            biased = ttnn.to_torch(dev_biased)[:1, :1, :tokens, :total_experts].float()
+            assert_index_domain(indices, K, TOTAL_EXPERTS)
+            assert_exact_where_strict(indices, golden(logits, bias, True), biased, context=f"[replay {seed}] ")
+    finally:
+        ttnn.release_trace(device, tid)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_ties.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_ties.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tie-ORDER coverage for moe_grouped_topk's single-group path, in Kimi-K2.6's configuration.
+
+The sibling suites check which experts are selected: ``test_moe_grouped_topk.py`` by set recall
+over deliberately distinct inputs, ``test_moe_grouped_topk_stable.py`` by set equality with a
+resolution tolerance. Neither sees ORDER, and order is the entire content of the stable-sort
+contract -- so a tie broken the wrong way is invisible to both.
+
+Every input here plants EXACT ties: experts sharing a tie class are given the same logit and the
+same bias, so their biased scores are bitwise equal whatever the input dtype and whatever the
+datapath's comparison resolution. That sidesteps the ~8e-4 relative resolution the sibling file
+measured: equal is equal at any resolution. Each test asserts the returned indices element-wise
+against a stable-argsort golden, with no tolerance.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
+    assert_index_domain,
+    assert_indices_exact,
+    build_padding_config,
+    grouped_gate_golden_act,
+    score_activation,
+)
+
+EPSILON = 1e-20
+
+# (n_groups, total_experts, summed_experts_per_group, topk_groups, n_activated_experts, route_scale)
+KIMI = (1, 384, 1, 1, 8, 2.827)
+SCORE_FUNC = "sigmoid"  # Kimi's router affinity
+
+# bf16 only: production feeds bf16 and the op upcasts internally, and the fp32 rows of this
+# directory are pruned on Blackhole in CI, so an fp32-only case would silently not run there.
+INPUT_DTYPE = ttnn.bfloat16
+
+TOKENS = 32  # one tile of rows; every row can carry a different tie layout
+
+# Per-class logit and bias both DECREASE with the class id, so the biased score is monotonic in it
+# and no bias progression can invert the intended order. Every value below has at most 3 mantissa
+# bits, so it survives the bf16 round-trip exactly and a shared class keeps a bitwise-equal score.
+LEVEL_LOGIT_BASE, LEVEL_LOGIT_STEP = 2.0, 0.75
+LEVEL_BIAS_STEP = 0.25
+
+# Smallest gap the construction must leave between adjacent classes, in biased-score units. The
+# realised gap is ~0.28; the datapath's effective comparison resolution is ~8e-4 relative, so this
+# leaves two orders of magnitude of headroom and only exact ties are ties.
+MIN_CLASS_GAP = 0.05
+
+
+def levels_to_inputs(levels, num_levels):
+    """Map a per-expert tie-class id to (logits, bias). Same class -> identical logit AND identical
+    bias -> bitwise-equal biased score. Class 0 is the highest-scoring."""
+    logit_of = torch.tensor([LEVEL_LOGIT_BASE - j * LEVEL_LOGIT_STEP for j in range(num_levels)], dtype=torch.float32)
+    bias_of = torch.tensor([-j * LEVEL_BIAS_STEP for j in range(num_levels)], dtype=torch.float32)
+
+    lv = torch.as_tensor(levels, dtype=torch.long)
+    logits = logit_of[lv].reshape(1, 1, *lv.shape)
+    bias = bias_of[lv].reshape(1, 1, *lv.shape)
+    return logits, bias
+
+
+def assert_ties_landed(biased, levels, context=""):
+    """Precondition on the device's OWN biased scores: bitwise equal within a class, and separated
+    by MIN_CLASS_GAP between classes. Without it a tie test can pass or fail for the wrong reason."""
+    lv = torch.as_tensor(levels, dtype=torch.long)
+    for row in range(biased.shape[-2]):
+        row_biased = biased[0, 0, row]
+        row_levels = lv[row] if lv.dim() == 2 else lv
+        class_value = {}
+        for j in row_levels.unique().tolist():
+            members = row_biased[row_levels == j]
+            assert torch.equal(
+                members, members[:1].expand_as(members)
+            ), f"{context}row {row} class {j} not bitwise tied on device: {members.unique().tolist()[:4]}"
+            class_value[j] = members[0].item()
+
+        ordered = [class_value[j] for j in sorted(class_value)]
+        gaps = [a - b for a, b in zip(ordered, ordered[1:])]
+        assert all(
+            g >= MIN_CLASS_GAP for g in gaps
+        ), f"{context}row {row} classes not separated / not descending: values {ordered} gaps {gaps}"
+
+
+def run_gate(device, logits, bias, stable_sort, num_real=None):
+    """One moe_grouped_topk call. Returns (weights, indices, biased_scores) trimmed to shape."""
+    n_groups, total_experts, summed, topk_groups, k, route_scale = KIMI
+    seq_len = logits.shape[-2]
+
+    dev_logits = ttnn.from_torch(logits, dtype=INPUT_DTYPE, layout=ttnn.TILE_LAYOUT, device=device)
+    dev_bias = ttnn.from_torch(bias, dtype=INPUT_DTYPE, layout=ttnn.TILE_LAYOUT, device=device)
+    dev_biased = ttnn.from_torch(torch.zeros_like(logits), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    padding_config = build_padding_config(device, num_real) if num_real is not None else None
+
+    weights, indices = ttnn.experimental.deepseek_prefill.moe_grouped_topk(
+        dev_logits,
+        dev_bias,
+        n_groups=n_groups,
+        summed_experts_per_group=summed,
+        topk_groups=topk_groups,
+        n_activated_experts=k,
+        route_scale=route_scale,
+        stable_sort=stable_sort,
+        epsilon=EPSILON,
+        score_func=SCORE_FUNC,
+        padding_config=padding_config,
+        biased_scores=dev_biased,
+    )
+    return (
+        ttnn.to_torch(weights)[:1, :1, :seq_len, :k],
+        ttnn.to_torch(indices)[:1, :1, :seq_len, :k],
+        ttnn.to_torch(dev_biased)[:1, :1, :seq_len, :total_experts].float(),
+    )
+
+
+def stable_golden(logits, bias):
+    """Reference indices under the stable contract, from the same bf16-quantised values the device
+    sees (ttnn.from_torch(bf16) rounds, so the golden must round first or the two can disagree)."""
+    q_logits = logits.to(torch.bfloat16).float()
+    q_bias = bias.to(torch.bfloat16).float()
+    n_groups, _, summed, topk_groups, k, route_scale = KIMI
+    indices, _ = grouped_gate_golden_act(
+        q_logits, q_bias, route_scale, EPSILON, n_groups, summed, topk_groups, k, SCORE_FUNC, stable=True
+    )
+    return indices
+
+
+# --------------------------------------------------------------------------------------------
+# Tie patterns. Each returns a per-expert tie-class id array of shape [TOKENS, total_experts].
+# --------------------------------------------------------------------------------------------
+
+TOTAL_EXPERTS = KIMI[1]
+K = KIMI[4]
+
+
+def pattern_all_equal():
+    """Every expert in one tie class. Stable must return 0..k-1 in order."""
+    return torch.zeros(TOKENS, TOTAL_EXPERTS, dtype=torch.long), 1
+
+
+def pattern_boundary_tie():
+    """Six strictly ordered winners, then a tie class straddling the k cut, then the rest.
+
+    Slots 0-5 are forced; slots 6 and 7 must be the two LOWEST-INDEXED members of the tied class,
+    which is the decision that actually changes routing in production.
+    """
+    levels = torch.full((TOKENS, TOTAL_EXPERTS), 7, dtype=torch.long)  # class 7 = the floor
+    for row in range(TOKENS):
+        g = torch.Generator().manual_seed(1000 + row)
+        perm = torch.randperm(TOTAL_EXPERTS, generator=g)
+        levels[row, perm[:6]] = torch.arange(6)  # six singleton winners, classes 0..5
+        levels[row, perm[6:16]] = 6  # ten-member tie class at the boundary
+    return levels, 8
+
+
+def pattern_chain_spanning():
+    """One tie class of 12, deliberately spread across the first and last of the 12 width tiles.
+
+    The insertion chain merges 11 times; a bitonic network is not stable even when every comparator
+    preserves order on equal keys, and that only shows when tied elements meet across non-adjacent
+    positions after several merges. k=8 of the 12 must come back in ascending index order.
+    """
+    members = [0, 3, 31, 32, 160, 200, 351, 352, 370, 380, 382, 383]
+    levels = torch.ones(TOKENS, TOTAL_EXPERTS, dtype=torch.long)  # class 1 = the floor
+    levels[:, members] = 0
+    return levels, 2
+
+
+PATTERNS = {
+    "all_equal": pattern_all_equal,
+    "boundary_tie": pattern_boundary_tie,
+    "chain_spanning": pattern_chain_spanning,
+}
+
+
+def build(pattern_name):
+    levels, num_levels = PATTERNS[pattern_name]()
+    logits, bias = levels_to_inputs(levels, num_levels)
+    return levels, logits, bias
+
+
+# --------------------------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------------------------
+
+
+# The LLK's stable arm orders a tie class correctly only while its members stay within reach of one
+# comparator. Once the insertion chain has to carry them across merges, the last slots come back
+# holding the HIGHEST-indexed members instead of the lowest. Tracked as tenstorrent/tt-metal#33492.
+BROKEN_ON_MAIN = pytest.mark.xfail(reason="stable tie order across the merge chain, #33492", strict=True)
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "all_equal",
+        pytest.param("boundary_tie", marks=BROKEN_ON_MAIN),
+        pytest.param("chain_spanning", marks=BROKEN_ON_MAIN),
+    ],
+)
+def test_tie_order_matches_stable_golden(device, pattern):
+    """Exact index parity against a stable-argsort golden, on exact ties."""
+    levels, logits, bias = build(pattern)
+    _, indices, biased = run_gate(device, logits, bias, stable_sort=True)
+
+    assert_ties_landed(biased, levels, context=f"[{pattern}] ")
+    assert_index_domain(indices, K, TOTAL_EXPERTS)
+    assert_indices_exact(indices, stable_golden(logits, bias), K, context=f"[{pattern}] ")
+
+
+def test_all_equal_row_is_identity(device):
+    """The strongest single assertion: an all-equal row must return exactly 0..k-1."""
+    levels, logits, bias = build("all_equal")
+    _, indices, biased = run_gate(device, logits, bias, stable_sort=True)
+
+    assert_ties_landed(biased, levels, context="[all_equal] ")
+    expected = torch.arange(K).expand(1, 1, TOKENS, K)
+    assert_indices_exact(indices, expected, K, context="[all_equal] ")
+
+
+def test_stable_and_unstable_differ_on_ties(device):
+    """The flag must change something on an exact tie. Without this every other assertion here
+    would still pass if stable_sort were wired to nothing."""
+    levels, logits, bias = build("chain_spanning")
+    _, stable_idx, biased = run_gate(device, logits, bias, stable_sort=True)
+    _, unstable_idx, _ = run_gate(device, logits, bias, stable_sort=False)
+
+    assert_ties_landed(biased, levels, context="[chain_spanning] ")
+    differing = int((stable_idx != unstable_idx).any(dim=-1).sum())
+    logger.info(f"[chain_spanning] stable vs unstable differ on {differing}/{TOKENS} tokens")
+    assert differing > 0, "stable_sort=True and False returned identical indices on an exact tie"
+
+
+def test_tie_order_is_deterministic(device):
+    """Repeat the boundary tie; the tie-break must be a function of the input, not of the run."""
+    _, logits, bias = build("boundary_tie")
+    _, first, _ = run_gate(device, logits, bias, stable_sort=True)
+    for i in range(1, 4):
+        _, again, _ = run_gate(device, logits, bias, stable_sort=True)
+        assert torch.equal(first, again), f"run {i} differs from run 0"
+
+
+@BROKEN_ON_MAIN
+def test_tie_order_under_padding(device):
+    """Ties plus right-padding: padded rows go to the sentinel, real rows keep stable order."""
+    num_real = TOKENS // 2
+    levels, logits, bias = build("boundary_tie")
+    _, indices, biased = run_gate(device, logits, bias, stable_sort=True, num_real=num_real)
+
+    assert_ties_landed(biased, levels, context="[padded] ")
+    assert_index_domain(indices, K, TOTAL_EXPERTS, num_real=num_real, apply_padding=True)
+    golden = stable_golden(logits, bias)[:, :, :num_real]
+    assert_indices_exact(indices[:, :, :num_real], golden, K, context="[padded] ")
+
+
+def negative_zeros(t):
+    return ((t == 0) & torch.signbit(t)).sum().item()
+
+
+def test_negative_zero_is_unreachable():
+    """The -0.0 canonicalisation sweep compiles in only under stable + fp32 dest, i.e. exactly this
+    op's configuration. Both score functions are non-negative and IEEE gives x + (-x) = +0.0, so no
+    input can put -0.0 into the biased scores. If this ever fails the sweep is live and needs a
+    device test."""
+    logits = torch.tensor([-1e30, -80.0, -1.0, 0.0, 1.0, 80.0, 1e30], dtype=torch.float32)
+    for func in ("sigmoid", "sqrtsoftplus"):
+        scores = score_activation(logits, func)
+        assert negative_zeros(scores) == 0, f"{func} emitted -0.0"
+
+        for name, bias in (
+            ("exact_cancel", -scores),
+            ("neg_zero_bias", torch.full_like(scores, -0.0)),
+            ("tiny_neg", torch.full_like(scores, -1e-45) - scores),
+            ("large_neg", torch.full_like(scores, -1.0)),
+        ):
+            biased = scores + bias
+            assert negative_zeros(biased) == 0, f"{func}/{name} produced -0.0 in the biased scores"

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_ties.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk_ties.py
@@ -2,18 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tie-ORDER coverage for moe_grouped_topk's single-group path, in Kimi-K2.6's configuration.
-
-The sibling suites check which experts are selected: ``test_moe_grouped_topk.py`` by set recall
-over deliberately distinct inputs, ``test_moe_grouped_topk_stable.py`` by set equality with a
-resolution tolerance. Neither sees ORDER, and order is the entire content of the stable-sort
-contract -- so a tie broken the wrong way is invisible to both.
+"""Tie-ORDER coverage for moe_grouped_topk's single-group path.
 
 Every input here plants EXACT ties: experts sharing a tie class are given the same logit and the
-same bias, so their biased scores are bitwise equal whatever the input dtype and whatever the
-datapath's comparison resolution. That sidesteps the ~8e-4 relative resolution the sibling file
-measured: equal is equal at any resolution. Each test asserts the returned indices element-wise
-against a stable-argsort golden, with no tolerance.
+same bias, so their biased scores are bitwise equal. Each test asserts the returned indices
+element-wise against a stable-argsort golden, with no tolerance.
 """
 
 import pytest
@@ -187,14 +180,6 @@ def build(pattern_name):
 # --------------------------------------------------------------------------------------------
 # Tests
 # --------------------------------------------------------------------------------------------
-
-
-# The LLK's stable arm orders a tie class correctly only while its members stay within reach of one
-# comparator. Once the insertion chain has to carry them across merges, the last slots come back
-# holding the HIGHEST-indexed members instead of the lowest. Tracked as tenstorrent/tt-metal#33492.
-BROKEN_ON_MAIN = pytest.mark.xfail(reason="stable tie order across the merge chain, #33492", strict=True)
-
-
 @pytest.mark.parametrize(
     "pattern",
     [
@@ -245,7 +230,7 @@ def test_tie_order_is_deterministic(device):
         assert torch.equal(first, again), f"run {i} differs from run 0"
 
 
-@BROKEN_ON_MAIN
+@pytest.mark.xfail(reason="stable tie order across the merge chain, #33492", strict=True)
 def test_tie_order_under_padding(device):
     """Ties plus right-padding: padded rows go to the sentinel, real rows keep stable order."""
     num_real = TOKENS // 2


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Relates to #33492 and its tracker #27223.

Problem statement:
`moe_grouped_topk` requests `stable_sort=True` on every Kimi-K2.6 MoE layer. At model runtime cores' DEST registers hold whatever the previous op left, whereas the uint16 indices travel through 32-bit DEST with an undefined high half.

New tests:

- **`test_moe_grouped_topk_ties.py`** exact ties (same logit AND bias per class) and asserts index order element-wise against a stable-argsort golden.
- **`test_moe_grouped_topk_state.py`**, DEST polluted with six adversarial bit patterns immediately before the gate;

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwroszTT/gate-tie-order-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwroszTT/gate-tie-order-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwroszTT/gate-tie-order-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwroszTT/gate-tie-order-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwroszTT/gate-tie-order-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwroszTT/gate-tie-order-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwroszTT/gate-tie-order-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwroszTT/gate-tie-order-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwroszTT/gate-tie-order-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwroszTT/gate-tie-order-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwroszTT/gate-tie-order-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwroszTT/gate-tie-order-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwroszTT/gate-tie-order-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwroszTT/gate-tie-order-tests)