### PR TITLE
#54235: Widen ternary program-cache reuse; key sharded on TensorAccessor radix

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_ternary_bcast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_ternary_bcast.py
@@ -323,3 +323,110 @@ def test_where_program_cache_same_input_volume_different_output_volume(device, i
         "the output-volume cases no longer collide in the program cache "
         f"(dispatches 2,3 added {deltas[1:]} entries); this test no longer covers issue 54235"
     )
+
+
+@pytest.mark.parametrize("variant", ["TTT", "TTS", "TST"])
+def test_where_program_cache_sharded_different_shape_reuses_cache(device, isolate_program_cache, variant):
+    """Two sharded dispatches with the same accessor radix share one entry and both stay bit-exact."""
+    torch.manual_seed(0)
+
+    sharded_mc = ttnn.create_sharded_memory_config(
+        shape=(32, 32),
+        core_grid=ttnn.CoreGrid(y=1, x=4),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    # Rank-3 vs rank-4, 4 tiles each; buffer_distribution_spec squeezes both to shape_in_pages=[4].
+    pred_shapes = [(4, 32, 32), (1, 4, 32, 32)]
+
+    def to_sharded(t):
+        return ttnn.from_torch(t, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=sharded_mc)
+
+    deltas = []
+    for pred_shape in pred_shapes:
+        pred = torch.randint(0, 2, pred_shape).to(torch.bfloat16)
+        true_t = torch.randn(pred_shape, dtype=torch.bfloat16)
+        false_t = torch.randn(pred_shape, dtype=torch.bfloat16)
+
+        pred_tt = to_sharded(pred)
+        if variant == "TTT":
+            expected = torch.where(pred.bool(), true_t, false_t)
+            args = (pred_tt, to_sharded(true_t), to_sharded(false_t))
+        elif variant == "TTS":
+            expected = torch.where(pred.bool(), true_t, torch.full_like(true_t, -2.5))
+            args = (pred_tt, to_sharded(true_t), -2.5)
+        else:  # TST
+            expected = torch.where(pred.bool(), torch.full_like(false_t, 1.5), false_t)
+            args = (pred_tt, 1.5, to_sharded(false_t))
+
+        device.cache_entries_counter.reset()
+        with device.cache_entries_counter.measure():
+            result = ttnn.to_torch(ttnn.where(*args))
+        deltas.append(device.cache_entries_counter.total)
+        assert_equal(expected, result)
+
+    # First dispatch must actually cache something (guards against "program cache off, everything passes vacuously").
+    assert deltas[0] == 1, f"first sharded dispatch added {deltas[0]} cache entries, expected exactly 1"
+    # Second must reuse; if the hash ever widens, sharded on-hit re-derive stops being exercised.
+    assert deltas[1] == 0, (
+        f"sharded predicates {pred_shapes[0]} vs {pred_shapes[1]} no longer share a cache entry "
+        f"(deltas={deltas}); the sharded on-hit re-derive path is no longer covered"
+    )
+
+
+@pytest.mark.parametrize("variant", ["TTT", "TTS", "TST"])
+def test_where_program_cache_sharded_distinct_radix_forces_miss(device, isolate_program_cache, variant):
+    """Same H,W,dtype,memory_config,shard_volume but different tensor_shape_in_pages must NOT share an entry.
+
+    Probe confirmed: patching sharded_tensor_shape_in_pages out of the key makes this pair collide
+    (deltas [1, 0]); with the key input in place it misses (deltas [1, 1]). Same MemoryConfig object
+    (grid 1x8, shard [32,32]) for both dispatches -- only the tensor's tile count varies, so the
+    accessor radix ([2] vs [4]) is what gates the miss.
+    """
+    torch.manual_seed(0)
+
+    sharded_mc = ttnn.create_sharded_memory_config(
+        shape=(32, 32),
+        core_grid=ttnn.CoreGrid(y=1, x=8),  # 8 cores accommodates both 2-shard and 4-shard dispatches
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    # Rank-4, same H=32 W=32; only batch dim varies -> tile count 2 vs 4 -> radix [2] vs [4].
+    pred_shapes = [(1, 2, 32, 32), (1, 4, 32, 32)]
+
+    def to_sharded(t):
+        return ttnn.from_torch(t, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=sharded_mc)
+
+    deltas = []
+    for pred_shape in pred_shapes:
+        pred = torch.randint(0, 2, pred_shape).to(torch.bfloat16)
+        true_t = torch.randn(pred_shape, dtype=torch.bfloat16)
+        false_t = torch.randn(pred_shape, dtype=torch.bfloat16)
+
+        pred_tt = to_sharded(pred)
+        if variant == "TTT":
+            expected = torch.where(pred.bool(), true_t, false_t)
+            args = (pred_tt, to_sharded(true_t), to_sharded(false_t))
+        elif variant == "TTS":
+            expected = torch.where(pred.bool(), true_t, torch.full_like(true_t, -2.5))
+            args = (pred_tt, to_sharded(true_t), -2.5)
+        else:  # TST
+            expected = torch.where(pred.bool(), torch.full_like(false_t, 1.5), false_t)
+            args = (pred_tt, 1.5, to_sharded(false_t))
+
+        device.cache_entries_counter.reset()
+        with device.cache_entries_counter.measure():
+            result = ttnn.to_torch(ttnn.where(*args))
+        deltas.append(device.cache_entries_counter.total)
+        assert_equal(expected, result)
+
+    assert deltas[0] == 1, f"first sharded dispatch added {deltas[0]} entries, expected exactly 1"
+    # Second dispatch MUST miss; sharing would bake the first radix into common runtime args and misread pages.
+    assert deltas[1] == 1, (
+        f"sharded predicates {pred_shapes[0]} vs {pred_shapes[1]} collided on one cache entry "
+        f"(deltas={deltas}); sharded_tensor_shape_in_pages is not gating the key"
+    )

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -549,133 +549,82 @@ Tensor TernaryDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-// Kept (not attribute_names): coarsens the input to its VOLUME (ternary is elementwise — program
-// depends on tile count, not shape). attribute_names can't express that — it only controls the attrs
-// struct, while the input shape is hashed from tensor_args. scalar_input_a/b are excluded here and
-// re-applied via get_dynamic_runtime_args.
+namespace {
+// Sharded common_runtime_args bake tensor_shape_in_pages at build and are never rewritten on hit.
+std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const tt::tt_metal::TensorSpec& spec) {
+    if (!spec.memory_config().is_sharded()) {
+        return std::nullopt;
+    }
+    // By value: buffer_distribution_spec() returns a ref INTO this temporary; binding it dangles.
+    const auto sharding_args = spec.compute_buffer_sharding_args();
+    const auto& distribution_spec = sharding_args.buffer_distribution_spec();
+    if (!distribution_spec.has_value()) {
+        return std::nullopt;
+    }
+    return distribution_spec->tensor_shape_in_pages();
+}
+
+// Prefer Buffer's spec (set_page_size/set_shard_spec reset it while TensorSpec keeps a stale copy).
+std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const Tensor& tensor) {
+    if (!tensor.memory_config().is_sharded()) {
+        return std::nullopt;
+    }
+    if (tensor.is_allocated() && tensor.storage_type() == StorageType::DEVICE) {
+        const auto& distribution_spec = tensor.buffer()->buffer_distribution_spec();
+        if (distribution_spec.has_value()) {
+            return distribution_spec->tensor_shape_in_pages();
+        }
+    }
+    return sharded_tensor_shape_in_pages(tensor.tensor_spec());
+}
+}  // namespace
+
+// Shape-blind key: interleaved reuses one entry (per-core args re-derive on hit); sharded keys on accessor radix.
+// scalar_input_a/b are excluded here and re-applied via get_dynamic_runtime_args on cache hit.
+// One call, variant rides in `args`; std::nullopt for the absent operand distinguishes TTS/TST from TTT.
 ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_a = tensor_args.input_tensor_a;
     const auto& input_b = tensor_args.input_tensor_b;
     const auto& input_c = tensor_args.input_tensor_c;
-    const auto& a_shape = input_a.padded_shape();
-    TernaryVariant variant = args.ternary_variant;
 
     TT_FATAL(is_device_tensor(input_a), "Unexpected Tensor type {}", input_a.storage_type());
-    ttsl::hash::hash_t hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
-        args, input_a.dtype(), input_a.memory_config(), a_shape.volume());
-
-    if (variant == TernaryVariant::TTT) {
+    if (input_b.has_value()) {
         TT_FATAL(is_device_tensor(*input_b), "Unexpected Tensor type {}", input_b->storage_type());
+    }
+    if (input_c.has_value()) {
         TT_FATAL(is_device_tensor(*input_c), "Unexpected Tensor type {}", input_c->storage_type());
-
-        const auto shard_volumes = get_shard_volumes(
-            input_a.tensor_spec(),
-            input_b->tensor_spec(),
-            input_c->tensor_spec(),
-            compute_output_specs(args, tensor_args));
-
-        // Include true/false tensor volumes so "true broadcast, false full" and "true full, false
-        // broadcast" get distinct cache keys (broadcast_type alone is the same for both).
-        // Also include H,W dimensions (last 2 dims) since they determine per-tensor broadcast
-        // configuration (SRC_BCAST_*, SRC_ROW_BCAST_*, SRC_SCALAR_*) in ROW_COL_BCAST kernels.
-        const auto b_shape = input_b->padded_shape();
-        const auto c_shape = input_c->padded_shape();
-
-        // Extract H,W dims (last 2 dimensions) for broadcast configuration differentiation
-        // Use logical_shape() since broadcast logic depends on logical dimensions, not padded
-        const auto& a_logical = input_a.logical_shape();
-        const auto& b_logical = input_b->logical_shape();
-        const auto& c_logical = input_c->logical_shape();
-        const uint32_t a_h = a_logical.rank() >= 2 ? a_logical[-2] : 1;
-        const uint32_t a_w = a_logical[-1];
-        const uint32_t b_h = b_logical.rank() >= 2 ? b_logical[-2] : 1;
-        const uint32_t b_w = b_logical[-1];
-        const uint32_t c_h = c_logical.rank() >= 2 ? c_logical[-2] : 1;
-        const uint32_t c_w = c_logical[-1];
-
-        hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
-            args,
-            input_a.dtype(),
-            input_a.memory_config(),
-            input_b.value().dtype(),
-            input_b.value().memory_config(),
-            input_c.value().dtype(),
-            input_c.value().memory_config(),
-            a_shape.volume(),
-            b_shape.volume(),
-            c_shape.volume(),
-            a_h,
-            a_w,  // Predicate H,W
-            b_h,
-            b_w,  // True tensor H,W
-            c_h,
-            c_w,  // False tensor H,W
-            shard_volumes);
-
-    } else if (variant == TernaryVariant::TTS) {
-        TT_FATAL(is_device_tensor(*input_b), "Unexpected Tensor type {}", input_b->storage_type());
-
-        const auto shard_volumes = get_shard_volumes(
-            input_a.tensor_spec(), input_b->tensor_spec(), std::nullopt, compute_output_specs(args, tensor_args));
-
-        const auto b_shape = input_b->padded_shape();
-
-        // Include H,W dims for broadcast configuration differentiation
-        // Use logical_shape() since broadcast logic depends on logical dimensions, not padded
-        const auto& a_logical = input_a.logical_shape();
-        const auto& b_logical = input_b->logical_shape();
-        const uint32_t a_h = a_logical.rank() >= 2 ? a_logical[-2] : 1;
-        const uint32_t a_w = a_logical[-1];
-        const uint32_t b_h = b_logical.rank() >= 2 ? b_logical[-2] : 1;
-        const uint32_t b_w = b_logical[-1];
-
-        hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
-            args,
-            input_a.dtype(),
-            input_a.memory_config(),
-            input_b.value().dtype(),
-            input_b.value().memory_config(),
-            a_shape.volume(),
-            b_shape.volume(),
-            a_h,
-            a_w,
-            b_h,
-            b_w,
-            shard_volumes);
-    } else if (variant == TernaryVariant::TST) {
-        TT_FATAL(is_device_tensor(*input_c), "Unexpected Tensor type {}", input_c->storage_type());
-
-        const auto shard_volumes = get_shard_volumes(
-            input_a.tensor_spec(), std::nullopt, input_c->tensor_spec(), compute_output_specs(args, tensor_args));
-
-        const auto c_shape = input_c->padded_shape();
-
-        // Include H,W dims for broadcast configuration differentiation
-        // Use logical_shape() since broadcast logic depends on logical dimensions, not padded
-        const auto& a_logical = input_a.logical_shape();
-        const auto& c_logical = input_c->logical_shape();
-        const uint32_t a_h = a_logical.rank() >= 2 ? a_logical[-2] : 1;
-        const uint32_t a_w = a_logical[-1];
-        const uint32_t c_h = c_logical.rank() >= 2 ? c_logical[-2] : 1;
-        const uint32_t c_w = c_logical[-1];
-
-        hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
-            args,
-            input_a.dtype(),
-            input_a.memory_config(),
-            input_c.value().dtype(),
-            input_c.value().memory_config(),
-            a_shape.volume(),
-            c_shape.volume(),
-            a_h,
-            a_w,
-            c_h,
-            c_w,
-            shard_volumes);
     }
 
-    return hash;
+    const auto output_spec = compute_output_specs(args, tensor_args);
+    const auto shard_volumes = get_shard_volumes(
+        input_a.tensor_spec(),
+        input_b.has_value() ? std::optional{input_b->tensor_spec()} : std::nullopt,
+        input_c.has_value() ? std::optional{input_c->tensor_spec()} : std::nullopt,
+        output_spec);
+
+    // logical (not padded) H,W drives SRC_BCAST_* / SRC_ROW_BCAST_* / SRC_SCALAR_* reader defines.
+    const auto hw = [](const Tensor& t) {
+        const auto& s = t.logical_shape();
+        return std::pair<uint32_t, uint32_t>{s.rank() >= 2 ? s[-2] : 1u, s[-1]};
+    };
+
+    return tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
+        args,
+        input_a.dtype(),
+        input_a.memory_config(),
+        hw(input_a),
+        input_b.has_value() ? std::optional<DataType>{input_b->dtype()} : std::nullopt,
+        input_b.has_value() ? std::optional<MemoryConfig>{input_b->memory_config()} : std::nullopt,
+        input_b.has_value() ? std::optional{hw(*input_b)} : std::nullopt,
+        input_c.has_value() ? std::optional<DataType>{input_c->dtype()} : std::nullopt,
+        input_c.has_value() ? std::optional<MemoryConfig>{input_c->memory_config()} : std::nullopt,
+        input_c.has_value() ? std::optional{hw(*input_c)} : std::nullopt,
+        shard_volumes,
+        sharded_tensor_shape_in_pages(input_a),
+        input_b.has_value() ? sharded_tensor_shape_in_pages(*input_b) : std::nullopt,
+        input_c.has_value() ? sharded_tensor_shape_in_pages(*input_c) : std::nullopt,
+        sharded_tensor_shape_in_pages(output_spec));
 }
 
 bool TernaryDeviceOperation::skip_launch(


### PR DESCRIPTION
### Ticket
Link to Github Issue #54235
closes #49749

### Problem
`compute_program_hash` in `ternary_device_operation.cpp` keyed on `padded_shape.volume()` -- same-H/W dispatches at different volumes miss the cache unnecessarily even though #55167's on-hit re-derive makes a single program correct for all.

### Fix
Drop `a/b/c_shape.volume()` from the key; keep per-tensor H,W (compile-time reader defines) + `shard_volumes` (CB sizes) + `sharded_tensor_shape_in_pages` (accessor radix, for sharded operands and output); hoist `a_shape_in_pages` into a local.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/ternary_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/ternary_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/ternary_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/ternary_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/ternary_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/ternary_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/ternary_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/ternary_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/ternary_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/ternary_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/ternary_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/ternary_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/ternary_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/ternary_cache_hit)
