### PR TITLE
#55397: adjust experimental quasar ops and resnet model to use less SRAM and make block sharded conv pass

### DIFF
--- a/models/demos/vision/classification/resnet50/quasar/demo/demo_runner.py
+++ b/models/demos/vision/classification/resnet50/quasar/demo/demo_runner.py
@@ -82,7 +82,7 @@ def run_resnet_imagenet_inference(
         predictions = []
         inputs = input_tensors_all[iter]
         labels = input_labels_all[iter]
-        tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device, inputs)
+        tt_inputs_host, input_mem_config = test_infra.setup_input(device, inputs)
         test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
         if is_first_run:
             profiler.start("compile")
@@ -165,7 +165,7 @@ def run_resnet_inference(
     profiler.end(f"move_weights")
 
     profiler.start(f"preprocessing")
-    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device, inputs)
+    tt_inputs_host, input_mem_config = test_infra.setup_input(device, inputs)
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     ttnn.synchronize_device(device)
     profiler.end(f"preprocessing")

--- a/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
@@ -287,8 +287,12 @@ class ResNet50TestInfra:
         if is_quasar():
             # Quasar uses the direct data-movement fold (ttnn...fold(use_transpose_as_fold=False,
             # input_is_nhwc=True)); it has no on-device NCHW->NHWC transpose kernel, so upload the image
-            # CHANNELS-LAST, host-padded to the 16B-aligned width (C -> nearest_y(c, 8)). Interleaved L1;
-            # the fold reshards onto its compute grid internally (see run()).
+            # CHANNELS-LAST, host-padded to the 16B-aligned width (C -> nearest_y(c, 8)). Upload to DRAM
+            # (interleaved): the fold reshards onto its compute grid internally (see run()), so it reads the
+            # input from DRAM and does NOT need it resident in L1. On a small-L1 device (e.g. the 3 MB/core
+            # Quasar SRAM variant, ~2.68 MB usable bank) keeping this ~846 KB channels-last input in L1 leaves
+            # too little room for the fold's own sharded intermediate on the 2-core grid -> OOM at the fold.
+            # DRAM frees that bank; the cost on a full-size bank is only a one-time DRAM read for the stem input.
             c_aligned = _nearest_y(c, 8)
             nhwc = torch_input_tensor.permute(0, 2, 3, 1).contiguous()
             if c_aligned != c:
@@ -296,7 +300,7 @@ class ResNet50TestInfra:
             tt_inputs_host = ttnn.from_torch(
                 nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_mapper=self.inputs_mesh_mapper
             )
-            return tt_inputs_host, ttnn.L1_MEMORY_CONFIG
+            return tt_inputs_host, ttnn.DRAM_MEMORY_CONFIG
 
         # Tie the shard count to the device's real compute-core count. The per-batch `core_grid`
         # above targets a full silicon part; Quasar has at most 32 Tensix neo clusters and the

--- a/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
@@ -289,8 +289,8 @@ class ResNet50TestInfra:
             # input_is_nhwc=True)); it has no on-device NCHW->NHWC transpose kernel, so upload the image
             # CHANNELS-LAST, host-padded to the 16B-aligned width (C -> nearest_y(c, 8)). Upload to DRAM
             # (interleaved): the fold reshards onto its compute grid internally (see run()), so it reads the
-            # input from DRAM and does NOT need it resident in L1. On a small-L1 device (e.g. the 3 MB/core
-            # Quasar SRAM variant, ~2.68 MB usable bank) keeping this ~846 KB channels-last input in L1 leaves
+            # input from DRAM and does NOT need it resident in L1. On a small-L1 device (e.g. if have3 MB/core,
+            # ~2.68 MB usable bank) keeping this ~846 KB channels-last input in L1 leaves
             # too little room for the fold's own sharded intermediate on the 2-core grid -> OOM at the fold.
             # DRAM frees that bank; the cost on a full-size bank is only a one-time DRAM read for the stem input.
             c_aligned = _nearest_y(c, 8)

--- a/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/common/resnet50_test_infra.py
@@ -261,7 +261,14 @@ class ResNet50TestInfra:
             output_mesh_composer = None
         return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
 
-    def setup_l1_sharded_input(self, device, torch_input_tensor=None):
+    def setup_input(self, device, torch_input_tensor=None):
+        """Build the host input tensor and the device memory_config to load it into.
+
+        The returned placement is arch-dependent (so read it from the returned mem_config, don't assume it
+        from the name): on Quasar the channels-last fold input goes to DRAM (interleaved) so it doesn't crowd
+        the small L1 bank; on Wormhole/Blackhole it is L1 HEIGHT_SHARDED over the compute grid.
+        Returns (tt_inputs_host, input_mem_config).
+        """
         # Default grid; the device-cap clamp below (num_cores = min(..., max_num_cores, ...)) reduces it
         # to the device's real core count, so batches not explicitly handled here (e.g. the small batches
         # used on the 2x3 emulator / craq-sim grid) still get a valid grid instead of an undefined name.
@@ -289,10 +296,10 @@ class ResNet50TestInfra:
             # input_is_nhwc=True)); it has no on-device NCHW->NHWC transpose kernel, so upload the image
             # CHANNELS-LAST, host-padded to the 16B-aligned width (C -> nearest_y(c, 8)). Upload to DRAM
             # (interleaved): the fold reshards onto its compute grid internally (see run()), so it reads the
-            # input from DRAM and does NOT need it resident in L1. On a small-L1 device (e.g. if have3 MB/core,
-            # ~2.68 MB usable bank) keeping this ~846 KB channels-last input in L1 leaves
-            # too little room for the fold's own sharded intermediate on the 2-core grid -> OOM at the fold.
-            # DRAM frees that bank; the cost on a full-size bank is only a one-time DRAM read for the stem input.
+            # input from DRAM and does NOT need it resident in L1. On a small-L1 device, keeping this ~846 KB
+            # channels-last input in L1 leaves too little room for the fold's own sharded intermediate on the
+            # 2-core grid -> OOM at the fold. DRAM frees that bank; the cost on a full-size device is only a
+            # one-time DRAM read for the stem input.
             c_aligned = _nearest_y(c, 8)
             nhwc = torch_input_tensor.permute(0, 2, 3, 1).contiguous()
             if c_aligned != c:
@@ -329,7 +336,7 @@ class ResNet50TestInfra:
 
     def setup_dram_sharded_input(self, device, torch_input_tensor=None):
         torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
-        tt_inputs_host, input_mem_config = self.setup_l1_sharded_input(device, torch_input_tensor)
+        tt_inputs_host, input_mem_config = self.setup_input(device, torch_input_tensor)
         dram_grid_size = device.dram_grid_size()
         dram_shard_spec = ttnn.ShardSpec(
             ttnn.CoreRangeSet(

--- a/models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d_stem_model.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d_stem_model.py
@@ -14,7 +14,7 @@ ON-DEVICE `fold` output (folded small-face geometry) with the model's real `self
 mirrors the model's ACTUAL stem path verbatim so the fault reproduces in seconds instead of a ~28-min run.
 
 Mirrored verbatim from ttnn_functional_resnet50.py (__init__ stem setup + run() lines ~940-1004) and
-resnet50_test_infra.setup_l1_sharded_input (Quasar branch):
+resnet50_test_infra.setup_input (Quasar branch):
   * input image (batch=1): torch (1,3,224,224) -> NHWC, host-padded C 3->nearest_y(3,8)=8 -> (1,224,224,8)
     bf16 ROW_MAJOR, interleaved L1.
   * fold: stride=2, padding=[3,3,3,3,0,5] (fold_pad_h/w=kernel_size=3, fold_pad_c=C-c=5),

--- a/models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d_stem_model.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d_stem_model.py
@@ -42,13 +42,16 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-def test_quasar_conv2d_stem_model(mesh_device):
+# batch=1 (emulator / small-grid) PASSES: the stem fits L1 in one slice (num_slices=1 -> L1_FULL). batch=16
+# (the WH full-model config) does NOT fit, so the stem takes the DRAM height-slicing path -- which is where
+# the WH full-model stem diverges (op002 stem_conv1 PCC ~0.52). Run the batch-16 case on WH to reproduce.
+@pytest.mark.parametrize("batch_size", [1, 16])
+def test_quasar_conv2d_stem_model(mesh_device, batch_size):
     device = mesh_device
     torch.manual_seed(0)
 
     # --- original stem params (resnet50_test_infra: input_shape=(bs,3,224,224), first-conv kernel_size=3,
-    #     stride=2). batch=1 for the emulator. ---
-    batch_size = 1
+    #     stride=2). batch_size comes from the parametrize above. ---
     c, h, w = 3, 224, 224
     fold_kernel_size = 3  # resnet50_first_conv_kernel_size
     fold_stride = 2  # resnet50_first_conv_stride

--- a/models/demos/vision/classification/resnet50/quasar/tests/ops/test_fold.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/ops/test_fold.py
@@ -94,14 +94,6 @@ def _fit_cores(total_rows, device):
     return num_cores, grid
 
 
-@pytest.mark.xfail(
-    run=False,
-    reason="use_transpose_as_fold=True routes through the Quasar transpose_wh compute (transpose_wh_rm), "
-    "which deadlocks in the tilize->transpose dest_section_flip TTI_STALLWAIT (LLK hand-off item). This is "
-    "the WH/BH fold path; the Quasar resnet model uses the direct channels-last fold (use_transpose_as_fold="
-    "False, input_is_nhwc=True) instead -- see ttnn_functional_resnet50.run() and test_fold_c8.py. run=False "
-    "so the deadlock does not execute.",
-)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("batch_size", [1, 2], ids=["b1", "b2"])
 def test_quasar_fold(mesh_device, batch_size):

--- a/models/demos/vision/classification/resnet50/quasar/tests/ops/test_fold.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/ops/test_fold.py
@@ -27,7 +27,7 @@ For resnet50 the constructor is called with kernel_size=3, stride=2 and a (N, 3,
     padding = [3, 3, 3, 3, 0, 1]
     fold_output_shape = (N, 230//2, 230//2, 4*2*2) = (N, 115, 115, 16)
 
-The input to fold is the ROW_MAJOR, HEIGHT_SHARDED NCHW image (setup_l1_sharded_input shards it over
+The input to fold is the ROW_MAJOR, HEIGHT_SHARDED NCHW image (setup_input shards it over
 the flattened N*C*H rows). This test reproduces that exact configuration; only the batch and the core
 count are tied to the device so it runs on the small Quasar sim grid as well as full silicon.
 
@@ -123,7 +123,7 @@ def test_quasar_fold(mesh_device, batch_size):
     golden = torch.permute(golden, (0, 2, 3, 1))
 
     # HEIGHT-shard the ROW_MAJOR NCHW image over the flattened N*C*H rows, tied to the device grid
-    # (mirrors setup_l1_sharded_input). Use an exact divisor so shards are unpadded.
+    # (mirrors setup_input). Use an exact divisor so shards are unpadded.
     total_rows = batch_size * c * h
     num_cores, grid = _fit_cores(total_rows, device)
     shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, row_wise=True)

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_e2e.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_e2e.py
@@ -75,7 +75,7 @@ def test_resnet50_e2e(device, use_pretrained_weight, model_location_generator):
             use_pretrained_weight=use_pretrained_weight,
             model_location_generator=model_location_generator,
         )
-        tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+        tt_inputs_host, input_mem_config = test_infra.setup_input(device)
         test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
         dev_out = test_infra.run()  # full network -> [1, 1, 1, 1000]-ish logits on device
 

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
@@ -51,8 +51,8 @@ def run_resnet_50(
 # far exceeds pytest-timeout's 300s default; bump it (>= 4h) so the batch-1 simulator run isn't killed
 # mid-sweep. Set to 0 to disable.
 @pytest.mark.timeout(14400)
-# [#54488] Emulate the target SRAM: 2 compute nodes x 3 MB each = 6 MB TOTAL, i.e. 3 MB PER CORE.
-# worker_l1_size is the per-core L1 partition, so set it to 3 MB so the e2e fit is validated against real
+# Emulate smaller target SRAM: 2 compute nodes x 3 MB each = 6 MB TOTAL, i.e. 3 MB PER CORE.
+# worker_l1_size is the per-core L1 partition, so set it to 3 MB so the e2e fit is validated against a smaller
 # Quasar SRAM rather than the 4 MB nominal descriptor. Flows through device_params -> ttnn.CreateDevice.
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "worker_l1_size": 3 * 1024 * 1024}], indirect=True)
 @pytest.mark.parametrize(

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
@@ -33,7 +33,7 @@ def run_resnet_50(
         use_pretrained_weight,
         model_location_generator=model_location_generator,
     )
-    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+    tt_inputs_host, input_mem_config = test_infra.setup_input(device)
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     # First run configures convs JIT
     test_infra.run()

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
@@ -51,7 +51,10 @@ def run_resnet_50(
 # far exceeds pytest-timeout's 300s default; bump it (>= 4h) so the batch-1 simulator run isn't killed
 # mid-sweep. Set to 0 to disable.
 @pytest.mark.timeout(14400)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# [#54488] Emulate the target SRAM: 2 compute nodes x 3 MB each = 6 MB TOTAL, i.e. 3 MB PER CORE.
+# worker_l1_size is the per-core L1 partition, so set it to 3 MB so the e2e fit is validated against real
+# Quasar SRAM rather than the 4 MB nominal descriptor. Flows through device_params -> ttnn.CreateDevice.
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "worker_l1_size": 3 * 1024 * 1024}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     (

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_functional.py
@@ -51,10 +51,7 @@ def run_resnet_50(
 # far exceeds pytest-timeout's 300s default; bump it (>= 4h) so the batch-1 simulator run isn't killed
 # mid-sweep. Set to 0 to disable.
 @pytest.mark.timeout(14400)
-# Emulate smaller target SRAM: 2 compute nodes x 3 MB each = 6 MB TOTAL, i.e. 3 MB PER CORE.
-# worker_l1_size is the per-core L1 partition, so set it to 3 MB so the e2e fit is validated against a smaller
-# Quasar SRAM rather than the 4 MB nominal descriptor. Flows through device_params -> ttnn.CreateDevice.
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "worker_l1_size": 3 * 1024 * 1024}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     (

--- a/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_layers_1_3.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_layers_1_3.py
@@ -71,7 +71,7 @@ def test_resnet50_layers_1_3(device, use_pretrained_weight, model_location_gener
             use_pretrained_weight=use_pretrained_weight,
             model_location_generator=model_location_generator,
         )
-        tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+        tt_inputs_host, input_mem_config = test_infra.setup_input(device)
         test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
         dev_l3 = test_infra.run()  # with the gate set, run() returns the layer3 output [1,1,NHW,1024]
 

--- a/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50.py
+++ b/models/demos/vision/classification/resnet50/quasar/tt/ttnn_functional_resnet50.py
@@ -1024,7 +1024,7 @@ class resnet50:
         # run fold
         if is_quasar():
             # Direct data-movement fold. Input arrives channels-last (NHWC), host-padded to the aligned
-            # width (see setup_l1_sharded_input); the transpose-chain fold has no Quasar kernel. output_shape
+            # width (see setup_input); the transpose-chain fold has no Quasar kernel. output_shape
             # C == groups*C_aligned (== fold_output_shape[3]) so c_keep == c_aligned -> the fold skips the
             # per-group padding strip and returns the aligned groups*C_aligned width directly, which conv1
             # consumes (its weights are folded to groups*C_aligned input channels with zero pad channels).

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -73,5 +73,10 @@ void kernel_main() {
     }
 
     // Pop the scalar tile from RHS CB
+    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
+    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker
+    // (POP_TILES races past WAIT_TILES). dummy_unpack() orders POP after WAIT via an UNPACR_NOP; it reads
+    // nothing (harmless on the common path where the scalar was already unpacked), no-op on WH/BH.
+    dummy_unpack(cb_post_rhs.get_id());
     cb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -73,10 +73,13 @@ void kernel_main() {
     }
 
     // Pop the scalar tile from RHS CB
-    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
-    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker
-    // (POP_TILES races past WAIT_TILES). dummy_unpack() orders POP after WAIT via an UNPACR_NOP; it reads
-    // nothing (harmless on the common path where the scalar was already unpacked), no-op on WH/BH.
-    dummy_unpack(cb_post_rhs.get_id());
+    // Only the zero-work path (num_tiles == 0) needs this: both chunk loops zero-trip, so nothing unpacks
+    // cb_post_rhs between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar
+    // unpacker (POP_TILES races past WAIT_TILES). dummy_unpack() interposes an UNPACR_NOP so POP follows a real
+    // unpack. For num_tiles > 0 the BINARY_OP already unpacked the RHS, so skip it. (On WH/BH dummy_unpack is a
+    // debug-only SrcA flush with no ordering role; the guard also keeps it off the hot path there.)
+    if (num_tiles == 0) {
+        dummy_unpack(cb_post_rhs.get_id());
+    }
     cb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -73,7 +73,7 @@ void kernel_main() {
     }
 
     // Pop the scalar tile from RHS CB
-    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
+    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
     // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker
     // (POP_TILES races past WAIT_TILES). dummy_unpack() orders POP after WAIT via an UNPACR_NOP; it reads
     // nothing (harmless on the common path where the scalar was already unpacked), no-op on WH/BH.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -121,5 +121,9 @@ void kernel_main() {
     }
 
     // Pop the scalar tile from RHS CB
+    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
+    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
+    // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
+    dummy_unpack(cb_post_rhs.get_id());
     cb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -121,7 +121,7 @@ void kernel_main() {
     }
 
     // Pop the scalar tile from RHS CB
-    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
+    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
     // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
     // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
     dummy_unpack(cb_post_rhs.get_id());

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -121,9 +121,13 @@ void kernel_main() {
     }
 
     // Pop the scalar tile from RHS CB
-    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks cb_post_rhs
-    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
-    // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
-    dummy_unpack(cb_post_rhs.get_id());
+    // Only the zero-work path (num_tiles == 0) needs this: both chunk loops zero-trip, so nothing unpacks
+    // cb_post_rhs between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar
+    // unpacker. dummy_unpack() interposes an UNPACR_NOP so POP follows a real unpack. For num_tiles > 0 the op
+    // already unpacked the RHS, so skip it. (On WH/BH dummy_unpack is a debug-only SrcA flush with no ordering
+    // role; the guard also keeps it off the hot path there.)
+    if (num_tiles == 0) {
+        dummy_unpack(cb_post_rhs.get_id());
+    }
     cb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
@@ -106,5 +106,9 @@ void kernel_main() {
     }
 
     // Pop the single reused scalar tile from the RHS DFB.
+    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
+    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
+    // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
+    dummy_unpack(dfb_post_rhs_id);
     dfb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
@@ -106,9 +106,13 @@ void kernel_main() {
     }
 
     // Pop the single reused scalar tile from the RHS DFB.
-    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
-    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
-    // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
-    dummy_unpack(dfb_post_rhs_id);
+    // Only the zero-work path (num_tiles == 0) needs this: both chunk loops zero-trip, so nothing unpacks
+    // dfb_post_rhs between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar
+    // unpacker. dummy_unpack() interposes an UNPACR_NOP so POP follows a real unpack. For num_tiles > 0 the op
+    // already unpacked the RHS, so skip it. (On WH/BH dummy_unpack is a debug-only SrcA flush with no ordering
+    // role; the guard also keeps it off the hot path there.)
+    if (num_tiles == 0) {
+        dummy_unpack(dfb_post_rhs_id);
+    }
     dfb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_dfb.cpp
@@ -106,7 +106,7 @@ void kernel_main() {
     }
 
     // Pop the single reused scalar tile from the RHS DFB.
-    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
+    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
     // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
     // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
     dummy_unpack(dfb_post_rhs_id);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
@@ -177,5 +177,9 @@ void kernel_main() {
     }
 
     // Pop the single reused scalar tile from the RHS DFB.
+    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
+    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
+    // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
+    dummy_unpack(dfb_post_rhs_id);
     dfb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
@@ -177,7 +177,7 @@ void kernel_main() {
     }
 
     // Pop the single reused scalar tile from the RHS DFB.
-    // TEN-4746 (#48552): when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
+    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
     // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
     // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
     dummy_unpack(dfb_post_rhs_id);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_dfb.cpp
@@ -177,9 +177,13 @@ void kernel_main() {
     }
 
     // Pop the single reused scalar tile from the RHS DFB.
-    // when num_tiles == 0 both chunk loops zero-trip, so nothing unpacks dfb_post_rhs
-    // between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar unpacker.
-    // dummy_unpack() orders POP after WAIT via an UNPACR_NOP; harmless on the common path, no-op on WH/BH.
-    dummy_unpack(dfb_post_rhs_id);
+    // Only the zero-work path (num_tiles == 0) needs this: both chunk loops zero-trip, so nothing unpacks
+    // dfb_post_rhs between its wait_front(1) above and this pop_front(1) -> a bare pair that traps the Quasar
+    // unpacker. dummy_unpack() interposes an UNPACR_NOP so POP follows a real unpack. For num_tiles > 0 the op
+    // already unpacked the RHS, so skip it. (On WH/BH dummy_unpack is a debug-only SrcA flush with no ordering
+    // role; the guard also keeps it off the hot path there.)
+    if (num_tiles == 0) {
+        dummy_unpack(dfb_post_rhs_id);
+    }
     dfb_post_rhs.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include <tt-metalium/allocator.hpp>  // Allocator::get_bank_size (real L1 bank, not nominal l1_size_per_core)
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>  // tt::tile_size (DFB ring-extent cap for no-spill conv)
 #include <tt_stl/assert.hpp>
@@ -713,7 +714,10 @@ Result conv2d_L1(
         // Program A's resident output = per-core tilized activation [per_core_M, full_K] tiles.
         const uint64_t tilized_act_bytes =
             static_cast<uint64_t>(per_core_m_ntiles) * full_inner_dim_k_ntiles * out_tile_bytes;
-        const uint64_t l1_bank = device->l1_size_per_core();
+        // [#54488] Use the REAL allocator L1 bank, NOT l1_size_per_core(): the latter reports the nominal arch
+        // L1 (>= 4 MB) even on the reduced-SRAM Quasar variant (~2.68 MB bank), so this guard never fired there
+        // and the split-program tilized activation OOMed at create_output_tensors.
+        const uint64_t l1_bank = device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1);
         // Ceiling on the per-core tilized activation: L1 fit. The tilized-activation output alone crowds the
         // bank, so reserve ~20 % for the resident halo input, weights, matmul CBs and allocator fragmentation.
         // (A former uint16_t DFB ring-extent cap of ~1 MB -- Program A's borrowed DFB_OUT holds the WHOLE
@@ -722,7 +726,12 @@ Result conv2d_L1(
         // ring_size field to uint32_t, so the ring extent is no longer binding and only L1 fit matters. This
         // also keeps such convs off the DRAM slice path, whose slice_write can't consume the per-core
         // tile-padding a height-sharded conv output carries for non-tile-aligned per-core heights.)
-        const uint64_t fit_threshold = (l1_bank * 80) / 100;
+        // [#54488] Small banks have far less headroom for the tilized activation alongside the halo input,
+        // weights, matmul CBs and allocator fragmentation, so slice more aggressively (60%) there; full-size
+        // banks keep the validated ~80% ceiling. (60% of ~2.68 MB ~= 1.6 MB, below the ~1.7 MB layer1 conv2
+        // tilized activation, so it now DRAM-slices instead of OOMing 31 KB short.)
+        const bool small_bank = l1_bank < (3ull * 1024 * 1024);
+        const uint64_t fit_threshold = small_bank ? (l1_bank * 60) / 100 : (l1_bank * 80) / 100;
         if (tilized_act_bytes > fit_threshold) {
             // Number of output-height slices so each slice's tilized activation ((per_core_M/num_slices)*full_K)
             // stays under half the bank, leaving ample room for the slice's halo input, weights and matmul CBs.
@@ -1053,8 +1062,17 @@ Result conv2d_L1(
                     // K-spill when full-K weights EXCEED 512 tiles, and when spilling keep the resident block well
                     // under (<=256 tiles) by picking the largest divisor of full_K with in0_block_w*N <= 256.
                     uint32_t in0_blk_w_mm = full_k_ntiles_mm;
-                    constexpr uint32_t kSingleBlockFitTiles = 512;
-                    constexpr uint32_t kSpillTargetTiles = 256;
+                    // [#54488] On a small-L1 bank (e.g. the 3 MB Quasar SRAM variant, ~2.68 MB) the matmul's
+                    // weights + activation CBs, sized by in0_block_w, alongside the resident tilized activation
+                    // overflow / clash with L1 (validate_dataflow_buffer_region: static DFBs overlap an L1
+                    // buffer). Spill harder there -- lower single-block ceiling AND smaller resident K-block --
+                    // to shrink the matmul CB footprint below the bank. NOTE: more K-blocks = more DRAM-weights
+                    // K-spill-accumulate steps (watch for the 0x10000 tile-counter HW race, though layer4
+                    // already K-spills fine). Full-size banks keep the validated 512/256 tuning.
+                    const bool small_bank_mm =
+                        device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1) < (3ull * 1024 * 1024);
+                    const uint32_t kSingleBlockFitTiles = small_bank_mm ? 256u : 512u;
+                    const uint32_t kSpillTargetTiles = small_bank_mm ? 64u : 256u;
                     if (n_ntiles_mm * full_k_ntiles_mm > kSingleBlockFitTiles) {
                         uint32_t k_blk = full_k_ntiles_mm;
                         while (k_blk > 1 &&
@@ -1162,9 +1180,13 @@ Result conv2d_L1(
         // block, unchanged and still passing.
         if (kernel_size[0] == 1 && kernel_size[1] == 1) {
             const uint32_t full_k_mm = full_inner_dim_k_ntiles;  // 1x1: = in_ch_padded/32
+            // [#54488] Same small-bank spill as the split-path Program B above: on a ~2.68 MB Quasar bank the
+            // wide 1x1 weights CB (conv3 256->1024 / 512->2048, downsample) clashes with L1, so spill harder.
+            const bool small_bank_mm =
+                device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1) < (3ull * 1024 * 1024);
+            const uint32_t kSingleBlockFitTiles = small_bank_mm ? 256u : 512u;
+            const uint32_t kSpillTargetTiles = small_bank_mm ? 64u : 256u;
             auto kspill_in0_bw = [&](uint32_t per_core_n) -> uint32_t {
-                constexpr uint32_t kSingleBlockFitTiles = 512;
-                constexpr uint32_t kSpillTargetTiles = 256;
                 if (per_core_n == 0 || per_core_n * full_k_mm <= kSingleBlockFitTiles) {
                     return full_k_mm;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -1175,7 +1175,15 @@ Result conv2d_L1(
         // This is the plain matmul (no fused conv_bmm, no 0x19); its DRAM-weights K-spill accumulate is the
         // Blocker-A capability (DPRINT-masked). Small 1x1 (<=512t, e.g. 1024->512 at 512t) keep the full-K single
         // block, unchanged and still passing.
-        if (kernel_size[0] == 1 && kernel_size[1] == 1) {
+        //
+        // HEIGHT-SHARDED ONLY: block-sharded splits K across grid columns, so the per-core shard K is
+        // full_K / num_cores_c (< full_K). Forcing in0_block_w = full_K then exceeds the per-core K and trips
+        // the matmul divisibility check ((shard_K_tiles) % in0_block_w == 0) — e.g. WH block-sharded layer3
+        // 1x1 with shard_K=2 tiles vs in0_block_w=16. Block-sharded also keeps per-core K small, so no DRAM
+        // spill is needed there. This mirrors the split-path Program B K-spill above, which is likewise
+        // height-sharded-only. On block-sharded convs (WH/BH layer3/4) the matmul config from
+        // determine_matmul_op_config_from_conv_op_config_qsr is used unchanged.
+        if (height_sharded_conv && kernel_size[0] == 1 && kernel_size[1] == 1) {
             const uint32_t full_k_mm = full_inner_dim_k_ntiles;  // 1x1: = in_ch_padded/32
             // [#54488] Same small-bank spill as the split-path Program B above: on a ~2.68 MB Quasar bank the
             // wide 1x1 weights CB (conv3 256->1024 / 512->2048, downsample) clashes with L1, so spill harder.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -714,9 +714,6 @@ Result conv2d_L1(
         // Program A's resident output = per-core tilized activation [per_core_M, full_K] tiles.
         const uint64_t tilized_act_bytes =
             static_cast<uint64_t>(per_core_m_ntiles) * full_inner_dim_k_ntiles * out_tile_bytes;
-        // [#54488] Use the REAL allocator L1 bank, NOT l1_size_per_core(): the latter reports the nominal arch
-        // L1 (>= 4 MB) even on the reduced-SRAM Quasar variant (~2.68 MB bank), so this guard never fired there
-        // and the split-program tilized activation OOMed at create_output_tensors.
         const uint64_t l1_bank = device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1);
         // Ceiling on the per-core tilized activation: L1 fit. The tilized-activation output alone crowds the
         // bank, so reserve ~20 % for the resident halo input, weights, matmul CBs and allocator fragmentation.
@@ -1062,7 +1059,7 @@ Result conv2d_L1(
                     // K-spill when full-K weights EXCEED 512 tiles, and when spilling keep the resident block well
                     // under (<=256 tiles) by picking the largest divisor of full_K with in0_block_w*N <= 256.
                     uint32_t in0_blk_w_mm = full_k_ntiles_mm;
-                    // [#54488] On a small-L1 bank (e.g. the 3 MB Quasar SRAM variant, ~2.68 MB) the matmul's
+                    // If have less memory to use per L1 bank (e.g. ~2.68 MB) the matmul's
                     // weights + activation CBs, sized by in0_block_w, alongside the resident tilized activation
                     // overflow / clash with L1 (validate_dataflow_buffer_region: static DFBs overlap an L1
                     // buffer). Spill harder there -- lower single-block ceiling AND smaller resident K-block --

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1267,14 +1267,33 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     // subsumed by the split-reader deferral above (enable_split_reader is forced false), so it can never
     // arise here.
 
-    // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated. matmul_partials
-    // is never aliased onto the output on this arch: get_cb_info() leaves MATMUL_PARTIALS.is_globally_allocated
-    // false here because partials_use_output_cb gates on arch != QUASAR (conv2d_op_program_factory_common.cpp), so
-    // partials already gets its own allocation and the compute kernel takes its !partials_cb_uses_output path
-    // (dedicated-ring RESTORE_PARTIALS). No extra arch guard is needed at this site.
-    const bool partials_cb_uses_output =
-        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
-    log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
+    // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
+    //
+    // matmul_partials in-place accumulate: the shared get_cb_info() borrows it onto the OUTPUT allocation
+    // (is_globally_allocated) and, for a MULTI-BLOCK per-core output, places it at a NON-ZERO address_offset --
+    // the END of the output region, so the scratch overlaps only the last-finalized output block. The Metal-2.0
+    // borrowed-DFB API (DataflowBufferSpec::borrowed_from, set below) has NO offset field: it can only alias at
+    // OFFSET 0 (the FRONT of the output). So when the mainline's address_offset is non-zero
+    // (num_blocks_act_h_per_core > 1), a borrow places the partials scratch over output block 0 and clobbers it
+    // the moment the second output block is produced -> corrupted, finite-but-wrong output. This is the WH
+    // batch-16 folded stem (HEIGHT_SHARDED, per_core_M=98 -> 2 height blocks): op002 stem_conv1 PCC ~0.52. It
+    // does NOT reproduce at batch 1 (single block, address_offset==0) nor under DRAM height-slicing (each slice
+    // is a single block), which is exactly what test_conv2d_stem_bisect.py showed.
+    //
+    // Fix: only borrow onto the output when the mainline offset is 0 (single output block, where FRONT==the whole
+    // region and the alias is safe); otherwise give matmul_partials its OWN L1 DFB, and the compute kernel takes
+    // its !partials_cb_uses_output path (dedicated-ring RESTORE_PARTIALS). On Quasar is_globally_allocated is
+    // already false (get_cb_info gates partials_use_output_cb on arch != QUASAR), so this is a no-op there; it
+    // only changes the multi-block case on WH/BH, which is where the offset-0 clobber bites.
+    const auto& matmul_partials_cb_info = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS);
+    const bool partials_cb_uses_output = !is_conv_1d_depthwise_conv && matmul_partials_cb_info.is_globally_allocated &&
+                                         matmul_partials_cb_info.address_offset == 0;
+    log_debug(
+        tt::LogOp,
+        "partials_cb_uses_output: {} (is_globally_allocated={} address_offset={})",
+        partials_cb_uses_output,
+        matmul_partials_cb_info.is_globally_allocated,
+        matmul_partials_cb_info.address_offset);
 
     const bool reader_indices_globally_allocated =
         get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).is_globally_allocated;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1267,22 +1267,13 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     // subsumed by the split-reader deferral above (enable_split_reader is forced false), so it can never
     // arise here.
 
-    // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
-    //
-    // [option 2 — no partials/output alias on Quasar] On WH/BH the one-block matmul_partials CB is aliased
-    // onto the output allocation (borrowed) to save one output-block of L1, and metal1.0 placed it at the
-    // END of the output region via CBInfo::address_offset so the scratch overlaps only the block finalized
-    // last. The Metal-2.0 borrowed-DFB API (DataflowBufferSpec::borrowed_from) has no offset field — it can
-    // only place the borrowed view at OFFSET 0 (the start) of the output. Front placement makes the partials
-    // scratch clobber output block 0 the moment a several-block output advances to block 1, corrupting /
-    // deadlocking the multi-block height- and block-sharded convs (exactly the ones that don't match WH/BH).
-    // Rather than reintroduce an offset mechanism, give matmul_partials its OWN L1 DFB on Quasar: the
-    // borrowed_from below is then skipped (own allocation), and the compute kernel takes its !partials_cb_
-    // uses_output path, which rewinds the dedicated partials ring (RESTORE_PARTIALS) between K-blocks and
-    // never touches OUT. Costs one output-block of L1 per compute node; a larger Quasar grid absorbs it.
-    // WH/BH keep the aliased+offset scheme (their CBDescriptor path still carries address_offset).
-    const bool partials_cb_uses_output = !is_conv_1d_depthwise_conv && !arch_is_quasar &&
-                                         get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+    // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated. matmul_partials
+    // is never aliased onto the output on this arch: get_cb_info() leaves MATMUL_PARTIALS.is_globally_allocated
+    // false here because partials_use_output_cb gates on arch != QUASAR (conv2d_op_program_factory_common.cpp), so
+    // partials already gets its own allocation and the compute kernel takes its !partials_cb_uses_output path
+    // (dedicated-ring RESTORE_PARTIALS). No extra arch guard is needed at this site.
+    const bool partials_cb_uses_output =
+        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
     log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
 
     const bool reader_indices_globally_allocated =

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -245,8 +245,30 @@ const m2::KernelSpecName KERNEL_OUT_DRAIN{"out_drain"};  // Program A: credit-on
 // that the orchestration function then moves into ProgramRunArgs; no logic changes. Namespace scope here
 // (ttnn::prim::qsr, with `using namespace tt::tt_metal` and `namespace m2 = ...experimental` active) so all
 // types resolve.
+// [#48552 / #55076] Multicast destination rectangle. Mirrors the fix already applied to the Quasar
+// matmul factories (matmul_multicore_reuse_mcast_2d_program_factory.cpp):
+//   * WH/BH (2 NOCs, torus): a NOC_1 multicast runs high->low, so start/end are swapped.
+//   * Quasar (single NOC, non-torus): the rectangle must be ASCENDING regardless of NOC. reader_noc /
+//     writer_mcast_noc derive from preferred_noc_for_dram_*(arch), which returns NOC_1 on Quasar too,
+//     so the WH/BH swap degenerates the rectangle to [max..min] and the sender blocks forever on
+//     multicast acks.
+//
+// Observed before this fix, on the block-sharded 3x3 repro: the act-mcast rectangle reached the kernel
+// as start=(1,1) end=(0,1) (end_x < start_x). Confirmed twice over -- the reader's ring buffer reported
+// that rectangle (0xAD041001) and the NOC sanitizer independently flagged the same coords as
+// "Tensix core range w/ virtual coords 1-1-0-1 (multicast invalid range)". DM2 then hung inside
+// noc_async_write_multicast (waypoint NMLW) with the semaphore handshake already satisfied and the NOC
+// drained clean on entry, which starved compute of tilized activations and produced the 0x19
+// ERROR_TRISC MEM_READ_NO_RESPONSE downstream.
+//
+// This is the Quasar-only conv factory, so normalising unconditionally would be correct; the arch guard
+// is kept so the intent stays explicit and the WH/BH branch is greppable next to the matmul version.
 static std::array<uint32_t, 4> setup_mcast_args(
-    bool is_noc_0, uint32_t start_x, uint32_t start_y, uint32_t end_x, uint32_t end_y) {
+    tt::ARCH arch, bool is_noc_0, uint32_t start_x, uint32_t start_y, uint32_t end_x, uint32_t end_y) {
+    if (arch == tt::ARCH::QUASAR) {
+        return std::array<uint32_t, 4>{
+            std::min(start_x, end_x), std::min(start_y, end_y), std::max(start_x, end_x), std::max(start_y, end_y)};
+    }
     return is_noc_0 ? std::array<uint32_t, 4>{start_x, start_y, end_x, end_y}
                     : std::array<uint32_t, 4>{end_x, end_y, start_x, start_y};
 }
@@ -293,6 +315,7 @@ static void populate_reader_runtime_args(
                     CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)num_cores_y - 1};
                     CoreCoord bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
                     mcast = setup_mcast_args(
+                        device->arch(),
                         reader_is_noc_0,
                         bottom_core_physical.x,
                         top_left_core_physical.y,
@@ -303,6 +326,7 @@ static void populate_reader_runtime_args(
                 } else {
                     CoreCoord core_physical = device->worker_core_from_logical_core(core);
                     mcast = setup_mcast_args(
+                        device->arch(),
                         reader_is_noc_0,
                         top_left_core_physical.x,
                         core_physical.y,
@@ -409,6 +433,7 @@ static void populate_writer_sender_runtime_args(
                     CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
                     TT_FATAL(core.x == 0, "Expected core.x to be 0 for sender in 2D mcast setup");
                     mcast = setup_mcast_args(
+                        device->arch(),
                         writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
                         top_left_core_plus_one_physical.x,
                         right_core_physical.y,
@@ -434,6 +459,7 @@ static void populate_writer_sender_runtime_args(
                     CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
                     TT_FATAL(core.y == 0, "Expected core.y to be 0 for sender in 2D mcast setup");
                     mcast = setup_mcast_args(
+                        device->arch(),
                         writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
                         top_core_physical.x,
                         top_left_core_plus_one_physical.y,
@@ -457,6 +483,7 @@ static void populate_writer_sender_runtime_args(
                 }
             } else {
                 std::array<uint32_t, 4> mcast = setup_mcast_args(
+                    device->arch(),
                     writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
                     top_left_core_physical.x,
                     top_left_core_physical.y,
@@ -1241,8 +1268,21 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     // arise here.
 
     // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
-    const bool partials_cb_uses_output =
-        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+    //
+    // [option 2 — no partials/output alias on Quasar] On WH/BH the one-block matmul_partials CB is aliased
+    // onto the output allocation (borrowed) to save one output-block of L1, and metal1.0 placed it at the
+    // END of the output region via CBInfo::address_offset so the scratch overlaps only the block finalized
+    // last. The Metal-2.0 borrowed-DFB API (DataflowBufferSpec::borrowed_from) has no offset field — it can
+    // only place the borrowed view at OFFSET 0 (the start) of the output. Front placement makes the partials
+    // scratch clobber output block 0 the moment a several-block output advances to block 1, corrupting /
+    // deadlocking the multi-block height- and block-sharded convs (exactly the ones that don't match WH/BH).
+    // Rather than reintroduce an offset mechanism, give matmul_partials its OWN L1 DFB on Quasar: the
+    // borrowed_from below is then skipped (own allocation), and the compute kernel takes its !partials_cb_
+    // uses_output path, which rewinds the dedicated partials ring (RESTORE_PARTIALS) between K-blocks and
+    // never touches OUT. Costs one output-block of L1 per compute node; a larger Quasar grid absorbs it.
+    // WH/BH keep the aliased+offset scheme (their CBDescriptor path still carries address_offset).
+    const bool partials_cb_uses_output = !is_conv_1d_depthwise_conv && !arch_is_quasar &&
+                                         get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
     log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
 
     const bool reader_indices_globally_allocated =

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -245,7 +245,7 @@ const m2::KernelSpecName KERNEL_OUT_DRAIN{"out_drain"};  // Program A: credit-on
 // that the orchestration function then moves into ProgramRunArgs; no logic changes. Namespace scope here
 // (ttnn::prim::qsr, with `using namespace tt::tt_metal` and `namespace m2 = ...experimental` active) so all
 // types resolve.
-// [#48552 / #55076] Multicast destination rectangle. Mirrors the fix already applied to the Quasar
+// Multicast destination rectangle. Mirrors the fix already applied to the Quasar
 // matmul factories (matmul_multicore_reuse_mcast_2d_program_factory.cpp):
 //   * WH/BH (2 NOCs, torus): a NOC_1 multicast runs high->low, so start/end are swapped.
 //   * Quasar (single NOC, non-torus): the rectangle must be ASCENDING regardless of NOC. reader_noc /

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_split_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_split_tilize_metal2.cpp
@@ -541,6 +541,10 @@ void kernel_main() {
                 uint32_t in0_index_subblock_offset = 0;
 #ifdef CHECK_SKIP_COMPUTE
                 if (skip_compute) {
+                    // TEN-4746 (#48552): on the skip_compute path nothing unpacks cb_mm_in0 between the
+                    // wait_front above and this pop_front. dummy_unpack() orders POP after WAIT via an
+                    // UNPACR_NOP; it reads nothing, no-op on WH/BH.
+                    dummy_unpack(mm_in0_cb_id);
                     cb_mm_in0.pop_front(in0_block_num_tiles);
                     continue;
                 }
@@ -687,7 +691,11 @@ void kernel_main() {
                 if constexpr (packer_l1_acc) {
                     if constexpr (fuse_bias) {
                         if (in0_block_w_i < in0_num_blocks_w - 1) {
+                            // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker
+                            // (POP_TILES races past WAIT_TILES). dummy_unpack() orders POP after WAIT via an
+                            // UNPACR_NOP; it reads nothing, no-op on WH/BH.
                             cb_matmul_partials.wait_front(out_block_num_tiles);
+                            dummy_unpack(matmul_partials_cb);
                             cb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
                                 UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));
@@ -697,7 +705,10 @@ void kernel_main() {
                         enable_reload = false;
                     } else {
                         if (in0_block_w_i < in0_num_blocks_w - 2) {
+                            // TEN-4746 (#48552, see above): dummy_unpack() orders POP after WAIT via an
+                            // UNPACR_NOP. No-op on WH/BH.
                             cb_matmul_partials.wait_front(out_block_num_tiles);
+                            dummy_unpack(matmul_partials_cb);
                             cb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
                                 UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_split_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_split_tilize_metal2.cpp
@@ -541,7 +541,7 @@ void kernel_main() {
                 uint32_t in0_index_subblock_offset = 0;
 #ifdef CHECK_SKIP_COMPUTE
                 if (skip_compute) {
-                    // TEN-4746 (#48552): on the skip_compute path nothing unpacks cb_mm_in0 between the
+                    // on the skip_compute path nothing unpacks cb_mm_in0 between the
                     // wait_front above and this pop_front. dummy_unpack() orders POP after WAIT via an
                     // UNPACR_NOP; it reads nothing, no-op on WH/BH.
                     dummy_unpack(mm_in0_cb_id);
@@ -691,7 +691,7 @@ void kernel_main() {
                 if constexpr (packer_l1_acc) {
                     if constexpr (fuse_bias) {
                         if (in0_block_w_i < in0_num_blocks_w - 1) {
-                            // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker
+                            // a bare wait_front->pop_front traps the Quasar unpacker
                             // (POP_TILES races past WAIT_TILES). dummy_unpack() orders POP after WAIT via an
                             // UNPACR_NOP; it reads nothing, no-op on WH/BH.
                             cb_matmul_partials.wait_front(out_block_num_tiles);
@@ -705,8 +705,7 @@ void kernel_main() {
                         enable_reload = false;
                     } else {
                         if (in0_block_w_i < in0_num_blocks_w - 2) {
-                            // TEN-4746 (#48552, see above): dummy_unpack() orders POP after WAIT via an
-                            // UNPACR_NOP. No-op on WH/BH.
+                            // dummy_unpack() orders POP after WAIT via an UNPACR_NOP. No-op on WH/BH.
                             cb_matmul_partials.wait_front(out_block_num_tiles);
                             dummy_unpack(matmul_partials_cb);
                             cb_matmul_partials.pop_front(out_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -529,7 +529,7 @@ void kernel_main() {
                 uint32_t in0_index_subblock_offset = 0;
 #ifdef CHECK_SKIP_COMPUTE
                 if (skip_compute) {
-                    // TEN-4746 (#48552): on the skip_compute path nothing unpacks cb_mm_in0 between the
+                    // on the skip_compute path nothing unpacks cb_mm_in0 between the
                     // wait_front above and this pop_front, so the bare pair would trap the Quasar unpacker
                     // (POP_TILES races past WAIT_TILES). dummy_unpack() issues an UNPACR_NOP that orders POP
                     // after WAIT; it reads nothing, no-op on WH/BH.
@@ -646,7 +646,7 @@ void kernel_main() {
                 if constexpr (packer_l1_acc) {
                     if constexpr (fuse_bias) {
                         if (in0_block_w_i < in0_num_blocks_w - 1) {
-                            // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker
+                            // a bare wait_front->pop_front traps the Quasar unpacker
                             // (POP_TILES races past WAIT_TILES). dummy_unpack() issues an UNPACR_NOP that orders
                             // POP after WAIT; it reads nothing and needs no reconfig/re-init (replaces the old
                             // copy_tile drain idiom). No-op on WH/BH.
@@ -661,8 +661,7 @@ void kernel_main() {
                         enable_reload = false;
                     } else {
                         if (in0_block_w_i < in0_num_blocks_w - 2) {
-                            // TEN-4746 (#48552, see above): dummy_unpack() orders POP after WAIT via an
-                            // UNPACR_NOP; replaces the old copy_tile drain idiom. No-op on WH/BH.
+                            // dummy_unpack() orders POP after WAIT via an UNPACR_NOP. No-op on WH/BH.
                             cb_matmul_partials.wait_front(out_block_num_tiles);
                             dummy_unpack(matmul_partials_cb);
                             cb_matmul_partials.pop_front(out_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -529,6 +529,11 @@ void kernel_main() {
                 uint32_t in0_index_subblock_offset = 0;
 #ifdef CHECK_SKIP_COMPUTE
                 if (skip_compute) {
+                    // TEN-4746 (#48552): on the skip_compute path nothing unpacks cb_mm_in0 between the
+                    // wait_front above and this pop_front, so the bare pair would trap the Quasar unpacker
+                    // (POP_TILES races past WAIT_TILES). dummy_unpack() issues an UNPACR_NOP that orders POP
+                    // after WAIT; it reads nothing, no-op on WH/BH.
+                    dummy_unpack(mm_in0_cb_id);
                     cb_mm_in0.pop_front(in0_block_num_tiles);
                     continue;
                 }
@@ -641,28 +646,13 @@ void kernel_main() {
                 if constexpr (packer_l1_acc) {
                     if constexpr (fuse_bias) {
                         if (in0_block_w_i < in0_num_blocks_w - 1) {
-#ifdef ARCH_QUASAR
-                            // TEN-4746: a bare wait_front->pop_front traps the Quasar unpacker (POP_TILES races
-                            // past WAIT_TILES). Interpose a REAL unpack TDMA (dummy copy_tile of tile 0); NOP/
-                            // TTI_NOP are INSUFFICIENT (LLK-team guidance + abhullar/pop-wait-fix 69014037a).
-                            // Reconfig srcA to partials for the copy, then restore srcA + re-init the matmul.
-                            reconfig_data_format_srca(in1_cb_id, matmul_partials_cb);
-                            copy_init(matmul_partials_cb);
-#endif
+                            // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker
+                            // (POP_TILES races past WAIT_TILES). dummy_unpack() issues an UNPACR_NOP that orders
+                            // POP after WAIT; it reads nothing and needs no reconfig/re-init (replaces the old
+                            // copy_tile drain idiom). No-op on WH/BH.
                             cb_matmul_partials.wait_front(out_block_num_tiles);
-#ifdef ARCH_QUASAR
-                            tile_regs_acquire();
-                            copy_tile(matmul_partials_cb, /*in_tile_index=*/0, /*dst_tile_index=*/0);
-                            tile_regs_commit();
-                            tile_regs_wait();
-                            tile_regs_release();
-#endif
+                            dummy_unpack(matmul_partials_cb);
                             cb_matmul_partials.pop_front(out_block_num_tiles);
-#ifdef ARCH_QUASAR
-                            reconfig_data_format_srca(matmul_partials_cb, in1_cb_id);
-                            matmul_block_init(
-                                mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
-#endif
                             if constexpr (spill) {
                                 UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
                                 PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials));
@@ -671,26 +661,11 @@ void kernel_main() {
                         enable_reload = false;
                     } else {
                         if (in0_block_w_i < in0_num_blocks_w - 2) {
-#ifdef ARCH_QUASAR
-                            // TEN-4746 (see above): REAL unpack TDMA (dummy copy_tile) between the bare
-                            // wait_front/pop_front; NOP/TTI_NOP insufficient.
-                            reconfig_data_format_srca(in1_cb_id, matmul_partials_cb);
-                            copy_init(matmul_partials_cb);
-#endif
+                            // TEN-4746 (#48552, see above): dummy_unpack() orders POP after WAIT via an
+                            // UNPACR_NOP; replaces the old copy_tile drain idiom. No-op on WH/BH.
                             cb_matmul_partials.wait_front(out_block_num_tiles);
-#ifdef ARCH_QUASAR
-                            tile_regs_acquire();
-                            copy_tile(matmul_partials_cb, /*in_tile_index=*/0, /*dst_tile_index=*/0);
-                            tile_regs_commit();
-                            tile_regs_wait();
-                            tile_regs_release();
-#endif
+                            dummy_unpack(matmul_partials_cb);
                             cb_matmul_partials.pop_front(out_block_num_tiles);
-#ifdef ARCH_QUASAR
-                            reconfig_data_format_srca(matmul_partials_cb, in1_cb_id);
-                            matmul_block_init(
-                                mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
-#endif
                             if constexpr (spill) {
                                 UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
                                 PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_unpack_tilize_probe_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_unpack_tilize_probe_metal2.cpp
@@ -84,6 +84,8 @@ void kernel_main() {
     DataflowBuffer out_cb(out_cb_id);
 
     in_scalar_cb.reserve_back(1);
+    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    dummy_pack(in_scalar_cb_id);
     in_scalar_cb.push_back(1);
     in_scalar_cb.wait_front(1);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_unpack_tilize_probe_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_unpack_tilize_probe_metal2.cpp
@@ -84,7 +84,7 @@ void kernel_main() {
     DataflowBuffer out_cb(out_cb_id);
 
     in_scalar_cb.reserve_back(1);
-    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    // Required Quasar pack-side drain
     dummy_pack(in_scalar_cb_id);
     in_scalar_cb.push_back(1);
     in_scalar_cb.wait_front(1);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
@@ -476,9 +476,17 @@ Tensor fold(
             real_c = static_cast<uint32_t>(input_tensor.logical_shape()[3]);
             in_grid = input_tensor.is_sharded() ? input_tensor.shard_spec().value().grid
                                                 : core_grid.value();  // caller must pass grid_size when interleaved
+            // [#54488] Spill the transient L1-interleaved copy of the fold input to DRAM. The sharded input
+            // (~800 KB) plus a second L1-interleaved copy of it did not co-fit the small (e.g. 3 MB/core,
+            // ~2.68 MB usable) Quasar bank on the 2-core grid -> OOM here at the fold. The very next step,
+            // interleaved_to_sharded below, re-shards this into L1 anyway, so DRAM only removes the redundant
+            // full copy from the bank -- extending the same dram_interleaved spill the fold OUTPUT already
+            // uses (see step-6 note above). Unconditional on the channels-last (Quasar) path: a device-size
+            // gate does NOT work, l1_size_per_core() reports the nominal arch L1, not the sim's reduced bank;
+            // the cost on a full-size bank is only a one-time DRAM round-trip for the stem fold input.
             processed_tensor =
                 input_tensor.is_sharded()
-                    ? ttnn::operations::experimental::quasar::sharded_to_interleaved(input_tensor, l1_interleaved)
+                    ? ttnn::operations::experimental::quasar::sharded_to_interleaved(input_tensor, dram_interleaved)
                     : input_tensor;
         } else {
             // NCHW input (WH/BH). Transpose to NHWC on-device via transpose(1,2) then transpose(2,3).

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/fold.cpp
@@ -476,7 +476,7 @@ Tensor fold(
             real_c = static_cast<uint32_t>(input_tensor.logical_shape()[3]);
             in_grid = input_tensor.is_sharded() ? input_tensor.shard_spec().value().grid
                                                 : core_grid.value();  // caller must pass grid_size when interleaved
-            // [#54488] Spill the transient L1-interleaved copy of the fold input to DRAM. The sharded input
+            // Spill the transient L1-interleaved copy of the fold input to DRAM. The sharded input
             // (~800 KB) plus a second L1-interleaved copy of it did not co-fit the small (e.g. 3 MB/core,
             // ~2.68 MB usable) Quasar bank on the 2-core grid -> OOM here at the fold. The very next step,
             // interleaved_to_sharded below, re-shards this into L1 anyway, so DRAM only removes the redundant

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -442,6 +442,11 @@ void kernel_main() {
                         // increments on a given CB are identical.
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker
+                            // (POP_TILES can retire before the WAIT_TILES it follows). dummy_unpack() orders
+                            // the POP after the WAIT via an UNPACR_NOP (required on Quasar, no-op on WH/BH);
+                            // it reads nothing, so PACKER_L1_ACC is undisturbed.
+                            dummy_unpack(mm_partials_cb_id);
                             mm_partials_cb.pop_front(out_subblock_num_tiles);
                         }
                     }
@@ -452,6 +457,9 @@ void kernel_main() {
                     if (block < num_blocks_inner_dim - 2) {
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            // TEN-4746 (#48552): drain mm_partials without consuming it (see the FUSE_BIAS
+                            // drain above). dummy_unpack() orders POP after WAIT via an UNPACR_NOP.
+                            dummy_unpack(mm_partials_cb_id);
                             mm_partials_cb.pop_front(out_subblock_num_tiles);
                         }
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -442,7 +442,7 @@ void kernel_main() {
                         // increments on a given CB are identical.
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
-                            // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker
+                            // a bare wait_front->pop_front traps the Quasar unpacker
                             // (POP_TILES can retire before the WAIT_TILES it follows). dummy_unpack() orders
                             // the POP after the WAIT via an UNPACR_NOP (required on Quasar, no-op on WH/BH);
                             // it reads nothing, so PACKER_L1_ACC is undisturbed.
@@ -457,7 +457,7 @@ void kernel_main() {
                     if (block < num_blocks_inner_dim - 2) {
                         for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
                             mm_partials_cb.wait_front(out_subblock_num_tiles);
-                            // TEN-4746 (#48552): drain mm_partials without consuming it (see the FUSE_BIAS
+                            // drain mm_partials without consuming it (see the FUSE_BIAS
                             // drain above). dummy_unpack() orders POP after WAIT via an UNPACR_NOP.
                             dummy_unpack(mm_partials_cb_id);
                             mm_partials_cb.pop_front(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -455,6 +455,10 @@ void kernel_main() {
             // Last iteration does spill and reload to output buffer
             if (block < num_blocks - 2 && spill) {
                 mm_partials_cb.wait_front(out_block_num_tiles);
+                // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker (POP_TILES can
+                // retire before the WAIT_TILES it follows). dummy_unpack() orders POP after WAIT via an
+                // UNPACR_NOP (required on Quasar, no-op on WH/BH); it reads nothing.
+                dummy_unpack(mm_partials_cb_id);
                 mm_partials_cb.pop_front(out_block_num_tiles);
             }
             if (block == num_blocks - 2 && spill) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -318,6 +318,8 @@ void kernel_main() {
             // Wait to receive in0 block
             if (block == 0) {
                 input0_cb.reserve_back(in0_block_num_tiles);
+                // TEN-4746 pack-side drain (dummy_pack helper pending).
+                dummy_pack(input0_cb_id);
                 input0_cb.push_back(in0_block_num_tiles);
             }
             input0_cb.wait_front(in0_block_num_tiles);
@@ -483,6 +485,9 @@ void kernel_main() {
 #ifdef ENABLE_GLOBAL_CB
         // Release in1
         sync_buf.reserve_back(1);
+        // TEN-4746 pack-side drain (dummy_pack helper pending). NOTE: sync_buf is a pure-signalling /
+        // credit-only buffer (no tile data) -- confirm with the LLK team whether the hazard even applies here.
+        dummy_pack(sync_cb);
         sync_buf.push_back(1);
         UNPACK((update_local_cb_rd_ptr(in1_cb_id, in1_rd_ptr_start_addr)));  // reset rd_ptr back to the initial addr
         UNPACK((update_rd_ptr_to_ring_index(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -318,7 +318,7 @@ void kernel_main() {
             // Wait to receive in0 block
             if (block == 0) {
                 input0_cb.reserve_back(in0_block_num_tiles);
-                // TEN-4746 pack-side drain (dummy_pack helper pending).
+                // Requires Quasar pack-side drain
                 dummy_pack(input0_cb_id);
                 input0_cb.push_back(in0_block_num_tiles);
             }
@@ -457,7 +457,7 @@ void kernel_main() {
             // Last iteration does spill and reload to output buffer
             if (block < num_blocks - 2 && spill) {
                 mm_partials_cb.wait_front(out_block_num_tiles);
-                // TEN-4746 (#48552): a bare wait_front->pop_front traps the Quasar unpacker (POP_TILES can
+                // a bare wait_front->pop_front traps the Quasar unpacker (POP_TILES can
                 // retire before the WAIT_TILES it follows). dummy_unpack() orders POP after WAIT via an
                 // UNPACR_NOP (required on Quasar, no-op on WH/BH); it reads nothing.
                 dummy_unpack(mm_partials_cb_id);
@@ -485,8 +485,7 @@ void kernel_main() {
 #ifdef ENABLE_GLOBAL_CB
         // Release in1
         sync_buf.reserve_back(1);
-        // TEN-4746 pack-side drain (dummy_pack helper pending). NOTE: sync_buf is a pure-signalling /
-        // credit-only buffer (no tile data) -- confirm with the LLK team whether the hazard even applies here.
+        // Requires Quasar pack-side drain
         dummy_pack(sync_cb);
         sync_buf.push_back(1);
         UNPACK((update_local_cb_rd_ptr(in1_cb_id, in1_rd_ptr_start_addr)));  // reset rd_ptr back to the initial addr

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -76,6 +76,9 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain: reserve_back->push_back needs a PACR between them (dummy_unpack/UNPACR
+    // can't order the pack side). dummy_pack helper pending creation.
+    dummy_pack(in0);
     dfb_in0.push_back(num_tiles);
 }
 
@@ -291,6 +294,8 @@ void recip_block_inplace(uint32_t in_dfb, uint32_t num_tiles) {
     }
     dfb_in.pop_front(num_tiles);
     dfb_in.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    dummy_pack(in_dfb);
     dfb_in.push_back(num_tiles);
 }
 
@@ -474,6 +479,8 @@ void mul_block_bcast_cols(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t out_dfb) 
             PACK((llk_pack_reconfig_l1_acc(false)));
             dfb_out.pop_front(num_tiles);
             dfb_out.reserve_back(num_tiles);
+            // TEN-4746 pack-side drain (dummy_pack helper pending).
+            dummy_pack(out_dfb);
             dfb_out.push_back(num_tiles);
         } else {
             dfb_out.push_back(num_tiles);
@@ -566,6 +573,8 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_dfb) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
 
@@ -599,6 +608,8 @@ void add_block_inplace(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t num_tiles) {
         dfb_in1.pop_front(num_tiles);
     }
     dfb_in0.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
 
@@ -1872,6 +1883,9 @@ void sdpa_inner_loop(
                         k_start_tile_for_mask,
                         lw_straddle_col,
                         lw_straddle_jump);
+                    // TEN-4746 pack-side drain (guarded path: the mask apply above can be a no-op, leaving
+                    // reserve_back->push_back bare). dummy_pack helper pending creation.
+                    dummy_pack(dfb_qk_im);
                     dfb_qk_im_obj.push_back(Sk_chunk_t * Sq_chunk_t);
                 } else {
                     add_block_inplace(dfb_qk_im, dfb_mask_in, qk_chunk_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1694,6 +1694,9 @@ void sdpa_inner_loop(
             dfb_k_range_obj.wait_front(1);
             k_chunk_start = ckernel::read_tile_value(dfb_windowed_k_range, 0, 0);
             k_chunk_end = ckernel::read_tile_value(dfb_windowed_k_range, 0, 1);
+            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
+            dummy_unpack(dfb_windowed_k_range);
             dfb_k_range_obj.pop_front(1);
         }
 
@@ -1724,6 +1727,11 @@ void sdpa_inner_loop(
             if (sdpa_type == RING && !chunked_enabled && k_chunk >= causal_k_limit && is_causal) {
                 dfb_k_in_obj.wait_front(k_chunk_tiles);
                 dfb_v_in_obj.wait_front(v_chunk_tiles);
+                // TEN-4746 (#48552): these bare wait_front->pop_front drains (this K/V chunk is skipped, no
+                // matmul consumes it) would trap the Quasar unpacker (POP_TILES races past WAIT_TILES).
+                // dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
+                dummy_unpack(dfb_k_in);
+                dummy_unpack(dfb_v_in);
                 dfb_k_in_obj.pop_front(k_chunk_tiles);
                 dfb_v_in_obj.pop_front(v_chunk_tiles);
 
@@ -1816,6 +1824,10 @@ void sdpa_inner_loop(
                     // Warning: this won't work if dfb_qk_im is double-buffered -- the stamps would land
                     // in the other buffer, leaving the QK scores unmasked.
                     dfb_qk_im_obj.wait_front(Sk_chunk_t * Sq_chunk_t);
+                    // TEN-4746 (#48552): bare wait_front->pop_front (the pop/re-reserve cycle only moves the
+                    // rd/wr ptr, no op consumes the QK tiles) would trap the Quasar unpacker. dummy_unpack()
+                    // orders POP after WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
+                    dummy_unpack(dfb_qk_im);
                     dfb_qk_im_obj.pop_front(Sk_chunk_t * Sq_chunk_t);
                     dfb_qk_im_obj.reserve_back(Sk_chunk_t * Sq_chunk_t);
                     // Chunked-prefill: feed abs K (matches abs q_start_tile so diag stamp lines up).
@@ -2097,6 +2109,10 @@ void sdpa_inner_loop(
         if (KV_chunks_processed_in_iter % 2 == 0) {
             dfb_k_in_obj.wait_front(k_chunk_tiles);
             dfb_v_in_obj.wait_front(v_chunk_tiles);
+            // TEN-4746 (#48552): bare wait_front->pop_front drains (nothing consumes these K/V tiles) would
+            // trap the Quasar unpacker. dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP.
+            dummy_unpack(dfb_k_in);
+            dummy_unpack(dfb_v_in);
             dfb_k_in_obj.pop_front(k_chunk_tiles);
             dfb_v_in_obj.pop_front(v_chunk_tiles);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -76,8 +76,8 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain: reserve_back->push_back needs a PACR between them (dummy_unpack/UNPACR
-    // can't order the pack side). dummy_pack helper pending creation.
+    // pack-side drain: reserve_back->push_back needs a PACR between them (dummy_unpack/UNPACR
+    // can't order the pack side).
     dummy_pack(in0);
     dfb_in0.push_back(num_tiles);
 }
@@ -294,7 +294,7 @@ void recip_block_inplace(uint32_t in_dfb, uint32_t num_tiles) {
     }
     dfb_in.pop_front(num_tiles);
     dfb_in.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    // Requires Quasar pack-side drain
     dummy_pack(in_dfb);
     dfb_in.push_back(num_tiles);
 }
@@ -479,7 +479,7 @@ void mul_block_bcast_cols(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t out_dfb) 
             PACK((llk_pack_reconfig_l1_acc(false)));
             dfb_out.pop_front(num_tiles);
             dfb_out.reserve_back(num_tiles);
-            // TEN-4746 pack-side drain (dummy_pack helper pending).
+            // Requires Quasar pack-side drain
             dummy_pack(out_dfb);
             dfb_out.push_back(num_tiles);
         } else {
@@ -573,7 +573,7 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_dfb) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    // Requires Quasar pack-side drain
     dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
@@ -608,7 +608,7 @@ void add_block_inplace(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t num_tiles) {
         dfb_in1.pop_front(num_tiles);
     }
     dfb_in0.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    // Requires Quasar pack-side drain
     dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
@@ -1705,7 +1705,7 @@ void sdpa_inner_loop(
             dfb_k_range_obj.wait_front(1);
             k_chunk_start = ckernel::read_tile_value(dfb_windowed_k_range, 0, 0);
             k_chunk_end = ckernel::read_tile_value(dfb_windowed_k_range, 0, 1);
-            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
             // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
             dummy_unpack(dfb_windowed_k_range);
             dfb_k_range_obj.pop_front(1);
@@ -1738,7 +1738,7 @@ void sdpa_inner_loop(
             if (sdpa_type == RING && !chunked_enabled && k_chunk >= causal_k_limit && is_causal) {
                 dfb_k_in_obj.wait_front(k_chunk_tiles);
                 dfb_v_in_obj.wait_front(v_chunk_tiles);
-                // TEN-4746 (#48552): these bare wait_front->pop_front drains (this K/V chunk is skipped, no
+                // these bare wait_front->pop_front drains (this K/V chunk is skipped, no
                 // matmul consumes it) would trap the Quasar unpacker (POP_TILES races past WAIT_TILES).
                 // dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
                 dummy_unpack(dfb_k_in);
@@ -1835,7 +1835,7 @@ void sdpa_inner_loop(
                     // Warning: this won't work if dfb_qk_im is double-buffered -- the stamps would land
                     // in the other buffer, leaving the QK scores unmasked.
                     dfb_qk_im_obj.wait_front(Sk_chunk_t * Sq_chunk_t);
-                    // TEN-4746 (#48552): bare wait_front->pop_front (the pop/re-reserve cycle only moves the
+                    // bare wait_front->pop_front (the pop/re-reserve cycle only moves the
                     // rd/wr ptr, no op consumes the QK tiles) would trap the Quasar unpacker. dummy_unpack()
                     // orders POP after WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
                     dummy_unpack(dfb_qk_im);
@@ -1883,8 +1883,8 @@ void sdpa_inner_loop(
                         k_start_tile_for_mask,
                         lw_straddle_col,
                         lw_straddle_jump);
-                    // TEN-4746 pack-side drain (guarded path: the mask apply above can be a no-op, leaving
-                    // reserve_back->push_back bare). dummy_pack helper pending creation.
+                    // pack-side drain (guarded path: the mask apply above can be a no-op, leaving
+                    // reserve_back->push_back bare).
                     dummy_pack(dfb_qk_im);
                     dfb_qk_im_obj.push_back(Sk_chunk_t * Sq_chunk_t);
                 } else {
@@ -2123,7 +2123,7 @@ void sdpa_inner_loop(
         if (KV_chunks_processed_in_iter % 2 == 0) {
             dfb_k_in_obj.wait_front(k_chunk_tiles);
             dfb_v_in_obj.wait_front(v_chunk_tiles);
-            // TEN-4746 (#48552): bare wait_front->pop_front drains (nothing consumes these K/V tiles) would
+            // bare wait_front->pop_front drains (nothing consumes these K/V tiles) would
             // trap the Quasar unpacker. dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP.
             dummy_unpack(dfb_k_in);
             dummy_unpack(dfb_v_in);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -2065,6 +2065,9 @@ void sdpa_standard_v2(
             dfb_k_range_obj.wait_front(1);
             k_loop_start = ckernel::read_tile_value(dfb_windowed_k_range, 0, 0);
             k_loop_end = ckernel::read_tile_value(dfb_windowed_k_range, 0, 1);
+            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
+            dummy_unpack(dfb_windowed_k_range);
             dfb_k_range_obj.pop_front(1);
         }
 
@@ -2475,10 +2478,15 @@ void sdpa_ring_v2(
             if constexpr (!has_sliding_window) {
                 if (is_causal_iter && k_chunk >= causal_k_limit) {
                     DataflowBuffer(dfb_kt_in).wait_front(DHt * Sk_chunk_t);
+                    // TEN-4746 (#48552): this K chunk is skipped (drained, not matmul'd), so the wait_front->
+                    // pop_front pair is bare and would trap the Quasar unpacker (POP_TILES races past
+                    // WAIT_TILES). dummy_unpack() orders POP after WAIT via an UNPACR_NOP; no-op on WH/BH.
+                    dummy_unpack(dfb_kt_in);
                     sdpa_dfb_pop_front_out_of_line(dfb_kt_in, DHt * Sk_chunk_t);
                     // In-place latent-V never pushes a V entry, so only K^T needs draining.
                     if constexpr (!kt_inplace_v) {
                         DataflowBuffer(dfb_v_in).wait_front(Sk_chunk_t * v_dfb_physical_width_t);
+                        dummy_unpack(dfb_v_in);
                         sdpa_dfb_pop_front_out_of_line(dfb_v_in, Sk_chunk_t * v_dfb_physical_width_t);
                     }
                     KV_chunks_processed_in_iter++;
@@ -2909,10 +2917,15 @@ void sdpa_ring_v2(
              dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(KV_chunks_processed_in_iter);
              ++dummy_chunk) {
             DataflowBuffer(dfb_kt_in).wait_front(DHt * Sk_chunk_t);
+            // TEN-4746 (#48552): dummy-KV alignment traffic is drained, never matmul'd, so this bare
+            // wait_front->pop_front would trap the Quasar unpacker. dummy_unpack() orders POP after WAIT
+            // via an UNPACR_NOP; no-op on WH/BH.
+            dummy_unpack(dfb_kt_in);
             sdpa_dfb_pop_front_out_of_line(dfb_kt_in, DHt * Sk_chunk_t);
             // In-place latent-V never pushes a V entry, so there is nothing extra to drain.
             if constexpr (!kt_inplace_v) {
                 DataflowBuffer(dfb_v_in).wait_front(Sk_chunk_t * v_dfb_physical_width_t);
+                dummy_unpack(dfb_v_in);
                 sdpa_dfb_pop_front_out_of_line(dfb_v_in, Sk_chunk_t * v_dfb_physical_width_t);
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -2065,7 +2065,7 @@ void sdpa_standard_v2(
             dfb_k_range_obj.wait_front(1);
             k_loop_start = ckernel::read_tile_value(dfb_windowed_k_range, 0, 0);
             k_loop_end = ckernel::read_tile_value(dfb_windowed_k_range, 0, 1);
-            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
             // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
             dummy_unpack(dfb_windowed_k_range);
             dfb_k_range_obj.pop_front(1);
@@ -2478,7 +2478,7 @@ void sdpa_ring_v2(
             if constexpr (!has_sliding_window) {
                 if (is_causal_iter && k_chunk >= causal_k_limit) {
                     DataflowBuffer(dfb_kt_in).wait_front(DHt * Sk_chunk_t);
-                    // TEN-4746 (#48552): this K chunk is skipped (drained, not matmul'd), so the wait_front->
+                    // this K chunk is skipped (drained, not matmul'd), so the wait_front->
                     // pop_front pair is bare and would trap the Quasar unpacker (POP_TILES races past
                     // WAIT_TILES). dummy_unpack() orders POP after WAIT via an UNPACR_NOP; no-op on WH/BH.
                     dummy_unpack(dfb_kt_in);
@@ -2917,7 +2917,7 @@ void sdpa_ring_v2(
              dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(KV_chunks_processed_in_iter);
              ++dummy_chunk) {
             DataflowBuffer(dfb_kt_in).wait_front(DHt * Sk_chunk_t);
-            // TEN-4746 (#48552): dummy-KV alignment traffic is drained, never matmul'd, so this bare
+            // dummy-KV alignment traffic is drained, never matmul'd, so this bare
             // wait_front->pop_front would trap the Quasar unpacker. dummy_unpack() orders POP after WAIT
             // via an UNPACR_NOP; no-op on WH/BH.
             dummy_unpack(dfb_kt_in);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -129,6 +129,9 @@ void kernel_main() {
         if (use_chunk_start_idx_tensor != 0) {
             dfb_chunk_start_idx_obj.wait_front(1);
             uint32_t chunk_start_idx = ckernel::read_tile_value(dfb_chunk_start_idx, 0, 0);
+            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
+            dummy_unpack(dfb_chunk_start_idx);
             dfb_chunk_start_idx_obj.pop_front(1);
             const uint32_t q_chunk_size = Sq_chunk_t * TILE_HEIGHT;
             chunked_q_chunk_offset_phase_1 = chunk_start_idx / q_chunk_size;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -129,7 +129,7 @@ void kernel_main() {
         if (use_chunk_start_idx_tensor != 0) {
             dfb_chunk_start_idx_obj.wait_front(1);
             uint32_t chunk_start_idx = ckernel::read_tile_value(dfb_chunk_start_idx, 0, 0);
-            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
             // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
             dummy_unpack(dfb_chunk_start_idx);
             dfb_chunk_start_idx_obj.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -1693,6 +1693,9 @@ void sdpa_inner_loop(
             dfb_k_range_obj.wait_front(1);
             k_chunk_start = ckernel::read_tile_value(dfb_windowed_k_range, 0, 0);
             k_chunk_end = ckernel::read_tile_value(dfb_windowed_k_range, 0, 1);
+            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
+            dummy_unpack(dfb_windowed_k_range);
             dfb_k_range_obj.pop_front(1);
         }
 
@@ -1723,6 +1726,11 @@ void sdpa_inner_loop(
             if (sdpa_type == RING && !chunked_enabled && k_chunk >= causal_k_limit && is_causal) {
                 dfb_k_in_obj.wait_front(k_chunk_tiles);
                 dfb_v_in_obj.wait_front(v_chunk_tiles);
+                // TEN-4746 (#48552): these bare wait_front->pop_front drains (this K/V chunk is skipped, no
+                // matmul consumes it) would trap the Quasar unpacker (POP_TILES races past WAIT_TILES).
+                // dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
+                dummy_unpack(dfb_k_in);
+                dummy_unpack(dfb_v_in);
                 dfb_k_in_obj.pop_front(k_chunk_tiles);
                 dfb_v_in_obj.pop_front(v_chunk_tiles);
 
@@ -1815,6 +1823,10 @@ void sdpa_inner_loop(
                     // Warning: this won't work if dfb_qk_im is double-buffered -- the stamps would land
                     // in the other buffer, leaving the QK scores unmasked.
                     dfb_qk_im_obj.wait_front(Sk_chunk_t * Sq_chunk_t);
+                    // TEN-4746 (#48552): bare wait_front->pop_front (the pop/re-reserve cycle only moves the
+                    // rd/wr ptr, no op consumes the QK tiles) would trap the Quasar unpacker. dummy_unpack()
+                    // orders POP after WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
+                    dummy_unpack(dfb_qk_im);
                     dfb_qk_im_obj.pop_front(Sk_chunk_t * Sq_chunk_t);
                     dfb_qk_im_obj.reserve_back(Sk_chunk_t * Sq_chunk_t);
                     // Chunked-prefill: feed abs K (matches abs q_start_tile so diag stamp lines up).
@@ -2096,6 +2108,10 @@ void sdpa_inner_loop(
         if (KV_chunks_processed_in_iter % 2 == 0) {
             dfb_k_in_obj.wait_front(k_chunk_tiles);
             dfb_v_in_obj.wait_front(v_chunk_tiles);
+            // TEN-4746 (#48552): bare wait_front->pop_front drains (nothing consumes these K/V tiles) would
+            // trap the Quasar unpacker. dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP.
+            dummy_unpack(dfb_k_in);
+            dummy_unpack(dfb_v_in);
             dfb_k_in_obj.pop_front(k_chunk_tiles);
             dfb_v_in_obj.pop_front(v_chunk_tiles);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -75,6 +75,9 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain: reserve_back->push_back needs a PACR between them (dummy_unpack/UNPACR
+    // can't order the pack side). dummy_pack helper pending creation.
+    dummy_pack(in0);
     dfb_in0.push_back(num_tiles);
 }
 
@@ -290,6 +293,8 @@ void recip_block_inplace(uint32_t in_dfb, uint32_t num_tiles) {
     }
     dfb_in.pop_front(num_tiles);
     dfb_in.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    dummy_pack(in_dfb);
     dfb_in.push_back(num_tiles);
 }
 
@@ -473,6 +478,8 @@ void mul_block_bcast_cols(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t out_dfb) 
             PACK((llk_pack_reconfig_l1_acc(false)));
             dfb_out.pop_front(num_tiles);
             dfb_out.reserve_back(num_tiles);
+            // TEN-4746 pack-side drain (dummy_pack helper pending).
+            dummy_pack(out_dfb);
             dfb_out.push_back(num_tiles);
         } else {
             dfb_out.push_back(num_tiles);
@@ -565,6 +572,8 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_dfb) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
 
@@ -598,6 +607,8 @@ void add_block_inplace(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t num_tiles) {
         dfb_in1.pop_front(num_tiles);
     }
     dfb_in0.reserve_back(num_tiles);
+    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
 
@@ -1871,6 +1882,9 @@ void sdpa_inner_loop(
                         k_start_tile_for_mask,
                         lw_straddle_col,
                         lw_straddle_jump);
+                    // TEN-4746 pack-side drain (guarded path: the mask apply above can be a no-op, leaving
+                    // reserve_back->push_back bare). dummy_pack helper pending creation.
+                    dummy_pack(dfb_qk_im);
                     dfb_qk_im_obj.push_back(Sk_chunk_t * Sq_chunk_t);
                 } else {
                     add_block_inplace(dfb_qk_im, dfb_mask_in, qk_chunk_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -75,8 +75,8 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain: reserve_back->push_back needs a PACR between them (dummy_unpack/UNPACR
-    // can't order the pack side). dummy_pack helper pending creation.
+    // reserve_back->push_back needs a PACR between them (dummy_unpack/UNPACR
+    // can't order the pack side).
     dummy_pack(in0);
     dfb_in0.push_back(num_tiles);
 }
@@ -293,7 +293,7 @@ void recip_block_inplace(uint32_t in_dfb, uint32_t num_tiles) {
     }
     dfb_in.pop_front(num_tiles);
     dfb_in.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    // Required Quasar pack-side drain
     dummy_pack(in_dfb);
     dfb_in.push_back(num_tiles);
 }
@@ -478,7 +478,7 @@ void mul_block_bcast_cols(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t out_dfb) 
             PACK((llk_pack_reconfig_l1_acc(false)));
             dfb_out.pop_front(num_tiles);
             dfb_out.reserve_back(num_tiles);
-            // TEN-4746 pack-side drain (dummy_pack helper pending).
+            // Requires Quasar pack-side drain
             dummy_pack(out_dfb);
             dfb_out.push_back(num_tiles);
         } else {
@@ -572,7 +572,7 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_dfb) {
     }
     dfb_in0.pop_front(num_tiles);
     dfb_in0.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    // Requires Quasar pack-side drain
     dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
@@ -607,7 +607,7 @@ void add_block_inplace(uint32_t in0_dfb, uint32_t in1_dfb, uint32_t num_tiles) {
         dfb_in1.pop_front(num_tiles);
     }
     dfb_in0.reserve_back(num_tiles);
-    // TEN-4746 pack-side drain (dummy_pack helper pending).
+    // Requires Quasar pack-side drain
     dummy_pack(in0_dfb);
     dfb_in0.push_back(num_tiles);
 }
@@ -1704,7 +1704,7 @@ void sdpa_inner_loop(
             dfb_k_range_obj.wait_front(1);
             k_chunk_start = ckernel::read_tile_value(dfb_windowed_k_range, 0, 0);
             k_chunk_end = ckernel::read_tile_value(dfb_windowed_k_range, 0, 1);
-            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
             // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
             dummy_unpack(dfb_windowed_k_range);
             dfb_k_range_obj.pop_front(1);
@@ -1737,7 +1737,7 @@ void sdpa_inner_loop(
             if (sdpa_type == RING && !chunked_enabled && k_chunk >= causal_k_limit && is_causal) {
                 dfb_k_in_obj.wait_front(k_chunk_tiles);
                 dfb_v_in_obj.wait_front(v_chunk_tiles);
-                // TEN-4746 (#48552): these bare wait_front->pop_front drains (this K/V chunk is skipped, no
+                // these bare wait_front->pop_front drains (this K/V chunk is skipped, no
                 // matmul consumes it) would trap the Quasar unpacker (POP_TILES races past WAIT_TILES).
                 // dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
                 dummy_unpack(dfb_k_in);
@@ -1834,7 +1834,7 @@ void sdpa_inner_loop(
                     // Warning: this won't work if dfb_qk_im is double-buffered -- the stamps would land
                     // in the other buffer, leaving the QK scores unmasked.
                     dfb_qk_im_obj.wait_front(Sk_chunk_t * Sq_chunk_t);
-                    // TEN-4746 (#48552): bare wait_front->pop_front (the pop/re-reserve cycle only moves the
+                    // bare wait_front->pop_front (the pop/re-reserve cycle only moves the
                     // rd/wr ptr, no op consumes the QK tiles) would trap the Quasar unpacker. dummy_unpack()
                     // orders POP after WAIT via an UNPACR_NOP; reads nothing, no-op on WH/BH.
                     dummy_unpack(dfb_qk_im);
@@ -1882,8 +1882,8 @@ void sdpa_inner_loop(
                         k_start_tile_for_mask,
                         lw_straddle_col,
                         lw_straddle_jump);
-                    // TEN-4746 pack-side drain (guarded path: the mask apply above can be a no-op, leaving
-                    // reserve_back->push_back bare). dummy_pack helper pending creation.
+                    // pack-side drain (guarded path: the mask apply above can be a no-op, leaving
+                    // reserve_back->push_back bare).
                     dummy_pack(dfb_qk_im);
                     dfb_qk_im_obj.push_back(Sk_chunk_t * Sq_chunk_t);
                 } else {
@@ -2122,7 +2122,7 @@ void sdpa_inner_loop(
         if (KV_chunks_processed_in_iter % 2 == 0) {
             dfb_k_in_obj.wait_front(k_chunk_tiles);
             dfb_v_in_obj.wait_front(v_chunk_tiles);
-            // TEN-4746 (#48552): bare wait_front->pop_front drains (nothing consumes these K/V tiles) would
+            // bare wait_front->pop_front drains (nothing consumes these K/V tiles) would
             // trap the Quasar unpacker. dummy_unpack() orders each POP after its WAIT via an UNPACR_NOP.
             dummy_unpack(dfb_k_in);
             dummy_unpack(dfb_v_in);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -181,6 +181,9 @@ void kernel_main() {
             DataflowBuffer dfb_cur_pos_buf(dfb_cur_pos);
             dfb_cur_pos_buf.wait_front(1);
             cur_pos = dfb_cur_pos_buf.read_tile_value(0, cur_batch / q_heads_parallel_factor);
+            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
+            dummy_unpack(dfb_cur_pos);
             dfb_cur_pos_buf.pop_front(1);
 #endif
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -181,7 +181,7 @@ void kernel_main() {
             DataflowBuffer dfb_cur_pos_buf(dfb_cur_pos);
             dfb_cur_pos_buf.wait_front(1);
             cur_pos = dfb_cur_pos_buf.read_tile_value(0, cur_batch / q_heads_parallel_factor);
-            // TEN-4746 (#48552): read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
+            // read_tile_value is a plain L1 load (no UNPACR), so this wait_front->pop_front
             // is bare; dummy_unpack issues an UNPACR_NOP that orders POP after WAIT.
             dummy_unpack(dfb_cur_pos);
             dfb_cur_pos_buf.pop_front(1);


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Relates to #51123 , #55397 , #54488 , and #55076

- Add in idma operations between bare DFB API pairs to experimental quasar ops
- Fix up mcast grid for conv
- Reduce L1/SRAM usage to 3MB
- Adjusts conv2d to deal with not experimental quasar matmul using metal 2.0 which does not support address_offset
- Add an extra parameter to a test

Tested locally that block sharded and e2e tests passed on emulator.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-55397_qsr_dfb_pairs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-55397_qsr_dfb_pairs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-55397_qsr_dfb_pairs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-55397_qsr_dfb_pairs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-55397_qsr_dfb_pairs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-55397_qsr_dfb_pairs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-55397_qsr_dfb_pairs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-55397_qsr_dfb_pairs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-55397_qsr_dfb_pairs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-55397_qsr_dfb_pairs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-55397_qsr_dfb_pairs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-55397_qsr_dfb_pairs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-55397_qsr_dfb_pairs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-55397_qsr_dfb_pairs)