### PR TITLE
[Cleanup] Split ScratchpadBindingToken and DFBBindingToken into their own headers

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -31,6 +31,7 @@ template <>
 struct noc_traits_t<DataflowBuffer>;
 #endif
 
+#include "api/dataflow/dfb_binding_token.h"
 #include "api/debug/assert.h"
 #include "api/debug/waypoint.h"
 #include "api/lock.h"
@@ -73,59 +74,6 @@ template <bool IsWrite, typename ReleaseFunc>
     uint32_t pointer, ReleaseFunc release) {
     return DfbScopedLock<IsWrite, ReleaseFunc>(pointer, release);
 }
-
-// Opaque handle for a DataflowBuffer binding (declared in kernel_bindings_generated.h).
-// The user will never directly interact with this type.
-//
-// The user's host code declares an accessor_name when binding a DFB endpoint to a kernel.
-// The user then uses that accessor_name to construct a DataflowBuffer in the kernel code.
-//
-// Usage example:
-//   // (Host code declares "my_dfb_name" as the DFB accessor name for this kernel.)
-//   // In the kernel code:
-//   DataflowBuffer my_dfb(dfb::my_dfb_name);
-//
-// Here my_dfb_name is a constexpr DFBBindingToken, auto-included in kernel_bindings_generated.h.
-//
-struct DFBBindingToken {
-    explicit constexpr DFBBindingToken(uint16_t id) noexcept : id_(id) {}
-
-    // DFBBindingToken is backed by a compile-time ID (an implicit CTA).
-
-    // Implicit conversion to uint32_t:
-    // This lets a Metal 2.0 kernel pass a DFBBindingToken directly to Gen1 (WH/BH) LLK
-    // compute APIs that expect a raw CB id.
-    // This conversion is constexpr; it's intended for Gen1 use only.
-    constexpr operator uint32_t() const noexcept { return id_; }
-
-private:
-    uint16_t id_;
-};
-
-// Compile-time handle for a CrossNode/PrefetcherPipe *relay* local DFB binding.
-// Distinct from DFBBindingToken so kernels cannot silently treat a normal DFB as a
-// relay (or vice versa) without a cast — no runtime "am I a relay?" check needed.
-// Emitted into kernel_bindings_generated.h when the host DFB was created as a relay.
-//
-// PrefetcherPipe relays additionally carry the prefetcher_pipe_id so the TRISC-side
-// DataflowBuffer constructor can O(1)-index that slot in the launch-msg persistent
-// region and snap the borrowed local iface to the durable fifo_ptr checkpoint.
-// CrossNode relays omit it (NO_PREFETCHER_PIPE): CrossNode state is re-zeroed every
-// launch, so the dispatch-written local CB config is already correct.
-struct RelayDFBBindingToken {
-    static constexpr uint8_t NO_PREFETCHER_PIPE = 0xFF;
-
-    explicit constexpr RelayDFBBindingToken(uint16_t id, uint8_t prefetcher_pipe_id = NO_PREFETCHER_PIPE) noexcept :
-        id_(id), prefetcher_pipe_id_(prefetcher_pipe_id) {}
-
-    constexpr operator uint32_t() const noexcept { return id_; }
-
-    constexpr uint8_t prefetcher_pipe_id() const noexcept { return prefetcher_pipe_id_; }
-
-private:
-    uint16_t id_;
-    uint8_t prefetcher_pipe_id_;
-};
 
 class DataflowBuffer {
 public:

--- a/tt_metal/hw/inc/api/dataflow/dfb_binding_token.h
+++ b/tt_metal/hw/inc/api/dataflow/dfb_binding_token.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Opaque handle for a DataflowBuffer binding (declared in kernel_bindings_generated.h).
+// The user will never directly interact with this type.
+//
+// The user's host code declares an accessor_name when binding a DFB endpoint to a kernel.
+// The user then uses that accessor_name to construct a DataflowBuffer in the kernel code.
+//
+// Usage example:
+//   // (Host code declares "my_dfb_name" as the DFB accessor name for this kernel.)
+//   // In the kernel code:
+//   DataflowBuffer my_dfb(dfb::my_dfb_name);
+//
+// Here my_dfb_name is a constexpr DFBBindingToken, auto-included in kernel_bindings_generated.h.
+//
+// This header holds only the tokens, with no dependency beyond <cstdint>, so the generated
+// bindings header (and anything else that just needs to name a binding) does not have to pull
+// in the whole DataflowBuffer implementation. See api/dataflow/dataflow_buffer.h for the
+// DataflowBuffer class these tokens construct.
+//
+struct DFBBindingToken {
+    explicit constexpr DFBBindingToken(uint16_t id) noexcept : id_(id) {}
+
+    // DFBBindingToken is backed by a compile-time ID (an implicit CTA).
+
+    // Implicit conversion to uint32_t:
+    // This lets a Metal 2.0 kernel pass a DFBBindingToken directly to Gen1 (WH/BH) LLK
+    // compute APIs that expect a raw CB id.
+    // This conversion is constexpr; it's intended for Gen1 use only.
+    constexpr operator uint32_t() const noexcept { return id_; }
+
+private:
+    uint16_t id_;
+};
+
+// Compile-time handle for a CrossNode/PrefetcherPipe *relay* local DFB binding.
+// Distinct from DFBBindingToken so kernels cannot silently treat a normal DFB as a
+// relay (or vice versa) without a cast — no runtime "am I a relay?" check needed.
+// Emitted into kernel_bindings_generated.h when the host DFB was created as a relay.
+//
+// PrefetcherPipe relays additionally carry the prefetcher_pipe_id so the TRISC-side
+// DataflowBuffer constructor can O(1)-index that slot in the launch-msg persistent
+// region and snap the borrowed local iface to the durable fifo_ptr checkpoint.
+// CrossNode relays omit it (NO_PREFETCHER_PIPE): CrossNode state is re-zeroed every
+// launch, so the dispatch-written local CB config is already correct.
+struct RelayDFBBindingToken {
+    static constexpr uint8_t NO_PREFETCHER_PIPE = 0xFF;
+
+    explicit constexpr RelayDFBBindingToken(uint16_t id, uint8_t prefetcher_pipe_id = NO_PREFETCHER_PIPE) noexcept :
+        id_(id), prefetcher_pipe_id_(prefetcher_pipe_id) {}
+
+    constexpr operator uint32_t() const noexcept { return id_; }
+
+    constexpr uint8_t prefetcher_pipe_id() const noexcept { return prefetcher_pipe_id_; }
+
+private:
+    uint16_t id_;
+    uint8_t prefetcher_pipe_id_;
+};

--- a/tt_metal/hw/inc/api/scratchpad.h
+++ b/tt_metal/hw/inc/api/scratchpad.h
@@ -9,33 +9,8 @@
 
 #include "api/core_local_mem.h"
 #include "api/debug/assert.h"
+#include "api/scratchpad_binding_token.h"
 #include "experimental/kernel_args.h"
-
-// Opaque handle for a Program-scope scratchpad binding (declared in kernel_bindings_generated.h).
-// The user will never directly interact with this type.
-//
-// The user's host code declares an accessor_name when binding a scratchpad to a kernel.
-// The user then uses that accessor_name to construct a Scratchpad in the kernel code.
-//
-// Usage example:
-//   // (Host code declares "my_scratchpad_name" as the scratchpad accessor name for this kernel.)
-//   // In the kernel code:
-//   Scratchpad<int32_t> my_pad(scratch::my_scratchpad_name);
-//
-// Here my_scratchpad_name is a constexpr ScratchpadBindingToken, auto-included in
-// kernel_bindings_generated.h.
-class ScratchpadBindingToken {
-public:
-    explicit constexpr ScratchpadBindingToken(uint32_t crta_offset, uint32_t size_in_bytes) noexcept :
-        crta_offset_(crta_offset), size_in_bytes_(size_in_bytes) {}
-
-private:
-    template <typename T>
-    friend class Scratchpad;
-
-    uint32_t crta_offset_;    // word index of the base-address slot in the CRTA buffer
-    uint32_t size_in_bytes_;  // static per-node size
-};
 
 /**
  * @brief Kernel-side typed span over a Program-scope scratchpad.

--- a/tt_metal/hw/inc/api/scratchpad_binding_token.h
+++ b/tt_metal/hw/inc/api/scratchpad_binding_token.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Forward declaration only: the token grants Scratchpad<T> access to its members, but nothing
+// in this header needs the definition. Defined in api/scratchpad.h.
+template <typename T>
+class Scratchpad;
+
+// Opaque handle for a Program-scope scratchpad binding (declared in kernel_bindings_generated.h).
+// The user will never directly interact with this type.
+//
+// The user's host code declares an accessor_name when binding a scratchpad to a kernel.
+// The user then uses that accessor_name to construct a Scratchpad in the kernel code.
+//
+// Usage example:
+//   // (Host code declares "my_scratchpad_name" as the scratchpad accessor name for this kernel.)
+//   // In the kernel code:
+//   Scratchpad<int32_t> my_pad(scratch::my_scratchpad_name);
+//
+// Here my_scratchpad_name is a constexpr ScratchpadBindingToken, auto-included in
+// kernel_bindings_generated.h.
+//
+// This header holds only the token, with no dependency beyond <cstdint>, so the generated
+// bindings header (and anything else that just needs to name a binding) does not have to pull
+// in the whole Scratchpad implementation. See api/scratchpad.h for the Scratchpad class this
+// token constructs.
+class ScratchpadBindingToken {
+public:
+    explicit constexpr ScratchpadBindingToken(uint32_t crta_offset, uint32_t size_in_bytes) noexcept :
+        crta_offset_(crta_offset), size_in_bytes_(size_in_bytes) {}
+
+private:
+    template <typename T>
+    friend class Scratchpad;
+
+    uint32_t crta_offset_;    // word index of the base-address slot in the CRTA buffer
+    uint32_t size_in_bytes_;  // static per-node size
+};

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -33,6 +33,7 @@ set(HW_JIT_API_HEADERS
     inc/api/tensor/pages_address_iterator.h
     inc/api/tensor/page.h
     inc/api/scratchpad.h
+    inc/api/scratchpad_binding_token.h
     inc/api/compute/compute_kernel_api.h
     inc/api/compute/add_int_sfpu.h
     inc/api/compute/atan2.h
@@ -201,6 +202,7 @@ set(HW_JIT_API_HEADERS
     inc/api/dataflow/cross_node_dfb.h
     inc/api/dataflow/prefetcher_pipe.h
     inc/api/dataflow/dataflow_buffer.h
+    inc/api/dataflow/dfb_binding_token.h
     inc/experimental/kernel_args.h
     inc/experimental/blaze_named_args.h
     inc/api/dataflow/noc_semaphore.h


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
`DFBBindingToken` and `ScratchpadBindingToken` were defined inside `dataflow_buffer.h` and `scratchpad.h`, so `kernel_bindings_generated.h` had to include a whole implementation header just to declare a token. 

This PR split the binding tokens out to their individual headers, matching `semaphore_binding_token.h` and `tensor_binding_token.h`:

- `DFBBindingToken` → `api/dataflow/dfb_binding_token.h`
- `ScratchpadBindingToken` → `api/scratchpad_binding_token.h`

Both depend on `<cstdint>` only. No behaviour change: the original headers now include the token header, so existing include sites are unaffected.

### Notes for reviewers
- Not done here: switching `genfiles.cpp` to emit the light headers only. The include migration is outside of the scope of this PR.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/m2-split-binding-token-headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/m2-split-binding-token-headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/m2-split-binding-token-headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/m2-split-binding-token-headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/m2-split-binding-token-headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/m2-split-binding-token-headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/m2-split-binding-token-headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/m2-split-binding-token-headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/m2-split-binding-token-headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/m2-split-binding-token-headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/m2-split-binding-token-headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/m2-split-binding-token-headers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/m2-split-binding-token-headers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/m2-split-binding-token-headers)
