### PR TITLE
[Fabric2D] Remove custom routing from generic all-to-all

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
@@ -20,53 +20,6 @@
 namespace ttnn::experimental::prim {
 
 namespace {
-// The active route-buffer size is specialized into the device kernel. Bound host-generated custom routes by the
-// smallest supported Fabric2D tier; the kernel additionally checks its exact compile-time capacity before injection.
-// TODO: Replace this conservative bound when an existing Fabric API exposes the active route-buffer capacity.
-constexpr uint32_t minimum_fabric2d_route_capacity = 19;
-
-struct CustomFabric2DRoute {
-    uint32_t num_commands = 0;
-    tt::tt_fabric::eth_chan_directions initial_direction = tt::tt_fabric::eth_chan_directions::COUNT;
-    std::vector<uint32_t> packed_commands;
-};
-
-uint8_t fabric_direction_command(tt::tt_fabric::eth_chan_directions direction) {
-    using MeshRoutingFields = tt::tt_fabric::RoutingFieldsConstants::Mesh;
-    switch (direction) {
-        case tt::tt_fabric::eth_chan_directions::EAST: return MeshRoutingFields::FORWARD_EAST;
-        case tt::tt_fabric::eth_chan_directions::WEST: return MeshRoutingFields::FORWARD_WEST;
-        case tt::tt_fabric::eth_chan_directions::NORTH: return MeshRoutingFields::FORWARD_NORTH;
-        case tt::tt_fabric::eth_chan_directions::SOUTH: return MeshRoutingFields::FORWARD_SOUTH;
-        default:
-            TT_THROW("All-to-all custom route does not support fabric direction {}", static_cast<uint32_t>(direction));
-    }
-}
-
-uint8_t fabric_terminal_command(tt::tt_fabric::eth_chan_directions incoming_direction) {
-    switch (incoming_direction) {
-        case tt::tt_fabric::eth_chan_directions::EAST:
-            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::WEST);
-        case tt::tt_fabric::eth_chan_directions::WEST:
-            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::EAST);
-        case tt::tt_fabric::eth_chan_directions::NORTH:
-            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::SOUTH);
-        case tt::tt_fabric::eth_chan_directions::SOUTH:
-            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::NORTH);
-        default:
-            TT_THROW(
-                "All-to-all custom route does not support fabric direction {}",
-                static_cast<uint32_t>(incoming_direction));
-    }
-}
-
-void set_packed_route_command(CustomFabric2DRoute& route, uint32_t command_index, uint8_t command) {
-    constexpr uint32_t commands_per_word = 8;
-    TT_FATAL(command_index / commands_per_word < route.packed_commands.size(), "Custom route command is out of range");
-    route.packed_commands[command_index / commands_per_word] |= static_cast<uint32_t>(command)
-                                                                << ((command_index % commands_per_word) * 4);
-}
-
 ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
     const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     const auto& shape = input_tensor.padded_shape();
@@ -401,7 +354,6 @@ AllToAllAsyncGenericProgram::create_at(
 
     const auto fabric_config = tt::tt_fabric::GetFabricConfig();
     const bool is_fabric_2d = tt::tt_fabric::is_2d_fabric_config(fabric_config);
-    const uint32_t fabric2d_route_capacity = is_fabric_2d ? minimum_fabric2d_route_capacity : 0;
     // FABRIC_2D_TORUS_X/Y wraps only one mesh axis even though get_fabric_topology() reports Torus for both.
     // Resolve wrapping for the collective's axis so a Ring on the other axis cannot open a nonexistent hop.
     const bool fabric_has_wrap_links = operation_attributes.axis_topology == tt::tt_fabric::Topology::Ring;
@@ -560,108 +512,9 @@ AllToAllAsyncGenericProgram::create_at(
     }
     const uint32_t num_direction_groups = static_cast<uint32_t>(direction_group_to_physical_direction.size());
     TT_FATAL(num_direction_groups > 0, "All-to-all collective has no remote direction groups");
-    auto get_direct_ring_hop_directions =
-        [&](const MeshCoordinate& source_coord,
-            int32_t device_offset) -> std::optional<std::vector<tt::tt_fabric::eth_chan_directions>> {
-        const uint32_t num_hops = std::abs(device_offset);
-        std::vector<tt::tt_fabric::eth_chan_directions> hop_directions;
-        hop_directions.reserve(num_hops);
-        auto previous_coord = source_coord;
-        for (uint32_t hop = 1; hop <= num_hops; ++hop) {
-            const int32_t hop_offset = device_offset > 0 ? static_cast<int32_t>(hop) : -static_cast<int32_t>(hop);
-            const auto next_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-                tensor_args.input_tensor,
-                source_coord,
-                hop_offset,
-                effective_topology,
-                operation_attributes.cluster_axis);
-            TT_FATAL(next_coord.has_value(), "No ring coordinate at offset {}", hop_offset);
-            const auto previous_node = device->get_fabric_node_id(previous_coord);
-            const auto next_node = device->get_fabric_node_id(*next_coord);
-            // Host boundaries do not affect this proof because every rank has the global physical direction map.
-            // Inter-mesh routers can replace a custom route at the boundary, so retain canonical routing for those
-            // arcs.
-            if (previous_node.mesh_id != next_node.mesh_id) {
-                return std::nullopt;
-            }
-            const auto directions = tt::tt_fabric::get_neighbor_eth_directions(previous_node, next_node);
-            if (directions.empty()) {
-                return std::nullopt;
-            }
-            hop_directions.push_back(directions.front());
-            previous_coord = *next_coord;
-        }
-        return hop_directions;
-    };
-
-    auto custom_ring_route_is_representable = [&](const std::optional<std::vector<tt::tt_fabric::eth_chan_directions>>&
-                                                      maybe_hop_directions) {
-        if (!maybe_hop_directions.has_value() || maybe_hop_directions->empty() ||
-            maybe_hop_directions->size() > fabric2d_route_capacity) {
-            return false;
-        }
-        const auto& hop_directions = *maybe_hop_directions;
-        auto is_spine_direction = [](tt::tt_fabric::eth_chan_directions direction) {
-            return direction == tt::tt_fabric::eth_chan_directions::NORTH ||
-                   direction == tt::tt_fabric::eth_chan_directions::SOUTH;
-        };
-        auto is_branch_direction = [](tt::tt_fabric::eth_chan_directions direction) {
-            return direction == tt::tt_fabric::eth_chan_directions::EAST ||
-                   direction == tt::tt_fabric::eth_chan_directions::WEST;
-        };
-        // The mesh header has only one branch offset per E/W direction. A custom route with zeroed branch offsets is
-        // therefore safe only when a spine router never hands the packet to an E/W branch router. Canonical routing
-        // remains the correctness fallback for folded arcs that need that transition (including multi-turn snakes).
-        for (uint32_t hop = 1; hop < hop_directions.size(); ++hop) {
-            if (is_spine_direction(hop_directions[hop - 1]) && is_branch_direction(hop_directions[hop])) {
-                return false;
-            }
-        }
-        return true;
-    };
-
-    bool split_antipode_across_arcs = is_ring && !is_fabric_2d;
-    if (is_ring && is_fabric_2d && operation_attributes.num_devices > 2 && operation_attributes.num_devices % 2 == 0) {
-        const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
-        split_antipode_across_arcs = true;
-        for (uint32_t source_device = 0; source_device < operation_attributes.num_devices; ++source_device) {
-            MeshCoordinate source_coord = mesh_coordinate;
-            source_coord[cluster_axis] = source_device;
-            const auto positive_hops = get_direct_ring_hop_directions(source_coord, half_ring);
-            const auto negative_hops = get_direct_ring_hop_directions(source_coord, -half_ring);
-            const bool source_can_split = custom_ring_route_is_representable(positive_hops) &&
-                                          custom_ring_route_is_representable(negative_hops) &&
-                                          positive_hops->front() != negative_hops->front();
-            if (!source_can_split) {
-                split_antipode_across_arcs = false;
-                break;
-            }
-        }
-    }
-
-    auto build_custom_ring_route = [&](int32_t device_offset) {
-        CustomFabric2DRoute route;
-        const auto maybe_hop_directions = get_direct_ring_hop_directions(mesh_coordinate, device_offset);
-        TT_FATAL(maybe_hop_directions.has_value(), "All-to-all custom Fabric2D route requires direct ring edges");
-        const auto& hop_directions = *maybe_hop_directions;
-        const uint32_t num_hops = hop_directions.size();
-        TT_FATAL(
-            custom_ring_route_is_representable(maybe_hop_directions),
-            "All-to-all custom Fabric2D route with {} hops is not representable by the active {}-command header",
-            num_hops,
-            fabric2d_route_capacity);
-        route.num_commands = num_hops;
-        route.packed_commands.resize((num_hops + 7) / 8, 0);
-        route.initial_direction = hop_directions.front();
-
-        // Injection selects hop 0's egress. Each intermediate router consumes the next hop's direction, and the
-        // destination consumes the direction opposite its ingress to drain locally.
-        for (uint32_t command = 0; command + 1 < num_hops; ++command) {
-            set_packed_route_command(route, command, fabric_direction_command(hop_directions[command + 1]));
-        }
-        set_packed_route_command(route, num_hops - 1, fabric_terminal_command(hop_directions.back()));
-        return route;
-    };
+    // Fabric2D route selection and encoding are owned by Fabric. Until Fabric exposes an arc-constrained routing API,
+    // send each antipodal destination through canonical unicast routing instead of constructing a route in TTNN.
+    const bool split_antipode_across_arcs = is_ring && !is_fabric_2d;
 
     const uint32_t max_useful_workers_per_direction =
         is_ring ? preferred_workers_per_direction
@@ -697,18 +550,10 @@ AllToAllAsyncGenericProgram::create_at(
     }
     // A single direct worker per direction is safe for generic scatter order. Bank-owned batches can cyclically block
     // independent direct directions, so use the compact schedule when a restricted subdevice cannot fit a mux tier.
-    // Fabric2D antipodes are safe once streams are grouped by their concrete first hop.
     if (workers_per_direction == 1 && use_bank_owned_schedule) {
         workers_per_direction = 0;
     }
     const bool use_direction_owned_schedule = workers_per_direction > 0;
-    // Explicit antipode routes belong to the direction-owned schedule. The compact schedule uses canonical Fabric2D
-    // routing, which also keeps its per-target runtime record below the Tensix RTA limit.
-    if (is_fabric_2d && !use_direction_owned_schedule) {
-        split_antipode_across_arcs = false;
-    }
-    const uint32_t custom_fabric2d_route_words =
-        is_fabric_2d && split_antipode_across_arcs ? (operation_attributes.num_devices / 2 + 7) / 8 : 0;
     const bool use_worker_mux = workers_per_direction > 1;
     const uint32_t mux_cores_per_direction = workers_per_direction + 1;
     const uint32_t direction_senders_per_link = num_direction_groups * workers_per_direction + 1;
@@ -1063,7 +908,6 @@ AllToAllAsyncGenericProgram::create_at(
             is_fabric_2d,                                // is_fabric_2d
             sender_stream_direction_masks[stream],       // fabric_direction_mask
             number_pages_per_packet,                     // max_pages_per_packet
-            custom_fabric2d_route_words,                 // custom_fabric2d_route_words
             use_multicast_initialization                 // use_multicast_initialization
         };
 
@@ -1092,15 +936,6 @@ AllToAllAsyncGenericProgram::create_at(
     const uint32_t mcast_dest_noc_start_y = coordinate_device->worker_core_from_logical_core(sender_box.end_coord).y;
     const uint32_t mcast_dest_noc_end_y = coordinate_device->worker_core_from_logical_core(sender_box.start_coord).y;
     const uint32_t mcast_size = sender_box.size();
-
-    CustomFabric2DRoute positive_antipode_route;
-    CustomFabric2DRoute negative_antipode_route;
-    if (is_fabric_2d && split_antipode_across_arcs) {
-        const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
-        positive_antipode_route = build_custom_ring_route(half_ring);
-        negative_antipode_route = build_custom_ring_route(-half_ring);
-    }
-    const CustomFabric2DRoute no_custom_route;
 
     for (uint32_t core_id = 0; core_id < sender_worker_cores.size(); ++core_id) {
         const auto& core = sender_worker_cores[core_id];
@@ -1162,30 +997,6 @@ AllToAllAsyncGenericProgram::create_at(
                 // The low-latency 1D header uses the second route field as a hop count.
                 sender_writer_rt_args.push_back(0);
                 sender_writer_rt_args.push_back(std::abs(device_offset));
-            }
-
-            const CustomFabric2DRoute* custom_route = &no_custom_route;
-            if (is_fabric_2d && split_antipode_across_arcs &&
-                std::abs(device_offset) * 2 == operation_attributes.num_devices) {
-                custom_route = device_offset > 0 ? &positive_antipode_route : &negative_antipode_route;
-            }
-            if (custom_fabric2d_route_words > 0) {
-                TT_FATAL(
-                    custom_route->packed_commands.empty() ||
-                        custom_route->packed_commands.size() == custom_fabric2d_route_words,
-                    "All-to-all custom route ABI expected {} packed words, got {}",
-                    custom_fabric2d_route_words,
-                    custom_route->packed_commands.size());
-                sender_writer_rt_args.push_back(custom_route->num_commands);
-                sender_writer_rt_args.push_back(static_cast<uint32_t>(custom_route->initial_direction));
-                if (custom_route->packed_commands.empty()) {
-                    sender_writer_rt_args.insert(sender_writer_rt_args.end(), custom_fabric2d_route_words, 0);
-                } else {
-                    sender_writer_rt_args.insert(
-                        sender_writer_rt_args.end(),
-                        custom_route->packed_commands.begin(),
-                        custom_route->packed_commands.end());
-                }
             }
         }
         const bool is_remote_sender = sender_stream != local_sender_stream || num_senders_per_link == 1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -40,9 +40,8 @@ constexpr uint16_t source_mesh_id = get_compile_time_arg_val(14);
 constexpr bool is_fabric_2d = get_compile_time_arg_val(15);
 constexpr uint32_t fabric_direction_mask = get_compile_time_arg_val(16);
 constexpr uint32_t max_pages_per_packet = get_compile_time_arg_val(17);
-constexpr uint32_t custom_fabric2d_route_words = get_compile_time_arg_val(18);
-constexpr bool use_multicast_initialization = get_compile_time_arg_val(19);
-constexpr auto output_tensor_args = TensorAccessorArgs<20>();
+constexpr bool use_multicast_initialization = get_compile_time_arg_val(18);
+constexpr auto output_tensor_args = TensorAccessorArgs<19>();
 constexpr uint32_t mux_ct_base = output_tensor_args.next_compile_time_args_offset();
 // This flag is specialized per stream by the host. Endpoint streams without a physical egress compile against the
 // routing-plane-manager ABI even when other streams in the same program use a worker mux.
@@ -50,16 +49,11 @@ constexpr bool stream_uses_mux = get_compile_time_arg_val(mux_ct_base) != 0;
 constexpr uint32_t mux_num_clients = get_compile_time_arg_val(mux_ct_base + 1);
 constexpr uint32_t compile_safe_mux_num_clients = mux_num_clients == 0 ? 1 : mux_num_clients;
 constexpr bool has_fabric_connections = fabric_direction_mask != 0;
-constexpr bool has_custom_fabric2d_routes = custom_fabric2d_route_words != 0;
-static_assert(!has_custom_fabric2d_routes || is_fabric_2d, "Custom routes require Fabric2D");
 // Base record: offset, block range/stride, completion, mesh and chip. Fabric2D adds the destination's harvested drain
-// coordinate. Only programs that actually split an antipode add route metadata and the words used by that route.
+// coordinate.
 constexpr uint32_t target_drain_args = is_fabric_2d ? 2 : 0;
-constexpr uint32_t target_custom_route_args = has_custom_fabric2d_routes ? 2 + custom_fabric2d_route_words : 0;
-constexpr uint32_t target_runtime_args = 7 + target_drain_args + target_custom_route_args;
+constexpr uint32_t target_runtime_args = 7 + target_drain_args;
 constexpr uint32_t target_drain_args_idx = 7;
-constexpr uint32_t target_custom_route_args_idx = target_drain_args_idx + target_drain_args;
-constexpr uint32_t default_initial_direction = static_cast<uint32_t>(tt::tt_fabric::eth_chan_directions::COUNT);
 constexpr auto fabric_directions =
     ttnn::operations::ccl::common::fabric_direction_mask_to_directions(fabric_direction_mask);
 using Fabric2DConnections = tt::tt_fabric::RoutingPlaneConnectionManager;
@@ -71,24 +65,6 @@ using DirectFabricConnections = std::conditional_t<is_fabric_2d, Fabric2DConnect
 using FabricConnections = std::conditional_t<stream_uses_mux, FabricMuxConnection, DirectFabricConnections>;
 constexpr bool fabric2d_multicast_initialization_is_safe = is_fabric_2d && use_multicast_initialization;
 
-FORCE_INLINE uint32_t get_custom_route_num_commands(size_t target_arg_idx) {
-    if constexpr (has_custom_fabric2d_routes) {
-        return get_arg_val<uint32_t>(target_arg_idx + target_custom_route_args_idx);
-    }
-    return 0;
-}
-
-FORCE_INLINE uint32_t get_custom_route_initial_direction(size_t target_arg_idx) {
-    if constexpr (has_custom_fabric2d_routes) {
-        return get_arg_val<uint32_t>(target_arg_idx + target_custom_route_args_idx + 1);
-    }
-    return default_initial_direction;
-}
-
-FORCE_INLINE size_t get_custom_route_packed_args_idx(size_t target_arg_idx) {
-    return target_arg_idx + target_custom_route_args_idx + 2;
-}
-
 [[noreturn]] FORCE_INLINE void fail_stop_invalid_fabric_route() {
     // ASSERT gives watcher builds a precise failure signal. The explicit trap and spin remain the production fallback:
     // an invalid route must not inject on an arbitrary egress and corrupt the collective's completion count.
@@ -98,51 +74,11 @@ FORCE_INLINE size_t get_custom_route_packed_args_idx(size_t target_arg_idx) {
     }
 }
 
-template <typename PacketHeader>
-FORCE_INLINE void set_target_unicast_route(
-    volatile PacketHeader* packet_header,
-    const ccl_routing_utils::line_unicast_route_info_t& route_info,
-    uint32_t custom_route_num_commands,
-    size_t custom_route_args_idx) {
-    if constexpr (std::is_base_of_v<tt::tt_fabric::HybridMeshPacketHeader, PacketHeader>) {
-        if (custom_route_num_commands == 0) {
-            tt::tt_fabric::fabric_set_unicast_route(packet_header, route_info.dst_chip_id, route_info.dst_mesh_id);
-        }
-        if (custom_route_num_commands != 0) {
-            if (custom_route_num_commands > tt::tt_fabric::FabricHeaderConfig::MESH_ROUTE_BUFFER_SIZE) {
-                fail_stop_invalid_fabric_route();
-            }
-            packet_header->dst_start_node_id =
-                (static_cast<uint32_t>(route_info.dst_mesh_id) << 16) | route_info.dst_chip_id;
-            packet_header->mcast_params_64 = 0;
-            packet_header->is_mcast_active = 0;
-            packet_header->routing_fields.value = 0;
-            for (uint32_t command = 0; command < tt::tt_fabric::FabricHeaderConfig::MESH_ROUTE_BUFFER_SIZE; ++command) {
-                constexpr uint32_t commands_per_word = 8;
-                uint8_t route_command = 0;
-                if (command < custom_route_num_commands) {
-                    const uint32_t packed_word =
-                        get_arg_val<uint32_t>(custom_route_args_idx + command / commands_per_word);
-                    route_command = static_cast<uint8_t>((packed_word >> ((command % commands_per_word) * 4)) & 0xf);
-                }
-                packet_header->route_buffer[command] = route_command;
-            }
-            return;
-        }
-    } else {
-        if (custom_route_num_commands != 0) {
-            fail_stop_invalid_fabric_route();
-        }
-        ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
-    }
-}
-
 inline FabricMuxSender& select_connection(
     FabricMuxConnection& fabric_connection,
     [[maybe_unused]] int device_offset,
     [[maybe_unused]] uint16_t dest_mesh_id,
-    [[maybe_unused]] uint16_t dest_chip_id,
-    [[maybe_unused]] uint32_t initial_direction) {
+    [[maybe_unused]] uint16_t dest_chip_id) {
     return fabric_connection.sender;
 }
 
@@ -160,11 +96,8 @@ inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     Fabric2DConnections& fabric_connections,
     [[maybe_unused]] int device_offset,
     uint16_t dest_mesh_id,
-    uint16_t dest_chip_id,
-    uint32_t initial_direction) {
-    const uint32_t direction = initial_direction == default_initial_direction
-                                   ? static_cast<uint32_t>(get_next_hop_router_direction(dest_mesh_id, dest_chip_id))
-                                   : initial_direction;
+    uint16_t dest_chip_id) {
+    const uint32_t direction = static_cast<uint32_t>(get_next_hop_router_direction(dest_mesh_id, dest_chip_id));
     return select_connection_by_direction(fabric_connections, direction);
 }
 
@@ -172,8 +105,7 @@ inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     FabricConnectionManager& fabric_connections,
     int device_offset,
     [[maybe_unused]] uint16_t dest_mesh_id,
-    [[maybe_unused]] uint16_t dest_chip_id,
-    [[maybe_unused]] uint32_t initial_direction) {
+    [[maybe_unused]] uint16_t dest_chip_id) {
     return (device_offset > 0) ? fabric_connections.get_forward_connection()
                                : fabric_connections.get_backward_connection();
 }
@@ -251,11 +183,7 @@ void send_initialization(
             auto* packet_header = device_offset > 0 ? pkt_hdr_sema_forward : pkt_hdr_sema_backward;
             const uint32_t packet_header_address =
                 device_offset > 0 ? packet_header_buffer_addr_sema_forward : packet_header_buffer_addr_sema_backward;
-            set_target_unicast_route(
-                packet_header,
-                route_info,
-                get_custom_route_num_commands(target_arg_idx),
-                get_custom_route_packed_args_idx(target_arg_idx));
+            ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
             packet_header->to_noc_unicast_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{target_init_semaphore_noc_addr, 1});
             send_mux_packet_blocking(fabric_connection, packet_header_address, sizeof(PacketHeader));
@@ -395,19 +323,11 @@ void send_initialization(
         auto* packet_header = device_offset > 0 ? pkt_hdr_sema_forward : pkt_hdr_sema_backward;
         const uint32_t packet_header_address =
             device_offset > 0 ? packet_header_buffer_addr_sema_forward : packet_header_buffer_addr_sema_backward;
-        set_target_unicast_route(
-            packet_header,
-            route_info,
-            get_custom_route_num_commands(target_arg_idx),
-            get_custom_route_packed_args_idx(target_arg_idx));
+        ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
         packet_header->to_noc_unicast_atomic_inc(
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{target_init_semaphore_noc_addr, 1});
-        auto& connection = select_connection(
-            fabric_connections,
-            device_offset,
-            route_info.dst_mesh_id,
-            route_info.dst_chip_id,
-            get_custom_route_initial_direction(target_arg_idx));
+        auto& connection =
+            select_connection(fabric_connections, device_offset, route_info.dst_mesh_id, route_info.dst_chip_id);
         connection.wait_for_empty_write_slot();
         connection.send_payload_flush_blocking_from_address(packet_header_address, sizeof(PacketHeader));
     }
@@ -677,14 +597,6 @@ void kernel_main() {
                 target_drain_sync_core_x = get_arg_val<uint32_t>(device_offsets_idx++);
                 target_drain_sync_core_y = get_arg_val<uint32_t>(device_offsets_idx++);
             }
-            uint32_t custom_route_num_commands = 0;
-            uint32_t custom_route_initial_direction = default_initial_direction;
-            if constexpr (has_custom_fabric2d_routes) {
-                custom_route_num_commands = get_arg_val<uint32_t>(device_offsets_idx++);
-                custom_route_initial_direction = get_arg_val<uint32_t>(device_offsets_idx++);
-            }
-            const size_t custom_route_args_idx = device_offsets_idx;
-            device_offsets_idx += custom_fabric2d_route_words;
             const uint64_t target_output_semaphore_noc_addr =
                 is_fabric_2d
                     ? safe_get_noc_addr(target_drain_sync_core_x, target_drain_sync_core_y, global_semaphore_addr)
@@ -698,15 +610,13 @@ void kernel_main() {
                 pkt_hdr = pkt_hdr_backward;
             }
             if (device_offset != 0) {
-                set_target_unicast_route(pkt_hdr, route_info, custom_route_num_commands, custom_route_args_idx);
+                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, route_info);
             }
-            auto* target_connection = device_offset == 0 ? nullptr
-                                                         : &select_connection(
-                                                               fabric_connections,
-                                                               device_offset,
-                                                               route_info.dst_mesh_id,
-                                                               route_info.dst_chip_id,
-                                                               custom_route_initial_direction);
+            auto* target_connection =
+                device_offset == 0
+                    ? nullptr
+                    : &select_connection(
+                          fabric_connections, device_offset, route_info.dst_mesh_id, route_info.dst_chip_id);
 
             auto calculate_params = [&](int b) {
                 const uint32_t o = b / (concat_num_tiles * inner_dims_size);


### PR DESCRIPTION
## Problem

Generic all-to-all constructs and packs Fabric2D routes in TTNN for even-ring antipodes. This couples the op to Fabric packet-header encoding, route-buffer capacity, and spine/branch behavior, so routing changes such as express links can invalidate the op without updating its private route implementation.

## Fix

- Remove TTNN-owned hop-by-hop route calculation, representability checks, opcode packing, and custom-route runtime arguments.
- Remove direct mutation of `HybridMeshPacketHeader` routing fields.
- Use the shared `ccl_routing_utils::fabric_set_line_unicast_route` helper for packet routing.
- Select Fabric2D connections using Fabric canonical `get_next_hop_router_direction`.
- Keep physical-egress grouping, routing-plane link selection, per-chip drain coordinates, synchronization, and Fabric1D antipode splitting.
- Use canonical Fabric2D routing for antipodal destinations until Fabric exposes an arc-constrained routing API.

### Additional CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/remove-all-to-all-custom-fabric-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/remove-all-to-all-custom-fabric-routing)
