### PR TITLE
[Bug Fix] Resolve I2S and Slice Issues for Metal 2.0

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -774,6 +774,25 @@ def test_slice_output_tensor_tile_via_rm_path(device, steps):
     assert_equal(torch_output, ttnn.to_torch(ttnn_output))
 
 
+def test_slice_output_tensor_rm_dtype_mismatch_rejected(device, expect_error):
+    # compute_output_specs pins the output's dtype to the input's, but that check used to sit in the
+    # TILE-only branch of validate_on_program_cache_miss. A row-major input therefore accepted a
+    # mismatched pre-allocated output and the writer filled it with input-dtype bytes. The layout
+    # comparison now runs for every input layout, so this is rejected rather than miswritten.
+    torch_input = torch.rand(1, 3, 64, 64, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros(1, 3, 32, 64),
+        device=device,
+        dtype=ttnn.float32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    with expect_error(RuntimeError, "needs a layout of"):
+        ttnn.slice(ttnn_input, starts=(0, 0, 0, 0), ends=(1, 3, 32, 64), steps=(1, 1, 1, 1), output_tensor=ttnn_output)
+
+
 @pytest.mark.parametrize(
     "input_shape, input_start, input_ends",
     (

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -741,6 +741,39 @@ def test_slice_output_tensor_tile(device):
     assert_with_pcc(torch_output, ttnn_output, 0.99)
 
 
+@pytest.mark.parametrize("steps", [(1, 1, 2, 2), (1, 1, 1, 1)], ids=["strided", "unaligned_begins"])
+def test_slice_output_tensor_tile_via_rm_path(device, steps):
+    # A step, or a begin that isn't tile-aligned, sends a TILE input down the rm_only path, which
+    # retilizes the input to ROW_MAJOR before the device op. The caller's output tensor stays
+    # tile-paged, so it cannot be the device op's destination — the row-major factories would page
+    # it by row. The result must still land in the caller's buffer, via the closing copy.
+    starts = (0, 0, 0, 0) if steps != (1, 1, 1, 1) else (0, 0, 16, 0)
+    ends = (1, 3, 640, 640)
+
+    torch_input = torch.rand(1, 3, 640, 640, dtype=torch.bfloat16)
+    torch_output = torch_input[
+        starts[0] : ends[0] : steps[0],
+        starts[1] : ends[1] : steps[1],
+        starts[2] : ends[2] : steps[2],
+        starts[3] : ends[3] : steps[3],
+    ]
+
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros_like(torch_output),
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    ttnn.slice(ttnn_input, starts=starts, ends=ends, steps=steps, output_tensor=ttnn_output)
+
+    # Read back the caller's tensor, not slice's return value: the point is that the data landed
+    # in the preallocated buffer, in tile order.
+    assert_equal(torch_output, ttnn.to_torch(ttnn_output))
+
+
 @pytest.mark.parametrize(
     "input_shape, input_start, input_ends",
     (

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -141,13 +141,21 @@ InterleavedToShardedDeviceOperation::tensor_return_value_t InterleavedToShardedD
 ttsl::hash::hash_t InterleavedToShardedDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
+    // keep_l1_aligned is deliberately absent: the factory hardcodes it to true and never reads the
+    // attribute, so keying on it would split the cache between byte-identical programs.
     return tt::tt_metal::operation::hash_operation<InterleavedToShardedDeviceOperation>(
         operation_attributes.output_mem_config,
         operation_attributes.output_dtype,
-        operation_attributes.keep_l1_aligned,
         input_tensor.dtype(),
         input_tensor.memory_config(),
         input_tensor.layout(),
+        // Both shapes are needed. The row-major branch of the factory takes the reader's row stride
+        // from logical_shape()[-1] and the last core's shard height from logical_volume(), and
+        // neither is patched on a cache hit. Padded shape alone does not pin those: an interleaved
+        // input's alignment is unconstrained (validate_alignment_rm only checks the width alignment
+        // of a sharded tensor), so a logical [1, 1, 32, 60] with Alignment{64} and a logical
+        // [1, 1, 32, 64] with the default alignment both pad to [1, 1, 32, 64].
+        input_tensor.logical_shape(),
         input_tensor.padded_shape());
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -12,35 +12,32 @@
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t padded_stick_size = get_arg_val<uint32_t>(1);
-    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
-    const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
-    const uint32_t num_dims = get_arg_val<uint32_t>(4);
-    const uint32_t misalignment = get_arg_val<uint32_t>(5);
-    const uint32_t start_id = get_arg_val<uint32_t>(6);
-    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(7);
-    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(8);
-    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(9);
+    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(1);
+    const uint32_t stick_size_offset = get_arg_val<uint32_t>(2);
+    const uint32_t num_dims = get_arg_val<uint32_t>(3);
+    const uint32_t misalignment = get_arg_val<uint32_t>(4);
+    const uint32_t start_id = get_arg_val<uint32_t>(5);
+    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(6);
+    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(7);
+    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(8);
     // Sub-row chunking: `num_chunks_per_stick` NOC transfers of `chunk_size` per stick (last = `last_chunk_size`).
-    const uint32_t chunk_size = get_arg_val<uint32_t>(10);
-    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(11);
-    const uint32_t last_chunk_size = get_arg_val<uint32_t>(12);
+    const uint32_t chunk_size = get_arg_val<uint32_t>(9);
+    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(10);
+    const uint32_t last_chunk_size = get_arg_val<uint32_t>(11);
     // Byte offset of the slice's W-begin within a row, rounded down to the source buffer's alignment;
     // the leftover `misalignment` bytes are trimmed on-device by the tt_memmove below.
-    const uint32_t src_offset_bytes = get_arg_val<uint32_t>(13);
+    const uint32_t src_offset_bytes = get_arg_val<uint32_t>(12);
 
-    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(14));
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(13));
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
     constexpr auto src_args = TensorAccessorArgs<0>();
     uint32_t read_size = unpadded_stick_size + misalignment;
 
-    // padded_stick_size = per-shard page size (shard_W on B/W-sharded, full row otherwise);
-    // feeds `noc_async_read_sharded`'s multi-shard split via `get_aligned_page_size()`.
     // The accessor base stays the unshifted buffer base: Metal 2.0 supplies it from the tensor binding
     // and offers no seam for a pre-offset base. The W-begin shift rides each read as `src_offset_bytes`.
-    const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
+    const auto s0 = TensorAccessor(src_args, src_addr);
 
     constexpr uint32_t dfb_id_in0 = 0;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -17,19 +17,16 @@ void kernel_main() {
     uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(4);
     uint32_t num_read_per_barrier = get_arg_val<uint32_t>(5);
     uint32_t start_id = get_arg_val<uint32_t>(6);
-    // Per-shard page size: shard_W on B/W-sharded outputs, full row otherwise.
-    // Feeds `noc_async_write_sharded`'s multi-shard split via `get_aligned_page_size()`.
-    uint32_t page_size_override = get_arg_val<uint32_t>(7);
     // Sub-row chunking (mirrors reader): `num_chunks_per_stick` CB pages of `chunk_size` per stick (last =
     // `last_chunk_size`).
-    const uint32_t chunk_size = get_arg_val<uint32_t>(8);
-    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(9);
-    const uint32_t last_chunk_size = get_arg_val<uint32_t>(10);
+    const uint32_t chunk_size = get_arg_val<uint32_t>(7);
+    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(8);
+    const uint32_t last_chunk_size = get_arg_val<uint32_t>(9);
 
     constexpr uint32_t dfb_id_out0 = get_compile_time_arg_val(0);
     constexpr auto dst_args = TensorAccessorArgs<1>();
 
-    const auto s0 = TensorAccessor(dst_args, dst_addr, page_size_override);
+    const auto s0 = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
     // Create DataflowBuffer for Device 2.0 API

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -142,13 +142,29 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
             args.slice_end[i]);
     }
     if (tensor_args.preallocated_output.has_value()) {
-        const auto output_shape_required = compute_output_specs(args, tensor_args).logical_shape();
+        const auto spec_required = compute_output_specs(args, tensor_args);
         const auto& out_tensor = tensor_args.preallocated_output.value();
+        // Padded, not logical: ttnn::slice pads the tile-path ends up to a tile boundary before
+        // calling here and views the result back down afterwards, so the caller's tensor legitimately
+        // carries the unpadded logical shape. Both shapes coincide on the row-major path.
         TT_FATAL(
-            out_tensor.padded_shape() == output_shape_required,
-            "The preallocated output tensor needs a shape of {}, however it is {}",
-            output_shape_required,
+            out_tensor.padded_shape() == spec_required.padded_shape(),
+            "The preallocated output tensor needs a padded shape of {}, however it is {}",
+            spec_required.padded_shape(),
             out_tensor.padded_shape());
+        // create_output_tensors hands the program the caller's tensor verbatim, so the destination's
+        // page geometry has to be what the factories were built against. One comparison covers dtype,
+        // page_config, memory_config and alignment — including the fields compute_program_hash omits.
+        // page_config is the load-bearing one: the writer's TensorAccessorArgs bakes the destination's
+        // aligned page size in as a compile-time word, and for a tile-paged buffer that size is
+        // tile.get_tile_size(dtype), so two outputs differing only in tile would share one program
+        // whose writer addresses the wrong page offsets. A mismatch here is a caller error in every
+        // case, so reject it rather than key on it.
+        TT_FATAL(
+            out_tensor.tensor_spec().tensor_layout() == spec_required.tensor_layout(),
+            "The preallocated output tensor needs a layout of {}, however it is {}",
+            spec_required.tensor_layout(),
+            out_tensor.tensor_spec().tensor_layout());
     }
     auto output_tensor_shape = compute_output_specs(args, tensor_args).logical_shape();
     if (has_step) {  // if all ones modify before passing in to function
@@ -172,30 +188,6 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
             "slice does not currently support tiles other than 32x32, got {}x{}",
             tile.get_height(),
             tile.get_width());
-        if (tensor_args.preallocated_output.has_value()) {
-            const auto& out_tensor = tensor_args.preallocated_output.value();
-            // Layout and dtype must be checked before the tile: PageConfig::get_tile() reports a default
-            // 32x32 Tile for a ROW_MAJOR tensor, so the comparison below would accept one. Both properties
-            // are pinned to the input by compute_output_specs, which is what the tile factories are built
-            // against, so this rejects only combinations the op never produced for itself.
-            TT_FATAL(
-                out_tensor.layout() == Layout::TILE,
-                "The preallocated output tensor must be TILE layout to match the input, but it has {} layout",
-                out_tensor.layout());
-            TT_FATAL(
-                out_tensor.dtype() == tensor_args.input.dtype(),
-                "The preallocated output tensor dtype ({}) must match the input tensor dtype ({})",
-                out_tensor.dtype(),
-                tensor_args.input.dtype());
-            const auto out_tile = out_tensor.tensor_spec().tile();
-            TT_FATAL(
-                out_tile == tile,
-                "The preallocated output tensor tile ({}x{}) must match the input tensor tile ({}x{})",
-                out_tile.get_height(),
-                out_tile.get_width(),
-                tile.get_height(),
-                tile.get_width());
-        }
         TT_FATAL(
             tensor_args.input.physical_volume() % TILE_HW == 0,
             "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -146,12 +146,25 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
         const auto& out_tensor = tensor_args.preallocated_output.value();
         // Padded, not logical: ttnn::slice pads the tile-path ends up to a tile boundary before
         // calling here and views the result back down afterwards, so the caller's tensor legitimately
-        // carries the unpadded logical shape. Both shapes coincide on the row-major path.
+        // carries a smaller logical shape than the spec. That licence is tile-only; see below.
         TT_FATAL(
             out_tensor.padded_shape() == spec_required.padded_shape(),
             "The preallocated output tensor needs a padded shape of {}, however it is {}",
             spec_required.padded_shape(),
             out_tensor.padded_shape());
+        // Row-major ends are passed through unpadded, so here the caller's logical shape has to match
+        // exactly too, and padded-versus-padded does not imply it: a sharded output's alignment is its
+        // shard width, so any logical width in the same shard column pads to the same value.
+        // SliceRmShardedProgramFactory sizes each row's copy from output.logical_shape()[-1] -- the one
+        // place any factory reads the logical shape -- so a short one there copies part of every row
+        // and leaves the remainder untouched, with no error.
+        if (tensor_args.input.layout() == Layout::ROW_MAJOR) {
+            TT_FATAL(
+                out_tensor.logical_shape() == spec_required.logical_shape(),
+                "The preallocated output tensor needs a logical shape of {}, however it is {}",
+                spec_required.logical_shape(),
+                out_tensor.logical_shape());
+        }
         // create_output_tensors hands the program the caller's tensor verbatim, so the destination's
         // page geometry has to be what the factories were built against. One comparison covers dtype,
         // page_config, memory_config and alignment — including the fields compute_program_hash omits.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -284,7 +284,8 @@ SliceCbSizing compute_cb_size(
 // size TensorAccessorArgs bakes into the compile-time args. That is interchangeable with the
 // per-shard page size they used to be handed only where the two agree: exactly, on a sharded buffer,
 // whose accessor strides by the value verbatim and whose `noc_async_*_sharded` splits pages by it;
-// and up to rounding on an interleaved one, where InterleavedAddrGen re-aligns internally. On a
+// and up to rounding on an interleaved one, whose accessor rounds the page size up to the allocator
+// alignment internally before using it as a stride, so a raw row and a pre-rounded one coincide. On a
 // block/width-sharded buffer that reduces to the shard row being a multiple of the buffer alignment,
 // which `has_subaligned_shard_row` guarantees for anything arriving via ttnn::slice -- but
 // MeshPartition builds these programs straight off select_program_factory and never sees that guard.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -280,6 +280,32 @@ SliceCbSizing compute_cb_size(
     return s;
 }
 
+// Both RM kernels build their TensorAccessor from the two-arg form, so each takes the aligned page
+// size TensorAccessorArgs bakes into the compile-time args. That is interchangeable with the
+// per-shard page size they used to be handed only where the two agree: exactly, on a sharded buffer,
+// whose accessor strides by the value verbatim and whose `noc_async_*_sharded` splits pages by it;
+// and up to rounding on an interleaved one, where InterleavedAddrGen re-aligns internally. On a
+// block/width-sharded buffer that reduces to the shard row being a multiple of the buffer alignment,
+// which `has_subaligned_shard_row` guarantees for anything arriving via ttnn::slice -- but
+// MeshPartition builds these programs straight off select_program_factory and never sees that guard.
+void check_accessor_page_size(const Tensor& t, uint32_t row_bytes, const char* role) {
+    const auto* buffer = t.buffer();
+    const uint32_t alignment = buffer->alignment();
+    const uint32_t aligned_page_size = static_cast<uint32_t>(buffer->aligned_page_size());
+    const uint32_t per_shard = per_shard_page_size_bytes(t, row_bytes);
+    const uint32_t effective = t.memory_config().is_sharded() ? per_shard : tt::round_up(per_shard, alignment);
+    TT_FATAL(
+        effective == aligned_page_size,
+        "ttnn::slice: {} per-shard page size {} B disagrees with the accessor's aligned page size {} B "
+        "({} B is not a multiple of the {} B buffer alignment). Reach this op through ttnn::slice, which "
+        "reshards such tensors, rather than building the program factory directly.",
+        role,
+        effective,
+        aligned_page_size,
+        per_shard,
+        alignment);
+}
+
 }  // namespace
 
 }  // namespace ttnn::operations::data_movement
@@ -303,6 +329,14 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
     tt::tt_metal::Buffer* src0_buffer = input.buffer();
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // The kernels take the accessor's compile-time page size rather than a runtime one, so pin the
+    // equivalence here: a route that skips slice.cpp's resharding guard fails loudly instead of
+    // striding by the wrong page.
+    ttnn::operations::data_movement::check_accessor_page_size(
+        input, input.padded_shape()[-1] * input.element_size(), "input");
+    ttnn::operations::data_movement::check_accessor_page_size(
+        output, output.padded_shape()[-1] * input.element_size(), "output");
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -48,7 +48,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     auto input_shape = input_tensor.padded_shape();
     auto output_shape = output_tensor.padded_shape();
 
-    uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
@@ -83,12 +82,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t misalignment = begins_bytes % src_buffer_alignment;
     uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
 
-    const uint32_t reader_page_size = per_shard_page_size_bytes(input_tensor, padded_row_size_bytes);
-
     // Reader arg 0 is the plain input buffer base address; it is emitted as a Buffer* binding in
     // create_descriptor (not here), so the args returned here start at arg 1.
     std::vector<uint32_t> common_reader_kernel_args = {
-        reader_page_size,
         unpadded_row_size_bytes,
         unpadded_row_size_bytes_offset,
         num_dims,
@@ -145,14 +141,13 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
         }
         std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        uint32_t addr_offset = 5;
+        uint32_t addr_offset = 4;
         reader_kernel_args[addr_offset++] = start_id;
         reader_kernel_args[addr_offset++] = num_sticks_per_core;
         reader_kernel_args[addr_offset++] = num_sticks_per_core_read;
         reader_kernel_args[addr_offset] = num_read_per_barrier;
         reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
-        const uint32_t writer_page_size = per_shard_page_size_bytes(output_tensor, unpadded_row_size_bytes);
         // Writer arg 0 is the plain output buffer base address; it is emitted as a Buffer* binding in
         // create_descriptor (not here), so the args returned here start at arg 1.
         std::vector<uint32_t> writer_kernel_args = {
@@ -162,7 +157,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             num_sticks_per_core_read,
             num_read_per_barrier,
             num_sticks_written,
-            writer_page_size,
             chunking.chunk_size,
             chunking.num_chunks_per_stick,
             chunking.last_chunk_size,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -388,6 +388,13 @@ ttnn::Tensor slice(
             input_tensor.device(),
             memory_config_arg.value_or(input_tensor.memory_config()));
     }
+    // prim::slice writes into the caller's buffer verbatim, so it can only be the destination when the
+    // buffer's page geometry matches the output the op computes for `input`. rm_only downgrades a TILE
+    // input to ROW_MAJOR, which leaves the caller's TILE tensor tile-paged while the RM factories page
+    // it by row; hand it over only when the layouts agree and let ret_adjustment retilize into it via
+    // finalize_into_preallocated's copy otherwise.
+    const auto prim_output =
+        (optional_output_tensor.has_value() && can_land_in_preallocated(input)) ? optional_output_tensor : std::nullopt;
     auto res = ttnn::prim::slice(
         input,
         ttnn::Shape(modified_begins),
@@ -400,7 +407,7 @@ ttnn::Tensor slice(
         std::nullopt,
         std::nullopt,
         sub_core_grids,
-        optional_output_tensor);
+        prim_output);
     res = ttnn::experimental::view(res, actual_shape, final_padded_shape);
 
     auto dim_needs_fill = [&input_shape, &actual_shape, &final_padded_shape](int i) {


### PR DESCRIPTION
### Summary
This PR fixes small issues in two data movement ops, which are necessary to prepare them for Metal 2.0 porting. 



**Slice**: Validate the pre-allocated output on every input layout

Move the pre-allocated output checks out of the TILE-only branch and
express them as one TensorLayout comparison against compute_output_specs,
which also covers the page_config the hash omits; stop handing the
caller's tensor to prim::slice on the rm_only path, where a retilized
input left it paged by row.


**Slice**: Remove Superfluous Third TensorAccessor Arguments
Of the slice op's 13 TensorAccessor constructions, only two passed a third argument — the RM reader and the RM writer, both fed from per_shard_page_size_bytes. The other 11 already used the two-arg form; this brings those two in line and deletes the host-side computation, renumbering the runtime args after each removed slot.

No functional change on any configuration that reaches these kernels. On a sharded buffer the value passed and the compile-time page size are the same number: has_subaligned_shard_row in slice.cpp reroutes any block/width-sharded input or output whose shard row is not a multiple of the buffer alignment, and for height-sharded the helper already returned aligned_page_size(). On an interleaved buffer the two differ — the kernel was receiving the raw row and now gets it rounded up to alignment — but the stride is identical, because InterleavedAddrGen applies exactly that rounding internally.

That equivalence is a property of slice, not of per_shard_page_size_bytes, which does not in general return the aligned page size. `gather` calls the same helper at six third-argument sites with no comparable guard, so the substitution is not safe there as-is. And because the guarantee rests on a guard in slice.cpp that MeshPartition bypasses — it builds these programs straight off select_program_factory — create_descriptor now asserts the equivalence for both tensors, so a route around the guard fails loudly instead of striding by the wrong page.

Overall, this change leaves both accessors fully described by their tensor bindings, which simplifies the Metal 2.0 port.




**I2S**: hash the logical shape
The row-major branch sizes the reader's row stride and the last core's
shard height from logical_shape/logical_volume, neither of which is
patched on a cache hit, so two inputs sharing a padded shape but
differing in alignment collide; also drop keep_l1_aligned, which the
factory hardcodes and never reads.

Sanity is matching the SDXL failure from main.
Nightly L2 data_movement failure is a timeout and a tilize issue that match main and are unrelated to this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/DM_Cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/DM_Cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/DM_Cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/DM_Cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/DM_Cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/DM_Cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/DM_Cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/DM_Cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/DM_Cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/DM_Cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/DM_Cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/DM_Cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/DM_Cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/DM_Cleanup)