### PR TITLE
[Cleanup] Downgrade cross node dfb to just do unicast or broadcast to receivers

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
@@ -107,8 +107,7 @@ TEST_F(CrossNodeDFBFixture, ProgramCrossNodeDFBsAPI) {
         EXPECT_FALSE(program.impl().get_per_core_cross_node_dfbs().empty());
         const auto& kernel_groups = program.impl().get_kernel_groups(index);
         ASSERT_FALSE(kernel_groups.empty());
-        EXPECT_NE(
-            kernel_groups[0]->launch_msg.view().kernel_config().cross_node_dfb_offset(), REMOTE_DFB_OFFSET_NONE);
+        EXPECT_NE(kernel_groups[0]->launch_msg.view().kernel_config().cross_node_dfb_offset(), REMOTE_DFB_OFFSET_NONE);
     }
     // UpdateDynamicCrossNodeDFBAddress: valid case - retargets to a distinct matching buffer.
     {
@@ -808,8 +807,7 @@ TEST_F(CrossNodeDFBFixture, CrossNodeDFB_BasicPushPop_1to1) {
     const uint32_t entry_size = 256;
     const uint32_t num_entries = 4;
 
-    // write_primitive=2: write_to_receiver(0) then push_back (1:1 uses receiver index 0).
-    uint32_t pass = run_1toN_program(mesh_device, sender_core, receiver_cores, entry_size, num_entries, 2);
+    uint32_t pass = run_1toN_program(mesh_device, sender_core, receiver_cores, entry_size, num_entries, 0);
     EXPECT_EQ(pass, 1u) << "1:1 basic push/pop failed";
 }
 
@@ -878,69 +876,6 @@ TEST_F(CrossNodeDFBFixture, CrossNodeDFB_WriteBroadcast_1to4) {
 
     uint32_t pass = run_1toN_program(mesh_device, sender_core, receiver_cores, entry_size, num_entries, 0);
     EXPECT_EQ(pass, 4u) << "write_broadcast 1:4 failed";
-}
-
-TEST_F(CrossNodeDFBFixture, CrossNodeDFB_WriteStrided_1to4) {
-    auto mesh_device = devices_[0];
-
-    CoreCoord sender_core(0, 0);
-    CoreRangeSet receiver_cores(CoreRange({1, 0}, {4, 0}));
-
-    const uint32_t entry_size = 256;
-    const uint32_t num_entries = 4;
-
-    // write_primitive=1: sender writes interleaved, each receiver verifies its index pattern.
-    uint32_t pass = run_1toN_program(mesh_device, sender_core, receiver_cores, entry_size, num_entries, 1);
-    EXPECT_EQ(pass, 4u) << "write_strided 1:4 failed";
-}
-
-TEST_F(CrossNodeDFBFixture, CrossNodeDFB_WriteToReceiver_ReceiverContiguous) {
-    auto mesh_device = devices_[0];
-
-    CoreCoord sender_core(0, 0);
-    CoreRangeSet receiver_cores(CoreRange({1, 0}, {4, 0}));
-
-    const uint32_t entry_size = 256;
-    const uint32_t num_entries = 4;
-
-    // write_primitive=2: write_to_receiver N times then collective push_back.
-    // Each receiver gets its unique data (receiver_idx pattern).
-    uint32_t pass = run_1toN_program(mesh_device, sender_core, receiver_cores, entry_size, num_entries, 2);
-    EXPECT_EQ(pass, 4u) << "write_to_receiver (receiver-contiguous) 1:4 failed";
-}
-
-TEST_F(CrossNodeDFBFixture, CrossNodeDFB_RoundRobinPushBackToReceiver) {
-    auto mesh_device = devices_[0];
-
-    CoreCoord sender_core(0, 0);
-    CoreRangeSet receiver_cores(CoreRange({1, 0}, {4, 0}));
-
-    const uint32_t entry_size = 256;
-    const uint32_t num_entries = 1;
-
-    // write_primitive=3: write_to_receiver + push_back_to_receiver per iteration.
-    uint32_t pass = run_1toN_program(mesh_device, sender_core, receiver_cores, entry_size, num_entries, 3);
-    EXPECT_EQ(pass, 4u) << "write_to_receiver + push_back_to_receiver round-robin failed";
-}
-
-TEST_F(CrossNodeDFBFixture, CrossNodeDFB_PerReceiverCreditInterleaved_RingDepth4) {
-    // Per-receiver credit with a ring deeper than one entry, pushed entry-major so the
-    // receivers are never in lockstep: receiver 0 is credited entry i while receiver 1 is
-    // still one entry behind. Every receiver must still see entry i at slot i, which only
-    // holds if the sender keeps an independent write position per receiver (derived from
-    // that receiver's entries_sent credits). A single shared cursor places receiver r's
-    // entry i at slot (i * num_receivers + r) % depth, so the rings come back rotated and
-    // partly overwritten.
-    auto mesh_device = devices_[0];
-
-    CoreCoord sender_core(0, 0);
-    CoreRangeSet receiver_cores(CoreRange({1, 0}, {2, 0}));
-
-    const uint32_t entry_size = 256;
-    const uint32_t num_entries = 4;
-
-    uint32_t pass = run_1toN_program(mesh_device, sender_core, receiver_cores, entry_size, num_entries, 5);
-    EXPECT_EQ(pass, 2u) << "Interleaved push_back_to_receiver must keep an independent write position per receiver";
 }
 
 TEST_F(CrossNodeDFBFixture, CrossNodeDFB_DecoupledWriteThenCredit) {
@@ -1211,8 +1146,7 @@ TEST_F(CrossNodeDFBFixture, CrossNodeDFB_BorrowedMemoryPushPop_1to1) {
 
     const uint32_t entry_size = 256;
     const uint32_t num_entries = 4;
-    constexpr uint32_t data_pattern =
-        static_cast<uint32_t>(cross_node_dfb_test::SenderDataPattern::PerReceiverConstant);
+    constexpr uint32_t data_pattern = static_cast<uint32_t>(cross_node_dfb_test::SenderDataPattern::MulticastCounter);
 
     auto user_data = cross_node_dfb_test::make_cross_node_data_buffer(device, all_cores, entry_size, num_entries);
     tt_metal::Program program = CreateProgram();
@@ -1231,8 +1165,7 @@ TEST_F(CrossNodeDFBFixture, CrossNodeDFB_BorrowedMemoryPushPop_1to1) {
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::NOC::RISCV_0_default,
-            // write_primitive=2: write_to_receiver(0) for 1:1
-            .compile_args = {remote_dfb_id, entry_size, num_entries, 2u, data_pattern, 0u}});
+            .compile_args = {remote_dfb_id, entry_size, num_entries, 0u, data_pattern, 0u}});
     tt::tt_metal::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/cross_node_dfb_receiver.cpp",
@@ -1597,14 +1530,7 @@ CrossNodeTracePushPop make_1to1_trace_push_pop(distributed::MeshDevice& device) 
     cross_node_dfb_test::set_sender_l1_staging_runtime_args(
         program, sender_k, ctx.sender_cores, *ctx.gdfb, staging_size);
     cross_node_dfb_test::write_sender_l1_staging(
-        device,
-        ctx.sender_cores,
-        *ctx.gdfb,
-        ctx.data_pattern,
-        ctx.entry_size,
-        ctx.num_entries,
-        1,
-        ctx.counter_base);
+        device, ctx.sender_cores, *ctx.gdfb, ctx.data_pattern, ctx.entry_size, ctx.num_entries, 1, ctx.counter_base);
 
     ctx.workload.add_program(unit_mesh_device_range(), std::move(program));
     return ctx;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/cross_node_dfb_relay_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/cross_node_dfb_relay_sender.cpp
@@ -24,12 +24,13 @@ void kernel_main() {
     constexpr uint32_t batch_size = get_compile_time_arg_val(3);
 
     const uint32_t staging_base = get_arg_val<uint32_t>(0);
+    const CoreLocalMem<uint8_t> staging(staging_base);
     Noc noc;
     experimental::CrossNodeDFB cn_dfb(remote_dfb_id);
 
     for (uint32_t offset = 0; offset < total_entries; offset += batch_size) {
         cn_dfb.reserve_back(batch_size);
-        cn_dfb.write_broadcast(staging_base + offset * entry_size, batch_size, noc);
+        cn_dfb.write_broadcast(noc, staging, batch_size, {.offset_bytes = offset * entry_size});
         cn_dfb.flush_writes(noc);
         cn_dfb.push_back(batch_size, noc);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/cross_node_dfb_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/cross_node_dfb_sender.cpp
@@ -8,13 +8,9 @@
 //   [0] remote_dfb_id      - runtime-assigned slot (CreateCrossNodeDFB remote_dfb_id on host)
 //   [1] entry_size         - bytes per entry (must be L1_ALIGNMENT multiple)
 //   [2] num_entries        - number of entries to push per receiver
-//   [3] write_primitive    - 0=write_broadcast, 1=write_strided,
-//                            2=write_to_receiver(r)+push_back (1:1 uses r=0),
-//                            3=write_to_receiver+push_back_to_receiver (per-receiver credit),
-//                            4=decoupled: reserve(n) + write_broadcast(n) + flush + push_back(n),
-//                            5=per-receiver credit interleaved across receivers (entry-major)
-//   [4] data_pattern       - 0=multicast counter layout, 1=strided per-receiver layout,
-//                            2=per-receiver constant layout (see cross_node_dfb_test_utils.hpp)
+//   [3] write_primitive    - 0=write_broadcast per entry,
+//                            4=decoupled: reserve(n) + write_broadcast(n) + flush + push_back(n)
+//   [4] data_pattern       - 0=multicast counter layout (see cross_node_dfb_test_utils.hpp)
 //   [5] do_barrier         - 1 to call barrier() after pushing all entries
 //
 // Runtime args:
@@ -36,8 +32,6 @@ void kernel_main() {
 
     // Must match SenderDataPattern in cross_node_dfb_test_utils.hpp.
     constexpr uint32_t pattern_multicast_counter = 0;
-    constexpr uint32_t pattern_strided_per_receiver = 1;
-    constexpr uint32_t pattern_per_receiver_constant = 2;
 
     const uint32_t staging_base = get_arg_val<uint32_t>(0);
 
@@ -54,19 +48,9 @@ void kernel_main() {
         write_primitive != 0 || data_pattern == pattern_multicast_counter,
         "write_broadcast expects multicast counter staging");
     static_assert(
-        write_primitive != 1 || data_pattern == pattern_strided_per_receiver, "write_strided expects strided staging");
-    static_assert(
-        write_primitive != 2 || data_pattern == pattern_per_receiver_constant,
-        "write_to_receiver expects per-receiver staging");
-    static_assert(
-        write_primitive != 3 || data_pattern == pattern_per_receiver_constant,
-        "push_back_to_receiver expects per-receiver staging");
-    static_assert(
         write_primitive != 4 || data_pattern == pattern_multicast_counter,
         "decoupled write_broadcast expects multicast counter staging");
-    static_assert(
-        write_primitive != 5 || data_pattern == pattern_multicast_counter,
-        "interleaved per-receiver credit expects multicast counter staging");
+    static_assert(write_primitive == 0 || write_primitive == 4, "Unsupported CrossNodeDFB write primitive");
 
     if constexpr (write_primitive == 0) {
         for (uint32_t i = 0; i < num_entries; ++i) {
@@ -80,57 +64,14 @@ void kernel_main() {
             gdfb.push_back(1, noc);
             DPRINT("Done push back\n");
         }
-    } else if constexpr (write_primitive == 1) {
-        const uint32_t num_recv = gdfb.num_receivers();
-        const uint32_t row_bytes = num_recv * entry_size;
-        for (uint32_t i = 0; i < num_entries; ++i) {
-            gdfb.reserve_back(1);
-            gdfb.write_strided(staging_addr(staging_base, i * row_bytes), 1, 1, entry_size, noc);
-            gdfb.flush_writes(noc);
-            gdfb.push_back(1, noc);
-        }
-    } else if constexpr (write_primitive == 2) {
-        const uint32_t num_recv = gdfb.num_receivers();
-        for (uint32_t i = 0; i < num_entries; ++i) {
-            gdfb.reserve_back(1);
-            for (uint32_t r = 0; r < num_recv; ++r) {
-                gdfb.write_to_receiver(r, staging_addr(staging_base, r * entry_size), 1, noc);
-            }
-            gdfb.flush_writes(noc);
-            gdfb.push_back(1, noc);
-        }
-    } else if constexpr (write_primitive == 3) {
-        const uint32_t num_recv = gdfb.num_receivers();
-        for (uint32_t r = 0; r < num_recv; ++r) {
-            for (uint32_t i = 0; i < num_entries; ++i) {
-                gdfb.reserve_back_for_receiver(r, 1);
-                gdfb.write_to_receiver(r, staging_addr(staging_base, r * entry_size), 1, noc);
-                gdfb.flush_writes(noc);
-                gdfb.push_back_to_receiver(r, 1, noc);
-            }
-        }
     } else if constexpr (write_primitive == 4) {
         // Layered contract: all payload writes land before any pages_sent credit.
-        // write_* does not advance fifo_wr_ptr, so one write_broadcast(n) covers the slot;
+        // write_broadcast does not advance the write position, so one call covers the slot;
         // a single push_back(n) then publishes credit for the whole batch.
         gdfb.reserve_back(num_entries);
         gdfb.write_broadcast(staging_base, num_entries, noc);
         gdfb.flush_writes(noc);
         gdfb.push_back(num_entries, noc);
-    } else if constexpr (write_primitive == 5) {
-        // Entry-major per-receiver credit: every receiver gets entry i before entry i+1.
-        // Each receiver must still land entry i in its own slot i, which only holds if the
-        // sender derives an independent write position per receiver from its credits
-        // rather than sharing one cursor for the slot.
-        const uint32_t num_recv = gdfb.num_receivers();
-        for (uint32_t i = 0; i < num_entries; ++i) {
-            for (uint32_t r = 0; r < num_recv; ++r) {
-                gdfb.reserve_back_for_receiver(r, 1);
-                gdfb.write_to_receiver(r, staging_addr(staging_base, i * entry_size), 1, noc);
-                gdfb.flush_writes(noc);
-                gdfb.push_back_to_receiver(r, 1, noc);
-            }
-        }
     }
 
     if constexpr (do_barrier) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/cross_node_dfb_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/cross_node_dfb_sender.cpp
@@ -17,10 +17,7 @@
 //   [0] l1_staging_addr    - sender-local L1 scratch region pre-populated by the host
 
 #include "api/dataflow/cross_node_dfb.h"
-#include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc.h"
-
-FORCE_INLINE uint32_t staging_addr(uint32_t staging_base, uint32_t byte_offset) { return staging_base + byte_offset; }
 
 void kernel_main() {
     constexpr uint8_t remote_dfb_id = get_compile_time_arg_val(0);
@@ -34,13 +31,13 @@ void kernel_main() {
     constexpr uint32_t pattern_multicast_counter = 0;
 
     const uint32_t staging_base = get_arg_val<uint32_t>(0);
+    const CoreLocalMem<uint8_t> staging(staging_base);
 
     Noc noc;
     // Spot-check: log first byte of each entry (host pre-populated staging)
     DPRINT("l1_staging_addr: 0x{:x}\n", staging_base);
 
     experimental::CrossNodeDFB gdfb(remote_dfb_id);
-    DPRINT("gdfb initial write_ptr: 0x{:x}\n", gdfb.get_write_ptr());
 
     DPRINT("Running write_primitive: {}\n", write_primitive);
 
@@ -56,8 +53,8 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_entries; ++i) {
             DPRINT("Reserving back for broadcast\n");
             gdfb.reserve_back(1);
-            DPRINT("Done reserve back for broadcast to {}\n", staging_addr(staging_base, i * entry_size));
-            gdfb.write_broadcast(staging_addr(staging_base, i * entry_size), 1, noc);
+            DPRINT("Done reserve back for broadcast to {}\n", staging_base + i * entry_size);
+            gdfb.write_broadcast(noc, staging, 1, {.offset_bytes = i * entry_size});
             DPRINT("Done write broadcast\n");
             gdfb.flush_writes(noc);
             DPRINT("Done posted write flush\n");
@@ -69,7 +66,7 @@ void kernel_main() {
         // write_broadcast does not advance the write position, so one call covers the slot;
         // a single push_back(n) then publishes credit for the whole batch.
         gdfb.reserve_back(num_entries);
-        gdfb.write_broadcast(staging_base, num_entries, noc);
+        gdfb.write_broadcast(noc, staging, num_entries);
         gdfb.flush_writes(noc);
         gdfb.push_back(num_entries, noc);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_coordinated_resize_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_coordinated_resize_sender.cpp
@@ -47,6 +47,7 @@ void kernel_main() {
     static_assert(num_entries_e1 > 0, "E1 phase must push at least one entry before resize");
 
     const uint32_t staging_base = get_arg_val<uint32_t>(0);
+    const CoreLocalMem<uint8_t> staging(staging_base);
     volatile tt_l1_ptr uint32_t* resized_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(1));
     volatile tt_l1_ptr uint32_t* go_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(2));
 
@@ -55,7 +56,7 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < num_entries_e1; ++i) {
         gdfb.reserve_back(1);
-        gdfb.write_broadcast(staging_base + i * entry_size_e1, 1, noc);
+        gdfb.write_broadcast(noc, staging, 1, {.offset_bytes = i * entry_size_e1});
         gdfb.flush_writes(noc);
         gdfb.push_back(1, noc);
     }
@@ -65,10 +66,10 @@ void kernel_main() {
     noc_semaphore_set(resized_sem, 1);
     noc_semaphore_wait(go_sem, 1);
 
-    const uint32_t staging_e2 = staging_base + num_entries_e1 * entry_size_e1;
+    const uint32_t staging_e2_offset = num_entries_e1 * entry_size_e1;
     for (uint32_t i = 0; i < num_entries_e2; ++i) {
         gdfb.reserve_back(1);
-        gdfb.write_broadcast(staging_e2 + i * entry_size_e2, 1, noc);
+        gdfb.write_broadcast(noc, staging, 1, {.offset_bytes = staging_e2_offset + i * entry_size_e2});
         gdfb.flush_writes(noc);
         gdfb.push_back(1, noc);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_sender.cpp
@@ -21,10 +21,7 @@
 //   [0] l1_staging_addr    - sender-local L1 scratch region pre-populated by the host
 
 #include "api/dataflow/prefetcher_pipe.h"
-#include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc.h"
-
-FORCE_INLINE uint32_t staging_addr(uint32_t staging_base, uint32_t byte_offset) { return staging_base + byte_offset; }
 
 void kernel_main() {
     constexpr uint8_t prefetcher_pipe_id = get_compile_time_arg_val(0);
@@ -40,6 +37,7 @@ void kernel_main() {
     constexpr uint32_t pattern_per_receiver_constant = 2;
 
     const uint32_t staging_base = get_arg_val<uint32_t>(0);
+    const CoreLocalMem<uint8_t> staging(staging_base);
 
     Noc noc;
     // Spot-check: log first byte of each entry (host pre-populated staging)
@@ -71,8 +69,8 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_entries; ++i) {
             DPRINT("Reserving back for broadcast\n");
             gdfb.reserve_back(1);
-            DPRINT("Done reserve back for broadcast to {}\n", staging_addr(staging_base, i * entry_size));
-            gdfb.write_broadcast(staging_addr(staging_base, i * entry_size), 1, noc);
+            DPRINT("Done reserve back for broadcast to {}\n", staging_base + i * entry_size);
+            gdfb.write_broadcast(noc, staging, 1, {.offset_bytes = i * entry_size});
             DPRINT("Done write broadcast\n");
             gdfb.flush_writes(noc);
             DPRINT("Done posted write flush\n");
@@ -84,7 +82,7 @@ void kernel_main() {
         const uint32_t row_bytes = num_recv * entry_size;
         for (uint32_t i = 0; i < num_entries; ++i) {
             gdfb.reserve_back(1);
-            gdfb.write_strided(staging_addr(staging_base, i * row_bytes), 1, 1, entry_size, noc);
+            gdfb.write_strided(noc, staging, 1, 1, entry_size, {.offset_bytes = i * row_bytes});
             gdfb.flush_writes(noc);
             gdfb.push_back(1, noc);
         }
@@ -93,7 +91,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_entries; ++i) {
             gdfb.reserve_back(1);
             for (uint32_t r = 0; r < num_recv; ++r) {
-                gdfb.write_to_receiver(r, staging_addr(staging_base, r * entry_size), 1, noc);
+                gdfb.write_to_receiver(noc, r, staging, 1, {.offset_bytes = r * entry_size});
             }
             gdfb.flush_writes(noc);
             gdfb.push_back(1, noc);
@@ -103,7 +101,7 @@ void kernel_main() {
         for (uint32_t r = 0; r < num_recv; ++r) {
             for (uint32_t i = 0; i < num_entries; ++i) {
                 gdfb.reserve_back_for_receiver(r, 1);
-                gdfb.write_to_receiver(r, staging_addr(staging_base, r * entry_size), 1, noc);
+                gdfb.write_to_receiver(noc, r, staging, 1, {.offset_bytes = r * entry_size});
                 gdfb.flush_writes(noc);
                 gdfb.push_back_to_receiver(r, 1, noc);
             }
@@ -113,7 +111,7 @@ void kernel_main() {
         // write_* does not advance fifo_wr_ptr, so one write_broadcast(n) covers the slot;
         // a single push_back(n) then publishes credit for the whole batch.
         gdfb.reserve_back(num_entries);
-        gdfb.write_broadcast(staging_base, num_entries, noc);
+        gdfb.write_broadcast(noc, staging, num_entries);
         gdfb.flush_writes(noc);
         gdfb.push_back(num_entries, noc);
     } else if constexpr (write_primitive == 5) {
@@ -125,7 +123,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_entries; ++i) {
             for (uint32_t r = 0; r < num_recv; ++r) {
                 gdfb.reserve_back_for_receiver(r, 1);
-                gdfb.write_to_receiver(r, staging_addr(staging_base, i * entry_size), 1, noc);
+                gdfb.write_to_receiver(noc, r, staging, 1, {.offset_bytes = i * entry_size});
                 gdfb.flush_writes(noc);
                 gdfb.push_back_to_receiver(r, 1, noc);
             }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/prefetcher_pipe_stale_commit.cpp
@@ -62,6 +62,7 @@ void kernel_main() {
     constexpr uint32_t new_entry_size = get_compile_time_arg_val(2);
     constexpr uint32_t poison_wr_ptr = get_compile_time_arg_val(3);
     const uint32_t staging_base = get_arg_val<uint32_t>(0);
+    const CoreLocalMem<uint8_t> staging(staging_base);
 
     static_assert(entry_size != new_entry_size, "stale-commit test requires distinct entry sizes");
 
@@ -70,7 +71,7 @@ void kernel_main() {
 
     // Advance one entry so the durable checkpoint is not fifo_start.
     dfb.reserve_back(1);
-    dfb.write_to_receiver(0, staging_base, 1, noc);
+    dfb.write_to_receiver(noc, 0, staging, 1);
     dfb.flush_writes(noc);
     dfb.push_back(1, noc);
 

--- a/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
+++ b/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
@@ -52,10 +52,10 @@ namespace experimental {
 //
 // Sync counters (pages_sent / pages_acked) are in L1_ALIGNMENT-byte units.
 //
-// Each receiver owns a private ring, so the sender needs an independent write position per
-// receiver. No cursor state is stored anywhere: a receiver's write offset is derived from
-// its local entries_sent counter (sent % ring_entries), which dispatch resets to zero on
-// every launch.
+// Each receiver owns a private ring. Writes and credits are collective, so every receiver
+// gets the same payload and advances in lockstep. No cursor state is stored anywhere: a
+// receiver's write offset is derived from its local entries_sent counter
+// (sent % ring_entries), which dispatch resets to zero on every launch.
 //
 // Writes are contiguous: a reserve/write/push of n entries must fit from the current
 // write position to fifo_limit without straddling the wrap (same rule as local CBs). The
@@ -72,32 +72,6 @@ namespace experimental {
 //    write_broadcast(src, n);                 // post NOC writes to all receivers
 //    flush_writes();                          // flush posted writes before credit
 //    push_back(n);                            // credit all receivers (advances positions)
-//
-//  Flow B — Receiver-contiguous / unique-per-receiver:
-//    reserve_back(n);
-//    write_to_receiver(0, src_a, n);          // receiver 0 gets tensor shard A
-//    write_to_receiver(1, src_b, n);          // receiver 1 gets tensor shard B
-//    ...
-//    flush_writes();
-//    push_back(n);                            // one collective credit to all receivers
-//
-//  Flow C — Per-receiver credit (round-robin, uneven shards):
-//    Use reserve_back_for_receiver(r, n) to check only receiver r's space; reserve_back(n)
-//    would poll ALL receivers and block on the slowest even when receiver r is ready.
-//    for r in 0..num_recv:
-//      reserve_back_for_receiver(r, n);         // polls only receiver r, no head-of-line block
-//      write_to_receiver(r, src, n);            // NOC write only to receiver r
-//      flush_writes();
-//      push_back_to_receiver(r, n);             // credit receiver r (advances its position)
-//
-//  Flow D — Interleaved scatter (prefetcher / write_strided):
-//    write_strided is a single call that handles ALL receivers simultaneously.
-//    Staging buffer layout: [recv0_chunk][recv1_chunk]...[recvN_chunk]
-//    Each chunk is written to the corresponding receiver's FIFO in one loop.
-//    reserve_back(n);
-//    write_strided(src, num_rows, pages_per_row, page_size);  // all receivers, one call
-//    flush_writes();
-//    push_back(n);                              // credit all receivers (advances positions)
 //
 // ═══════════════════════════════════════════════════════════════════════
 //  RECEIVER FLOW
@@ -158,8 +132,6 @@ public:
     // -----------------------------------------------------------------------
 
     // Spin until ALL receivers have space for num_entries entries of the current entry_size.
-    // Use this for Flows A, B, D (collective credit patterns).
-    // For Flow C (per-receiver credit), use reserve_back_for_receiver(r, n) instead.
     FORCE_INLINE void reserve_back(uint32_t num_entries) {
         WAYPOINT("GSRW");
         CrossNodeSenderDFBInterface& iface = interface_.sender;
@@ -179,31 +151,13 @@ public:
         WAYPOINT("GSRD");
     }
 
-    // Spin until a SINGLE receiver (receiver_idx) has space for num_entries entries.
-    // Use this for Flow C (per-receiver credit) to avoid blocking on unrelated receivers.
-    FORCE_INLINE void reserve_back_for_receiver(uint32_t receiver_idx, uint32_t num_entries) {
-        WAYPOINT("GSRW");
-        CrossNodeSenderDFBInterface& iface = interface_.sender;
-        const uint32_t fifo_size = get_config_word(iface.config_ptr, 3);
-        const uint32_t num_units = fifo_size / L1_ALIGNMENT;
-        const uint32_t total_units_needed = units_for_write(iface, num_entries);
-
-        volatile tt_l1_ptr uint32_t* sent_ptr = local_sent_ptr(iface, receiver_idx);
-        volatile tt_l1_ptr uint32_t* acked_ptr = sent_ptr + (L1_ALIGNMENT / sizeof(uint32_t));
-        assert_contiguous_write(iface, wr_offset_from_sent(iface, *sent_ptr), num_entries);
-        do {
-            invalidate_l1_cache();
-        } while ((num_units - (*sent_ptr - *acked_ptr)) < total_units_needed);
-        WAYPOINT("GSRD");
-    }
-
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
 
     // ------------------------------------------------------------------
     // Write primitives — kick off NoC writes at each receiver's write position,
     // derived from that receiver's entries_sent credits. They do NOT increment
     // credits, so repeating a write before crediting overwrites the same slots.
-    // Call push_back() or push_back_to_receiver() after all writes.
+    // Call push_back() after all writes.
     // ------------------------------------------------------------------
 
     FORCE_INLINE void noc_unicast_write_l1(
@@ -222,55 +176,9 @@ public:
             {.noc_x = noc_x, .noc_y = noc_y, .addr = dest_l1_addr});
     }
 
-    // Interleaved scatter
-    // Writes rows from src_l1_addr interleaved across num_receivers destinations.
-    // Each receiver i gets rows at src_l1_addr + i * (num_rows * coalesced_page_size),
-    // written at that receiver's write position.
-    FORCE_INLINE void write_strided(
-        uint32_t src_l1_addr,
-        uint32_t num_rows,
-        uint32_t coalesced_num_pages_per_row,
-        uint32_t coalesced_page_size,
-        const Noc& noc = Noc{}) {
-        CrossNodeSenderDFBInterface& iface = interface_.sender;
-        const uint32_t num_recv = cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
-        volatile tt_l1_ptr uint32_t* xy_base =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
-
-        const uint32_t row_bytes_per_recv = coalesced_num_pages_per_row * coalesced_page_size;
-        const uint32_t bytes_per_recv = num_rows * row_bytes_per_recv;
-        const uint32_t row_stride_in_stage = row_bytes_per_recv * num_recv;
-
-        UnicastEndpoint dst;
-        uint32_t recv_src_offset = 0;
-        for (uint32_t i = 0; i < num_recv; ++i) {
-            const uint32_t wr_offset = derived_wr_offset(iface, i);
-            assert_contiguous_bytes(iface, wr_offset, bytes_per_recv);
-            const uint32_t noc_x = xy_base[2 * i];
-            const uint32_t noc_y = xy_base[2 * i + 1];
-
-            uint32_t dest_addr = iface.fifo_start_addr + wr_offset;
-            uint32_t src_addr = src_l1_addr + recv_src_offset;
-            noc.set_async_write_state<NocOptions::POSTED>(
-                dst, coalesced_page_size, {.noc_x = noc_x, .noc_y = noc_y, .addr = dest_addr});
-            for (uint32_t h = 0; h < num_rows; ++h) {
-                const uint32_t row_src_start = src_addr;
-                for (uint32_t w = 0; w < coalesced_num_pages_per_row; ++w) {
-                    noc.async_write_with_state<NocOptions::POSTED>(
-                        CoreLocalMem<uint32_t>(src_addr), dst, coalesced_page_size, {}, {.addr = dest_addr});
-                    src_addr += coalesced_page_size;
-                    dest_addr += coalesced_page_size;
-                }
-                src_addr = row_src_start + row_stride_in_stage;
-            }
-            recv_src_offset += row_bytes_per_recv;
-        }
-    }
-
     // Broadcast: write n entries of identical data from src_l1_addr to all receivers
     // at their current write position. Uses loop-unicast (hardware NOC multicast requires
-    // a rectangular destination grid). For different bytes per receiver, use
-    // write_to_receiver / write_strided instead.
+    // a rectangular destination grid).
     FORCE_INLINE void write_broadcast(uint32_t src_l1_addr, uint32_t num_entries, const Noc& noc = Noc{}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
         const uint32_t entry_size = iface.fifo_page_size;
@@ -292,26 +200,6 @@ public:
         }
     }
 
-    // Write n entries from src_l1_addr to a single receiver (receiver_idx) at that
-    // receiver's write position.  Does NOT increment credits.  Pair with push_back()
-    // (collective credit after all per-receiver writes) or push_back_to_receiver()
-    // (per-receiver credit) as appropriate.
-    FORCE_INLINE void write_to_receiver(
-        uint32_t receiver_idx, uint32_t src_l1_addr, uint32_t num_entries, const Noc& noc = Noc{}) {
-        CrossNodeSenderDFBInterface& iface = interface_.sender;
-        const uint32_t entry_size = iface.fifo_page_size;
-        const uint32_t len_bytes = num_entries * entry_size;
-        const uint32_t wr_offset = derived_wr_offset(iface, receiver_idx);
-        assert_contiguous_write(iface, wr_offset, num_entries);
-        const uint32_t dest_l1_addr = iface.fifo_start_addr + wr_offset;
-        volatile tt_l1_ptr uint32_t* xy_base =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
-
-        const uint32_t noc_x = xy_base[2 * receiver_idx];
-        const uint32_t noc_y = xy_base[2 * receiver_idx + 1];
-        noc_unicast_write_l1(src_l1_addr, dest_l1_addr, len_bytes, noc_x, noc_y, noc);
-    }
-
     // Flush all posted payload writes from this core before publishing pages_sent.
     // Posted writes do not return completion acknowledgements; receiver visibility of
     // the subsequently posted credit is the end-to-end synchronization point.
@@ -319,7 +207,7 @@ public:
 
     // Credit-only: NOC-inc pages_sent on ALL receivers by num_entries. Advancing each
     // receiver's entries_sent is what moves its derived write position forward.
-    // Call after all write_* for this slot.
+    // Call after write_broadcast for this slot.
     FORCE_INLINE void push_back(uint32_t num_entries, const Noc& noc = Noc{}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
         const uint32_t num_recv = cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
@@ -334,27 +222,6 @@ public:
         const uint8_t noc_id = noc.get_noc_id();
         detail::update_pages_sent(
             reinterpret_cast<const RemoteSenderCBInterface&>(iface), num_units, noc_id, true, write_at_cmd_buf);
-    }
-
-    // Credit-only for one receiver: NOC-inc pages_sent on receiver_idx by num_entries,
-    // which also advances that receiver's derived write position. Used for round-robin /
-    // uneven per-receiver credit distribution (caller manages receiver index).
-    FORCE_INLINE void push_back_to_receiver(uint32_t receiver_idx, uint32_t num_entries, const Noc& noc = Noc{}) {
-        CrossNodeSenderDFBInterface& iface = interface_.sender;
-
-        const uint32_t num_units = units_for_write(iface, num_entries);
-        assert_contiguous_write(iface, derived_wr_offset(iface, receiver_idx), num_entries);
-
-        volatile tt_l1_ptr uint32_t* xy_base =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
-        volatile tt_l1_ptr uint32_t* local_sent = local_sent_ptr(iface, receiver_idx);
-        const uint8_t noc_id = noc.get_noc_id();
-        const uint32_t noc_x = xy_base[2 * receiver_idx];
-        const uint32_t noc_y = xy_base[2 * receiver_idx + 1];
-        *local_sent += num_units;
-        const uint64_t remote_addr =
-            noc_address_backend::worker_address(noc_x, noc_y, (uint32_t)(uintptr_t)local_sent, noc_id);
-        noc_semaphore_inc<true>(remote_addr, num_units, noc_id);
     }
 
 #endif  // KERNEL_BUILD && !COMPILE_FOR_TRISC
@@ -461,12 +328,11 @@ public:
         return cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
     }
 
-    // Next write address in one receiver's ring, derived from that receiver's credits.
-    // Every receiver has its own position, so callers that fan out unevenly must ask
-    // per receiver.
-    FORCE_INLINE uint32_t get_write_ptr(uint32_t receiver_idx = 0) {
+    // Next collective write address, derived from receiver 0's credits. Collective
+    // pushes keep all receiver write positions in lockstep.
+    FORCE_INLINE uint32_t get_write_ptr() {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
-        return iface.fifo_start_addr + derived_wr_offset(iface, receiver_idx);
+        return iface.fifo_start_addr + derived_wr_offset(iface, 0);
     }
 
     FORCE_INLINE uint32_t get_read_ptr() { return interface_.receiver.fifo_rd_ptr; }

--- a/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
+++ b/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
@@ -21,7 +21,6 @@
 #include "noc_address_backend.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/remote_circular_buffer.h"
 
@@ -36,6 +35,28 @@ static_assert(
 static_assert(
     offsetof(CrossNodeReceiverDFBInterface, remote_pages_acked_ptr) ==
     offsetof(RemoteReceiverCBInterface, remote_pages_acked_ptr));
+#endif
+
+namespace experimental {
+class CrossNodeDFB;
+}
+
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
+// dst_args_type must be visible before CrossNodeDFB::write_* method bodies.
+// RISC-V g++ parses those templates at class definition (-Wtemplate-body).
+template <>
+struct noc_traits_t<experimental::CrossNodeDFB> {
+    struct src_args_type {};
+    struct dst_args_type {
+        uint32_t receiver_idx{};
+    };
+
+    template <Noc::AddressType address_type>
+    static uint32_t src_addr(const experimental::CrossNodeDFB& src, const Noc& noc, const src_args_type& args);
+
+    template <Noc::AddressType address_type>
+    static uint64_t dst_addr(const experimental::CrossNodeDFB& dst, const Noc& noc, const dst_args_type& args);
+};
 #endif
 
 namespace experimental {
@@ -80,8 +101,9 @@ namespace experimental {
 //
 //  Standard receiver (NCRISC/BRISC consumes data):
 //    wait_front(n);
-//    rd_ptr = get_read_ptr();
-//    // process data at rd_ptr ...
+//    auto lock = scoped_read_lock(n);
+//    auto rd = lock.get_ptr();
+//    // process data at rd ...
 //    pop_front(n);                            // advance rd_ptr + NOC-ack sender
 //
 // ═══════════════════════════════════════════════════════════════════════
@@ -180,43 +202,24 @@ public:
     // Call push_back() after all writes.
     // ------------------------------------------------------------------
 
-    FORCE_INLINE void noc_unicast_write_l1(
-        uint32_t src_l1_addr,
-        uint32_t dest_l1_addr,
-        uint32_t len_bytes,
-        uint32_t noc_x,
-        uint32_t noc_y,
-        const Noc& noc) {
-        UnicastEndpoint dst;
-        noc.async_write<NocOptions::POSTED>(
-            CoreLocalMem<uint32_t>(src_l1_addr),
-            dst,
-            len_bytes,
-            {},
-            {.noc_x = noc_x, .noc_y = noc_y, .addr = dest_l1_addr});
-    }
-
-    // Broadcast: write n entries of identical data from src_l1_addr to all receivers
+    // Broadcast: write n entries of identical data from src to all receivers
     // at their current write position. Uses loop-unicast (hardware NOC multicast requires
     // a rectangular destination grid).
-    FORCE_INLINE void write_broadcast(uint32_t src_l1_addr, uint32_t num_entries, const Noc& noc = Noc{}) {
+    template <typename Src>
+    FORCE_INLINE void write_broadcast(
+        const Noc& noc,
+        const Src& src,
+        uint32_t num_entries,
+        const typename noc_traits_t<Src>::src_args_type& src_args = {}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
         const uint32_t entry_size = iface.fifo_page_size;
         const uint32_t len_bytes = num_entries * entry_size;
         const uint32_t num_recv = cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
-        volatile tt_l1_ptr uint32_t* xy_base =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
-
-        DPRINT("src_l1_addr: {}\n", src_l1_addr);
 
         for (uint32_t i = 0; i < num_recv; ++i) {
             const uint32_t wr_offset = derived_wr_offset(iface, i);
             assert_contiguous_write(iface, wr_offset, num_entries);
-            const uint32_t noc_x = xy_base[2 * i];
-            const uint32_t noc_y = xy_base[2 * i + 1];
-            const uint32_t dest_l1_addr = iface.fifo_start_addr + wr_offset;
-            DPRINT("noc_x: {} noc_y: {} dest: {}\n", noc_x, noc_y, dest_l1_addr);
-            noc_unicast_write_l1(src_l1_addr, dest_l1_addr, len_bytes, noc_x, noc_y, noc);
+            noc.async_write<NocOptions::POSTED>(src, *this, len_bytes, src_args, {.receiver_idx = i});
         }
     }
 
@@ -348,18 +351,20 @@ public:
         return cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
     }
 
-    // Next collective write address, derived from receiver 0's credits. Collective
-    // pushes keep all receiver write positions in lockstep.
-    FORCE_INLINE uint32_t get_write_ptr() {
-        CrossNodeSenderDFBInterface& iface = interface_.sender;
-        return iface.fifo_start_addr + derived_wr_offset(iface, 0);
+    // Lock entries at the receiver's current front for direct CPU access.
+    [[nodiscard]] FORCE_INLINE auto scoped_read_lock(uint32_t num_entries = 1) {
+        const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
+        ASSERT(iface.fifo_rd_ptr + num_entries * iface.fifo_page_size <= iface.fifo_limit_page_aligned);
+        return make_dfb_scoped_lock<false>(iface.fifo_rd_ptr, []() {});
     }
-
-    FORCE_INLINE uint32_t get_read_ptr() { return interface_.receiver.fifo_rd_ptr; }
 
     FORCE_INLINE uint32_t get_entry_size() { return interface_.sender.fifo_page_size; }
 
 private:
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
+    friend struct ::noc_traits_t<CrossNodeDFB>;
+#endif
+
     CrossNodeDFBInterface interface_;
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
@@ -449,5 +454,31 @@ private:
 };
 
 }  // namespace experimental
+
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
+template <Noc::AddressType address_type>
+FORCE_INLINE uint32_t noc_traits_t<experimental::CrossNodeDFB>::src_addr(
+    const experimental::CrossNodeDFB& src, const Noc&, const src_args_type&) {
+    static_assert(address_type == Noc::AddressType::LOCAL_L1, "CrossNodeDFB can only be used as a local L1 source");
+    ASSERT(!static_cast<bool>(
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src.interface_.receiver.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+    return src.interface_.receiver.fifo_rd_ptr;
+}
+
+template <Noc::AddressType address_type>
+FORCE_INLINE uint64_t noc_traits_t<experimental::CrossNodeDFB>::dst_addr(
+    const experimental::CrossNodeDFB& dst, const Noc& noc, const dst_args_type& args) {
+    static_assert(address_type == Noc::AddressType::NOC, "CrossNodeDFB can only be used as a NoC destination");
+    const CrossNodeSenderDFBInterface& iface = dst.interface_.sender;
+    ASSERT(
+        static_cast<bool>(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+    ASSERT(args.receiver_idx < cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr));
+    volatile tt_l1_ptr uint32_t* xy =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr) + 2 * args.receiver_idx;
+    const uint32_t local_address =
+        iface.fifo_start_addr + experimental::CrossNodeDFB::derived_wr_offset(iface, args.receiver_idx);
+    return noc_address_backend::worker_address(xy[0], xy[1], local_address, noc.get_noc_id());
+}
+#endif
 
 #endif  // !ARCH_QUASAR

--- a/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
+++ b/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
@@ -16,7 +16,7 @@
 #include "internal/risc_attribs.h"
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
-#include <new>
+#include <optional>
 #include "api/dataflow/noc.h"
 #include "noc_address_backend.h"
 #include "api/dataflow/dataflow_api.h"
@@ -43,7 +43,8 @@ namespace experimental {
 // CrossNodeDFB: device-side kernel class for a globally-allocated ring FIFO shared across
 // kernels within a single program (WH/BH only).
 // Not persistent across programs: firmware resets fifo ptrs and credit counters on every
-// program init. Cross-program persistence is GlobalDFB.
+// program init. The receiver destructor ASSERTs
+// that unread credits are zero; the sender destructor does not wait (see barrier()).
 //
 // entry_size is fixed at Create for the life of a CrossNodeDFB. Mid-flight entry_size
 // reconfiguration (remote CB / prefetcher style) is intentionally omitted here — CrossNode
@@ -125,6 +126,25 @@ public:
             region + REMOTE_DFB_REGION_HEADER_WORDS + remote_dfb_id * UINT32_WORDS_PER_REMOTE_DFB_CONFIG;
         setup_cross_node_dfb_interface(
             interface_, /*config_page_addr=*/slot[0], /*entry_size=*/slot[1], /*relay_dfb_id=*/slot[2]);
+    }
+
+    // Receiver: unread credits must be zero (forgotten pop_front). Does not wait —
+    // Sender does not join here; use barrier() if this kernel must stall until all receivers ack.
+    FORCE_INLINE ~CrossNodeDFB() {
+#if WATCHER_ASSERT_ENABLED
+        volatile tt_l1_ptr uint32_t* l1_config =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(interface_.sender.config_ptr);
+        if (static_cast<bool>(l1_config[REMOTE_DFB_CFG_IS_SENDER])) {
+            return;
+        }
+        invalidate_l1_cache();
+        const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
+        volatile tt_l1_ptr uint32_t* acked_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.aligned_pages_acked_ptr);
+        volatile tt_l1_ptr uint32_t* sent_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.aligned_pages_acked_ptr - L1_ALIGNMENT);
+        ASSERT(*sent_ptr == *acked_ptr);
+#endif
     }
 
     // -----------------------------------------------------------------------
@@ -279,7 +299,7 @@ public:
     // If bind_relay() was called, waits until compute has consumed num_entries first.
     FORCE_INLINE void pop_front(uint32_t num_entries, const Noc& noc = Noc{}) {
         if (interface_.receiver.relay_id != RELAY_DFB_INVALID) {
-            ASSERT(relay_dfb_ != nullptr);
+            ASSERT(relay_dfb_.has_value());
             wait_relay_consumed(num_entries);
         }
         pop_front_impl(num_entries, noc);
@@ -310,8 +330,8 @@ public:
     FORCE_INLINE RelayView bind_relay() {
         const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
         ASSERT(iface.relay_id != RELAY_DFB_INVALID);
-        ASSERT(relay_dfb_ == nullptr);
-        relay_dfb_ = new (relay_dfb_storage_) DataflowBuffer(RelayDFBBindingToken{iface.relay_id});
+        ASSERT(!relay_dfb_.has_value());
+        relay_dfb_.emplace(RelayDFBBindingToken{iface.relay_id});
         const uintptr_t entries_acked_ptr = reinterpret_cast<uintptr_t>(get_cb_tiles_acked_ptr(iface.relay_id));
         relay_entries_acked_checkpoint_ = static_cast<uint16_t>(reg_read(entries_acked_ptr));
         return RelayView(*relay_dfb_);
@@ -343,8 +363,7 @@ private:
     CrossNodeDFBInterface interface_;
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
-    DataflowBuffer* relay_dfb_ = nullptr;
-    alignas(DataflowBuffer) unsigned char relay_dfb_storage_[sizeof(DataflowBuffer)];
+    std::optional<DataflowBuffer> relay_dfb_;
     uint16_t relay_entries_acked_checkpoint_ = 0;
 
     FORCE_INLINE void wait_relay_consumed(uint32_t num_entries) {

--- a/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
+++ b/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
@@ -18,7 +18,7 @@
 #include "internal/risc_attribs.h"
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
-#include <new>
+#include <optional>
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -486,7 +486,7 @@ public:
     // If bind_relay() was called, waits until compute has consumed num_entries first.
     FORCE_INLINE void pop_front(uint32_t num_entries, const Noc& noc = Noc{}) {
         if (interface_.receiver.relay_id != RELAY_DFB_INVALID) {
-            ASSERT(relay_dfb_ != nullptr);
+            ASSERT(relay_dfb_.has_value());
             wait_relay_consumed(num_entries);
         }
         pop_front_impl(num_entries, noc);
@@ -535,9 +535,9 @@ public:
     FORCE_INLINE RelayView bind_relay() {
         const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
         ASSERT(iface.relay_id != RELAY_DFB_INVALID);
-        ASSERT(relay_dfb_ == nullptr);
+        ASSERT(!relay_dfb_.has_value());
         align_local_dfb_to_prefetcher_pipe_receiver_iface(iface.relay_id, iface);
-        relay_dfb_ = new (relay_dfb_storage_) DataflowBuffer(RelayDFBBindingToken{iface.relay_id});
+        relay_dfb_.emplace(RelayDFBBindingToken{iface.relay_id});
         const uintptr_t entries_acked_ptr = reinterpret_cast<uintptr_t>(get_cb_tiles_acked_ptr(iface.relay_id));
         relay_entries_acked_checkpoint_ = static_cast<uint16_t>(reg_read(entries_acked_ptr));
         return RelayView(*relay_dfb_);
@@ -549,8 +549,7 @@ private:
     uint8_t prefetcher_pipe_id_ = 0;
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
-    DataflowBuffer* relay_dfb_ = nullptr;
-    alignas(DataflowBuffer) unsigned char relay_dfb_storage_[sizeof(DataflowBuffer)];
+    std::optional<DataflowBuffer> relay_dfb_;
     uint16_t relay_entries_acked_checkpoint_ = 0;
 
     FORCE_INLINE void wait_relay_consumed(uint32_t num_entries) {

--- a/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
+++ b/tt_metal/hw/inc/api/dataflow/prefetcher_pipe.h
@@ -22,7 +22,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/remote_circular_buffer.h"
 
@@ -37,6 +36,28 @@ static_assert(
 static_assert(
     offsetof(CrossNodeReceiverDFBInterface, remote_pages_acked_ptr) ==
     offsetof(RemoteReceiverCBInterface, remote_pages_acked_ptr));
+#endif
+
+namespace experimental {
+class PrefetcherPipe;
+}
+
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
+// dst_args_type must be visible before PrefetcherPipe::write_* method bodies.
+// RISC-V g++ parses those templates at class definition (-Wtemplate-body).
+template <>
+struct noc_traits_t<experimental::PrefetcherPipe> {
+    struct src_args_type {};
+    struct dst_args_type {
+        uint32_t receiver_idx{};
+    };
+
+    template <Noc::AddressType address_type>
+    static uint32_t src_addr(const experimental::PrefetcherPipe& src, const Noc& noc, const src_args_type& args);
+
+    template <Noc::AddressType address_type>
+    static uint64_t dst_addr(const experimental::PrefetcherPipe& dst, const Noc& noc, const dst_args_type& args);
+};
 #endif
 
 namespace experimental {
@@ -104,7 +125,8 @@ namespace experimental {
 //
 //  Standard receiver (DM consumes data):
 //    wait_front(n);
-//    auto rd = get_read_ptr();  // CoreLocalMem at fifo front
+//    auto lock = scoped_read_lock(n);
+//    auto rd = lock.get_ptr();  // CoreLocalMem at fifo front
 //    // process data at rd.get_address() / rd.get_unsafe_ptr() ...
 //    pop_front(n);
 //
@@ -292,110 +314,90 @@ public:
     // Call push_back() or push_back_to_receiver() after all writes.
     // ------------------------------------------------------------------
 
-    FORCE_INLINE void noc_unicast_write_l1(
-        uint32_t src_l1_addr,
-        uint32_t dest_l1_addr,
-        uint32_t len_bytes,
-        uint32_t noc_x,
-        uint32_t noc_y,
-        const Noc& noc) {
-        UnicastEndpoint dst;
-        noc.async_write<NocOptions::POSTED>(
-            CoreLocalMem<uint32_t>(src_l1_addr),
-            dst,
-            len_bytes,
-            {},
-            {.noc_x = noc_x, .noc_y = noc_y, .addr = dest_l1_addr});
-    }
-
     // Interleaved scatter
-    // Writes rows from src_l1_addr interleaved across num_receivers destinations.
-    // Each receiver i gets rows at src_l1_addr + i * (num_rows * coalesced_page_size),
+    // Writes rows from src interleaved across num_receivers destinations.
+    // Each receiver i gets rows at src + i * (num_rows * coalesced_page_size),
     // written at that receiver's write position.
+    template <typename Src>
     FORCE_INLINE void write_strided(
-        uint32_t src_l1_addr,
+        const Noc& noc,
+        const Src& src,
         uint32_t num_rows,
         uint32_t coalesced_num_pages_per_row,
         uint32_t coalesced_page_size,
-        const Noc& noc = Noc{}) {
+        const typename noc_traits_t<Src>::src_args_type& src_args = {}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
         const uint32_t num_recv = cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
-        volatile tt_l1_ptr uint32_t* xy_base =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
 
         const uint32_t row_bytes_per_recv = coalesced_num_pages_per_row * coalesced_page_size;
         const uint32_t bytes_per_recv = num_rows * row_bytes_per_recv;
         const uint32_t row_stride_in_stage = row_bytes_per_recv * num_recv;
 
-        UnicastEndpoint dst;
+        uint32_t src_addr = noc_traits_t<Src>::template src_addr<Noc::AddressType::LOCAL_L1>(src, noc, src_args);
         uint32_t recv_src_offset = 0;
         for (uint32_t i = 0; i < num_recv; ++i) {
             const uint32_t wr_offset = derived_wr_offset(iface, i);
             assert_contiguous_bytes(iface, wr_offset, bytes_per_recv);
-            const uint32_t noc_x = xy_base[2 * i];
-            const uint32_t noc_y = xy_base[2 * i + 1];
 
-            uint32_t dest_addr = iface.fifo_start_addr + wr_offset;
-            uint32_t src_addr = src_l1_addr + recv_src_offset;
-            noc.set_async_write_state<NocOptions::POSTED>(
-                dst, coalesced_page_size, {.noc_x = noc_x, .noc_y = noc_y, .addr = dest_addr});
+            uint32_t current_src_addr = src_addr + recv_src_offset;
+            destination_offset_bytes_ = 0;
+            noc.set_async_write_state<NocOptions::POSTED>(*this, coalesced_page_size, {.receiver_idx = i});
             for (uint32_t h = 0; h < num_rows; ++h) {
-                const uint32_t row_src_start = src_addr;
+                const uint32_t row_src_start = current_src_addr;
                 for (uint32_t w = 0; w < coalesced_num_pages_per_row; ++w) {
                     noc.async_write_with_state<NocOptions::POSTED>(
-                        CoreLocalMem<uint32_t>(src_addr), dst, coalesced_page_size, {}, {.addr = dest_addr});
-                    src_addr += coalesced_page_size;
-                    dest_addr += coalesced_page_size;
+                        CoreLocalMem<uint32_t>(current_src_addr), *this, coalesced_page_size, {}, {.receiver_idx = i});
+                    current_src_addr += coalesced_page_size;
+                    destination_offset_bytes_ += coalesced_page_size;
                 }
-                src_addr = row_src_start + row_stride_in_stage;
+                current_src_addr = row_src_start + row_stride_in_stage;
             }
             recv_src_offset += row_bytes_per_recv;
         }
+        destination_offset_bytes_ = 0;
     }
 
-    // Broadcast: write n entries of identical data from src_l1_addr to all receivers
+    // Broadcast: write n entries of identical data from src to all receivers
     // at their current write position. Uses loop-unicast (hardware NOC multicast requires
     // a rectangular destination grid). For different bytes per receiver, use
     // write_to_receiver / write_strided instead.
-    FORCE_INLINE void write_broadcast(uint32_t src_l1_addr, uint32_t num_entries, const Noc& noc = Noc{}) {
+    template <typename Src>
+    FORCE_INLINE void write_broadcast(
+        const Noc& noc,
+        const Src& src,
+        uint32_t num_entries,
+        const typename noc_traits_t<Src>::src_args_type& src_args = {}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
         const uint32_t entry_size = iface.fifo_page_size;
         const uint32_t len_bytes = num_entries * entry_size;
         const uint32_t num_recv = cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
-        volatile tt_l1_ptr uint32_t* xy_base =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
 
-        DPRINT("src_l1_addr: {}\n", src_l1_addr);
-
+        destination_offset_bytes_ = 0;
         for (uint32_t i = 0; i < num_recv; ++i) {
             const uint32_t wr_offset = derived_wr_offset(iface, i);
             assert_contiguous_write(iface, wr_offset, num_entries);
-            const uint32_t noc_x = xy_base[2 * i];
-            const uint32_t noc_y = xy_base[2 * i + 1];
-            const uint32_t dest_l1_addr = iface.fifo_start_addr + wr_offset;
-            DPRINT("noc_x: {} noc_y: {} dest: {}\n", noc_x, noc_y, dest_l1_addr);
-            noc_unicast_write_l1(src_l1_addr, dest_l1_addr, len_bytes, noc_x, noc_y, noc);
+            noc.async_write<NocOptions::POSTED>(src, *this, len_bytes, src_args, {.receiver_idx = i});
         }
     }
 
-    // Write n entries from src_l1_addr to a single receiver (receiver_idx) at that
+    // Write n entries from src to a single receiver (receiver_idx) at that
     // receiver's write position.  Does NOT increment credits.  Pair with push_back()
     // (collective credit after all per-receiver writes) or push_back_to_receiver()
     // (per-receiver credit) as appropriate.
+    template <typename Src>
     FORCE_INLINE void write_to_receiver(
-        uint32_t receiver_idx, uint32_t src_l1_addr, uint32_t num_entries, const Noc& noc = Noc{}) {
+        const Noc& noc,
+        uint32_t receiver_idx,
+        const Src& src,
+        uint32_t num_entries,
+        const typename noc_traits_t<Src>::src_args_type& src_args = {}) {
         CrossNodeSenderDFBInterface& iface = interface_.sender;
         const uint32_t entry_size = iface.fifo_page_size;
         const uint32_t len_bytes = num_entries * entry_size;
         const uint32_t wr_offset = derived_wr_offset(iface, receiver_idx);
         assert_contiguous_write(iface, wr_offset, num_entries);
-        const uint32_t dest_l1_addr = iface.fifo_start_addr + wr_offset;
-        volatile tt_l1_ptr uint32_t* xy_base =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
-
-        const uint32_t noc_x = xy_base[2 * receiver_idx];
-        const uint32_t noc_y = xy_base[2 * receiver_idx + 1];
-        noc_unicast_write_l1(src_l1_addr, dest_l1_addr, len_bytes, noc_x, noc_y, noc);
+        destination_offset_bytes_ = 0;
+        noc.async_write<NocOptions::POSTED>(src, *this, len_bytes, src_args, {.receiver_idx = receiver_idx});
     }
 
     // Flush all posted payload writes from this core before publishing pages_sent.
@@ -503,9 +505,11 @@ public:
         return cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr);
     }
 
-    // Front of the receiver ring as a typed L1 handle (raw address via .get_address()).
-    FORCE_INLINE CoreLocalMem<uint32_t> get_read_ptr() {
-        return CoreLocalMem<uint32_t>(interface_.receiver.fifo_rd_ptr);
+    // Lock entries at the receiver's current front for direct CPU access.
+    [[nodiscard]] FORCE_INLINE auto scoped_read_lock(uint32_t num_entries = 1) {
+        const CrossNodeReceiverDFBInterface& iface = interface_.receiver;
+        ASSERT(iface.fifo_rd_ptr + num_entries * iface.fifo_page_size <= iface.fifo_limit_page_aligned);
+        return make_dfb_scoped_lock<false>(iface.fifo_rd_ptr, []() {});
     }
 
     FORCE_INLINE uint32_t get_entry_size() { return interface_.sender.fifo_page_size; }
@@ -545,8 +549,13 @@ public:
 #endif
 
 private:
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
+    friend struct ::noc_traits_t<PrefetcherPipe>;
+#endif
+
     CrossNodeDFBInterface interface_;
     uint8_t prefetcher_pipe_id_ = 0;
+    uint32_t destination_offset_bytes_ = 0;
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
     std::optional<DataflowBuffer> relay_dfb_;
@@ -679,13 +688,13 @@ private:
         const uint32_t remote_sent_ptr =
             cross_node_dfb_remote_pages_sent_ptr(iface.num_receivers_and_remote_pages_sent_ptr) +
             2 * receiver_idx * L1_ALIGNMENT;
-        const uint32_t remote_noc_xy = uint32_t(NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, xy[0]), DYNAMIC_NOC_Y(noc, xy[1])));
+        const uint64_t remote_sent_noc_addr = noc_address_backend::worker_address(xy[0], xy[1], remote_sent_ptr, noc);
 
         *sent_ptr += adjustment;
         noc_fast_atomic_increment<nm>(
             noc,
             cmd_buf,
-            get_noc_addr_helper(remote_noc_xy, remote_sent_ptr),
+            remote_sent_noc_addr,
             NOC_UNICAST_WRITE_VC,
             adjustment,
             31 /*wrap*/,
@@ -819,5 +828,32 @@ private:
 };
 
 }  // namespace experimental
+
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
+template <Noc::AddressType address_type>
+FORCE_INLINE uint32_t noc_traits_t<experimental::PrefetcherPipe>::src_addr(
+    const experimental::PrefetcherPipe& src, const Noc&, const src_args_type&) {
+    static_assert(address_type == Noc::AddressType::LOCAL_L1, "PrefetcherPipe can only be used as a local L1 source");
+    ASSERT(!static_cast<bool>(
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src.interface_.receiver.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+    return src.interface_.receiver.fifo_rd_ptr;
+}
+
+template <Noc::AddressType address_type>
+FORCE_INLINE uint64_t noc_traits_t<experimental::PrefetcherPipe>::dst_addr(
+    const experimental::PrefetcherPipe& dst, const Noc& noc, const dst_args_type& args) {
+    static_assert(address_type == Noc::AddressType::NOC, "PrefetcherPipe can only be used as a NoC destination");
+    const CrossNodeSenderDFBInterface& iface = dst.interface_.sender;
+    ASSERT(
+        static_cast<bool>(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr)[REMOTE_DFB_CFG_IS_SENDER]));
+    ASSERT(args.receiver_idx < cross_node_dfb_num_receivers(iface.num_receivers_and_remote_pages_sent_ptr));
+    volatile tt_l1_ptr uint32_t* xy =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr) + 2 * args.receiver_idx;
+    const uint32_t local_address = iface.fifo_start_addr +
+                                   experimental::PrefetcherPipe::derived_wr_offset(iface, args.receiver_idx) +
+                                   dst.destination_offset_bytes_;
+    return noc_address_backend::worker_address(xy[0], xy[1], local_address, noc.get_noc_id());
+}
+#endif
 
 #endif  // !ARCH_QUASAR

--- a/tt_metal/impl/buffers/cross_node_dfb.cpp
+++ b/tt_metal/impl/buffers/cross_node_dfb.cpp
@@ -27,7 +27,7 @@ namespace tt::tt_metal::experimental {
 namespace {
 
 void initialize_cross_node_dfb(
-    IDevice* device,
+    distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
     CoreRangeSet& sender_cores_out,
@@ -79,15 +79,13 @@ ConfigPageLayout compute_config_page_layout(uint32_t max_num_receivers_per_sende
     return ConfigPageLayout{.noc_xy_offset = noc_xy_offset, .counters_offset = counters_offset, .page_size = page_size};
 }
 
-bool is_compatible_borrowed_device(IDevice* expected, IDevice* buffer_device) {
+bool is_compatible_borrowed_device(distributed::MeshDevice* expected, IDevice* buffer_device) {
     if (expected == buffer_device) {
         return true;
     }
-    if (auto* mesh = dynamic_cast<distributed::MeshDevice*>(expected)) {
-        for (IDevice* local : mesh->get_devices()) {
-            if (local == buffer_device) {
-                return true;
-            }
+    for (IDevice* local : expected->get_devices()) {
+        if (local == buffer_device) {
+            return true;
         }
     }
     return false;
@@ -96,7 +94,7 @@ bool is_compatible_borrowed_device(IDevice* expected, IDevice* buffer_device) {
 }  // namespace
 
 CrossNodeDFB::CrossNodeDFB(
-    IDevice* device,
+    distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
     uint32_t entry_size,
@@ -110,7 +108,7 @@ CrossNodeDFB::CrossNodeDFB(
 }
 
 CrossNodeDFB::CrossNodeDFB(
-    IDevice* device,
+    distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
     uint32_t entry_size,
@@ -312,7 +310,7 @@ const CoreRangeSet& CrossNodeDFB::all_cores() const { return all_cores_; }
 
 uint8_t CreateCrossNodeDFB(
     Program& program,
-    IDevice* device,
+    distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
     uint32_t entry_size,
@@ -324,7 +322,7 @@ uint8_t CreateCrossNodeDFB(
 
 uint8_t CreateCrossNodeDFB(
     Program& program,
-    IDevice* device,
+    distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
     uint32_t entry_size,

--- a/tt_metal/impl/dataflow_buffer/cross_node_dfb.hpp
+++ b/tt_metal/impl/dataflow_buffer/cross_node_dfb.hpp
@@ -18,8 +18,11 @@
 namespace tt::tt_metal {
 
 class Buffer;
-class IDevice;
 class Program;
+
+namespace distributed {
+class MeshDevice;
+}
 
 namespace experimental {
 
@@ -28,7 +31,7 @@ public:
     // One sender core and a non-empty receiver CoreRangeSet (1:1 or 1:N).
     // Sender and receiver cores must be disjoint.
     CrossNodeDFB(
-        IDevice* device,
+        distributed::MeshDevice* device,
         CoreCoord sender_core,
         const CoreRangeSet& receiver_cores,
         uint32_t entry_size,
@@ -39,7 +42,7 @@ public:
     // `data_buffer` for the CrossNodeDFB lifetime; this object only records its address.
     // The config Buffer is owned by CrossNodeDFB
     CrossNodeDFB(
-        IDevice* device,
+        distributed::MeshDevice* device,
         CoreCoord sender_core,
         const CoreRangeSet& receiver_cores,
         uint32_t entry_size,
@@ -70,7 +73,7 @@ public:
     const CoreRangeSet& sender_cores() const;
     const CoreRangeSet& receiver_cores() const;
     const CoreRangeSet& all_cores() const;
-    IDevice* get_device() const { return device_; }
+    distributed::MeshDevice* get_device() const { return device_; }
 
     // Retarget the data ring to `data_buffer` and rebuild host config pages in place.
     // The next program launch picks up the updates.
@@ -95,7 +98,7 @@ private:
     // Data-ring L1 address. From owned_dfb_buffer_ when owning; from the caller's Buffer
     // when borrowing. Device config/relays only need this address.
     uint32_t data_address_ = 0;
-    IDevice* device_ = nullptr;
+    distributed::MeshDevice* device_ = nullptr;
     CoreCoord sender_core_;
     CoreRangeSet sender_cores_;
     CoreRangeSet receiver_cores_;
@@ -122,7 +125,7 @@ private:
  */
 uint8_t CreateCrossNodeDFB(
     Program& program,
-    IDevice* device,
+    distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
     uint32_t entry_size,
@@ -143,7 +146,7 @@ uint8_t CreateCrossNodeDFB(
  */
 uint8_t CreateCrossNodeDFB(
     Program& program,
-    IDevice* device,
+    distributed::MeshDevice* device,
     CoreCoord sender_core,
     const CoreRangeSet& receiver_cores,
     uint32_t entry_size,


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
CrossNodeDFB had functionality to write unique data to each receiver and do strided writes. For now the use case of CrossNodeDFB is limited so we are only keeping unicast and broadcast writes.

Also making the relay dfb owned by CrossNodeDFB and PrefetcherPipe a std::optional member and updated the CrossNodeDFB and PrefetcherPipe device apis to use dev2.0 style

https://github.com/tenstorrent/tt-metal/actions/runs/34060200875

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/cndfb-cu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/cndfb-cu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/cndfb-cu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/cndfb-cu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/cndfb-cu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/cndfb-cu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/cndfb-cu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/cndfb-cu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/cndfb-cu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/cndfb-cu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/cndfb-cu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/cndfb-cu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/cndfb-cu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/cndfb-cu)