### PR TITLE
Gemma4 BH-Galaxy dp=4×tp=8 bring-up

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -433,7 +433,7 @@ models:
     wh_galaxy_perf: 430
     bh_quietbox_2: 310
     wh_llmbox: 342
-    bh_loudbox: 75
+    bh_loudbox: 115  # 75 (Llama-3.1-8B dp=8) + 40 (Gemma4-12B tp=8)
     bh_galaxy: 65
     wh_n150: 65
 umd:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -433,7 +433,7 @@ models:
     wh_galaxy_perf: 430
     bh_quietbox_2: 310
     wh_llmbox: 342
-    bh_loudbox: 115  # 75 (Llama-3.1-8B dp=8) + 40 (Gemma4-12B tp=8)
+    bh_loudbox: 155  # 75 (Llama-3.1-8B dp=8) + 40 (Gemma4-12B tp=8) + 40 (Gemma4-31B tp=8)
     bh_galaxy: 65
     wh_n150: 65
 umd:

--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -382,7 +382,10 @@ jobs:
                   export GEMMA4_BOUNDED_SLIDING_KV_CACHE=1
                   export G4_FORCE_BATCH_PREFILL=1
                   export GEMMA4_CHUNKED_PREFILL_TRACE=0
-                  echo "Gemma4 P150x8: bounded sliding + batched prefill + eager chunks (gated wedges on 1x8)"
+                  # linear CCL is part of the validated P150X8 spec (the default
+                  # resolves to Ring here).
+                  export GEMMA4_CCL_TOPOLOGY=linear
+                  echo "Gemma4 P150x8: bounded sliding + batched prefill + eager chunks + linear CCL (gated wedges on 1x8)"
                 fi
                 echo "Gemma4 KV pool: GEMMA4_MAX_TOKENS_ALL_USERS=$GEMMA4_MAX_TOKENS_ALL_USERS (from max_model_len=${MAX_MODEL_LEN:-default})"
               fi

--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -371,6 +371,19 @@ jobs:
                   export GEMMA4_GEN_PREFILL_CHUNK=2048
                   echo "Gemma4 WH-T3K: GEMMA4_GEN_PREFILL_CHUNK=$GEMMA4_GEN_PREFILL_CHUNK"
                 fi
+                # 12B on P150x8 (LoudBox): serve the validated target config —
+                # bounded sliding KV + batched prefill + eager chunks (overrides
+                # the CHUNKED_PREFILL_TRACE=1 export above). The gated
+                # traced-sequential-prefill default deterministically wedges 12B
+                # on a 1x8 BH mesh under concurrent prefill+decode (chip-local
+                # NOC1 write/ack stall); same reason the tt-inference-server
+                # P150X8 spec defaults to bounded.
+                if [ "$HF_MODEL" = "google/gemma-4-12B-it" ] && [ "${{ matrix.test-group.mesh-device }}" = "P150x8" ]; then
+                  export GEMMA4_BOUNDED_SLIDING_KV_CACHE=1
+                  export G4_FORCE_BATCH_PREFILL=1
+                  export GEMMA4_CHUNKED_PREFILL_TRACE=0
+                  echo "Gemma4 P150x8: bounded sliding + batched prefill + eager chunks (gated wedges on 1x8)"
+                fi
                 echo "Gemma4 KV pool: GEMMA4_MAX_TOKENS_ALL_USERS=$GEMMA4_MAX_TOKENS_ALL_USERS (from max_model_len=${MAX_MODEL_LEN:-default})"
               fi
               ;;

--- a/models/demos/gemma4/demo/text_demo_v2.py
+++ b/models/demos/gemma4/demo/text_demo_v2.py
@@ -593,6 +593,11 @@ def test_demo_text(
         full_idxs = [i for i, is_sliding in enumerate(sliding_mask) if not is_sliding]
         if full_idxs:
             page_table = per_layer_pts[full_idxs[0]]
+        else:
+            # Reduced all-sliding models (GEMMA4_NUM_LAYERS <= 5) have no
+            # full-attention table; match against the first sliding table —
+            # with no full layers there is nothing it can mis-address.
+            page_table = per_layer_pts[0]
         logger.info(f"Bounded sliding: installed {len(per_layer_pts)} per-layer page tables")
 
     # ── Warmup (prefill compile + optional trace) ──────────────────────────

--- a/models/demos/gemma4/tt/attention/__init__.py
+++ b/models/demos/gemma4/tt/attention/__init__.py
@@ -24,6 +24,9 @@ from .kv_cache import init_kv_cache
 from .decode import decode_forward, packed_decode_forward
 from .prefill import flush_deferred_bounded_fills, prefill_forward
 
+# Named sentinel for optional per-request arguments (clearer than a bare `...`).
+_UNSET = object()
+
 
 class Gemma4AttentionConfig:
     """Configuration for a single attention layer, derived from HF config + layer type."""
@@ -441,7 +444,7 @@ class Gemma4Attention:
             except Exception:
                 pass
 
-    def _release_sliding_prefill_tail(self, *, clear_persistent: bool = False, req_key=..., all_keys: bool = False):
+    def _release_sliding_prefill_tail(self, *, clear_persistent: bool = False, req_key=_UNSET, all_keys: bool = False):
         """Drop cross-chunk sliding tails.
 
         Default (``req_key`` given): drop only that request's tail — the shared
@@ -457,7 +460,7 @@ class Gemma4Attention:
         """
         tails = getattr(self, "_sliding_tails_by_key", None) or {}
         pool_map = getattr(self, "_tail_pool_map", None)
-        if req_key is not ... and not all_keys and not clear_persistent:
+        if req_key is not _UNSET and not all_keys and not clear_persistent:
             self._dealloc_tail(tails.pop(req_key, None))
             if pool_map is not None:
                 pool_map.pop(req_key, None)  # pool buffers persist (boot-owned)

--- a/models/demos/gemma4/tt/generator_trace.py
+++ b/models/demos/gemma4/tt/generator_trace.py
@@ -859,6 +859,12 @@ def warmup_gemma4_batched_prefill_traces(
     warmup (before any traced decode) keeps runtime prefills to trace *replay*,
     avoiding the #49083 cold-eager-capture fetch-queue wedge.
     """
+    # Two-phase note: the plugin's warmup calls this twice (enable_trace=False
+    # compile pass, then enable_trace=True capture pass) and RESETS
+    # already_warmed_up_prefill between the phases (tt model_runner), so the
+    # early-return below does not suppress the capture pass in serving. The
+    # sp1 chunked capture in warmup_gemma4_model_prefill is gated on
+    # enable_trace so it cannot capture during the compile pass.
     if generator.already_warmed_up_prefill:
         return
     generator.already_warmed_up_prefill = True
@@ -1004,7 +1010,13 @@ def warmup_gemma4_batched_prefill_traces(
                         sampling_params=param,
                     )
 
-                sampling_parameters_sweeped = True
+                # The b=1 iteration is forced greedy-only (penalty masks are only
+                # shape-valid on the batched sharded-logits path), so it must not
+                # complete the sweep: a batch-N iteration (or an explicitly
+                # greedy-only warmup) does, otherwise the penalty/log-prob
+                # variants first-compile at runtime under live traces.
+                if greedy_only or batch_size > 1:
+                    sampling_parameters_sweeped = True
 
             if skip_sequence_lengths:
                 break
@@ -1074,7 +1086,11 @@ def warmup_gemma4_model_prefill(
     # prefill (warmup_prefill=True). The batched helper early-returns via
     # already_warmed_up_prefill, but this 8192 sp1 capture used to re-run
     # and add ~1.4s to every request TTFT.
-    if chunked_prefill_trace_enabled() and not getattr(generator, "_warmed_chunked_prefill_sp1", False):
+    if (
+        enable_trace
+        and chunked_prefill_trace_enabled()
+        and not getattr(generator, "_warmed_chunked_prefill_sp1", False)
+    ):
         chunk = int(getattr(generator.model_args[0], "max_prefill_chunk_size", GEMMA4_DEFAULT_PREFILL_CHUNK))
         chunk = min(chunk, GEMMA4_MAX_TRACE_PREFILL_SEQ_LEN)
         if chunk > 0:

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -1820,10 +1820,14 @@ class Gemma4Model:
         lst = getattr(self, "_g4_retired_dev_tensors", None)
         if lst:
             for t in lst:
-                try:
-                    t.deallocate(True)
-                except Exception:
-                    pass
+                # Already-freed tensors are the benign case (the shared
+                # consumption released them); a real deallocation failure
+                # must PROPAGATE — continuing would let the next trace
+                # replay run with a retired buffer still allocated (the
+                # exact #30187 aliasing this scavenge exists to prevent).
+                if hasattr(t, "is_allocated") and not t.is_allocated():
+                    continue
+                t.deallocate(True)
             lst.clear()
 
     def _g4_retire(self, t):

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -129,6 +129,30 @@
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
 
+# 31B tp=8 on the BH LoudBox. Unlike 12B, 31B keeps the gated (traced
+# sequential prefill) default — it is immune to the 12B 1x8 wedge and this is
+# the config validated by the full benchmark sweep on the link-exact emulated
+# LoudBox (rc=0, b32 identity byte-equal, 17.4 tok/s/u b32@4k). Serving knobs
+# mirror the 31B QB2 leg. First run on a fresh cache needs mlperf-write-access
+# and may take two dispatches (the 31B bfp8 conversion is resumable but can
+# exceed the 20 min server gate in one shot; warm thereafter).
+- name: "Gemma4-31B tp=8"
+  model: google/gemma-4-31B-it
+  coherence-test: true
+  server-timeout: 20
+  benchmark-timeout: 5
+  mesh-device: P150x8
+  arch: arch-blackhole
+  tt-config: '{"sample_on_device_mode": "decode_only", "fabric_config": "FABRIC_1D", "trace_region_size": 512000000}'
+  additional-server-args: "--max_model_len 262144 --max_num_seqs 32 --enable_chunked_prefill --max_num_batched_tokens 2048 --long_prefill_token_threshold 2048 --async-scheduling"
+  multimodal: false
+  skus:
+    bh_loudbox:
+      timeout: 40
+      tier: 1
+  owner_id: U088413NP0Q # Ashai Reddy
+  team: models
+
 - name: "Gemma4-26B-A4B"
   model: google/gemma-4-26B-A4B-it
   coherence-test: true

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -86,10 +86,7 @@
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
 
-# Product path on QB2: 256k + chunked prefill + B=32. LoudBox legs are omitted
-# — models.vllm bh_loudbox budget (75) is fully consumed by Llama-3.1-8B.
-# SKU timeouts kept at main's allocation so verify_time_budget stays green
-# without touching .github/time_budget.yaml.
+# Product path on QB2: 256k + chunked prefill + B=32.
 - name: "Gemma4-12B"
   model: google/gemma-4-12B-it
   coherence-test: true
@@ -105,6 +102,31 @@
       timeout: 40
       tier: 1
   owner_id: U08TJ70UFRT # Harry Andrews
+  team: models
+
+# tp=8 coverage on the 8-chip BH LoudBox (P150x8) — the flagship 12B config.
+# Serving knobs mirror the QB2 leg; the impl workflow additionally exports the
+# P150x8 target config (bounded sliding KV + batched prefill + eager chunks):
+# the gated traced-sequential-prefill default deterministically WEDGES 12B on
+# a 1x8 BH mesh under concurrent prefill+decode (chip-local NOC1 write/ack
+# stall at the fabric-heaviest chip), which is also why the tt-inference-server
+# P150X8 spec defaults to bounded. First run on a fresh runner cold-builds the
+# P150x8-mesh weight cache (~15 min, fits the gate; warm after).
+- name: "Gemma4-12B tp=8"
+  model: google/gemma-4-12B-it
+  coherence-test: true
+  server-timeout: 20
+  benchmark-timeout: 5
+  mesh-device: P150x8
+  arch: arch-blackhole
+  tt-config: '{"sample_on_device_mode": "decode_only", "fabric_config": "FABRIC_1D", "trace_region_size": 512000000}'
+  additional-server-args: "--max_model_len 262144 --max_num_seqs 32 --enable_chunked_prefill --max_num_batched_tokens 4096 --long_prefill_token_threshold 4096 --async-scheduling"
+  multimodal: false
+  skus:
+    bh_loudbox:
+      timeout: 40
+      tier: 1
+  owner_id: U088413NP0Q # Ashai Reddy
   team: models
 
 - name: "Gemma4-26B-A4B"


### PR DESCRIPTION
Identical to arg/gemma4_coherence_fix; the full metal dp=4 campaign (4 concurrent tp=8 replicas, all cells, both models) runs on stock code. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arg/gemma4_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arg/gemma4_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arg/gemma4_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arg/gemma4_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arg/gemma4_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arg/gemma4_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arg/gemma4_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arg/gemma4_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arg/gemma4_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arg/gemma4_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arg/gemma4_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arg/gemma4_galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arg/gemma4_galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arg/gemma4_galaxy)