### PR TITLE
[Cleanup] Hide ControlPlane from the public MetalEnv API.

### DIFF
--- a/tests/tt_metal/tt_metal/context/test_metal_env_api.cpp
+++ b/tests/tt_metal/tt_metal/context/test_metal_env_api.cpp
@@ -198,16 +198,7 @@ TEST(MetalEnv, AccessorFabricConfigMatchesDescriptor) {
     EXPECT_EQ(accessor.get_fabric_udm_mode(), tt_fabric::FabricUDMMode::ENABLED);
 }
 
-// --- Control plane and system mesh tests ---
-
-TEST(MetalEnv, ControlPlaneAccessibleOnMock) {
-    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1);
-    MetalEnvDescriptor settings(mock_path);
-    MetalEnv env(settings);
-
-    auto& cp = env.get_control_plane();
-    EXPECT_EQ(cp.get_fabric_config(), tt_fabric::FabricConfig::DISABLED);
-}
+// --- System mesh tests ---
 
 TEST(MetalEnv, SystemMeshAccessibleOnMock) {
     auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1);
@@ -218,26 +209,10 @@ TEST(MetalEnv, SystemMeshAccessibleOnMock) {
     EXPECT_GT(mesh.shape().mesh_size(), 0);
 }
 
-TEST(MetalEnv, ControlPlaneReflectsFabricConfig) {
-    FabricConfigDescriptor fc;
-    fc.fabric_config = tt_fabric::FabricConfig::FABRIC_1D;
-
-    auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 2);
-    MetalEnvDescriptor settings(mock_path, fc);
-    MetalEnv env(settings);
-
-    auto& cp = env.get_control_plane();
-    EXPECT_EQ(cp.get_fabric_config(), tt_fabric::FabricConfig::FABRIC_1D);
-}
-
-TEST(MetalEnv, ControlPlaneAndSystemMeshSameEnv) {
+TEST(MetalEnv, SystemMeshSameEnv) {
     auto mock_path = experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 2);
     MetalEnvDescriptor settings(mock_path);
     MetalEnv env(settings);
-
-    auto& cp1 = env.get_control_plane();
-    auto& cp2 = env.get_control_plane();
-    EXPECT_EQ(&cp1, &cp2);
 
     auto& mesh1 = env.get_system_mesh();
     auto& mesh2 = env.get_system_mesh();
@@ -257,7 +232,7 @@ TEST(MetalEnv, ReconfigureFabricForDispatch) {
 
     EXPECT_EQ(accessor.get_fabric_config(), tt_fabric::FabricConfig::DISABLED);
 
-    auto& cp_before = env.get_control_plane();
+    auto& cp_before = accessor.get_control_plane();
     EXPECT_EQ(cp_before.get_fabric_config(), tt_fabric::FabricConfig::DISABLED);
 
     auto& mesh_before = env.get_system_mesh();
@@ -269,7 +244,7 @@ TEST(MetalEnv, ReconfigureFabricForDispatch) {
 
     EXPECT_EQ(accessor.get_fabric_config(), tt_fabric::FabricConfig::FABRIC_1D);
 
-    auto& cp_after = env.get_control_plane();
+    auto& cp_after = accessor.get_control_plane();
     EXPECT_EQ(cp_after.get_fabric_config(), tt_fabric::FabricConfig::FABRIC_1D);
     EXPECT_NE(cp_ptr_before, &cp_after);
 

--- a/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
+++ b/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
@@ -12,14 +12,6 @@
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
 
-namespace tt::tt_fabric {
-class ControlPlane;
-}  // namespace tt::tt_fabric
-
-namespace tt::tt_metal::distributed {
-class SystemMesh;
-}  // namespace tt::tt_metal::distributed
-
 namespace tt::tt_metal {
 
 // Describes the fabric topology and routing configuration for the devices in the environment.
@@ -66,8 +58,8 @@ class MetalEnvImpl;
 // It exposes several query functions for the hardware capabilities and cluster configuration.
 //
 // The FabricConfigDescriptor in the MetalEnvDescriptor describes the topology of the devices — how they are
-// interconnected and how traffic is routed between them. From this topology the MetalEnv constructs the fabric
-// control plane and the system mesh, which virtualize and partition the physical hardware.
+// interconnected and how traffic is routed between them. From this topology the MetalEnv constructs the
+// system mesh, which virtualizes and partitions the physical hardware for placement queries.
 //
 // Note, MetalEnv is a RAII object. As such, it must outlive every object that uses it (e.g. MeshDevice).
 // The MetalEnv should be destroyed before forking to avoid undefined behavior.
@@ -120,11 +112,6 @@ public:
 
     /// @return Representable SFPU Infinity value of this environment.
     float get_inf() const;
-
-    /// @return The fabric control plane, lazily initialized.
-    /// The control plane manages routing tables and fabric channels based on the device topology
-    /// described by the environment's FabricConfigDescriptor.
-    tt::tt_fabric::ControlPlane& get_control_plane();
 
     /// @return The system mesh, lazily initialized.
     /// The system mesh provides a virtualized coordinate system over the physical devices, allowing

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -637,10 +637,6 @@ float MetalEnv::get_eps() const { return impl_->get_hal().get_eps(); }
 float MetalEnv::get_nan() const { return impl_->get_hal().get_nan(); }
 float MetalEnv::get_inf() const { return impl_->get_hal().get_inf(); }
 
-tt::tt_fabric::ControlPlane& MetalEnv::get_control_plane() {
-    impl_->ensure_context_registered(*this);
-    return impl_->get_control_plane();
-}
 distributed::SystemMesh& MetalEnv::get_system_mesh() {
     impl_->ensure_context_registered(*this);
     return impl_->get_system_mesh();


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
ControlPlane sees no usage in user code.  Hiding it from public Metal API.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/metal-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/metal-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/metal-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/metal-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/metal-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/metal-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/metal-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/metal-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/metal-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/metal-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/metal-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/metal-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/metal-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/metal-env)