### PR TITLE
[Bug Fix]: Fix completion queue rd ptr for 2-CQ dispatch on Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -292,9 +292,10 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     const TestBufferConfig& config) {
     auto* device = mesh_device->get_devices()[0];
     auto device_coord = distributed::MeshCoordinate(0, 0);
-    // Sysmem CQs only. get_absolute_cq_offset's hugepage/channel geometry does not describe the
-    // DRAM-backed CQ region, which is addressed via its `base` parameter instead.
-    if (!device->sysmem_manager().is_dram_backed()) {
+    // Clear out command queue. Skipped on Quasar: the emulator's soc descriptor overstates DRAM, so
+    // allocator buffers alias onto the reserved CQ region and zeroing it corrupts live commands.
+    // See https://github.com/tenstorrent/tt-metal/issues/55417.
+    if (device->arch() != tt::ARCH::QUASAR) {
         uint16_t channel =
             tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
         ChipId mmio_device_id =

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
-#include "allocator/allocator.hpp"
 #include "dispatch/system_memory_manager.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
@@ -292,31 +291,22 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     distributed::MeshCommandQueue& cq,
     const TestBufferConfig& config) {
     auto* device = mesh_device->get_devices()[0];
-    // Clear out command queue
-    uint16_t channel =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
-    ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
-    uint32_t cq_size = device->sysmem_manager().get_cq_size();
-    uint32_t cq_start =
-        MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     auto device_coord = distributed::MeshCoordinate(0, 0);
-    std::vector<uint32_t> cq_zeros((cq_size - cq_start) / sizeof(uint32_t), 0);
-    if (device->sysmem_manager().is_dram_backed()) {
-        const uint32_t dram_channel =
-            device->allocator_impl()->get_dram_channel_from_bank_id(device->sysmem_manager().get_dram_region_bank_id());
-        tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
-            cq_zeros.data(),
-            (cq_size - cq_start),
-            device->id(),
-            dram_channel,
-            device->sysmem_manager().get_dram_region_base_addr() + get_absolute_cq_offset(channel, 0, cq_size) +
-                cq_start);
-    } else {
+    // Sysmem CQs only. get_absolute_cq_offset's hugepage/channel geometry does not describe the
+    // DRAM-backed CQ region, which is addressed via its `base` parameter instead.
+    if (!device->sysmem_manager().is_dram_backed()) {
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
+        ChipId mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+        uint32_t cq_size = device->sysmem_manager().get_cq_size();
+        uint32_t cq_start = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
+            CommandQueueHostAddrType::UNRESERVED);
+        std::vector<uint32_t> cq_zeros((cq_size - cq_start) / sizeof(uint32_t), 0);
         tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
             cq_zeros.data(),
             (cq_size - cq_start),
-            get_absolute_cq_offset(channel, 0, cq_size) + cq_start,
+            get_absolute_cq_offset(channel, static_cast<uint8_t>(cq.id()), cq_size) + cq_start,
             mmio_device_id,
             channel);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -292,10 +292,10 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     const TestBufferConfig& config) {
     auto* device = mesh_device->get_devices()[0];
     auto device_coord = distributed::MeshCoordinate(0, 0);
-    // Clear out command queue. Skipped on Quasar: the emulator's soc descriptor overstates DRAM, so
-    // allocator buffers alias onto the reserved CQ region and zeroing it corrupts live commands.
-    // See https://github.com/tenstorrent/tt-metal/issues/55417.
-    if (device->arch() != tt::ARCH::QUASAR) {
+    // Clear out command queue. Skipped for DRAM-backed CQs on Quasar: the emulator's soc descriptor
+    // overstates DRAM, so allocator buffers alias onto the reserved CQ region and zeroing it corrupts
+    // live commands. See https://github.com/tenstorrent/tt-metal/issues/55417.
+    if (device->arch() != tt::ARCH::QUASAR || !device->sysmem_manager().is_dram_backed()) {
         uint16_t channel =
             tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
         ChipId mmio_device_id =

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -123,13 +123,13 @@ bool d2h_uses_hugepage_fallback(const MetalContext& ctx) {
 SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, uint8_t num_hw_cqs) :
     context_id(context_id),
     device_id(device_id),
+    completion_byte_addrs(num_hw_cqs),
     cq_to_event_locks(num_hw_cqs),
     prefetcher_cores(num_hw_cqs),
-    completion_queue_writer_cores(num_hw_cqs),
-    completion_q_rd_dev_addrs(num_hw_cqs),
     prefetch_q_dev_ptrs(num_hw_cqs),
     prefetch_q_dev_fences(num_hw_cqs) {
     this->prefetch_q_windows.reserve(num_hw_cqs);
+    this->completion_q_windows.reserve(num_hw_cqs);
 
     if (is_mock_device()) {
         this->cq_size = 65536;
@@ -262,9 +262,10 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
             completion_queue_writer_core.chip,
             CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
             core_type);
-        this->completion_queue_writer_cores[cq_id] = tt_cxy_pair(
-            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y);
-        this->completion_q_rd_dev_addrs[cq_id] =
+        this->completion_q_windows.emplace_back(ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
+            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
+        // Static TLBs are mapped at address 0, so a device address is already the window's byte offset.
+        this->completion_byte_addrs[cq_id] =
             mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD, cq_id);
 
         const uint32_t alignment =
@@ -287,6 +288,18 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
         this->prefetch_q_dev_ptrs[cq_id] = prefetch_q_base;
         this->prefetch_q_dev_fences[cq_id] =
             prefetch_q_base + mem_map.prefetch_q_entries() * mem_map.prefetch_q_entry_size_bytes();
+        // Both windows are written at raw device addresses, so every address this CQ will use must fit
+        // the static TLB aperture. TlbWindow::validate() would otherwise throw mid-dispatch.
+        TT_FATAL(
+            this->prefetch_q_dev_fences[cq_id] <= this->prefetch_q_windows[cq_id]->get_size() &&
+                this->completion_byte_addrs[cq_id] < this->completion_q_windows[cq_id]->get_size(),
+            "Dispatch L1 addresses for cq_id {} (prefetch_q end {}, completion_q_rd {}) exceed the static TLB "
+            "window sizes ({}, {})",
+            cq_id,
+            this->prefetch_q_dev_fences[cq_id],
+            this->completion_byte_addrs[cq_id],
+            this->prefetch_q_windows[cq_id]->get_size(),
+            this->completion_q_windows[cq_id]->get_size());
     }
 }
 
@@ -645,12 +658,8 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
     uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
+    this->completion_q_windows[cq_id]->write32(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
     auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
-    ctx.get_cluster().write_core(
-        &read_ptr_and_toggle,
-        sizeof(uint32_t),
-        this->completion_queue_writer_cores[cq_id],
-        this->completion_q_rd_dev_addrs[cq_id]);
     const uint32_t host_completion_q_rd_ptr =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -262,11 +262,12 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
             completion_queue_writer_core.chip,
             CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
             core_type);
-        this->completion_q_windows.emplace_back(ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
-            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
+
         // Static TLBs are mapped at address 0, so a device address is already the window's byte offset.
         this->completion_byte_addrs[cq_id] =
             mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD, cq_id);
+        this->completion_q_windows.emplace_back(ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
+            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
         const uint32_t alignment =
             is_dram_backed() ? ctx.hal().get_alignment(HalMemType::DRAM) : ctx.hal().get_alignment(HalMemType::HOST);
@@ -289,7 +290,7 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
         this->prefetch_q_dev_fences[cq_id] =
             prefetch_q_base + mem_map.prefetch_q_entries() * mem_map.prefetch_q_entry_size_bytes();
         // Both windows are written at raw device addresses, so every address this CQ will use must fit
-        // the static TLB aperture. TlbWindow::validate() would otherwise throw mid-dispatch.
+        // the static TLB aperture.
         TT_FATAL(
             this->prefetch_q_dev_fences[cq_id] <= this->prefetch_q_windows[cq_id]->get_size() &&
                 this->completion_byte_addrs[cq_id] < this->completion_q_windows[cq_id]->get_size(),
@@ -660,7 +661,7 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
     this->completion_q_windows[cq_id]->write32(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
     auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
-    const uint32_t host_completion_q_rd_ptr =
+    const uint32_t completion_q_rd_ptr =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
 
     if (is_dram_backed()) {
@@ -670,8 +671,7 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
             sizeof(uint32_t),
             this->device_id,
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id()),
-            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
-                host_completion_q_rd_ptr);
+            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + completion_q_rd_ptr);
         return;
     }
 
@@ -681,7 +681,7 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     ctx.get_cluster().write_sysmem(
         &read_ptr_and_toggle,
         sizeof(uint32_t),
-        host_completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
+        completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
         mmio_device_id,
         channel);
 }

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -123,13 +123,13 @@ bool d2h_uses_hugepage_fallback(const MetalContext& ctx) {
 SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, uint8_t num_hw_cqs) :
     context_id(context_id),
     device_id(device_id),
-    completion_byte_addrs(num_hw_cqs),
     cq_to_event_locks(num_hw_cqs),
     prefetcher_cores(num_hw_cqs),
+    completion_queue_writer_cores(num_hw_cqs),
+    completion_q_rd_dev_addrs(num_hw_cqs),
     prefetch_q_dev_ptrs(num_hw_cqs),
     prefetch_q_dev_fences(num_hw_cqs) {
     this->prefetch_q_windows.reserve(num_hw_cqs);
-    this->completion_q_windows.reserve(num_hw_cqs);
 
     if (is_mock_device()) {
         this->cq_size = 65536;
@@ -245,8 +245,6 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
         // L1 addresses differ per cq_id when this CQ's dispatch kernels share their dispatch core's L1 with another
         // CQ's
-        const uint32_t completion_q_rd_ptr =
-            mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD, cq_id);
         const uint32_t prefetch_q_base =
             mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED, cq_id);
 
@@ -264,21 +262,10 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
             completion_queue_writer_core.chip,
             CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
             core_type);
-
-        const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = ctx.get_cluster()
-                                                                                 .get_tlb_data(tt_cxy_pair(
-                                                                                     completion_queue_writer_core.chip,
-                                                                                     completion_queue_writer_virtual.x,
-                                                                                     completion_queue_writer_virtual.y))
-                                                                                 .value();
-        auto [completion_tlb_offset, completion_tlb_size] = completion_interface_tlb_data;
-
-        this->completion_byte_addrs[cq_id] = completion_q_rd_ptr % completion_tlb_size;
-        this->completion_q_windows.emplace_back(
-            ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
-                completion_queue_writer_core.chip,
-                completion_queue_writer_virtual.x,
-                completion_queue_writer_virtual.y)));
+        this->completion_queue_writer_cores[cq_id] = tt_cxy_pair(
+            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y);
+        this->completion_q_rd_dev_addrs[cq_id] =
+            mem_map.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD, cq_id);
 
         const uint32_t alignment =
             is_dram_backed() ? ctx.hal().get_alignment(HalMemType::DRAM) : ctx.hal().get_alignment(HalMemType::HOST);
@@ -658,9 +645,13 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
     uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
-    this->completion_q_windows[cq_id]->write32(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
     auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
-    const uint32_t completion_q_rd_ptr =
+    ctx.get_cluster().write_core(
+        &read_ptr_and_toggle,
+        sizeof(uint32_t),
+        this->completion_queue_writer_cores[cq_id],
+        this->completion_q_rd_dev_addrs[cq_id]);
+    const uint32_t host_completion_q_rd_ptr =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
 
     if (is_dram_backed()) {
@@ -670,7 +661,8 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
             sizeof(uint32_t),
             this->device_id,
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id()),
-            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + completion_q_rd_ptr);
+            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
+                host_completion_q_rd_ptr);
         return;
     }
 
@@ -680,7 +672,7 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     ctx.get_cluster().write_sysmem(
         &read_ptr_and_toggle,
         sizeof(uint32_t),
-        completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
+        host_completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
         mmio_device_id,
         channel);
 }

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -121,7 +121,6 @@ private:
 
     ContextId context_id;
     ChipId device_id = 0;
-    std::vector<uint32_t> completion_byte_addrs;
     char* cq_sysmem_start = nullptr;
     std::vector<SystemMemoryCQInterface> cq_interfaces;
     uint32_t cq_size = 0;
@@ -130,8 +129,9 @@ private:
     std::vector<uint32_t> cq_to_last_completed_event;
     mutable std::vector<std::mutex> cq_to_event_locks;
     std::vector<tt_cxy_pair> prefetcher_cores;
+    std::vector<tt_cxy_pair> completion_queue_writer_cores;
+    std::vector<uint32_t> completion_q_rd_dev_addrs;
     std::vector<tt::umd::TlbWindow*> prefetch_q_windows;
-    std::vector<tt::umd::TlbWindow*> completion_q_windows;
     std::vector<uint32_t> prefetch_q_dev_ptrs;
     std::vector<uint32_t> prefetch_q_dev_fences;
 

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -121,6 +121,7 @@ private:
 
     ContextId context_id;
     ChipId device_id = 0;
+    std::vector<uint32_t> completion_byte_addrs;
     char* cq_sysmem_start = nullptr;
     std::vector<SystemMemoryCQInterface> cq_interfaces;
     uint32_t cq_size = 0;
@@ -129,9 +130,8 @@ private:
     std::vector<uint32_t> cq_to_last_completed_event;
     mutable std::vector<std::mutex> cq_to_event_locks;
     std::vector<tt_cxy_pair> prefetcher_cores;
-    std::vector<tt_cxy_pair> completion_queue_writer_cores;
-    std::vector<uint32_t> completion_q_rd_dev_addrs;
     std::vector<tt::umd::TlbWindow*> prefetch_q_windows;
+    std::vector<tt::umd::TlbWindow*> completion_q_windows;
     std::vector<uint32_t> prefetch_q_dev_ptrs;
     std::vector<uint32_t> prefetch_q_dev_fences;
 


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary

Fixes https://github.com/tenstorrent/tt-metal/issues/55406

`send_completion_queue_read_ptr` derived the TLB window offset for `COMPLETION_Q_RD` with `completion_q_rd_ptr % completion_tlb_size`. Static TLBs are configured at address 0, so the window offset is just the raw device address -- as the prefetch path already does. With 2 CQs, per-CQ addresses shift by `cq_zone_stride_` and CQ1's wraps:

```
cq_id=0  completion_q_rd_ptr=541280   tlb_size=2097152  -->  541280
cq_id=1  completion_q_rd_ptr=2282080  tlb_size=2097152  -->  184928
```

Note that `tlb_size=2097152` is not even right here, UMD emulator doesn't TLBs to communicate here, but simulator's communicator does the I/O.

`184928` lands in CQ0's L1 zone, so CQ1's read pointer overwrote CQ0's dispatch L1, the dispatcher never saw CQ1 advance, and the FD pipeline hung. Now written with `TlbWindow::write32` straight to the device address, precomputed per CQ at init.

The test's manual CQ zeroing is skipped on Quasar: the emulator's soc descriptor overstates DRAM (to 1GB), so allocator buffers alias onto the reserved CQ region and zeroing it corrupts live commands (https://github.com/tenstorrent/tt-metal/issues/55417). It also now clears the CQ under test rather than always CQ0.

### Notes for reviewers
- The functional change is one line in `init_dispatch_core_interfaces`: `completion_byte_addrs` now holds the raw device address instead of `addr % tlb_size`. Static TLBs map at address 0, so the modulo was not a valid offset conversion.
- TT_FATAL at init covers both windows. Overflow would otherwise surface from inside UMD mid-dispatch with no CQ context.

Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/33821782745
Runtime perf tests: https://github.com/tenstorrent/tt-metal/actions/runs/33821764909

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_completion_ptr_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_completion_ptr_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_completion_ptr_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_completion_ptr_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_completion_ptr_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_completion_ptr_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_completion_ptr_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_completion_ptr_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_completion_ptr_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_completion_ptr_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_completion_ptr_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_completion_ptr_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_completion_ptr_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_completion_ptr_qsr)