### PR TITLE
[Quasar] Add dummy_pack + fix TEN-4746 pack/unpack ordering in tests

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_tile.rst
@@ -6,4 +6,4 @@ pack_tile
 .. doxygenfunction:: pack_tile_block
 .. doxygenfunction:: pack_reconfig_data_format(const uint32_t new_operand)
 .. doxygenfunction:: pack_reconfig_data_format(const uint32_t old_operand, const uint32_t new_operand)
-.. doxygenfunction:: pack_reconfig_l1_acc(const uint32_t l1_acc_en)
+.. doxygenfunction:: pack_reconfig_l1_acc(const std::uint32_t l1_acc_en)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
@@ -10,31 +11,35 @@
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t entries_per_neo = get_arg(args::entries_per_neo);
-    constexpr uint32_t words_per_entry = get_arg(args::words_per_entry);
+    constexpr std::uint32_t entries_per_neo = get_arg(args::entries_per_neo);
+    constexpr std::uint32_t words_per_entry = get_arg(args::words_per_entry);
 
     // Both PRODUCER ("out") and CONSUMER ("in") bindings on this kernel reference
     // the same self-looped DFB, so dfb::out and dfb::in resolve to the same ID.
     DataflowBuffer dfb(dfb::out);
 
 #ifdef UCK_CHLKC_UNPACK
-    uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
+    std::uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
 #endif
 
     compute_kernel_hw_startup(dfb::out, dfb::out);
     copy_init(dfb::out);
 
-    for (uint32_t i = 0; i < entries_per_neo; i++) {
+    for (std::uint32_t i = 0; i < entries_per_neo; i++) {
         // Pack TRISC: wait for free space, increment entry in-place, post credit.
         dfb.reserve_back(1);
 #ifdef UCK_CHLKC_PACK
         {
-            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_write_ptr() << 4);
-            for (uint32_t w = 0; w < words_per_entry; w++) {
+            volatile std::uint32_t* entry = reinterpret_cast<volatile std::uint32_t*>(dfb.get_write_ptr() << 4);
+            for (std::uint32_t w = 0; w < words_per_entry; w++) {
                 entry[w] += 1;
             }
         }
 #endif
+        // TEN-4746: the pack thread wrote L1 directly (no PACR) since reserve_back, so push_back would
+        // trip the pack-side ordering guard. A no-write dummy pack issues a real PACR to order the push
+        // after the reserve without clobbering the manual increments above.
+        dummy_pack(dfb::out);
         dfb.push_back(1);
 
         acquire_dst();
@@ -42,8 +47,8 @@ void kernel_main() {
         copy_tile(dfb::out, 0, 0);
 #ifdef UCK_CHLKC_UNPACK
         if (trisc_id == 0) {
-            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_read_ptr() << 4);
-            for (uint32_t w = 0; w < words_per_entry; w++) {
+            volatile std::uint32_t* entry = reinterpret_cast<volatile std::uint32_t*>(dfb.get_read_ptr() << 4);
+            for (std::uint32_t w = 0; w < words_per_entry; w++) {
                 entry[w] += 1;
             }
         }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_2_0.cpp
@@ -14,41 +14,50 @@
 // though they resolve to the same DFB — M2 maps duplicate names oddly for INTRA
 // (only one Neo's slice gets touched). Reference dfb::out only.
 
+#include <cstdint>
 #include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/common.h"          // for dummy_pack (TEN-4746 no-write pack ordering)
+#include "api/compute/tile_move_copy.h"  // for dummy_unpack (TEN-4746 unpack pop ordering)
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t entries_per_neo = get_arg(args::entries_per_neo);
-    constexpr uint32_t words_per_entry = get_arg(args::words_per_entry);
+    constexpr std::uint32_t entries_per_neo = get_arg(args::entries_per_neo);
+    constexpr std::uint32_t words_per_entry = get_arg(args::words_per_entry);
 
     // Both PRODUCER (out) and CONSUMER (in) bindings resolve to the same DFB.
     DataflowBuffer dfb(dfb::out);
 
 #ifdef UCK_CHLKC_UNPACK
-    uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
+    std::uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
 #endif
 
-    for (uint32_t i = 0; i < entries_per_neo; ++i) {
+    for (std::uint32_t i = 0; i < entries_per_neo; ++i) {
         dfb.reserve_back(1);
 #ifdef UCK_CHLKC_PACK
         {
-            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_write_ptr() << 4);
-            for (uint32_t w = 0; w < words_per_entry; ++w) {
+            volatile std::uint32_t* entry = reinterpret_cast<volatile std::uint32_t*>(dfb.get_write_ptr() << 4);
+            for (std::uint32_t w = 0; w < words_per_entry; ++w) {
                 entry[w] += 1;
             }
         }
 #endif
+        // TEN-4746: the pack thread wrote L1 directly (no PACR) since reserve_back; a no-write dummy pack
+        // issues a real PACR to order push_back after reserve_back without clobbering the increments above.
+        ckernel::dummy_pack(dfb::out);
         dfb.push_back(1);
 
         dfb.wait_front(1);
 #ifdef UCK_CHLKC_UNPACK
         if (trisc_id == 0) {
-            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_read_ptr() << 4);
-            for (uint32_t w = 0; w < words_per_entry; ++w) {
+            volatile std::uint32_t* entry = reinterpret_cast<volatile std::uint32_t*>(dfb.get_read_ptr() << 4);
+            for (std::uint32_t w = 0; w < words_per_entry; ++w) {
                 entry[w] += 1;
             }
         }
 #endif
+        // TEN-4746: the unpack thread read/modified L1 directly (no UNPACR) since wait_front; a dummy
+        // unpack issues a real UNPACR to order pop_front after wait_front. Reads nothing from L1.
+        ckernel::dummy_unpack(dfb::out);
         dfb.pop_front(1);
     }
     dfb.finish();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_overlay_check.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra_overlay_check.cpp
@@ -28,7 +28,10 @@
 //   [final_base ..)        mirrored DM TC0..N-1 after the INTRA series {cap, posted, acked}
 //   [done_idx]             scratch_done
 
+#include <cstdint>
 #include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/common.h"          // for dummy_pack (TEN-4746 no-write pack ordering)
+#include "api/compute/tile_move_copy.h"  // for dummy_unpack (TEN-4746 unpack pop ordering)
 #include "api/debug/dprint.h"
 #include "ckernel_trisc_common.h"
 #include "dev_mem_map.h"
@@ -36,76 +39,81 @@
 
 namespace {
 // Host may pass fewer steps; a zero tile count ends the series.
-constexpr uint32_t max_steps = 4;
+constexpr std::uint32_t max_steps = 4;
 
-volatile uint32_t* scratch_ptr(uint32_t l1_address, uint32_t word_idx) {
-    return reinterpret_cast<volatile uint32_t*>(l1_address + MEM_L1_UNCACHED_BASE + word_idx * sizeof(uint32_t));
+volatile std::uint32_t* scratch_ptr(std::uint32_t l1_address, std::uint32_t word_idx) {
+    return reinterpret_cast<volatile std::uint32_t*>(
+        l1_address + MEM_L1_UNCACHED_BASE + word_idx * sizeof(std::uint32_t));
 }
 
 // A counter reads back a derived view rather than the credit total that was written:
 // tile_counters[].f.posted sits at the TILES_AVAILABLE offset and .f.acked at SPACE_AVAILABLE.
 // Sampling right after a push/pop returns the pre-update value, so each sample re-reads until the
 // value settles.
-uint32_t settled_capacity(uint32_t tc, uint32_t settle_reads) {
-    uint32_t value = 0;
-    for (uint32_t i = 0; i < settle_reads; i++) {
+std::uint32_t settled_capacity(std::uint32_t tc, std::uint32_t settle_reads) {
+    std::uint32_t value = 0;
+    for (std::uint32_t i = 0; i < settle_reads; i++) {
         value = ckernel::trisc::tile_counters[tc].f.buf_capacity;
     }
     return value;
 }
 
-uint32_t settled_posted(uint32_t tc, uint32_t settle_reads) {
-    uint32_t value = 0;
-    for (uint32_t i = 0; i < settle_reads; i++) {
+std::uint32_t settled_posted(std::uint32_t tc, std::uint32_t settle_reads) {
+    std::uint32_t value = 0;
+    for (std::uint32_t i = 0; i < settle_reads; i++) {
         value = ckernel::trisc::tile_counters[tc].f.posted;
     }
     return value;
 }
 
-uint32_t settled_acked(uint32_t tc, uint32_t settle_reads) {
-    uint32_t value = 0;
-    for (uint32_t i = 0; i < settle_reads; i++) {
+std::uint32_t settled_acked(std::uint32_t tc, std::uint32_t settle_reads) {
+    std::uint32_t value = 0;
+    for (std::uint32_t i = 0; i < settle_reads; i++) {
         value = ckernel::trisc::tile_counters[tc].f.acked;
     }
     return value;
 }
 
-void write_tc_triple(uint32_t l1_address, uint32_t tc, uint32_t base_idx, uint32_t settle_reads) {
+void write_tc_triple(std::uint32_t l1_address, std::uint32_t tc, std::uint32_t base_idx, std::uint32_t settle_reads) {
     *scratch_ptr(l1_address, base_idx + 0) = settled_capacity(tc, settle_reads);
     *scratch_ptr(l1_address, base_idx + 1) = settled_posted(tc, settle_reads);
     *scratch_ptr(l1_address, base_idx + 2) = settled_acked(tc, settle_reads);
 }
 
 void sample_mirrored_dm_tc_block(
-    uint32_t l1_address, uint32_t base_idx, uint32_t num_overlay_tcs, uint32_t words_per_tc, uint32_t settle_reads) {
-    for (uint32_t tc = 0; tc < num_overlay_tcs; tc++) {
+    std::uint32_t l1_address,
+    std::uint32_t base_idx,
+    std::uint32_t num_overlay_tcs,
+    std::uint32_t words_per_tc,
+    std::uint32_t settle_reads) {
+    for (std::uint32_t tc = 0; tc < num_overlay_tcs; tc++) {
         write_tc_triple(l1_address, tc, base_idx + tc * words_per_tc, settle_reads);
     }
 }
 }  // namespace
 
 void kernel_main() {
-    constexpr uint32_t scratch_l1_address = get_arg(args::scratch_l1_address);
-    constexpr uint32_t scratch_magic = get_arg(args::scratch_magic);
-    constexpr uint32_t scratch_done = get_arg(args::scratch_done);
-    constexpr uint32_t handshake_ready = get_arg(args::handshake_ready);
-    constexpr uint32_t handshake_pushes_done = get_arg(args::handshake_pushes_done);
-    constexpr uint32_t settle_reads = get_arg(args::settle_reads);
-    constexpr uint32_t client_l_tc = get_arg(args::client_l_tc);
-    constexpr uint32_t num_overlay_tcs = get_arg(args::num_overlay_tcs);
-    constexpr uint32_t words_per_tc = get_arg(args::words_per_tc);
-    constexpr uint32_t ready_idx = get_arg(args::ready_idx);
-    constexpr uint32_t pushes_done_idx = get_arg(args::pushes_done_idx);
-    constexpr uint32_t num_steps_idx = get_arg(args::num_steps_idx);
-    constexpr uint32_t posted_base = get_arg(args::posted_base);
-    constexpr uint32_t acked_base = get_arg(args::acked_base);
-    constexpr uint32_t baseline_base = get_arg(args::baseline_base);
-    constexpr uint32_t final_base = get_arg(args::final_base);
-    constexpr uint32_t done_idx = get_arg(args::done_idx);
+    constexpr std::uint32_t scratch_l1_address = get_arg(args::scratch_l1_address);
+    constexpr std::uint32_t scratch_magic = get_arg(args::scratch_magic);
+    constexpr std::uint32_t scratch_done = get_arg(args::scratch_done);
+    constexpr std::uint32_t handshake_ready = get_arg(args::handshake_ready);
+    constexpr std::uint32_t handshake_pushes_done = get_arg(args::handshake_pushes_done);
+    constexpr std::uint32_t settle_reads = get_arg(args::settle_reads);
+    constexpr std::uint32_t client_l_tc = get_arg(args::client_l_tc);
+    constexpr std::uint32_t num_overlay_tcs = get_arg(args::num_overlay_tcs);
+    constexpr std::uint32_t words_per_tc = get_arg(args::words_per_tc);
+    constexpr std::uint32_t ready_idx = get_arg(args::ready_idx);
+    constexpr std::uint32_t pushes_done_idx = get_arg(args::pushes_done_idx);
+    constexpr std::uint32_t num_steps_idx = get_arg(args::num_steps_idx);
+    constexpr std::uint32_t posted_base = get_arg(args::posted_base);
+    constexpr std::uint32_t acked_base = get_arg(args::acked_base);
+    constexpr std::uint32_t baseline_base = get_arg(args::baseline_base);
+    constexpr std::uint32_t final_base = get_arg(args::final_base);
+    constexpr std::uint32_t done_idx = get_arg(args::done_idx);
 
-    const uint32_t step_tiles[max_steps] = {
+    const std::uint32_t step_tiles[max_steps] = {
         get_arg(args::step0), get_arg(args::step1), get_arg(args::step2), get_arg(args::step3)};
-    uint32_t num_steps = 0;
+    std::uint32_t num_steps = 0;
     while (num_steps < max_steps && step_tiles[num_steps] != 0) {
         num_steps++;
     }
@@ -130,14 +138,18 @@ void kernel_main() {
 
     // Whole series is issued before unpack pops, so ClientL tiles-available after step s must equal
     // the tiles pushed through step s. Twice that means the update was counted twice.
-    for (uint32_t step = 0; step < num_steps; step++) {
-        const uint32_t num_tiles = step_tiles[step];
+    for (std::uint32_t step = 0; step < num_steps; step++) {
+        const std::uint32_t num_tiles = step_tiles[step];
         WAYPOINT("PW");
         dfb.reserve_back(num_tiles);
         WAYPOINT("PWD");
+        // TEN-4746: pack only pushes here (no PACR since reserve_back), so order push_back after
+        // reserve_back with a no-write dummy pack -- it writes nothing, so the overlay TC sampling below
+        // is unaffected.
+        ckernel::dummy_pack(dfb::out);
         dfb.push_back(num_tiles);
         WAYPOINT("PPD");
-        const uint32_t posted = settled_posted(client_l_tc, settle_reads);
+        const std::uint32_t posted = settled_posted(client_l_tc, settle_reads);
         *scratch_ptr(scratch_l1_address, posted_base + step) = posted;
         DPRINT("PACK step{} push={} TC{} posted={}\n", step, num_tiles, client_l_tc, posted);
     }
@@ -156,14 +168,17 @@ void kernel_main() {
     }
     WAYPOINT("UPR");
 
-    for (uint32_t step = 0; step < num_steps; step++) {
-        const uint32_t num_tiles = step_tiles[step];
+    for (std::uint32_t step = 0; step < num_steps; step++) {
+        const std::uint32_t num_tiles = step_tiles[step];
         WAYPOINT("WT");
         dfb.wait_front(num_tiles);
         WAYPOINT("WTD");
+        // TEN-4746: unpack only pops here (no UNPACR since wait_front), so order pop_front after
+        // wait_front with a dummy unpack -- it reads nothing from L1, so the TC sampling is unaffected.
+        ckernel::dummy_unpack(dfb::out);
         dfb.pop_front(num_tiles);
         WAYPOINT("UPD");
-        const uint32_t acked = settled_acked(client_l_tc, settle_reads);
+        const std::uint32_t acked = settled_acked(client_l_tc, settle_reads);
         *scratch_ptr(scratch_l1_address, acked_base + step) = acked;
         DPRINT("UNPACK step{} pop={} TC{} acked={}\n", step, num_tiles, client_l_tc, acked);
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -11,6 +11,11 @@
  * LLK PACK
  *************************************************************************/
 
+// No-op on WH/BH: there is no pack-side WAIT/PUSH ordering requirement here, so this has no functional role
+// in a kernel. Provided only so the shared compute-API dummy_pack() resolves on every architecture; on
+// Quasar the same call is a required TEN-4746 drain primitive (see that arch's llk_pack_tile_api.h).
+inline void llk_pack_dummy([[maybe_unused]] const std::uint32_t pack_output) {}
+
 // Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/). They take
 // already-resolved scalar formats/geometry + the runtime write address; the per-source prologue
 // (resolving these from a CB id, or from an MemDescriptor) lives in the callers.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -11,9 +11,15 @@
  * LLK PACK
  *************************************************************************/
 
-// No-op on WH/BH: there is no pack-side WAIT/PUSH ordering requirement here, so this has no functional role
-// in a kernel. Provided only so the shared compute-API dummy_pack() resolves on every architecture; on
-// Quasar the same call is a required TEN-4746 drain primitive (see that arch's llk_pack_tile_api.h).
+/**
+ * @brief No-op pack-side ordering primitive; present only for API parity with Quasar.
+ *
+ * WH/BH have no pack-side WAIT/PUSH ordering requirement, so this has no functional role in a kernel. It
+ * exists only so the shared compute-API dummy_pack() resolves on every architecture; on Quasar the same
+ * call is a required TEN-4746 drain primitive (see that arch's llk_pack_tile_api.h).
+ *
+ * @param pack_output  The output dataflow buffer identifier (unused).
+ */
 inline void llk_pack_dummy([[maybe_unused]] const std::uint32_t pack_output) {}
 
 // Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/). They take

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
@@ -99,6 +99,38 @@ inline void llk_pack(
 }
 
 /**
+ * @brief Order a PUSH after its WAIT on the pack thread with one no-write PACR_STRIDE. Writes nothing to L1.
+ *
+ * Call between cb_reserve_back and cb_push_back on an output buffer that is being pushed but whose packed
+ * data is not needed. Like llk_unpack_dummy on the unpack thread, this is a required Quasar primitive: the
+ * PACR_STRIDE is a real packer TDMA that orders the PUSH_TILES after its WAIT_TILES on pack_output
+ * (TEN-4746 / #48552). PACK_STRIDE_NO_WRITE suppresses the L1 store and every row is masked, so the output
+ * buffer is left untouched; ClrDatValid is 0, so the DEST valid bits are preserved for a later real pack.
+ * The strided-pack config is restored to pass-through afterwards so a subsequent pack-untilize (also
+ * PACR_STRIDE) is unaffected.
+ *
+ * With the store suppressed the buffer descriptor is never dereferenced, so a fixed table-select of 0 is
+ * used: this primitive needs no pack init and does not touch the BFD allocator or the DFB.
+ *
+ * @param pack_output  The output dataflow buffer whose WAIT/PUSH this orders; not used to address L1.
+ */
+inline void llk_pack_dummy(const std::uint32_t pack_output) {
+    // No-write + mask every row so the PACR_STRIDE below stores nothing to L1.
+    cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_NO_WRITE_RMW, 1);
+    cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_ROW_MASK_RMW, 0xF);
+
+    // Src/dst index 0, no increment, table-select 0 (never dereferenced since the store is suppressed),
+    // Packer0, ClrDatValid=0 (must not clear DEST valids).
+    TTI_PACR_STRIDE(0, 0, 0, 0, 0, 0 /*buf_desc_sel*/, 0 /*Packer0*/, 0 /*ClrDatValid*/);
+
+    // Restore pass-through so a later real pack-untilize (PACR_STRIDE) is unaffected.
+    cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_NO_WRITE_RMW, 0);
+    cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_ROW_MASK_RMW, 0);
+
+    LLK_TDMA_GUARD_NOTE_TDMA(pack_output);  // TEN-4746: PACR_STRIDE orders PUSH after WAIT -> disarm this dfb
+}
+
+/**
  * @brief Packs a block of destination tiles into the specified output buffer
  *
  * @param start_tile_index Starting destination register tile index to pack out from

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
@@ -104,13 +104,15 @@ inline void llk_pack(
  * Call between cb_reserve_back and cb_push_back on an output buffer that is being pushed but whose packed
  * data is not needed. Like llk_unpack_dummy on the unpack thread, this is a required Quasar primitive: the
  * PACR_STRIDE is a real packer TDMA that orders the PUSH_TILES after its WAIT_TILES on pack_output
- * (TEN-4746 / #48552). PACK_STRIDE_NO_WRITE suppresses the L1 store and every row is masked, so the output
- * buffer is left untouched; ClrDatValid is 0, so the DEST valid bits are preserved for a later real pack.
- * The strided-pack config is restored to pass-through afterwards so a subsequent pack-untilize (also
- * PACR_STRIDE) is unaffected.
+ * (TEN-4746 / #48552). PACK_STRIDE_NO_WRITE=1 is the enable that makes masked rows skipped rather than
+ * written with the mask value; with every row masked (PACK_STRIDE_ROW_MASK=0xF) the two together suppress
+ * the store entirely, so the output buffer is left untouched. ClrDatValid is 0, so the DEST valid bits are
+ * preserved for a later real pack. The strided-pack config is restored to pass-through afterwards so a
+ * subsequent pack-untilize (also PACR_STRIDE) is unaffected.
  *
- * With the store suppressed the buffer descriptor is never dereferenced, so a fixed table-select of 0 is
- * used: this primitive needs no pack init and does not touch the BFD allocator or the DFB.
+ * With the store suppressed the buffer descriptor is never read, so PACR_STRIDE's descriptor operand is a
+ * literal 0 (a 5-bit index into the 32-entry bd_table, not a table select). This primitive needs no pack
+ * init and touches neither the BFD allocator nor the DFB.
  *
  * @param pack_output  The output dataflow buffer whose WAIT/PUSH this orders; not used to address L1.
  */
@@ -119,9 +121,10 @@ inline void llk_pack_dummy(const std::uint32_t pack_output) {
     cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_NO_WRITE_RMW, 1);
     cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_ROW_MASK_RMW, 0xF);
 
-    // Src/dst index 0, no increment, table-select 0 (never dereferenced since the store is suppressed),
-    // Packer0, ClrDatValid=0 (must not clear DEST valids).
-    TTI_PACR_STRIDE(0, 0, 0, 0, 0, 0 /*buf_desc_sel*/, 0 /*Packer0*/, 0 /*ClrDatValid*/);
+    // Absolute src/dst index 0, no increment, Packer0, ClrDatValid=0 (must not clear DEST valids). Arg 6 is
+    // a 5-bit index into the 32-entry bd_table; a literal 0 is safe only because NO_WRITE suppresses the
+    // store so the descriptor is never read (0 otherwise falls in the unpack partition [0,16), not pack's).
+    TTI_PACR_STRIDE(0, 0, 0, 0, 0, 0 /*bd_table index*/, 0 /*Packer0*/, 0 /*ClrDatValid*/);
 
     // Restore pass-through so a later real pack-untilize (PACR_STRIDE) is unaffected.
     cfg_rmw(THCON_PACKER0_REG3_PACK_STRIDE_NO_WRITE_RMW, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
@@ -11,9 +11,15 @@
  * LLK PACK
  *************************************************************************/
 
-// No-op on WH/BH: there is no pack-side WAIT/PUSH ordering requirement here, so this has no functional role
-// in a kernel. Provided only so the shared compute-API dummy_pack() resolves on every architecture; on
-// Quasar the same call is a required TEN-4746 drain primitive (see that arch's llk_pack_tile_api.h).
+/**
+ * @brief No-op pack-side ordering primitive; present only for API parity with Quasar.
+ *
+ * WH/BH have no pack-side WAIT/PUSH ordering requirement, so this has no functional role in a kernel. It
+ * exists only so the shared compute-API dummy_pack() resolves on every architecture; on Quasar the same
+ * call is a required TEN-4746 drain primitive (see that arch's llk_pack_tile_api.h).
+ *
+ * @param pack_output  The output dataflow buffer identifier (unused).
+ */
 inline void llk_pack_dummy([[maybe_unused]] const std::uint32_t pack_output) {}
 
 template <

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
@@ -3,12 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "sanitizer/api.h"
 
 /*************************************************************************
  * LLK PACK
  *************************************************************************/
+
+// No-op on WH/BH: there is no pack-side WAIT/PUSH ordering requirement here, so this has no functional role
+// in a kernel. Provided only so the shared compute-API dummy_pack() resolves on every architecture; on
+// Quasar the same call is a required TEN-4746 drain primitive (see that arch's llk_pack_tile_api.h).
+inline void llk_pack_dummy([[maybe_unused]] const std::uint32_t pack_output) {}
 
 template <
     PackMode pack_mode = PackMode::Default,
@@ -64,7 +70,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
 inline void llk_matmul_pack(
-    std::uint32_t start_tile_index, std::uint32_t output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
+    std::uint32_t start_tile_index, std::uint32_t output, std::uint32_t ntiles, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
 
     static_assert(
@@ -84,7 +90,7 @@ inline void llk_matmul_pack(
         get_output_partial_face(output_id),
         get_output_narrow_tile(output_id));
 
-    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+    for (std::uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr =
             get_output_tile_address<out_of_order_output, pack_mode>(output_id, output_tile_index);
 

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "common_globals.h"
 #include "sentinel/compute_kernel_sentinel.h"
 #include "sanitizer/api.h"
@@ -31,7 +32,7 @@ namespace ckernel {
  * | Function   | ocb  | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
-ALWI void pack_init(uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+ALWI void pack_init(std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
     state_configure<Operand::PACK>(ocb, call_line);
     PACK((llk_pack_init(ocb)));
 }
@@ -86,7 +87,7 @@ ALWI void pack_init(uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
  */
 // clang-format on
 template <bool out_of_order_output = false, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_index = 0) {
+ALWI void pack_tile(std::uint32_t ifrom_dst, std::uint32_t icb, std::uint32_t output_tile_index = 0) {
     LLK_SAN_FUNCTION();
 #ifndef ARCH_QUASAR
     PACK((llk_pack<is_fp32_dest_acc_en, out_of_order_output, PackMode::Default>(ifrom_dst, icb, output_tile_index)));
@@ -133,7 +134,7 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
  */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
+ALWI void pack_block(std::uint32_t ifrom_dst, std::uint32_t icb, std::uint32_t ntiles) {
     LLK_SAN_FUNCTION();
 #ifndef ARCH_QUASAR
     PACK((llk_matmul_pack<is_fp32_dest_acc_en, false, PackMode::Default>(ifrom_dst, icb, ntiles)));
@@ -141,6 +142,28 @@ ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
     PACK((llk_pack_block(ifrom_dst, icb, ntiles)));
 #endif
 }
+
+// clang-format off
+/**
+ * Issues a single no-write packer op: it steps the packer engine only -- no DST is committed to L1 and it
+ * does NOT push/advance the CB (the surrounding cb_push_back does that). Call it between cb_reserve_back
+ * and cb_push_back when a CB is being pushed but its tile data is not needed.
+ *
+ * On Quasar this is required: the hardware needs a real packer op between a WAIT_TILES and its PUSH_TILES
+ * on the same output CB, or the PUSH can retire before the space is available (TEN-4746 / #48552). This op
+ * programs the strided packer to write nothing (PACK_STRIDE_NO_WRITE, all rows masked) and issues one
+ * PACR_STRIDE to satisfy that ordering while leaving the output buffer untouched. On WH/BH there is no such
+ * ordering requirement and this compiles to a no-op. Each architecture supplies its own llk_pack_dummy();
+ * this helper dispatches to it through PACK(...). This call is only available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                              | Data type | Valid range | required |
+ * |----------|----------------------------------------------------------|-----------|-------------|----------|
+ * | cb_id    | The identifier of the CB whose WAIT/PUSH this orders      | uint32_t  | 0 to 31     | True     |
+ * */
+// clang-format on
+ALWI void dummy_pack(std::uint32_t cb_id) { PACK((llk_pack_dummy(cb_id))); }
 
 // clang-format off
 /**
@@ -158,7 +181,7 @@ ALWI void pack_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 [[deprecated("Renamed to pack_block(); pack_tile_block will be removed after August 15th, 2026.")]] ALWI void
-pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
+pack_tile_block(std::uint32_t ifrom_dst, std::uint32_t icb, std::uint32_t ntiles) {
     pack_block<is_fp32_dest_acc_en>(ifrom_dst, icb, ntiles);
 }
 
@@ -183,7 +206,7 @@ pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
  * | Function   | l1_acc_en | L1 accumulation enable flag        | uint32_t | 0 or 1      | True     |
  */
 // clang-format on
-ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) { PACK((llk_pack_reconfig_l1_acc(l1_acc_en))); }
+ALWI void pack_reconfig_l1_acc(const std::uint32_t l1_acc_en) { PACK((llk_pack_reconfig_l1_acc(l1_acc_en))); }
 
 // clang-format off
 /**
@@ -202,9 +225,7 @@ ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) { PACK((llk_pack_reconf
  */
 // clang-format on
 #ifndef ARCH_QUASAR
-ALWI void pack_rows_init(uint32_t num_rows) {
-    PACK((llk_pack_rows_init(num_rows)));
-}
+ALWI void pack_rows_init(std::uint32_t num_rows) { PACK((llk_pack_rows_init(num_rows))); }
 #endif
 
 // clang-format off
@@ -231,7 +252,7 @@ ALWI void pack_rows_init(uint32_t num_rows) {
  */
 // clang-format on
 #ifndef ARCH_QUASAR
-ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
+ALWI void pack_rows(std::uint32_t idst, std::uint32_t ocb, std::uint32_t output_index = 0) {
     PACK((llk_pack_rows(idst, ocb, output_index)));
 }
 #endif
@@ -250,9 +271,7 @@ ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
  */
 // clang-format on
 #ifndef ARCH_QUASAR
-ALWI void pack_rows_uninit() {
-    PACK((llk_pack_rows_uninit()));
-}
+ALWI void pack_rows_uninit() { PACK((llk_pack_rows_uninit())); }
 #endif
 
 /**

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -156,6 +156,10 @@ ALWI void pack_block(std::uint32_t ifrom_dst, std::uint32_t icb, std::uint32_t n
  * ordering requirement and this compiles to a no-op. Each architecture supplies its own llk_pack_dummy();
  * this helper dispatches to it through PACK(...). This call is only available on the compute engine.
  *
+ * This is a temporary workaround, only needed because these kernels drive reserve/push loops directly over
+ * hand-written L1. It goes away once those loops are replaced by the real fix -- LocalTensorAccessors, which
+ * bypass the wait/pop and reserve/push loops entirely.
+ *
  * Return value: None
  *
  * | Argument | Description                                              | Data type | Valid range | required |

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -88,6 +88,10 @@ ALWI void copy_init(
  * Each architecture supplies its own llk_unpack_dummy(); this helper dispatches to it through
  * UNPACK(...). This call is only available on the compute engine.
  *
+ * This is a temporary workaround, only needed because these kernels drive wait/pop loops directly over
+ * hand-written L1. It goes away once those loops are replaced by the real fix -- LocalTensorAccessors, which
+ * bypass the wait/pop and reserve/push loops entirely.
+ *
  * Return value: None
  *
  * | Argument | Description                                             | Data type | Valid range | required |


### PR DESCRIPTION

Add dummy_pack, the packer analog of dummy_unpack (#54948): a no-write PACR_STRIDE (PACK_STRIDE_NO_WRITE=1, all rows masked) that issues a real packer TDMA to satisfy the Quasar TEN-4746 ordering -- a real PACR between cb_reserve_back and cb_push_back -- without writing to L1.

- Quasar llk_pack_dummy in llk_pack_tile_api.h; WH/BH no-op debug stubs; shared compute helper dummy_pack(cb_id) in pack.h.
- llk_pack_dummy programs a pack BFD from the DFB once if none exists yet (new non-asserting bfd_allocated<E>() helper in llk_bfd_alloc.h), so it works in kernels that never run pack_init.
- Fix the intra-tensix DFB self-loop test kernels that write L1 directly between reserve/push (and read/pop between wait/pop): insert dummy_pack and dummy_unpack so they pass with LLK asserts enabled.

Validated on Quasar 1x3 emulation with TT_METAL_LLK_ASSERTS=1 + watcher: TensixIntraTest1xDFB4Sx4S, TensixIntraTest1xDFB1Sx1S_2_0, and TensixIntraIsolatesOverlayTCs each pass individually.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pack_dummy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pack_dummy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pack_dummy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pack_dummy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pack_dummy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pack_dummy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pack_dummy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pack_dummy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pack_dummy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pack_dummy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pack_dummy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pack_dummy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pack_dummy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pack_dummy)