### PR TITLE
[Cleanup] Avoid duplicative tile metadata for `DataflowBufferSpec`

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -78,6 +78,7 @@ set(UNIT_TESTS_API_SOURCES
     test_simple_l1_buffer.cpp
     test_soc_descriptor.cpp
     test_stream_scratch_register.cpp
+    test_tile.cpp
     test_tilize_untilize.cpp
     test_worker_config_buffer.cpp
     test_blockfloat_common.cpp

--- a/tests/tt_metal/tt_metal/api/test_tile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tile.cpp
@@ -126,8 +126,7 @@ TEST(TileConstructor, CustomFaceShapeRejectsTooManyFacesAlongADim) {
 }
 
 // transpose_tile is an extra flag on both constructors, not part of shape validation.
-// The tile-shape-only constructor additionally requires height 16 or 32; the custom
-// face-shape constructor does not.
+// Both constructors require height 16 or 32 when transpose is enabled.
 TEST(TileConstructorTranspose, DefaultsToOff) {
     const Tile tile({32, 32});
     EXPECT_FALSE(tile.get_transpose_within_face());
@@ -150,10 +149,16 @@ TEST(TileConstructorTranspose, TileShapeOnlyRejectsHeightOtherThan16Or32) {
         ThrowsMessage<std::runtime_error>(HasSubstr("Tile height must equal 16 or 32 in transpose mode")));
 }
 
-TEST(TileConstructorTranspose, CustomFaceShapeEnablesFlagsWithoutHeightCheck) {
-    const Tile tile({8, 32}, {8, 16}, /*transpose_tile=*/true);
+TEST(TileConstructorTranspose, CustomFaceShapeEnablesFlagsWhenHeightIs16Or32) {
+    const Tile tile({16, 32}, {8, 16}, /*transpose_tile=*/true);
     EXPECT_TRUE(tile.get_transpose_within_face());
     EXPECT_TRUE(tile.get_transpose_of_faces());
+}
+
+TEST(TileConstructorTranspose, CustomFaceShapeRejectsHeightOtherThan16Or32) {
+    EXPECT_THAT(
+        [] { Tile({8, 32}, {8, 16}, /*transpose_tile=*/true); },
+        ThrowsMessage<std::runtime_error>(HasSubstr("Tile height must equal 16 or 32 in transpose mode")));
 }
 
 TEST(TileFromFaceGrid, DefaultFaceProduces32x32) { EXPECT_EQ(Tile::from_face_grid({2, 2}), Tile()); }

--- a/tests/tt_metal/tt_metal/api/test_tile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tile.cpp
@@ -156,5 +156,21 @@ TEST(TileConstructorTranspose, CustomFaceShapeEnablesFlagsWithoutHeightCheck) {
     EXPECT_TRUE(tile.get_transpose_of_faces());
 }
 
+TEST(TileFromFaceGrid, DefaultFaceProduces32x32) { EXPECT_EQ(Tile::from_face_grid({2, 2}), Tile()); }
+
+TEST(TileFromFaceGrid, CustomFaceMatchesEquivalentConstructor) {
+    constexpr std::array<uint32_t, 2> face_shape{8, 16};
+    const Tile from_grid = Tile::from_face_grid({2, 2}, face_shape);
+    const Tile from_ctor({16, 32}, face_shape);
+    EXPECT_EQ(from_grid, from_ctor);
+}
+
+TEST(TileFromFaceGrid, RejectsGridThatExceedsMaxFaces) {
+    // 4x2 faces of 8x16 → 32x32 tile, but 4 faces along a dim exceeds the max of 2.
+    EXPECT_THAT(
+        [] { (void)Tile::from_face_grid({4, 2}, {8, 16}); },
+        ThrowsMessage<std::runtime_error>(HasSubstr("exceeds the maximum supported num_faces")));
+}
+
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_tile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tile.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tile.hpp>
+
+namespace tt::tt_metal {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::ThrowsMessage;
+
+struct KnownTileShape {
+    std::array<uint32_t, 2> tile_shape;
+    std::array<uint32_t, 2> default_face_shape;
+};
+
+// Must stay in sync with TILE_FACE_HW_CHOICES in tt_metal/impl/data_format/tile.cpp.
+constexpr KnownTileShape kKnownTileShapes[] = {
+    {{{32, 32}}, {{16, 16}}},
+    {{{16, 32}}, {{16, 16}}},
+    {{{32, 16}}, {{16, 16}}},
+    {{{16, 16}}, {{16, 16}}},
+    {{{8, 32}}, {{8, 16}}},
+    {{{4, 32}}, {{4, 16}}},
+    {{{2, 32}}, {{2, 16}}},
+    {{{1, 32}}, {{1, 16}}},
+    {{{8, 16}}, {{8, 16}}},
+    {{{4, 16}}, {{4, 16}}},
+    {{{2, 16}}, {{2, 16}}},
+    {{{1, 16}}, {{1, 16}}},
+};
+
+void ExpectDerivedFields(const Tile& tile, std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape) {
+    const uint32_t tile_hw = tile_shape[0] * tile_shape[1];
+    const uint32_t face_hw = face_shape[0] * face_shape[1];
+
+    EXPECT_EQ(tile.get_tile_shape(), tile_shape);
+    EXPECT_EQ(tile.get_face_shape(), face_shape);
+    EXPECT_EQ(tile.get_height(), tile_shape[0]);
+    EXPECT_EQ(tile.get_width(), tile_shape[1]);
+    EXPECT_EQ(tile.get_tile_hw(), tile_hw);
+    EXPECT_EQ(tile.get_face_hw(), face_hw);
+    EXPECT_EQ(tile.get_num_faces(), tile_hw / face_hw);
+    EXPECT_EQ(tile.get_partial_face(), static_cast<uint32_t>(tile_shape[0] < constants::TILE_HEIGHT));
+    EXPECT_EQ(tile.get_narrow_tile(), static_cast<uint32_t>(tile_shape[1] < constants::TILE_WIDTH));
+}
+
+TEST(TileConstructor, DefaultIsFull32x32) {
+    const Tile tile;
+    ExpectDerivedFields(
+        tile, {constants::TILE_HEIGHT, constants::TILE_WIDTH}, {constants::FACE_HEIGHT, constants::FACE_WIDTH});
+}
+
+TEST(TileConstructor, TileShapeOnlyDerivesDefaultFaceForKnownShapes) {
+    for (const auto& known : kKnownTileShapes) {
+        const Tile tile(known.tile_shape);
+        ExpectDerivedFields(tile, known.tile_shape, known.default_face_shape);
+    }
+}
+
+TEST(TileConstructor, TileShapeOnlyRejectsUnknownTileShape) {
+    constexpr std::array<std::array<uint32_t, 2>, 6> kInvalidShapes = {{
+        {3, 32},
+        {5, 7},
+        {3, 16},
+        {0, 32},
+        {32, 3},
+        {6, 32},
+    }};
+
+    for (const auto& shape : kInvalidShapes) {
+        EXPECT_THAT(
+            [&] { (void)Tile(shape); },
+            ThrowsMessage<std::runtime_error>(HasSubstr("Tile size is not valid for our hardware")));
+    }
+}
+
+TEST(TileConstructor, CustomFaceShapeMatchesTileShapeOnlyWhenFaceIsDefault) {
+    for (const auto& known : kKnownTileShapes) {
+        const Tile derived(known.tile_shape);
+        const Tile explicit_face(known.tile_shape, known.default_face_shape);
+        EXPECT_EQ(derived, explicit_face);
+        ExpectDerivedFields(explicit_face, known.tile_shape, known.default_face_shape);
+    }
+}
+
+TEST(TileConstructor, CustomFaceShapeAcceptsFaceThatTilesEvenly) {
+    // 16x32 tile with 8x16 faces: 2x2 face grid, within the LLK max of 2 faces per dim.
+    constexpr std::array<uint32_t, 2> tile_shape{16, 32};
+    constexpr std::array<uint32_t, 2> face_shape{8, 16};
+    const Tile tile(tile_shape, face_shape);
+    ExpectDerivedFields(tile, tile_shape, face_shape);
+}
+
+TEST(TileConstructor, CustomFaceShapeRejectsUnknownTileShape) {
+    EXPECT_THAT(
+        [] { Tile({3, 32}, {16, 16}); },
+        ThrowsMessage<std::runtime_error>(HasSubstr("Tile size is not valid for our hardware")));
+}
+
+TEST(TileConstructor, CustomFaceShapeRejectsFaceThatDoesNotTileEvenly) {
+    EXPECT_THAT(
+        [] { Tile({32, 32}, {16, 12}); },
+        ThrowsMessage<std::runtime_error>(HasSubstr("must tile evenly into face shape")));
+}
+
+TEST(TileConstructor, CustomFaceShapeRejectsFaceExceedingMaxDims) {
+    EXPECT_THAT(
+        [] { Tile({32, 32}, {32, 16}); },
+        ThrowsMessage<std::runtime_error>(HasSubstr("exceeds the maximum supported face shape")));
+}
+
+TEST(TileConstructor, CustomFaceShapeRejectsTooManyFacesAlongADim) {
+    // 32x32 / 8x16 = 4x2 faces; max faces along a dim is 2.
+    EXPECT_THAT(
+        [] { Tile({32, 32}, {8, 16}); },
+        ThrowsMessage<std::runtime_error>(HasSubstr("exceeds the maximum supported num_faces")));
+}
+
+// transpose_tile is an extra flag on both constructors, not part of shape validation.
+// The tile-shape-only constructor additionally requires height 16 or 32; the custom
+// face-shape constructor does not.
+TEST(TileConstructorTranspose, DefaultsToOff) {
+    const Tile tile({32, 32});
+    EXPECT_FALSE(tile.get_transpose_within_face());
+    EXPECT_FALSE(tile.get_transpose_of_faces());
+}
+
+TEST(TileConstructorTranspose, TileShapeOnlyEnablesFlagsWhenHeightIs16Or32) {
+    const Tile transposed_full({32, 32}, /*transpose_tile=*/true);
+    EXPECT_TRUE(transposed_full.get_transpose_within_face());
+    EXPECT_TRUE(transposed_full.get_transpose_of_faces());
+
+    const Tile transposed_half({16, 32}, /*transpose_tile=*/true);
+    EXPECT_TRUE(transposed_half.get_transpose_within_face());
+    EXPECT_TRUE(transposed_half.get_transpose_of_faces());
+}
+
+TEST(TileConstructorTranspose, TileShapeOnlyRejectsHeightOtherThan16Or32) {
+    EXPECT_THAT(
+        [] { Tile({8, 32}, /*transpose_tile=*/true); },
+        ThrowsMessage<std::runtime_error>(HasSubstr("Tile height must equal 16 or 32 in transpose mode")));
+}
+
+TEST(TileConstructorTranspose, CustomFaceShapeEnablesFlagsWithoutHeightCheck) {
+    const Tile tile({8, 32}, {8, 16}, /*transpose_tile=*/true);
+    EXPECT_TRUE(tile.get_transpose_within_face());
+    EXPECT_TRUE(tile.get_transpose_of_faces());
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -32,6 +32,7 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tile.hpp>
 #include "llk_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include "hostdevcommon/kernel_structs.h"
@@ -59,6 +60,16 @@ namespace tt::tt_metal {
 using std::vector;
 using namespace tt;
 using namespace tt::test_utils;
+
+namespace {
+// Describe a tile that holds `num_faces` faces of `face_r_dim` rows each, laid out as a
+// 1xN or 2xN face grid (the LLK caps the grid at 2x2).
+Tile tile_from_face_layout(uint32_t face_r_dim, uint32_t num_faces) {
+    const uint32_t tile_r_dim = face_r_dim * (num_faces > 2 ? 2 : 1);
+    const uint32_t tile_c_dim = num_faces == 1 ? constants::FACE_WIDTH : constants::TILE_WIDTH;
+    return Tile({tile_r_dim, tile_c_dim}, {face_r_dim, constants::FACE_WIDTH});
+}
+}  // namespace
 
 namespace unit_tests::compute::tilize {
 
@@ -245,18 +256,18 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
         .data_format_metadata = output_buf_format,
     };
     if (test_config.untilize_type.has_value() && test_config.untilize_type == UntilizeType::DST) {
-        // DST untilize reads face geometry from the output CB metadata (no explicit kernel args).
-        output_dfb_spec.unpack_face_geometry_metadata =
-            tt::tt_metal::FaceGeometry{test_config.face_r_dim, test_config.num_faces_per_tile};
+        // DST untilize reads the face layout from the output CB metadata (no explicit kernel args).
+        output_dfb_spec.tile_format_metadata =
+            tile_from_face_layout(test_config.face_r_dim, test_config.num_faces_per_tile);
     } else if (
         test_config.tilize_type.has_value() && test_config.tilize_type == TilizeType::UNPACK_A &&
         (test_config.num_faces_per_tile != 4 || test_config.face_r_dim != 16)) {
         // Tiny/shortened-face tilize (e.g. 16x32, or face_r_dim < 16): the unpack/pack LLKs read the
-        // tile's face geometry from the CB metadata, so tag both the input and output buffers with it.
+        // tile's face layout from the CB metadata, so tag both the input and output buffers with it.
         // Gate on either fewer faces or a shorter face row dim so shortened four-face tiles are caught too.
-        const auto fg = tt::tt_metal::FaceGeometry{test_config.face_r_dim, test_config.num_faces_per_tile};
-        input_dfb_spec.unpack_face_geometry_metadata = fg;
-        output_dfb_spec.unpack_face_geometry_metadata = fg;
+        const auto tile = tile_from_face_layout(test_config.face_r_dim, test_config.num_faces_per_tile);
+        input_dfb_spec.tile_format_metadata = tile;
+        output_dfb_spec.tile_format_metadata = tile;
     }
 
     // Reader kernel: untilize types stream native tiles from DRAM (`reader_unary_2_0`);
@@ -998,9 +1009,9 @@ static void run_quasar_tilize_untilize_test(
         .data_format_metadata = output_data_format,
     };
     if (tiny_tile) {
-        const auto fg = tt::tt_metal::FaceGeometry{face_r_dim, num_faces};
-        input_dfb_spec.unpack_face_geometry_metadata = fg;
-        output_dfb_spec.unpack_face_geometry_metadata = fg;
+        const auto tile = tile_from_face_layout(face_r_dim, num_faces);
+        input_dfb_spec.tile_format_metadata = tile;
+        output_dfb_spec.tile_format_metadata = tile;
     }
 
     experimental::KernelSpec reader_spec{

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <cctype>
 #include <functional>
@@ -61,16 +62,6 @@ using std::vector;
 using namespace tt;
 using namespace tt::test_utils;
 
-namespace {
-// Describe a tile that holds `num_faces` faces of `face_r_dim` rows each, laid out as a
-// 1xN or 2xN face grid (the LLK caps the grid at 2x2).
-Tile tile_from_face_layout(uint32_t face_r_dim, uint32_t num_faces) {
-    const uint32_t tile_r_dim = face_r_dim * (num_faces > 2 ? 2 : 1);
-    const uint32_t tile_c_dim = num_faces == 1 ? constants::FACE_WIDTH : constants::TILE_WIDTH;
-    return Tile({tile_r_dim, tile_c_dim}, {face_r_dim, constants::FACE_WIDTH});
-}
-}  // namespace
-
 namespace unit_tests::compute::tilize {
 
 enum UntilizeType : std::uint8_t { PACK = 1, DST = 2 };
@@ -109,9 +100,12 @@ struct TestConfig {
     std::uint32_t num_tiles_r;
     // Block width in tiles:
     std::uint32_t num_tiles_c;
-    std::uint32_t num_faces_per_tile = 4;
+    // Face grid. Default 2x2 is a full 32x32 tile.
+    std::uint32_t tile_shape_in_faces_r = 2;
+    std::uint32_t tile_shape_in_faces_c = 2;
     // Face height in datums:
     std::uint32_t face_r_dim = 16;
+    // (Face width is always 16 in this test)
     std::optional<UntilizeType> untilize_type = std::nullopt;
     std::optional<TilizeType> tilize_type = std::nullopt;
     tt::DataFormat input_fmt = tt::DataFormat::Float16_b;
@@ -135,7 +129,7 @@ static void validate_result(
         .num_tiles_c_dim = test_config.num_tiles_c,
         .face_r_dim = test_config.face_r_dim,
         .face_c_dim = 16,
-        .num_faces = test_config.num_faces_per_tile,
+        .num_faces = static_cast<int>(test_config.tile_shape_in_faces_r * test_config.tile_shape_in_faces_c),
         .datum_bytes = tt::datum_size(test_config.input_fmt),
     };
 
@@ -257,15 +251,19 @@ void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const 
     };
     if (test_config.untilize_type.has_value() && test_config.untilize_type == UntilizeType::DST) {
         // DST untilize reads the face layout from the output CB metadata (no explicit kernel args).
-        output_dfb_spec.tile_format_metadata =
-            tile_from_face_layout(test_config.face_r_dim, test_config.num_faces_per_tile);
+        output_dfb_spec.tile_format_metadata = Tile::from_face_grid(
+            {test_config.tile_shape_in_faces_r, test_config.tile_shape_in_faces_c},
+            {test_config.face_r_dim, constants::FACE_WIDTH});
     } else if (
         test_config.tilize_type.has_value() && test_config.tilize_type == TilizeType::UNPACK_A &&
-        (test_config.num_faces_per_tile != 4 || test_config.face_r_dim != 16)) {
+        (test_config.tile_shape_in_faces_r != 2 || test_config.tile_shape_in_faces_c != 2 ||
+         test_config.face_r_dim != 16)) {
         // Tiny/shortened-face tilize (e.g. 16x32, or face_r_dim < 16): the unpack/pack LLKs read the
         // tile's face layout from the CB metadata, so tag both the input and output buffers with it.
-        // Gate on either fewer faces or a shorter face row dim so shortened four-face tiles are caught too.
-        const auto tile = tile_from_face_layout(test_config.face_r_dim, test_config.num_faces_per_tile);
+        // Gate on either a non-2x2 face grid or a shorter face row dim so shortened four-face tiles are caught too.
+        const auto tile = Tile::from_face_grid(
+            {test_config.tile_shape_in_faces_r, test_config.tile_shape_in_faces_c},
+            {test_config.face_r_dim, constants::FACE_WIDTH});
         input_dfb_spec.tile_format_metadata = tile;
         output_dfb_spec.tile_format_metadata = tile;
     }
@@ -874,11 +872,12 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeUInt8) {
 // Exercises llk_unpack_tilize_block with a 16x32 tiny tile across multiple tile-rows, using a
 // nonzero input_tile_index (tilize_across_tile_rows.cpp) so the cross-tile-row stride is hit.
 TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
+    constexpr std::uint32_t tile_shape_in_faces_r = 1;  // 16x32 = 1x2 faces of 16x16
+    constexpr std::uint32_t tile_shape_in_faces_c = 2;
     constexpr std::uint32_t face_r_dim = tt::constants::FACE_HEIGHT;
     constexpr std::uint32_t face_c_dim = tt::constants::FACE_WIDTH;
-    // 16x32 tiny tile = one face-row, TILE_WIDTH/FACE_WIDTH face-columns.
-    constexpr std::uint32_t num_faces = tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH;
-    constexpr std::uint32_t tile_bytes = num_faces * face_r_dim * face_c_dim * sizeof(std::uint16_t);
+    constexpr std::uint32_t tile_bytes =
+        tile_shape_in_faces_r * tile_shape_in_faces_c * face_r_dim * face_c_dim * sizeof(std::uint16_t);
     // num_tiles_r >= 2 so the cross-tile-row stride in llk_unpack_tilize_block is exercised.
     vector<vector<std::uint32_t>> num_tiles = {{2, 1}, {2, 2}, {4, 1}};
     for (auto num_tile : num_tiles) {
@@ -890,7 +889,8 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
                 .output_single_tile_size = tile_bytes,
                 .num_tiles_r = num_tile[0],
                 .num_tiles_c = num_tile[1],
-                .num_faces_per_tile = num_faces,
+                .tile_shape_in_faces_r = tile_shape_in_faces_r,
+                .tile_shape_in_faces_c = tile_shape_in_faces_c,
                 .face_r_dim = face_r_dim,
                 .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
@@ -953,7 +953,7 @@ static void run_quasar_tilize_untilize_test(
     bool fp32_dest_acc_en,
     tt::DataFormat input_data_format,
     tt::DataFormat output_data_format,
-    std::uint32_t num_faces = 4,
+    std::array<uint32_t, 2> tile_shape_in_faces = {2, 2},
     std::uint32_t face_r_dim = tt::constants::FACE_HEIGHT,
     bool tilize_cross_tile_rows = false) {
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
@@ -962,7 +962,8 @@ static void run_quasar_tilize_untilize_test(
     const experimental::NodeCoord node{0, 0};
 
     constexpr std::uint32_t face_c_dim = tt::constants::FACE_WIDTH;
-    const bool tiny_tile = (num_faces != 4 || face_r_dim != 16);
+    const uint32_t num_faces = tile_shape_in_faces[0] * tile_shape_in_faces[1];
+    const bool tiny_tile = (tile_shape_in_faces != std::array<uint32_t, 2>{2, 2} || face_r_dim != 16);
 
     bool is_8bit_integer = (input_data_format == tt::DataFormat::Int8 || input_data_format == tt::DataFormat::UInt8);
     std::uint32_t num_tiles = num_tiles_r * num_tiles_c;
@@ -1009,7 +1010,7 @@ static void run_quasar_tilize_untilize_test(
         .data_format_metadata = output_data_format,
     };
     if (tiny_tile) {
-        const auto tile = tile_from_face_layout(face_r_dim, num_faces);
+        const auto tile = Tile::from_face_grid(tile_shape_in_faces, {face_r_dim, constants::FACE_WIDTH});
         input_dfb_spec.tile_format_metadata = tile;
         output_dfb_spec.tile_format_metadata = tile;
     }
@@ -1271,10 +1272,10 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDst) {
 }
 
 // Pack Untilize tiny tile (1x32, 2x32) via pack_untilize_block (unpack in the loop).
-// {num_faces, face_r_dim}: 1x32 = {2, 1}, 2x32 = {2, 2}.
+// {faces_r, faces_c, face_r_dim}: 1x32 = {1, 2, 1}, 2x32 = {1, 2, 2}.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeTinyTile) {
     std::vector<vector<std::uint32_t>> test_configs = {{1, 1}, {2, 2}};
-    std::vector<vector<std::uint32_t>> geometries = {{2, 1}, {2, 2}};
+    std::vector<std::array<uint32_t, 3>> geometries = {{1, 2, 1}, {1, 2, 2}};
     for (auto& cfg : test_configs) {
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
@@ -1287,18 +1288,18 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeTinyTile) 
                     /*fp32_dest_acc_en=*/false,
                     tt::DataFormat::Float16_b,
                     tt::DataFormat::Float16_b,
-                    /*num_faces=*/geo[0],
-                    /*face_r_dim=*/geo[1]);
+                    /*tile_shape_in_faces=*/{geo[0], geo[1]},
+                    /*face_r_dim=*/geo[2]);
             }
         }
     }
 }
 
 // Pack Untilize Dst tiny tile (1x32, 2x32): tiles pre-loaded into dest via copy_tile.
-// {num_faces, face_r_dim}: 1x32 = {2, 1}, 2x32 = {2, 2}.
+// {faces_r, faces_c, face_r_dim}: 1x32 = {1, 2, 1}, 2x32 = {1, 2, 2}.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstTinyTile) {
     std::vector<vector<std::uint32_t>> test_configs = {{1, 1}, {2, 2}};
-    std::vector<vector<std::uint32_t>> geometries = {{2, 1}, {2, 2}};
+    std::vector<std::array<uint32_t, 3>> geometries = {{1, 2, 1}, {1, 2, 2}};
     for (auto& cfg : test_configs) {
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
@@ -1311,8 +1312,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstTinyTil
                     /*fp32_dest_acc_en=*/false,
                     tt::DataFormat::Float16_b,
                     tt::DataFormat::Float16_b,
-                    /*num_faces=*/geo[0],
-                    /*face_r_dim=*/geo[1]);
+                    /*tile_shape_in_faces=*/{geo[0], geo[1]},
+                    /*face_r_dim=*/geo[2]);
             }
         }
     }
@@ -1345,10 +1346,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilize) {
 }
 
 // Unpack Tilize tiny tile (1x32, 2x32) via tilize_block.
-// {num_faces, face_r_dim}: 1x32 = {2, 1}, 2x32 = {2, 2}.
+// {faces_r, faces_c, face_r_dim}: 1x32 = {1, 2, 1}, 2x32 = {1, 2, 2}.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTile) {
     std::vector<vector<std::uint32_t>> test_configs = {{1, 1}, {2, 2}};
-    std::vector<vector<std::uint32_t>> geometries = {{2, 1}, {2, 2}};
+    std::vector<std::array<uint32_t, 3>> geometries = {{1, 2, 1}, {1, 2, 2}};
     for (auto& cfg : test_configs) {
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
@@ -1361,8 +1362,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTile) 
                     /*fp32_dest_acc_en=*/false,
                     tt::DataFormat::Float16_b,
                     tt::DataFormat::Float16_b,
-                    /*num_faces=*/geo[0],
-                    /*face_r_dim=*/geo[1]);
+                    /*tile_shape_in_faces=*/{geo[0], geo[1]},
+                    /*face_r_dim=*/geo[2]);
             }
         }
     }
@@ -1372,7 +1373,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTile) 
 // (tilize_across_tile_rows.cpp), so the cross-tile-row stride in llk_unpack_tilize_block is
 // exercised, like the Blackhole TensixComputeUnpackTilizeTinyTile16x32 test.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTileCrossTileRows) {
-    std::vector<vector<std::uint32_t>> geometries = {{2, 1}, {2, 2}};
+    std::vector<std::array<uint32_t, 3>> geometries = {{1, 2, 1}, {1, 2, 2}};
     std::vector<vector<std::uint32_t>> test_configs = {{2, 1}, {2, 2}};
     for (auto& geometry : geometries) {
         for (auto& cfg : test_configs) {
@@ -1386,8 +1387,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTileCr
                     false,
                     tt::DataFormat::Float16_b,
                     tt::DataFormat::Float16_b,
-                    geometry[0],
-                    geometry[1],
+                    /*tile_shape_in_faces=*/{geometry[0], geometry[1]},
+                    /*face_r_dim=*/geometry[2],
                     /*tilize_cross_tile_rows=*/true);
             }
         }
@@ -1635,23 +1636,33 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputePackUntilizeUInt8) {
 }
 
 // Tests pack_untilize with tiny tile dims.
-// Row dim 1x32, which is faces = 2, rows = 1
-// Row dim 1x16, which is faces = 1, rows = 1
+// 1x16 = 1x1 faces of height 1; 1x32 = 1x2 faces of height 1.
 TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilizeDstTinyTile) {
-    vector<vector<std::uint32_t>> test_config_values = {{1, 1, 1, 1}, {1, 1, 2, 1}, {1, 2, 2, 1}};
+    struct TinyTileCase {
+        std::uint32_t num_tiles_r;
+        std::uint32_t num_tiles_c;
+        std::uint32_t tile_shape_in_faces_r;
+        std::uint32_t tile_shape_in_faces_c;
+        std::uint32_t face_r_dim;
+    };
+    const std::vector<TinyTileCase> test_cases = {
+        {.num_tiles_r = 1, .num_tiles_c = 1, .tile_shape_in_faces_r = 1, .tile_shape_in_faces_c = 1, .face_r_dim = 1},
+        {.num_tiles_r = 1, .num_tiles_c = 1, .tile_shape_in_faces_r = 1, .tile_shape_in_faces_c = 2, .face_r_dim = 1},
+        {.num_tiles_r = 1, .num_tiles_c = 2, .tile_shape_in_faces_r = 1, .tile_shape_in_faces_c = 2, .face_r_dim = 1},
+    };
     std::uint32_t face_c_dim = 16;
-    for (auto test_config_value : test_config_values) {
+    for (const auto& test_case : test_cases) {
         for (bool dst_full_sync_en : {true, false}) {
-            std::uint32_t num_faces_per_tile = test_config_value[2];
-            std::uint32_t face_r_dim = test_config_value[3];
             unit_tests::compute::tilize::TestConfig test_config = {
                 .dst_full_sync_en = dst_full_sync_en,
                 .input_single_tile_size = 2 * 1024,
-                .output_single_tile_size = 2 * num_faces_per_tile * face_r_dim * face_c_dim,
-                .num_tiles_r = test_config_value[0],
-                .num_tiles_c = test_config_value[1],
-                .num_faces_per_tile = num_faces_per_tile,
-                .face_r_dim = face_r_dim,
+                .output_single_tile_size = 2 * test_case.tile_shape_in_faces_r * test_case.tile_shape_in_faces_c *
+                                           test_case.face_r_dim * face_c_dim,
+                .num_tiles_r = test_case.num_tiles_r,
+                .num_tiles_c = test_case.num_tiles_c,
+                .tile_shape_in_faces_r = test_case.tile_shape_in_faces_r,
+                .tile_shape_in_faces_c = test_case.tile_shape_in_faces_c,
+                .face_r_dim = test_case.face_r_dim,
                 .untilize_type = unit_tests::compute::tilize::UntilizeType::DST,
                 .output_fmt = tt::DataFormat::Float16_b,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
-#include <tt-metalium/face_geometry.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>  // tt::DataFormat
 #include <tt_stl/strong_type.hpp>
@@ -96,18 +95,13 @@ struct DataflowBufferSpec {
     // The data format is required for any DFB bound to a compute kernel
     std::optional<tt::DataFormat> data_format_metadata = std::nullopt;
 
-    // Optional; if unspecified, the default tile format (32x32) is assumed
-    std::optional<tt::tt_metal::Tile> tile_format_metadata = std::nullopt;
-
-    // Optional override for this DFB's tile face layout.
+    // Optional; if unspecified, the default tile format (32x32) is assumed.
     //
-    // A tile is physically stored as a grid of fixed-size sub-blocks called "faces". The compute
-    // engine normally infers how many faces a tile has, and how many rows each face holds, from
-    // `tile_format_metadata`. Set this field only when an entry does not occupy a full tile, so it
-    // holds fewer faces and/or shorter faces than the default; the compute engine then reads exactly
-    // that much data instead of a whole tile. `FaceGeometry` carries those two values (rows-per-face
-    // and number of faces).
-    std::optional<FaceGeometry> unpack_face_geometry_metadata = std::nullopt;
+    // A tile is physically stored as a grid of fixed-size sub-blocks called "faces", and the compute
+    // engine derives the face layout from this field. If an entry holds shorter, more numerous faces
+    // than the default layout for its tile shape, say so with the `Tile(tile_shape, face_shape)`
+    // constructor -- the compute engine then reads exactly that much data.
+    std::optional<tt::tt_metal::Tile> tile_format_metadata = std::nullopt;
 
     //////////////////////////////
     // Backing memory

--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -25,6 +25,17 @@ struct Tile {
         std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH},
         bool transpose_tile = false);
 
+    // Explicit face layout.
+    //
+    // The single-argument constructor derives `face_shape` from `tile_shape` via a fixed table, which
+    // only ever yields the "tallest" face layout for a given tile. Use this overload when an operand
+    // packs its data into shorter, more numerous faces than that default: e.g. a 2x32 tile holding
+    // four 1x16 faces (a 2x2 face grid) rather than the default two 2x16 faces.
+    //
+    // `num_faces` stays derived (`tile_hw / face_hw`), so the face grid is always exactly
+    // `tile_shape / face_shape` and cannot be set inconsistently.
+    Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape, bool transpose_tile = false);
+
     // Getter methods
     uint32_t get_height() const { return tile_shape[0]; }
     uint32_t get_width() const { return tile_shape[1]; }
@@ -47,6 +58,9 @@ struct Tile {
     auto attribute_values() const { return std::forward_as_tuple(tile_shape, face_shape, num_faces); }
 
 private:
+    // Fills in everything derived from `tile_shape` / `face_shape`. Shared by both constructors.
+    void init_derived_dims(bool transpose_tile);
+
     std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH};
     std::array<uint32_t, 2> face_shape = {constants::FACE_HEIGHT, constants::FACE_WIDTH};
     uint32_t tile_hw = constants::TILE_HW;

--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -35,6 +35,17 @@ struct Tile {
      */
     Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape, bool transpose_tile = false);
 
+    /**
+     * Factory function to construct a Tile from tile shape in faces
+     *
+     * If a face shape is not provided, the default face shape (16x16) is used.
+     */
+    static Tile from_face_grid(
+        std::array<uint32_t, 2> tile_shape_in_faces,
+        std::array<uint32_t, 2> face_shape = {constants::FACE_HEIGHT, constants::FACE_WIDTH}) {
+        return Tile({face_shape[0] * tile_shape_in_faces[0], face_shape[1] * tile_shape_in_faces[1]}, face_shape);
+    }
+
     // Getter methods
     uint32_t get_height() const { return tile_shape[0]; }
     uint32_t get_width() const { return tile_shape[1]; }

--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -21,19 +21,18 @@ enum class DataFormat : uint8_t;
 namespace tt::tt_metal {
 
 struct Tile {
+    /**
+     * Construct a Tile with a given tile shape (H, W).
+     *
+     * The tile face shape is derived automatically from the tile shape.
+     */
     Tile(
         std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH},
         bool transpose_tile = false);
 
-    // Explicit face layout.
-    //
-    // The single-argument constructor derives `face_shape` from `tile_shape` via a fixed table, which
-    // only ever yields the "tallest" face layout for a given tile. Use this overload when an operand
-    // packs its data into shorter, more numerous faces than that default: e.g. a 2x32 tile holding
-    // four 1x16 faces (a 2x2 face grid) rather than the default two 2x16 faces.
-    //
-    // `num_faces` stays derived (`tile_hw / face_hw`), so the face grid is always exactly
-    // `tile_shape / face_shape` and cannot be set inconsistently.
+    /**
+     * Construct a Tile with a given tile shape (H, W) and custom face shape (H, W).
+     */
     Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape, bool transpose_tile = false);
 
     // Getter methods
@@ -58,9 +57,6 @@ struct Tile {
     auto attribute_values() const { return std::forward_as_tuple(tile_shape, face_shape, num_faces); }
 
 private:
-    // Fills in everything derived from `tile_shape` / `face_shape`. Shared by both constructors.
-    void init_derived_dims(bool transpose_tile);
-
     std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH};
     std::array<uint32_t, 2> face_shape = {constants::FACE_HEIGHT, constants::FACE_WIDTH};
     uint32_t tile_hw = constants::TILE_HW;

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -46,6 +46,54 @@ Tile::Tile(std::array<uint32_t, 2> tile_shape, bool transpose_tile) : tile_shape
         TT_THROW("Tile size is not valid for our hardware");
     }
 
+    this->init_derived_dims(transpose_tile);
+}
+
+Tile::Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape, bool transpose_tile) :
+    tile_shape(tile_shape), face_shape(face_shape) {
+    const bool known_tile_shape =
+        std::any_of(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(), [&tile_shape](const auto& pair) {
+            return pair[0] == tile_shape;
+        });
+    TT_FATAL(known_tile_shape, "Tile size is not valid for our hardware");
+
+    // Face width is fixed in hardware: the LLK tensor-shape descriptor always reports MAX_FACE_C_DIM
+    // (see tt-llk/common/tensor_shape.h), so a face can only ever be shortened in rows.
+    TT_FATAL(
+        face_shape[1] == constants::FACE_WIDTH,
+        "face_shape width ({}) must equal FACE_WIDTH ({})",
+        face_shape[1],
+        constants::FACE_WIDTH);
+    TT_FATAL(
+        face_shape[0] > 0 && face_shape[0] <= constants::FACE_HEIGHT,
+        "face_shape height ({}) must be in [1, FACE_HEIGHT ({})]",
+        face_shape[0],
+        constants::FACE_HEIGHT);
+    TT_FATAL(
+        tile_shape[0] % face_shape[0] == 0 && tile_shape[1] % face_shape[1] == 0,
+        "face_shape ({}x{}) must tile evenly into tile_shape ({}x{})",
+        face_shape[0],
+        face_shape[1],
+        tile_shape[0],
+        tile_shape[1]);
+
+    // The LLK face grid is capped at MAX_NUM_FACES_R_DIM x MAX_NUM_FACES_C_DIM (2x2).
+    constexpr uint32_t max_faces_r = constants::TILE_HEIGHT / constants::FACE_HEIGHT;
+    constexpr uint32_t max_faces_c = constants::TILE_WIDTH / constants::FACE_WIDTH;
+    const uint32_t num_faces_r = tile_shape[0] / face_shape[0];
+    const uint32_t num_faces_c = tile_shape[1] / face_shape[1];
+    TT_FATAL(
+        num_faces_r <= max_faces_r && num_faces_c <= max_faces_c,
+        "face grid ({}x{}) exceeds the maximum supported face grid ({}x{})",
+        num_faces_r,
+        num_faces_c,
+        max_faces_r,
+        max_faces_c);
+
+    this->init_derived_dims(transpose_tile);
+}
+
+void Tile::init_derived_dims(bool transpose_tile) {
     if (transpose_tile) {
         transpose_within_face = true;
         transpose_of_faces = true;

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -42,6 +42,14 @@ std::array<uint32_t, 2> get_default_face_shape(std::array<uint32_t, 2> tile_shap
     return (*it)[1];
 }
 
+void validate_transpose_height(uint32_t tile_height, bool transpose_tile) {
+    if (transpose_tile) {
+        TT_FATAL(
+            tile_height == constants::FACE_HEIGHT || tile_height == constants::TILE_HEIGHT,
+            "Tile height must equal 16 or 32 in transpose mode");
+    }
+}
+
 Tile::Tile(std::array<uint32_t, 2> tile_shape, bool transpose_tile) :
     tile_shape(tile_shape),
     face_shape(get_default_face_shape(tile_shape)),
@@ -52,11 +60,7 @@ Tile::Tile(std::array<uint32_t, 2> tile_shape, bool transpose_tile) :
     narrow_tile(static_cast<uint32_t>(tile_shape[1] < constants::TILE_WIDTH)),
     transpose_within_face(transpose_tile),
     transpose_of_faces(transpose_tile) {
-    if (transpose_tile) {
-        TT_FATAL(
-            (this->tile_shape[0] == constants::FACE_HEIGHT || this->tile_shape[0] == constants::TILE_HEIGHT),
-            "Tile height must equal 16 or 32 in transpose mode");
-    }
+    validate_transpose_height(this->tile_shape[0], transpose_tile);
 }
 
 Tile::Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape, bool transpose_tile) :
@@ -125,6 +129,8 @@ Tile::Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shap
         "num_faces ({}) exceeds the maximum supported num_faces ({})",
         num_faces,
         MAX_NUM_FACES);
+
+    validate_transpose_height(this->tile_shape[0], transpose_tile);
 }
 
 uint32_t Tile::get_tile_size(const DataFormat& format) const {

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -33,86 +33,98 @@ constexpr std::array<std::array<std::array<uint32_t, 2>, 2>, 12> TILE_FACE_HW_CH
      {{{2, 16}, {2, 16}}},
      {{{1, 16}, {1, 16}}}}};
 
-Tile::Tile(std::array<uint32_t, 2> tile_shape, bool transpose_tile) : tile_shape(tile_shape) {
-    const auto* it = std::find_if(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(), [this](const auto& pair) {
-        if (pair[0] == this->tile_shape) {
-            this->face_shape = pair[1];
-            return true;
-        }
-        return false;
-    });
-
-    if (it == TILE_FACE_HW_CHOICES.end()) {
-        TT_THROW("Tile size is not valid for our hardware");
-    }
-
-    this->init_derived_dims(transpose_tile);
-}
-
-Tile::Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape, bool transpose_tile) :
-    tile_shape(tile_shape), face_shape(face_shape) {
-    const bool known_tile_shape =
-        std::any_of(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(), [&tile_shape](const auto& pair) {
+std::array<uint32_t, 2> get_default_face_shape(std::array<uint32_t, 2> tile_shape) {
+    const auto* it =
+        std::find_if(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(), [tile_shape](const auto& pair) {
             return pair[0] == tile_shape;
         });
-    TT_FATAL(known_tile_shape, "Tile size is not valid for our hardware");
-
-    // Face width is fixed in hardware: the LLK tensor-shape descriptor always reports MAX_FACE_C_DIM
-    // (see tt-llk/common/tensor_shape.h), so a face can only ever be shortened in rows.
-    TT_FATAL(
-        face_shape[1] == constants::FACE_WIDTH,
-        "face_shape width ({}) must equal FACE_WIDTH ({})",
-        face_shape[1],
-        constants::FACE_WIDTH);
-    TT_FATAL(
-        face_shape[0] > 0 && face_shape[0] <= constants::FACE_HEIGHT,
-        "face_shape height ({}) must be in [1, FACE_HEIGHT ({})]",
-        face_shape[0],
-        constants::FACE_HEIGHT);
-    TT_FATAL(
-        tile_shape[0] % face_shape[0] == 0 && tile_shape[1] % face_shape[1] == 0,
-        "face_shape ({}x{}) must tile evenly into tile_shape ({}x{})",
-        face_shape[0],
-        face_shape[1],
-        tile_shape[0],
-        tile_shape[1]);
-
-    // The LLK face grid is capped at MAX_NUM_FACES_R_DIM x MAX_NUM_FACES_C_DIM (2x2).
-    constexpr uint32_t max_faces_r = constants::TILE_HEIGHT / constants::FACE_HEIGHT;
-    constexpr uint32_t max_faces_c = constants::TILE_WIDTH / constants::FACE_WIDTH;
-    const uint32_t num_faces_r = tile_shape[0] / face_shape[0];
-    const uint32_t num_faces_c = tile_shape[1] / face_shape[1];
-    TT_FATAL(
-        num_faces_r <= max_faces_r && num_faces_c <= max_faces_c,
-        "face grid ({}x{}) exceeds the maximum supported face grid ({}x{})",
-        num_faces_r,
-        num_faces_c,
-        max_faces_r,
-        max_faces_c);
-
-    this->init_derived_dims(transpose_tile);
+    TT_FATAL(it != TILE_FACE_HW_CHOICES.end(), "Tile size is not valid for our hardware");
+    return (*it)[1];
 }
 
-void Tile::init_derived_dims(bool transpose_tile) {
-    if (transpose_tile) {
-        transpose_within_face = true;
-        transpose_of_faces = true;
-    } else {
-        transpose_within_face = false;
-        transpose_of_faces = false;
-    }
-
+Tile::Tile(std::array<uint32_t, 2> tile_shape, bool transpose_tile) :
+    tile_shape(tile_shape),
+    face_shape(get_default_face_shape(tile_shape)),
+    tile_hw(tile_shape[0] * tile_shape[1]),
+    face_hw(face_shape[0] * face_shape[1]),
+    num_faces(tile_hw / face_hw),
+    partial_face(static_cast<uint32_t>(tile_shape[0] < constants::TILE_HEIGHT)),
+    narrow_tile(static_cast<uint32_t>(tile_shape[1] < constants::TILE_WIDTH)),
+    transpose_within_face(transpose_tile),
+    transpose_of_faces(transpose_tile) {
     if (transpose_tile) {
         TT_FATAL(
             (this->tile_shape[0] == constants::FACE_HEIGHT || this->tile_shape[0] == constants::TILE_HEIGHT),
             "Tile height must equal 16 or 32 in transpose mode");
     }
+}
 
-    tile_hw = this->tile_shape[0] * this->tile_shape[1];
-    face_hw = face_shape[0] * face_shape[1];
-    num_faces = tile_hw / face_hw;
-    partial_face = static_cast<uint32_t>(this->tile_shape[0] < constants::TILE_HEIGHT);
-    narrow_tile = static_cast<uint32_t>(this->tile_shape[1] < constants::TILE_WIDTH);
+Tile::Tile(std::array<uint32_t, 2> tile_shape, std::array<uint32_t, 2> face_shape, bool transpose_tile) :
+    tile_shape(tile_shape),
+    face_shape(face_shape),
+    tile_hw(tile_shape[0] * tile_shape[1]),
+    face_hw(face_shape[0] * face_shape[1]),
+    num_faces(tile_hw / face_hw),
+    partial_face(static_cast<uint32_t>(tile_shape[0] < constants::TILE_HEIGHT)),
+    narrow_tile(static_cast<uint32_t>(tile_shape[1] < constants::TILE_WIDTH)),
+    transpose_within_face(transpose_tile),
+    transpose_of_faces(transpose_tile) {
+    const bool known_tile_shape =
+        std::any_of(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(), [&tile_shape](const auto& pair) {
+            return pair[0] == tile_shape;
+        });
+
+    TT_FATAL(known_tile_shape, "Tile size is not valid for our hardware");
+
+    // Face shape must fit evenly into tile shape
+    TT_FATAL(
+        (tile_shape[0] % face_shape[0]) == 0 && (tile_shape[1] % face_shape[1]) == 0,
+        "tile shape ({}x{}) must tile evenly into face shape ({}x{})",
+        tile_shape[0],
+        tile_shape[1],
+        face_shape[0],
+        face_shape[1]);
+
+    // These constants are derived from device side constants at (tt-llk/common/tensor_shape.h)
+    // Maintainers: Please keep these in sync with device side constants.
+    constexpr std::uint8_t MAX_FACE_R_DIM = 16;
+    constexpr std::uint8_t MAX_FACE_C_DIM = 16;
+    constexpr std::uint8_t MAX_TILE_R_DIM = 32;
+    constexpr std::uint8_t MAX_TILE_C_DIM = 32;
+    constexpr std::uint8_t MAX_NUM_FACES_R_DIM = 2;
+    constexpr std::uint8_t MAX_NUM_FACES_C_DIM = 2;
+    constexpr std::uint8_t MAX_NUM_FACES = MAX_NUM_FACES_R_DIM * MAX_NUM_FACES_C_DIM;
+
+    TT_FATAL(
+        face_shape[0] <= MAX_FACE_R_DIM && face_shape[1] <= MAX_FACE_C_DIM,
+        "face shape ({}x{}) exceeds the maximum supported face shape ({}x{})",
+        face_shape[0],
+        face_shape[1],
+        MAX_FACE_R_DIM,
+        MAX_FACE_C_DIM);
+    TT_FATAL(
+        tile_shape[0] <= MAX_TILE_R_DIM && tile_shape[1] <= MAX_TILE_C_DIM,
+        "tile shape ({}x{}) exceeds the maximum supported tile shape ({}x{})",
+        tile_shape[0],
+        tile_shape[1],
+        MAX_TILE_R_DIM,
+        MAX_TILE_C_DIM);
+
+    auto num_faces_r = tile_shape[0] / face_shape[0];
+    auto num_faces_c = tile_shape[1] / face_shape[1];
+    TT_FATAL(
+        num_faces_r <= MAX_NUM_FACES_R_DIM && num_faces_c <= MAX_NUM_FACES_C_DIM,
+        "num_faces ({}x{}) exceeds the maximum supported num_faces ({}x{})",
+        num_faces_r,
+        num_faces_c,
+        MAX_NUM_FACES_R_DIM,
+        MAX_NUM_FACES_C_DIM);
+
+    TT_FATAL(
+        num_faces <= MAX_NUM_FACES,
+        "num_faces ({}) exceeds the maximum supported num_faces ({})",
+        num_faces,
+        MAX_NUM_FACES);
 }
 
 uint32_t Tile::get_tile_size(const DataFormat& format) const {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -2789,9 +2789,7 @@ void ProgramImpl::set_dfb_data_fmt_and_tile(const std::vector<CoreRange>& crs, J
             if (data_format == DataFormat::Invalid) {
                 continue;
             }
-            const auto& tile_opt = dfb->config.tile;
-            const auto& unpack_geom = dfb->config.unpack_face_geometry;
-            build_options.set_cb_data_fmt_tile_and_face_geometry(cb_index, data_format, tile_opt, unpack_geom);
+            build_options.set_cb_data_fmt_and_tile(cb_index, data_format, dfb->config.tile);
         }
     }
 }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.hpp
@@ -10,7 +10,6 @@
 #include <variant>
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/face_geometry.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/kernel_types.hpp>
 
@@ -54,12 +53,6 @@ struct DataflowBufferConfig {
     // Data format and tile formats for LLKs
     DataFormat data_format = tt::DataFormat::Float16_b;
     std::optional<Tile> tile = std::nullopt;
-    /**
-     * Optional override for how the compute engine interprets this DFB's tile faces. When set, it overrides the
-     * face layout otherwise derived from @ref tile. Use it when an operand's data is laid out with a non-default
-     * number of faces or rows-per-face.
-     */
-    std::optional<FaceGeometry> unpack_face_geometry = std::nullopt;
     // Set only when both producer and consumer are the same compute kernel
     std::optional<TensixScope> tensix_scope = std::nullopt;
     // When true, the DFB borrows L1 memory from an externally managed buffer

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -3138,9 +3138,9 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
             MetalContext::instance().hal().get_arch_num_circular_buffers());
         // Same faced-tile geometry carry as the CB pass above, else full-tile 16/4.
         uint32_t dfb_face_r_dim = 16, dfb_num_faces = 4;
-        if (cfg.unpack_face_geometry.has_value()) {
-            dfb_face_r_dim = cfg.unpack_face_geometry->face_r_dim;
-            dfb_num_faces = cfg.unpack_face_geometry->num_faces;
+        if (cfg.tile.has_value()) {
+            dfb_face_r_dim = cfg.tile->get_face_shape()[0];
+            dfb_num_faces = cfg.tile->get_num_faces();
         }
         core->init_cb_sync(
             static_cast<uint8_t>(device_slot),

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2711,7 +2711,6 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         .enable_consumer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.consumers),
         .data_format = dfb_spec->data_format_metadata.value_or(tt::DataFormat::Invalid),
         .tile = dfb_spec->tile_format_metadata,
-        .unpack_face_geometry = dfb_spec->unpack_face_geometry_metadata,
         .tensix_scope = tensix_scope,
         // DFB borrowed memory mode is declared at program creation time.
         // The actual backing memory L1 address is attached at runtime.

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -111,6 +111,11 @@ inline uint64_t stable_hash_hlk_desc(const tt::tt_hlk_desc& obj) {
         hasher.update(static_cast<uint64_t>(obj.get_buf_dataformat(i)));
         hasher.update(static_cast<uint64_t>(obj.get_buf_tile_r_dim(i)));
         hasher.update(static_cast<uint64_t>(obj.get_buf_tile_c_dim(i)));
+        // The face layout is baked into the generated kernel headers as constexpr arrays, so it has to
+        // participate in the hash: two operands with the same tile shape but different face layouts
+        // must not share a compiled kernel.
+        hasher.update(static_cast<uint64_t>(obj.get_buf_face_r_dim(i)));
+        hasher.update(static_cast<uint64_t>(obj.get_buf_num_faces(i)));
     }
     hasher.update(static_cast<uint64_t>(obj.get_hlk_math_fidelity()));
     hasher.update(obj.get_hlk_math_approx_mode() ? 1u : 0u);

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -111,9 +111,6 @@ inline uint64_t stable_hash_hlk_desc(const tt::tt_hlk_desc& obj) {
         hasher.update(static_cast<uint64_t>(obj.get_buf_dataformat(i)));
         hasher.update(static_cast<uint64_t>(obj.get_buf_tile_r_dim(i)));
         hasher.update(static_cast<uint64_t>(obj.get_buf_tile_c_dim(i)));
-        // The face layout is baked into the generated kernel headers as constexpr arrays, so it has to
-        // participate in the hash: two operands with the same tile shape but different face layouts
-        // must not share a compiled kernel.
         hasher.update(static_cast<uint64_t>(obj.get_buf_face_r_dim(i)));
         hasher.update(static_cast<uint64_t>(obj.get_buf_num_faces(i)));
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -40,6 +40,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -1477,7 +1478,9 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
                 .entry_size = tilized_info.page_size,
                 .num_entries = 1,
                 .data_format_metadata = tilized_info.data_format,
-                .unpack_face_geometry_metadata = FaceGeometry{.face_r_dim = 1, .num_faces = 4},
+                // Four single-row faces: a 2x2 grid of 1x16 faces.
+                .tile_format_metadata =
+                    tt::tt_metal::Tile({2, tt::constants::TILE_WIDTH}, {1, tt::constants::FACE_WIDTH}),
             });
         } else if (split_program_tilize_only) {
             // OPTION B / Program A: the tilize writes STRAIGHT INTO the borrowed OUT (sized to M*K below,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1479,8 +1479,7 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
                 .num_entries = 1,
                 .data_format_metadata = tilized_info.data_format,
                 // Four single-row faces: a 2x2 grid of 1x16 faces.
-                .tile_format_metadata =
-                    tt::tt_metal::Tile({2, tt::constants::TILE_WIDTH}, {1, tt::constants::FACE_WIDTH}),
+                .tile_format_metadata = tt::tt_metal::Tile::from_face_grid({2, 2}, {1, tt::constants::FACE_WIDTH}),
             });
         } else if (split_program_tilize_only) {
             // OPTION B / Program A: the tilize writes STRAIGHT INTO the borrowed OUT (sized to M*K below,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -366,7 +366,6 @@ DataflowBufferSpec local_dfb(
     uint32_t page_size,
     uint32_t num_pages,
     tt::DataFormat df,
-    std::optional<FaceGeometry> face = std::nullopt,
     std::optional<tt::tt_metal::Tile> tile = std::nullopt) {
     return DataflowBufferSpec{
         .unique_id = id,
@@ -374,7 +373,6 @@ DataflowBufferSpec local_dfb(
         .num_entries = num_pages,
         .data_format_metadata = df,
         .tile_format_metadata = tile,
-        .unpack_face_geometry_metadata = face,
     };
 }
 
@@ -385,7 +383,6 @@ DataflowBufferSpec borrowed_dfb(
     uint32_t num_pages,
     tt::DataFormat df,
     const TensorParamName& borrowed_from,
-    std::optional<FaceGeometry> face = std::nullopt,
     std::optional<tt::tt_metal::Tile> tile = std::nullopt) {
     return DataflowBufferSpec{
         .unique_id = id,
@@ -393,7 +390,6 @@ DataflowBufferSpec borrowed_dfb(
         .num_entries = num_pages,
         .data_format_metadata = df,
         .tile_format_metadata = tile,
-        .unpack_face_geometry_metadata = face,
         .borrowed_from = borrowed_from,
     };
 }
@@ -686,7 +682,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // -----------------------------------------------------------------------
     // Dataflow buffers.
     // -----------------------------------------------------------------------
-    //  Reduce scaler (srcB) face geometry. num_faces MUST be 1, not 4: the reduce-col strided
+    //  Reduce scaler (srcB) face layout. num_faces MUST be 1, not 4: the reduce-col strided
     // tilize unpacks srcB with a single UNPACR1_FACE and NO L1 increment (TT_OP_UNPACR1_FACE_INC(0,0,0,0,...)
     // in llk_unpack_reduce_col_tilizeA_strided.h), so it re-reads the same one scalar face regardless of the
     // face count -- z=1 and z=4 are byte-identical. num_faces=4 built an illegal (x=16, y=1, z=4) buffer
@@ -694,7 +690,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // z_dim is 4" (ckernel_trisc_common.h). num_faces=1 gives the (x=16, y=1, z=1) descriptor the LLK
     // documents as the expected srcB scaler layout, which validates with the assert enabled. (srcA keeps its
     // full 32x32 4-face geometry below -- that operand genuinely needs it.)
-    const auto scalar_face = FaceGeometry{.face_r_dim = 1, .num_faces = 1};
+    const auto scalar_tile = tt::tt_metal::Tile({1, tt::constants::FACE_WIDTH});
     const uint32_t window_size_hw = kernel_h * kernel_w;
     // WORKAROUND (Quasar): the input-CB tile's face_r_dim feeds both the reduce tensor-shape and the
     // TDMA buffer-descriptor y_dim, and Quasar LLK restricts both to powers of 2 <= 16
@@ -722,21 +718,18 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // full-tile-padded, round_up(in_cb_sz, TILE_HW)) in_cb page as 4 faces; the padding rows
     // [window_size, 32) hold the pool identity (-inf max / 0 avg via force_max_clear + clear_value_cb,
     // AVG scalar = 1/true_window), so reducing the extra rows is a no-op.
-    const uint32_t num_faces_in_input_tile_for_cb = 4u;
-    const std::optional<FaceGeometry> input_face_geometry =
-        return_indices
-            ? std::nullopt
-            : std::optional{FaceGeometry{.face_r_dim = raw_face_r, .num_faces = num_faces_in_input_tile_for_cb}};
+    // A 2x2 grid of raw_face_r-row faces, i.e. a (2 * raw_face_r) x 32 tile.
+    const std::optional<tt::tt_metal::Tile> input_tile =
+        return_indices ? std::nullopt
+                       : std::optional{tt::tt_metal::Tile(
+                             {2 * raw_face_r, tt::constants::TILE_WIDTH}, {raw_face_r, tt::constants::FACE_WIDTH})};
 
-    constexpr uint32_t pack_untilize_face_r_dim = 1;
+    // Single-row faces: one 1x16 face, or two of them side by side (a 1x32 tile).
     const bool last_tile_is_partial = in_c % tt::constants::TILE_WIDTH != 0;
     const bool single_partial_fits_in_face = last_tile_is_partial && in_c <= tt::constants::FACE_WIDTH;
-    const uint32_t pack_untilize_num_faces = single_partial_fits_in_face ? 1u : 2u;
-    const auto pack_untilize_face =
-        FaceGeometry{.face_r_dim = pack_untilize_face_r_dim, .num_faces = pack_untilize_num_faces};
-    const std::optional<tt::tt_metal::Tile> pack_untilize_tile =
-        single_partial_fits_in_face ? std::optional{tt::tt_metal::Tile({1, tt::constants::FACE_WIDTH}, false)}
-                                    : std::nullopt;
+    const auto pack_untilize_tile = single_partial_fits_in_face
+                                        ? tt::tt_metal::Tile({1, tt::constants::FACE_WIDTH})
+                                        : tt::tt_metal::Tile({1, tt::constants::TILE_WIDTH});
 
     std::vector<DataflowBufferSpec> dfbs;
 
@@ -754,10 +747,10 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         (cb_sizes.has_pre_tilize ? 2 : 0) + (cb_sizes.has_out_idx ? 1 : 0) + (one_scalar_per_core ? 0 : 1));
 
     dfbs.push_back(local_dfb(
-        DFB_IN_SCALAR_0, cb_sizes.scalar_cb_pagesize, cb_sizes.scalar_cb_npages, params.data_format, scalar_face));
+        DFB_IN_SCALAR_0, cb_sizes.scalar_cb_pagesize, cb_sizes.scalar_cb_npages, params.data_format, scalar_tile));
     if (has_second_input_cb) {
         dfbs.push_back(local_dfb(
-            DFB_IN_SCALAR_1, cb_sizes.scalar_cb_pagesize, cb_sizes.scalar_cb_npages, params.data_format, scalar_face));
+            DFB_IN_SCALAR_1, cb_sizes.scalar_cb_pagesize, cb_sizes.scalar_cb_npages, params.data_format, scalar_tile));
     }
     // clear value CB
     dfbs.push_back(local_dfb(DFB_CLEAR_VALUE, cb_sizes.clear_value_cb_size, 1, params.data_format));
@@ -778,10 +771,10 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // input CB(s). The second input stream (in_cb_1) only exists for the pool2d split-reader
     // (mpwi has a single input stream — reader1 is the writer face, not a second producer).
     dfbs.push_back(
-        local_dfb(DFB_IN_0, cb_sizes.in_cb_pagesize, cb_sizes.in_cb_npages, params.data_format, input_face_geometry));
+        local_dfb(DFB_IN_0, cb_sizes.in_cb_pagesize, cb_sizes.in_cb_npages, params.data_format, input_tile));
     if (has_second_input_cb) {
         dfbs.push_back(local_dfb(
-            DFB_IN_1, cb_sizes.in_cb_pagesize, cb_sizes.in_cb_npages, params.data_format, input_face_geometry));
+            DFB_IN_1, cb_sizes.in_cb_pagesize, cb_sizes.in_cb_npages, params.data_format, input_tile));
     }
 
     // MPWI scratch / index CBs
@@ -817,7 +810,6 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
             cb_sizes.pre_tilize_cb_pagesize,
             cb_sizes.pre_tilize_cb_npages,
             params.data_format,
-            pack_untilize_face,
             pack_untilize_tile);
         pre.advanced_options.alias_with = {DFB_FAST_TILIZE};
         DataflowBufferSpec fast = local_dfb(
@@ -834,24 +826,21 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         cb_sizes.out_cb_npages,
         params.output_data_format,
         OUTPUT_TENSOR,
-        is_output_tiled ? std::nullopt : std::optional{pack_untilize_face},
-        is_output_tiled ? std::nullopt : pack_untilize_tile));
+        is_output_tiled ? std::nullopt : std::optional{pack_untilize_tile}));
     // [DEBUG scratch] local (non-borrowed) pack-untilize target, same spec as out_cb's RM view, so the
     // compute kernel can pack the reduced DEST into it and DPRINT the result in isolation (remove after).
     if (!return_indices) {
-        // [DEBUG scratch 32x32] FULL-TILE pack target: face geometry {face_r_dim=16, num_faces=4} so the
+        // [DEBUG scratch 32x32] FULL-TILE pack target: the default 32x32 tile (four 16x16 faces) so the
         // pack reads DEST as a full 32x32 tile (not the narrow face_r_dim=1 pool output). Sized for one full
         // 32-row write: output_shard_width * out_nbytes * TILE_HEIGHT (page = FACE_WIDTH*nbytes face unit).
         const uint32_t scratch_npages =
             (output_shard_shape[1] / tt::constants::FACE_WIDTH) * tt::constants::TILE_HEIGHT;
-        const auto scratch_full_face = FaceGeometry{.face_r_dim = tt::constants::FACE_HEIGHT, .num_faces = 4};
         dfbs.push_back(local_dfb(
             DFB_SCRATCH_0,
             cb_sizes.out_cb_pagesize,
             scratch_npages,
             params.output_data_format,
-            std::optional{scratch_full_face},
-            std::nullopt));
+            tt::tt_metal::Tile()));
         // Second scratch CB for reader1 (only exists under split reader, like in_cb_1).
         if (cb_sizes.has_split_reader) {
             dfbs.push_back(local_dfb(
@@ -859,8 +848,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
                 cb_sizes.out_cb_pagesize,
                 scratch_npages,
                 params.output_data_format,
-                std::optional{scratch_full_face},
-                std::nullopt));
+                tt::tt_metal::Tile()));
         }
         // [DEBUG scratch->out] borrowed OUTPUT view (per-stick RM rows) that the DM readers write into
         // via NoC. page = output row bytes; npages = output sticks per core. Mirrors DFB_IN_SHARD.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -682,7 +682,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // -----------------------------------------------------------------------
     // Dataflow buffers.
     // -----------------------------------------------------------------------
-    //  Reduce scaler (srcB) face layout. num_faces MUST be 1, not 4: the reduce-col strided
+    //  Reduce scaler (srcB) face geometry. num_faces MUST be 1, not 4: the reduce-col strided
     // tilize unpacks srcB with a single UNPACR1_FACE and NO L1 increment (TT_OP_UNPACR1_FACE_INC(0,0,0,0,...)
     // in llk_unpack_reduce_col_tilizeA_strided.h), so it re-reads the same one scalar face regardless of the
     // face count -- z=1 and z=4 are byte-identical. num_faces=4 built an illegal (x=16, y=1, z=4) buffer
@@ -690,7 +690,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // z_dim is 4" (ckernel_trisc_common.h). num_faces=1 gives the (x=16, y=1, z=1) descriptor the LLK
     // documents as the expected srcB scaler layout, which validates with the assert enabled. (srcA keeps its
     // full 32x32 4-face geometry below -- that operand genuinely needs it.)
-    const auto scalar_tile = tt::tt_metal::Tile({1, tt::constants::FACE_WIDTH});
+    const auto scalar_tile = tt::tt_metal::Tile::from_face_grid({1, 1}, {1, tt::constants::FACE_WIDTH});
     const uint32_t window_size_hw = kernel_h * kernel_w;
     // WORKAROUND (Quasar): the input-CB tile's face_r_dim feeds both the reduce tensor-shape and the
     // TDMA buffer-descriptor y_dim, and Quasar LLK restricts both to powers of 2 <= 16
@@ -709,6 +709,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         raw_face_r_pow2 <<= 1;
     }
     const uint32_t raw_face_r = raw_face_r_pow2;
+    const std::array<uint32_t, 2> raw_face_shape = {raw_face_r, tt::constants::FACE_WIDTH};
     // QSR: the reduce-col strided tilize (_llk_unpack_reduce_col_tilizeA_strided_) only supports a full
     // 32x32 (4-face) SrcA tile (LLK_ASSERT total_row_dim()==32 && total_col_dim()==32 at
     // llk_unpack_reduce_col_tilizeA_strided.h). The WH/BH 2-face small-window optimization feeds it a
@@ -718,11 +719,11 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // full-tile-padded, round_up(in_cb_sz, TILE_HW)) in_cb page as 4 faces; the padding rows
     // [window_size, 32) hold the pool identity (-inf max / 0 avg via force_max_clear + clear_value_cb,
     // AVG scalar = 1/true_window), so reducing the extra rows is a no-op.
-    // A 2x2 grid of raw_face_r-row faces, i.e. a (2 * raw_face_r) x 32 tile.
-    const std::optional<tt::tt_metal::Tile> input_tile =
-        return_indices ? std::nullopt
-                       : std::optional{tt::tt_metal::Tile(
-                             {2 * raw_face_r, tt::constants::TILE_WIDTH}, {raw_face_r, tt::constants::FACE_WIDTH})};
+    const std::array<uint32_t, 2> faces_grid_in_input_tile_for_cb = {2u, 2u};
+    const auto input_tile =
+        return_indices
+            ? std::nullopt
+            : std::optional{tt::tt_metal::Tile::from_face_grid(faces_grid_in_input_tile_for_cb, raw_face_shape)};
 
     // Single-row faces: one 1x16 face, or two of them side by side (a 1x32 tile).
     const bool last_tile_is_partial = in_c % tt::constants::TILE_WIDTH != 0;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

`DataflowBufferSpec` currently carries two overlapping LLK metadata fields: `tile_format_metadata` (`Tile`) and `unpack_face_geometry_metadata` (`FaceGeometry`). `FaceGeometry` carries a strict subset of what `Tile` describes, the metadata is duplicative here.

That split existed because `Tile` could only derive a face shape from a fixed lookup table. Callers that needed a non-default layout (shorter faces, fewer faces) had to set `FaceGeometry` as an override. When both fields were set, Metal 2.0 preferred `FaceGeometry` and ignored the `Tile`, so the two could silently disagree.

This PR makes `Tile` the single source of face layout on the DFB path:
- Add `Tile(tile_shape, face_shape)` so a known tile can carry a custom face layout, validated against the LLK limits (face tiles evenly into the tile; max 16×16 face; max 2×2 face grid).
- Add `Tile::from_face_grid(...)` for the common “N×M faces of this size” construction used by ops.
- Remove `unpack_face_geometry_metadata` from `DataflowBufferSpec`
- Updated usages.

**I'm not familiar with llk constraints, reviewers please take extra care, esp on:**
- `FaceGeometry` seems to only allow you to describe the face by number of rows of elements, but not the number of columns of elements.  The number of columns of elements seems to be hardcoded to 16? This constraint is not reintroduced into the Tile class as it doesn't match up with internal docs: https://tenstorrent.atlassian.net/wiki/spaces/LLK/pages/1228308684/Collection+of+hw+and+llk+implementation+details#Tile-sizes Please advise.

### Notes for reviewers
- The legacy `CircularBufferConfig::set_unpack_face_geometry` path is untouched as it will likely be deprecated in favor of metal 2.0.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/m2-tile-face-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/m2-tile-face-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/m2-tile-face-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/m2-tile-face-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/m2-tile-face-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/m2-tile-face-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/m2-tile-face-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/m2-tile-face-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/m2-tile-face-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/m2-tile-face-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/m2-tile-face-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/m2-tile-face-shape)