### PR TITLE
[Bug fix] Fix Dispatch Telemetry unit tests failing under wh_n300_civ2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,6 +107,7 @@ tt_metal/api/ @tenstorrent/metalium-api-owners
 tt_metal/api/tt-metalium/experimental/disaggregation/ @SeanNijjar @ubcheema # disaggregation experimental APIs
 tt_metal/api/tt-metalium/experimental/fabric @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @cfjchu @p1-0tr # fabric experimental APIs
 tt_metal/api/tt-metalium/experimental/noc_estimator/ @nstamatovicTT @atatuzunerTT
+tt_metal/api/tt-metalium/experimental/dispatch_telemetry.hpp @anashTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT
 tt_metal/api/tt-metalium/experimental/udm/ @yugaoTT @SeanNijjar
 tt_metal/api/internal/disaggregation/ @SeanNijjar @ubcheema # disaggregation internal APIs (moved from experimental in #48638)
 tt_metal/common/ @abhullar-tt @tt-aho @tt-asaigal @cfjchu
@@ -123,6 +124,7 @@ tt_metal/fabric/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNij
 tt_metal/hal.cpp @ruizhangTT
 tt_metal/hostdevcommon/ @tenstorrent/metalium-runtime # this should go away
 tt_metal/hostdevcommon/**/CMakeLists.txt @tenstorrent/metalium-runtime @tenstorrent/metalium-developers-infra # this should go away
+tt_metal/hostdevcommon/api/hostdevcommon/dispatch_telemetry_types.hpp @anashTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/metalium-runtime
 tt_metal/hw @abhullar-tt @jbaumanTT @nathan-TT @kstevensTT
 tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @ndivnicTT @fvranicTT
 tt_metal/hw/ckernels/**/llk_api/llk_sfpu @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @ndivnicTT @fvranicTT @nmauriceTT
@@ -148,6 +150,7 @@ tt_metal/impl/dataflow_buffer/ @abhullar-tt @arikTT
 tt_metal/impl/debug/ @abhullar-tt @ruizhangTT @sidnadTT @tenstorrent/metalium-developers-triage
 tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @cfjchu
 tt_metal/impl/dispatch/ @jbaumanTT @tt-asaigal @tt-aho @sidnadTT
+tt_metal/impl/dispatch/*telemetry* @anashTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT
 tt_metal/impl/dispatch/kernels/*telemetry* @anashTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT
 tt_metal/impl/dispatch/kernels/*realtime_profiler* @mo-tenstorrent @yusufbashiTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT
 tt_metal/impl/dispatch/kernels/REALTIME_PROFILER.md @mo-tenstorrent @yusufbashiTT @jbaumanTT @tt-asaigal @tt-aho @sidnadTT
@@ -245,6 +248,7 @@ tests/tt_metal/test_utils/ @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-a
 tests/tt_metal/test_utils/**/CMakeLists.txt @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @tenstorrent/metalium-developers-infra
 tests/tt_metal/tt_metal/ @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT
 tests/tt_metal/tt_metal/dispatch/dispatch_program/*realtime_profiler* @mo-tenstorrent @yusufbashiTT @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT
+tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp @anashTT @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT
 tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp @yusufbashiTT @mo-tenstorrent @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT
 tests/tt_metal/tt_metal/sources.cmake @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @sidnadTT @riverwuTT @akerteszTT
 tests/tt_metal/tt_metal/**/CMakeLists.txt @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @tt-aho @cfjchu @tenstorrent/metalium-developers-infra

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <spawn.h>
 #include <string>
 #include <sys/wait.h>
 #include <thread>
@@ -37,10 +38,31 @@
 #include "distributed/mesh_trace.hpp"
 #include "llrt/core_descriptor.hpp"
 
+// Clang TSan sets __has_feature(thread_sanitizer) but not always __SANITIZE_THREAD__.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer) && !defined(__SANITIZE_THREAD__)
+#define __SANITIZE_THREAD__ 1
+#endif
+#endif
+
 namespace tt::tt_metal {
 namespace {
 
 constexpr const char* kObserverChildEnv = "TT_METAL_DISPATCH_TELEMETRY_OBSERVER_PCI_DEVICE_ID";
+
+// Copies environ, replacing an existing KEY= if present. Pointers alias `observer_env`.
+std::vector<char*> envp_with_observer_pci_id(std::string& observer_env) {
+    const std::string prefix = std::string(kObserverChildEnv) + "=";
+    std::vector<char*> envp;
+    for (char** entry = environ; entry != nullptr && *entry != nullptr; ++entry) {
+        if (std::strncmp(*entry, prefix.c_str(), prefix.size()) != 0) {
+            envp.push_back(*entry);
+        }
+    }
+    envp.push_back(observer_env.data());
+    envp.push_back(nullptr);
+    return envp;
+}
 
 template <typename TCoreType>
 Program create_blank_program(const TCoreType& core) {
@@ -395,12 +417,16 @@ TEST_F(DispatchTelemetryReadApiTest, SMCControlIsInitialized) {
     const uint8_t control_flags = control->flags;
     const uint32_t dispatch_telemetry_addr = control->dispatch_telemetry_addr;
     const uint8_t num_hw_cqs = control->num_hw_cqs;
+    const uint16_t num_worker_cores = control->num_worker_cores;
     EXPECT_EQ(control_version, dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION);
     EXPECT_EQ(control_signature, dispatch_telemetry_types::SMC_TELEMETRY_SIGNATURE);
     EXPECT_EQ(control_flags, 0);
     EXPECT_EQ(dispatch_telemetry_addr, expected_addr);
     EXPECT_EQ(num_hw_cqs, device()->num_hw_cqs());
     ASSERT_LE(num_hw_cqs, dispatch_telemetry_types::RESERVED_CQ_SPACE);
+    const CoreCoord compute_grid = device()->compute_with_storage_grid_size();
+    EXPECT_EQ(num_worker_cores, compute_grid.x * compute_grid.y);
+    EXPECT_GT(num_worker_cores, 0u);
 
     {
         auto& metal_context = MetalContext::instance();
@@ -485,6 +511,7 @@ TEST_F(DispatchTelemetrySlowDispatchTest, SMCControlIsInitialized) {
     const uint8_t control_flags = control->flags;
     const uint32_t dispatch_telemetry_addr = control->dispatch_telemetry_addr;
     const uint8_t num_hw_cqs = control->num_hw_cqs;
+    const uint16_t num_worker_cores = control->num_worker_cores;
     EXPECT_EQ(control_version, dispatch_telemetry_types::DISPATCH_TELEMETRY_VERSION);
     EXPECT_EQ(control_signature, dispatch_telemetry_types::SMC_TELEMETRY_SIGNATURE);
     EXPECT_TRUE(
@@ -493,6 +520,9 @@ TEST_F(DispatchTelemetrySlowDispatchTest, SMCControlIsInitialized) {
     EXPECT_EQ(dispatch_telemetry_addr, expected_addr);
     EXPECT_EQ(num_hw_cqs, device()->num_hw_cqs());
     ASSERT_LE(num_hw_cqs, dispatch_telemetry_types::RESERVED_CQ_SPACE);
+    const CoreCoord compute_grid = device()->compute_with_storage_grid_size();
+    EXPECT_EQ(num_worker_cores, compute_grid.x * compute_grid.y);
+    EXPECT_GT(num_worker_cores, 0u);
 
     for (auto smc_coords : control->cq_dispatch_core_coords) {
         const uint32_t prefetch_xy = smc_coords.prefetch_xy;
@@ -531,6 +561,11 @@ TEST(DispatchTelemetryObserverChild, ReadInfoFromDeviceOwnedByAnotherProcess) {
 }
 
 TEST_F(DispatchTelemetryHostL1WaitTest, ReadInfoFromSeparateProcessWhileDeviceInUse) {
+#ifdef __SANITIZE_THREAD__
+    GTEST_SKIP() << "TSan has no happens-before across processes when a child attaches to a live "
+                    "device the parent still owns; posix_spawn only avoids fork-from-multithreaded-parent";
+#endif
+
     constexpr const char* observerChildFilter =
         "DispatchTelemetryObserverChild.ReadInfoFromDeviceOwnedByAnotherProcess";
 
@@ -554,27 +589,25 @@ TEST_F(DispatchTelemetryHostL1WaitTest, ReadInfoFromSeparateProcessWhileDeviceIn
     }
     ASSERT_TRUE(worker_started);
 
-    pid_t pid = fork();
-    if (pid == -1) {
-        const int fork_errno = errno;
+    // posix_spawn is the POSIX way to start a process from a multi-threaded parent
+    // (fork()+execv() is unsafe once the CQ reader / executor pool exist).
+    std::string observer_env = std::string(kObserverChildEnv) + "=" + std::to_string(pci_device_num);
+    std::vector<char*> envp = envp_with_observer_pci_id(observer_env);
+    const std::string filter_arg = std::string("--gtest_filter=") + observerChildFilter;
+    char* const argv[] = {const_cast<char*>("/proc/self/exe"), const_cast<char*>(filter_arg.c_str()), nullptr};
+
+    pid_t pid = 0;
+    const int spawn_ret = posix_spawn(&pid, argv[0], nullptr, nullptr, argv, envp.data());
+    if (spawn_ret != 0) {
         release_core_and_finish(worker_core);
-        FAIL() << "fork() failed: " << std::strerror(fork_errno);
-    }
-
-    if (pid == 0) {
-        const std::string pci_device_id = std::to_string(pci_device_num);
-        if (setenv(kObserverChildEnv, pci_device_id.c_str(), 1) != 0) {
-            _exit(2);
-        }
-
-        const std::string filter_arg = std::string("--gtest_filter=") + observerChildFilter;
-        char* const args[] = {const_cast<char*>("/proc/self/exe"), const_cast<char*>(filter_arg.c_str()), nullptr};
-        execv("/proc/self/exe", args);
-        _exit(3);
+        FAIL() << "posix_spawn() failed: " << std::strerror(spawn_ret);
     }
 
     int status = 0;
-    const pid_t wait_result = waitpid(pid, &status, 0);
+    pid_t wait_result = -1;
+    do {
+        wait_result = waitpid(pid, &status, 0);
+    } while (wait_result < 0 && errno == EINTR);
     release_core_and_finish(worker_core);
 
     ASSERT_EQ(wait_result, pid) << "waitpid failed";
@@ -1575,8 +1608,8 @@ TEST_F(DispatchTelemetryHostL1WaitTest, DispatchCoreEfficiencyAndUtilization) {
         auto info = telemetry.read_info();
         ASSERT_TRUE(info.has_value());
         ASSERT_TRUE(info->device_core_efficiency_since_last_read.has_value());
-        // Since we're only putting work on the tensix cores and not the eth cores, core efficiency will not be
-        // exactly 1.0
+        // Dispatch tensix and ethernet tiles are excluded from the worker-core denominator, so a
+        // wait covering the full compute grid should report near-1.0 efficiency.
         EXPECT_GT(info->device_core_efficiency_since_last_read.value(), 0.9f);
         ASSERT_TRUE(info->info_cqs.front().utilization_since_last_read.has_value());
         EXPECT_FLOAT_EQ(info->info_cqs.front().utilization_since_last_read.value(), 1.0f);

--- a/tt_metal/api/tt-metalium/experimental/dispatch_telemetry.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dispatch_telemetry.hpp
@@ -36,9 +36,14 @@ struct DispatchTelemetryCqInfo {
 
 struct DispatchTelemetryDeviceInfo {
     /**
-     * @brief   Device core efficiency describes the percentage of time the cores are actively
+     * @brief   Device core efficiency describes the percentage of time the worker cores are actively
      *          executing work. Requires worker dispatch.
-     * @note    core_efficiency = avg_core_runtime / uptime
+     * @note    core_efficiency = avg_worker_core_runtime / uptime, where the average is over the
+     *          compute-with-storage tensix count published in the SMC dispatch telemetry control
+     *          block (dispatch tensix and ethernet tiles are excluded).
+     *          Sub-device worker counts still include ACTIVE_ETH, so ethernet cores can add
+     *          worker-cycles to the numerator and the raw ratio can exceed 1.0. Host clamps to
+     *          [0.0, 1.0].
      * @return  Normalized core efficiency since the last read, or std::nullopt if worker dispatch is
      *          disabled. 1.0 = 100%, 0.0 = 0%.
      */

--- a/tt_metal/hostdevcommon/api/hostdevcommon/dispatch_telemetry_types.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dispatch_telemetry_types.hpp
@@ -65,7 +65,9 @@ struct __attribute__((packed, aligned(8))) DispatchCoreTelemetry {
     uint64_t current_timestamp = 0;
 
     // dispatch_s_compute writes
-    // Computed average time a worker core was running, updated only on sub device count change.
+    // Cumulative worker-cycles compressed as avg * num_worker_cores. Updated on overflow or
+    // sub-device count change. Host recovers total cycles as avg_work_runtime_per_worker * N,
+    // where N is SMCDispatchTelemetryControl::num_worker_cores.
     uint64_t avg_work_runtime_per_worker = 0;  //_per_worker
 
     // dispatch_s_compute writes
@@ -145,6 +147,9 @@ struct __attribute__((packed)) SMCDispatchTelemetryControl {
     uint32_t dispatch_telemetry_addr = 0;
     uint8_t num_hw_cqs = RESERVED_CQ_SPACE;
     SMCDispatchCoreCoords cq_dispatch_core_coords[RESERVED_CQ_SPACE];
+    // Tensix cores in the compute-with-storage grid (excludes dispatch tensix and ethernet).
+    // Host-published at device init. 0 means the field was not written (legacy control block).
+    uint16_t num_worker_cores = 0;
     struct __attribute__((packed)) SDTelemetry {
         // Reserved for future use
     } sd_telemetry[RESERVED_CQ_SPACE];

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -97,7 +97,8 @@ Device::Device(
 }
 
 void Device::initialize_smc_dispatch_telemetry_control() {
-    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+    // Versim has no firmware, so there is no SMC telemetry buffer to publish.
+    if (context_->rtoptions().get_dispatch_telemetry_disabled() || context_->rtoptions().get_simulator_enabled()) {
         return;
     }
     auto* tt_device = [&]() -> tt::umd::TTDevice* {
@@ -132,7 +133,7 @@ void Device::initialize_smc_dispatch_telemetry_control() {
 }
 
 void Device::invalidate_smc_dispatch_telemetry_control() {
-    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+    if (context_->rtoptions().get_dispatch_telemetry_disabled() || context_->rtoptions().get_simulator_enabled()) {
         return;
     }
 
@@ -155,7 +156,7 @@ void Device::invalidate_smc_dispatch_telemetry_control() {
 
 void Device::update_smc_dispatch_telemetry_for_fast_dispatch(
     uint8_t cq_id, const dispatch_telemetry_types::SMCDispatchCoreCoords& coords) {
-    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+    if (context_->rtoptions().get_dispatch_telemetry_disabled() || context_->rtoptions().get_simulator_enabled()) {
         return;
     }
 
@@ -184,7 +185,7 @@ void Device::update_smc_dispatch_telemetry_for_fast_dispatch(
 }
 
 void Device::set_smc_dispatch_telemetry_slow_dispatch_enabled(bool enabled) {
-    if (context_->rtoptions().get_dispatch_telemetry_disabled()) {
+    if (context_->rtoptions().get_dispatch_telemetry_disabled() || context_->rtoptions().get_simulator_enabled()) {
         return;
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <map>
 #include <optional>
@@ -120,6 +121,13 @@ void Device::initialize_smc_dispatch_telemetry_control() {
         context_->dispatch_mem_map().get_device_command_queue_addr(
             CommandQueueDeviceAddrType::DISPATCH_TELEMETRY, /*cq_id=*/0);
     smc_dispatch_telemetry_control_.num_hw_cqs = this->num_hw_cqs_;
+    const CoreCoord compute_grid = this->compute_with_storage_grid_size();
+    const size_t worker_core_count = compute_grid.x * compute_grid.y;
+    TT_FATAL(
+        worker_core_count <= std::numeric_limits<uint16_t>::max(),
+        "Compute grid has {} worker cores, which exceeds the uint16_t SMC num_worker_cores field",
+        worker_core_count);
+    smc_dispatch_telemetry_control_.num_worker_cores = static_cast<uint16_t>(worker_core_count);
     write_smc_dispatch_telemetry_control(*tt_device, smc_dispatch_telemetry_control_);
 }
 

--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -252,11 +252,26 @@ private:
         uint8_t cq_id = 0;
     };
 
-    static uint32_t get_total_worker_and_active_eth_cores(tt::umd::TTDevice& tt_device) {
-        const auto& soc_desc = tt_device.get_soc_descriptor();
-        uint32_t total_cores = soc_desc.get_cores(tt::CoreType::TENSIX, tt::CoordSystem::TRANSLATED).size();
-        total_cores += soc_desc.get_cores(tt::CoreType::ETH, tt::CoordSystem::TRANSLATED).size();
-        return total_cores;
+    static uint32_t tensix_core_count_fallback(tt::umd::TTDevice& tt_device) {
+        return tt_device.get_soc_descriptor().get_cores(tt::CoreType::TENSIX, tt::CoordSystem::TRANSLATED).size();
+    }
+
+    static uint32_t resolve_num_worker_cores(
+        const dispatch_telemetry_types::SMCDispatchTelemetryControl& control, tt::umd::TTDevice& tt_device) {
+        // Copy to avoid taking a reference to a packed struct member, which could be unaligned.
+        const uint16_t num_worker_cores = control.num_worker_cores;
+        if (num_worker_cores > 0) {
+            return num_worker_cores;
+        }
+        return tensix_core_count_fallback(tt_device);
+    }
+
+    static uint32_t get_num_worker_cores(tt::umd::TTDevice& tt_device) {
+        auto control = read_smc_dispatch_telemetry_control(tt_device);
+        if (!control.has_value()) {
+            return tensix_core_count_fallback(tt_device);
+        }
+        return resolve_num_worker_cores(*control, tt_device);
     }
 
     std::vector<std::vector<CoreEntry>> collect_telemetry_cores() {
@@ -264,6 +279,7 @@ private:
         if (!control.has_value() || control->num_hw_cqs > dispatch_telemetry_types::RESERVED_CQ_SPACE) {
             return {};
         }
+        total_number_of_cores_ = resolve_num_worker_cores(*control, tt_device_);
 
         std::vector<std::vector<CoreEntry>> entries_per_active_cq;
         const uint8_t num_cqs = control->num_hw_cqs;
@@ -310,8 +326,7 @@ private:
     }
 
 public:
-    Impl(tt::umd::TTDevice& device) :
-        tt_device_(device), total_number_of_cores_(get_total_worker_and_active_eth_cores(device)) {
+    Impl(tt::umd::TTDevice& device) : tt_device_(device), total_number_of_cores_(get_num_worker_cores(device)) {
         // Init private members to construction time
         (void)read_info();
     }
@@ -421,8 +436,8 @@ public:
         const double avg_work_runtime_per_core = delta_total_work_runtime / static_cast<double>(total_number_of_cores);
         const float core_efficiency = static_cast<float>(avg_work_runtime_per_core / delta_elapsed_device_time);
 
-        TT_ASSERT(
-            core_efficiency <= 1.0f, "If core_efficiency is greater than 100%, there is an issue with the telemetry");
+        // ACTIVE_ETH cores still contribute worker-cycles while N is tensix-only, so the raw
+        // ratio can exceed 1.0. Clamp rather than treating that as a telemetry error.
         TT_ASSERT(core_efficiency >= 0.0f, "If core_efficiency is less than 0%, there is an issue with the telemetry");
         return std::clamp(core_efficiency, 0.0f, 1.0f);
     }

--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -49,7 +49,7 @@ std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control
     }
 
     auto size = firmware_info_provider->get_runtime_telemetry_buffer_size();
-    if (!size.has_value()) {
+    if (!size.has_value() || size.value() == 0) {
         log_debug(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
         return std::nullopt;
     }
@@ -63,7 +63,8 @@ std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control
     }
 
     auto addr = firmware_info_provider->get_runtime_telemetry_buffer_address();
-    if (!addr.has_value()) {
+    // 0 is unpublished, not a valid buffer. Same class of versim trap as L1 addr_offset == 0.
+    if (!addr.has_value() || addr.value() == 0) {
         log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer address is unavailable or invalid");
         return std::nullopt;
     }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -369,6 +369,7 @@ void DispatchSKernel::CreateKernel() {
             {"DISPATCH_TELEMETRY_DISABLED", std::to_string(static_config_.dispatch_telemetry_disabled.value_or(false))},
             {"TOTAL_SUB_DEVICES", std::to_string(static_config_.max_num_worker_sems.value())},
             {"DISPATCH_TELEMETRY_CONTROL_ADDR", std::to_string(static_config_.dispatch_telemetry_control_addr.value())},
+            {"NUM_WORKER_CORES", std::to_string(device_worker_cores.size())},
         };
         tt::tt_metal::ComputeConfig compute_config;
         compute_config.defines = compute_defines;

--- a/tt_metal/impl/dispatch/kernels/cq_telemetry_dispatch_subordinate.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_telemetry_dispatch_subordinate.hpp
@@ -11,6 +11,7 @@
 
 constexpr uint32_t first_stream_index = FIRST_STREAM_INDEX;
 constexpr uint32_t total_sub_devices = TOTAL_SUB_DEVICES;
+constexpr uint32_t num_worker_cores = NUM_WORKER_CORES;
 constexpr bool telemetry_enabled = !DISPATCH_TELEMETRY_DISABLED;
 constexpr uintptr_t dispatch_telemetry_base = DISPATCH_TELEMETRY_ADDR;
 constexpr uintptr_t dispatch_telemetry_control_addr = DISPATCH_TELEMETRY_CONTROL_ADDR;
@@ -20,13 +21,14 @@ FORCE_INLINE uint32_t stream_wrap_delta(uint32_t current, uint32_t previous) {
     return ((current - previous) << shift) >> shift;
 }
 
-// Compress work runtime into avg_work_runtime_per_worker only when needed to avoid losing cycles
+// Compress work runtime into avg_work_runtime_per_worker only when needed to avoid losing cycles.
+// Divide by the chip-wide worker core count so host can recover total cycles as avg * num_worker_cores.
 FORCE_INLINE void compress_work_runtime(
-    uint64_t& avg_work_runtime_per_worker, uint64_t& current_sub_device_work_runtime, uint32_t workers_per_sub_device) {
-    if (workers_per_sub_device == 0) {
+    uint64_t& avg_work_runtime_per_worker, uint64_t& current_sub_device_work_runtime) {
+    if (num_worker_cores == 0) {
         return;
     }
-    avg_work_runtime_per_worker += current_sub_device_work_runtime / workers_per_sub_device;
+    avg_work_runtime_per_worker += current_sub_device_work_runtime / num_worker_cores;
     current_sub_device_work_runtime = 0;
     auto dispatch_telemetry =
         reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
@@ -97,10 +99,7 @@ FORCE_INLINE void dispatch_subordinate_telemetry() {
                     while (completion_count[i] < workers_per_sub_device[i]) {
                         const bool will_overflow = UINT64_MAX - current_sub_device_work_runtime[i] < delta_work_runtime;
                         if (will_overflow) {
-                            compress_work_runtime(
-                                avg_work_runtime_per_worker,
-                                current_sub_device_work_runtime[i],
-                                workers_per_sub_device[i]);
+                            compress_work_runtime(avg_work_runtime_per_worker, current_sub_device_work_runtime[i]);
                         }
                         current_sub_device_work_runtime[i] += delta_work_runtime;
                         completion_count[i]++;
@@ -110,8 +109,7 @@ FORCE_INLINE void dispatch_subordinate_telemetry() {
                 if (sub_device_update) {
                     // If the workers_per_sub_device has changed, the cumulative work runtime must be compressed
                     if (dispatch_telemetry->workers_per_sub_device[i] != workers_per_sub_device[i]) {
-                        compress_work_runtime(
-                            avg_work_runtime_per_worker, current_sub_device_work_runtime[i], workers_per_sub_device[i]);
+                        compress_work_runtime(avg_work_runtime_per_worker, current_sub_device_work_runtime[i]);
                         current_sub_device_work_runtime[i] = 0;
                         dispatch_telemetry->current_sub_device_work_runtime[i] = current_sub_device_work_runtime[i];
                         workers_per_sub_device[i] = dispatch_telemetry->workers_per_sub_device[i];
@@ -210,8 +208,7 @@ FORCE_INLINE void dispatch_subordinate_telemetry() {
                 while (delta_sem_count > 0 && completion_count[i] < workers_per_sub_device[i]) {
                     const bool will_overflow = UINT64_MAX - current_sub_device_work_runtime[i] < delta_work_runtime;
                     if (will_overflow) {
-                        compress_work_runtime(
-                            avg_work_runtime_per_worker, current_sub_device_work_runtime[i], workers_per_sub_device[i]);
+                        compress_work_runtime(avg_work_runtime_per_worker, current_sub_device_work_runtime[i]);
                     }
                     current_sub_device_work_runtime[i] += delta_work_runtime;
                     completion_count[i]++;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes 2 failing tests under wh_n300_civ2:
* DispatchTelemetryHostL1WaitTest.ReadInfoFromSeparateProcessWhileDeviceInUse
* DispatchTelemetryHostL1WaitTest.DispatchCoreEfficiencyAndUtilization

Changes:
* Added total tensix worker count to SMC telemetry buffer for accurate core utilization calculations
* Disabled ReadInfoFromSeparateProcessWhileDeviceInUse during TSan, as it spawns a second thread to verify reading telemetry on a running workload without owning the device context

### Notes for reviewers
Fixes broken wh_n300_civ2 run on merge gate

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/fix-dispatch-telemetry-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/fix-dispatch-telemetry-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/fix-dispatch-telemetry-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/fix-dispatch-telemetry-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/fix-dispatch-telemetry-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/fix-dispatch-telemetry-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/fix-dispatch-telemetry-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/fix-dispatch-telemetry-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/fix-dispatch-telemetry-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/fix-dispatch-telemetry-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/fix-dispatch-telemetry-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/fix-dispatch-telemetry-utests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/fix-dispatch-telemetry-utests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/fix-dispatch-telemetry-utests)