### PR TITLE
[llk_helper_library] 1/8 eltwise helpers: framework and validation matrix

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -90,10 +90,11 @@ ttnn:
     wh_llmbox: 50
     wh_galaxy: 120
     bh_galaxy: 40
-    bh_p100: 805
-    bh_p150b_civ2: 840
-    wh_n150_civ2: 1010
-    wh_n300_civ2: 1180
+    # Add 10 minutes per single-card SKU for the daily kernel-lib eltwise chain correctness job.
+    bh_p100: 815
+    bh_p150b_civ2: 850
+    wh_n150_civ2: 1020
+    wh_n300_civ2: 1190
     bh_p150b_civ2_viommu: 115
     bh_p300: 60
     bh_quietbox_2: 60

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -90,7 +90,6 @@ ttnn:
     wh_llmbox: 50
     wh_galaxy: 120
     bh_galaxy: 40
-    # Add 10 minutes per single-card SKU for the daily kernel-lib eltwise chain correctness job.
     bh_p100: 815
     bh_p150b_civ2: 850
     wh_n150_civ2: 1020

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -73,7 +73,7 @@ on:
       additional_test_categories:
         description: >
           Additional test categories to run (comma-separated, e.g.,
-          conv,pool,sdpa,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,reduction,data_movement,transformers,compute_fused)
+          conv,pool,sdpa,eltwise,kernel_lib,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,reduction,data_movement,transformers,compute_fused)
         required: false
         type: string
         default: ""
@@ -224,7 +224,7 @@ jobs:
       enabled-skus: ${{ needs.generate-arch-matrix.outputs.l2-nightly-skus }}
       additional_test_categories: >-
         ${{ (github.event_name == 'schedule' &&
-        'conv,matmul,fused,reduction,experimental,pool,eltwise,transformers,moreh,misc,sdpa,data_movement,ccl,docs_examples,cpp_accessor,cpp_lab_examples')
+        'conv,matmul,fused,reduction,experimental,pool,eltwise,kernel_lib,transformers,moreh,misc,sdpa,data_movement,ccl,docs_examples,cpp_accessor,cpp_lab_examples')
         || (inputs.run_ccl_tests && inputs.run_cpp_tests && format('{0},ccl,cpp_accessor,cpp_lab_examples', inputs.additional_test_categories))
         || (inputs.run_ccl_tests && format('{0},ccl', inputs.additional_test_categories))
         || (inputs.run_cpp_tests && format('{0},cpp_accessor,cpp_lab_examples', inputs.additional_test_categories))

--- a/setup.py
+++ b/setup.py
@@ -342,7 +342,10 @@ class CMakeBuild(build_ext):
             "ttnn/operations/data_movement/**/*",
             "ttnn/operations/moreh/**/*",
             "ttnn/kernel/*",
-            "ttnn/kernel_lib/*",
+            # Kernel-library JIT headers are organized into nested API domains (for example,
+            # eltwise/core and eltwise/unary). Keep this recursive so every migrated kernel sees
+            # the same header tree in an installed wheel as it does in a source checkout.
+            "ttnn/kernel_lib/**/*.{hpp,inl}",
             "ttnn/operations/normalization/kernel_util/**/*",
         ]
         tt_metal_patterns = [

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -152,6 +152,25 @@
   team: ttnn
   category: pool
 
+- name: ttnn kernel-lib eltwise chain tests
+  cmd: >-
+    pytest tests/ttnn/unit_tests/kernel_lib -xv
+    --ignore=tests/ttnn/unit_tests/kernel_lib/test_chain_perf.py
+    --ignore=tests/ttnn/unit_tests/kernel_lib/test_chain_skip_compute_perf.py
+    --timeout=600
+  skus:
+    wh_n150_civ2:
+      timeout: 10
+    wh_n300_civ2:
+      timeout: 10
+    bh_p100:
+      timeout: 10
+    bh_p150b_civ2:
+      timeout: 10
+  owner_id: U08ADLJ4PLP # Aleksandar Stancov
+  team: ttnn
+  category: kernel_lib
+
 - name: ttnn nightly eltwise tests group 1
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 1 -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:

--- a/tests/ttnn/unit_tests/kernel_lib/chain_test_lib.py
+++ b/tests/ttnn/unit_tests/kernel_lib/chain_test_lib.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared harness for eltwise_chain helper tests.
+
+Factored out of test_chain_reconfig.py so every helper-test suite (operand-kind,
+DEST/block, out-of-bounds, lifecycle, ...) builds its generic_op programs the same
+way instead of copy-pasting the builders.
+
+The reader/writer dataflow kernels live under tests/eltwise/chain/reconfig/ (they are generic
+N-input / N-output streamers, reused unchanged). Each suite supplies its own compute
+kernel path.
+"""
+
+import torch
+import ttnn
+
+# Tile size in bytes per dtype (tt_metal/api/tt-metalium/tt_backend_api_types.hpp).
+# bfloat8_b is a block-float format: 32*32 one-byte mantissas plus 16 shared-exponent
+# bytes per 16x16 face -> 1024 + 4*16 = 1088.
+DTYPE_TILE_BYTES = {
+    ttnn.bfloat16: 2048,
+    ttnn.float32: 4096,
+    ttnn.bfloat8_b: 1088,
+}
+
+# Reusable generic dataflow kernels (live alongside the reconfig suite).
+DATAFLOW_DIR = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig"
+READER = f"{DATAFLOW_DIR}/reader_inputs.cpp"
+WRITER_1OUT = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp"
+WRITER_2OUT = f"{DATAFLOW_DIR}/writer_2_outputs.cpp"
+
+
+def torch_dtype_for(ttnn_dtype):
+    if ttnn_dtype == ttnn.float32:
+        return torch.float32
+    if ttnn_dtype == ttnn.bfloat16:
+        return torch.bfloat16
+    # bfp8_b host-side stays float32 so quantization happens during ttnn.from_torch.
+    return torch.float32
+
+
+def make_input(shape, ttnn_dtype, device, seed, scale=0.5, bias=0.25):
+    torch.manual_seed(seed)
+    torch_t = torch.randn(shape, dtype=torch.float32) * scale + bias
+    torch_t = torch_t.to(torch_dtype_for(ttnn_dtype))
+    tt_t = ttnn.from_torch(
+        torch_t,
+        dtype=ttnn_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return torch_t, tt_t
+
+
+def assert_close(golden, actual, label, rtol=0.05, atol=0.02):
+    """Numerical assertion for helper tests; PCC is intentionally not a correctness oracle here."""
+    assert torch.allclose(golden, actual, rtol=rtol, atol=atol, equal_nan=True), (
+        f"{label}: max abs error {(golden - actual).abs().nan_to_num().max().item()} "
+        f"exceeded rtol={rtol}, atol={atol}"
+    )
+
+
+def single_core_grid():
+    core = ttnn.CoreCoord(0, 0)
+    return ttnn.CoreRangeSet([ttnn.CoreRange(core, core)])
+
+
+def cb_descriptor(cb_id, dtype, num_pages, core_grid):
+    page_size = DTYPE_TILE_BYTES[dtype]
+    fmt = ttnn.CBFormatDescriptor(buffer_index=cb_id, data_format=dtype, page_size=page_size)
+    return ttnn.CBDescriptor(
+        total_size=page_size * num_pages,
+        core_ranges=core_grid,
+        format_descriptors=[fmt],
+    )
+
+
+def build_reader_kernel(input_tensors, num_tiles, core_grid):
+    """N-input streamer; N inferred from len(input_tensors). Pushes num_tiles to each CB c_0..c_{N-1}."""
+    n = len(input_tensors)
+    cta = [n]
+    for t in input_tensors:
+        cta.extend(ttnn.TensorAccessorArgs(t).get_compile_time_args())
+    # The device compiler validates TensorAccessorArgs in discarded branches of the
+    # 1..4-input reader. Pad metadata so all four declarations remain well-formed;
+    # only the selected NumInputs branch emits reads or consumes runtime addresses.
+    for _ in range(4 - n):
+        cta.extend(ttnn.TensorAccessorArgs(input_tensors[0]).get_compile_time_args())
+    rt = ttnn.RuntimeArgs()
+    rt[0][0] = [t.buffer_address() for t in input_tensors] + [num_tiles, 0]
+    return ttnn.KernelDescriptor(
+        kernel_source=READER,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
+        compile_time_args=cta,
+        runtime_args=rt,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+
+def build_reader_asym_kernel(input_tensors, counts, core_grid):
+    """2-input reader pushing counts[0] tiles to c_0 and counts[1] to c_1 (asymmetric)."""
+    assert len(input_tensors) == 2 and len(counts) == 2
+    cta = []
+    for t in input_tensors:
+        cta.extend(ttnn.TensorAccessorArgs(t).get_compile_time_args())
+    rt = ttnn.RuntimeArgs()
+    rt[0][0] = [t.buffer_address() for t in input_tensors] + [counts[0], counts[1]]
+    return ttnn.KernelDescriptor(
+        kernel_source="ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/reader_2_asym.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
+        compile_time_args=cta,
+        runtime_args=rt,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+
+def build_compute_kernel_rt(
+    kernel_source, compile_time_args, runtime_args, core_grid, fp32_dest_acc_en=False, dst_full_sync_en=False
+):
+    """Compute kernel with both compile-time AND runtime args (e.g. a TileAddressing base)."""
+    rt = ttnn.RuntimeArgs()
+    rt[0][0] = list(runtime_args)
+    return ttnn.KernelDescriptor(
+        kernel_source=kernel_source,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
+        compile_time_args=list(compile_time_args),
+        runtime_args=rt,
+        config=ttnn.ComputeConfigDescriptor(fp32_dest_acc_en=fp32_dest_acc_en, dst_full_sync_en=dst_full_sync_en),
+    )
+
+
+def build_writer_1out_kernel(output_tensor, num_tiles, core_grid):
+    cta = [16] + ttnn.TensorAccessorArgs(output_tensor).get_compile_time_args()
+    rt = ttnn.RuntimeArgs()
+    rt[0][0] = [output_tensor.buffer_address(), num_tiles, 0]
+    return ttnn.KernelDescriptor(
+        kernel_source=WRITER_1OUT,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
+        compile_time_args=cta,
+        runtime_args=rt,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+
+def build_writer_2out_kernel(output_tensors, num_tiles, core_grid):
+    cta = []
+    for t in output_tensors:
+        cta.extend(ttnn.TensorAccessorArgs(t).get_compile_time_args())
+    rt = ttnn.RuntimeArgs()
+    rt[0][0] = [t.buffer_address() for t in output_tensors] + [num_tiles, 0]
+    return ttnn.KernelDescriptor(
+        kernel_source=WRITER_2OUT,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
+        compile_time_args=cta,
+        runtime_args=rt,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+
+def build_compute_kernel(
+    kernel_source,
+    compile_time_args,
+    core_grid,
+    fp32_dest_acc_en=False,
+    dst_full_sync_en=False,
+    math_fidelity=None,
+    defines=None,
+):
+    """kernel_source is a full repo-relative path. compile_time_args is a list of uint32.
+    math_fidelity is an optional ttnn.MathFidelity (defaults to the descriptor default when None).
+    defines optionally supplies (name, value) preprocessor definitions."""
+    cfg_kwargs = dict(fp32_dest_acc_en=fp32_dest_acc_en, dst_full_sync_en=dst_full_sync_en)
+    if math_fidelity is not None:
+        cfg_kwargs["math_fidelity"] = math_fidelity
+    return ttnn.KernelDescriptor(
+        kernel_source=kernel_source,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
+        compile_time_args=list(compile_time_args),
+        defines=[] if defines is None else list(defines),
+        runtime_args=[],
+        config=ttnn.ComputeConfigDescriptor(**cfg_kwargs),
+    )

--- a/tests/ttnn/unit_tests/kernel_lib/chain_test_lib.py
+++ b/tests/ttnn/unit_tests/kernel_lib/chain_test_lib.py
@@ -23,6 +23,7 @@ import ttnn
 DTYPE_TILE_BYTES = {
     ttnn.bfloat16: 2048,
     ttnn.float32: 4096,
+    ttnn.int32: 4096,
     ttnn.bfloat8_b: 1088,
 }
 

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_blocking.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_blocking.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Blocking correctness for eltwise_chain.
+
+block_size processes multiple tiles per inner iter across DEST lanes. It is a loop-structure
+optimization: every supported size must match exp(x) and remain bit-identical to block_size=1.
+Tail tests separately cover the two physical synchronization contracts.
+"""
+
+import torch
+import pytest
+import ttnn
+from loguru import logger
+from tests.ttnn.utils_for_testing import comp_ulp
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp.cpp"
+FIXED_BLOCK_TAIL_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_chunked_fixed_tail.cpp"
+MULTISLOT_TAIL_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_multislot_tail.cpp"
+
+# Accuracy bound for the Exp<> (Approx::Exact) chains below, in bf16 ULPs of the float32
+# golden.  ULP is sensitive to systematic accuracy loss that correlation would miss.
+EXP_ULP_THRESHOLD = 2
+
+
+def _assert_matches_golden(golden, actual, label):
+    """ULP accuracy against the float32 exp golden.
+
+    The device result is bf16, so the ULP error is measured in bf16 ULPs: comp_ulp keeps the
+    float32 golden as the higher-precision reference and sizes one ULP from its bf16 cast.
+    """
+    ulp_ok, ulp_msg = comp_ulp(golden, actual.to(torch.bfloat16), EXP_ULP_THRESHOLD)
+    logger.debug(f"{label} | {ulp_msg}")
+    assert ulp_ok, ulp_msg
+
+
+def _build(device, n, block_size):
+    """Returns (program, [tensors], torch_in) for a Bulk+Block exp chain at the given block_size."""
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=601)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    # Bulk stages the full window upfront -> size both CBs for all n tiles.
+    cbs = [lib.cb_descriptor(0, dt, n, core_grid), lib.cb_descriptor(16, dt, n, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [n, block_size], core_grid)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    return program, [tt_in, tt_out], torch_in
+
+
+def _run_once(device, n, block_size):
+    program, tensors, torch_in = _build(device, n, block_size)
+    output = ttnn.generic_op(tensors, program)
+    return torch_in.to(torch.float32), ttnn.to_torch(output).to(torch.float32)
+
+
+# =============================================================================
+# Correctness — blocking must not change the per-tile result.
+# =============================================================================
+def test_blocking_correctness_and_equivalence(device):
+    """One execution matrix checks both the math golden and the stronger cross-size invariant."""
+    n = 8
+    results = {}
+    for block_size in (1, 2, 4, 8):
+        torch_in, out = _run_once(device, n, block_size)
+        golden = torch.exp(torch_in)
+        _assert_matches_golden(golden, out, f"blocking correctness block_size={block_size}")
+        results[block_size] = out
+
+    base = results[1]
+    for bs, out in results.items():
+        max_diff = (out - base).abs().max().item()
+        logger.debug(f"blocking identical: block_size={bs} vs 1 -> max abs diff {max_diff}")
+        assert torch.equal(out, base), f"block_size={bs} diverged from block_size=1 (max diff {max_diff})"
+
+
+@pytest.mark.parametrize("n", [1, 7, 8, 9, 15])
+def test_fixed_block_tail_executes_only_valid_tiles(device, n):
+    """A fixed-size physical tail synchronizes a full chunk while math covers only valid tiles."""
+    block_size = 8
+    physical_n = ((n + block_size - 1) // block_size) * block_size
+    dt = ttnn.bfloat16
+    physical_shape = [1, 1, 32, 32 * physical_n]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(physical_shape, dt, device, seed=602 + n)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(physical_shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    # Both dataflow sides exchange the complete physical chunk. Only the first n output tiles
+    # contain defined results; the tail pages exist to exercise the full-block CB contract.
+    pages = 2 * block_size
+    cbs = [lib.cb_descriptor(0, dt, pages, core_grid), lib.cb_descriptor(16, dt, pages, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], physical_n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, physical_n, core_grid)
+    compute = lib.build_compute_kernel(FIXED_BLOCK_TAIL_KERNEL, [1, n, block_size, 1], core_grid)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    valid_columns = 32 * n
+    actual = ttnn.to_torch(output).to(torch.float32)[..., :valid_columns]
+    golden = torch.exp(torch_in.to(torch.float32)[..., :valid_columns])
+    _assert_matches_golden(golden, actual, f"padded PerBlockSize tail n={n}, physical_n={physical_n}")
+
+
+@pytest.mark.parametrize("Ht,Wt", [(2, 3), (2, 9)])
+def test_fixed_block_tail_is_synchronized_per_row(device, Ht, Wt):
+    """Every logical row gets its own full physical tail chunk."""
+    block_size = 8
+    physical_Wt = ((Wt + block_size - 1) // block_size) * block_size
+    physical_n = Ht * physical_Wt
+    dt = ttnn.bfloat16
+    physical_shape = [1, 1, 32 * Ht, 32 * physical_Wt]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(physical_shape, dt, device, seed=702 + Ht * 10 + Wt)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(physical_shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    pages = 2 * block_size
+    cbs = [lib.cb_descriptor(0, dt, pages, core_grid), lib.cb_descriptor(16, dt, pages, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], physical_n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, physical_n, core_grid)
+    compute = lib.build_compute_kernel(FIXED_BLOCK_TAIL_KERNEL, [Ht, Wt, block_size, 1], core_grid)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    valid_columns = 32 * Wt
+    actual = ttnn.to_torch(output).to(torch.float32)[..., :valid_columns]
+    golden = torch.exp(torch_in.to(torch.float32)[..., :valid_columns])
+    _assert_matches_golden(golden, actual, f"row-blocked tail Ht={Ht}, Wt={Wt}, physical_Wt={physical_Wt}")
+
+
+@pytest.mark.parametrize("Ht,Wt", [(2, 3), (2, 9)])
+def test_clamped_block_tail_synchronizes_only_valid_tiles(device, Ht, Wt):
+    """ValidTiles mode clamps both PerBlockSize synchronization and math to each logical row tail."""
+    block_size = 8
+    n = Ht * Wt
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32 * Ht, 32 * Wt]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=802 + Ht * 10 + Wt)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+
+    # A row-clamped grid repeats after Wt logical pages, so keep the CB ring row-aligned.
+    # A block-sized ring would let the partial first-row tail misalign a later full chunk
+    # across the physical ring boundary.
+    pages = 2 * Wt
+    cbs = [lib.cb_descriptor(0, dt, pages, core_grid), lib.cb_descriptor(16, dt, pages, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(FIXED_BLOCK_TAIL_KERNEL, [Ht, Wt, block_size, 0], core_grid)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    actual = ttnn.to_torch(output).to(torch.float32)
+    golden = torch.exp(torch_in.to(torch.float32))
+    _assert_matches_golden(golden, actual, f"clamped PerBlockSize tail Ht={Ht}, Wt={Wt}")
+
+
+@pytest.mark.parametrize("n", [1, 3, 5])
+def test_multislot_dest_partial_tail(device, n):
+    """D1 gives each lane a two-slot footprint; n=1/3/5 exercises partial tails at block_size=4."""
+    block_size = 4  # DEST_AUTO_LIMIT(8) / lane_width(2)
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=903 + n)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [
+        lib.cb_descriptor(0, dt, 2 * block_size, core_grid),
+        lib.cb_descriptor(16, dt, 2 * block_size, core_grid),
+    ]
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, n, core_grid),
+            lib.build_compute_kernel(MULTISLOT_TAIL_KERNEL, [n, block_size], core_grid),
+        ],
+        semaphores=[],
+        cbs=cbs,
+    )
+    actual = ttnn.to_torch(ttnn.generic_op([tt_in, tt_out], program)).to(torch.float32)
+    _assert_matches_golden(torch.exp(torch_in.to(torch.float32)), actual, f"multislot partial tail n={n}")

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_dest_accumulation.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_dest_accumulation.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/accumulation.cpp"
+
+
+def _run_configuration(
+    device,
+    tt_a,
+    tt_b,
+    tiles_per_output,
+    total_input_tiles,
+    output_tiles,
+    num_outputs,
+    block_size,
+    caller_managed,
+    whole_shape,
+):
+    dtype = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32, 32 * output_tiles]),
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_a, tt_b], total_input_tiles, core_grid),
+            lib.build_writer_1out_kernel(tt_out, output_tiles, core_grid),
+            lib.build_compute_kernel(
+                KERNEL,
+                [0, tiles_per_output, block_size, int(caller_managed), num_outputs, int(whole_shape)],
+                core_grid,
+            ),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, total_input_tiles, core_grid),
+            lib.cb_descriptor(1, dtype, total_input_tiles, core_grid),
+            lib.cb_descriptor(16, dtype, output_tiles, core_grid),
+        ],
+    )
+    return ttnn.to_torch(ttnn.generic_op([tt_a, tt_b, tt_out], program)).to(torch.float32)
+
+
+@pytest.mark.parametrize("whole_shape", [False, True], ids=["per-row", "whole-shape"])
+def test_dest_accumulation_modes_and_lifecycle_equivalence(device, whole_shape):
+    """Each scope checks its golden plus block-size and managed/caller-managed equivalence."""
+    n = 8
+    num_outputs = 3
+    total_input_tiles = n * num_outputs
+    dtype = ttnn.bfloat16
+
+    torch_a, tt_a = lib.make_input([1, 1, 32, 32 * total_input_tiles], dtype, device, seed=1701)
+    torch_b, tt_b = lib.make_input([1, 1, 32, 32 * total_input_tiles], dtype, device, seed=1702)
+    output_tiles = 1 if whole_shape else num_outputs
+
+    a_tiles = torch.stack(torch_a.to(torch.float32).split(32, dim=-1)).reshape(num_outputs, n, 1, 1, 32, 32)
+    b_tiles = torch.stack(torch_b.to(torch.float32).split(32, dim=-1)).reshape(num_outputs, n, 1, 1, 32, 32)
+    reduced = (a_tiles + b_tiles).sum(dim=1)
+    golden = reduced.sum(dim=0) if whole_shape else torch.cat([reduced[i] for i in range(num_outputs)], dim=-1)
+    # Whole-shape reduction preserves one hardware DEST accumulation across all rows, so its
+    # addition order intentionally differs from torch's tree reduction over the reshaped tensor.
+    results = {}
+    for block_size in (1, 2, 8):
+        for caller_managed in (False, True):
+            out = _run_configuration(
+                device,
+                tt_a,
+                tt_b,
+                n,
+                total_input_tiles,
+                output_tiles,
+                num_outputs,
+                block_size,
+                caller_managed,
+                whole_shape,
+            )
+            lib.assert_close(
+                golden,
+                out,
+                f"DEST accumulation block={block_size}, caller_managed={caller_managed}, whole_shape={whole_shape}",
+                rtol=0.1,
+                atol=0.1,
+            )
+            results[(block_size, caller_managed)] = out
+
+    reference = results[(1, False)]
+    for config, out in results.items():
+        assert torch.equal(out, reference), f"DEST accumulation changed across lifecycle/block config {config}"
+
+
+def _run_l1_configuration(device, tt_in, caller_managed):
+    n = 8
+    dtype = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32, 32]), dtype, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, 1, core_grid),
+            lib.build_compute_kernel(KERNEL, [1, n, 1, int(caller_managed), 1, 0], core_grid),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, 2, core_grid),
+            lib.cb_descriptor(15, dtype, 1, core_grid),
+            lib.cb_descriptor(16, dtype, 2, core_grid),
+        ],
+    )
+    return ttnn.to_torch(ttnn.generic_op([tt_in, tt_out], program)).to(torch.float32)
+
+
+def test_l1_accumulation_managed_and_caller_managed_are_equivalent(device):
+    n = 8
+    dtype = ttnn.bfloat16
+    torch_in, tt_in = lib.make_input([1, 1, 32, 32 * n], dtype, device, seed=1701, scale=0.125)
+
+    golden = torch_in.to(torch.float32).reshape(1, 1, 32, n, 32).sum(dim=3)
+    outputs = {}
+    for caller_managed in (False, True):
+        out = _run_l1_configuration(device, tt_in, caller_managed)
+        lib.assert_close(golden, out, f"L1 accumulation caller_managed={caller_managed}", rtol=0.1, atol=0.1)
+        outputs[caller_managed] = out
+
+    assert torch.equal(outputs[False], outputs[True]), "L1 accumulation changed with lifecycle ownership"

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_elements.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_elements.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Coverage for chain element types that the other suites don't exercise.
+
+  - DestReuseBinary: feeds the DEST result back as an FPU operand (DEST->srcA/srcB) instead of a
+    second CB read. out = (A + B) * C.
+
+  - Ternary Where: selects between two DEST tiles.
+  - Pack ReLU: applies activation on one output while a second pack remains linear.
+
+Fill / Rand (no-CB-input elements with special init) and quaternary SFPU are tracked as follow-up.
+"""
+
+import torch
+import pytest
+import ttnn
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+DEST_REUSE_PARAM = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/dest_reuse_param.cpp"
+MISC_ELEMENTS = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/misc_elements.cpp"
+UNARY_BCAST = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/unary_bcast.cpp"
+
+# reuse selector -> name; op selector -> (name, torch fn applied as `lhs op rhs`)
+_REUSE = {0: "DEST_TO_SRCA", 1: "DEST_TO_SRCB"}
+_OP = {0: ("add", lambda x, y: x + y), 1: ("sub", lambda x, y: x - y), 2: ("mul", lambda x, y: x * y)}
+
+
+@pytest.mark.parametrize(
+    "reuse,op",
+    [(0, 0), (0, 1), (1, 1), (0, 2)],
+    ids=["add-SRCA", "sub-SRCA", "sub-SRCB", "mul-SRCA"],
+)
+def test_dest_reuse_matrix(device, reuse, op):
+    """DestReuseBinary reuse-direction x op. Stage1 D0=A+B; stage2 routes DEST per ReuseType:
+    SRCA -> (A+B) op C, SRCB -> C op (A+B). Sub covers both directions because it distinguishes
+    operand order; commutative Add/Mul need only one direction to cover their op emission."""
+    n = 4
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    ta, tt_a = lib.make_input(shape, dt, device, seed=1301)
+    tb, tt_b = lib.make_input(shape, dt, device, seed=1302)
+    tc, tt_c = lib.make_input(shape, dt, device, seed=1303)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(i, dt, 2, core_grid) for i in (0, 1, 2)] + [lib.cb_descriptor(16, dt, 2, core_grid)]
+    reader = lib.build_reader_kernel([tt_a, tt_b, tt_c], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(DEST_REUSE_PARAM, [n, reuse, op], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_b, tt_c, tt_out], program)
+
+    dest = (ta + tb).to(torch.float32)
+    c = tc.to(torch.float32)
+    _, fn = _OP[op]
+    golden = fn(dest, c) if reuse == 0 else fn(c, dest)  # SRCA: DEST op C ; SRCB: C op DEST
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(golden, out, f"DestReuse {_REUSE[reuse]} {_OP[op][0]}")
+
+
+def test_ternary_where(device):
+    """Where ternary: out = where(cond != 0, a, b). cond is a 0/1 mask so both branches are taken."""
+    n = 4
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    # cond as a 0/1 mask so where exercises both the 'a' and 'b' branches.
+    torch.manual_seed(1201)
+    cond_f = (torch.randn(shape) > 0).to(torch.float32)
+    tt_cond = ttnn.from_torch(
+        cond_f.to(torch.bfloat16),
+        dtype=dt,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ta, tt_a = lib.make_input(shape, dt, device, seed=1202)
+    tb, tt_b = lib.make_input(shape, dt, device, seed=1203)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(i, dt, 2, core_grid) for i in (0, 1, 2)] + [lib.cb_descriptor(16, dt, 2, core_grid)]
+    reader = lib.build_reader_kernel([tt_cond, tt_a, tt_b], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(MISC_ELEMENTS, [n, 0], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_cond, tt_a, tt_b, tt_out], program)
+
+    golden = torch.where(cond_f != 0, ta.to(torch.float32), tb.to(torch.float32))
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(golden, out, "Where ternary")
+
+
+def test_pack_relu(device):
+    """One pack applies ReLU while a fan-out pack preserves the original tile."""
+    n = 8
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=1801, scale=2.0, bias=-1.0)
+    tt_relu = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    tt_linear = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_2out_kernel([tt_relu, tt_linear], n, core_grid),
+            lib.build_compute_kernel(MISC_ELEMENTS, [n, 1], core_grid),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dt, 2, core_grid),
+            lib.cb_descriptor(16, dt, 2, core_grid),
+            lib.cb_descriptor(17, dt, 2, core_grid),
+        ],
+    )
+    ttnn.generic_op([tt_in, tt_relu, tt_linear], program)
+
+    for output, golden in (
+        (tt_relu, torch.clamp_min(torch_in.to(torch.float32), 0)),
+        (tt_linear, torch_in.to(torch.float32)),
+    ):
+        lib.assert_close(golden, ttnn.to_torch(output).to(torch.float32), "pack relu")
+
+
+@pytest.mark.parametrize("dim", [0, 1, 2, 3], ids=["none", "col", "row", "scalar"])
+def test_unary_bcast(device, dim):
+    """UnaryBcast passes through or replicates one column, row, or scalar within each tile."""
+    n = 4
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    torch.manual_seed(1401)
+    host = torch.randn(shape, dtype=torch.bfloat16)
+    tt_in = ttnn.from_torch(
+        host,
+        dtype=dt,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(0, dt, 2, core_grid), lib.cb_descriptor(16, dt, 2, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(UNARY_BCAST, [n, dim], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_in, tt_out], program)
+
+    tiles = host.to(torch.float32).reshape(1, 1, 32, n, 32).permute(0, 1, 3, 2, 4)
+    if dim == 0:
+        golden_tiles = tiles
+    elif dim == 1:
+        golden_tiles = tiles[..., :1].expand_as(tiles)
+    elif dim == 2:
+        golden_tiles = tiles[..., :1, :].expand_as(tiles)
+    else:
+        golden_tiles = tiles[..., :1, :1].expand_as(tiles)
+    golden = golden_tiles.permute(0, 1, 3, 2, 4).reshape(shape)
+
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(golden, out, f"UnaryBcast dim={dim}")

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_elements.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_elements.py
@@ -127,6 +127,31 @@ def test_pack_relu(device):
         lib.assert_close(golden, ttnn.to_torch(output).to(torch.float32), "pack relu")
 
 
+def test_copy_dest_int32(device):
+    """CopyDest must use the DataFormat-aware LLK path when moving an integer tile between DEST slots."""
+    n = 2
+    dt = ttnn.int32
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    torch.manual_seed(1802)
+    torch_in = torch.randint(-(2**20), 2**20, shape, dtype=torch.int32)
+    tt_in = ttnn.from_torch(
+        torch_in, dtype=dt, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, n, core_grid),
+            lib.build_compute_kernel(MISC_ELEMENTS, [n, 2], core_grid),
+        ],
+        semaphores=[],
+        cbs=[lib.cb_descriptor(0, dt, 2, core_grid), lib.cb_descriptor(16, dt, 2, core_grid)],
+    )
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    assert torch.equal(ttnn.to_torch(output), torch_in)
+
+
 @pytest.mark.parametrize("dim", [0, 1, 2, 3], ids=["none", "col", "row", "scalar"])
 def test_unary_bcast(device, dim):
     """UnaryBcast passes through or replicates one column, row, or scalar within each tile."""

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_indexing.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_indexing.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Index and broadcast axes for eltwise helpers.
+
+    InputTileMapping   per-iter tile index
+    Scalar        0
+    Block         ht*Wt + wt
+    Row           wt          (one tile per column)
+    Col           ht          (one tile per row)
+    TileAddressing    base + index
+
+Golden changes if the wrong tile is read: a Row<->Col swap or dropped TileAddressing base fails the numerical comparison.
+The broadcast case separately validates which row, column, or scalar is replicated within a tile.
+"""
+
+import torch
+import pytest
+import ttnn
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+ADDRESSING_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/tile_addressing.cpp"
+INDEX_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/index_2d.cpp"
+STRIDED_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/strided_tile_range.cpp"
+BCAST_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/bcast_binary_add.cpp"
+MODE = {"row": 2, "col": 1}
+
+
+# =============================================================================
+# TileAddressing — Block walker reading tiles [base, base+n). output[i] == input[base+i].
+# =============================================================================
+@pytest.mark.parametrize("base", [0, 3])
+def test_tile_addressing_base(device, base):
+    n = 4
+    dt = ttnn.bfloat16
+    total = base + n  # input holds base+n tiles; chain reads the last n.
+    in_shape = [1, 1, 32, 32 * total]
+    out_shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(in_shape, dt, device, seed=401)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(out_shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    # Bulk reader stages all `total` tiles upfront -> size cb_in for total, cb_out for n.
+    cbs = [lib.cb_descriptor(0, dt, total, core_grid), lib.cb_descriptor(16, dt, n, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], total, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel_rt(ADDRESSING_KERNEL, [n], [base], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_in, tt_out], program)
+
+    in_f = torch_in.to(torch.float32)
+    golden = in_f[:, :, :, 32 * base : 32 * (base + n)]
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(golden, out, f"TileAddressing base={base}")
+
+
+# =============================================================================
+# Row / Col inter-tile index — 2D grid add where B's tile is selected by its index mode.
+# =============================================================================
+def _run_index_2d(device, axis, Ht=2, Wt=4):
+    dt = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+    a_shape = [1, 1, 32 * Ht, 32 * Wt]
+    # Row: B is one tile-row (Wt tiles); Col: B is one tile-column (Ht tiles).
+    b_shape = [1, 1, 32, 32 * Wt] if axis == "row" else [1, 1, 32 * Ht, 32]
+    b_count = Wt if axis == "row" else Ht
+
+    torch_a, tt_a = lib.make_input(a_shape, dt, device, seed=411)
+    torch_b, tt_b = lib.make_input(b_shape, dt, device, seed=412)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(a_shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [
+        lib.cb_descriptor(0, dt, Ht * Wt, core_grid),
+        lib.cb_descriptor(1, dt, b_count, core_grid),
+        lib.cb_descriptor(16, dt, Ht * Wt, core_grid),
+    ]
+    reader = lib.build_reader_asym_kernel([tt_a, tt_b], [Ht * Wt, b_count], core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, Ht * Wt, core_grid)
+    compute = lib.build_compute_kernel(INDEX_KERNEL, [Ht, Wt, MODE[axis]], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_b, tt_out], program)
+
+    a_f = torch_a.to(torch.float32)
+    b_f = torch_b.to(torch.float32)
+    if axis == "row":  # B (one tile-row) repeated down all Ht tile-rows
+        golden = a_f + b_f.repeat(1, 1, Ht, 1)
+    else:  # B (one tile-col) repeated across all Wt tile-cols
+        golden = a_f + b_f.repeat(1, 1, 1, Wt)
+    return golden, ttnn.to_torch(output).to(torch.float32)
+
+
+def test_index_2d_axes_are_correct_and_distinct(device):
+    """Run each axis once, check both goldens, then prove the outputs discriminate an axis swap."""
+    results = {axis: _run_index_2d(device, axis) for axis in ("row", "col")}
+    for axis, (golden, out) in results.items():
+        lib.assert_close(golden, out, f"index axis={axis}")
+
+    col_golden, _ = results["col"]
+    _, row_out = results["row"]
+    assert not torch.allclose(
+        col_golden, row_out, rtol=0.01, atol=0.01
+    ), "ROW-index output matched COL golden — a Row<->Col index swap would slip through."
+
+
+def test_strided_tile_range(device):
+    Ht, Wt = 2, 2
+    input_stride, output_stride = 4, 5
+    input_base, output_base = 1, 2
+    dt = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+
+    in_shape = [1, 1, 32 * Ht, 32 * input_stride]
+    out_shape = [1, 1, 32 * Ht, 32 * output_stride]
+    torch_in, tt_in = lib.make_input(in_shape, dt, device, seed=421)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(out_shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    cbs = [
+        lib.cb_descriptor(0, dt, Ht * input_stride, core_grid),
+        lib.cb_descriptor(16, dt, Ht * output_stride, core_grid),
+    ]
+    reader = lib.build_reader_kernel([tt_in], Ht * input_stride, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, Ht * output_stride, core_grid)
+    compute = lib.build_compute_kernel(
+        STRIDED_KERNEL, [Ht, Wt, input_stride, output_stride, input_base, output_base], core_grid
+    )
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    out = ttnn.to_torch(output).to(torch.float32)
+
+    golden_region = torch_in.to(torch.float32)[:, :, :, 32 * input_base : 32 * (input_base + Wt)]
+    output_region = out[:, :, :, 32 * output_base : 32 * (output_base + Wt)]
+    lib.assert_close(golden_region, output_region, "strided tile range")
+
+
+BCAST_DIM = {"row": 2, "col": 1, "scalar": 3}
+
+
+def _broadcast_operand(torch_b, axis):
+    if axis == "row":
+        return torch_b[:, :, 0:1, :].expand_as(torch_b)
+    if axis == "col":
+        return torch_b[:, :, :, 0:1].expand_as(torch_b)
+    return torch_b[:, :, 0:1, 0:1].expand_as(torch_b)
+
+
+def _run_bcast_add(device, axis):
+    shape = [1, 1, 32, 32]
+    dt = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+    torch_a, tt_a = lib.make_input(shape, dt, device, seed=201)
+    torch_b, tt_b = lib.make_input(shape, dt, device, seed=202)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [
+        lib.cb_descriptor(0, dt, 2, core_grid),
+        lib.cb_descriptor(1, dt, 2, core_grid),
+        lib.cb_descriptor(16, dt, 2, core_grid),
+    ]
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_a, tt_b], 1, core_grid),
+            lib.build_writer_1out_kernel(tt_out, 1, core_grid),
+            lib.build_compute_kernel(BCAST_KERNEL, [1, BCAST_DIM[axis]], core_grid),
+        ],
+        semaphores=[],
+        cbs=cbs,
+    )
+    output = ttnn.generic_op([tt_a, tt_b, tt_out], program)
+    golden = torch_a.to(torch.float32) + _broadcast_operand(torch_b, axis).to(torch.float32)
+    return golden, ttnn.to_torch(output).to(torch.float32)
+
+
+def test_bcast_axes_are_correct_and_distinct(device):
+    """Validate all intra-tile broadcast axes and ensure row/column are distinguishable."""
+    results = {axis: _run_bcast_add(device, axis) for axis in ("row", "col", "scalar")}
+    for axis, (golden, out) in results.items():
+        lib.assert_close(golden, out, f"bcast add axis={axis}")
+
+    col_golden, _ = results["col"]
+    _, row_out = results["row"]
+    assert not torch.allclose(
+        col_golden, row_out, rtol=0.01, atol=0.01
+    ), "ROW output matched COL golden; an axis swap would slip through."

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_lifecycle.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_lifecycle.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Lifecycle & CB-synchronization (the hang suite). Run under --dev.
+
+A lifecycle is the (WaitPolicy, PopPolicy) pair an input declares — whether the chain or the CALLER
+emits cb_wait_front / cb_pop_front. A miscount deadlocks the device.
+
+held_b.cpp computes out[i] = A[i] + B[0]: A streams, B is one held tile reused each iter on a
+selectable lifecycle, with the kernel supplying whatever edge the chain doesn't. Each case asserts
+BOTH no-hang (--dev timeout trips triage) AND correct values (a miscount reads a stale tile).
+"""
+
+import torch
+import pytest
+import ttnn
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+HELD_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/held_b.cpp"
+
+# Selector -> lifecycle name (must match held_b.cpp).
+LIFECYCLES = {
+    0: "Bulk",
+    1: "HeldBulk",
+    2: "HeldStream",
+    3: "CallerManaged",
+    4: "DeferredPop",
+}
+
+
+@pytest.mark.parametrize("life,name", list(LIFECYCLES.items()), ids=list(LIFECYCLES.values()))
+def test_held_b_lifecycle(device, life, name):
+    n = 8
+    dt = ttnn.bfloat16
+    a_shape = [1, 1, 32, 32 * n]
+    b_shape = [1, 1, 32, 32]  # single held tile
+    core_grid = lib.single_core_grid()
+
+    torch_a, tt_a = lib.make_input(a_shape, dt, device, seed=701)
+    torch_b, tt_b = lib.make_input(b_shape, dt, device, seed=702)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(a_shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [
+        lib.cb_descriptor(0, dt, 2, core_grid),
+        lib.cb_descriptor(1, dt, 2, core_grid),
+        lib.cb_descriptor(16, dt, 2, core_grid),
+    ]
+    reader = lib.build_reader_asym_kernel([tt_a, tt_b], [n, 1], core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(HELD_KERNEL, [n, life], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_b, tt_out], program)  # a hang here trips --dev triage
+
+    golden = torch_a.to(torch.float32) + torch_b.to(torch.float32).repeat(1, 1, 1, n)
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(golden, out, f"lifecycle={name}")
+
+
+OUTPUT_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/out_lifecycle.cpp"
+OUT_LIFECYCLES = {
+    0: "Streaming",
+    1: "Bulk",
+    2: "ReserveAllPushPerTile",
+    3: "CallerManaged",
+    4: "ReserveNonePushEnd",
+}
+
+
+@pytest.mark.parametrize("life,name", list(OUT_LIFECYCLES.items()), ids=list(OUT_LIFECYCLES.values()))
+def test_output_lifecycle(device, life, name):
+    """Validate reserve/push ownership independently from input wait/pop."""
+    n = 8
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=901)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(0, dt, 2, core_grid), lib.cb_descriptor(16, dt, n, core_grid)]
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, n, core_grid),
+            lib.build_compute_kernel(OUTPUT_KERNEL, [n, life], core_grid),
+        ],
+        semaphores=[],
+        cbs=cbs,
+    )
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(torch_in.to(torch.float32), out, f"output lifecycle={name}")
+
+
+INPLACE_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/inplace_chain.cpp"
+INPLACE_LIFECYCLES = {
+    0: "BulkDrain+Streaming",
+    1: "PerBlockSize+PerBlockSize",
+    2: "Streaming+Streaming",
+}
+
+
+@pytest.mark.parametrize("life,name", list(INPLACE_LIFECYCLES.items()), ids=list(INPLACE_LIFECYCLES.values()))
+def test_inplace_chain_lifecycle(device, life, name):
+    """Validate safe input/output lifecycle pairs when one CB is both source and destination."""
+    n = 8
+    block_size = 4
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=1301)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [
+        lib.cb_descriptor(0, dt, n, core_grid),
+        lib.cb_descriptor(1, dt, n, core_grid),
+        lib.cb_descriptor(16, dt, n, core_grid),
+    ]
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, n, core_grid),
+            lib.build_compute_kernel(INPLACE_KERNEL, [n, life, block_size], core_grid),
+        ],
+        semaphores=[],
+        cbs=cbs,
+    )
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(torch.exp(torch_in.to(torch.float32)), out, f"in-place lifecycle={name}")
+
+
+OUTER_DIR = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/outer_stream"
+
+
+def _build_outer_reader(tt_a, tt_b, height_tiles, width_tiles, grid):
+    cta = list(ttnn.TensorAccessorArgs(tt_a).get_compile_time_args())
+    cta += list(ttnn.TensorAccessorArgs(tt_b).get_compile_time_args())
+    rt = ttnn.RuntimeArgs()
+    rt[0][0] = [tt_a.buffer_address(), tt_b.buffer_address(), height_tiles, width_tiles]
+    return ttnn.KernelDescriptor(
+        kernel_source=f"{OUTER_DIR}/reader_a_full_b_per_row.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=grid,
+        compile_time_args=cta,
+        runtime_args=rt,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+
+@pytest.mark.parametrize("Ht,Wt,fp32_dest_acc_en", [(2, 1, False), (3, 5, True)])
+def test_outer_stream_broadcast(device, Ht, Wt, fp32_dest_acc_en):
+    """PerTile + Col holds one streamed B tile across each output row."""
+    dt = ttnn.bfloat16
+    a_shape = [1, 1, 32, 32 * Ht * Wt]
+    b_shape = [1, 1, 32, 32 * Ht]
+    torch_a, tt_a = lib.make_input(a_shape, dt, device, seed=101)
+    torch_b, tt_b = lib.make_input(b_shape, dt, device, seed=202)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(a_shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    grid = lib.single_core_grid()
+    cbs = [
+        lib.cb_descriptor(0, dt, 2, grid),
+        lib.cb_descriptor(1, dt, 2, grid),
+        lib.cb_descriptor(16, dt, 2, grid),
+    ]
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            _build_outer_reader(tt_a, tt_b, Ht, Wt, grid),
+            lib.build_writer_1out_kernel(tt_out, Ht * Wt, grid),
+            lib.build_compute_kernel(
+                f"{OUTER_DIR}/chain_outer_stream.cpp",
+                [Ht, Wt],
+                grid,
+                fp32_dest_acc_en=fp32_dest_acc_en,
+            ),
+        ],
+        semaphores=[],
+        cbs=cbs,
+    )
+    output = ttnn.generic_op([tt_a, tt_b, tt_out], program)
+    torch_out = ttnn.to_torch(output).to(torch.float32)
+    a_v = torch_a.to(torch.float32).view(1, 1, 32, Ht, Wt, 32)
+    b_v = torch_b.to(torch.float32).view(1, 1, 32, Ht, 1, 32)
+    golden = (a_v + b_v).reshape(1, 1, 32, 32 * Ht * Wt)
+    lib.assert_close(golden, torch_out, f"StreamedCol Ht={Ht} Wt={Wt} fp32_dest_acc_en={fp32_dest_acc_en}")

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_oob.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_oob.py
@@ -17,6 +17,7 @@ fp32_dest_acc_en) and asserts either a legal slot compiles + reproduces the inpu
 slot FAILS to compile with "DEST slot exceeds DEST_AUTO_LIMIT" (surfaced as a generic_op exception).
 """
 
+import pytest
 import torch
 import ttnn
 from loguru import logger
@@ -150,10 +151,9 @@ def test_dst_slot5_overflow_fp32(device, expect_error):
 BLOCK_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/block_clamp.cpp"
 
 
-def test_block_size_clamp_identity(device):
-    """chain_lane_width=1 here -> chain_max_block_v=8 (half-sync bf16). block_size=1000 must clamp
-    to 8 and still copy the input exactly. Ordinary block sizes are covered by the blocking suite."""
-    block_size = 1000
+@pytest.mark.parametrize("block_size", [0, 1000], ids=["zero-normalizes-to-one", "oversized-clamps"])
+def test_block_size_clamp_identity(device, block_size):
+    """A zero block size normalizes to one; an oversized value clamps to the DEST limit. Both preserve identity."""
     n = 16
     dt = ttnn.bfloat16
     shape = [1, 1, 32, 32 * n]
@@ -210,6 +210,9 @@ SHARED_CB_LIFECYCLE_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/s
 SHARED_CB_LIFECYCLE_MSG = "staged CB window shares its front"
 PRNG_SEED_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/prng_seed.cpp"
 PRNG_SEED_MSG = "one shared hardware PRNG"
+RUNTIME_PRNG_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/runtime_prng.cpp"
+RUNTIME_PRNG_MSG = "non-PRNG DEST-only"
+CONVENIENCE_ARITY_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/convenience_arity.cpp"
 
 
 def _expect_chain_compile_rejection(device, kernel, compile_time_args, message, with_input):
@@ -254,6 +257,23 @@ def test_shared_cb_staged_window_rejected_peer_first(device, expect_error):
 def test_multiple_prng_seeders_rejected(device, expect_error):
     inputs, program, message = _expect_chain_compile_rejection(
         device, PRNG_SEED_KERNEL, [2], PRNG_SEED_MSG, with_input=True
+    )
+    with expect_error(Exception, message):
+        ttnn.generic_op(inputs, program)
+
+
+def test_runtime_conditional_prng_seeder_rejected(device, expect_error):
+    inputs, program, message = _expect_chain_compile_rejection(
+        device, RUNTIME_PRNG_KERNEL, [2], RUNTIME_PRNG_MSG, with_input=True
+    )
+    with expect_error(Exception, message):
+        ttnn.generic_op(inputs, program)
+
+
+@pytest.mark.parametrize("mode", [0, 1], ids=["binary-used-as-unary", "unary-used-as-binary"])
+def test_convenience_wrapper_arity_rejected(device, expect_error, mode):
+    inputs, program, message = _expect_chain_compile_rejection(
+        device, CONVENIENCE_ARITY_KERNEL, [2, mode], "DEST operation", with_input=True
     )
     with expect_error(Exception, message):
         ttnn.generic_op(inputs, program)

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_oob.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_oob.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Out-of-bounds / boundary tests for eltwise_chain.
+
+DST-capacity cases: the helper static_asserts every element's DEST slot against DEST_AUTO_LIMIT,
+which depends on the compute config:
+
+    sync mode      bf16 (fp32_acc off)    fp32 (fp32_acc on)
+    half-sync             8                       4
+    full-sync           16                       8
+
+So a slot legal in one config is over-limit in another. Each test pins (slot, dst_full_sync_en,
+fp32_dest_acc_en) and asserts either a legal slot compiles + reproduces the input, or an over-limit
+slot FAILS to compile with "DEST slot exceeds DEST_AUTO_LIMIT" (surfaced as a generic_op exception).
+"""
+
+import torch
+import ttnn
+from loguru import logger
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/dst_slot.cpp"
+DST_OVERFLOW_MSG = "DEST slot exceeds"
+
+
+def _run_identity_copy(device, slot, num_tiles, fp32_dest_acc_en, dst_full_sync_en, host_input=None):
+    """Build + run the dst_slot identity-copy chain. Returns (golden, output) torch tensors."""
+    shape = [1, 1, 32, 32 * num_tiles]
+    dt = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+
+    if host_input is None:
+        torch_in, tt_in = lib.make_input(shape, dt, device, seed=101)
+    else:
+        assert tuple(host_input.shape) == tuple(shape)
+        torch_in = host_input.to(torch.bfloat16)
+        tt_in = ttnn.from_torch(
+            torch_in, dtype=dt, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [
+        lib.cb_descriptor(0, dt, 2, core_grid),
+        lib.cb_descriptor(16, dt, 2, core_grid),
+    ]
+    reader = lib.build_reader_kernel([tt_in], num_tiles, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, num_tiles, core_grid)
+    compute = lib.build_compute_kernel(
+        KERNEL,
+        compile_time_args=[num_tiles, slot],
+        core_grid=core_grid,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        dst_full_sync_en=dst_full_sync_en,
+    )
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    return torch_in.to(torch.float32), ttnn.to_torch(output).to(torch.float32)
+
+
+# =============================================================================
+# Positive twin — a legal slot compiles, runs, and copies the input exactly.
+# =============================================================================
+def test_dst_slot3_legal_fp32(device):
+    """D3 is the highest legal half-sync FP32 slot, providing the positive twin for FP32 overflow."""
+    golden, out = _run_identity_copy(device, slot=3, num_tiles=4, fp32_dest_acc_en=True, dst_full_sync_en=False)
+    assert torch.equal(golden, out)
+
+
+def test_dst_slot7_legal_bf16(device):
+    """D7 is the highest legal half-sync BF16 slot (the positive twin for D8 rejection)."""
+    golden, out = _run_identity_copy(device, slot=7, num_tiles=4, fp32_dest_acc_en=False, dst_full_sync_en=False)
+    assert torch.equal(golden, out)
+
+
+def test_zero_tiles_is_a_noop(device):
+    """A zero-tile chain must not touch the caller's input, output, or DFB lifecycle windows."""
+    dt = ttnn.bfloat16
+    physical_shape = [1, 1, 32, 32]
+    core_grid = lib.single_core_grid()
+    torch_in = torch.full(physical_shape, 1.0, dtype=torch.bfloat16)
+    sentinel = torch.full(physical_shape, -0.5, dtype=torch.bfloat16)
+    tt_in = ttnn.from_torch(torch_in, dtype=dt, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = ttnn.from_torch(sentinel, dtype=dt, layout=ttnn.TILE_LAYOUT, device=device)
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], 0, core_grid),
+            lib.build_writer_1out_kernel(tt_out, 0, core_grid),
+            lib.build_compute_kernel(KERNEL, [0, 0], core_grid),
+        ],
+        semaphores=[],
+        cbs=[lib.cb_descriptor(0, dt, 1, core_grid), lib.cb_descriptor(16, dt, 1, core_grid)],
+    )
+    out = ttnn.to_torch(ttnn.generic_op([tt_in, tt_out], program)).to(torch.bfloat16)
+    assert torch.equal(out, sentinel)
+
+
+def test_identity_chain_bf16_special_value_contract(device):
+    """BF16 copy/pack canonicalizes NaN to +inf and -0 to +0, while preserving signed infinities."""
+    values = torch.tensor([-0.0, 0.0, float("inf"), float("-inf"), float("nan"), -1.5, 2.0], dtype=torch.bfloat16)
+    host_input = values.repeat((32 * 32 + len(values) - 1) // len(values))[: 32 * 32].reshape(1, 1, 32, 32)
+    _, out = _run_identity_copy(
+        device, slot=0, num_tiles=1, fp32_dest_acc_en=False, dst_full_sync_en=False, host_input=host_input
+    )
+    expected = torch.where(
+        torch.isnan(host_input),
+        torch.full_like(host_input, float("inf")),
+        torch.where(host_input == 0, torch.zeros_like(host_input), host_input),
+    ).to(torch.float32)
+    assert torch.equal(out, expected)
+
+
+# =============================================================================
+# Slot 8 over the half-sync bf16 limit (8). Must fail to compile.
+# =============================================================================
+def test_dst_overflow_halfsync_bf16(device, expect_error):
+    """D8 is not < 8 (half-sync bf16 limit) -> the per-element static_assert must fire."""
+    with expect_error(Exception, DST_OVERFLOW_MSG):
+        _run_identity_copy(device, slot=8, num_tiles=4, fp32_dest_acc_en=False, dst_full_sync_en=False)
+    logger.debug("D8 over half-sync bf16 limit correctly rejected at compile time")
+
+
+# =============================================================================
+# Cross-mode boundary. Slot 5: legal half-sync bf16 (limit 8),
+#          over-limit once fp32_dest_acc shrinks the limit to 4.
+# =============================================================================
+def test_dst_slot5_legal_bf16(device):
+    """Same slot, bf16 half-sync (limit 8): 5 < 8 -> compiles + runs correctly."""
+    golden, out = _run_identity_copy(device, slot=5, num_tiles=4, fp32_dest_acc_en=False, dst_full_sync_en=False)
+    assert torch.equal(golden, out)
+
+
+def test_dst_slot5_overflow_fp32(device, expect_error):
+    """Same slot under fp32_dest_acc (limit 4): 5 is not < 4 -> must fail to compile."""
+    with expect_error(Exception, DST_OVERFLOW_MSG):
+        _run_identity_copy(device, slot=5, num_tiles=4, fp32_dest_acc_en=True, dst_full_sync_en=False)
+    logger.debug("fp32: slot=5 over fp32 half-sync limit (4) correctly rejected")
+
+
+# =============================================================================
+# Runtime block_size clamp. block_size is a runtime IterationShape field, so it
+# can't be static_asserted; the chain clamps it down to chain_max_block_v at runtime
+# so it can NEVER overflow DEST. An over-large block_size
+# must therefore still produce the exact identity copy (clamp only changes loop structure).
+#
+# The chain here is a Bulk + Block reader (block-capable), so block_size is honored. Bulk
+# stages the whole window upfront -> the input CB must hold all n pages.
+# =============================================================================
+BLOCK_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/block_clamp.cpp"
+
+
+def test_block_size_clamp_identity(device):
+    """chain_lane_width=1 here -> chain_max_block_v=8 (half-sync bf16). block_size=1000 must clamp
+    to 8 and still copy the input exactly. Ordinary block sizes are covered by the blocking suite."""
+    block_size = 1000
+    n = 16
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=303)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    # Bulk reader/writer stage the full window upfront -> size both CBs for all n tiles.
+    cbs = [lib.cb_descriptor(0, dt, n, core_grid), lib.cb_descriptor(16, dt, n, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(BLOCK_KERNEL, [n, block_size], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    golden = torch_in.to(torch.float32)
+    out = ttnn.to_torch(output).to(torch.float32)
+    assert torch.equal(golden, out)
+
+
+# =============================================================================
+# Exhaustive classification. An element without a kind tag (CB reader / CB writer /
+# DEST-only) must be rejected at compile time instead of silently no-opping
+# through every chain stage.
+# =============================================================================
+UNCLASSIFIED_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/unclassified_element.cpp"
+UNCLASSIFIED_MSG = "every element must carry exactly one kind tag"
+
+
+def test_unclassified_element_rejected(device, expect_error):
+    """A tag-less element in the chain must fail to compile, not silently no-op."""
+    num_tiles = 2
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * num_tiles]
+    core_grid = lib.single_core_grid()
+
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=131)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(0, dt, 2, core_grid), lib.cb_descriptor(16, dt, 2, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], num_tiles, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, num_tiles, core_grid)
+    compute = lib.build_compute_kernel(UNCLASSIFIED_KERNEL, [num_tiles], core_grid)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+
+    with expect_error(Exception, UNCLASSIFIED_MSG):
+        ttnn.generic_op([tt_in, tt_out], program)
+    logger.debug("tag-less chain element correctly rejected at compile time")
+
+
+# =============================================================================
+# Shared CB lifecycle and shared-PRNG ownership are compile-time-only contracts.
+# =============================================================================
+SHARED_CB_LIFECYCLE_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/shared_cb_lifecycle.cpp"
+SHARED_CB_LIFECYCLE_MSG = "staged CB window shares its front"
+PRNG_SEED_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/prng_seed.cpp"
+PRNG_SEED_MSG = "one shared hardware PRNG"
+
+
+def _expect_chain_compile_rejection(device, kernel, compile_time_args, message, with_input):
+    num_tiles = compile_time_args[0]
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * num_tiles]
+    core_grid = lib.single_core_grid()
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(16, dt, 2, core_grid)]
+    inputs = [tt_out]
+    if with_input:
+        _, tt_in = lib.make_input(shape, dt, device, seed=191)
+        cbs.insert(0, lib.cb_descriptor(0, dt, 2, core_grid))
+        inputs.insert(0, tt_in)
+        reader = lib.build_reader_kernel([tt_in], num_tiles, core_grid)
+    else:
+        reader = None
+    writer = lib.build_writer_1out_kernel(tt_out, num_tiles, core_grid)
+    compute = lib.build_compute_kernel(kernel, compile_time_args, core_grid)
+    kernels = [writer, compute] if reader is None else [reader, writer, compute]
+    program = ttnn.ProgramDescriptor(kernels=kernels, semaphores=[], cbs=cbs)
+
+    return inputs, program, message
+
+
+def test_shared_cb_staged_window_rejected_owner_first(device, expect_error):
+    inputs, program, message = _expect_chain_compile_rejection(
+        device, SHARED_CB_LIFECYCLE_KERNEL, [2, 1], SHARED_CB_LIFECYCLE_MSG, with_input=True
+    )
+    with expect_error(Exception, message):
+        ttnn.generic_op(inputs, program)
+
+
+def test_shared_cb_staged_window_rejected_peer_first(device, expect_error):
+    inputs, program, message = _expect_chain_compile_rejection(
+        device, SHARED_CB_LIFECYCLE_KERNEL, [2, 0], SHARED_CB_LIFECYCLE_MSG, with_input=True
+    )
+    with expect_error(Exception, message):
+        ttnn.generic_op(inputs, program)
+
+
+def test_multiple_prng_seeders_rejected(device, expect_error):
+    inputs, program, message = _expect_chain_compile_rejection(
+        device, PRNG_SEED_KERNEL, [2], PRNG_SEED_MSG, with_input=True
+    )
+    with expect_error(Exception, message):
+        ttnn.generic_op(inputs, program)

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_optional.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_optional.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Compile-time optional and runtime-conditional chain elements.
+
+  - compile-time unary gate: ON -> out = -A, OFF -> out = A (inert marker).
+  - compile-time pack gate: gate a second PackTile (fan-out). ON -> both cb_out0 and cb_out1 written;
+    OFF -> only cb_out0, and the tag-less marker must remain neutral in pack planning and emission.
+  - runtime conditional: exercise bare runtime_if(...), runtime_if(...).else_if(...), and explicit
+    .otherwise(...) branches.
+"""
+
+import torch
+import pytest
+import ttnn
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/optional.cpp"
+
+
+def _run_optional_unary(device, enabled):
+    n = 4
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=1401)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(0, dt, 2, core_grid), lib.cb_descriptor(16, dt, 2, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [n, 0, int(enabled)], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_in, tt_out], program)
+    return torch_in.to(torch.float32), ttnn.to_torch(output).to(torch.float32)
+
+
+def test_optional_unary_gate(device):
+    """One paired check proves both the enabled operation and the disabled marker's neutrality."""
+    outputs = {}
+    for enabled in (False, True):
+        a, out = _run_optional_unary(device, enabled)
+        golden = -a if enabled else a
+        lib.assert_close(golden, out, f"Optional unary gate enabled={enabled}")
+        outputs[enabled] = out
+    assert torch.equal(outputs[True], -outputs[False])
+
+
+def _run_optional_pack(device, enabled):
+    n = 4
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=1402)
+    tt_o0 = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    outputs = [tt_o0]
+    cbs = [lib.cb_descriptor(0, dt, 2, core_grid), lib.cb_descriptor(16, dt, 2, core_grid)]
+    if enabled:
+        outputs.append(
+            ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+        )
+        cbs.append(lib.cb_descriptor(17, dt, 2, core_grid))
+    reader = lib.build_reader_kernel([tt_in], n, core_grid)
+    writer = (
+        lib.build_writer_2out_kernel(outputs, n, core_grid)
+        if enabled
+        else lib.build_writer_1out_kernel(tt_o0, n, core_grid)
+    )
+    compute = lib.build_compute_kernel(KERNEL, [n, 1, int(enabled)], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    ttnn.generic_op([tt_in, *outputs], program)
+    return torch_in.to(torch.float32), [ttnn.to_torch(t).to(torch.float32) for t in outputs]
+
+
+def test_optional_pack_gate(device):
+    """The same paired test covers disabled-marker neutrality and enabled fan-out."""
+    primary = {}
+    for enabled in (False, True):
+        golden, outputs = _run_optional_pack(device, enabled)
+        for index, out in enumerate(outputs):
+            assert torch.equal(golden, out), f"optional pack enabled={enabled} output={index} changed data"
+        primary[enabled] = outputs[0]
+    assert torch.equal(primary[False], primary[True])
+
+
+@pytest.mark.parametrize("mode", [0, 1, 2, 3, 4, 5, 6])
+def test_runtime_conditional(device, mode):
+    """The first matching runtime_if arm runs; an unmatched conditional is inert."""
+    n = 4
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=1404)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(0, dt, 2, core_grid), lib.cb_descriptor(16, dt, 2, core_grid)]
+    reader = lib.build_reader_kernel([tt_in], n, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, n, core_grid)
+    compute = lib.build_compute_kernel_rt(KERNEL, [n, 2, 0], [mode], core_grid)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_in, tt_out], program)
+
+    a = torch_in.to(torch.float32)
+    golden = {
+        0: -a,
+        1: -(a * a),
+        2: torch.abs(a),
+        3: torch.abs(-a),
+        4: a * a,
+        5: a * a,
+        6: -a,
+    }[mode]
+    out = ttnn.to_torch(output).to(torch.float32)
+    lib.assert_close(golden, out, f"runtime conditional mode={mode}")

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_perf.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_perf.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Device-profiler performance tests for the eltwise_chain helper, swept across tile count.
+
+Follows the SDXL op-unit perf pattern (models/demos/stable_diffusion_xl_base/tests/
+test_sdxl_op_unit_test_perf.py): a functional test runs the config; a perf test marked
+@models_device_performance_bare_metal re-runs it under the device profiler via
+run_device_perf_detailed and reads the real DEVICE KERNEL duration (ns) for "GenericOpDeviceOperation".
+
+WHY SWEEP N: a single small tile count is dominated by fixed per-launch overhead and is not
+representative. Blocking and hoisting retain the small/large endpoints; the lifecycle comparison
+also keeps the two-batch transition at n=128 because Bulk is explicitly batched in that workload.
+Blocking uses a CHUNKED block-capable chain so the CB stays small and n can scale to thousands of
+tiles. Hoisting is streaming, so n scales freely.
+
+Comparisons are A/B at each n and each measurement is checked against a recorded baseline.
+The op runs ITERS times per profile.
+"""
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+OP = "GenericOpDeviceOperation"
+ITERS = 20
+PERF = "tests/ttnn/unit_tests/kernel_lib/test_chain_perf.py"
+
+BLOCK_CHUNKED = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_chunked.cpp"
+HOIST = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/hoist.cpp"
+FUSED = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/fused_chain.cpp"  # FPU add + Exp + DestReuse mul
+
+# PerBlockSize-vs-Bulk comparison on a REALISTIC fused chain (out = exp(A+B)*C: FPU add + Exp + DestReuse
+# mul). Neither lifecycle stages the whole window — both keep a BOUNDED CB and process N over many
+# iterations, so N scales to thousands (1024 tiles). Three configs isolate the two effects:
+#   bulk1  -> Bulk, batched (window=BULK_BATCH), block_size=1   : no blocking, batched-upfront baseline
+#   bulk8  -> Bulk, batched (window=BULK_BATCH), block_size=max : blocking WITHIN Bulk (bulk1 -> bulk8)
+#   chunk8 -> PerBlockSize, single call, block_size=max        : lifecycle gain (bulk8 -> chunk8)
+LIFECYCLE_NS = [64, 128, 1024]
+MAX_CHUNK = 8
+BULK_BATCH = 64  # Bulk window per chain call (bounded; CB = 2*BULK_BATCH pages, independent of N)
+
+# Tile-count sweep: small (overhead-dominated) -> large (work-dominated).
+HOIST_N = [64, 4096]
+BLOCK_N = [64, 2048]
+BLOCK_SIZES = [1, 8]
+
+
+# =============================================================================
+# Functional configs (profiled below). Each runs the op ITERS times + a correctness sanity.
+# =============================================================================
+def _run_block_chunked(device, n, block_size):
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    cg = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=2001)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    pages = max(4, 2 * block_size)  # PerBlockSize: CB holds ~block_size tiles, double-buffered
+    cbs = [lib.cb_descriptor(0, dt, pages, cg), lib.cb_descriptor(16, dt, pages, cg)]
+    reader = lib.build_reader_kernel([tt_in], n, cg)
+    writer = lib.build_writer_1out_kernel(tt_out, n, cg)
+    compute = lib.build_compute_kernel(BLOCK_CHUNKED, [n, block_size], cg)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    out = None
+    for _ in range(ITERS):
+        out = ttnn.generic_op([tt_in, tt_out], program)
+    ttnn.synchronize_device(device)
+    res = ttnn.to_torch(out).to(torch.float32)
+    assert torch.allclose(torch.exp(torch_in.to(torch.float32)), res, atol=0.1, rtol=0.1)
+
+
+def _run_hoist(device, n, mode, iters=ITERS):
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    cg = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dt, device, seed=2002)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    cbs = [lib.cb_descriptor(0, dt, 2, cg), lib.cb_descriptor(16, dt, 2, cg)]
+    reader = lib.build_reader_kernel([tt_in], n, cg)
+    writer = lib.build_writer_1out_kernel(tt_out, n, cg)
+    mode_id = {"single": 0, "pertile": 1, "caller": 2}[mode]
+    compute = lib.build_compute_kernel(HOIST, [n, mode_id], cg)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    out = None
+    for _ in range(iters):
+        out = ttnn.generic_op([tt_in, tt_out], program)
+    ttnn.synchronize_device(device)
+    result = ttnn.to_torch(out).to(torch.float32)
+    assert torch.allclose(torch.exp(torch_in.to(torch.float32)), result, atol=0.1, rtol=0.1)
+    return result
+
+
+@pytest.mark.parametrize("n", BLOCK_N)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+def test_func_block(device, n, block_size):
+    _run_block_chunked(device, n, block_size)
+
+
+@pytest.mark.parametrize("n", HOIST_N)
+@pytest.mark.parametrize("mode", ["single", "pertile"])
+def test_func_hoist(device, n, mode):
+    _run_hoist(device, n, mode)
+
+
+def test_setup_placements_are_bit_identical(device):
+    """Hoisted, per-tile, and caller-owned setup must produce the same bits."""
+    single = _run_hoist(device, 16, "single", iters=1)
+    per_tile = _run_hoist(device, 16, "pertile", iters=1)
+    caller = _run_hoist(device, 16, "caller", iters=1)
+    assert torch.equal(single, per_tile), "hoisted and per-tile initialization produced different results"
+    assert torch.equal(single, caller), "hoisted and caller-owned initialization produced different results"
+
+
+def _run_lifecycle(device, mode, n):
+    """Fused chain out = exp(A+B)*C; `mode` selects lifecycle, block size, and CB sizing."""
+    dt = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    cg = lib.single_core_grid()
+    ta, tt_a = lib.make_input(shape, dt, device, seed=2003)
+    tb, tt_b = lib.make_input(shape, dt, device, seed=2004)
+    tc, tt_c = lib.make_input(shape, dt, device, seed=2005)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dt, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    if mode == "bulk1":  # Bulk, batched window, block_size 1 (no blocking)
+        cta, pages = [n, 1, 0, BULK_BATCH], 2 * BULK_BATCH
+    elif mode == "bulk8":  # Bulk, batched window, block_size max (blocking within Bulk)
+        cta, pages = [n, MAX_CHUNK, 0, BULK_BATCH], 2 * BULK_BATCH
+    else:  # chunk8: PerBlockSize, single call, block_size max
+        cta, pages = [n, MAX_CHUNK, 1, 0], 2 * MAX_CHUNK
+    cbs = [lib.cb_descriptor(i, dt, pages, cg) for i in (0, 1, 2)] + [lib.cb_descriptor(16, dt, pages, cg)]
+    reader = lib.build_reader_kernel([tt_a, tt_b, tt_c], n, cg)
+    writer = lib.build_writer_1out_kernel(tt_out, n, cg)
+    compute = lib.build_compute_kernel(FUSED, cta, cg)
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    out = None
+    for _ in range(ITERS):
+        out = ttnn.generic_op([tt_a, tt_b, tt_c, tt_out], program)
+    ttnn.synchronize_device(device)
+    res = ttnn.to_torch(out).to(torch.float32)
+    golden = torch.exp((ta + tb).to(torch.float32)) * tc.to(torch.float32)
+    assert torch.allclose(golden, res, atol=0.15, rtol=0.15), "fused exp(A+B)*C mismatch"
+
+
+@pytest.mark.parametrize("n", LIFECYCLE_NS)
+@pytest.mark.parametrize("mode", ["bulk1", "bulk8", "chunk8"])
+def test_func_lifecycle(device, mode, n):
+    _run_lifecycle(device, mode, n)
+
+
+# =============================================================================
+# Perf tests — profile each config across the n sweep and compare real DEVICE KERNEL ns.
+# =============================================================================
+def _device_kernel_ns(node, subdir):
+    from models.perf.device_perf_utils import run_device_perf_detailed
+
+    command = f'pytest "{PERF}::{node}" -v'
+    results = run_device_perf_detailed(command=command, subdir=subdir, cols=["DEVICE KERNEL"], op_name=OP)
+    return results["DEVICE KERNEL"]["AVG"]
+
+
+# Recorded device-kernel baselines (ns), measured 2026-06-09 on a single Wormhole core, build_Release
+# with device profiler. Assert each measurement within MARGIN of its baseline (SDXL-style regression
+# guard) — NOT a directional "blocking helps" claim (it doesn't for this workload; see the table the
+# test logs). Profiler is stable to ~0.02%; MARGIN is generous for build/condition drift.
+MARGIN = 0.08
+HOIST_BASELINE_NS = {
+    (64, "single"): 47449,
+    (64, "pertile"): 49030,
+    (4096, "single"): 2938401,
+    (4096, "pertile"): 3040781,
+}
+BLOCK_BASELINE_NS = {
+    (64, 1): 47458,
+    (64, 8): 52653,
+    (2048, 1): 1469962,
+    (2048, 8): 1482795,
+}
+
+
+def _check_baseline(measured, baseline, label):
+    lo, hi = baseline * (1 - MARGIN), baseline * (1 + MARGIN)
+    assert lo <= measured <= hi, (
+        f"{label}: {measured:.0f} ns outside {baseline} ± {MARGIN*100:.0f}% ({lo:.0f}-{hi:.0f}). "
+        f"A real device-perf change — update the baseline if intentional."
+    )
+
+
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize("n", HOIST_N)
+def test_perf_hoisting_device(n):
+    """Init-once vs init-per-tile device-kernel ns at tile count n. Logs the ratio (the helper-design
+    signal: hoisting is ~3.5% faster across the whole n range) and regression-guards each config."""
+    ns_single = _device_kernel_ns(f"test_func_hoist[mode=single-n={n}]", f"eltwise_hoist_single_n{n}")
+    ns_pertile = _device_kernel_ns(f"test_func_hoist[mode=pertile-n={n}]", f"eltwise_hoist_pertile_n{n}")
+    logger.info(
+        f"[n={n}] DEVICE KERNEL ns | hoist-single {ns_single:.0f} | per-tile {ns_pertile:.0f} | "
+        f"hoist x{ns_pertile/ns_single:.3f}"
+    )
+    _check_baseline(ns_single, HOIST_BASELINE_NS[(n, "single")], f"hoist-single n={n}")
+    _check_baseline(ns_pertile, HOIST_BASELINE_NS[(n, "pertile")], f"hoist-pertile n={n}")
+    assert (
+        ns_single < ns_pertile * 0.99
+    ), f"hoisting lost its expected device-side benefit: {ns_single:.0f} ns vs {ns_pertile:.0f} ns"
+
+
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize("n", BLOCK_N)
+def test_perf_blocking_device(n):
+    """block_size 1 vs 8 device-kernel ns at tile count n (PerBlockSize block-capable chain). Logs the
+    ratio — blocking is neutral-to-slightly-negative for this Exp chain and the penalty amortizes as n
+    grows (x0.90 @ n=64 -> x0.99 @ n=2048), which is why the n sweep matters. Regression-guards each config."""
+    ns_b1 = _device_kernel_ns(f"test_func_block[block_size=1-n={n}]", f"eltwise_block1_n{n}")
+    ns_b8 = _device_kernel_ns(f"test_func_block[block_size=8-n={n}]", f"eltwise_block8_n{n}")
+    logger.info(
+        f"[n={n}] DEVICE KERNEL ns | block=1 {ns_b1:.0f} | block=8 {ns_b8:.0f} | block8/block1 x{ns_b8/ns_b1:.3f}"
+    )
+    _check_baseline(ns_b1, BLOCK_BASELINE_NS[(n, 1)], f"block=1 n={n}")
+    _check_baseline(ns_b8, BLOCK_BASELINE_NS[(n, 8)], f"block=8 n={n}")
+
+
+# PerBlockSize-vs-Bulk baselines (ns), measured 2026-06-09. Findings:
+#   - blocking within Bulk does NOTHING: bulk1 ≈ bulk8 (x0.99-1.00) — upfront serialization is the
+#     bottleneck, not loop overhead.
+#   - the REAL gain is PerBlockSize vs Bulk at the same block size because PerBlockSize overlaps per-block-size
+#     reads with compute while Bulk waits for each bounded window first.
+# Bounded-CB fused chain out=exp(A+B)*C, batched Bulk (window=64) vs single-call PerBlockSize, 2026-06-09.
+# KEY FINDING: when Bulk is used REALISTICALLY (batched with a bounded window, not whole-window
+# staging), the PerBlockSize advantage shrinks sharply with N: x1.77 @ n=64 (1 batch = whole window) ->
+# x1.41 @ n=128 -> only x1.05 @ n=1024 (16 batches). Double-buffered batches recover cross-batch
+# pipelining, so at scale batched-Bulk ≈ PerBlockSize (~5% behind). Blocking within Bulk stays ~1-2%.
+LIFECYCLE_BASELINE_NS = {
+    (64, "bulk1"): 115359,
+    (64, "bulk8"): 114173,
+    (64, "chunk8"): 64773,
+    (128, "bulk1"): 173789,
+    (128, "bulk8"): 170937,
+    (128, "chunk8"): 121282,
+    (1024, "bulk1"): 986744,
+    (1024, "bulk8"): 962285,
+    (1024, "chunk8"): 912314,
+}
+
+
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize("n", LIFECYCLE_NS)
+def test_perf_lifecycle_compare(n):
+    """Same exp(A+B)*C chain under Bulk(blk=1), Bulk(blk=max), and PerBlockSize(blk=max).
+
+    bulk1->bulk8 isolates blocking within Bulk; bulk8->chunk8 isolates lifecycle at the same block size.
+    """
+    modes = ("bulk1", "bulk8", "chunk8")
+    ns = {}
+    for mode in modes:
+        ns[mode] = _device_kernel_ns(f"test_func_lifecycle[mode={mode}-n={n}]", f"eltwise_life_{mode}_n{n}")
+    fastest = min(ns.values())
+    for mode in modes:
+        logger.info(f"[chunk-vs-bulk n={n}] {mode:7s} {ns[mode]:.0f} ns | x{ns[mode]/fastest:.3f} vs fastest")
+    logger.info(
+        f"[chunk-vs-bulk n={n}] blocking gain (bulk1/bulk8) x{ns['bulk1']/ns['bulk8']:.3f} | "
+        f"PerBlockSize-vs-Bulk gain (bulk8/chunk8) x{ns['bulk8']/ns['chunk8']:.3f}"
+    )
+    for mode in modes:
+        if (n, mode) in LIFECYCLE_BASELINE_NS:
+            _check_baseline(ns[mode], LIFECYCLE_BASELINE_NS[(n, mode)], f"{mode} n={n}")

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_reconfig.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_reconfig.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Validation for the eltwise_chain data-format reconfig emission.
+
+The format-transition kernels exercise 4-arg _with_dt, 2-arg combined, mixed-prev, single-side,
+and pack-side behavior. Per-CB dtypes are chosen so should_reconfigure_cbs sees mismatched formats
+and the reprogram actually fires. A separate repeated-same-CB case validates streaming accounting
+without claiming to observe compile-time elision.
+"""
+
+import torch
+import pytest
+import ttnn
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+
+KERNEL_DIR = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig"
+KERNEL = f"{KERNEL_DIR}/scenarios.cpp"
+
+
+def _assert_each_tile(golden, actual, label, rtol=0.1, atol=0.05):
+    """A multi-tile run covers first-use and steady state with an absolute/relative accuracy bound."""
+    assert golden.shape == actual.shape
+    num_tiles = golden.shape[-1] // 32
+    for tile in range(num_tiles):
+        tile_slice = slice(32 * tile, 32 * (tile + 1))
+        lib.assert_close(golden[..., tile_slice], actual[..., tile_slice], f"{label}, tile={tile}", rtol, atol)
+
+
+# =============================================================================
+# 4-arg reconfig_data_format(prev_a, curr_a, prev_b, curr_b) (_with_dt)
+# =============================================================================
+# Chain: BinaryFpu(CbA,CbB) -> BinaryFpu(CbC,CbD) -> PackTile(CbOut).
+# At element 1: srca rotates CbA->CbC with prev set AND srcb rotates CbB->CbD with prev set.
+# CbA=bfp8, CbB=bf16, CbC=bf16, CbD=fp32 produces dual format delta on both sides simultaneously.
+# Net semantic = CbC + CbD (first add overwritten in D0).
+def test_4arg_with_dt(device):
+    num_tiles = 8
+    fp32_dest_acc_en = False
+    shape = [1, 1, 32, 32 * num_tiles]
+    dt_a, dt_b, dt_c, dt_d, dt_out = ttnn.bfloat8_b, ttnn.bfloat16, ttnn.bfloat16, ttnn.float32, ttnn.bfloat16
+
+    _, tt_a = lib.make_input(shape, dt_a, device, seed=11)
+    _, tt_b = lib.make_input(shape, dt_b, device, seed=22)
+    torch_c, tt_c = lib.make_input(shape, dt_c, device, seed=33)
+    torch_d, tt_d = lib.make_input(shape, dt_d, device, seed=44)
+
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape), dt_out, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    core_grid = lib.single_core_grid()
+    cbs = [
+        lib.cb_descriptor(0, dt_a, 2, core_grid),
+        lib.cb_descriptor(1, dt_b, 2, core_grid),
+        lib.cb_descriptor(2, dt_c, 2, core_grid),
+        lib.cb_descriptor(3, dt_d, 2, core_grid),
+        lib.cb_descriptor(16, dt_out, 2, core_grid),
+    ]
+
+    reader = lib.build_reader_kernel([tt_a, tt_b, tt_c, tt_d], num_tiles, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, num_tiles, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [num_tiles, 0], core_grid, fp32_dest_acc_en=fp32_dest_acc_en)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_b, tt_c, tt_d, tt_out], program)
+    torch_out = ttnn.to_torch(output).to(torch.float32)
+
+    golden = torch_c.to(torch.float32) + torch_d.to(torch.float32)
+    _assert_each_tile(
+        golden,
+        torch_out,
+        f"4arg with-dt fp32_dest={fp32_dest_acc_en}",
+    )
+
+
+# =============================================================================
+# 2-arg combined reconfig_data_format(curr_a, curr_b) (no _with_dt)
+# =============================================================================
+# Chain: BinaryFpu(CbA,CbB) -> PackTile(CbOut), first chain element.
+# Both srca and srcb are first-emit on the BinaryFpu, neither has prev. 2-arg combined fires.
+# CbA=bfp8, CbB=fp32 maxes format delta to catch argument-routing regressions.
+def test_2arg_combined(device):
+    num_tiles = 8
+    fp32_dest_acc_en = True
+    shape = [1, 1, 32, 32 * num_tiles]
+    dt_a, dt_b, dt_out = ttnn.bfloat8_b, ttnn.float32, ttnn.bfloat16
+
+    torch_a, tt_a = lib.make_input(shape, dt_a, device, seed=51)
+    torch_b, tt_b = lib.make_input(shape, dt_b, device, seed=52)
+
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape), dt_out, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    core_grid = lib.single_core_grid()
+    cbs = [
+        lib.cb_descriptor(0, dt_a, 2, core_grid),
+        lib.cb_descriptor(1, dt_b, 2, core_grid),
+        lib.cb_descriptor(16, dt_out, 2, core_grid),
+    ]
+
+    reader = lib.build_reader_kernel([tt_a, tt_b], num_tiles, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, num_tiles, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [num_tiles, 1], core_grid, fp32_dest_acc_en=fp32_dest_acc_en)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_b, tt_out], program)
+    torch_out = ttnn.to_torch(output).to(torch.float32)
+
+    golden = torch_a.to(torch.float32) + torch_b.to(torch.float32)
+    _assert_each_tile(
+        golden,
+        torch_out,
+        f"2arg combined fp32_dest={fp32_dest_acc_en}",
+    )
+
+
+# =============================================================================
+# Mixed prev (srca has prev, srcb first-emit)
+# =============================================================================
+# Chain: CopyTile(CbA->D0) -> BinaryFpu(CbB,CbC->D1) -> AddBinary(D0+D1->D0) -> PackTile(CbOut).
+# At BinaryFpu: prev_a=CbA (from CopyTile), curr_a=CbB → srca _with_dt; prev_b=NO_PREV_CB, curr_b=CbC
+# → srcb single-arg first-emit. Every result feeds the output — net = CbA + (CbB + CbC) — so a
+# botched srca reconfig (CbA->CbB) changes the numerical result (CbA is load-bearing, not discarded).
+@pytest.mark.parametrize("fp32_dest_acc_en", [False, True])
+def test_mixed_prev(device, fp32_dest_acc_en):
+    num_tiles = 8
+    shape = [1, 1, 32, 32 * num_tiles]
+    dt_a, dt_b, dt_c, dt_out = ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32, ttnn.bfloat16
+
+    torch_a, tt_a = lib.make_input(shape, dt_a, device, seed=61)
+    torch_b, tt_b = lib.make_input(shape, dt_b, device, seed=62)
+    torch_c, tt_c = lib.make_input(shape, dt_c, device, seed=63)
+
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape), dt_out, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    core_grid = lib.single_core_grid()
+    cbs = [
+        lib.cb_descriptor(0, dt_a, 2, core_grid),
+        lib.cb_descriptor(1, dt_b, 2, core_grid),
+        lib.cb_descriptor(2, dt_c, 2, core_grid),
+        lib.cb_descriptor(16, dt_out, 2, core_grid),
+    ]
+
+    reader = lib.build_reader_kernel([tt_a, tt_b, tt_c], num_tiles, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, num_tiles, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [num_tiles, 2], core_grid, fp32_dest_acc_en=fp32_dest_acc_en)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_b, tt_c, tt_out], program)
+    torch_out = ttnn.to_torch(output).to(torch.float32)
+
+    golden = torch_a.to(torch.float32) + torch_b.to(torch.float32) + torch_c.to(torch.float32)
+    _assert_each_tile(
+        golden,
+        torch_out,
+        f"mixed-prev fp32_dest={fp32_dest_acc_en}",
+    )
+
+
+# =============================================================================
+# Single-side _with_dt on srca
+# =============================================================================
+# Chain: CopyTile(CbA, D0) -> CopyTile(CbB, D0) -> PackTile(CbOut).
+# At element 1: prev_a=CbA, curr_a=CbB → srca per-side _with_dt fires. srcb untouched throughout.
+# CbA=bfp8, CbB=bf16 spans block-float -> IEEE on srca. Net semantic = CbB.
+def test_singleside(device):
+    num_tiles = 8
+    fp32_dest_acc_en = False
+    shape = [1, 1, 32, 32 * num_tiles]
+    dt_a, dt_b, dt_out = ttnn.bfloat8_b, ttnn.bfloat16, ttnn.bfloat16
+
+    _, tt_a = lib.make_input(shape, dt_a, device, seed=71)
+    torch_b, tt_b = lib.make_input(shape, dt_b, device, seed=72)
+
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape), dt_out, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    core_grid = lib.single_core_grid()
+    cbs = [
+        lib.cb_descriptor(0, dt_a, 2, core_grid),
+        lib.cb_descriptor(1, dt_b, 2, core_grid),
+        lib.cb_descriptor(16, dt_out, 2, core_grid),
+    ]
+
+    reader = lib.build_reader_kernel([tt_a, tt_b], num_tiles, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, num_tiles, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [num_tiles, 3], core_grid, fp32_dest_acc_en=fp32_dest_acc_en)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_b, tt_out], program)
+    torch_out = ttnn.to_torch(output).to(torch.float32)
+
+    golden = torch_b.to(torch.float32)
+    _assert_each_tile(
+        golden,
+        torch_out,
+        f"single-side fp32_dest={fp32_dest_acc_en}",
+    )
+
+
+# =============================================================================
+# Pack-side _with_dt: multi-pack heterogeneous output chain
+# =============================================================================
+# Chain: CopyTile(CbA, D0) -> PackTile(CbOut1, D0) -> PackTile(CbOut2, D0).
+# Both PackTiles read D0 (the CopyTile result = CbA) and pack to their respective output CBs with
+# different dtypes (CbOut1=bf16, CbOut2=bfp8). Heterogeneous pack CBs trigger the per-stage emission
+# path: boot programs only the first opt-in pack
+# site; subsequent sites emit the 2-arg `pack_reconfig_data_format(prev_p, curr_p)` form before
+# their per-iter pack work, with wraparound for site 0 to handle iter-to-iter cycling.
+def test_pack_to_bfp8(device):
+    num_tiles = 8
+    fp32_dest_acc_en = True
+    shape = [1, 1, 32, 32 * num_tiles]
+    dt_a, dt_out1, dt_out2 = ttnn.bfloat16, ttnn.bfloat16, ttnn.bfloat8_b
+
+    torch_a, tt_a = lib.make_input(shape, dt_a, device, seed=81)
+
+    tt_out1 = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape), dt_out1, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt_out2 = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape), dt_out2, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    core_grid = lib.single_core_grid()
+    cbs = [
+        lib.cb_descriptor(0, dt_a, 2, core_grid),
+        lib.cb_descriptor(16, dt_out1, 2, core_grid),
+        lib.cb_descriptor(17, dt_out2, 2, core_grid),
+    ]
+
+    reader = lib.build_reader_kernel([tt_a], num_tiles, core_grid)
+    writer = lib.build_writer_2out_kernel([tt_out1, tt_out2], num_tiles, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [num_tiles, 4], core_grid, fp32_dest_acc_en=fp32_dest_acc_en)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    ttnn.generic_op([tt_a, tt_out1, tt_out2], program)
+    out1 = ttnn.to_torch(tt_out1).to(torch.float32)
+    out2 = ttnn.to_torch(tt_out2).to(torch.float32)
+
+    golden = torch_a.to(torch.float32)
+    _assert_each_tile(
+        golden,
+        out1,
+        f"heterogeneous pack bf16 fp32_dest={fp32_dest_acc_en}",
+    )
+    _assert_each_tile(
+        golden,
+        out2,
+        f"heterogeneous pack bfp8 fp32_dest={fp32_dest_acc_en}",
+    )
+
+
+# =============================================================================
+# Repeated streaming reads from the same CB
+# =============================================================================
+# Chain: CopyTile(CbA, D0) x3 -> PackTile(CbOut). Each CopyTile must independently consume
+# one tile while the final copy overwrites D0. This validates repeated same-CB reader accounting;
+# whether redundant reconfiguration was compile-time-elided requires a separate codegen oracle.
+#
+# Note on tile accounting: each of the 3 CopyTiles is on Streaming lifecycle and consumes one
+# CbA tile per outer iter. Total CbA tiles consumed = 3 * num_iters. Output is 1 tile per outer
+# iter (PackTile). Each output tile = the 3rd CopyTile's D0 value = the 3rd tile of the triplet
+# (since each CopyTile overwrites D0). The input tensor is sized to hold the full 3*num_iters
+# tiles, and the golden picks every 3rd input tile.
+def test_repeated_same_cb_reads(device):
+    num_iters = 8
+    fp32_dest_acc_en = False
+    tiles_consumed_per_iter = 3
+    total_input_tiles = tiles_consumed_per_iter * num_iters
+    input_shape = [1, 1, 32, 32 * total_input_tiles]
+    output_shape = [1, 1, 32, 32 * num_iters]
+    dt_a, dt_out = ttnn.bfloat16, ttnn.bfloat16
+
+    torch_a, tt_a = lib.make_input(input_shape, dt_a, device, seed=91)
+
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(output_shape), dt_out, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    core_grid = lib.single_core_grid()
+    cbs = [
+        lib.cb_descriptor(0, dt_a, 2, core_grid),
+        lib.cb_descriptor(16, dt_out, 2, core_grid),
+    ]
+
+    # Reader pushes total_input_tiles tiles to CbA; chain consumes 3 per outer iter.
+    reader = lib.build_reader_kernel([tt_a], total_input_tiles, core_grid)
+    writer = lib.build_writer_1out_kernel(tt_out, num_iters, core_grid)
+    compute = lib.build_compute_kernel(KERNEL, [num_iters, 5], core_grid, fp32_dest_acc_en=fp32_dest_acc_en)
+
+    program = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    output = ttnn.generic_op([tt_a, tt_out], program)
+    torch_out = ttnn.to_torch(output).to(torch.float32)
+
+    # Per-tile golden: output[i] = input[3*i + 2] (the third CopyTile in iter i overwrites D0 last).
+    torch_a_f32 = torch_a.to(torch.float32)
+    # Reshape input into (..., 32, num_iters, 3, 32), keep the last of the 3 along the triplet axis.
+    a_view = torch_a_f32.view(1, 1, 32, num_iters, 3, 32)
+    golden = a_view[..., 2, :].contiguous().view(1, 1, 32, 32 * num_iters)
+
+    _assert_each_tile(
+        golden,
+        torch_out,
+        f"repeated same-CB reads fp32_dest={fp32_dest_acc_en}",
+    )

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_skip_compute.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_skip_compute.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coverage for the CKL_ELTWISE_CHAIN_SKIP_COMPUTE profiling knob.
+
+Each test compiles an existing functional chain with the build knob enabled. Completion proves
+that the helper retained its CB and tile-register synchronization lifecycle; disagreement with the
+real golden proves that helper-owned init, reconfiguration, compute, and pack execution were
+elided. The ordinary and unified accumulation fixtures are intentionally shared with the normal
+correctness tests so skip-on and skip-off exercise identical call sites.
+"""
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+from tests.ttnn.utils_for_testing import comp_pcc
+
+HOIST_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/hoist.cpp"
+ACCUMULATION_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/accumulation.cpp"
+SKIP_DEFINE = [("CKL_ELTWISE_CHAIN_SKIP_COMPUTE", "1")]
+
+
+@pytest.mark.parametrize("n", [8, 32])
+def test_skip_compute_ordinary_walk_preserves_handshake(device, n):
+    dtype = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    torch_in, tt_in = lib.make_input(shape, dtype, device, seed=90011)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dtype, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, n, core_grid),
+            lib.build_compute_kernel(HOIST_KERNEL, [n, 0], core_grid, defines=SKIP_DEFINE),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, 2, core_grid),
+            lib.cb_descriptor(16, dtype, 2, core_grid),
+        ],
+    )
+
+    output = ttnn.to_torch(ttnn.generic_op([tt_in, tt_out], program)).to(torch.float32)
+    golden = torch.exp(torch_in.to(torch.float32))
+    matches, message = comp_pcc(golden, output, 0.99)
+    logger.debug(f"skip ordinary n={n} | completed without deadlock | {message}")
+    assert not matches, f"Skip output matched exp(x) ({message}); compute was not elided"
+
+
+@pytest.mark.parametrize("whole_shape", [False, True], ids=["per-row", "whole-shape"])
+@pytest.mark.parametrize("block_size", [1, 8])
+@pytest.mark.parametrize("caller_managed", [False, True], ids=["managed", "caller-managed"])
+def test_skip_compute_dest_accumulation_preserves_handshake(device, whole_shape, block_size, caller_managed):
+    tiles_per_output = 8
+    num_outputs = 3
+    total_input_tiles = tiles_per_output * num_outputs
+    output_tiles = 1 if whole_shape else num_outputs
+    dtype = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+    input_shape = [1, 1, 32, 32 * total_input_tiles]
+    torch_a, tt_a = lib.make_input(input_shape, dtype, device, seed=90021)
+    torch_b, tt_b = lib.make_input(input_shape, dtype, device, seed=90022)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32, 32 * output_tiles]),
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_a, tt_b], total_input_tiles, core_grid),
+            lib.build_writer_1out_kernel(tt_out, output_tiles, core_grid),
+            lib.build_compute_kernel(
+                ACCUMULATION_KERNEL,
+                [0, tiles_per_output, block_size, int(caller_managed), num_outputs, int(whole_shape)],
+                core_grid,
+                defines=SKIP_DEFINE,
+            ),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, total_input_tiles, core_grid),
+            lib.cb_descriptor(1, dtype, total_input_tiles, core_grid),
+            lib.cb_descriptor(16, dtype, output_tiles, core_grid),
+        ],
+    )
+
+    output = ttnn.to_torch(ttnn.generic_op([tt_a, tt_b, tt_out], program)).to(torch.float32)
+    a_tiles = torch.stack(torch_a.to(torch.float32).split(32, dim=-1)).reshape(
+        num_outputs, tiles_per_output, 1, 1, 32, 32
+    )
+    b_tiles = torch.stack(torch_b.to(torch.float32).split(32, dim=-1)).reshape(
+        num_outputs, tiles_per_output, 1, 1, 32, 32
+    )
+    reduced = (a_tiles + b_tiles).sum(dim=1)
+    golden = reduced.sum(dim=0) if whole_shape else torch.cat([reduced[i] for i in range(num_outputs)], dim=-1)
+    matches, message = comp_pcc(golden, output, 0.99)
+    logger.debug(
+        f"skip DEST whole_shape={whole_shape}, block={block_size}, caller_managed={caller_managed} | "
+        f"completed without deadlock | {message}"
+    )
+    assert not matches, f"Skip output matched the DEST reduction ({message}); compute was not elided"
+
+
+@pytest.mark.parametrize("caller_managed", [False, True], ids=["managed", "caller-managed"])
+def test_skip_compute_l1_accumulation_preserves_handshake(device, caller_managed):
+    n = 8
+    dtype = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+    shape = [1, 1, 32, 32 * n]
+    torch_in, tt_in = lib.make_input(shape, dtype, device, seed=90031, scale=0.125, bias=0.0)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32, 32]), dtype, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, 1, core_grid),
+            lib.build_compute_kernel(
+                ACCUMULATION_KERNEL,
+                [1, n, 1, int(caller_managed), 1, 0],
+                core_grid,
+                defines=SKIP_DEFINE,
+            ),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, 2, core_grid),
+            lib.cb_descriptor(15, dtype, 1, core_grid),
+            lib.cb_descriptor(16, dtype, 2, core_grid),
+        ],
+    )
+
+    output = ttnn.to_torch(ttnn.generic_op([tt_in, tt_out], program)).to(torch.float32)
+    golden = torch_in.to(torch.float32).reshape(1, 1, 32, n, 32).sum(dim=3)
+    matches, message = comp_pcc(golden, output, 0.99)
+    logger.debug(f"skip L1 caller_managed={caller_managed} | completed without deadlock | {message}")
+    assert not matches, f"Skip output matched the L1 accumulation ({message}); compute was not elided"

--- a/tests/ttnn/unit_tests/kernel_lib/test_chain_skip_compute_perf.py
+++ b/tests/ttnn/unit_tests/kernel_lib/test_chain_skip_compute_perf.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-profiler A/B coverage for CKL_ELTWISE_CHAIN_SKIP_COMPUTE.
+
+The profile fixtures run identical kernels with the macro off and on. They cover every ordinary
+setup placement plus the managed/caller-managed and block-size variants of L1 and DEST
+accumulation. The outer tests invoke each fixture through the device profiler and require the
+skipped DEVICE KERNEL duration to decrease.
+"""
+
+import pytest
+import ttnn
+from loguru import logger
+
+import tests.ttnn.unit_tests.kernel_lib.chain_test_lib as lib
+from models.perf.device_perf_utils import run_device_perf_detailed
+
+pytestmark = pytest.mark.models_device_performance_bare_metal
+
+OP = "GenericOpDeviceOperation"
+PERF_FILE = "tests/ttnn/unit_tests/kernel_lib/test_chain_skip_compute_perf.py"
+HOIST_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/hoist.cpp"
+ACCUMULATION_KERNEL = "ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/accumulation.cpp"
+SKIP_DEFINE = [("CKL_ELTWISE_CHAIN_SKIP_COMPUTE", "1")]
+N_ITERS = 20
+CASES = {
+    "ordinary-hoisted": ("ordinary", 0),
+    "ordinary-per-call": ("ordinary", 1),
+    "ordinary-caller-setup": ("ordinary", 2),
+    "l1-managed": ("l1", False),
+    "l1-caller-managed": ("l1", True),
+    "dest-per-row-b1-managed": ("dest", False, 1, False),
+    "dest-per-row-b1-caller-managed": ("dest", False, 1, True),
+    "dest-per-row-b8-managed": ("dest", False, 8, False),
+    "dest-per-row-b8-caller-managed": ("dest", False, 8, True),
+    "dest-whole-shape-b1-managed": ("dest", True, 1, False),
+    "dest-whole-shape-b1-caller-managed": ("dest", True, 1, True),
+    "dest-whole-shape-b8-managed": ("dest", True, 8, False),
+    "dest-whole-shape-b8-caller-managed": ("dest", True, 8, True),
+}
+VARIANTS = tuple(f"{case}-{mode}" for case in CASES for mode in ("run", "skip"))
+
+
+def _defines(variant):
+    return SKIP_DEFINE if variant.endswith("-skip") else None
+
+
+def _ordinary(device, variant, setup_mode):
+    n = 256
+    dtype = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    _, tt_in = lib.make_input(shape, dtype, device, seed=91001)
+    tt_out = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), dtype, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, n, core_grid),
+            lib.build_compute_kernel(HOIST_KERNEL, [n, setup_mode], core_grid, defines=_defines(variant)),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, 2, core_grid),
+            lib.cb_descriptor(16, dtype, 2, core_grid),
+        ],
+    )
+    return [tt_in, tt_out], program
+
+
+def _l1(device, variant, caller_managed):
+    n = 256
+    dtype = ttnn.bfloat16
+    shape = [1, 1, 32, 32 * n]
+    core_grid = lib.single_core_grid()
+    _, tt_in = lib.make_input(shape, dtype, device, seed=91002, scale=0.125, bias=0.0)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32, 32]), dtype, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_in], n, core_grid),
+            lib.build_writer_1out_kernel(tt_out, 1, core_grid),
+            lib.build_compute_kernel(
+                ACCUMULATION_KERNEL,
+                [1, n, 1, int(caller_managed), 1, 0],
+                core_grid,
+                defines=_defines(variant),
+            ),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, 2, core_grid),
+            lib.cb_descriptor(15, dtype, 1, core_grid),
+            lib.cb_descriptor(16, dtype, 2, core_grid),
+        ],
+    )
+    return [tt_in, tt_out], program
+
+
+def _dest(device, variant, whole_shape, block_size, caller_managed):
+    tiles_per_output = 8
+    num_outputs = 8
+    total_input_tiles = tiles_per_output * num_outputs
+    output_tiles = 1 if whole_shape else num_outputs
+    dtype = ttnn.bfloat16
+    core_grid = lib.single_core_grid()
+    shape = [1, 1, 32, 32 * total_input_tiles]
+    _, tt_a = lib.make_input(shape, dtype, device, seed=91003)
+    _, tt_b = lib.make_input(shape, dtype, device, seed=91004)
+    tt_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32, 32 * output_tiles]),
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    program = ttnn.ProgramDescriptor(
+        kernels=[
+            lib.build_reader_kernel([tt_a, tt_b], total_input_tiles, core_grid),
+            lib.build_writer_1out_kernel(tt_out, output_tiles, core_grid),
+            lib.build_compute_kernel(
+                ACCUMULATION_KERNEL,
+                [0, tiles_per_output, block_size, int(caller_managed), num_outputs, int(whole_shape)],
+                core_grid,
+                defines=_defines(variant),
+            ),
+        ],
+        semaphores=[],
+        cbs=[
+            lib.cb_descriptor(0, dtype, total_input_tiles, core_grid),
+            lib.cb_descriptor(1, dtype, total_input_tiles, core_grid),
+            lib.cb_descriptor(16, dtype, output_tiles, core_grid),
+        ],
+    )
+    return [tt_a, tt_b, tt_out], program
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_profile_fixture(device, variant):
+    case = variant.rsplit("-", 1)[0]
+    kind, *args = CASES[case]
+    if kind == "ordinary":
+        tensors, program = _ordinary(device, variant, *args)
+    elif kind == "l1":
+        tensors, program = _l1(device, variant, *args)
+    else:
+        tensors, program = _dest(device, variant, *args)
+
+    for _ in range(N_ITERS):
+        ttnn.generic_op(tensors, program)
+    ttnn.synchronize_device(device)
+    ttnn.ReadDeviceProfiler(device)
+
+
+def _device_kernel_ns(variant):
+    results = run_device_perf_detailed(
+        command=f'pytest "{PERF_FILE}::test_profile_fixture[variant={variant}]" -v',
+        subdir=f"eltwise_skip_compute_{variant}",
+        cols=["DEVICE KERNEL"],
+        op_name=OP,
+        warmup_iters=2,
+    )
+    return results["DEVICE KERNEL"]["AVG"]
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_skip_compute_reduces_device_kernel_time(case):
+    run_ns = _device_kernel_ns(f"{case}-run")
+    skip_ns = _device_kernel_ns(f"{case}-skip")
+    logger.info(
+        f"skip-compute {case} | run={run_ns:.0f} ns | skip={skip_ns:.0f} ns | " f"speedup={run_ns / skip_ns:.3f}x"
+    )
+    assert skip_ns < run_ns, f"{case}: skip did not reduce DEVICE KERNEL time ({skip_ns:.0f} >= {run_ns:.0f} ns)"

--- a/ttnn/cpp/ttnn/kernel_lib/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/kernel_lib/CMakeLists.txt
@@ -2,11 +2,12 @@ add_library(ttnn_kernel_lib INTERFACE)
 add_library(TTNN::KernelLib ALIAS ttnn_kernel_lib)
 
 file(
-    GLOB kernel_lib_jit_api
+    GLOB_RECURSE kernel_lib_jit_api
     CONFIGURE_DEPENDS
     *.hpp
     *.inl
 )
+list(FILTER kernel_lib_jit_api EXCLUDE REGEX "/tests/")
 list(SORT kernel_lib_jit_api)
 
 set_target_properties(

--- a/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.hpp
@@ -20,7 +20,9 @@ ALWI uint32_t get_full_tile_size(DataFormat format);
 
 ALWI constexpr bool is_block_float_format(uint32_t format);
 
-// Arch-independent CB FIFO arithmetic; needed by the regular tilize path on Quasar (no fast tilize).
+// Returns a DFB's page capacity (regular tilize path; no fast tilize on Quasar). WH/BH: CB-FIFO
+// arithmetic (fifo_size / fifo_page_size); Quasar: reads the HW tile-counter register instead
+// (Quasar tracks DFB state in g_dfb_interface, not cb_interface).
 ALWI uint32_t get_dfb_num_pages(uint32_t dfb_id);
 
 #ifndef ARCH_QUASAR

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp
@@ -1,0 +1,536 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file chain.hpp
+ * @brief Element-wise compute helper — one chain surface for all eltwise patterns.
+ *
+ * Every element-wise compute pattern (FPU binary, SFPU unary/binary/ternary, dest-reuse, copy,
+ * pack, fill, rand, unary broadcast) is expressed as a sequence of chain elements passed to
+ * `eltwise_chain(shape, elem0, elem1, ...)` (shape is an `IterationShape`, e.g.
+ * `IterationShape::tiles(num_tiles)`).
+ *
+ * The chain owns, per call:
+ *   - the dst-sync window (`tile_regs_acquire/commit/wait/release`);
+ *   - per-element init and exec dispatch;
+ *   - CB lifecycle (input wait/pop, output reserve/push), selected by each element's policy enums;
+ *   - input- and pack-side dtype reconfig, compile-time-elided when the previous CB on that side
+ *     already carries the right format;
+ *   - compile-time invariant checks (illegal lifecycle/index combos, duplicate upfront CBs,
+ *     pack-output collisions, hoist-safety).
+ *
+ * Caller-init contract
+ * --------------------
+ * The chain never issues engine-wide ("BIG") init. The caller owns `compute_kernel_hw_startup`
+ * (plus `compute_kernel_hw_startup` / `mm_init` / `reduce_init` when the kernel mixes those
+ * primitives). The chain owns only per-element init — `*_tile_init`, `init_bcast`,
+ * `copy_tile_init` / `copy_tile_to_dst_init_short`, the `reconfig_data_format_*` fold, and the
+ * dst-sync lifecycle. Do not add a `*_with_init` wrapper that folds `compute_kernel_hw_startup`
+ * into the chain: it is only correct for single-stage kernels and breaks multi-stage / mid-loop
+ * ones.
+ *
+ * compute_kernel_hw_startup placement
+ * -----------------------------------
+ * Call it as the first statement of `MAIN()` for any chain that both reads and writes a CB.
+ * Multi-stage kernels (a different pack-output CB per stage) issue one boot per stage: stage 1
+ * at the top of `MAIN()`, later stages immediately before their chain call. It is an MMIO write,
+ * so it is undefined mid-`MAIN()`; when an outer `compute_kernel_hw_startup` already covers the chain,
+ * omit it.
+ *
+ * FP32 DEST accumulation
+ * ----------------------
+ * Determined kernel-wide by the build flag `FP32_DEST_ACC_EN`; `DEST_AUTO_LIMIT` (dest_helpers.hpp)
+ * already halves the usable slot count when it is on. There is no per-element opt-in and no
+ * mid-kernel `enable_fp32_dest_acc()` / `disable_fp32_dest_acc()` toggle.
+ *
+ * Examples
+ * --------
+ *   // Streaming unary — Exp(x) -> out (dfb_* are dataflow-buffer ids, i.e. buffer indices)
+ *   eltwise_chain(IterationShape::tiles(num_tiles),
+ *       CopyTile<input(dfb_in)>{},
+ *       Exp<>{},
+ *       PackTile<output(dfb_out)>{});
+ *
+ *   // Streaming binary — A + B -> out (BinaryFpu writes DEST; the output buffer lives on PackTile)
+ *   eltwise_chain(IterationShape::tiles(num_tiles),
+ *       BinaryFpu<BinaryFpuOp::Add, input(dfb_a), input(dfb_b)>{},
+ *       PackTile<output(dfb_out)>{});
+ *
+ * Not supported: per-iteration (mid-loop) dtype swaps — each element's dtype reconfig point is
+ * resolved per element at compile time (fold-driven, emitted once at element entry), so there is
+ * no per-loop-iteration reconfig path; and the legacy `acquire_dst/release_dst` macros
+ * (modern dst-sync only).
+ */
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+#include "api/compute/common_globals.h"  // ALWI (used by the public eltwise_chain() declaration)
+// The heavier LLK / compute-API includes are impl-only and live in chain.inl.
+
+namespace compute_kernel_lib {
+
+// Buffer identities throughout the chain (the `cb_id` fields on InputSpec / OutputSpec,
+// `dfb`-named implementation accessors and ElemDesc fields, and the INVALID_DFB /
+// NO_PREV_DFB sentinels) are dataflow-buffer ids: today an integer `tt::CBIndex` value.
+// The public element aliases accept complete input(...) / output(...) specs and forward each
+// id as a separate implementation NTTP so it does not consume packed configuration bits.
+
+// (The marker-tag hierarchy — CbReaderTag/CbWriterTag/DestOnlyTag + the per-element
+//  leaf tags — and the is_*_op_v classification predicates are internal pipeline
+//  scaffolding, defined in chain.inl. Concrete elements declared below inherit
+//  the leaf tags from there.)
+
+// =============================================================================
+// 1a. 2D shape — (Ht, Wt) tile grid for the 2D chain overload
+// =============================================================================
+
+/// How a `PerBlockSize` lifecycle synchronizes the partial tail of a blocked walk.
+///
+/// Math and pack always execute only valid tiles. This policy controls only the CB lifecycle
+/// count (wait/pop/reserve/push) of the partial final block.
+enum class BlockTailSync : uint8_t {
+    ValidTiles,  // synchronize min(block_size, tiles remaining)
+    FullBlock,   // synchronize block_size even when fewer tiles are mathematically valid
+};
+
+/// Looping shape for `eltwise_chain`. `Ht`, `Wt`, and `block_size` describe how the chain driver
+/// iterates and groups its work; they do not necessarily equal the number of tiles present on any
+/// input or output. Operand indexing and lifecycle policies may pin, reuse, accumulate, or defer
+/// tiles independently of this iteration space. Ht=1 expresses the 1D case (no row axis, plain
+/// linear walk); the `Row`/`Col` indexing modes degenerate for 1D usage but remain well-defined.
+///
+/// Factories establish the iteration extent. Blocking is configured fluently when needed:
+///   - `IterationShape::tiles(n)` — 1D, block size 1
+///   - `IterationShape::tiles(n).block_size(blk)` — 1D + block
+///   - `IterationShape::tiles(n).block_size(blk, BlockTailSync::FullBlock)`
+///                                                   — 1D fixed-size physical blocks
+///   - `IterationShape::grid(H, W)` — 2D, block size 1
+///   - `IterationShape::grid(H, W).block_size(blk)` — 2D + block
+///   - `IterationShape::grid(H, W).block_size(blk, BlockTailSync::FullBlock)`
+///                                                   — 2D row-blocked fixed-size physical blocks
+///
+/// Construction from a tile count is `explicit`: a bare number is NOT accepted as a
+/// shape — call sites must spell the iteration shape out as `IterationShape::tiles(n)`
+/// (or `IterationShape::one_tile()` for one tile). This keeps `eltwise_chain(...)` and the
+/// convenience wrappers from silently treating a stray integer as a tile count.
+///
+/// `row/col/one_tile` aliases mirror `binary_op_helpers`' `BinaryInputBlockShape`.
+struct IterationShape {
+    uint32_t Ht;
+    uint32_t Wt;
+    uint32_t block_tiles;  // tiles per inner block iteration; named apart from the fluent method
+    BlockTailSync tail_sync;
+
+    constexpr IterationShape(uint32_t H, uint32_t W) :
+        Ht(H), Wt(W), block_tiles(1), tail_sync(BlockTailSync::ValidTiles) {}
+
+    // Explicit: bare numbers are forbidden at call sites. Use IterationShape::tiles(n) or
+    // IterationShape::one_tile() so the iteration shape is always written out.
+    explicit constexpr IterationShape(uint32_t n_tiles) : IterationShape(1, n_tiles) {}
+
+    static constexpr IterationShape tiles(uint32_t n) { return {1, n}; }
+    static constexpr IterationShape grid(uint32_t H, uint32_t W) { return {H, W}; }
+
+    static constexpr IterationShape row(uint32_t c) { return {1, c}; }
+    static constexpr IterationShape col(uint32_t r) { return {r, 1}; }
+    static constexpr IterationShape one_tile() { return {1, 1}; }
+
+    /// Configures blocking and returns the shape, so it chains on factory temporaries:
+    /// `IterationShape::tiles(n).block_size(blk)`.
+    constexpr IterationShape block_size(uint32_t value, BlockTailSync tail = BlockTailSync::ValidTiles) {
+        block_tiles = value;
+        tail_sync = tail;
+        return *this;
+    }
+};
+
+/// Who performs the chain's one-time setup — init + reconfig — the leading template arg to
+/// `eltwise_chain`. This is about *ownership*, NOT about whether inits are hoistable: which inits
+/// are hoistable is deduced from the chain's uniformity and is never a manual choice.
+///
+///   eltwise_chain(shape, elts...);                       // default: InitReconfigOwner::Chain
+///   // To hoist the setup out of your own loop: emit it ONCE before the loop yourself (e.g. the
+///   // original raw *_init call), then hand ownership to the caller so the chain skips it:
+///   <emit the chain's one-time setup once, before the loop>
+///   for (...) eltwise_chain<InitReconfigOwner::Caller>(IterationShape::one_tile(), elts...);
+///
+/// InitReconfigOwner::Caller is only valid when the chain's entire setup is boot-hoistable (uniform math
+/// MOP + SFPU init AND homogeneous pack CBs) — i.e. there's a single "once, before the loop" the
+/// caller can own. eltwise_chain static_asserts this; a chain that must re-emit setup per tile
+/// (so the caller can't pre-do it once) is a compile error pointing you back to InitReconfigOwner::Chain.
+enum class InitReconfigOwner {
+    Chain,   // this eltwise_chain call emits the one-time setup (init + reconfig)
+    Caller,  // the caller emitted it once, outside the loop — the chain emits none of it here
+};
+
+// -----------------------------------------------------------------------------
+// Skip-compute — a performance-debugging BUILD knob, NOT part of the eltwise_chain API.
+//
+// With CKL_ELTWISE_CHAIN_SKIP_COMPUTE=1, every eltwise_chain in the translation unit emits only
+// its CB lifecycle (wait/pop/reserve/push) and tile_regs synchronization. All helper-owned init,
+// reconfiguration, compute, and pack execution is compile-time-elided. CB counts are unchanged, so
+// the dataflow handshake remains intact, but the published output is intentionally garbage.
+//
+// Use this only for local run-versus-skip profiling to separate compute cost from the
+// CB/data-movement floor. Do not use it in production or correctness runs.
+//
+// Opt in either before including this header or through the kernel's compiler defines:
+//
+//   #define CKL_ELTWISE_CHAIN_SKIP_COMPUTE 1
+//   #include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+//
+// The knob covers ordinary, L1-accumulation, and DEST-accumulation walks. It does not suppress
+// caller-owned work outside eltwise_chain, including compute_kernel_hw_startup or setup emitted for
+// InitReconfigOwner::Caller.
+#ifndef CKL_ELTWISE_CHAIN_SKIP_COMPUTE
+#define CKL_ELTWISE_CHAIN_SKIP_COMPUTE 0
+#endif
+
+// =============================================================================
+// 1b. Input and output CB synchronization policies
+// =============================================================================
+
+/// Lifecycle policies control FIFO synchronization together with `InputTileMapping`, which controls tile
+/// indexing. `PerBlockSize` synchronizes once per `IterationShape::block_size` group. For an input,
+/// `PerTile + Col` denotes a streamed column: the chain waits for one tile at each grid-row boundary,
+/// reuses the current front tile across that row, then pops it. `Upfront + Col` instead stages an
+/// Ht-tile window and indexes it by row. Output `PerTile` remains literal: one output tile is reserved
+/// and pushed per grid cell. `PerOuter` exists only for output DEST-row accumulation.
+/// On a partial final block, `BlockTailSync` selects whether synchronization covers the valid
+/// remainder or the full `block_size`.
+
+/// When the chain waits for an input CB.
+enum class WaitPolicy : uint8_t { None, PerTile, PerBlockSize, Upfront, Cumulative };
+
+/// When the chain pops an input CB.
+enum class PopPolicy : uint8_t { None, PerTile, PerBlockSize, AtEnd };
+
+/// When the chain reserves an output CB.
+enum class ReservePolicy : uint8_t { None, PerTile, PerBlockSize, Upfront, PerOuter, OneUpfront };
+
+/// When the chain pushes an output CB.
+enum class PushPolicy : uint8_t { None, PerTile, PerBlockSize, AtEnd, PerOuter, OneAtEnd };
+
+/// Which tile of an input operand to read at each step of the (Ht x Wt) walk.
+/// Pick the one that matches how your input maps onto the output:
+///   - Block  — a distinct tile every step; the index advances with the walk (full Ht x Wt input).
+///   - Row    — indexed by column only: the same tile-row is re-read for every output row ([1, Wt] input).
+///   - Col    — with a staged lifecycle, indexed by row so the same tile-column is re-read for every
+///              output column ([Ht, 1] input); with PerTile/PerTile, streamed one tile per row.
+///   - Scalar — contribute index 0 every step, pinning the read to the operand's base tile
+///              (`TileAddressing::Offset` may make that base nonzero). This is inter-tile indexing, not a
+///              hardware scalar broadcast; it is independent of `BroadcastDim`.
+/// The size aspect only matters with an upfront-wait policy, where the mapping also sets
+/// how many tiles are waited/popped upfront: Scalar 1, Row Wt, Col Ht, Block Ht x Wt.
+/// The 1D tiles(n) shape allows only Block and Scalar; Row and Col need the 2D grid(H, W) shape.
+/// The output is always Block, so there is no output mapping.
+enum class InputTileMapping : uint8_t {
+    Block,
+    Row,
+    Col,
+    Scalar,
+};
+
+// =============================================================================
+// 1c. TileAddressing — orthogonal tile-index addressing
+// =============================================================================
+//
+// Composes with `InputTileMapping`: `tile_id = base + derived_from_mapping(r, c)`, where
+// TileAddressing supplies `base` and InputTileMapping supplies the mapping-derived term.
+//   - `Direct` (default): no base offset, zero overhead — the `+base` term and stored value
+//     are compile-time-elided.
+//   - `Offset`: base offset present; its value comes from the element's constructor (runtime,
+//     or a compile-time constant that constant-propagates into the address add).
+//   - `Strided`: base and row stride come from a `StridedTileRange`. Block maps to
+//     `base + r * row_stride + c`, Col to `base + r * row_stride`, while Row and
+//     Scalar retain their ordinary column/pinned behavior.
+//
+// `Offset` is restricted to upfront/deferred-pop or caller-managed wait/pop pairs.
+// Iter-dependent wait/pop counts can't compose with a runtime base. Caller must
+// size the CB for `base + window`; the chain inflates its wait/reserve/pop/push counts
+// by `base` at runtime.
+//
+// `Strided` is restricted to caller-managed `(None, None)` policies: a gapped window cannot be
+// represented by a single wait/pop/reserve/push count, so the enclosing kernel owns it.
+
+enum class TileAddressing : uint8_t { Direct, Offset, Strided };
+
+struct StridedTileRange {
+    uint32_t base;
+    uint32_t row_stride;
+};
+
+/// Whether the chain updates the data format for an operand.
+enum class DataFormatReconfig : bool { Disabled = false, Enabled = true };
+
+/// Whether a pack accumulates into one output tile in L1.
+enum class L1Accumulation : uint8_t {
+    Disabled,
+    Enabled,        // the first pack seeds the output; subsequent packs accumulate
+    AddToExisting,  // every pack, including the first, adds to the existing output
+};
+
+/// Scope of an FPU binary's persistent DEST accumulation.
+///
+/// PerRow acquires, packs, and clears DEST once per row of the walk. WholeShape keeps DEST
+/// acquired across the complete shape and emits one tile. With a single-row shape (`tiles(n)`)
+/// the two coincide; spell WholeShape for a 1D reduction.
+enum class DestAccumulation : uint8_t {
+    Disabled,
+    PerRow,
+    WholeShape,
+};
+
+/// ReLU applied by the packer before writing an output tile.
+enum class PackRelu : bool { Disabled = false, Zero = true };
+
+/// Intra-tile broadcast applied to an FPU binary's srcB operand. Mirrors
+/// `ckernel::BroadcastType` values (NONE=0, COL=1, ROW=2, SCALAR=3).
+///
+/// Given srcB:
+///   [b00 b01 ...]         Row    -> [b00 b01 ...]  output row 0
+///   [b10 b11 ...]                   [b00 b01 ...]  output row 1
+///
+///                         Col    -> [b00 b00 ...]  output row 0
+///                                   [b10 b10 ...]  output row 1
+///
+///                         Scalar -> [b00 b00 ...]  every output row
+///
+///                         None   -> [br0 br1 ...]  output row r
+enum class BroadcastDim : uint8_t {
+    None = 0,
+    Col = 1,
+    Row = 2,
+    Scalar = 3,
+};
+
+// =============================================================================
+// 1d. Grouped operand configuration
+// =============================================================================
+//
+// `input(...)` and `output(...)` bind a buffer id to the compile-time properties of one operand.
+
+struct InputSpec {
+    uint32_t cb_id;
+    WaitPolicy wait;
+    PopPolicy pop;
+    InputTileMapping mapping;
+    DataFormatReconfig reconfig;
+    TileAddressing addressing;
+};
+
+/// The second (srcB) input of a `BinaryFpu`. srcB is the only operand the FPU broadcast path
+/// supports, so it carries a richer spec than the plain `InputSpec` used for srcA. Broadcast is
+/// kept out of `InputSpec` because ordinary inputs (CopyTile, SFPU operands, unary broadcast,
+/// and srcA) cannot consume this FPU-specific state.
+struct BroadcastInputSpec {
+    InputSpec input_spec;
+    BroadcastDim broadcast;
+
+    constexpr BroadcastInputSpec(InputSpec spec, BroadcastDim dim) noexcept : input_spec(spec), broadcast(dim) {}
+
+    /// Implicit: a plain input participates as srcB without broadcasting.
+    constexpr BroadcastInputSpec(InputSpec spec) noexcept : input_spec(spec), broadcast(BroadcastDim::None) {}
+};
+
+struct OutputSpec {
+    uint32_t cb_id;
+    ReservePolicy reserve;
+    PushPolicy push;
+    DataFormatReconfig reconfig;
+    TileAddressing addressing;
+    DestAccumulation dest_accumulation;
+    L1Accumulation l1_accumulation;
+    PackRelu relu;
+};
+
+/// Bind one input buffer id to its configuration.
+/// Defaults: wait/pop per tile, Scalar mapping, reconfig enabled, and Direct addressing.
+/// `PerTile/PerTile + Col` streams one front tile per grid row; other `Col` lifecycles retain
+/// row-indexed window semantics.
+constexpr InputSpec input(
+    uint32_t cb_id,
+    WaitPolicy wait = WaitPolicy::PerTile,
+    PopPolicy pop = PopPolicy::PerTile,
+    InputTileMapping mapping = InputTileMapping::Scalar,
+    DataFormatReconfig reconfig = DataFormatReconfig::Enabled,
+    TileAddressing addressing = TileAddressing::Direct) noexcept;
+constexpr InputSpec input(uint32_t cb_id, WaitPolicy wait, PopPolicy pop, DataFormatReconfig reconfig) noexcept;
+
+/// Bind srcB of a BinaryFpu and optionally select its intra-tile broadcast. The overload taking
+/// an existing InputSpec makes compile-time helper-produced input configurations composable.
+constexpr BroadcastInputSpec input(InputSpec input_spec, BroadcastDim broadcast) noexcept;
+constexpr BroadcastInputSpec input(
+    uint32_t cb_id,
+    BroadcastDim broadcast,
+    WaitPolicy wait = WaitPolicy::PerTile,
+    PopPolicy pop = PopPolicy::PerTile,
+    InputTileMapping mapping = InputTileMapping::Scalar,
+    DataFormatReconfig reconfig = DataFormatReconfig::Enabled,
+    TileAddressing addressing = TileAddressing::Direct) noexcept;
+constexpr BroadcastInputSpec input(
+    uint32_t cb_id, BroadcastDim broadcast, WaitPolicy wait, PopPolicy pop, DataFormatReconfig reconfig) noexcept;
+
+/// Bind one output buffer id to its configuration.
+/// Defaults: reserve/push per tile, reconfig enabled, Direct addressing, no accumulation,
+/// and no pack ReLU. Parameters are ordered by how often call sites set them, so the rare
+/// knobs pay the trailing-default spelling cost instead of the common ones.
+constexpr OutputSpec output(
+    uint32_t cb_id,
+    ReservePolicy reserve = ReservePolicy::PerTile,
+    PushPolicy push = PushPolicy::PerTile,
+    DataFormatReconfig reconfig = DataFormatReconfig::Enabled,
+    TileAddressing addressing = TileAddressing::Direct,
+    DestAccumulation dest_accumulation = DestAccumulation::Disabled,
+    L1Accumulation l1_accumulation = L1Accumulation::Disabled,
+    PackRelu relu = PackRelu::Disabled) noexcept;
+
+// =============================================================================
+// 2. DEST slot enum — capped at compile-time DEST capacity
+// =============================================================================
+
+/// Compile-time DEST slot identifier. Cap depends on sync mode + fp32_dest_acc (DEST_AUTO_LIMIT).
+/// Names D0..D15 are nominal — `static_assert` on each slot's use checks
+/// `(uint32_t)Slot < DEST_AUTO_LIMIT`. Never use a literal `8` to bound DEST slots.
+enum class Dst : uint32_t {
+    D0 = 0,
+    D1 = 1,
+    D2 = 2,
+    D3 = 3,
+    D4 = 4,
+    D5 = 5,
+    D6 = 6,
+    D7 = 7,
+    D8 = 8,
+    D9 = 9,
+    D10 = 10,
+    D11 = 11,
+    D12 = 12,
+    D13 = 13,
+    D14 = 14,
+    D15 = 15,
+};
+
+constexpr uint32_t to_u32(Dst s) noexcept;
+
+// =============================================================================
+// 3. Block size — `IterationShape::block_size` semantics
+// =============================================================================
+//
+// Op-struct template-param enums (Approx / Legacy) live in op_params.hpp — they
+// are an op-helper concern, not part of the chain mechanics, so they are not defined here.
+
+/// Block size. Configured with `IterationShape::tiles(n).block_size(blk)` or
+/// `grid(H, W).block_size(blk)`, then passed as the shape to `eltwise_chain(shape, ...)`.
+/// Each full outer iter processes `block_size` tiles across `block_size` DEST lanes (lane j at
+/// slot dst_slot + j * chain_lane_width); `block_size == 1` is the per-tile shape. A partial
+/// final iter always executes only its valid remainder. `BlockTailSync` selects whether
+/// `PerBlockSize` lifecycles synchronize that valid remainder or the full `block_size`.
+///
+/// For numeric shapes, the chain clamps `block_size` at runtime so
+/// `block_size * chain_lane_width` always fits DEST (`DEST_AUTO_LIMIT`): an oversized value can't
+/// overflow DEST, it only costs extra outer iterations. Streaming CB-reader chains consume one
+/// tile per iter, so block_size is clamped to 1 for them. A shape using `FullBlock` mode instead
+/// describes a physical CB contract and must already fit; the chain
+/// asserts rather than changing it.
+
+// =============================================================================
+// 4. Operation selectors
+// =============================================================================
+
+/// FPU binary op selector.
+enum class BinaryFpuOp : uint8_t { Add, Sub, Mul };
+
+/// DestReuseBinary side selector.
+enum class DestReuseType : uint8_t {
+    DEST_TO_SRCA,  // CB → srcb, DEST → srca
+    DEST_TO_SRCB,  // CB → srca, DEST → srcb
+};
+
+// =============================================================================
+// 5. Chain element declarations
+// =============================================================================
+
+namespace detail {
+
+constexpr uint32_t copy_tile_config_bits(Dst dst, InputSpec input_spec) noexcept;
+
+constexpr uint32_t pack_tile_config_bits(OutputSpec output_spec, Dst dst) noexcept;
+
+constexpr uint32_t binary_fpu_config_bits(
+    BinaryFpuOp op, InputSpec a, BroadcastInputSpec b, Dst dst, DestAccumulation accumulation) noexcept;
+
+constexpr uint32_t dest_reuse_binary_config_bits(
+    BinaryFpuOp op, DestReuseType reuse, InputSpec input_spec, Dst dst) noexcept;
+
+template <uint32_t Cb, uint32_t ConfigBits>
+struct CopyTileImpl;
+template <uint32_t Cb, uint32_t ConfigBits>
+struct PackTileImpl;
+template <uint32_t CbA, uint32_t CbB, uint32_t ConfigBits>
+struct BinaryFpuImpl;
+template <uint32_t Cb, uint32_t ConfigBits>
+struct DestReuseBinaryImpl;
+
+}  // namespace detail
+
+template <InputSpec Input, Dst DstSlot = Dst::D0>
+using CopyTile = detail::CopyTileImpl<Input.cb_id, detail::copy_tile_config_bits(DstSlot, Input)>;
+
+template <
+    BinaryFpuOp Op,
+    InputSpec AInput,
+    BroadcastInputSpec BInput,
+    Dst DstSlot = Dst::D0,
+    DestAccumulation Accumulation = DestAccumulation::Disabled>
+using BinaryFpu = detail::BinaryFpuImpl<
+    AInput.cb_id,
+    BInput.input_spec.cb_id,
+    detail::binary_fpu_config_bits(Op, AInput, BInput, DstSlot, Accumulation)>;
+
+/// Apply an FPU binary operation between one CB input and `DstSlot`.
+/// The LLK operation is in-place in DEST: it reads and overwrites the same slot.
+/// `Op` is the first template argument, matching `BinaryFpu`.
+template <BinaryFpuOp Op, InputSpec Input, DestReuseType ReuseType, Dst DstSlot = Dst::D0>
+using DestReuseBinary =
+    detail::DestReuseBinaryImpl<Input.cb_id, detail::dest_reuse_binary_config_bits(Op, ReuseType, Input, DstSlot)>;
+
+template <OutputSpec Output, Dst DstSlot = Dst::D0>
+using PackTile = detail::PackTileImpl<Output.cb_id, detail::pack_tile_config_bits(Output, DstSlot)>;
+
+// (Chain-shape trait predicates, the EltwiseChain type-list wrapper, and the INVALID_DFB sentinel
+//  are implementation detail — declared in chain.inl, not on this public surface.)
+
+// =============================================================================
+// 6. Public API — eltwise_chain
+// =============================================================================
+//
+// Caller-init contract (see the @file block): the caller owns engine-wide init
+// (compute_kernel_hw_startup as the first statement of MAIN() for any read+write chain,
+// one boot per stage for multi-stage kernels); the chain owns only per-element init.
+
+/// Run the chain over an (Ht, Wt) tile grid with optional per-outer-iter block size.
+/// `IterationShape` covers both walks: `tiles(n)` (1D, Ht=1),
+/// `tiles(n).block_size(blk, BlockTailSync::FullBlock)` for a fixed-block 1D CB contract, or
+/// `grid(H, W).block_size(blk, BlockTailSync::FullBlock)` for a row-blocked 2D contract.
+/// A bare number is not accepted — write `IterationShape::tiles(n)` (or
+/// `IterationShape::one_tile()` for one tile) so the iteration shape is always explicit.
+///
+/// Compile-time validation static_asserts on: illegal (Policy × Mapping) cells,
+/// duplicate upfront CBs across CB-readers, colliding pack writes, and hoist requested on
+/// a non-hoist-safe chain.
+///
+/// Index-mode (InputTileMapping) and block-mode behavior match the enum docs above: Block /
+/// Row / Col / Scalar pick the per-iter tile index; input policies that own a staged CB
+/// window take the upfront-block path; chains with per-tile input or output lifecycles clamp block_size to 1.
+/// `BlockTailSync` affects only per-block-size synchronization counts. Row/Col need a non-streaming policy.
+template <InitReconfigOwner Owner = InitReconfigOwner::Chain, class... Es>
+ALWI void eltwise_chain(IterationShape shape, Es... elts);
+
+}  // namespace compute_kernel_lib
+
+// Bring the implementation in.
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/chain.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file convenience.hpp
+ * @brief One-liner entry points for the dominant eltwise chain shapes.
+ *
+ * Each wrapper is a pure inline forwarder to `eltwise_chain` for one common shape, so a
+ * simple op needs one call instead of a hand-written chain. The op is baked into the name
+ * (`add`/`sub`/`mul`, or the SFPU op as a type parameter); broadcast and the grouped input/output
+ * configurations carry their buffer ids, so the streaming case is a three-argument call
+ * and the broadcast / held-operand cases stay a single call:
+ *
+ *     mul<input(dfb_a), input(dfb_b), output(dfb_out)>(IterationShape::tiles(n));
+ *     sub<input(dfb_x), input(dfb_row, BroadcastDim::Col, WaitPolicy::PerTile, PopPolicy::None),
+ *         output(dfb_out)>(shape);
+ *     unary<Exp<>, input(dfb_in), output(dfb_out)>(IterationShape::tiles(n));
+ *     binary_sfpu<DivBinary<>, input(dfb_a), input(dfb_b), output(dfb_out)>(IterationShape::tiles(n));
+ *     copy<input(dfb_in), output(dfb_out)>(IterationShape::one_tile());
+ *
+ * The shape argument is an `IterationShape`. A bare number is not accepted (the `uint32_t`
+ * ctor is `explicit`): write `op<...>(IterationShape::tiles(n))`, `IterationShape::one_tile()`,
+ * or `op<...>(IterationShape::grid(Ht, Wt))` so the iteration shape is always explicit.
+ *
+ * Like `eltwise_chain`, these emit no engine-wide init — the caller owns
+ * `compute_kernel_hw_startup(...)` as the first statement of `MAIN()`. Drop to
+ * `eltwise_chain` directly for anything outside these shapes (fused multi-op chains,
+ * DEST-reuse, fill, etc.).
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/dfb_helpers_compute.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
+
+namespace compute_kernel_lib {
+
+// ---------------------------------------------------------------------------
+// FPU binary — BinaryFpu(D0) -> PackTile(D0). Op baked into the name.
+// Defaults: no broadcast, both operands per-tile streaming.
+// ---------------------------------------------------------------------------
+
+template <InputSpec AInput, BroadcastInputSpec BInput, OutputSpec Output>
+ALWI void add(IterationShape shape);
+
+template <InputSpec AInput, BroadcastInputSpec BInput, OutputSpec Output>
+ALWI void sub(IterationShape shape);
+
+template <InputSpec AInput, BroadcastInputSpec BInput, OutputSpec Output>
+ALWI void mul(IterationShape shape);
+
+// ---------------------------------------------------------------------------
+// FPU square — x * x, via BinaryFpu reading the one input buffer for both operands
+// (the chain's same-buffer path waits/pops it once). Mirrors mul's knobs minus the ones
+// that don't apply when both operands are the same tile: no broadcast, and a single
+// operand lifecycle / index instead of separate A/B.
+// ---------------------------------------------------------------------------
+
+template <InputSpec Input, OutputSpec Output>
+ALWI void square(IterationShape shape);
+
+// ---------------------------------------------------------------------------
+// SFPU unary — CopyTile(D0) -> SfpuOp -> PackTile(D0). SfpuOp is the (DEST-only) op type.
+// ---------------------------------------------------------------------------
+
+template <class SfpuOp, InputSpec Input, OutputSpec Output>
+ALWI void unary(IterationShape shape);
+
+// Typecast — derives the LLK input/output formats from the bound buffers.
+template <InputSpec Input, OutputSpec Output>
+ALWI void typecast(IterationShape shape);
+
+// ---------------------------------------------------------------------------
+// SFPU binary — two CopyTile loads (D0, D1) -> SfpuBinOp -> PackTile(D0).
+// SfpuBinOp is a DEST-only SFPU binary op type (e.g. DivBinary<>, BinaryMax<>).
+// ---------------------------------------------------------------------------
+
+template <class SfpuBinOp, InputSpec AInput, InputSpec BInput, OutputSpec Output>
+ALWI void binary_sfpu(IterationShape shape);
+
+// ---------------------------------------------------------------------------
+// Pure copy — CopyTile(D0) -> PackTile(D0).
+// ---------------------------------------------------------------------------
+
+template <InputSpec Input, OutputSpec Output>
+ALWI void copy(IterationShape shape);
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.inl
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace compute_kernel_lib {
+
+template <InputSpec AInput, BroadcastInputSpec BInput, OutputSpec Output>
+ALWI void add(IterationShape shape) {
+    eltwise_chain(
+        shape, BinaryFpu<BinaryFpuOp::Add, AInput, BInput, Dst::D0, Output.dest_accumulation>{}, PackTile<Output>{});
+}
+
+template <InputSpec AInput, BroadcastInputSpec BInput, OutputSpec Output>
+ALWI void sub(IterationShape shape) {
+    eltwise_chain(
+        shape, BinaryFpu<BinaryFpuOp::Sub, AInput, BInput, Dst::D0, Output.dest_accumulation>{}, PackTile<Output>{});
+}
+
+template <InputSpec AInput, BroadcastInputSpec BInput, OutputSpec Output>
+ALWI void mul(IterationShape shape) {
+    eltwise_chain(
+        shape, BinaryFpu<BinaryFpuOp::Mul, AInput, BInput, Dst::D0, Output.dest_accumulation>{}, PackTile<Output>{});
+}
+
+template <InputSpec Input, OutputSpec Output>
+ALWI void square(IterationShape shape) {
+    eltwise_chain(
+        shape, BinaryFpu<BinaryFpuOp::Mul, Input, Input, Dst::D0, Output.dest_accumulation>{}, PackTile<Output>{});
+}
+
+template <class SfpuOp, InputSpec Input, OutputSpec Output>
+ALWI void unary(IterationShape shape) {
+    static_assert(is_dest_only_op_v<SfpuOp>, "unary<SfpuOp, ...>: SfpuOp must be a DEST-only SFPU element");
+    eltwise_chain(shape, CopyTile<Input>{}, SfpuOp{}, PackTile<Output>{});
+}
+
+template <InputSpec Input, OutputSpec Output>
+ALWI void typecast(IterationShape shape) {
+    constexpr auto in_df = dfb_l1_format<Input.cb_id>();
+    constexpr auto out_df = dfb_l1_format<Output.cb_id>();
+    unary<Typecast<in_df, out_df>, Input, Output>(shape);
+}
+
+template <class SfpuBinOp, InputSpec AInput, InputSpec BInput, OutputSpec Output>
+ALWI void binary_sfpu(IterationShape shape) {
+    static_assert(is_dest_only_op_v<SfpuBinOp>, "binary_sfpu<Op, ...>: Op must be a DEST-only SFPU binary element");
+    eltwise_chain(shape, CopyTile<AInput>{}, CopyTile<BInput, Dst::D1>{}, SfpuBinOp{}, PackTile<Output>{});
+}
+
+template <InputSpec Input, OutputSpec Output>
+ALWI void copy(IterationShape shape) {
+    eltwise_chain(shape, CopyTile<Input>{}, PackTile<Output>{});
+}
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.inl
@@ -31,7 +31,9 @@ ALWI void square(IterationShape shape) {
 
 template <class SfpuOp, InputSpec Input, OutputSpec Output>
 ALWI void unary(IterationShape shape) {
-    static_assert(is_dest_only_op_v<SfpuOp>, "unary<SfpuOp, ...>: SfpuOp must be a DEST-only SFPU element");
+    static_assert(
+        is_unary_op_v<SfpuOp> && is_sfpu_op_v<SfpuOp>,
+        "unary<SfpuOp, ...>: SfpuOp must be a unary DEST operation");
     eltwise_chain(shape, CopyTile<Input>{}, SfpuOp{}, PackTile<Output>{});
 }
 
@@ -44,7 +46,9 @@ ALWI void typecast(IterationShape shape) {
 
 template <class SfpuBinOp, InputSpec AInput, InputSpec BInput, OutputSpec Output>
 ALWI void binary_sfpu(IterationShape shape) {
-    static_assert(is_dest_only_op_v<SfpuBinOp>, "binary_sfpu<Op, ...>: Op must be a DEST-only SFPU binary element");
+    static_assert(
+        is_binary_op_v<SfpuBinOp> && is_sfpu_op_v<SfpuBinOp>,
+        "binary_sfpu<Op, ...>: Op must be a binary DEST operation");
     eltwise_chain(shape, CopyTile<AInput>{}, CopyTile<BInput, Dst::D1>{}, SfpuBinOp{}, PackTile<Output>{});
 }
 

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file basic.hpp
+ * @brief Basic floating-point DEST-DEST SFPU binary chain elements.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <
+    Dst In0 = Dst::D0,
+    Dst In1 = Dst::D1,
+    Dst Out = Dst::D0,
+    ckernel::DstRoundingMode Rounding = ckernel::DstRoundingMode::Default>
+struct AddBinary;
+template <
+    Dst In0 = Dst::D0,
+    Dst In1 = Dst::D1,
+    Dst Out = Dst::D0,
+    ckernel::DstRoundingMode Rounding = ckernel::DstRoundingMode::Default>
+struct SubBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct MulBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct DivBinary;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.inl
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#define CKL_ELTWISE_BINARY_SFPU_BASIC
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.inl"
+#undef CKL_ELTWISE_BINARY_SFPU_BASIC

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file extended.hpp
+ * @brief Extended DEST-DEST SFPU binary chain elements.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct RemainderBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct RemainderInt32Binary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct FmodBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct FmodInt32Binary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct PowerBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct RsubBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct GcdBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LcmBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LeftShiftBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct RightShiftBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LogicalRightShiftBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BitwiseAndBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BitwiseOrBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BitwiseXorBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct XlogyBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct Atan2Binary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LtBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct GtBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LeBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct GeBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct EqBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct NeBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LtIntBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct GtIntBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LeIntBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct GeIntBinary;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.inl
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#define CKL_ELTWISE_BINARY_SFPU_EXTENDED
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.inl"
+#undef CKL_ELTWISE_BINARY_SFPU_EXTENDED

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/int.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/int.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file int.hpp
+ * @brief Integer arithmetic DEST-DEST SFPU binary chain elements.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct AddIntBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct SubIntBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct MulIntBinary;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct RsubIntBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct DivInt32Binary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct DivInt32FloorBinary;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct DivInt32TruncBinary;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/int.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/int.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/int.inl
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#define CKL_ELTWISE_BINARY_SFPU_INT
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.inl"
+#undef CKL_ELTWISE_BINARY_SFPU_INT

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file minmax.hpp
+ * @brief Floating-point and integer DEST-DEST min/max chain elements.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BinaryMax;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BinaryMin;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BinaryMaxInt32;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BinaryMaxUint32;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BinaryMinInt32;
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct BinaryMinUint32;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.inl
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#define CKL_ELTWISE_BINARY_SFPU_MINMAX
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.inl"
+#undef CKL_ELTWISE_BINARY_SFPU_MINMAX

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file sfpu.hpp
+ * @brief Umbrella include for DEST-DEST SFPU binary chain elements.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/int.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/minmax.hpp"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/sfpu.inl
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_BASIC)
+#include "api/compute/eltwise_binary_sfpu.h"
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_MINMAX)
+#include "api/compute/binary_max_min.h"
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_INT)
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_EXTENDED)
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#endif
+
+namespace compute_kernel_lib {
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_BASIC)
+template <Dst In0, Dst In1, Dst Out, ckernel::DstRoundingMode Rounding>
+struct AddBinary : BinaryOp<AddBinary<In0, In1, Out, Rounding>, In0, In1, Out> {
+    static ALWI void init() { add_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        add_binary_tile<Rounding>(
+            to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out, ckernel::DstRoundingMode Rounding>
+struct SubBinary : BinaryOp<SubBinary<In0, In1, Out, Rounding>, In0, In1, Out> {
+    static ALWI void init() { sub_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        sub_binary_tile<Rounding>(
+            to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct MulBinary : BinaryOp<MulBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { mul_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        mul_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct DivBinary : BinaryOp<DivBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { div_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        div_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_MINMAX)
+// binary_max_tile / binary_min_tile — SFPU two-DEST max/min into third DEST slot.
+template <Dst In0, Dst In1, Dst Out>
+struct BinaryMax : BinaryOp<BinaryMax<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_max_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_max_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct BinaryMin : BinaryOp<BinaryMin<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_min_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_min_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_INT)
+// ============================================================================
+// Integer-typed binary ops (DataFormat-templated).
+// One struct per OpConfig::SfpuBinaryOp integer variant.
+// ============================================================================
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct AddIntBinary : BinaryOp<AddIntBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { add_int_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        add_int_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct SubIntBinary : BinaryOp<SubIntBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { sub_int_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        sub_int_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct MulIntBinary : BinaryOp<MulIntBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { mul_int_tile_init<DF>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        mul_int_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct RsubIntBinary : BinaryOp<RsubIntBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { rsub_int_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        rsub_int_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// Integer division family (int32 only — no DataFormat template).
+template <Dst In0, Dst In1, Dst Out>
+struct DivInt32Binary : BinaryOp<DivInt32Binary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { div_int32_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        div_int32_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct DivInt32FloorBinary : BinaryOp<DivInt32FloorBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { div_int32_floor_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        div_int32_floor_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct DivInt32TruncBinary : BinaryOp<DivInt32TruncBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { div_int32_trunc_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        div_int32_trunc_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_EXTENDED)
+// Remainder / fmod (float + int32 variants).
+template <Dst In0, Dst In1, Dst Out>
+struct RemainderBinary : BinaryOp<RemainderBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { remainder_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        remainder_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct RemainderInt32Binary : BinaryOp<RemainderInt32Binary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { remainder_int32_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        remainder_int32_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct FmodBinary : BinaryOp<FmodBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { fmod_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        fmod_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct FmodInt32Binary : BinaryOp<FmodInt32Binary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { fmod_int32_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        fmod_int32_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// Power (float pow), RsubBinary (float reverse subtract).
+template <Dst In0, Dst In1, Dst Out>
+struct PowerBinary : BinaryOp<PowerBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { power_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        power_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct RsubBinary : BinaryOp<RsubBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { rsub_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        rsub_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// GCD / LCM (int).
+template <Dst In0, Dst In1, Dst Out>
+struct GcdBinary : BinaryOp<GcdBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { gcd_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        gcd_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct LcmBinary : BinaryOp<LcmBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { lcm_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        lcm_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// Bit shift (DataFormat-templated).
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct LeftShiftBinary : BinaryOp<LeftShiftBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_shift_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_left_shift_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct RightShiftBinary : BinaryOp<RightShiftBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_shift_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_right_shift_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct LogicalRightShiftBinary : BinaryOp<LogicalRightShiftBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_shift_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_logical_right_shift_tile<DF>(
+            to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// Bitwise (DataFormat-templated).
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct BitwiseAndBinary : BinaryOp<BitwiseAndBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_bitwise_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        bitwise_and_binary_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct BitwiseOrBinary : BinaryOp<BitwiseOrBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_bitwise_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        bitwise_or_binary_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <DataFormat DF, Dst In0, Dst In1, Dst Out>
+struct BitwiseXorBinary : BinaryOp<BitwiseXorBinary<DF, In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_bitwise_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        bitwise_xor_binary_tile<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_MINMAX)
+// Integer max/min variants (BinaryMax/BinaryMin above cover float).
+template <Dst In0, Dst In1, Dst Out>
+struct BinaryMaxInt32 : BinaryOp<BinaryMaxInt32<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_max_int32_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_max_int32_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct BinaryMaxUint32 : BinaryOp<BinaryMaxUint32<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_max_uint32_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_max_uint32_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct BinaryMinInt32 : BinaryOp<BinaryMinInt32<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_min_int32_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_min_int32_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct BinaryMinUint32 : BinaryOp<BinaryMinUint32<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { binary_min_uint32_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        binary_min_uint32_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+#endif
+
+#if defined(CKL_ELTWISE_BINARY_SFPU_EXTENDED)
+// Misc float ops.
+template <Dst In0, Dst In1, Dst Out>
+struct XlogyBinary : BinaryOp<XlogyBinary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { xlogy_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        xlogy_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct Atan2Binary : BinaryOp<Atan2Binary<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { atan2_binary_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        atan2_binary_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// Comparison ops — float-only variants (output 0/1 mask).
+#define _CKL_BIN_CMP_FLOAT(Name, llk_call, init_call)                                                  \
+    template <Dst In0, Dst In1, Dst Out>                                                               \
+    struct Name : BinaryOp<Name<In0, In1, Out>, In0, In1, Out> {                                       \
+        static ALWI void init() { init_call(); }                                                       \
+        static ALWI void exec_impl(uint32_t slot_offset) {                                             \
+            llk_call(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset); \
+        }                                                                                              \
+    };
+
+_CKL_BIN_CMP_FLOAT(LtBinary, lt_binary_tile, lt_binary_tile_init)
+_CKL_BIN_CMP_FLOAT(GtBinary, gt_binary_tile, gt_binary_tile_init)
+_CKL_BIN_CMP_FLOAT(LeBinary, le_binary_tile, le_binary_tile_init)
+_CKL_BIN_CMP_FLOAT(GeBinary, ge_binary_tile, ge_binary_tile_init)
+_CKL_BIN_CMP_FLOAT(EqBinary, eq_binary_tile, eq_binary_tile_init)
+_CKL_BIN_CMP_FLOAT(NeBinary, ne_binary_tile, ne_binary_tile_init)
+
+#undef _CKL_BIN_CMP_FLOAT
+
+// Comparison ops — integer (DataFormat-templated init+call).
+#define _CKL_BIN_CMP_INT(Name, llk_call, init_call)                                                        \
+    template <DataFormat DF, Dst In0, Dst In1, Dst Out>                                                    \
+    struct Name : BinaryOp<Name<DF, In0, In1, Out>, In0, In1, Out> {                                       \
+        static ALWI void init() { init_call<DF>(); }                                                       \
+        static ALWI void exec_impl(uint32_t slot_offset) {                                                 \
+            llk_call<DF>(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset); \
+        }                                                                                                  \
+    };
+
+_CKL_BIN_CMP_INT(LtIntBinary, lt_int_tile, lt_int_tile_init)
+_CKL_BIN_CMP_INT(GtIntBinary, gt_int_tile, gt_int_tile_init)
+_CKL_BIN_CMP_INT(LeIntBinary, le_int_tile, le_int_tile_init)
+_CKL_BIN_CMP_INT(GeIntBinary, ge_int_tile, ge_int_tile_init)
+
+#undef _CKL_BIN_CMP_INT
+
+// Quant / Requant / Dequant are not currently included. (Their init() takes a runtime zero_point,
+// but that is NOT the blocker — the chain dispatches init on the element instance, so a
+// runtime-stateful init is already supported; Dropout does exactly this with its seed.)
+#endif
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/broadcast/bcast.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/broadcast/bcast.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file bcast.hpp
+ * @brief Unary broadcast chain element and convenience entry point.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+namespace detail {
+
+constexpr uint32_t unary_bcast_config_bits(BroadcastDim dim, InputSpec input_spec, Dst dst) noexcept;
+
+template <uint32_t Cb, uint32_t ConfigBits>
+struct UnaryBcastImpl;
+
+}  // namespace detail
+
+template <BroadcastDim Dim, InputSpec Input, Dst DstSlot = Dst::D0>
+using UnaryBcast = detail::UnaryBcastImpl<Input.cb_id, detail::unary_bcast_config_bits(Dim, Input, DstSlot)>;
+
+template <BroadcastDim Dim, InputSpec Input, OutputSpec Output>
+ALWI void unary_bcast(IterationShape shape);
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/broadcast/bcast.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/broadcast/bcast.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/broadcast/bcast.inl
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/bcast.h"
+
+namespace compute_kernel_lib {
+
+namespace detail {
+
+struct UnaryBcastConfig {
+    using DimField = ConfigField<BroadcastDim, first_config_bit, BroadcastDim::Scalar>;
+    using InputField = ConfigField<uint16_t, DimField::end, static_cast<uint16_t>(InputSpecConfig::storage_mask)>;
+    using DstField = ConfigField<Dst, InputField::end, Dst::D15>;
+
+    uint32_t bits;
+
+    constexpr UnaryBcastConfig(BroadcastDim dim, InputSpec input_spec, Dst dst) noexcept :
+        bits(DimField::encode(dim) | InputField::encode(InputSpecConfig::encode(input_spec)) | DstField::encode(dst)) {}
+    constexpr explicit UnaryBcastConfig(uint32_t encoded) noexcept : bits(encoded) {}
+
+    constexpr BroadcastDim dim() const noexcept { return DimField::decode(bits); }
+    constexpr InputSpec input_spec(uint32_t cb_id) const noexcept {
+        return InputSpecConfig::decode(InputField::decode(bits), cb_id);
+    }
+    constexpr Dst dst() const noexcept { return DstField::decode(bits); }
+};
+
+constexpr uint32_t unary_bcast_config_bits(BroadcastDim dim, InputSpec input_spec, Dst dst) noexcept {
+    return UnaryBcastConfig{dim, input_spec, dst}.bits;
+}
+
+}  // namespace detail
+
+template <uint32_t Cb, uint32_t ConfigBits>
+struct detail::UnaryBcastImpl : InputStream, UnaryBcastTag {
+    static constexpr UnaryBcastConfig Config{ConfigBits};
+    static constexpr BroadcastDim Dim = Config.dim();
+    static constexpr InputSpec Input = Config.input_spec(Cb);
+    static constexpr Dst DstSlot = Config.dst();
+    static constexpr WaitPolicy Wait = Input.wait;
+    static constexpr PopPolicy Pop = Input.pop;
+    static constexpr InputTileMapping Mapping = Input.mapping;
+    static constexpr TileAddressing Addressing = Input.addressing;
+    using Base = InputStream;
+    using Base::tile_base;
+
+    static_assert(to_u32(DstSlot) < DEST_AUTO_LIMIT, "UnaryBcast: DEST slot exceeds DEST_AUTO_LIMIT");
+    static_assert(
+        is_legal_input_policy_for_mapping(Mapping, Wait, Pop),
+        "UnaryBcast: input wait/pop pair is incompatible with input tile mapping");
+    static_assert(
+        Addressing == TileAddressing::Direct || is_legal_input_policy_with_base(Wait, Pop),
+        "UnaryBcast: TileAddressing::Offset requires an upfront, deferred-pop, or caller-managed input pair");
+    static_assert(
+        Addressing != TileAddressing::Strided || ((Wait == WaitPolicy::None) && (Pop == PopPolicy::None)),
+        "UnaryBcast: TileAddressing::Strided requires caller-managed (None, None) input policies");
+
+    static constexpr uint32_t dfb = Cb;
+    static constexpr uint32_t dfb_a_id() { return Cb; }
+    static constexpr InputSpec a_input() { return Input; }
+
+    static constexpr uint32_t reconfig_srca_dfb = Input.reconfig == DataFormatReconfig::Enabled ? Cb : NO_PREV_DFB;
+    static constexpr uint32_t reconfig_srcb_dfb = Input.reconfig == DataFormatReconfig::Enabled ? Cb : NO_PREV_DFB;
+
+    constexpr UnaryBcastImpl() noexcept = default;
+    constexpr explicit UnaryBcastImpl(uint32_t base) noexcept : Base(base) {}
+    constexpr explicit UnaryBcastImpl(StridedTileRange range) noexcept : Base(range) {}
+
+    static ALWI void init() {
+        constexpr ckernel::BroadcastType bt = static_cast<ckernel::BroadcastType>(static_cast<uint8_t>(Dim));
+        ::unary_bcast_init<bt>(Cb);
+    }
+
+    ALWI void exec(uint32_t i_flat, uint32_t ht, uint32_t wt, uint32_t slot_offset) const {
+        constexpr ckernel::BroadcastType bt = static_cast<ckernel::BroadcastType>(static_cast<uint8_t>(Dim));
+        const uint32_t in_idx = tile_base_value<Addressing>(tile_base) +
+                                detail::input_idx<Mapping, Wait, Pop, Addressing>(i_flat, ht, wt, row_stride);
+        ::unary_bcast<bt>(Cb, in_idx, to_u32(DstSlot) + slot_offset);
+    }
+
+    static constexpr uint32_t lane_width = to_u32(DstSlot) + 1;
+};
+
+template <BroadcastDim Dim, InputSpec Input, OutputSpec Output>
+ALWI void unary_bcast(IterationShape shape) {
+    eltwise_chain(shape, UnaryBcast<Dim, Input>{}, PackTile<Output>{});
+}
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/chain.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/chain.inl
@@ -1,0 +1,3306 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file chain.inl
+ * @brief Implementation of the eltwise chain pipeline + chain element types + traits.
+ *
+ * Included from `chain.hpp`. Do NOT include directly.
+ */
+
+#include <climits>
+#include <type_traits>
+#include <utility>
+
+// Impl-only includes (the public chain.hpp surface — element decls + enums — needs
+// none of these; they live here, with the implementation that uses them).
+#include "api/compute/bcast.h"
+#include "api/dataflow/dataflow_buffer.h"  // DataflowBuffer — chain routes CB sync (wait/pop/reserve/push) through it
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/pack.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/compute/reg_api.h"
+#include "api/compute/tile_move_copy.h"
+
+namespace compute_kernel_lib {
+
+constexpr bool is_legal_input_policy(WaitPolicy wait, PopPolicy pop) noexcept {
+    switch (wait) {
+        case WaitPolicy::None: return pop == PopPolicy::None || pop == PopPolicy::PerTile || pop == PopPolicy::AtEnd;
+        case WaitPolicy::PerTile: return pop == PopPolicy::None || pop == PopPolicy::PerTile;
+        case WaitPolicy::PerBlockSize: return pop == PopPolicy::PerBlockSize;
+        case WaitPolicy::Upfront: return pop == PopPolicy::None || pop == PopPolicy::PerTile || pop == PopPolicy::AtEnd;
+        case WaitPolicy::Cumulative: return pop == PopPolicy::None || pop == PopPolicy::AtEnd;
+    }
+    return false;
+}
+
+constexpr bool is_legal_output_policy(ReservePolicy reserve, PushPolicy push) noexcept {
+    switch (reserve) {
+        case ReservePolicy::None: return push == PushPolicy::None || push == PushPolicy::AtEnd;
+        case ReservePolicy::PerTile: return push == PushPolicy::PerTile;
+        case ReservePolicy::PerBlockSize: return push == PushPolicy::PerBlockSize;
+        case ReservePolicy::Upfront:
+            return push == PushPolicy::PerTile || push == PushPolicy::PerBlockSize || push == PushPolicy::AtEnd;
+        case ReservePolicy::PerOuter: return push == PushPolicy::PerOuter;
+        case ReservePolicy::OneUpfront: return push == PushPolicy::OneAtEnd;
+    }
+    return false;
+}
+
+constexpr bool is_legal_input_policy_for_mapping(InputTileMapping kind, WaitPolicy wait, PopPolicy pop) noexcept {
+    if (!is_legal_input_policy(wait, pop)) {
+        return false;
+    }
+
+    switch (kind) {
+        case InputTileMapping::Block:
+            return (wait == WaitPolicy::PerBlockSize && pop == PopPolicy::PerBlockSize) ||
+                   (wait == WaitPolicy::Cumulative && (pop == PopPolicy::None || pop == PopPolicy::AtEnd)) ||
+                   ((wait == WaitPolicy::Upfront || wait == WaitPolicy::None) &&
+                    (pop == PopPolicy::None || pop == PopPolicy::AtEnd));
+        case InputTileMapping::Row:
+            return (wait == WaitPolicy::Upfront || wait == WaitPolicy::None) &&
+                   (pop == PopPolicy::None || pop == PopPolicy::AtEnd);
+        case InputTileMapping::Col:
+            return (wait == WaitPolicy::PerTile && pop == PopPolicy::PerTile) ||
+                   ((wait == WaitPolicy::Upfront || wait == WaitPolicy::None) &&
+                    (pop == PopPolicy::None || pop == PopPolicy::AtEnd));
+        case InputTileMapping::Scalar:
+            return wait == WaitPolicy::None || wait == WaitPolicy::PerTile || wait == WaitPolicy::Upfront;
+    }
+    return false;
+}
+
+constexpr bool is_legal_input_policy_with_base(WaitPolicy wait, PopPolicy pop) noexcept {
+    if (wait == WaitPolicy::Upfront) {
+        return pop == PopPolicy::None || pop == PopPolicy::PerTile || pop == PopPolicy::AtEnd;
+    }
+    return wait == WaitPolicy::None && (pop == PopPolicy::None || pop == PopPolicy::AtEnd);
+}
+
+constexpr bool is_legal_output_policy_with_base(ReservePolicy reserve, PushPolicy push) noexcept {
+    if (reserve == ReservePolicy::None) {
+        return push == PushPolicy::None || push == PushPolicy::AtEnd;
+    }
+    return reserve == ReservePolicy::Upfront && push == PushPolicy::AtEnd;
+}
+
+// A reader that stages (or cumulatively grows) a multi-tile window owns that CB
+// front for the duration of the chain. Two independently managed readers cannot
+// own the same front: their wait/pop schedules would alias. Keep this derived
+// from input() itself so new reader elements and policy additions
+// cannot drift through copied per-element flags.
+constexpr bool input_owns_cb_window(InputSpec spec) noexcept {
+    return spec.wait == WaitPolicy::Upfront ||
+           ((spec.wait == WaitPolicy::Cumulative) && (spec.pop == PopPolicy::AtEnd));
+}
+
+// A peer which pops a staged CB front invalidates the owner's absolute window indices.
+// Keep this separate from ownership: non-popping readers may safely observe the same window.
+constexpr bool input_pops_cb_front(InputSpec spec) noexcept { return spec.pop != PopPolicy::None; }
+
+constexpr uint32_t to_u32(Dst s) noexcept { return static_cast<uint32_t>(s); }
+
+namespace detail {
+
+constexpr uint32_t bit_width_for_max(uint32_t max_value) noexcept {
+    uint32_t width = 1;
+    while ((max_value >>= 1) != 0) {
+        ++width;
+    }
+    return width;
+}
+
+constexpr uint32_t low_bits_mask(uint32_t width) noexcept { return (uint32_t{1} << width) - uint32_t{1}; }
+
+inline constexpr uint32_t first_config_bit = 0;
+
+template <class Value, uint32_t Shift, Value MaxValue>
+struct ConfigField {
+    static constexpr uint32_t max_value = static_cast<uint32_t>(MaxValue);
+    static constexpr uint32_t width = bit_width_for_max(max_value);
+    static_assert(Shift + width <= sizeof(uint32_t) * CHAR_BIT, "ConfigField exceeds uint32_t storage");
+
+    static constexpr uint32_t value_mask = low_bits_mask(width);
+    static constexpr uint32_t end = Shift + width;
+
+    static constexpr uint32_t encode(Value value) noexcept {
+        return (static_cast<uint32_t>(value) & value_mask) << Shift;
+    }
+
+    static constexpr Value decode(uint32_t storage) noexcept {
+        return static_cast<Value>((storage >> Shift) & value_mask);
+    }
+};
+
+struct InputSpecConfig {
+    // Buffer identity remains a separate Impl NTTP; this key packs only operand behavior.
+    using WaitField = ConfigField<WaitPolicy, first_config_bit, WaitPolicy::Cumulative>;
+    using PopField = ConfigField<PopPolicy, WaitField::end, PopPolicy::AtEnd>;
+    using MappingField = ConfigField<InputTileMapping, PopField::end, InputTileMapping::Scalar>;
+    using AddressingField = ConfigField<TileAddressing, MappingField::end, TileAddressing::Strided>;
+    using ReconfigField = ConfigField<DataFormatReconfig, AddressingField::end, DataFormatReconfig::Enabled>;
+
+    static constexpr uint32_t used_bits = ReconfigField::end;
+    static constexpr uint32_t storage_mask = low_bits_mask(used_bits);
+    static_assert(used_bits <= sizeof(uint16_t) * CHAR_BIT, "InputSpec behavior exceeds uint16_t storage");
+
+    static constexpr uint16_t encode(InputSpec spec) noexcept {
+        return static_cast<uint16_t>(
+            WaitField::encode(spec.wait) | PopField::encode(spec.pop) | MappingField::encode(spec.mapping) |
+            AddressingField::encode(spec.addressing) | ReconfigField::encode(spec.reconfig));
+    }
+
+    static constexpr InputSpec decode(uint16_t storage, uint32_t cb_id) noexcept;
+};
+
+struct OutputSpecConfig {
+    // Buffer identity remains a separate Impl NTTP; this key packs only operand behavior.
+    using ReserveField = ConfigField<ReservePolicy, first_config_bit, ReservePolicy::OneUpfront>;
+    using PushField = ConfigField<PushPolicy, ReserveField::end, PushPolicy::OneAtEnd>;
+    using ReconfigField = ConfigField<DataFormatReconfig, PushField::end, DataFormatReconfig::Enabled>;
+    using ReluField = ConfigField<PackRelu, ReconfigField::end, PackRelu::Zero>;
+    using L1AccumulationField = ConfigField<L1Accumulation, ReluField::end, L1Accumulation::AddToExisting>;
+    using DestAccumulationField = ConfigField<DestAccumulation, L1AccumulationField::end, DestAccumulation::WholeShape>;
+    using AddressingField = ConfigField<TileAddressing, DestAccumulationField::end, TileAddressing::Strided>;
+
+    static constexpr uint32_t used_bits = AddressingField::end;
+    static constexpr uint32_t storage_mask = low_bits_mask(used_bits);
+    static_assert(used_bits <= sizeof(uint16_t) * CHAR_BIT, "OutputSpec behavior exceeds uint16_t storage");
+
+    static constexpr uint16_t encode(OutputSpec spec) noexcept {
+        return static_cast<uint16_t>(
+            ReserveField::encode(spec.reserve) | PushField::encode(spec.push) | ReconfigField::encode(spec.reconfig) |
+            ReluField::encode(spec.relu) | L1AccumulationField::encode(spec.l1_accumulation) |
+            DestAccumulationField::encode(spec.dest_accumulation) | AddressingField::encode(spec.addressing));
+    }
+
+    static constexpr OutputSpec decode(uint16_t storage, uint32_t cb_id) noexcept;
+};
+
+}  // namespace detail
+
+namespace detail {
+
+constexpr InputSpec InputSpecConfig::decode(uint16_t storage, uint32_t cb_id) noexcept {
+    return {
+        cb_id,
+        WaitField::decode(storage),
+        PopField::decode(storage),
+        MappingField::decode(storage),
+        ReconfigField::decode(storage),
+        AddressingField::decode(storage)};
+}
+
+constexpr OutputSpec OutputSpecConfig::decode(uint16_t storage, uint32_t cb_id) noexcept {
+    return {
+        cb_id,
+        ReserveField::decode(storage),
+        PushField::decode(storage),
+        ReconfigField::decode(storage),
+        AddressingField::decode(storage),
+        DestAccumulationField::decode(storage),
+        L1AccumulationField::decode(storage),
+        ReluField::decode(storage)};
+}
+
+}  // namespace detail
+
+constexpr InputSpec input(
+    uint32_t cb_id,
+    WaitPolicy wait,
+    PopPolicy pop,
+    InputTileMapping mapping,
+    DataFormatReconfig reconfig,
+    TileAddressing addressing) noexcept {
+    return {cb_id, wait, pop, mapping, reconfig, addressing};
+}
+
+constexpr InputSpec input(uint32_t cb_id, WaitPolicy wait, PopPolicy pop, DataFormatReconfig reconfig) noexcept {
+    return input(cb_id, wait, pop, InputTileMapping::Scalar, reconfig);
+}
+
+constexpr BroadcastInputSpec input(InputSpec input_spec, BroadcastDim broadcast) noexcept {
+    return {input_spec, broadcast};
+}
+
+constexpr BroadcastInputSpec input(
+    uint32_t cb_id,
+    BroadcastDim broadcast,
+    WaitPolicy wait,
+    PopPolicy pop,
+    InputTileMapping mapping,
+    DataFormatReconfig reconfig,
+    TileAddressing addressing) noexcept {
+    return {input(cb_id, wait, pop, mapping, reconfig, addressing), broadcast};
+}
+
+constexpr BroadcastInputSpec input(
+    uint32_t cb_id, BroadcastDim broadcast, WaitPolicy wait, PopPolicy pop, DataFormatReconfig reconfig) noexcept {
+    return input(input(cb_id, wait, pop, reconfig), broadcast);
+}
+
+constexpr OutputSpec output(
+    uint32_t cb_id,
+    ReservePolicy reserve,
+    PushPolicy push,
+    DataFormatReconfig reconfig,
+    TileAddressing addressing,
+    DestAccumulation dest_accumulation,
+    L1Accumulation l1_accumulation,
+    PackRelu relu) noexcept {
+    return {cb_id, reserve, push, reconfig, addressing, dest_accumulation, l1_accumulation, relu};
+}
+
+
+namespace detail {
+
+struct CopyTileConfig {
+    using DstField = ConfigField<Dst, first_config_bit, Dst::D15>;
+    using InputField = ConfigField<uint16_t, DstField::end, static_cast<uint16_t>(InputSpecConfig::storage_mask)>;
+
+    uint32_t bits;
+
+    constexpr CopyTileConfig(Dst dst, InputSpec input_spec) noexcept :
+        bits(DstField::encode(dst) | InputField::encode(InputSpecConfig::encode(input_spec))) {}
+    constexpr explicit CopyTileConfig(uint32_t encoded) noexcept : bits(encoded) {}
+
+    constexpr Dst dst() const noexcept { return DstField::decode(bits); }
+    constexpr InputSpec input_spec(uint32_t cb_id) const noexcept {
+        return InputSpecConfig::decode(InputField::decode(bits), cb_id);
+    }
+};
+
+struct PackTileConfig {
+    using OutputField = ConfigField<uint16_t, first_config_bit, static_cast<uint16_t>(OutputSpecConfig::storage_mask)>;
+    using DstField = ConfigField<Dst, OutputField::end, Dst::D15>;
+
+    uint32_t bits;
+
+    constexpr PackTileConfig(OutputSpec output_spec, Dst dst) noexcept :
+        bits(OutputField::encode(OutputSpecConfig::encode(output_spec)) | DstField::encode(dst)) {}
+    constexpr explicit PackTileConfig(uint32_t encoded) noexcept : bits(encoded) {}
+
+    constexpr OutputSpec output_spec(uint32_t cb_id) const noexcept {
+        return OutputSpecConfig::decode(OutputField::decode(bits), cb_id);
+    }
+    constexpr Dst dst() const noexcept { return DstField::decode(bits); }
+};
+
+struct BinaryFpuConfig {
+    using OpField = ConfigField<BinaryFpuOp, first_config_bit, BinaryFpuOp::Mul>;
+    using BroadcastField = ConfigField<BroadcastDim, OpField::end, BroadcastDim::Scalar>;
+    using AInputField =
+        ConfigField<uint16_t, BroadcastField::end, static_cast<uint16_t>(InputSpecConfig::storage_mask)>;
+    using BInputField = ConfigField<uint16_t, AInputField::end, static_cast<uint16_t>(InputSpecConfig::storage_mask)>;
+    using DstField = ConfigField<Dst, BInputField::end, Dst::D15>;
+    using AccumulationField = ConfigField<DestAccumulation, DstField::end, DestAccumulation::WholeShape>;
+
+    uint32_t bits;
+
+    constexpr BinaryFpuConfig(
+        BinaryFpuOp op, BroadcastDim bcast, InputSpec a, InputSpec b, Dst dst, DestAccumulation accumulation) noexcept :
+        bits(
+            OpField::encode(op) | BroadcastField::encode(bcast) | AInputField::encode(InputSpecConfig::encode(a)) |
+            BInputField::encode(InputSpecConfig::encode(b)) | DstField::encode(dst) |
+            AccumulationField::encode(accumulation)) {}
+    constexpr explicit BinaryFpuConfig(uint32_t encoded) noexcept : bits(encoded) {}
+
+    constexpr BinaryFpuOp op() const noexcept { return OpField::decode(bits); }
+    constexpr BroadcastDim broadcast() const noexcept { return BroadcastField::decode(bits); }
+    constexpr InputSpec a_input_spec(uint32_t cb_id) const noexcept {
+        return InputSpecConfig::decode(AInputField::decode(bits), cb_id);
+    }
+    constexpr InputSpec b_input_spec(uint32_t cb_id) const noexcept {
+        return InputSpecConfig::decode(BInputField::decode(bits), cb_id);
+    }
+    constexpr Dst dst() const noexcept { return DstField::decode(bits); }
+    constexpr DestAccumulation accumulation() const noexcept { return AccumulationField::decode(bits); }
+};
+
+struct DestReuseBinaryConfig {
+    using OpField = ConfigField<BinaryFpuOp, first_config_bit, BinaryFpuOp::Mul>;
+    using ReuseField = ConfigField<DestReuseType, OpField::end, DestReuseType::DEST_TO_SRCB>;
+    using InputField = ConfigField<uint16_t, ReuseField::end, static_cast<uint16_t>(InputSpecConfig::storage_mask)>;
+    using DstField = ConfigField<Dst, InputField::end, Dst::D15>;
+
+    uint32_t bits;
+
+    constexpr DestReuseBinaryConfig(BinaryFpuOp op, DestReuseType reuse, InputSpec input_spec, Dst dst) noexcept :
+        bits(
+            OpField::encode(op) | ReuseField::encode(reuse) | InputField::encode(InputSpecConfig::encode(input_spec)) |
+            DstField::encode(dst)) {}
+    constexpr explicit DestReuseBinaryConfig(uint32_t encoded) noexcept : bits(encoded) {}
+
+    constexpr BinaryFpuOp op() const noexcept { return OpField::decode(bits); }
+    constexpr DestReuseType reuse() const noexcept { return ReuseField::decode(bits); }
+    constexpr InputSpec input_spec(uint32_t cb_id) const noexcept {
+        return InputSpecConfig::decode(InputField::decode(bits), cb_id);
+    }
+    constexpr Dst dst() const noexcept { return DstField::decode(bits); }
+};
+
+constexpr uint32_t copy_tile_config_bits(Dst dst, InputSpec input_spec) noexcept {
+    return CopyTileConfig{dst, input_spec}.bits;
+}
+
+constexpr uint32_t pack_tile_config_bits(OutputSpec output_spec, Dst dst) noexcept {
+    return PackTileConfig{output_spec, dst}.bits;
+}
+
+constexpr uint32_t binary_fpu_config_bits(
+    BinaryFpuOp op, InputSpec a, BroadcastInputSpec b, Dst dst, DestAccumulation accumulation) noexcept {
+    return BinaryFpuConfig{op, b.broadcast, a, b.input_spec, dst, accumulation}.bits;
+}
+
+constexpr uint32_t dest_reuse_binary_config_bits(
+    BinaryFpuOp op, DestReuseType reuse, InputSpec input_spec, Dst dst) noexcept {
+    return DestReuseBinaryConfig{op, reuse, input_spec, dst}.bits;
+}
+
+}  // namespace detail
+
+// Internal sentinel + type-list wrapper + chain-shape trait declarations. These are
+// implementation detail of the chain pipeline — no chain caller references them, so they
+// live here rather than on the public chain.hpp surface.
+inline constexpr uint32_t INVALID_DFB = 0xFFFFFFFFu;      // "no CB on this slot" (== NO_PREV_DFB); a real
+                                                          // tt::CBIndex is 0..31, so 0xFFFFFFFF never aliases one.
+inline constexpr uint32_t CONDITIONAL_DFB = 0xFFFFFFFEu;  // a runtime branch may leave either the old or a new
+                                                          // format programmed; force the following element to
+                                                          // re-establish its expected input-side format.
+
+template <class... Es>
+struct EltwiseChain;  // typed list of elements (defined below)
+
+template <class Chain>
+struct chain_has_duplicate_upfront_dfbs;
+template <class Chain>
+struct chain_pack_writes_collide;
+template <class Chain>
+struct chain_per_side_dfbs_consistent;
+template <class Chain>
+struct chain_math_mop_uniform;
+template <class Chain>
+struct chain_sfpu_inits_uniform;
+template <class Chain>
+struct chain_hoist_math_mop;
+template <class Chain>
+struct chain_hoist_sfpu;
+template <class Chain>
+struct chain_hoist_pack;
+
+template <class Chain>
+inline constexpr bool chain_has_duplicate_upfront_cbs_v = chain_has_duplicate_upfront_dfbs<Chain>::value;
+template <class Chain>
+inline constexpr bool chain_pack_writes_collide_v = chain_pack_writes_collide<Chain>::value;
+template <class Chain>
+inline constexpr bool chain_per_side_cbs_consistent_v = chain_per_side_dfbs_consistent<Chain>::value;
+template <class Chain>
+inline constexpr bool chain_math_mop_uniform_v = chain_math_mop_uniform<Chain>::value;
+template <class Chain>
+inline constexpr bool chain_sfpu_inits_uniform_v = chain_sfpu_inits_uniform<Chain>::value;
+template <class Chain>
+inline constexpr bool chain_hoist_math_mop_v = chain_hoist_math_mop<Chain>::value;
+template <class Chain>
+inline constexpr bool chain_hoist_sfpu_v = chain_hoist_sfpu<Chain>::value;
+template <class Chain>
+inline constexpr bool chain_hoist_pack_v = chain_hoist_pack<Chain>::value;
+
+// =============================================================================
+// Marker tag hierarchy (data direction → kind)
+// =============================================================================
+// Internal classification scaffolding — chain callers never name these. Concrete
+// element types (declared on the .hpp surface) inherit the leaf tags; the chain
+// pipeline + SFPU/FPU op-helper headers classify elements via the is_*_op_v
+// predicates below.
+
+/// Element reads ≥1 CB. Pure marker — concrete elements declare `dfb_a_id()` and
+/// (if binary) `dfb_b_id()`. No stub defaults, so a missing accessor is a compile
+/// error rather than a silently-wrong default CB id.
+struct CbReaderTag {};
+/// Element writes to a CB. Pure marker — concrete elements declare `pack_dfb_id()`.
+/// No stub defaults.
+struct CbWriterTag {};
+/// Element neither reads nor writes a CB (DEST-internal). No CB-id stubs: the
+/// chain pipeline SFINAE-detects `dfb_a_id()` / `dfb_b_id()` /
+/// `pack_dfb_id()` on the element directly.
+struct DestOnlyTag {};
+
+/// Marker mixed into runtime-conditional wrappers. It is orthogonal to the element-kind
+/// hierarchy so the wrapped element keeps its ordinary reader / DEST-only classification.
+struct RuntimeConditionalTag {};
+
+/// Marks a runtime-conditional sequence handled as one chain stage. Unlike a
+/// single-element runtime wrapper, the sequence performs its own ordered walk
+/// so one runtime decision guards every element in the selected branch.
+struct RuntimeConditionalSequenceTag {};
+
+/// Pure CB → DEST move (no compute).
+struct CopyTileTag : CbReaderTag {};
+/// 2 CBs → DEST FPU compute (add/sub/mul + bcast variants).
+struct BinaryFpuTag : CbReaderTag {};
+/// 1 CB + DEST → DEST FPU compute (op-specific reuse-dest tiles).
+struct DestReuseBinaryTag : CbReaderTag {};
+/// 1 CB → DEST row/col/scalar broadcast (unary_bcast).
+struct UnaryBcastTag : CbReaderTag {};
+
+/// DEST → CB store (pack_tile / pack_tile_block).
+struct PackTileTag : CbWriterTag {};
+
+/// Constant → DEST (no CB read).
+struct FillTileTag : DestOnlyTag {};
+/// DEST-only element whose init seeds the shared hardware PRNG.
+struct PrngSeedTag {};
+/// RNG → DEST (no CB read).
+struct RandTileTag : DestOnlyTag, PrngSeedTag {};
+
+// Trait predicates — which predicate drives each chain decision:
+//
+//  Sweep / decision                                            | predicate
+//  ------------------------------------------------------------|---------------------------
+//  Duplicate upfront-CB check across all CB-consumers          | is_cb_reader_op_v
+//  Output-CB collision / fan-out across all writers            | is_cb_writer_op_v
+//  Hoist-safety "chain shape is CopyTile + 1 SFPU op"          | is_copy_tile_op_v
+//  FPU-clash reinit                                            | is_binary_fpu_op_v ‖
+//                                                              | is_dest_reuse_binary_op_v ‖
+//                                                              | is_unary_bcast_op_v
+//  Hoist exclusion: element issues a pack inside the loop      | is_pack_tile_op_v
+//  No CB lifecycle to check — pure DEST internal               | is_dest_only_op_v
+template <class T>
+inline constexpr bool is_cb_reader_op_v = std::is_base_of_v<CbReaderTag, T>;
+template <class T>
+inline constexpr bool is_cb_writer_op_v = std::is_base_of_v<CbWriterTag, T>;
+template <class T>
+inline constexpr bool is_dest_only_op_v = std::is_base_of_v<DestOnlyTag, T>;
+template <class T>
+inline constexpr bool is_copy_tile_op_v = std::is_base_of_v<CopyTileTag, T>;
+template <class T>
+inline constexpr bool is_binary_fpu_op_v = std::is_base_of_v<BinaryFpuTag, T>;
+template <class T>
+inline constexpr bool is_dest_reuse_binary_op_v = std::is_base_of_v<DestReuseBinaryTag, T>;
+template <class T>
+inline constexpr bool is_unary_bcast_op_v = std::is_base_of_v<UnaryBcastTag, T>;
+template <class T>
+inline constexpr bool is_pack_tile_op_v = std::is_base_of_v<PackTileTag, T>;
+template <class T>
+inline constexpr bool is_fill_tile_op_v = std::is_base_of_v<FillTileTag, T>;
+template <class T>
+inline constexpr bool is_rand_tile_op_v = std::is_base_of_v<RandTileTag, T>;
+template <class T>
+inline constexpr bool is_prng_seed_op_v = std::is_base_of_v<PrngSeedTag, T>;
+template <class T>
+inline constexpr bool is_runtime_conditional_op_v = std::is_base_of_v<RuntimeConditionalTag, T>;
+template <class T>
+inline constexpr bool is_runtime_conditional_sequence_op_v = std::is_base_of_v<RuntimeConditionalSequenceTag, T>;
+
+struct DisabledChainElement;  // defined in optional.hpp — the inert compile-time-disabled Optional marker
+
+/// Chain-element classification is exhaustive: every element must carry exactly one
+/// data-direction kind tag (CB reader, CB writer, or DEST-only). The tag-less
+/// `DisabledChainElement` is the one sanctioned exception. Anything else without a kind tag
+/// would flow through every pipeline stage as an `UnselectedElement` no-op — a silently inert
+/// chain position — so `eltwise_chain` rejects it up front instead.
+template <class T>
+inline constexpr bool is_classified_chain_element_v =
+    (uint32_t{is_cb_reader_op_v<T>} + uint32_t{is_cb_writer_op_v<T>} + uint32_t{is_dest_only_op_v<T>}) == 1 ||
+    std::is_same_v<T, DisabledChainElement>;
+/// SFPU (DEST-internal, non-RNG, non-fill) element predicate. SFPU ops inherit
+/// from `DestOnlyTag` via `UnaryOp` / `BinaryOp` / `TernaryOp`;
+/// Fill / PRNG-seeding elements share the `DestOnlyTag` lineage but their init programs
+/// fill state or the shared PRNG, not the SFPU MOP / ADDR_MOD_7 lane. The hoist gate counts distinct
+/// SFPU init types — `is_sfpu_op_v` is the predicate.
+template <class T>
+inline constexpr bool is_sfpu_op_v = is_dest_only_op_v<T> && !is_fill_tile_op_v<T> && !is_prng_seed_op_v<T>;
+
+/// FPU-kind (non-CopyTile, FPU-MOP-touching) element predicate. Groups
+/// `BinaryFpu`, `DestReuseBinary`, `UnaryBcast` — each programs the FPU MOP /
+/// ADDR_MOD_0..3 lane on init via the binary-op init path.
+template <class T>
+inline constexpr bool is_fpu_kind_op_v =
+    is_binary_fpu_op_v<T> || is_dest_reuse_binary_op_v<T> || is_unary_bcast_op_v<T>;
+
+/// MATH-MOP-touching element predicate. Groups every element whose init
+/// programs the MATH MOP / ADDR_MOD_0..3 lane: `CopyTile` (via
+/// `copy_tile_to_dst_init_short`) and the FPU-kind ops (`BinaryFpu`,
+/// `DestReuseBinary`, `UnaryBcast`). The hoist gate requires all such
+/// elements in a chain (including the CopyTile-versus-FPU init clash) to be
+/// the same instantiated type — otherwise the boot-time fold leaves only the
+/// last init's MOP programmed and earlier elements run with the wrong MOP.
+template <class T>
+inline constexpr bool is_math_mop_op_v = is_copy_tile_op_v<T> || is_fpu_kind_op_v<T>;
+
+// =============================================================================
+// tile_base_value — orthogonal tile-index offset extractor (impl helper)
+// =============================================================================
+/// Extract the offset value stored on an element. Returns 0 (compile-time-folded) when the
+/// element's `Addressing` is `Direct`, so the `+base` term and the stored field vanish.
+template <TileAddressing Addressing>
+ALWI uint32_t tile_base_value([[maybe_unused]] uint32_t stored) noexcept {
+    if constexpr (Addressing == TileAddressing::Direct) {
+        return 0u;
+    } else {
+        return stored;
+    }
+}
+
+// =============================================================================
+// CRTP bases — UnaryOp / BinaryOp / TernaryOp
+// =============================================================================
+//
+// Dispatch contract: the DEST-only op bases expose `void exec(uint32_t i, uint32_t slot_offset) const`
+// and forward to a static `exec_impl(uint32_t slot_offset)` supplied by the derived op; runtime-param
+// ops (Power, Hardtanh, …) override `exec` directly to capture instance state. (CB elements — CopyTile /
+// BinaryFpu — define a wider exec: (i_flat, ht, wt, slot_offset) or the per-side form.) Defining
+// neither is a compile error (no silent fallthrough).
+//
+//   template <Approx A = Approx::Exact, Approx F = Approx::Fast, Dst Slot = Dst::D0>
+//   struct Exp : UnaryOp<Exp<A, Slot>, Slot> {
+//       static void init()                        { exp_tile_init<A == Approx::Fast, F == Approx::Fast>(); }
+//       static void exec_impl(uint32_t slot_off)  { exp_tile<A == Approx::Fast, F == Approx::Fast>(to_u32(Slot) +
+//       slot_off); }
+//   };
+
+template <class Derived, Dst Slot>
+struct UnaryOp : DestOnlyTag {
+    static_assert(
+        to_u32(Slot) < DEST_AUTO_LIMIT, "UnaryOp: DEST slot exceeds compile-time DEST capacity (DEST_AUTO_LIMIT)");
+
+    static constexpr uint32_t max_dst() { return to_u32(Slot); }
+    /// Per-lane DEST footprint. Used by chain to pick auto BlockSize.
+    /// Default = `to_u32(Slot) + 1` (op writes only Slot). Override per-op when the
+    /// op references more slots (e.g. Mask uses DataSlot AND DataSlot+1).
+    static constexpr uint32_t lane_width = to_u32(Slot) + 1;
+
+    /// Pipeline dispatch — forwards to `Derived::exec_impl(slot_offset)`. Override
+    /// in derived to consume runtime payload (per-instance fields). `slot_offset`
+    /// is added by the chain to shift DEST writes into lane `j` when `BlockSize > 1`;
+    /// `BlockSize == 1` passes 0 (per-tile shape).
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { Derived::exec_impl(slot_offset); }
+};
+
+template <class Derived, Dst In0, Dst In1, Dst Out>
+struct BinaryOp : DestOnlyTag {
+    static_assert(
+        to_u32(In0) < DEST_AUTO_LIMIT && to_u32(In1) < DEST_AUTO_LIMIT && to_u32(Out) < DEST_AUTO_LIMIT,
+        "BinaryOp: DEST slot exceeds compile-time DEST capacity (DEST_AUTO_LIMIT)");
+    // NOTE: slot-distinctness is *not* enforced here. SFPU binary ops (AddBinary /
+    // SubBinary / MulBinary / DivBinary) routinely operate in-place (Out == In0 or
+    // Out == In1) and even `In0 == In1` is legal (e.g. squaring). The FPU binary
+    // chain element (`BinaryFpu`) reads its inputs from CBs, not DEST slots, so it
+    // also doesn't need In0 != In1. If a future op truly requires distinct DEST
+    // slots, it should enforce that locally rather than at the CRTP base.
+
+    static constexpr uint32_t max_dst() {
+        uint32_t a = to_u32(In0), b = to_u32(In1), c = to_u32(Out);
+        return a > b ? (a > c ? a : c) : (b > c ? b : c);
+    }
+    static constexpr uint32_t lane_width = max_dst() + 1;
+
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { Derived::exec_impl(slot_offset); }
+};
+
+template <class Derived, Dst In0, Dst In1, Dst In2, Dst Out>
+struct TernaryOp : DestOnlyTag {
+    static_assert(
+        to_u32(In0) < DEST_AUTO_LIMIT && to_u32(In1) < DEST_AUTO_LIMIT && to_u32(In2) < DEST_AUTO_LIMIT &&
+            to_u32(Out) < DEST_AUTO_LIMIT,
+        "TernaryOp: DEST slot exceeds compile-time DEST capacity (DEST_AUTO_LIMIT)");
+    // NOTE: slot-distinctness is *not* enforced here (mirrors BinaryOp). SFPU ternary
+    // ops (where / lerp / addcmul / addcdiv) routinely write Out into one of the input
+    // slots in-place — the kernel reads all three inputs before overwriting. If a
+    // future op truly requires distinct DEST slots, enforce it locally rather than at
+    // the CRTP base.
+
+    static constexpr uint32_t lane_width = []() {
+        uint32_t m = to_u32(In0);
+        if (to_u32(In1) > m) {
+            m = to_u32(In1);
+        }
+        if (to_u32(In2) > m) {
+            m = to_u32(In2);
+        }
+        if (to_u32(Out) > m) {
+            m = to_u32(Out);
+        }
+        return m + 1;
+    }();
+
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { Derived::exec_impl(slot_offset); }
+};
+
+// =============================================================================
+// Compile-time prev-CB tracking — drives the reconfig fold
+// =============================================================================
+//
+// Each element exposes uniform static accessors for the CB it routes to each Side
+// (SrcA / SrcB / Pack), letting the pipeline compute the most recent CB on each side
+// before a given element. NO_PREV_DFB is the "doesn't touch this side" sentinel.
+
+inline constexpr uint32_t NO_PREV_DFB = 0xFFFFFFFFu;
+
+enum class Side : uint8_t { SrcA, SrcB, Pack };
+
+namespace detail {
+
+// =============================================================================
+// A0. 2D tile-mapping helpers (InputTileMapping → tile index / upfront window)
+//
+// Compile-time-elided `idx` / `window` (defined below), inlined by every CB-reader's
+// `exec` / `wait_upfront` — `if constexpr` collapses to one arithmetic op at run time.
+// `TileBase` layers a runtime offset on top. Policy validation lives in
+// `is_legal_input_policy_for_mapping`, next to the wait/pop allow-list.
+// =============================================================================
+
+template <InputTileMapping M, TileAddressing Addressing>
+ALWI constexpr uint32_t idx(
+    [[maybe_unused]] uint32_t flat_index,
+    [[maybe_unused]] uint32_t row,
+    [[maybe_unused]] uint32_t column,
+    [[maybe_unused]] uint32_t row_stride) noexcept {
+    if constexpr (M == InputTileMapping::Scalar) {
+        return 0;
+    } else if constexpr (M == InputTileMapping::Row) {
+        return column;
+    } else if constexpr (M == InputTileMapping::Col) {
+        if constexpr (Addressing == TileAddressing::Strided) {
+            return row * row_stride;
+        } else {
+            return row;
+        }
+    } else {
+        static_assert(M == InputTileMapping::Block);
+        if constexpr (Addressing == TileAddressing::Strided) {
+            return row * row_stride + column;
+        } else {
+            return flat_index;
+        }
+    }
+}
+
+// PerTile + Col is a row-stream lifecycle rather than an Ht-tile staged window. Its front advances
+// at row boundaries, so every access within the current row uses front index 0. Other Col policies
+// retain ordinary absolute-row indexing.
+template <InputTileMapping M, WaitPolicy Wait, PopPolicy Pop, TileAddressing Addressing>
+ALWI constexpr uint32_t input_idx(uint32_t flat_index, uint32_t row, uint32_t column, uint32_t row_stride) noexcept {
+    if constexpr (M == InputTileMapping::Col && Wait == WaitPolicy::PerTile && Pop == PopPolicy::PerTile) {
+        return 0;
+    } else {
+        return idx<M, Addressing>(flat_index, row, column, row_stride);
+    }
+}
+
+template <InputTileMapping M>
+ALWI constexpr uint32_t window([[maybe_unused]] uint32_t Ht, [[maybe_unused]] uint32_t Wt) noexcept {
+    if constexpr (M == InputTileMapping::Block) {
+        return Ht * Wt;
+    } else if constexpr (M == InputTileMapping::Row) {
+        return Wt;
+    } else if constexpr (M == InputTileMapping::Col) {
+        return Ht;
+    } else {
+        return 1u;  // Scalar
+    }
+}
+
+// =============================================================================
+// B. Static cb-id / dst-slot extraction predicates per element
+//
+// Every CB-reader element exposes dfb_a_id() (primary CB) + a_input(). Binary readers also expose
+// dfb_b_id() (secondary CB) + b_input(); unary readers omit them — the defaults below supply
+// dfb_b = INVALID_DFB (0xFFFFFFFF, "no CB"; not 0, which is a real CB) and b_input = CallerManaged.
+// (default impls below cover non-CB-reader elements.)
+//
+// Every CB-writer element must expose:
+//   static constexpr uint32_t pack_dfb_id();
+//   static constexpr Dst pack_dst_slot;
+// (output addressing derives from the walk + TileAddressing, not a pack_output_index accessor.)
+// =============================================================================
+
+template <class T, class = void>
+struct has_dfb_a : std::false_type {};
+template <class T>
+struct has_dfb_a<T, std::void_t<decltype(T::dfb_a_id())>> : std::true_type {};
+
+template <class T, class = void>
+struct has_dfb_b : std::false_type {};
+template <class T>
+struct has_dfb_b<T, std::void_t<decltype(T::dfb_b_id())>> : std::true_type {};
+
+template <class T, class = void>
+struct has_pack_dfb : std::false_type {};
+template <class T>
+struct has_pack_dfb<T, std::void_t<decltype(T::pack_dfb_id())>> : std::true_type {};
+
+// Forward declarations — defined below (used by reader_pair_collide / writer_pair_collide
+// earlier in the file's flow).
+template <class E>
+constexpr uint32_t dfb_a_of();
+template <class E>
+constexpr uint32_t dfb_b_of();
+template <class E>
+constexpr uint32_t pack_dfb_of();
+
+// ChainTraits<Es...> — the one value-reflection aggregate for the whole chain (defined
+// once below, after the per-element accessors it reads). Forward-declared here so the
+// trait wrappers (chain_lane_width etc.) can name it.
+template <class... Es>
+struct ChainTraits;
+
+// =============================================================================
+// Per-Side prev-CB SFINAE probe
+//
+// `dfb_for_side<Side, E>` reads `E::reconfig_srca_dfb` / `_srcb_cb` / `_pack_cb`
+// when present, returns `NO_PREV_DFB` otherwise. Elements that don't declare the
+// accessors still participate in the fold transparently (treated as no-prev).
+// =============================================================================
+
+template <class E, class = void>
+struct has_reconfig_srca : std::false_type {};
+template <class E>
+struct has_reconfig_srca<E, std::void_t<decltype(E::reconfig_srca_dfb)>> : std::true_type {};
+
+template <class E, class = void>
+struct has_reconfig_srcb : std::false_type {};
+template <class E>
+struct has_reconfig_srcb<E, std::void_t<decltype(E::reconfig_srcb_dfb)>> : std::true_type {};
+
+template <class E, class = void>
+struct has_reconfig_pack : std::false_type {};
+template <class E>
+struct has_reconfig_pack<E, std::void_t<decltype(E::reconfig_pack_dfb)>> : std::true_type {};
+
+template <Side S, class E>
+constexpr uint32_t dfb_for_side() {
+    if constexpr (S == Side::SrcA) {
+        if constexpr (has_reconfig_srca<E>::value) {
+            return E::reconfig_srca_dfb;
+        } else {
+            return NO_PREV_DFB;
+        }
+    } else if constexpr (S == Side::SrcB) {
+        if constexpr (has_reconfig_srcb<E>::value) {
+            return E::reconfig_srcb_dfb;
+        } else {
+            return NO_PREV_DFB;
+        }
+    } else {  // Pack
+        if constexpr (has_reconfig_pack<E>::value) {
+            return E::reconfig_pack_dfb;
+        } else {
+            return NO_PREV_DFB;
+        }
+    }
+}
+
+// True iff NO element in the pack requests any srca / srcb / pack reconfig — i.e. every element's
+// reconfig knob is None. Under InitReconfigOwner::Caller the chain emits zero reconfig, so a non-None knob
+// is inert and lies about what the helper does; eltwise_chain uses this to forbid that, forcing the
+// caller to declare None — which honestly reflects "the chain does no reconfig, I own the format."
+template <class... Es>
+constexpr bool chain_requests_no_reconfig() {
+    return (
+        (dfb_for_side<Side::SrcA, Es>() == NO_PREV_DFB && dfb_for_side<Side::SrcB, Es>() == NO_PREV_DFB &&
+         dfb_for_side<Side::Pack, Es>() == NO_PREV_DFB) &&
+        ...);
+}
+
+// Per-side prev-CB history, last opt-in pack CB, and heterogeneous-pack detection are
+// single-sweep fields on `ChainTraits` (prev / last_pack_cb / pack_hetero), computed
+// once from the reflected ElemDesc array.
+
+}  // namespace detail
+
+// =============================================================================
+// 0. Operand streams — runtime state for driver-managed CB lifecycles
+//
+// Every CB-reader element's wait/pop hooks are a function of exactly one operand
+// tuple (Cb, Policy, Mapping, Addressing, tile_base); every CB-writer's reserve/push
+// hooks of one (Cb, Policy, Addressing, tile_base). Cb and the spec remain compile-time
+// element metadata for planning/reconfig. The existing chain workers emit the lifecycle
+// operations directly and pass the CB ids to DataflowBuffer as ordinary values; ALWI
+// inlining constant-folds those values and the policy gates without creating one
+// stream-method specialization per element configuration.
+//
+// Single-stream elements (CopyTile / DestReuseBinary / UnaryBcast) inherit the
+// non-template `InputStream` state; BinaryFpu holds two and the driver handles its
+// second input explicitly; PackTile inherits `OutputStream`.
+//
+// All policy gates below are a verbatim transcription of the per-element bodies —
+// a wrong gate is a hang or a PCC failure, never benign.
+// =============================================================================
+
+struct InputStream {
+    uint32_t tile_base = 0;
+    uint32_t row_stride = 0;
+
+    constexpr InputStream() noexcept = default;
+    constexpr explicit InputStream(uint32_t base) noexcept : tile_base(base) {}
+    constexpr explicit InputStream(StridedTileRange range) noexcept :
+        tile_base(range.base), row_stride(range.row_stride) {}
+};
+
+struct OutputStream {
+    uint32_t tile_base = 0;
+    uint32_t row_stride = 0;
+
+    constexpr OutputStream() noexcept = default;
+    constexpr explicit OutputStream(uint32_t base) noexcept : tile_base(base) {}
+    constexpr explicit OutputStream(StridedTileRange range) noexcept :
+        tile_base(range.base), row_stride(range.row_stride) {}
+};
+
+// =============================================================================
+// 1. CopyTile chain element
+// =============================================================================
+
+template <uint32_t Cb, uint32_t ConfigBits>
+struct detail::CopyTileImpl : InputStream, CopyTileTag {
+    static constexpr CopyTileConfig Config{ConfigBits};
+    static constexpr InputSpec Input = Config.input_spec(Cb);
+    static constexpr Dst DstSlot = Config.dst();
+    static constexpr WaitPolicy Wait = Input.wait;
+    static constexpr PopPolicy Pop = Input.pop;
+    static constexpr DataFormatReconfig Reconfig = Input.reconfig;
+    static constexpr InputTileMapping Mapping = Input.mapping;
+    static constexpr TileAddressing Addressing = Input.addressing;
+    using Base = InputStream;
+    using Base::tile_base;
+
+    // ---- compile-time validation ----
+    static_assert(to_u32(DstSlot) < DEST_AUTO_LIMIT, "CopyTile: DEST slot exceeds DEST_AUTO_LIMIT");
+    static_assert(
+        is_legal_input_policy_for_mapping(Mapping, Wait, Pop),
+        "CopyTile: input wait/pop pair is incompatible with input tile mapping");
+    // TileAddressing::Offset requires (Upfront, AtEnd)-family / (None, None) lifecycle — iter-dependent
+    // counts
+    // ((PerTile, PerTile)/(PerBlockSize, PerBlockSize)/Cumulative/Held{Stream,Cumulative}/(None, PerTile))
+    // can't compose with runtime base offsets. Caller must size CB to base+window.
+    static_assert(
+        Addressing == TileAddressing::Direct || is_legal_input_policy_with_base(Wait, Pop),
+        "CopyTile: TileAddressing::Offset requires an upfront, deferred-pop, or caller-managed input pair");
+    static_assert(
+        Addressing != TileAddressing::Strided || ((Wait == WaitPolicy::None) && (Pop == PopPolicy::None)),
+        "CopyTile: TileAddressing::Strided requires caller-managed (None, None) input policies");
+
+    static constexpr uint32_t dfb = Cb;
+    static constexpr uint32_t dfb_a_id() { return Cb; }
+    // CopyTile reads one CB front (srcA via dfb_a_id); srcB is absent.
+    static constexpr InputSpec a_input() { return Input; }
+
+    // Prev-CB fold: CopyTile loads CbA only. srcb/pack sides are absent -> dfb_for_side
+    // defaults them to NO_PREV_DFB.
+    static constexpr uint32_t reconfig_srca_dfb = (Reconfig == DataFormatReconfig::Enabled) ? Cb : NO_PREV_DFB;
+
+    constexpr CopyTileImpl() noexcept = default;
+    constexpr explicit CopyTileImpl(uint32_t base) noexcept : Base(base) {}
+    constexpr explicit CopyTileImpl(StridedTileRange range) noexcept : Base(range) {}
+
+    // ---- chain pipeline hooks ----
+    static ALWI void init() { copy_tile_init(Cb); }
+
+    ALWI void exec(uint32_t i_flat, uint32_t ht, uint32_t wt, uint32_t slot_offset) const {
+        const uint32_t in_idx = tile_base_value<Addressing>(tile_base) +
+                                detail::input_idx<Mapping, Wait, Pop, Addressing>(i_flat, ht, wt, row_stride);
+        copy_tile(Cb, in_idx, to_u32(DstSlot) + slot_offset);
+    }
+
+    static constexpr uint32_t lane_width = to_u32(DstSlot) + 1;
+
+    // The chain driver emits wait/pop operations from the metadata above and the
+    // runtime `tile_base` inherited from InputStream.
+};
+
+// =============================================================================
+// 2. PackTile chain element
+// =============================================================================
+
+template <uint32_t Cb, uint32_t ConfigBits>
+struct detail::PackTileImpl : OutputStream, PackTileTag {
+    static constexpr PackTileConfig Config{ConfigBits};
+    static constexpr OutputSpec Output = Config.output_spec(Cb);
+    static constexpr ReservePolicy Reserve = Output.reserve;
+    static constexpr PushPolicy Push = Output.push;
+    static constexpr DataFormatReconfig Reconfig = Output.reconfig;
+    static constexpr PackRelu Relu = Output.relu;
+    static constexpr L1Accumulation L1AccumulationMode = Output.l1_accumulation;
+    static constexpr DestAccumulation DestAccumulationMode = Output.dest_accumulation;
+    static constexpr Dst DstSlot = Config.dst();
+    static constexpr TileAddressing Addressing = Output.addressing;
+    using Base = OutputStream;
+    using Base::tile_base;
+    // Walk vs pinned output addressing is derived from reserve policy: upfront-reserve
+    // policies and caller-pre-reserved windows write distinct tiles; front-advancing policies stay pinned.
+    static constexpr bool walk = L1AccumulationMode == L1Accumulation::Disabled &&
+                                 (Reserve == ReservePolicy::Upfront || Reserve == ReservePolicy::None);
+
+    static_assert(to_u32(DstSlot) < DEST_AUTO_LIMIT, "PackTile: DEST slot exceeds DEST_AUTO_LIMIT");
+    static_assert(is_legal_output_policy(Reserve, Push), "PackTile: output reserve/push policy pair is invalid");
+    static_assert(
+        L1AccumulationMode == L1Accumulation::Disabled ||
+            ((Reserve == ReservePolicy::OneUpfront) && (Push == PushPolicy::OneAtEnd)) ||
+            ((Reserve == ReservePolicy::None) && (Push == PushPolicy::None)),
+        "PackTile: L1 accumulation requires (OneUpfront, OneAtEnd) or caller-managed (None, None)");
+    static_assert(
+        !((Reserve == ReservePolicy::OneUpfront) && (Push == PushPolicy::OneAtEnd)) ||
+            L1AccumulationMode != L1Accumulation::Disabled,
+        "PackTile: (OneUpfront, OneAtEnd) requires L1 accumulation");
+    static_assert(
+        DestAccumulationMode == DestAccumulation::Disabled ||
+            ((Reserve == ReservePolicy::PerOuter) && (Push == PushPolicy::PerOuter)) ||
+            ((Reserve == ReservePolicy::None) && (Push == PushPolicy::None)),
+        "PackTile: DEST accumulation requires (PerOuter, PerOuter) or caller-managed (None, None)");
+    static_assert(
+        !((Reserve == ReservePolicy::PerOuter) && (Push == PushPolicy::PerOuter)) ||
+            DestAccumulationMode != DestAccumulation::Disabled,
+        "PackTile: (PerOuter, PerOuter) requires DEST accumulation");
+    static_assert(
+        L1AccumulationMode == L1Accumulation::Disabled || DestAccumulationMode == DestAccumulation::Disabled,
+        "PackTile: L1 and DEST accumulation cannot be combined");
+    static_assert(
+        L1AccumulationMode == L1Accumulation::Disabled || Relu == PackRelu::Disabled,
+        "PackTile: pack ReLU cannot be combined with L1 accumulation");
+    // TileBase != None on pack side requires caller-managed-style lifecycle on the
+    // output CB (caller pre-reserved a window large enough for base + kind window).
+    // (PerTile, PerTile) / (PerBlockSize, PerBlockSize) reserve+push counts can't be inflated by a runtime base
+    // without per-iter bookkeeping the chain doesn't own.
+    static_assert(
+        Addressing == TileAddressing::Direct || is_legal_output_policy_with_base(Reserve, Push),
+        "PackTile: TileAddressing::Offset requires upfront, push-at-end, or caller-managed output policies");
+    static_assert(
+        Addressing != TileAddressing::Strided || ((Reserve == ReservePolicy::None) && (Push == PushPolicy::None)),
+        "PackTile: TileAddressing::Strided requires caller-managed (None, None) output policies");
+
+    static constexpr uint32_t dfb = Cb;
+    static constexpr uint32_t pack_dfb_id() { return Cb; }
+    static constexpr Dst pack_dst_slot = DstSlot;
+    static constexpr bool uses_l1_accumulation = L1AccumulationMode != L1Accumulation::Disabled;
+    static constexpr bool seeds_l1_accumulation = L1AccumulationMode == L1Accumulation::Enabled;
+    static constexpr bool manages_l1_accumulation_lifecycle =
+        ((Reserve == ReservePolicy::OneUpfront) && (Push == PushPolicy::OneAtEnd));
+    static constexpr bool uses_dest_accumulation_lifecycle = DestAccumulationMode != DestAccumulation::Disabled;
+    static constexpr bool manages_dest_accumulation_lifecycle =
+        ((Reserve == ReservePolicy::PerOuter) && (Push == PushPolicy::PerOuter));
+    static constexpr bool uses_pack_relu = Relu != PackRelu::Disabled;
+    static constexpr bool uses_per_block_pack =
+        ((Reserve == ReservePolicy::PerBlockSize) && (Push == PushPolicy::PerBlockSize));
+    // `walk` (walk vs pinned output addressing) is derived from output policy pair above.
+
+    // Prev-CB fold: PackTile writes pack-side; mark Cb under reconfig only when
+    // the user opted into pack reconfig (Output). Otherwise no pack reconfig is
+    // emitted — fold keeps prior pack target.
+    // srca/srcb absent -> dfb_for_side defaults them to NO_PREV_DFB; PackTile programs pack only.
+    static constexpr uint32_t reconfig_pack_dfb = (Reconfig == DataFormatReconfig::Enabled) ? Cb : NO_PREV_DFB;
+
+    constexpr PackTileImpl() noexcept = default;
+    constexpr explicit PackTileImpl(uint32_t base) noexcept : Base(base) {}
+    constexpr explicit PackTileImpl(StridedTileRange range) noexcept : Base(range) {}
+
+    static ALWI void configure_relu() {
+        if constexpr (Relu == PackRelu::Zero) {
+            pack_relu_config(ReluConfig::zero());
+        } else {
+            pack_relu_config(ReluConfig::none());
+        }
+    }
+
+    // Pack exec — walk the reserved output window (base + i_flat) for the upfront-reserve outputs
+    // (Bulk / ReserveAllPushPerTile / ReserveAllPushPerBlockSize) and ReserveNonePushEnd's caller-pre-reserved
+    // window, or stay pinned at base for the front-advancing policies (Streaming / PerBlockSize) whose CB front
+    // already advanced. TileAddressing adds base.
+    //
+    // OOO gating: the LLK's sequential pack path (out_of_order_output=false) derives its write
+    // address from an internal running `fifo_wr_tile_ptr` and IGNORES `out_idx` entirely. That is
+    // correct only when the intended index coincides with the sequential counter — i.e. when there
+    // is no base offset (walk: 0,1,2,…; pinned: 0). The moment `Addressing == Offset`, `out_idx` carries a
+    // non-coincident base that the sequential path would silently drop (data lands at index 0, not
+    // base). L1 accumulation also has to stay pinned to one output tile. Both cases use
+    // `pack_tile<true>`, which honors `out_idx`
+    // (addr = fifo_wr_ptr + page_size*out_idx - 1) without advancing the internal counter — exactly
+    // matching the explicit tile index we pass each iteration. Direct keeps the proven
+    // sequential path with zero behavior change.
+    ALWI void exec(uint32_t i_flat, uint32_t ht, uint32_t wt, uint32_t slot_offset) const {
+        const uint32_t base = tile_base_value<Addressing>(tile_base);
+        uint32_t out_idx;
+        if constexpr (Addressing == TileAddressing::Strided) {
+            out_idx = base + detail::idx<InputTileMapping::Block, TileAddressing::Strided>(i_flat, ht, wt, row_stride);
+        } else {
+            out_idx = walk ? (base + i_flat) : base;
+        }
+        pack_tile<
+            /*out_of_order_output=*/Addressing != TileAddressing::Direct || L1AccumulationMode != L1Accumulation::Disabled>(
+            to_u32(DstSlot) + slot_offset, Cb, out_idx);
+    }
+
+    static constexpr uint32_t lane_width = to_u32(DstSlot) + 1;
+
+    // The chain driver emits reserve/push operations from the metadata above and the
+    // runtime `tile_base` inherited from OutputStream.
+};
+
+// =============================================================================
+// 3. BinaryFpu chain element
+// =============================================================================
+
+template <uint32_t CbA, uint32_t CbB, uint32_t ConfigBits>
+struct detail::BinaryFpuImpl : BinaryFpuTag {
+    static constexpr BinaryFpuConfig Config{ConfigBits};
+    static constexpr InputSpec AInput = Config.a_input_spec(CbA);
+    static constexpr InputSpec BInput = Config.b_input_spec(CbB);
+    static constexpr BinaryFpuOp Op = Config.op();
+    static constexpr BroadcastDim Bcast = Config.broadcast();
+    static constexpr DestAccumulation Accumulation = Config.accumulation();
+    static constexpr WaitPolicy AWait = AInput.wait;
+    static constexpr PopPolicy APop = AInput.pop;
+    static constexpr WaitPolicy BWait = BInput.wait;
+    static constexpr PopPolicy BPop = BInput.pop;
+    static constexpr Dst DstSlot = Config.dst();
+    static constexpr InputTileMapping AMapping = AInput.mapping;
+    static constexpr InputTileMapping BMapping = BInput.mapping;
+    static constexpr TileAddressing AddressingA = AInput.addressing;
+    static constexpr TileAddressing AddressingB = BInput.addressing;
+    static_assert(to_u32(DstSlot) < DEST_AUTO_LIMIT, "BinaryFpu: DEST slot exceeds DEST_AUTO_LIMIT");
+    static_assert(
+        Accumulation == DestAccumulation::Disabled || DstSlot == Dst::D0,
+        "BinaryFpu: DEST accumulation requires Dst::D0");
+    static_assert(
+        is_legal_input_policy_for_mapping(AMapping, AWait, APop),
+        "BinaryFpu: A input wait/pop pair is incompatible with A input tile mapping");
+    static_assert(
+        is_legal_input_policy_for_mapping(BMapping, BWait, BPop),
+        "BinaryFpu: B input wait/pop pair is incompatible with B input tile mapping");
+    // same_dfb dedup safety: when CbA == CbB the B-side wait/pop is skipped. Matching
+    // indices ensure both sides walk the same shared-CB range; matching lifecycles ensure
+    // the retained A-side wait/pop schedule also satisfies B.
+    static_assert(
+        (CbA != CbB) || AMapping == BMapping,
+        "BinaryFpu: when CbA == CbB, AMapping and BMapping must match "
+        "(B-side wait/pop is deduped — asymmetric indices would under-wait).");
+    static_assert(
+        (CbA != CbB) || (AWait == BWait && APop == BPop),
+        "BinaryFpu: when CbA == CbB, AInput and BInput must use the same wait/pop policies "
+        "(B-side wait/pop is deduped).");
+    // Per-operand TileBase lifecycle compatibility — (PerTile, PerTile)/(PerBlockSize, PerBlockSize)/Cumulative
+    // can't compose with runtime base offsets (iter-dependent wait/pop counts).
+    static_assert(
+        AddressingA == TileAddressing::Direct || is_legal_input_policy_with_base(AWait, APop),
+        "BinaryFpu: AddressingA Offset requires upfront, deferred-pop, or caller-managed A policies");
+    static_assert(
+        AddressingB == TileAddressing::Direct || is_legal_input_policy_with_base(BWait, BPop),
+        "BinaryFpu: AddressingB Offset requires upfront, deferred-pop, or caller-managed B policies");
+    static_assert(
+        AddressingA != TileAddressing::Strided || ((AWait == WaitPolicy::None) && (APop == PopPolicy::None)),
+        "BinaryFpu: strided A input requires caller-managed (None, None) policies");
+    static_assert(
+        AddressingB != TileAddressing::Strided || ((BWait == WaitPolicy::None) && (BPop == PopPolicy::None)),
+        "BinaryFpu: strided B input requires caller-managed (None, None) policies");
+    // Per-block streaming uses chunk-local CB front. When the two sides use
+    // DIFFERENT regimes (one per-block → chunk-local index `j`; the other upfront /
+    // caller-managed → absolute index `base_tile + j`), the chain dispatcher
+    // resolves them separately via the 3-arg exec / exec overloads gated by
+    // `needs_per_side_idx`. Same-regime hits the 2-arg fast path.
+
+    static constexpr uint32_t dfb_a_id() { return CbA; }
+    static constexpr uint32_t dfb_b_id() { return CbB; }
+    static constexpr InputSpec a_input() { return AInput; }
+    static constexpr InputSpec b_input() { return BInput; }
+    static constexpr bool same_dfb = (CbA == CbB);
+    static constexpr bool uses_dest_accumulation = (Accumulation != DestAccumulation::Disabled);
+    static constexpr Dst accumulated_dst_slot = DstSlot;
+
+    // Per-side local-vs-absolute index resolution. When the two operands declare
+    // DIFFERENT regimes (A=PerBlock + B=Upfront, or vice versa), the chain calls
+    // the 3-arg exec / exec overload and passes both indices; each side picks.
+    // Same-regime falls through to the 2-arg forwarder.
+    static constexpr bool a_uses_local_idx = ((AWait == WaitPolicy::PerBlockSize) && (APop == PopPolicy::PerBlockSize));
+    static constexpr bool b_uses_local_idx = ((BWait == WaitPolicy::PerBlockSize) && (BPop == PopPolicy::PerBlockSize));
+    static constexpr bool needs_per_side_idx = (a_uses_local_idx != b_uses_local_idx);
+
+    // Prev-CB fold: BinaryFpu touches srca (CbA) and srcb (CbB) only. Pack-side
+    // reconfig is owned by the downstream PackTile element.
+    // — BinaryFpu writes to DEST, not to a CB, so it has no pack-side responsibility.
+    //
+    // Per-side selection (Input / SrcA / SrcB) lets the caller opt into a single-side
+    // fold when the other side is already programmed (by a previous chain element on
+    // the same side, or by external init).
+    static constexpr uint32_t reconfig_srca_dfb = (AInput.reconfig == DataFormatReconfig::Enabled) ? CbA : NO_PREV_DFB;
+    static constexpr uint32_t reconfig_srcb_dfb = (BInput.reconfig == DataFormatReconfig::Enabled) ? CbB : NO_PREV_DFB;
+    // pack side absent -> dfb_for_side defaults to NO_PREV_DFB (downstream PackTile owns pack).
+
+    InputStream a;
+    InputStream b;
+
+    constexpr BinaryFpuImpl() noexcept = default;
+    constexpr BinaryFpuImpl(uint32_t base_a, uint32_t base_b) noexcept : a(base_a), b(base_b) {}
+    constexpr explicit BinaryFpuImpl(uint32_t base_a) noexcept : a(base_a) {}
+    constexpr BinaryFpuImpl(StridedTileRange range_a, StridedTileRange range_b) noexcept : a(range_a), b(range_b) {}
+    constexpr BinaryFpuImpl(StridedTileRange range_a, uint32_t base_b) noexcept : a(range_a), b(base_b) {}
+    constexpr BinaryFpuImpl(uint32_t base_a, StridedTileRange range_b) noexcept : a(base_a), b(range_b) {}
+    constexpr explicit BinaryFpuImpl(StridedTileRange range_a) noexcept : a(range_a) {}
+
+    // Lifecycle fan-out lives in the chain driver. When same_dfb, it emits one
+    // physical wait/pop and uses max(base_a, base_b) for the shared window.
+
+    // ---- init / reconfig ----
+    // srca / srcb / pack reconfig are fold-driven (compile-time-elided
+    // when prev_*_cb == cur_*_cb). init() programs only the per-op LLK shape.
+    static ALWI void init() {
+        // Op-specific init.
+        if constexpr (Bcast == BroadcastDim::None) {
+            constexpr bool acc_to_dest = Accumulation != DestAccumulation::Disabled;
+            if constexpr (Op == BinaryFpuOp::Add) {
+                add_init(CbA, CbB, acc_to_dest);
+            } else if constexpr (Op == BinaryFpuOp::Sub) {
+                sub_init(CbA, CbB, acc_to_dest);
+            } else {
+                mul_init(CbA, CbB, static_cast<uint32_t>(acc_to_dest), __builtin_LINE());
+            }
+        } else {
+            // Use the *_init_short form from bcast.h:352-446 (math init + unpack init only,
+            // no hw_configure / pack_dest_init / sync_init — the full init is undefined
+            // mid-MAIN). The operand form reads the actual tensor shape from CB metadata via
+            // get_operand_tensor_shape, matching `add_bcast_rows_init` /
+            // `sub_bcast_cols_init` etc. exactly.
+            constexpr auto bt = static_cast<ckernel::BroadcastType>(static_cast<uint8_t>(Bcast));
+            constexpr auto et = (Op == BinaryFpuOp::Add)   ? ckernel::EltwiseBinaryType::ELWADD
+                                : (Op == BinaryFpuOp::Sub) ? ckernel::EltwiseBinaryType::ELWSUB
+                                                           : ckernel::EltwiseBinaryType::ELWMUL;
+            if constexpr (Op == BinaryFpuOp::Mul) {
+                MATH((llk_math_eltwise_binary_init<et, bt, MATH_FIDELITY>(
+                    CbA, CbB, Accumulation != DestAccumulation::Disabled)));
+            } else {
+                MATH((llk_math_eltwise_binary_init<et, bt, MathFidelity::LoFi>(
+                    CbA, CbB, Accumulation != DestAccumulation::Disabled)));
+            }
+            UNPACK((llk_unpack_AB_init<bt>(CbA, CbB)));
+        }
+    }
+
+    // Per-side tile mapping. AMapping drives a_idx, BMapping drives b_idx. The canonical
+    // bcast walk is A=Block (walks the tile range) + B=Scalar (pins the
+    // scaler/vector operand at tile 0). AddressingA / AddressingB add a runtime or
+    // compile-time base offset to the per-iter index. The 3-arg overload accepts a
+    // chunk-local index (`i_local`) and an absolute index (`i_abs`); each side
+    // picks via `a_uses_local_idx` / `b_uses_local_idx`. The 2-arg overload is
+    // the same-regime fast path and forwards with i_local == i_abs.
+    static constexpr uint32_t lane_width = to_u32(DstSlot) + 1;
+
+    // 2D variants — per-side index + window. 3-arg form takes both chunk-local
+    // (`i_local`) and absolute (`i_abs`) flat indices; each side picks via the
+    // per-side traits. `ht` is unchanged (always absolute row); `wt_local` /
+    // `wt_abs` cover the per-side column index when needed. Same-regime fast
+    // path forwards through the 2-arg overload.
+    ALWI void exec(
+        uint32_t i_flat_local,
+        uint32_t i_flat_abs,
+        uint32_t ht,
+        uint32_t wt_local,
+        uint32_t wt_abs,
+        uint32_t slot_offset) const {
+        const uint32_t a_flat = a_uses_local_idx ? i_flat_local : i_flat_abs;
+        const uint32_t b_flat = b_uses_local_idx ? i_flat_local : i_flat_abs;
+        const uint32_t a_wt = a_uses_local_idx ? wt_local : wt_abs;
+        const uint32_t b_wt = b_uses_local_idx ? wt_local : wt_abs;
+        const uint32_t a_idx = tile_base_value<AddressingA>(a.tile_base) +
+                               detail::input_idx<AMapping, AWait, APop, AddressingA>(a_flat, ht, a_wt, a.row_stride);
+        const uint32_t b_idx = tile_base_value<AddressingB>(b.tile_base) +
+                               detail::input_idx<BMapping, BWait, BPop, AddressingB>(b_flat, ht, b_wt, b.row_stride);
+        const uint32_t dst =
+            Accumulation != DestAccumulation::Disabled ? to_u32(DstSlot) : to_u32(DstSlot) + slot_offset;
+        if constexpr (Bcast == BroadcastDim::None) {
+            if constexpr (Op == BinaryFpuOp::Add) {
+                add_tiles(CbA, CbB, a_idx, b_idx, dst);
+            } else if constexpr (Op == BinaryFpuOp::Sub) {
+                sub_tiles(CbA, CbB, a_idx, b_idx, dst);
+            } else {
+                mul_tiles(CbA, CbB, a_idx, b_idx, dst);
+            }
+        } else {
+            constexpr auto bt = static_cast<ckernel::BroadcastType>(static_cast<uint8_t>(Bcast));
+            if constexpr (Op == BinaryFpuOp::Add) {
+                add_tiles_bcast<bt>(CbA, CbB, a_idx, b_idx, dst);
+            } else if constexpr (Op == BinaryFpuOp::Sub) {
+                sub_tiles_bcast<bt>(CbA, CbB, a_idx, b_idx, dst);
+            } else {
+                mul_tiles_bcast<bt>(CbA, CbB, a_idx, b_idx, dst);
+            }
+        }
+    }
+
+    ALWI void exec(uint32_t i_flat, uint32_t ht, uint32_t wt, uint32_t slot_offset) const {
+        exec(i_flat, i_flat, ht, wt, wt, slot_offset);
+    }
+};
+
+// =============================================================================
+// 5. DestReuseBinary chain element
+// =============================================================================
+
+template <uint32_t Cb, uint32_t ConfigBits>
+struct detail::DestReuseBinaryImpl : InputStream, DestReuseBinaryTag {
+    static constexpr DestReuseBinaryConfig Config{ConfigBits};
+    static constexpr BinaryFpuOp Op = Config.op();
+    static constexpr DestReuseType ReuseType = Config.reuse();
+    static constexpr InputSpec InputConfig = Config.input_spec(Cb);
+    static constexpr Dst DstSlot = Config.dst();
+    static constexpr WaitPolicy Wait = InputConfig.wait;
+    static constexpr PopPolicy Pop = InputConfig.pop;
+    static constexpr InputTileMapping Mapping = InputConfig.mapping;
+    static constexpr TileAddressing Addressing = InputConfig.addressing;
+    using Base = InputStream;
+    using Base::tile_base;
+
+    static_assert(to_u32(DstSlot) < DEST_AUTO_LIMIT, "DestReuseBinary: DEST slot exceeds DEST_AUTO_LIMIT");
+    static_assert(
+        is_legal_input_policy_for_mapping(Mapping, Wait, Pop),
+        "DestReuseBinary: input wait/pop pair is incompatible with input tile mapping");
+    static_assert(
+        Addressing == TileAddressing::Direct || is_legal_input_policy_with_base(Wait, Pop),
+        "DestReuseBinary: TileAddressing::Offset requires upfront, deferred-pop, or caller-managed input policies");
+    static_assert(
+        Addressing != TileAddressing::Strided || ((Wait == WaitPolicy::None) && (Pop == PopPolicy::None)),
+        "DestReuseBinary: TileAddressing::Strided requires caller-managed (None, None) input policies");
+
+    // The one CB feeds the src that DEST is NOT routed to: DEST_TO_SRCB -> CB on srcA (dfb_a),
+    // DEST_TO_SRCA -> CB on srcB (dfb_b). The other side is the DEST register, not a CB (INVALID_DFB).
+    static constexpr uint32_t dfb = Cb;
+    static constexpr uint32_t dfb_a_id() { return (ReuseType == DestReuseType::DEST_TO_SRCB) ? Cb : INVALID_DFB; }
+    static constexpr uint32_t dfb_b_id() { return (ReuseType == DestReuseType::DEST_TO_SRCA) ? Cb : INVALID_DFB; }
+    static constexpr InputSpec a_input() {
+        if constexpr (ReuseType == DestReuseType::DEST_TO_SRCB) {
+            return InputConfig;
+        }
+        return {
+            INVALID_DFB,
+            WaitPolicy::None,
+            PopPolicy::None,
+            InputTileMapping::Scalar,
+            DataFormatReconfig::Disabled,
+            TileAddressing::Direct};
+    }
+    static constexpr InputSpec b_input() {
+        if constexpr (ReuseType == DestReuseType::DEST_TO_SRCA) {
+            return InputConfig;
+        }
+        return {
+            INVALID_DFB,
+            WaitPolicy::None,
+            PopPolicy::None,
+            InputTileMapping::Scalar,
+            DataFormatReconfig::Disabled,
+            TileAddressing::Direct};
+    }
+
+    // Prev-CB fold: DestReuseBinary loads CB into srca (when DEST → srcb) or srcb
+    // (when DEST → srca). Reconfig only fires when opted in.
+    //
+    static constexpr uint32_t reconfig_srca_dfb =
+        (InputConfig.reconfig == DataFormatReconfig::Enabled && ReuseType == DestReuseType::DEST_TO_SRCB) ? Cb
+                                                                                                          : NO_PREV_DFB;
+    static constexpr uint32_t reconfig_srcb_dfb =
+        (InputConfig.reconfig == DataFormatReconfig::Enabled && ReuseType == DestReuseType::DEST_TO_SRCA) ? Cb
+                                                                                                          : NO_PREV_DFB;
+    // pack side absent -> dfb_for_side defaults to NO_PREV_DFB.
+
+    constexpr DestReuseBinaryImpl() noexcept = default;
+    constexpr explicit DestReuseBinaryImpl(uint32_t base) noexcept : Base(base) {}
+    constexpr explicit DestReuseBinaryImpl(StridedTileRange range) noexcept : Base(range) {}
+
+    // srca / srcb reconfig is fold-driven; init() programs only the per-op
+    // LLK shape.
+    static ALWI void init() {
+        constexpr auto reuse = (ReuseType == DestReuseType::DEST_TO_SRCA)
+                                   ? ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA
+                                   : ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB;
+        if constexpr (Op == BinaryFpuOp::Add) {
+            add_reuse_dest_init<reuse>(Cb);
+        } else if constexpr (Op == BinaryFpuOp::Sub) {
+            sub_reuse_dest_init<reuse>(Cb);
+        } else {
+            mul_reuse_dest_init<reuse>(Cb);
+        }
+    }
+
+    ALWI void exec(uint32_t i_flat, uint32_t ht, uint32_t wt, uint32_t slot_offset) const {
+        constexpr auto reuse = (ReuseType == DestReuseType::DEST_TO_SRCA)
+                                   ? ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCA
+                                   : ckernel::EltwiseBinaryReuseDestType::DEST_TO_SRCB;
+        const uint32_t in_idx = tile_base_value<Addressing>(tile_base) +
+                                detail::input_idx<Mapping, Wait, Pop, Addressing>(i_flat, ht, wt, row_stride);
+        if constexpr (Op == BinaryFpuOp::Add) {
+            add_reuse_dest_tiles<reuse>(Cb, in_idx, to_u32(DstSlot) + slot_offset);
+        } else if constexpr (Op == BinaryFpuOp::Sub) {
+            sub_reuse_dest_tiles<reuse>(Cb, in_idx, to_u32(DstSlot) + slot_offset);
+        } else {
+            mul_reuse_dest_tiles<reuse>(Cb, in_idx, to_u32(DstSlot) + slot_offset);
+        }
+    }
+
+    static constexpr uint32_t lane_width = to_u32(DstSlot) + 1;
+
+    // The chain driver emits wait/pop operations from the metadata above and the
+    // runtime `tile_base` inherited from InputStream.
+};
+
+// Fill and random elements live in their feature headers so their LLK dependencies
+// are absent from the base chain include cone.
+
+// =============================================================================
+// 8. EltwiseChain typed list — defined here, declared in .hpp
+// =============================================================================
+
+template <class... Es>
+struct EltwiseChain {
+    static constexpr size_t size = sizeof...(Es);
+};
+
+// =============================================================================
+// 9. Chain-shape trait predicates
+// =============================================================================
+
+// chain_lane_width — N-element fold. Max of per-element `lane_width`. The chain clamps block_size
+// at runtime so `block_size * chain_lane_width <= DEST_AUTO_LIMIT` (block_size is a runtime
+// IterationShape field, so this is a clamp, not a static_assert). Each element writes to
+// DEST[dst_slot + j * chain_lane_width] for lane j in [0, block_size).
+//
+// SFINAE fallback: elements that don't expose a `lane_width` member (caller-defined
+// chain elements that inherit directly from `CopyTileTag` / `PackTileTag` / `DestOnlyTag`
+// without inheriting from `UnaryOp`/`BinaryOp`/`TernaryOp` bases) default
+// to 1. Member ambiguity in caller-defined multiple-inheritance elements is sidestepped
+// by reading via this detector instead of `Es::lane_width` directly.
+namespace detail {
+template <class, class = void>
+struct elem_lane_width : std::integral_constant<uint32_t, 1> {};
+
+template <class E>
+struct elem_lane_width<E, std::void_t<decltype(E::lane_width)>> : std::integral_constant<uint32_t, E::lane_width> {};
+
+template <class E>
+constexpr uint32_t elem_lane_width_v = elem_lane_width<E>::value;
+}  // namespace detail
+
+template <class Chain>
+struct chain_lane_width;
+
+template <class... Es>
+struct chain_lane_width<EltwiseChain<Es...>>
+    : std::integral_constant<uint32_t, detail::ChainTraits<Es...>::lane_width> {};
+
+template <class Chain>
+inline constexpr uint32_t chain_lane_width_v = chain_lane_width<Chain>::value;
+
+template <class Chain>
+struct chain_transient_lane_width;
+
+template <class... Es>
+struct chain_transient_lane_width<EltwiseChain<Es...>>
+    : std::integral_constant<uint32_t, detail::ChainTraits<Es...>::transient_lane_width> {};
+
+template <class Chain>
+inline constexpr uint32_t chain_transient_lane_width_v = chain_transient_lane_width<Chain>::value;
+
+// chain_max_block_v — largest block_size that fits in DEST for this chain, given its
+// lane-width fold. Caller-facing compile-time constant: pass any value <= this to
+// the runtime `block_size` arg on `eltwise_chain`. Caller can `static_assert` their
+// chosen block against this value to recover the build-time DEST overflow signal.
+template <class Chain>
+struct chain_max_block;
+
+namespace detail {
+template <class... Es>
+constexpr uint32_t chain_max_block_value() {
+    using Traits = ChainTraits<Es...>;
+    if constexpr (Traits::any_dest_accumulation) {
+        if constexpr (Traits::transient_lane_width == 0) {
+            return ~uint32_t{0};
+        } else {
+            return (DEST_AUTO_LIMIT - 1) / Traits::transient_lane_width;
+        }
+    } else {
+        return DEST_AUTO_LIMIT / Traits::lane_width;
+    }
+}
+}  // namespace detail
+
+template <class... Es>
+struct chain_max_block<EltwiseChain<Es...>> : std::integral_constant<uint32_t, detail::chain_max_block_value<Es...>()> {
+};
+
+template <class Chain>
+inline constexpr uint32_t chain_max_block_v = chain_max_block<Chain>::value;
+
+// chain_supports_block — N-element fold. True when every CB lifecycle is compatible with a
+// multi-tile iteration. A block-invariant operand may stay held across the walk; a block-managed
+// operand synchronizes the block. Per-tile policies, however, synchronize one page while a blocked
+// iteration touches several, so those chains are safely clamped to block_size=1 at runtime (the
+// requested size is not a compile-time value).
+namespace detail {
+template <class E>
+constexpr InputSpec b_input_of();  // defined below (defaults to caller-managed)
+
+constexpr bool input_supports_block(InputSpec spec) {
+    return (spec.wait == WaitPolicy::Upfront && (spec.pop == PopPolicy::None || spec.pop == PopPolicy::AtEnd)) ||
+           (spec.wait == WaitPolicy::Cumulative && (spec.pop == PopPolicy::None || spec.pop == PopPolicy::AtEnd)) ||
+           (spec.wait == WaitPolicy::None && (spec.pop == PopPolicy::None || spec.pop == PopPolicy::AtEnd)) ||
+           (spec.wait == WaitPolicy::PerBlockSize && spec.pop == PopPolicy::PerBlockSize);
+}
+
+constexpr bool output_supports_block(OutputSpec spec) {
+    switch (spec.reserve) {
+        case ReservePolicy::None: return spec.push == PushPolicy::None || spec.push == PushPolicy::AtEnd;
+        case ReservePolicy::PerTile: return false;
+        case ReservePolicy::PerBlockSize: return spec.push == PushPolicy::PerBlockSize;
+        case ReservePolicy::Upfront: return spec.push == PushPolicy::PerBlockSize || spec.push == PushPolicy::AtEnd;
+        case ReservePolicy::PerOuter: return spec.push == PushPolicy::PerOuter;
+        case ReservePolicy::OneUpfront: return spec.push == PushPolicy::OneAtEnd;
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool element_supports_block() {
+    if constexpr (is_cb_reader_op_v<E>) {
+        return input_supports_block(E::a_input()) && input_supports_block(b_input_of<E>());
+    } else if constexpr (is_cb_writer_op_v<E>) {
+        return output_supports_block(E::Output);
+    } else {
+        return true;  // DEST-only elements do not own a CB lifecycle
+    }
+}
+
+}  // namespace detail
+
+// =============================================================================
+// ChainTraits — reflect each element once into an ElemDesc record, then derive every
+// value-based chain property as a field. Type-uniformity (chain_*_uniform) stays
+// separate — it reads element types, not values. Emission stays separate too.
+// All compile-time: the whole struct folds to constants (zero runtime cost).
+// =============================================================================
+namespace detail {
+
+// SFINAE accessor for PackTile's destination slot.
+template <class E, class = void>
+struct has_pack_dst_slot_m : std::false_type {};
+template <class E>
+struct has_pack_dst_slot_m<E, std::void_t<decltype(E::pack_dst_slot)>> : std::true_type {};
+template <class E>
+constexpr Dst pack_dst_slot_of() {
+    if constexpr (has_pack_dst_slot_m<E>::value) {
+        return E::pack_dst_slot;
+    } else {
+        return Dst::D0;
+    }
+}
+// b_input defaults to caller-managed (the unary-reader / no-srcB-CB case), so only
+// elements with a genuine srcB operand declare it.
+template <class E, class = void>
+struct has_b_input_m : std::false_type {};
+template <class E>
+struct has_b_input_m<E, std::void_t<decltype(E::b_input())>> : std::true_type {};
+template <class E>
+constexpr InputSpec b_input_of() {
+    if constexpr (has_b_input_m<E>::value) {
+        return E::b_input();
+    } else {
+        return {
+            INVALID_DFB,
+            WaitPolicy::None,
+            PopPolicy::None,
+            InputTileMapping::Scalar,
+            DataFormatReconfig::Disabled,
+            TileAddressing::Direct};
+    }
+}
+
+template <class E>
+constexpr bool a_owns_cb_window_of() {
+    if constexpr (is_cb_reader_op_v<E>) {
+        return input_owns_cb_window(E::a_input());
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool b_owns_cb_window_of() {
+    if constexpr (is_cb_reader_op_v<E>) {
+        return input_owns_cb_window(b_input_of<E>());
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool a_pops_cb_front_of() {
+    if constexpr (is_cb_reader_op_v<E>) {
+        return input_pops_cb_front(E::a_input());
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool b_pops_cb_front_of() {
+    if constexpr (is_cb_reader_op_v<E>) {
+        return input_pops_cb_front(b_input_of<E>());
+    }
+    return false;
+}
+
+// One plain-data descriptor per element — reflected once via the existing accessors.
+struct ElemDesc {
+    bool is_cb_reader;
+    bool is_pack;
+    uint32_t srca_cb;        // dfb_for_side<SrcA> (NO_PREV_DFB when not programmed) — per-side consistency + prev input
+    uint32_t srcb_cb;        // dfb_for_side<SrcB>
+    uint32_t pack_side_dfb;  // dfb_for_side<Pack> (reconfig_pack_dfb) — prev / last_pack / hetero input
+    uint32_t dfb_a;          // dfb_a_of (INVALID_DFB when n/a) — reader-collision input
+    uint32_t dfb_b;          // dfb_b_of (INVALID_DFB when n/a)
+    uint32_t pack_dfb;       // pack_dfb_of (INVALID_DFB when n/a) — writer-collision input
+    Dst pack_dst_slot;
+    bool uses_l1_accumulation;
+    bool seeds_l1_accumulation;
+    bool manages_l1_accumulation_lifecycle;
+    bool uses_dest_accumulation;
+    DestAccumulation dest_accumulation_mode;
+    Dst accumulated_dst_slot;
+    bool uses_dest_accumulation_lifecycle;
+    bool manages_dest_accumulation_lifecycle;
+    bool uses_pack_relu;
+    bool a_owns_cb_window;
+    bool b_owns_cb_window;
+    bool a_pops_cb_front;
+    bool b_pops_cb_front;
+    uint32_t lane_width;
+    uint32_t transient_lane_width;
+    bool supports_block;
+    uint32_t row_stream_input_a_cb;
+    uint32_t row_stream_input_b_cb;
+    bool wait_a_per_row;
+    bool wait_b_per_row;
+    bool pop_a_per_row;
+    bool pop_b_per_row;
+    bool reserve_per_outer;
+    bool push_per_outer;
+};
+
+template <class E>
+constexpr bool uses_l1_accumulation_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::uses_l1_accumulation;
+    }
+    return false;
+}
+template <class E>
+constexpr bool seeds_l1_accumulation_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::seeds_l1_accumulation;
+    }
+    return false;
+}
+template <class E>
+constexpr bool manages_l1_accumulation_lifecycle_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::manages_l1_accumulation_lifecycle;
+    }
+    return false;
+}
+template <class E>
+constexpr bool uses_dest_accumulation_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::uses_dest_accumulation;
+    }
+    return false;
+}
+template <class E>
+constexpr DestAccumulation dest_accumulation_mode_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::Accumulation;
+    } else if constexpr (is_pack_tile_op_v<E>) {
+        return E::DestAccumulationMode;
+    }
+    return DestAccumulation::Disabled;
+}
+template <class E>
+constexpr Dst accumulated_dst_slot_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::accumulated_dst_slot;
+    }
+    return Dst::D0;
+}
+template <class E>
+constexpr bool uses_dest_accumulation_lifecycle_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::uses_dest_accumulation_lifecycle;
+    }
+    return false;
+}
+template <class E>
+constexpr bool manages_dest_accumulation_lifecycle_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::manages_dest_accumulation_lifecycle;
+    }
+    return false;
+}
+template <class E>
+constexpr bool uses_pack_relu_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::uses_pack_relu;
+    }
+    return false;
+}
+template <class E>
+constexpr uint32_t transient_lane_width_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::uses_dest_accumulation ? 0u : elem_lane_width_v<E>;
+    } else if constexpr (is_pack_tile_op_v<E>) {
+        return 0u;
+    }
+    return elem_lane_width_v<E>;
+}
+
+template <class E>
+constexpr uint32_t row_stream_input_a_cb_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::dfb_a_id();
+    } else if constexpr (is_cb_reader_op_v<E>) {
+        return E::dfb;
+    } else {
+        return INVALID_DFB;
+    }
+}
+
+template <class E>
+constexpr uint32_t row_stream_input_b_cb_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        if constexpr (!E::same_dfb) {
+            return E::dfb_b_id();
+        }
+    }
+    return INVALID_DFB;
+}
+
+template <class E>
+constexpr bool wait_a_per_row_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::AWait == WaitPolicy::PerTile && E::APop == PopPolicy::PerTile && E::AMapping == InputTileMapping::Col;
+    } else if constexpr (is_runtime_conditional_sequence_op_v<E>) {
+        return false;
+    } else if constexpr (is_cb_reader_op_v<E>) {
+        return E::Wait == WaitPolicy::PerTile && E::Pop == PopPolicy::PerTile && E::Mapping == InputTileMapping::Col;
+    } else {
+        return false;
+    }
+}
+
+template <class E>
+constexpr bool wait_b_per_row_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        if constexpr (!E::same_dfb) {
+            return E::BWait == WaitPolicy::PerTile && E::BPop == PopPolicy::PerTile && E::BMapping == InputTileMapping::Col;
+        }
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool pop_a_per_row_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::AWait == WaitPolicy::PerTile && E::APop == PopPolicy::PerTile && E::AMapping == InputTileMapping::Col;
+    } else if constexpr (is_runtime_conditional_sequence_op_v<E>) {
+        return false;
+    } else if constexpr (is_cb_reader_op_v<E>) {
+        return E::Wait == WaitPolicy::PerTile && E::Pop == PopPolicy::PerTile && E::Mapping == InputTileMapping::Col;
+    } else {
+        return false;
+    }
+}
+
+template <class E>
+constexpr bool pop_b_per_row_of() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        if constexpr (!E::same_dfb) {
+            return E::BWait == WaitPolicy::PerTile && E::BPop == PopPolicy::PerTile && E::BMapping == InputTileMapping::Col;
+        }
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool reserve_per_outer_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::Reserve == ReservePolicy::PerOuter;
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool push_per_outer_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        return E::Push == PushPolicy::PerOuter;
+    }
+    return false;
+}
+
+template <class E>
+constexpr ElemDesc describe() {
+    return ElemDesc{
+        is_cb_reader_op_v<E>,
+        is_pack_tile_op_v<E>,
+        dfb_for_side<Side::SrcA, E>(),
+        dfb_for_side<Side::SrcB, E>(),
+        dfb_for_side<Side::Pack, E>(),
+        dfb_a_of<E>(),
+        dfb_b_of<E>(),
+        pack_dfb_of<E>(),
+        pack_dst_slot_of<E>(),
+        uses_l1_accumulation_of<E>(),
+        seeds_l1_accumulation_of<E>(),
+        manages_l1_accumulation_lifecycle_of<E>(),
+        uses_dest_accumulation_of<E>(),
+        dest_accumulation_mode_of<E>(),
+        accumulated_dst_slot_of<E>(),
+        uses_dest_accumulation_lifecycle_of<E>(),
+        manages_dest_accumulation_lifecycle_of<E>(),
+        uses_pack_relu_of<E>(),
+        a_owns_cb_window_of<E>(),
+        b_owns_cb_window_of<E>(),
+        a_pops_cb_front_of<E>(),
+        b_pops_cb_front_of<E>(),
+        elem_lane_width_v<E>,
+        transient_lane_width_of<E>(),
+        element_supports_block<E>(),
+        row_stream_input_a_cb_of<E>(),
+        row_stream_input_b_cb_of<E>(),
+        wait_a_per_row_of<E>(),
+        wait_b_per_row_of<E>(),
+        pop_a_per_row_of<E>(),
+        pop_b_per_row_of<E>(),
+        reserve_per_outer_of<E>(),
+        push_per_outer_of<E>(),
+    };
+}
+
+// Derivations over the descriptor array — flat loops bounded by the real element count
+// `n` (the array is sized [N?N:1], so an empty chain must NOT read the lone default slot).
+constexpr uint32_t ct_lane_width(const ElemDesc* d, int n) {
+    uint32_t w = 1;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].lane_width > w) {
+            w = d[i].lane_width;
+        }
+    }
+    return w;
+}
+constexpr uint32_t ct_transient_lane_width(const ElemDesc* d, int n) {
+    uint32_t w = 0;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].transient_lane_width > w) {
+            w = d[i].transient_lane_width;
+        }
+    }
+    return w;
+}
+constexpr bool ct_supports_block(const ElemDesc* d, int n) {
+    bool r = true;
+    for (int i = 0; i < n; ++i) {
+        r = r && d[i].supports_block;
+    }
+    return r;
+}
+constexpr bool ct_side_consistent(const ElemDesc* d, int n, uint32_t ElemDesc::* side) {
+    uint32_t seen = NO_PREV_DFB;
+    for (int i = 0; i < n; ++i) {
+        uint32_t dfb = d[i].*side;
+        if (dfb == NO_PREV_DFB) {
+            continue;
+        }
+        if (seen == NO_PREV_DFB) {
+            seen = dfb;
+        } else if (seen != dfb) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr bool ct_reader_collide(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+            if (!(d[i].is_cb_reader && d[j].is_cb_reader)) {
+                continue;
+            }
+            uint32_t a0 = d[i].dfb_a, a1 = d[i].dfb_b, b0 = d[j].dfb_a, b1 = d[j].dfb_b;
+            if ((a0 != INVALID_DFB && d[i].a_owns_cb_window &&
+                 ((a0 == b0 && (d[j].a_owns_cb_window || d[j].a_pops_cb_front)) ||
+                  (a0 == b1 && (d[j].b_owns_cb_window || d[j].b_pops_cb_front)))) ||
+                (a1 != INVALID_DFB && d[i].b_owns_cb_window &&
+                 ((a1 == b0 && (d[j].a_owns_cb_window || d[j].a_pops_cb_front)) ||
+                  (a1 == b1 && (d[j].b_owns_cb_window || d[j].b_pops_cb_front)))) ||
+                (b0 != INVALID_DFB && d[j].a_owns_cb_window &&
+                 ((b0 == a0 && (d[i].a_owns_cb_window || d[i].a_pops_cb_front)) ||
+                  (b0 == a1 && (d[i].b_owns_cb_window || d[i].b_pops_cb_front)))) ||
+                (b1 != INVALID_DFB && d[j].b_owns_cb_window &&
+                 ((b1 == a0 && (d[i].a_owns_cb_window || d[i].a_pops_cb_front)) ||
+                  (b1 == a1 && (d[i].b_owns_cb_window || d[i].b_pops_cb_front))))) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+constexpr bool ct_writer_collide(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+            if (d[i].is_pack && d[j].is_pack && d[i].pack_dfb == d[j].pack_dfb &&
+                d[i].pack_dst_slot == d[j].pack_dst_slot) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+constexpr bool ct_any_l1_accumulation(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].uses_l1_accumulation) {
+            return true;
+        }
+    }
+    return false;
+}
+constexpr bool ct_all_writers_l1_accumulation(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].is_pack && !d[i].uses_l1_accumulation) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr bool ct_l1_accumulation_modes_consistent(const ElemDesc* d, int n) {
+    bool found = false;
+    bool seed_first = false;
+    for (int i = 0; i < n; ++i) {
+        if (!d[i].is_pack || !d[i].uses_l1_accumulation) {
+            continue;
+        }
+        if (!found) {
+            found = true;
+            seed_first = d[i].seeds_l1_accumulation;
+        } else if (seed_first != d[i].seeds_l1_accumulation) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr bool ct_any_seed_first_l1_accumulation(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].seeds_l1_accumulation) {
+            return true;
+        }
+    }
+    return false;
+}
+constexpr bool ct_pack_dfbs_consistent(const ElemDesc* d, int n) {
+    uint32_t seen = INVALID_DFB;
+    for (int i = 0; i < n; ++i) {
+        if (!d[i].is_pack) {
+            continue;
+        }
+        if (seen == INVALID_DFB) {
+            seen = d[i].pack_dfb;
+        } else if (seen != d[i].pack_dfb) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr uint32_t ct_managed_l1_accumulation_lifecycles(const ElemDesc* d, int n) {
+    uint32_t count = 0;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].manages_l1_accumulation_lifecycle) {
+            ++count;
+        }
+    }
+    return count;
+}
+constexpr bool ct_any_dest_accumulation(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].uses_dest_accumulation) {
+            return true;
+        }
+    }
+    return false;
+}
+constexpr bool ct_dest_accumulation_modes_consistent(const ElemDesc* d, int n) {
+    DestAccumulation mode = DestAccumulation::Disabled;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].dest_accumulation_mode == DestAccumulation::Disabled) {
+            continue;
+        }
+        if (mode == DestAccumulation::Disabled) {
+            mode = d[i].dest_accumulation_mode;
+        } else if (mode != d[i].dest_accumulation_mode) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr DestAccumulation ct_dest_accumulation_mode(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].dest_accumulation_mode != DestAccumulation::Disabled) {
+            return d[i].dest_accumulation_mode;
+        }
+    }
+    return DestAccumulation::Disabled;
+}
+constexpr uint32_t ct_dest_accumulation_slot_count(const ElemDesc* d, int n) {
+    bool seen[DEST_AUTO_LIMIT] = {};
+    uint32_t count = 0;
+    for (int i = 0; i < n; ++i) {
+        if (!d[i].uses_dest_accumulation) {
+            continue;
+        }
+        const uint32_t slot = to_u32(d[i].accumulated_dst_slot);
+        if (!seen[slot]) {
+            seen[slot] = true;
+            ++count;
+        }
+    }
+    return count;
+}
+constexpr uint32_t ct_pack_writer_count(const ElemDesc* d, int n) {
+    uint32_t count = 0;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].is_pack) {
+            ++count;
+        }
+    }
+    return count;
+}
+constexpr bool ct_dest_accumulation_pack_matches(const ElemDesc* d, int n) {
+    Dst sticky = Dst::D0;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].uses_dest_accumulation) {
+            sticky = d[i].accumulated_dst_slot;
+            break;
+        }
+    }
+    for (int i = 0; i < n; ++i) {
+        if (d[i].is_pack && d[i].pack_dst_slot != sticky) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr bool ct_all_writers_dest_accumulation_lifecycle(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].is_pack && !d[i].uses_dest_accumulation_lifecycle) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr bool ct_any_dest_accumulation_lifecycle(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].uses_dest_accumulation_lifecycle) {
+            return true;
+        }
+    }
+    return false;
+}
+constexpr uint32_t ct_managed_dest_accumulation_lifecycles(const ElemDesc* d, int n) {
+    uint32_t count = 0;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].manages_dest_accumulation_lifecycle) {
+            ++count;
+        }
+    }
+    return count;
+}
+constexpr bool ct_any_pack_relu(const ElemDesc* d, int n) {
+    for (int i = 0; i < n; ++i) {
+        if (d[i].uses_pack_relu) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Per-side "previous programmed CB at each index" tables, built in ONE forward sweep:
+// carry a running prev per side, record it BEFORE each element, update it when the
+// element programs that side. prev.srca[I] is the most recent CB programmed on SrcA by
+// any element before index I (NO_PREV_DFB if none).
+template <int M>
+struct PrevTable {
+    uint32_t srca[M];
+    uint32_t srcb[M];
+    uint32_t pack[M];
+};
+template <int M>
+constexpr PrevTable<M> ct_build_prev(const ElemDesc* d, int n) {
+    PrevTable<M> t{};
+    uint32_t pa = NO_PREV_DFB, pb = NO_PREV_DFB, pp = NO_PREV_DFB;
+    for (int i = 0; i < n; ++i) {
+        t.srca[i] = pa;
+        t.srcb[i] = pb;
+        t.pack[i] = pp;
+        if (d[i].srca_cb != NO_PREV_DFB) {
+            pa = d[i].srca_cb;
+        }
+        if (d[i].srcb_cb != NO_PREV_DFB) {
+            pb = d[i].srcb_cb;
+        }
+        if (d[i].pack_side_dfb != NO_PREV_DFB) {
+            pp = d[i].pack_side_dfb;
+        }
+    }
+    return t;
+}
+// Last opt-in pack CB in chain order (iter-to-iter wraparound prev for pack site 0).
+constexpr uint32_t ct_last_pack_cb(const ElemDesc* d, int n) {
+    uint32_t last = NO_PREV_DFB;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].pack_side_dfb != NO_PREV_DFB) {
+            last = d[i].pack_side_dfb;
+        }
+    }
+    return last;
+}
+// True iff ≥2 opt-in pack sites declare different CBs (boot can't program all).
+constexpr bool ct_pack_hetero(const ElemDesc* d, int n) {
+    uint32_t first = NO_PREV_DFB;
+    for (int i = 0; i < n; ++i) {
+        if (d[i].pack_side_dfb == NO_PREV_DFB) {
+            continue;
+        }
+        if (first == NO_PREV_DFB) {
+            first = d[i].pack_side_dfb;
+        } else if (first != d[i].pack_side_dfb) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <class... Es>
+struct ChainTraits {
+    static constexpr int N = int(sizeof...(Es));
+    static constexpr ElemDesc d[N ? N : 1] = {describe<Es>()...};  // the one walk
+
+    static constexpr uint32_t lane_width = ct_lane_width(d, N);
+    static constexpr uint32_t transient_lane_width = ct_transient_lane_width(d, N);
+    static constexpr bool supports_block = ct_supports_block(d, N);
+    static constexpr bool srca_consistent = ct_side_consistent(d, N, &ElemDesc::srca_cb);
+    static constexpr bool srcb_consistent = ct_side_consistent(d, N, &ElemDesc::srcb_cb);
+    static constexpr bool reader_collide = ct_reader_collide(d, N);
+    static constexpr bool writer_collide = ct_writer_collide(d, N);
+    static constexpr bool any_l1_accumulation = ct_any_l1_accumulation(d, N);
+    static constexpr bool any_seed_first_l1_accumulation = ct_any_seed_first_l1_accumulation(d, N);
+    static constexpr bool all_writers_l1_accumulation = ct_all_writers_l1_accumulation(d, N);
+    static constexpr bool l1_accumulation_modes_consistent = ct_l1_accumulation_modes_consistent(d, N);
+    static constexpr bool pack_dfbs_consistent = ct_pack_dfbs_consistent(d, N);
+    static constexpr uint32_t managed_l1_accumulation_lifecycles = ct_managed_l1_accumulation_lifecycles(d, N);
+    static constexpr bool any_dest_accumulation = ct_any_dest_accumulation(d, N);
+    static constexpr bool dest_accumulation_modes_consistent = ct_dest_accumulation_modes_consistent(d, N);
+    static constexpr DestAccumulation dest_accumulation_mode = ct_dest_accumulation_mode(d, N);
+    static constexpr uint32_t dest_accumulation_slot_count = ct_dest_accumulation_slot_count(d, N);
+    static constexpr uint32_t pack_writer_count = ct_pack_writer_count(d, N);
+    static constexpr bool dest_accumulation_pack_matches = ct_dest_accumulation_pack_matches(d, N);
+    static constexpr bool all_writers_dest_accumulation_lifecycle = ct_all_writers_dest_accumulation_lifecycle(d, N);
+    static constexpr bool any_dest_accumulation_lifecycle = ct_any_dest_accumulation_lifecycle(d, N);
+    static constexpr uint32_t managed_dest_accumulation_lifecycles = ct_managed_dest_accumulation_lifecycles(d, N);
+    static constexpr bool any_pack_relu = ct_any_pack_relu(d, N);
+
+    // Per-side prev-CB history (one sweep), + pack-side metadata.
+    static constexpr PrevTable<N ? N : 1> prev = ct_build_prev<N ? N : 1>(d, N);
+    static constexpr uint32_t last_pack_cb = ct_last_pack_cb(d, N);
+    static constexpr bool pack_hetero = ct_pack_hetero(d, N);
+};
+
+}  // namespace detail
+
+template <class Chain>
+struct chain_supports_block;
+
+template <class... Es>
+struct chain_supports_block<EltwiseChain<Es...>> : std::bool_constant<detail::ChainTraits<Es...>::supports_block> {};
+
+template <class Chain>
+inline constexpr bool chain_supports_block_v = chain_supports_block<Chain>::value;
+
+// element_uses_per_block_index_v — true when the element's CB front is chunk-
+// local (per-block streaming reader or pack), so the pipeline passes `j`
+// instead of `base_tile + j` as the tile index seen by `exec`. SFINAE on each
+// element kind. False for elements that don't read/write CBs (DEST-only ops).
+namespace detail {
+
+template <class E, class = void>
+struct elem_per_block_reader : std::false_type {};
+
+template <class E>
+struct elem_per_block_reader<E, std::enable_if_t<is_cb_reader_op_v<E>>>
+    : std::bool_constant<
+          (E::a_input().wait == WaitPolicy::PerBlockSize && E::a_input().pop == PopPolicy::PerBlockSize) ||
+          (b_input_of<E>().wait == WaitPolicy::PerBlockSize && b_input_of<E>().pop == PopPolicy::PerBlockSize)> {};
+
+template <class E, class = void>
+struct elem_per_block_pack : std::false_type {};
+
+template <class E>
+struct elem_per_block_pack<E, std::void_t<decltype(E::uses_per_block_pack)>>
+    : std::bool_constant<E::uses_per_block_pack> {};
+
+template <class E>
+inline constexpr bool element_uses_per_block_index_v = elem_per_block_reader<E>::value || elem_per_block_pack<E>::value;
+
+// elem_needs_per_side_idx_v — true when the element wants per-side
+// local-vs-absolute index resolution (BinaryFpu when A/B policies disagree on
+// the per-block regime). SFINAE-tolerant: absence of `needs_per_side_idx`
+// static member defaults to false.
+template <class E, class = void>
+struct elem_needs_per_side_idx : std::false_type {};
+
+template <class E>
+struct elem_needs_per_side_idx<E, std::void_t<decltype(E::needs_per_side_idx)>>
+    : std::bool_constant<E::needs_per_side_idx> {};
+
+template <class E>
+inline constexpr bool elem_needs_per_side_idx_v = elem_needs_per_side_idx<E>::value;
+
+}  // namespace detail
+
+// chain_has_duplicate_upfront_dfbs / chain_pack_writes_collide — pairwise collision
+// checks, implemented as flat nested loops in ChainTraits (reader_collide / writer_collide).
+template <class... Es>
+struct chain_has_duplicate_upfront_dfbs<EltwiseChain<Es...>>
+    : std::bool_constant<detail::ChainTraits<Es...>::reader_collide> {};
+
+template <class... Es>
+struct chain_pack_writes_collide<EltwiseChain<Es...>> : std::bool_constant<detail::ChainTraits<Es...>::writer_collide> {
+};
+
+// `chain_hoist_math_mop` / `chain_hoist_sfpu` — per-cohort decisions on whether each
+// element's init() can run once at boot instead of per tile. The two cohorts (math-MOP =
+// ADDR_MOD_0..3 + MATH MOP; SFPU = ADDR_MOD_7 + SFPU CSR) are hardware-disjoint, so the
+// decisions are independent in principle; we constrain hoist_sfpu to imply hoist_math_mop
+// to keep the dispatcher simple. Eltwise-only scope (no matmul/reduce hazards).
+//
+// All three conditions guard the same failure mode — boot programs each lane once, so a
+// non-uniform chain leaves only the LAST init's state programmed and earlier elements run
+// with the wrong MOP/format:
+//   - Per-side CB consistency: every element programming a side (srcA/srcB) uses the same CB.
+//   - MATH-MOP uniformity: all `is_math_mop_op_v` elements (CopyTile / BinaryFpu /
+//     DestReuseBinary / UnaryBcast) are the same instantiated type.
+//   - SFPU-init uniqueness: all `is_sfpu_op_v` elements are the same type. (Caught
+//     mish FP32 Exp/Log1p/Tanh → tanh saturation PCC 0.988; logit stage-2
+//     Rsub/DivBinary/Log → ATOL 9-12.)
+//
+// "Identical" is `std::is_same_v` — rejects some safe chains (two `Exp<...>` differing only
+// in slot), but false negatives only cost a per-tile init, never correctness.
+
+namespace detail {
+
+// Per-side CB consistency is ChainTraits::srca_consistent / srcb_consistent.
+
+// Trait wrappers (Pred<E>::value form) — `is_sfpu_op_v` / `is_math_mop_op_v`
+// are `inline constexpr bool` variable templates; wrap them so they fit the
+// `Pred<E>::value` interface used by the uniformity fold.
+template <class E>
+struct is_sfpu_op_t : std::bool_constant<is_sfpu_op_v<E>> {};
+template <class E>
+struct is_math_mop_op_t : std::bool_constant<is_math_mop_op_v<E>> {};
+
+// Uniformity helper (used for both the MATH-MOP and SFPU cohorts): across all
+// `Es...` satisfying `Pred<E>`, require every instantiated type to be
+// `std::is_same_v` with every other (≤ 1 distinct).
+//
+// Strategy: find the first `E` in `Es...` with `Pred<E>::value == true`;
+// call it `Rep`. Then every other `E` with `Pred<E>::value == true` must
+// satisfy `std::is_same_v<Rep, E>`. If no element matches, the chain is
+// vacuously uniform (returns true).
+template <template <class> class Pred, class... Es>
+struct first_match {
+    using type = void;
+};
+
+template <template <class> class Pred, class First, class... Rest>
+struct first_match<Pred, First, Rest...> {
+    using type = std::conditional_t<Pred<First>::value, First, typename first_match<Pred, Rest...>::type>;
+};
+
+template <template <class> class Pred, class Rep, class... Es>
+struct all_match_rep : std::bool_constant<(((!Pred<Es>::value) || std::is_same_v<Rep, Es>) && ...)> {};
+
+// Empty `Rep == void` short-circuits to `true` (no element matched Pred at all,
+// so the "must equal Rep" condition is vacuously satisfied).
+template <template <class> class Pred, class... Es>
+constexpr bool chain_all_pred_uniform_v = []() {
+    using Rep = typename first_match<Pred, Es...>::type;
+    if constexpr (std::is_same_v<Rep, void>) {
+        return true;
+    } else {
+        return all_match_rep<Pred, Rep, Es...>::value;
+    }
+}();
+
+}  // namespace detail
+
+template <class Chain>
+struct chain_per_side_dfbs_consistent : std::true_type {};
+
+template <class... Es>
+struct chain_per_side_dfbs_consistent<EltwiseChain<Es...>>
+    : std::bool_constant<detail::ChainTraits<Es...>::srca_consistent && detail::ChainTraits<Es...>::srcb_consistent> {};
+
+template <class Chain>
+struct chain_math_mop_uniform : std::true_type {};
+
+template <class... Es>
+struct chain_math_mop_uniform<EltwiseChain<Es...>>
+    : std::bool_constant<detail::chain_all_pred_uniform_v<detail::is_math_mop_op_t, Es...>> {};
+
+template <class Chain>
+struct chain_sfpu_inits_uniform : std::true_type {};
+
+template <class... Es>
+struct chain_sfpu_inits_uniform<EltwiseChain<Es...>>
+    : std::bool_constant<detail::chain_all_pred_uniform_v<detail::is_sfpu_op_t, Es...>> {};
+
+// Math-MOP cohort hoist: per-side CB consistency + math-MOP uniformity.
+// True when CopyTile / BinaryFpu / DestReuseBinary / UnaryBcast inits can be
+// emitted once at boot instead of per tile. Independent of SFPU uniformity.
+template <class Chain>
+struct chain_hoist_math_mop : std::false_type {};
+
+template <class... Es>
+struct chain_hoist_math_mop<EltwiseChain<Es...>>
+    : std::bool_constant<
+          ((!is_runtime_conditional_sequence_op_v<Es>) && ...) &&
+          chain_per_side_cbs_consistent_v<EltwiseChain<Es...>> && chain_math_mop_uniform_v<EltwiseChain<Es...>>> {};
+
+// SFPU cohort hoist: requires math-MOP hoist AND SFPU init uniformity.
+// True when every element's init can be emitted at boot (the fully-hoisted shape).
+template <class Chain>
+struct chain_hoist_sfpu : std::false_type {};
+
+template <class... Es>
+struct chain_hoist_sfpu<EltwiseChain<Es...>>
+    : std::bool_constant<
+          chain_hoist_math_mop_v<EltwiseChain<Es...>> && chain_sfpu_inits_uniform_v<EltwiseChain<Es...>>> {};
+
+// Pack cohort hoist: pack init + reconfig are fully boot-emitted, with NO per-stage pack
+// reconfig in the loop. True iff the chain isn't pack-hetero (homogeneous opt-in pack CBs).
+// The output-reconfig leg of "all one-time setup is boot-hoistable" (with math-MOP + SFPU).
+template <class Chain>
+struct chain_hoist_pack : std::true_type {};
+
+template <class... Es>
+struct chain_hoist_pack<EltwiseChain<Es...>> : std::bool_constant<!detail::ChainTraits<Es...>::pack_hetero> {};
+
+// True iff no element requests any reconfig. InitReconfigOwner::Caller requires this so an enabled but
+// inert operand reconfig (which the helper would silently ignore) is a compile error
+// instead of a lie about what runs inside the chain.
+template <class Chain>
+struct chain_no_reconfig_requested : std::true_type {};
+
+template <class... Es>
+struct chain_no_reconfig_requested<EltwiseChain<Es...>>
+    : std::bool_constant<detail::chain_requests_no_reconfig<Es...>()> {};
+
+template <class Chain>
+inline constexpr bool chain_no_reconfig_requested_v = chain_no_reconfig_requested<Chain>::value;
+
+// =============================================================================
+// 10. Chain pipeline — per-iteration emit
+// =============================================================================
+
+namespace detail {
+
+// CB lifecycles are emitted in the existing compute/pack workers and outer adapters below.
+// Their policy gates remain `if constexpr`, so unused operations disappear without creating a
+// separate lifecycle-method specialization for every element configuration.
+
+// A direct fold still names every chain element at its call site. Do not make that imply that
+// every phase worker is instantiated for every element: select the elements that can contribute
+// to a phase before entering its worker. The shared empty sentinel carries neither the rejected
+// element type nor the chain pack. Selected references carry one element plus only the small set
+// of per-position facts consumed by that phase (never `Es...`).
+struct UnselectedElement {};
+
+template <class E, class Facts = void>
+struct SelectedElement {
+    const E& value;
+};
+
+template <bool Select, class Facts = void, class E>
+ALWI constexpr auto select_element(const E& elem) {
+    if constexpr (Select) {
+        return SelectedElement<E, Facts>{elem};
+    } else {
+        return UnselectedElement{};
+    }
+}
+
+template <class E>
+inline constexpr bool participates_in_compute_v = is_cb_reader_op_v<E> || is_dest_only_op_v<E>;
+
+template <class E>
+constexpr bool waits_upfront() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::AWait == WaitPolicy::Upfront || (!E::same_dfb && E::BWait == WaitPolicy::Upfront);
+    } else if constexpr (is_cb_reader_op_v<E>) {
+        return E::Wait == WaitPolicy::Upfront;
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool reserves_upfront() {
+    if constexpr (is_cb_writer_op_v<E>) {
+        return E::Reserve == ReservePolicy::Upfront || E::Reserve == ReservePolicy::OneUpfront;
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool pops_at_end() {
+    if constexpr (is_binary_fpu_op_v<E>) {
+        return E::APop == PopPolicy::AtEnd || (!E::same_dfb && E::BPop == PopPolicy::AtEnd);
+    } else if constexpr (is_cb_reader_op_v<E>) {
+        return E::Pop == PopPolicy::AtEnd;
+    }
+    return false;
+}
+
+template <class E>
+constexpr bool pushes_at_end() {
+    if constexpr (is_cb_writer_op_v<E>) {
+        return E::Push == PushPolicy::AtEnd || E::Push == PushPolicy::OneAtEnd;
+    }
+    return false;
+}
+
+// All CB lifecycle operations terminate in one of these four emitters. `Enabled` is a
+// compile-time policy fact, so disabled actions disappear without a runtime sentinel check;
+// the emitted function identity is independent of both the element type and the chain pack.
+template <bool Enabled>
+ALWI void emit_wait(uint32_t cb, uint32_t count) {
+    if constexpr (Enabled) {
+        DataflowBuffer(cb).wait_front(count);
+    }
+}
+
+template <bool Enabled>
+ALWI void emit_pop(uint32_t cb, uint32_t count) {
+    if constexpr (Enabled) {
+        DataflowBuffer(cb).pop_front(count);
+    }
+}
+
+template <bool Enabled>
+ALWI void emit_reserve(uint32_t cb, uint32_t count) {
+    if constexpr (Enabled) {
+        DataflowBuffer(cb).reserve_back(count);
+    }
+}
+
+template <bool Enabled>
+ALWI void emit_push(uint32_t cb, uint32_t count) {
+    if constexpr (Enabled) {
+        DataflowBuffer(cb).push_back(count);
+    }
+}
+
+// init() dispatch convention — the compute-cohort init is emitted on the element
+// *instance* (`elem.init()`), exactly like `exec`, so an init can read the struct's
+// runtime members when it needs to (e.g. Dropout seeding the SFPU with its runtime
+// `seed`). Most inits don't and are declared `static`; a static member is callable
+// through an instance, so the call site is uniform either way. PackTile is the one
+// exception — its init is dispatched by type in the indexed setup fold (no instance
+// needed), which is fine because pack init never needs runtime state.
+
+// =============================================================================
+// emit_pre_element_transitions<E, PrevA, PrevB, PrevP, PackHetero>()
+//
+// Emits srca / srcb / pack reconfig for element I, each compile-time-elided when
+// prev_*_cb == curr_*_cb. A chain that shares a CB on a side thus reconfigs it once (at
+// element 0, prev == NO_PREV_DFB) and never again. Zero run-time cost — `if constexpr`.
+//
+// srca+srcb coalesce: both-with-known-prev → 4-arg _with_dt; both-without-known-prev →
+// 2-arg combined; mixed → independent per-side. CONDITIONAL_DFB is an unknown previous
+// state, so it takes the unconditional path and is never passed to an LLK as a CB id.
+// Pack is always independent. The LLK _with_dt overloads
+// fast-path-skip on format equality, so an emitted reconfig on matching dtypes is a
+// hardware no-op (a few compares).
+//
+// Pack-side hoist: homogeneous chains (≤1 opt-in pack site, or all share a CB) emit at
+// boot via the indexed setup fold; heterogeneous chains (≥2 sites, different CBs) emit only
+// the first site at boot and defer the rest to per-stage `emit_per_stage_pack_reconfig`.
+// DEST accumulation is build-flag-driven (no per-element fp32 fold here).
+// =============================================================================
+
+// Takes only the element and the preceding CB descriptors needed to decide its transitions.
+template <class E, uint32_t PrevA, uint32_t PrevB, uint32_t PrevP, bool PackHetero>
+ALWI void emit_pre_element_transitions() {
+    constexpr uint32_t curr_a = dfb_for_side<Side::SrcA, E>();
+    constexpr uint32_t curr_b = dfb_for_side<Side::SrcB, E>();
+    constexpr uint32_t curr_p = dfb_for_side<Side::Pack, E>();
+
+    constexpr uint32_t prev_a = (curr_a != NO_PREV_DFB) ? PrevA : NO_PREV_DFB;
+    constexpr uint32_t prev_b = (curr_b != NO_PREV_DFB) ? PrevB : NO_PREV_DFB;
+    constexpr uint32_t prev_p = (curr_p != NO_PREV_DFB) ? PrevP : NO_PREV_DFB;
+
+    constexpr bool reconf_a = (curr_a != NO_PREV_DFB) && (curr_a != prev_a);
+    constexpr bool reconf_b = (curr_b != NO_PREV_DFB) && (curr_b != prev_b);
+    constexpr bool reconf_p = (curr_p != NO_PREV_DFB) && (curr_p != prev_p);
+    constexpr bool known_prev_a = prev_a != NO_PREV_DFB && prev_a != CONDITIONAL_DFB;
+    constexpr bool known_prev_b = prev_b != NO_PREV_DFB && prev_b != CONDITIONAL_DFB;
+
+    // Pack-side deferral: in heterogeneous chains, only the first opt-in pack
+    // site (prev_p == NO_PREV_DFB) emits at boot. Later sites defer to per-stage
+    // via `emit_per_stage_pack_reconfig`, where the 2-arg LLK form's cache check
+    // handles intra-stage transitions cheaply and the per-iter wraparound from
+    // last-pack-cb to first-pack-cb is correctly programmed.
+    constexpr bool defer_pack_to_per_stage = PackHetero && (prev_p != NO_PREV_DFB);
+
+    // ---- srca + srcb: coalesce when both sides share prev-state ----
+    if constexpr (reconf_a && reconf_b) {
+        if constexpr (known_prev_a && known_prev_b) {
+            // both sides have prev → 4-arg _with_dt
+            reconfig_data_format(prev_a, curr_a, prev_b, curr_b);
+        } else if constexpr (!known_prev_a && !known_prev_b) {
+            // first/unknown on both sides → 2-arg combined (unconditional reprogram)
+            reconfig_data_format(curr_a, curr_b);
+        } else {
+            // mixed prev-state → independent per-side
+            if constexpr (known_prev_a) {
+                reconfig_data_format_srca(prev_a, curr_a);
+            } else {
+                reconfig_data_format_srca(curr_a);
+            }
+            if constexpr (known_prev_b) {
+                reconfig_data_format_srcb(prev_b, curr_b);
+            } else {
+                reconfig_data_format_srcb(curr_b);
+            }
+        }
+    } else if constexpr (reconf_a) {
+        if constexpr (known_prev_a) {
+            reconfig_data_format_srca(prev_a, curr_a);
+        } else {
+            reconfig_data_format_srca(curr_a);
+        }
+    } else if constexpr (reconf_b) {
+        if constexpr (known_prev_b) {
+            reconfig_data_format_srcb(prev_b, curr_b);
+        } else {
+            reconfig_data_format_srcb(curr_b);
+        }
+    }
+
+    // ---- pack: always independent; deferred to per-stage in heterogeneous chains ----
+    if constexpr (reconf_p && !defer_pack_to_per_stage) {
+        if constexpr (prev_p != NO_PREV_DFB) {
+            pack_reconfig_data_format(prev_p, curr_p);
+        } else {
+            pack_reconfig_data_format(curr_p);
+        }
+    }
+}
+
+// emit_per_stage_pack_reconfig(curr, prev, last, heterogeneous)
+//
+// Per-stage pack reconfig used only when the chain has heterogeneous opt-in
+// pack CBs (boot can't program all of them). For every opt-in pack site,
+// emit the 2-arg `pack_reconfig_data_format(prev, curr)` form before that
+// site's per-iter pack work, using wraparound `prev` for the first pack site
+// (so iter k+1's site 0 sees iter k's site N-1 as the previous descriptor
+// state). The LLK's compare-and-skip on matching formats keeps the cost to
+// a few cycles when adjacent stages happen to share a dtype.
+ALWI void emit_per_stage_pack_reconfig(uint32_t curr_p, uint32_t prev_chain, uint32_t last_pack_cb, bool pack_hetero) {
+    if (!pack_hetero || curr_p == NO_PREV_DFB) {
+        return;
+    }
+    // Wraparound: first opt-in pack site has no in-chain prev; on iter ≥ 1 the
+    // packer ended the previous iter on `last_pack_cb`. The LLK 2-arg form does
+    // the right thing on iter 0 too (cache check vs. boot-initialized state).
+    const uint32_t prev_p = (prev_chain != NO_PREV_DFB) ? prev_chain : last_pack_cb;
+    if (prev_p != NO_PREV_DFB) {
+        pack_reconfig_data_format(prev_p, curr_p);
+    }
+}
+
+// Pack-phase setup (Pack* only). Pack is its own cohort (disjoint from math-MOP / SFPU),
+// excluded from the compute-init fold and always boot-hoisted by the pack-init fold.
+// Reconfig is fold-driven (see emit_pre_element_transitions): homogeneous chains program
+// the packer once at boot; heterogeneous chains defer later sites to per-stage emission so
+// the per-iter wraparound stays correct.
+template <uint32_t PrevA, uint32_t PrevB, uint32_t PrevP, bool PackHetero>
+struct TransitionFacts {};
+
+ALWI void elem_pack_init(UnselectedElement) {}
+
+template <class E, uint32_t PrevA, uint32_t PrevB, uint32_t PrevP, bool PackHetero>
+ALWI void elem_pack_init(SelectedElement<E, TransitionFacts<PrevA, PrevB, PrevP, PackHetero>>) {
+    emit_pre_element_transitions<E, PrevA, PrevB, PrevP, PackHetero>();
+}
+
+// =============================================================================
+// Two-phase per-element apply: compute / pack
+//
+// Each element owns its full lifecycle slice of the outer iteration. Per outer iter:
+//
+//   tile_regs_acquire();
+//   elem_apply_compute(...);    // per element: wait + init? + for(j) exec + pop
+//   tile_regs_commit();
+//   tile_regs_wait();
+//   elem_apply_pack(...);       // per pack element: reserve + for(j) pack_exec + push
+//   tile_regs_release();
+//
+// Upfront-policy lifecycle (elem_pop_upfront_end / elem_push_at_end) fires after the loop.
+//
+// pop_per_tile / push_per_tile live inside the apply body. cb_pop_front right after exec
+// is safe — by then the unpack-read is queued and the framework manages in-flight reads
+// vs producer L1 reuse; push right after pack_exec wakes the consumer while DEST is still
+// held. Both are policy-guarded (no-op for upfront / no-pop / no-push policies).
+// =============================================================================
+
+// Boot-time hoist of compute-cohort init (math-MOP and/or DEST-only ops). The chain dispatcher
+// computes `HoistMath` from `chain_hoist_math_mop_v` and `HoistSfpu` from `chain_hoist_sfpu_v`,
+// then this walk emits the element's transitions + init() only when its cohort is hoisted. The
+// HoistSfpu leg covers ordinary SFPU and Fill init. PRNG seeders are emitted by the dedicated
+// final boot pass below, so they cannot be replayed by a per-block fallback.
+//
+// PackTile is intentionally excluded from this walk — pack-side reconfig is
+// emitted unconditionally at boot via the indexed pack-init fold (PACK cohort is
+// disjoint from compute cohorts and is always hoisted).
+ALWI void hoist_compute_init_one(UnselectedElement) {}
+
+template <class E, uint32_t PrevA, uint32_t PrevB, uint32_t PrevP, bool PackHetero>
+ALWI void hoist_compute_init_one(SelectedElement<E, TransitionFacts<PrevA, PrevB, PrevP, PackHetero>> selected) {
+    emit_pre_element_transitions<E, PrevA, PrevB, PrevP, PackHetero>();
+    selected.value.init();  // instance dispatch: runtime-stateful init may read element members
+}
+
+}  // namespace detail
+
+// =============================================================================
+// 11. Public eltwise_chain()
+//
+// Caller-init contract:
+//   - Caller writes `compute_kernel_hw_startup(dfb_a, dfb_b, cb_out)` (or its
+//     unary/binary variant) as the FIRST statement of `MAIN()`.
+//   - Helper does NOT wrap any "BIG init" (`compute_kernel_hw_startup`,
+//     `compute_kernel_hw_startup`, `mm_init`, `reduce_init`).
+//   - Helper owns per-element init only — `add_init`, `*_tile_init`,
+//     `init_bcast`, `copy_tile_to_dst_init_short`, `reconfig_data_format_*`,
+//     `tile_regs_*` lifecycle.
+//   - Per `compute_kernel_hw_startup.h:26-30`, mid-`MAIN()` boot is undefined.
+//     Multi-stage kernels are the only exception (one boot per stage,
+//     immediately before that stage's chain call).
+// =============================================================================
+
+// =============================================================================
+// 11b. eltwise_chain — unified (Ht, Wt) walk with per-element broadcast indexing
+//
+// Walks an (Ht, Wt) tile grid (Ht=1 expresses the 1D case). Inner loop blocks W
+// (block_size tiles per inner iter). Per-element tile mapping picks the tile index
+// for each CB-reader: Block → flat (ht*Wt + wt), Row → wt, Col → ht,
+// Scalar → 0.
+// =============================================================================
+
+namespace detail {
+
+inline constexpr bool eltwise_chain_skip_compute_v = CKL_ELTWISE_CHAIN_SKIP_COMPUTE != 0;
+
+template <
+    bool EmitMathInit,
+    bool EmitSfpuInit,
+    uint32_t SlotBase,
+    uint32_t PrevA,
+    uint32_t PrevB,
+    uint32_t PrevP,
+    bool PackHetero>
+struct ComputeFacts {};
+
+ALWI void elem_apply_compute(
+    UnselectedElement, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t) {}
+
+template <
+    class ElemT,
+    bool EmitMathInit,
+    bool EmitSfpuInit,
+    uint32_t SlotBase,
+    uint32_t PrevA,
+    uint32_t PrevB,
+    uint32_t PrevP,
+    bool PackHetero>
+ALWI void elem_apply_compute(
+    SelectedElement<ElemT, ComputeFacts<EmitMathInit, EmitSfpuInit, SlotBase, PrevA, PrevB, PrevP, PackHetero>>
+        selected,
+    [[maybe_unused]] uint32_t i_flat,
+    [[maybe_unused]] uint32_t ht,
+    [[maybe_unused]] uint32_t wt,
+    [[maybe_unused]] uint32_t inner_count,
+    [[maybe_unused]] uint32_t block_sync_count,
+    [[maybe_unused]] uint32_t chain_lane_width,
+    [[maybe_unused]] uint32_t Ht,
+    [[maybe_unused]] uint32_t Wt) {
+    const ElemT& elem = selected.value;
+    // Per-block streaming: pass chunk-local index `j` to exec so Block
+    // returns the local CB-front offset (the just-waited window).
+    [[maybe_unused]] constexpr bool use_local_idx = element_uses_per_block_index_v<ElemT>;
+    if constexpr (is_runtime_conditional_sequence_op_v<ElemT>) {
+        if constexpr (!eltwise_chain_skip_compute_v) {
+            elem.template apply<SlotBase, PrevA, PrevB, PrevP, PackHetero>(
+                i_flat, ht, wt, inner_count, chain_lane_width, Ht, Wt);
+        }
+    } else if constexpr (is_cb_reader_op_v<ElemT>) {
+        // Per-block-iteration input waits — mutually exclusive by policy (Streaming forces
+        // block_size 1, so per_tile and per_block never both fire). The Bulk upfront wait is NOT
+        // here: it's hoisted once to the chain boundary (elem_wait_upfront, pre-loop fold), so it's
+        // placed exactly once rather than re-issued per block-iter relying on idempotency.
+        if constexpr (is_binary_fpu_op_v<ElemT>) {
+            if constexpr (ElemT::AWait == WaitPolicy::PerTile && ElemT::AMapping != InputTileMapping::Col) {
+                emit_wait<true>(ElemT::dfb_a_id(), 1);
+            } else if constexpr (ElemT::AWait == WaitPolicy::Cumulative) {
+                emit_wait<true>(ElemT::dfb_a_id(), i_flat + inner_count);
+            } else if constexpr (ElemT::AWait == WaitPolicy::PerBlockSize) {
+                emit_wait<true>(ElemT::dfb_a_id(), block_sync_count);
+            }
+            if constexpr (!ElemT::same_dfb) {
+                if constexpr (ElemT::BWait == WaitPolicy::PerTile && ElemT::BMapping != InputTileMapping::Col) {
+                    emit_wait<true>(ElemT::dfb_b_id(), 1);
+                } else if constexpr (ElemT::BWait == WaitPolicy::Cumulative) {
+                    emit_wait<true>(ElemT::dfb_b_id(), i_flat + inner_count);
+                } else if constexpr (ElemT::BWait == WaitPolicy::PerBlockSize) {
+                    emit_wait<true>(ElemT::dfb_b_id(), block_sync_count);
+                }
+            }
+        } else {
+            if constexpr (ElemT::Wait == WaitPolicy::PerTile && ElemT::Mapping != InputTileMapping::Col) {
+                emit_wait<true>(ElemT::dfb, 1);
+            } else if constexpr (ElemT::Wait == WaitPolicy::Cumulative) {
+                emit_wait<true>(ElemT::dfb, i_flat + inner_count);
+            } else if constexpr (ElemT::Wait == WaitPolicy::PerBlockSize) {
+                emit_wait<true>(ElemT::dfb, block_sync_count);
+            }
+        }
+        if constexpr (EmitMathInit && !eltwise_chain_skip_compute_v) {
+            emit_pre_element_transitions<ElemT, PrevA, PrevB, PrevP, PackHetero>();
+            elem.init();  // instance dispatch (see convention note above)
+        }
+        if constexpr (!eltwise_chain_skip_compute_v) {
+            constexpr bool per_side = elem_needs_per_side_idx_v<ElemT>;
+#pragma GCC unroll 0
+            for (uint32_t j = 0; j < inner_count; ++j) {
+                if constexpr (per_side) {
+                    // Per-side path: chain hands both indices; element picks per operand.
+                    elem.exec(
+                        /*i_flat_local=*/j,
+                        /*i_flat_abs=*/(i_flat + j),
+                        ht,
+                        /*wt_local=*/j,
+                        /*wt_abs=*/(wt + j),
+                        SlotBase + j * chain_lane_width);
+                } else {
+                    const uint32_t i_arg = use_local_idx ? j : (i_flat + j);
+                    elem.exec(i_arg, ht, wt + j, SlotBase + j * chain_lane_width);
+                }
+            }
+        }
+        if constexpr (is_binary_fpu_op_v<ElemT>) {
+            if constexpr (ElemT::APop == PopPolicy::PerTile && ElemT::AMapping != InputTileMapping::Col) {
+                emit_pop<true>(ElemT::dfb_a_id(), 1);
+            } else if constexpr (ElemT::APop == PopPolicy::PerBlockSize) {
+                emit_pop<true>(ElemT::dfb_a_id(), block_sync_count);
+            }
+            if constexpr (!ElemT::same_dfb) {
+                if constexpr (ElemT::BPop == PopPolicy::PerTile && ElemT::BMapping != InputTileMapping::Col) {
+                    emit_pop<true>(ElemT::dfb_b_id(), 1);
+                } else if constexpr (ElemT::BPop == PopPolicy::PerBlockSize) {
+                    emit_pop<true>(ElemT::dfb_b_id(), block_sync_count);
+                }
+            }
+        } else {
+            if constexpr (ElemT::Pop == PopPolicy::PerTile && ElemT::Mapping != InputTileMapping::Col) {
+                emit_pop<true>(ElemT::dfb, 1);
+            } else if constexpr (ElemT::Pop == PopPolicy::PerBlockSize) {
+                emit_pop<true>(ElemT::dfb, block_sync_count);
+            }
+        }
+    } else if constexpr (is_dest_only_op_v<ElemT> && !eltwise_chain_skip_compute_v) {
+        if constexpr (EmitSfpuInit && !is_prng_seed_op_v<ElemT>) {
+            emit_pre_element_transitions<ElemT, PrevA, PrevB, PrevP, PackHetero>();
+            elem.init();  // instance dispatch (see convention note above)
+        }
+        for (uint32_t j = 0; j < inner_count; ++j) {
+            elem.exec(i_flat + j, SlotBase + j * chain_lane_width);
+        }
+    }
+}
+
+template <bool AnyPackRelu, uint32_t PrevPack, uint32_t LastPackCb, bool PackHetero>
+struct PackFacts {};
+
+ALWI void elem_apply_pack(
+    UnselectedElement, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t) {}
+
+template <class ElemT, bool AnyPackRelu, uint32_t PrevPack, uint32_t LastPackCb, bool PackHetero>
+ALWI void elem_apply_pack(
+    SelectedElement<ElemT, PackFacts<AnyPackRelu, PrevPack, LastPackCb, PackHetero>> selected,
+    [[maybe_unused]] uint32_t i_flat,
+    [[maybe_unused]] uint32_t ht,
+    [[maybe_unused]] uint32_t wt,
+    [[maybe_unused]] uint32_t inner_count,
+    [[maybe_unused]] uint32_t block_sync_count,
+    [[maybe_unused]] uint32_t chain_lane_width,
+    [[maybe_unused]] uint32_t Ht,
+    [[maybe_unused]] uint32_t Wt) {
+    const ElemT& elem = selected.value;
+    [[maybe_unused]] constexpr bool use_local_idx = element_uses_per_block_index_v<ElemT>;
+    // upfront reserve is emitted once before the loop (see eltwise_chain_impl)
+    if constexpr (!eltwise_chain_skip_compute_v) {
+        emit_per_stage_pack_reconfig(dfb_for_side<Side::Pack, ElemT>(), PrevPack, LastPackCb, PackHetero);
+    }
+    if constexpr (ElemT::Reserve == ReservePolicy::PerTile) {
+        emit_reserve<true>(ElemT::dfb, 1);
+    } else if constexpr (ElemT::Reserve == ReservePolicy::PerBlockSize) {
+        emit_reserve<true>(ElemT::dfb, block_sync_count);
+    }
+    if constexpr (AnyPackRelu && !eltwise_chain_skip_compute_v) {
+        elem.configure_relu();
+    }
+    if constexpr (!eltwise_chain_skip_compute_v) {
+#pragma GCC unroll 0
+        for (uint32_t j = 0; j < inner_count; ++j) {
+            const uint32_t i_arg = use_local_idx ? j : (i_flat + j);
+            elem.exec(i_arg, ht, wt + j, j * chain_lane_width);
+        }
+    }
+    if constexpr (ElemT::Push == PushPolicy::PerTile) {
+        emit_push<true>(ElemT::dfb, 1);
+    } else if constexpr (ElemT::Push == PushPolicy::PerBlockSize) {
+        emit_push<true>(ElemT::dfb, block_sync_count);
+    }
+}
+
+ALWI void elem_apply_seed_first_l1_pack(UnselectedElement, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t) {}
+
+template <class ElemT>
+ALWI void elem_apply_seed_first_l1_pack(
+    SelectedElement<ElemT> selected,
+    [[maybe_unused]] uint32_t i_flat,
+    [[maybe_unused]] uint32_t ht,
+    [[maybe_unused]] uint32_t wt,
+    [[maybe_unused]] uint32_t j,
+    [[maybe_unused]] uint32_t chain_lane_width) {
+    if constexpr (!eltwise_chain_skip_compute_v) {
+        constexpr bool use_local_idx = element_uses_per_block_index_v<ElemT>;
+        const uint32_t i_arg = use_local_idx ? j : (i_flat + j);
+        selected.value.exec(i_arg, ht, wt + j, j * chain_lane_width);
+    }
+}
+
+ALWI void emit_wait_upfront(UnselectedElement, uint32_t, uint32_t) {}
+
+template <class E>
+ALWI void emit_wait_upfront(SelectedElement<E> selected, uint32_t Ht, uint32_t Wt) {
+    const E& e = selected.value;
+    if constexpr (is_binary_fpu_op_v<E>) {
+        if constexpr (E::same_dfb) {
+            const uint32_t base_a = tile_base_value<E::AddressingA>(e.a.tile_base);
+            const uint32_t base_b = tile_base_value<E::AddressingB>(e.b.tile_base);
+            const uint32_t base = base_a > base_b ? base_a : base_b;
+            if constexpr (E::AWait == WaitPolicy::Upfront && E::APop == PopPolicy::PerTile) {
+                emit_wait<true>(E::dfb_a_id(), Ht * Wt + base);
+            } else if constexpr (E::AWait == WaitPolicy::Upfront) {
+                emit_wait<true>(E::dfb_a_id(), detail::window<E::AMapping>(Ht, Wt) + base);
+            }
+        } else {
+            if constexpr (E::AWait == WaitPolicy::Upfront && E::APop == PopPolicy::PerTile) {
+                emit_wait<true>(E::dfb_a_id(), Ht * Wt + tile_base_value<E::AddressingA>(e.a.tile_base));
+            } else if constexpr (E::AWait == WaitPolicy::Upfront) {
+                emit_wait<true>(
+                    E::dfb_a_id(), detail::window<E::AMapping>(Ht, Wt) + tile_base_value<E::AddressingA>(e.a.tile_base));
+            }
+            if constexpr (E::BWait == WaitPolicy::Upfront && E::BPop == PopPolicy::PerTile) {
+                emit_wait<true>(E::dfb_b_id(), Ht * Wt + tile_base_value<E::AddressingB>(e.b.tile_base));
+            } else if constexpr (E::BWait == WaitPolicy::Upfront) {
+                emit_wait<true>(
+                    E::dfb_b_id(), detail::window<E::BMapping>(Ht, Wt) + tile_base_value<E::AddressingB>(e.b.tile_base));
+            }
+        }
+    } else if constexpr (is_cb_reader_op_v<E>) {
+        if constexpr (E::Wait == WaitPolicy::Upfront && E::Pop == PopPolicy::PerTile) {
+            emit_wait<true>(E::dfb, Ht * Wt + tile_base_value<E::Addressing>(e.tile_base));
+        } else if constexpr (E::Wait == WaitPolicy::Upfront) {
+            emit_wait<true>(E::dfb, detail::window<E::Mapping>(Ht, Wt) + tile_base_value<E::Addressing>(e.tile_base));
+        }
+    }
+}
+
+ALWI void emit_reserve_upfront(UnselectedElement, uint32_t, uint32_t) {}
+
+template <class E>
+ALWI void emit_reserve_upfront(SelectedElement<E> selected, uint32_t Ht, uint32_t Wt) {
+    const E& e = selected.value;
+    if constexpr (E::Reserve == ReservePolicy::Upfront) {
+        emit_reserve<true>(E::dfb, (Ht * Wt) + tile_base_value<E::Addressing>(e.tile_base));
+    } else if constexpr (E::Reserve == ReservePolicy::OneUpfront) {
+        emit_reserve<true>(E::dfb, 1);
+    }
+}
+
+ALWI void emit_pop_at_end(UnselectedElement, uint32_t, uint32_t) {}
+
+template <class E>
+ALWI void emit_pop_at_end(SelectedElement<E> selected, uint32_t Ht, uint32_t Wt) {
+    const E& e = selected.value;
+    if constexpr (is_binary_fpu_op_v<E>) {
+        if constexpr (E::same_dfb) {
+            if constexpr (E::APop == PopPolicy::AtEnd) {
+                const uint32_t base_a = tile_base_value<E::AddressingA>(e.a.tile_base);
+                const uint32_t base_b = tile_base_value<E::AddressingB>(e.b.tile_base);
+                const uint32_t base = base_a > base_b ? base_a : base_b;
+                emit_pop<true>(E::dfb_a_id(), detail::window<E::AMapping>(Ht, Wt) + base);
+            }
+        } else {
+            if constexpr (E::APop == PopPolicy::AtEnd) {
+                emit_pop<true>(
+                    E::dfb_a_id(), detail::window<E::AMapping>(Ht, Wt) + tile_base_value<E::AddressingA>(e.a.tile_base));
+            }
+            if constexpr (E::BPop == PopPolicy::AtEnd) {
+                emit_pop<true>(
+                    E::dfb_b_id(), detail::window<E::BMapping>(Ht, Wt) + tile_base_value<E::AddressingB>(e.b.tile_base));
+            }
+        }
+    } else if constexpr (is_cb_reader_op_v<E>) {
+        if constexpr (E::Pop == PopPolicy::AtEnd) {
+            emit_pop<true>(E::dfb, detail::window<E::Mapping>(Ht, Wt) + tile_base_value<E::Addressing>(e.tile_base));
+        }
+    }
+}
+
+ALWI void emit_push_at_end(UnselectedElement, uint32_t, uint32_t) {}
+
+template <class E>
+ALWI void emit_push_at_end(SelectedElement<E> selected, uint32_t Ht, uint32_t Wt) {
+    const E& e = selected.value;
+    if constexpr (E::Push == PushPolicy::AtEnd) {
+        emit_push<true>(E::dfb, (E::walk ? (Ht * Wt) : 1u) + tile_base_value<E::Addressing>(e.tile_base));
+    } else if constexpr (E::Push == PushPolicy::OneAtEnd) {
+        emit_push<true>(E::dfb, 1);
+    }
+}
+
+template <bool WaitA, bool WaitB>
+ALWI void emit_wait_per_row(uint32_t cb_a, uint32_t cb_b) {
+    emit_wait<WaitA>(cb_a, 1);
+    emit_wait<WaitB>(cb_b, 1);
+}
+
+template <bool PopA, bool PopB>
+ALWI void emit_pop_per_row(uint32_t cb_a, uint32_t cb_b) {
+    emit_pop<PopA>(cb_a, 1);
+    emit_pop<PopB>(cb_b, 1);
+}
+
+template <bool Reserve>
+ALWI void emit_reserve_per_row(uint32_t cb) {
+    emit_reserve<Reserve>(cb, 1);
+}
+
+template <bool Push>
+ALWI void emit_push_per_row(uint32_t cb) {
+    emit_push<Push>(cb, 1);
+}
+
+}  // namespace detail
+
+// eltwise_chain_impl — the walk. InitReconfigOwner::Chain (default) emits the chain's one-time setup
+// (pack boot init + the uniform math-MOP / SFPU init + their srca/srcb reconfig) before walking.
+// InitReconfigOwner::Caller skips ALL of it: the caller emitted the chain's whole one-time setup itself,
+// once, before its own loop, so this call is pure per-tile compute. InitReconfigOwner is about WHO emits
+// the hoistable setup — it never changes which init is hoistable (that's deduced from uniformity).
+template <InitReconfigOwner Owner = InitReconfigOwner::Chain, std::size_t... Is, class... Es>
+ALWI void eltwise_chain_impl([[maybe_unused]] std::index_sequence<Is...> indices, IterationShape shape, Es... elts) {
+    using Chain = EltwiseChain<Es...>;
+    static_assert(
+        (is_classified_chain_element_v<Es> && ...),
+        "eltwise_chain: every element must carry exactly one kind tag (CB reader, CB writer, or DEST-only); "
+        "an unclassified element would silently no-op through every stage");
+    static_assert(
+        detail::ChainTraits<Es...>::any_dest_accumulation ==
+            detail::ChainTraits<Es...>::any_dest_accumulation_lifecycle,
+        "eltwise_chain: DEST accumulation must be enabled on both BinaryFpu and output(...)");
+    static_assert(
+        detail::ChainTraits<Es...>::dest_accumulation_modes_consistent,
+        "eltwise_chain: BinaryFpu and output(...) must use the same DEST accumulation mode");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_dest_accumulation ||
+            detail::ChainTraits<Es...>::dest_accumulation_slot_count == 1,
+        "eltwise_chain: DEST accumulation requires one sticky DEST slot");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_dest_accumulation || detail::ChainTraits<Es...>::pack_writer_count == 1,
+        "eltwise_chain: DEST accumulation requires exactly one PackTile");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_dest_accumulation ||
+            detail::ChainTraits<Es...>::dest_accumulation_pack_matches,
+        "eltwise_chain: DEST accumulation PackTile must pack the sticky DEST slot");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_dest_accumulation ||
+            detail::ChainTraits<Es...>::all_writers_dest_accumulation_lifecycle,
+        "eltwise_chain: DEST accumulation cannot mix ordinary and accumulating outputs");
+    static_assert(
+        detail::ChainTraits<Es...>::managed_dest_accumulation_lifecycles <= 1,
+        "eltwise_chain: only one PackTile may manage the DEST-accumulation output lifecycle");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_dest_accumulation ||
+            detail::ChainTraits<Es...>::transient_lane_width < DEST_AUTO_LIMIT,
+        "eltwise_chain: sticky D0 leaves insufficient DEST capacity for a transient lane");
+    static_assert(
+        chain_max_block_v<Chain> > 0, "eltwise_chain: an element's DEST footprint exceeds the available DEST capacity");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_dest_accumulation || !detail::ChainTraits<Es...>::any_l1_accumulation,
+        "eltwise_chain: DEST and L1 accumulation cannot be combined");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_l1_accumulation || detail::ChainTraits<Es...>::pack_dfbs_consistent,
+        "eltwise_chain: L1 accumulation requires one output CB");
+    static_assert(
+        !detail::ChainTraits<Es...>::any_l1_accumulation || detail::ChainTraits<Es...>::all_writers_l1_accumulation,
+        "eltwise_chain: L1 accumulation cannot mix ordinary and accumulating PackTile elements");
+    static_assert(
+        detail::ChainTraits<Es...>::l1_accumulation_modes_consistent,
+        "eltwise_chain: accumulating PackTile elements must use one L1 accumulation mode");
+    static_assert(
+        detail::ChainTraits<Es...>::managed_l1_accumulation_lifecycles <= 1,
+        "eltwise_chain: only one PackTile may manage the L1-accumulation output lifecycle");
+    static_assert(
+        !chain_has_duplicate_upfront_cbs_v<Chain>,
+        "eltwise_chain: a staged CB window shares its front with another reader that can pop it.");
+    static_assert(
+        !chain_pack_writes_collide_v<Chain>, "eltwise_chain: two PackTile elements collide on (dfb, dst_slot).");
+    static_assert(
+        (uint32_t{0} + ... + uint32_t{is_prng_seed_op_v<Es>}) <= 1,
+        "eltwise_chain: RandTile and Dropout seed one shared hardware PRNG; use at most one PRNG-seeding element.");
+    static_assert(
+        !((false || ... || is_prng_seed_op_v<Es>) && (false || ... || is_sfpu_op_v<Es>)),
+        "eltwise_chain: a PRNG-seeding element may be combined only with Fill and non-SFPU stages; "
+        "mixed SFPU stages need a separate PRNG reconfiguration design.");
+    static_assert(
+        Owner == InitReconfigOwner::Chain || (!(false || ... || is_prng_seed_op_v<Es>)),
+        "eltwise_chain: PRNG-seeding elements require InitReconfigOwner::Chain so the helper seeds the PRNG once.");
+    // InitReconfigOwner::Caller means "the caller did the chain's whole one-time setup itself, once,
+    // before the loop." That's only achievable if EVERY part of it is boot-hoistable: uniform
+    // math MOP + SFPU init (so input/srca-srcb reconfig is boot-only) AND homogeneous pack CBs
+    // (so output/pack reconfig is boot-only — no per-stage pack reconfig in the loop). Otherwise
+    // some setup must re-emit per tile, the caller can't pre-do it once, and the knob silently
+    // skips a needed init/reconfig — a footgun. Forbid it at compile time.
+    static_assert(
+        Owner == InitReconfigOwner::Chain ||
+            (chain_hoist_math_mop_v<Chain> && chain_hoist_sfpu_v<Chain> && chain_hoist_pack_v<Chain>),
+        "InitReconfigOwner::Caller requires a chain whose entire one-time setup is boot-hoistable "
+        "(uniform math MOP + SFPU init AND homogeneous pack CBs) so that input AND output "
+        "reconfig are boot-only and nothing self-emits per tile. This chain has setup that "
+        "must re-emit per tile, so the caller cannot own it once — use InitReconfigOwner::Chain.");
+    // Honesty: under InitReconfigOwner::Caller the chain emits NO reconfig at all (the caller owns the
+    // setup), so enabled operand reconfig on any element is inert and lies about what runs inside
+    // the helper. Require each input/output spec to disable it.
+    static_assert(
+        Owner == InitReconfigOwner::Chain || chain_no_reconfig_requested_v<Chain>,
+        "InitReconfigOwner::Caller with enabled operand reconfig: under Caller the chain emits no "
+        "reconfig (the caller owns the setup), so the setting is inert and misleading. Disable "
+        "reconfig in every input/output spec — the caller's manual setup owns the format.");
+    static_assert(
+        Owner == InitReconfigOwner::Chain || ((!is_runtime_conditional_op_v<Es>) && ...),
+        "InitReconfigOwner::Caller cannot be used with runtime-conditional elements because their "
+        "selected init must execute inside each chain invocation.");
+    // An empty walk is a valid no-op.  Return before any init or DFB lifecycle operation: an
+    // upfront wait/reserve for zero tiles is not merely redundant, it can consume a caller-owned
+    // window that the chain was asked not to touch.
+    if (shape.Ht == 0 || shape.Wt == 0) {
+        return;
+    }
+    // Per-cohort hoist decisions: math-MOP init can be hoisted at boot even when SFPU isn't
+    // uniform; the SFPU side then re-inits per tile.
+    constexpr bool hoist_math = chain_hoist_math_mop_v<Chain>;
+    constexpr bool hoist_sfpu = chain_hoist_sfpu_v<Chain>;
+    if constexpr (Owner == InitReconfigOwner::Chain && !detail::eltwise_chain_skip_compute_v) {
+        (detail::elem_pack_init(detail::select_element<
+                                is_pack_tile_op_v<Es>,
+                                detail::TransitionFacts<
+                                    detail::ChainTraits<Es...>::prev.srca[Is],
+                                    detail::ChainTraits<Es...>::prev.srcb[Is],
+                                    detail::ChainTraits<Es...>::prev.pack[Is],
+                                    detail::ChainTraits<Es...>::pack_hetero>>(elts)),
+         ...);
+        (detail::hoist_compute_init_one(
+             detail::select_element < (is_math_mop_op_v<Es> && hoist_math) ||
+                 ((is_dest_only_op_v<Es> && !is_prng_seed_op_v<Es>) && hoist_sfpu),
+             detail::TransitionFacts < detail::ChainTraits<Es...>::prev.srca[Is],
+             detail::ChainTraits<Es...>::prev.srcb[Is],
+             detail::ChainTraits<Es...>::prev.pack[Is],
+             detail::ChainTraits<Es...>::pack_hetero >> (elts)),
+         ...);
+        // Seed last, after Fill and ordinary one-time setup. The seed must remain live across every
+        // block, so PRNG seeders never participate in the per-block SFPU-init fallback.
+        (detail::hoist_compute_init_one(detail::select_element<
+                                        is_prng_seed_op_v<Es>,
+                                        detail::TransitionFacts<
+                                            detail::ChainTraits<Es...>::prev.srca[Is],
+                                            detail::ChainTraits<Es...>::prev.srcb[Is],
+                                            detail::ChainTraits<Es...>::prev.pack[Is],
+                                            detail::ChainTraits<Es...>::pack_hetero>>(elts)),
+         ...);
+    }
+    constexpr uint32_t chain_lane_w = detail::ChainTraits<Es...>::any_dest_accumulation
+                                          ? chain_transient_lane_width_v<Chain>
+                                          : chain_lane_width_v<Chain>;
+    uint32_t block_size = shape.block_tiles;
+    ASSERT(shape.Ht > 0);
+    ASSERT(shape.Wt > 0);
+    ASSERT(block_size > 0);
+    const bool synchronize_full_blocks = shape.tail_sync == BlockTailSync::FullBlock;
+    if constexpr (!chain_supports_block_v<Chain>) {
+        ASSERT(!synchronize_full_blocks || block_size == 1);
+        block_size = 1;
+    } else {
+        constexpr uint32_t max_block = chain_max_block_v<Chain>;
+        ASSERT(!synchronize_full_blocks || block_size <= max_block);
+        if (block_size > max_block) {
+            block_size = max_block;
+        }
+    }
+
+    const uint32_t Ht = shape.Ht;
+    const uint32_t Wt = shape.Wt;
+
+    (detail::emit_wait_upfront(detail::select_element<detail::waits_upfront<Es>()>(elts), Ht, Wt), ...);
+    (detail::emit_reserve_upfront(detail::select_element<detail::reserves_upfront<Es>()>(elts), Ht, Wt), ...);
+
+    constexpr DestAccumulation dest_accumulation_mode = detail::ChainTraits<Es...>::dest_accumulation_mode;
+    constexpr bool dest_accumulation = dest_accumulation_mode != DestAccumulation::Disabled;
+    constexpr bool per_row_dest_accumulation = dest_accumulation_mode == DestAccumulation::PerRow;
+    constexpr bool whole_shape_dest_accumulation = dest_accumulation_mode == DestAccumulation::WholeShape;
+    if constexpr (detail::ChainTraits<Es...>::any_l1_accumulation && !detail::eltwise_chain_skip_compute_v) {
+        pack_reconfig_l1_acc(detail::ChainTraits<Es...>::any_seed_first_l1_accumulation ? 0 : 1);
+    }
+    if constexpr (whole_shape_dest_accumulation) {
+        (detail::emit_reserve_per_row<detail::ChainTraits<Es...>::d[Is].reserve_per_outer>(
+             detail::ChainTraits<Es...>::d[Is].pack_dfb),
+         ...);
+        tile_regs_acquire();
+    }
+    for (uint32_t ht = 0; ht < Ht; ++ht) {
+        const uint32_t row_base = ht * Wt;
+        (detail::emit_wait_per_row<
+             detail::ChainTraits<Es...>::d[Is].wait_a_per_row,
+             detail::ChainTraits<Es...>::d[Is].wait_b_per_row>(
+             detail::ChainTraits<Es...>::d[Is].row_stream_input_a_cb,
+             detail::ChainTraits<Es...>::d[Is].row_stream_input_b_cb),
+         ...);
+        if constexpr (per_row_dest_accumulation) {
+            (detail::emit_reserve_per_row<detail::ChainTraits<Es...>::d[Is].reserve_per_outer>(
+                 detail::ChainTraits<Es...>::d[Is].pack_dfb),
+             ...);
+            tile_regs_acquire();
+        }
+        for (uint32_t wt_base = 0; wt_base < Wt;) {
+            const uint32_t inner_count = (wt_base + block_size <= Wt) ? block_size : (Wt - wt_base);
+            const uint32_t block_sync_count = synchronize_full_blocks ? block_size : inner_count;
+            const uint32_t i_flat = row_base + wt_base;
+            if constexpr (!dest_accumulation) {
+                tile_regs_acquire();
+            }
+            (detail::elem_apply_compute(
+                 detail::select_element<
+                     detail::participates_in_compute_v<Es>,
+                     detail::ComputeFacts<
+                         !hoist_math,
+                         !hoist_sfpu,
+                         dest_accumulation ? 1 : 0,
+                         detail::ChainTraits<Es...>::prev.srca[Is],
+                         detail::ChainTraits<Es...>::prev.srcb[Is],
+                         detail::ChainTraits<Es...>::prev.pack[Is],
+                         detail::ChainTraits<Es...>::pack_hetero>>(elts),
+                 i_flat,
+                 ht,
+                 wt_base,
+                 inner_count,
+                 block_sync_count,
+                 chain_lane_w,
+                 Ht,
+                 Wt),
+             ...);
+            if constexpr (!dest_accumulation) {
+                tile_regs_commit();
+                tile_regs_wait();
+                if constexpr (detail::ChainTraits<Es...>::any_seed_first_l1_accumulation) {
+                    for (uint32_t j = 0; j < inner_count; ++j) {
+                        (detail::elem_apply_seed_first_l1_pack(
+                             detail::select_element<is_pack_tile_op_v<Es>>(elts), i_flat, ht, wt_base, j, chain_lane_w),
+                         ...);
+                        if constexpr (!detail::eltwise_chain_skip_compute_v) {
+                            if (i_flat == 0 && j == 0) {
+                                pack_reconfig_l1_acc(1);
+                            }
+                        }
+                    }
+                } else {
+                    (detail::elem_apply_pack(
+                         detail::select_element<
+                             is_pack_tile_op_v<Es>,
+                             detail::PackFacts<
+                                 detail::ChainTraits<Es...>::any_pack_relu,
+                                 detail::ChainTraits<Es...>::prev.pack[Is],
+                                 detail::ChainTraits<Es...>::last_pack_cb,
+                                 detail::ChainTraits<Es...>::pack_hetero>>(elts),
+                         i_flat,
+                         ht,
+                         wt_base,
+                         inner_count,
+                         block_sync_count,
+                         chain_lane_w,
+                         Ht,
+                         Wt),
+                     ...);
+                }
+                tile_regs_release();
+            }
+            wt_base += inner_count;
+        }
+        if constexpr (per_row_dest_accumulation) {
+            tile_regs_commit();
+            tile_regs_wait();
+            (detail::elem_apply_pack(
+                 detail::select_element<
+                     is_pack_tile_op_v<Es>,
+                     detail::PackFacts<
+                         detail::ChainTraits<Es...>::any_pack_relu,
+                         detail::ChainTraits<Es...>::prev.pack[Is],
+                         detail::ChainTraits<Es...>::last_pack_cb,
+                         detail::ChainTraits<Es...>::pack_hetero>>(elts),
+                 row_base,
+                 ht,
+                 0,
+                 1,
+                 1,
+                 0,
+                 Ht,
+                 Wt),
+             ...);
+            tile_regs_release();
+            (detail::emit_push_per_row<detail::ChainTraits<Es...>::d[Is].push_per_outer>(
+                 detail::ChainTraits<Es...>::d[Is].pack_dfb),
+             ...);
+        }
+        (detail::emit_pop_per_row<
+             detail::ChainTraits<Es...>::d[Is].pop_a_per_row,
+             detail::ChainTraits<Es...>::d[Is].pop_b_per_row>(
+             detail::ChainTraits<Es...>::d[Is].row_stream_input_a_cb,
+             detail::ChainTraits<Es...>::d[Is].row_stream_input_b_cb),
+         ...);
+    }
+    if constexpr (whole_shape_dest_accumulation) {
+        tile_regs_commit();
+        tile_regs_wait();
+        (detail::elem_apply_pack(
+             detail::select_element<
+                 is_pack_tile_op_v<Es>,
+                 detail::PackFacts<
+                     detail::ChainTraits<Es...>::any_pack_relu,
+                     detail::ChainTraits<Es...>::prev.pack[Is],
+                     detail::ChainTraits<Es...>::last_pack_cb,
+                     detail::ChainTraits<Es...>::pack_hetero>>(elts),
+             0,
+             0,
+             0,
+             1,
+             1,
+             0,
+             Ht,
+             Wt),
+         ...);
+        tile_regs_release();
+        (detail::emit_push_per_row<detail::ChainTraits<Es...>::d[Is].push_per_outer>(
+             detail::ChainTraits<Es...>::d[Is].pack_dfb),
+         ...);
+    }
+    if constexpr (detail::ChainTraits<Es...>::any_l1_accumulation && !detail::eltwise_chain_skip_compute_v) {
+        pack_reconfig_l1_acc(0);
+    }
+
+    if constexpr (detail::ChainTraits<Es...>::any_pack_relu && !detail::eltwise_chain_skip_compute_v) {
+        pack_relu_config(ReluConfig::none());
+    }
+    (detail::emit_pop_at_end(detail::select_element<detail::pops_at_end<Es>()>(elts), Ht, Wt), ...);
+    (detail::emit_push_at_end(detail::select_element<detail::pushes_at_end<Es>()>(elts), Ht, Wt), ...);
+}
+
+// =============================================================================
+// 11c. Public eltwise_chain — forwards every element straight to eltwise_chain_impl.
+//
+// A compile-time-disabled optional resolves to the shared, members-less,
+// tag-less `DisabledChainElement`. Every op-kind trait (is_cb_reader / is_pack / is_dest_only / is_math_mop
+// = std::is_base_of on a tag it lacks) is false for it, and every ElemDesc accessor is
+// SFINAE-guarded (dfb_* gate on the op-kind, lane_width defaults to 1, etc.), so it reflects
+// into a NEUTRAL ElemDesc — no CB, no reconfig, no pack, lane_width 1 — and every stage
+// (planner, hoist, reconfig fold, per-tile loop) treats it as inert. It is transparent to
+// the prev-CB sweep too: its NO_PREV_DFB sides never update the running prev, so a later
+// element sees the same previous CB as if the marker were absent.
+//
+// Passing the marker through the folds leaves it inert and transparent to neighboring elements.
+// =============================================================================
+
+// Public entry. `InitReconfigOwner Owner` (default Chain) says who emits the chain's one-time setup:
+// Chain = this call emits it; Caller = the caller emitted it once, outside its loop (see the
+// InitReconfigOwner enum doc). It never changes which init is hoistable. (default lives on the
+// declaration in chain.hpp.)
+template <InitReconfigOwner Owner, class... Es>
+ALWI void eltwise_chain(IterationShape shape, Es... elts) {
+    eltwise_chain_impl<Owner>(std::index_sequence_for<Es...>{}, shape, elts...);
+}
+
+// =============================================================================
+// 12. dfb_a_of / dfb_b_of / pack_dfb_of — single-element CB id deducers used by the
+// collision-detection static_asserts (chain_has_duplicate_upfront_cbs_v,
+// chain_pack_writes_collide_v). Caller-side hw_startup is the caller's
+// responsibility — there is no deduced wrapper.
+// =============================================================================
+
+namespace detail {
+
+template <class E>
+constexpr uint32_t dfb_a_of() {
+    if constexpr (is_cb_reader_op_v<E>) {
+        static_assert(has_dfb_a<E>::value, "CbReader element must declare 'static constexpr uint32_t dfb_a_id()'");
+        return E::dfb_a_id();
+    } else {
+        return INVALID_DFB;
+    }
+}
+
+template <class E>
+constexpr uint32_t dfb_b_of() {
+    if constexpr (is_binary_fpu_op_v<E> || is_dest_reuse_binary_op_v<E>) {
+        static_assert(
+            has_dfb_b<E>::value, "Binary CbReader element must declare 'static constexpr uint32_t dfb_b_id()'");
+        return E::dfb_b_id();
+    } else {
+        return INVALID_DFB;
+    }
+}
+
+template <class E>
+constexpr uint32_t pack_dfb_of() {
+    if constexpr (is_pack_tile_op_v<E>) {
+        static_assert(
+            has_pack_dfb<E>::value, "CbWriter element must declare 'static constexpr uint32_t pack_dfb_id()'");
+        return E::pack_dfb_id();
+    } else {
+        return INVALID_DFB;
+    }
+}
+
+}  // namespace detail
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/chain.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/chain.inl
@@ -429,6 +429,14 @@ struct CbWriterTag {};
 /// `pack_dfb_id()` on the element directly.
 struct DestOnlyTag {};
 
+/// DEST-only SFPU operation arity markers.  These are intentionally separate
+/// from the data-direction tag: convenience wrappers need to distinguish the
+/// DEST operands an operation consumes, while chain scheduling only needs to
+/// know that the operation has no CB lifecycle.
+struct UnaryOpTag : DestOnlyTag {};
+struct BinaryOpTag : DestOnlyTag {};
+struct TernaryOpTag : DestOnlyTag {};
+
 /// Marker mixed into runtime-conditional wrappers. It is orthogonal to the element-kind
 /// hierarchy so the wrapped element keeps its ordinary reader / DEST-only classification.
 struct RuntimeConditionalTag {};
@@ -475,6 +483,12 @@ template <class T>
 inline constexpr bool is_cb_writer_op_v = std::is_base_of_v<CbWriterTag, T>;
 template <class T>
 inline constexpr bool is_dest_only_op_v = std::is_base_of_v<DestOnlyTag, T>;
+template <class T>
+inline constexpr bool is_unary_op_v = std::is_base_of_v<UnaryOpTag, T>;
+template <class T>
+inline constexpr bool is_binary_op_v = std::is_base_of_v<BinaryOpTag, T>;
+template <class T>
+inline constexpr bool is_ternary_op_v = std::is_base_of_v<TernaryOpTag, T>;
 template <class T>
 inline constexpr bool is_copy_tile_op_v = std::is_base_of_v<CopyTileTag, T>;
 template <class T>
@@ -564,7 +578,7 @@ ALWI uint32_t tile_base_value([[maybe_unused]] uint32_t stored) noexcept {
 //   };
 
 template <class Derived, Dst Slot>
-struct UnaryOp : DestOnlyTag {
+struct UnaryOp : UnaryOpTag {
     static_assert(
         to_u32(Slot) < DEST_AUTO_LIMIT, "UnaryOp: DEST slot exceeds compile-time DEST capacity (DEST_AUTO_LIMIT)");
 
@@ -582,7 +596,7 @@ struct UnaryOp : DestOnlyTag {
 };
 
 template <class Derived, Dst In0, Dst In1, Dst Out>
-struct BinaryOp : DestOnlyTag {
+struct BinaryOp : BinaryOpTag {
     static_assert(
         to_u32(In0) < DEST_AUTO_LIMIT && to_u32(In1) < DEST_AUTO_LIMIT && to_u32(Out) < DEST_AUTO_LIMIT,
         "BinaryOp: DEST slot exceeds compile-time DEST capacity (DEST_AUTO_LIMIT)");
@@ -603,7 +617,7 @@ struct BinaryOp : DestOnlyTag {
 };
 
 template <class Derived, Dst In0, Dst In1, Dst In2, Dst Out>
-struct TernaryOp : DestOnlyTag {
+struct TernaryOp : TernaryOpTag {
     static_assert(
         to_u32(In0) < DEST_AUTO_LIMIT && to_u32(In1) < DEST_AUTO_LIMIT && to_u32(In2) < DEST_AUTO_LIMIT &&
             to_u32(Out) < DEST_AUTO_LIMIT,
@@ -3055,10 +3069,13 @@ ALWI void eltwise_chain_impl([[maybe_unused]] std::index_sequence<Is...> indices
     constexpr uint32_t chain_lane_w = detail::ChainTraits<Es...>::any_dest_accumulation
                                           ? chain_transient_lane_width_v<Chain>
                                           : chain_lane_width_v<Chain>;
-    uint32_t block_size = shape.block_tiles;
+    // Assertions are intentionally absent in normal kernels.  Keep the debug
+    // contract, but normalize a malformed zero block size so the outer walk
+    // still makes forward progress in a release kernel.
+    uint32_t block_size = shape.block_tiles == 0 ? 1 : shape.block_tiles;
     ASSERT(shape.Ht > 0);
     ASSERT(shape.Wt > 0);
-    ASSERT(block_size > 0);
+    ASSERT(shape.block_tiles > 0);
     const bool synchronize_full_blocks = shape.tail_sync == BlockTailSync::FullBlock;
     if constexpr (!chain_supports_block_v<Chain>) {
         ASSERT(!synchronize_full_blocks || block_size == 1);

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/op_params.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/op_params.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file op_params.hpp
+ * @brief Self-documenting template-param enums shared by the eltwise op-helper structs.
+ *
+ * These are an op-helper concern, not part of the chain machinery, so they live here rather
+ * than in chain.hpp. The op-helper headers (math.hpp, special.hpp,
+ * activations.hpp) include this; kernels pick the values up transitively through them.
+ */
+
+namespace compute_kernel_lib {
+
+/// SFPU approximation mode for transcendental ops (Exp, Log, Sqrt, Rsqrt, Erf, the Gelu/Tanh
+/// derivatives, …). Lowers to the LLK op's `APPROXIMATE` template bool: `Exact` keeps the
+/// precise path, `Fast` selects the lower-precision fast approximation.
+enum class Approx : bool { Exact = false, Fast = true };
+
+/// Legacy code-path toggle. Currently used only by `Rsqrt`, whose `rsqrt_tile<...>` takes a
+/// leading `legacy` template bool selecting the older implementation. `Off` = modern path.
+enum class Legacy : bool { Off = false, On = true };
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+#include <type_traits>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+/**
+ * @file optional.hpp
+ * @brief Compile-time optional and runtime-conditional chain elements.
+ *
+ * Compile-time optional:
+ *
+ *     Optional<COND, Op>
+ *
+ * Runtime conditionals use one surface:
+ *
+ *     runtime_if(condition_a, OpA{}, OpB{})
+ *         .else_if(condition_b, OpB{}, OpC{})
+ *         .otherwise(DefaultOp{})
+ *
+ * `runtime_if(condition, ...)` and an if / else-if chain may be used directly;
+ * their unmatched case performs no element work. `.otherwise(...)` adds an
+ * explicit final else. Branch selection is ordered and exclusive: the first true
+ * branch wins. Every branch is one chain position, so one runtime decision guards
+ * the whole element sequence.
+ *
+ * Runtime-conditional sequences deliberately support only DEST-only operations
+ * and caller-managed CB readers. Writers and driver-managed waits/pops are rejected:
+ * their lifecycle cannot be conservatively planned across a disabled branch.
+ */
+
+namespace compute_kernel_lib {
+
+/// Shared inert, tag-less chain position used by every disabled compile-time optional.
+struct DisabledChainElement {
+    constexpr DisabledChainElement() noexcept = default;
+
+    template <class... Ignored>
+    constexpr explicit DisabledChainElement(Ignored&&...) noexcept {}
+};
+
+/// Enabled optionals are exactly `Inner`; disabled optionals share one short marker type.
+template <bool COND, class Inner>
+using Optional = std::conditional_t<COND, Inner, DisabledChainElement>;
+
+namespace detail {
+
+template <class Inner>
+constexpr bool runtime_conditional_element_supported();
+
+template <class... Elements>
+struct RuntimeConditionalBranch {
+    static_assert(sizeof...(Elements) > 0, "A runtime conditional branch requires at least one element");
+    static_assert(
+        (runtime_conditional_element_supported<Elements>() && ...),
+        "Runtime conditional elements must be DEST-only or use caller-managed input lifecycles");
+
+    std::tuple<Elements...> elements;
+
+    constexpr explicit RuntimeConditionalBranch(Elements... elements_) noexcept : elements(elements_...) {}
+};
+
+template <class Branch>
+struct RuntimeConditionalBranchTraits;
+
+template <class... Elements>
+struct RuntimeConditionalBranchTraits<RuntimeConditionalBranch<Elements...>> {
+    static constexpr bool any_reader = (is_cb_reader_op_v<Elements> || ...);
+    static constexpr bool touches_srca = ((dfb_for_side<Side::SrcA, Elements>() != NO_PREV_DFB) || ...);
+    static constexpr bool touches_srcb = ((dfb_for_side<Side::SrcB, Elements>() != NO_PREV_DFB) || ...);
+    static constexpr uint32_t lane_width = []() {
+        uint32_t result = 1;
+        ((result = result < elem_lane_width_v<Elements> ? elem_lane_width_v<Elements> : result), ...);
+        return result;
+    }();
+};
+
+template <class... Branches>
+struct RuntimeConditionalSequenceTraits {
+    static constexpr bool any_reader = (RuntimeConditionalBranchTraits<Branches>::any_reader || ...);
+    static constexpr bool touches_srca = (RuntimeConditionalBranchTraits<Branches>::touches_srca || ...);
+    static constexpr bool touches_srcb = (RuntimeConditionalBranchTraits<Branches>::touches_srcb || ...);
+    static constexpr uint32_t lane_width = []() {
+        uint32_t result = 1;
+        ((result = result < RuntimeConditionalBranchTraits<Branches>::lane_width
+                       ? RuntimeConditionalBranchTraits<Branches>::lane_width
+                       : result),
+         ...);
+        return result;
+    }();
+};
+
+template <bool AnyReader>
+struct RuntimeConditionalSequenceBase;
+
+template <>
+struct RuntimeConditionalSequenceBase<false> : DestOnlyTag {};
+
+template <>
+struct RuntimeConditionalSequenceBase<true> : CbReaderTag {
+    static constexpr WaitPolicy Wait = WaitPolicy::None;
+    static constexpr PopPolicy Pop = PopPolicy::None;
+    static constexpr uint32_t dfb = INVALID_DFB;
+
+    static constexpr uint32_t dfb_a_id() { return INVALID_DFB; }
+    static constexpr InputSpec a_input() {
+        return {INVALID_DFB, Wait, Pop, InputTileMapping::Scalar, DataFormatReconfig::Disabled, TileAddressing::Direct};
+    }
+};
+
+}  // namespace detail
+
+/// One runtime-selected chain position. `selected_branch == sizeof...(Branches)`
+/// means no branch is selected, which is how an unmatched `runtime_if(...)` becomes inert.
+template <class... Branches>
+struct RuntimeConditionalSequence
+    : detail::RuntimeConditionalSequenceBase<detail::RuntimeConditionalSequenceTraits<Branches...>::any_reader>,
+      RuntimeConditionalTag,
+      RuntimeConditionalSequenceTag {
+    static_assert(sizeof...(Branches) > 0, "A runtime conditional requires at least one branch");
+
+    using Traits = detail::RuntimeConditionalSequenceTraits<Branches...>;
+
+    // A conditional reader may or may not change each input-side format. Poison the
+    // outer previous-CB fold so a following reader reconfigures conservatively.
+    static constexpr uint32_t reconfig_srca_dfb = Traits::touches_srca ? CONDITIONAL_DFB : NO_PREV_DFB;
+    static constexpr uint32_t reconfig_srcb_dfb = Traits::touches_srcb ? CONDITIONAL_DFB : NO_PREV_DFB;
+    static constexpr uint32_t lane_width = Traits::lane_width;
+
+    uint32_t selected_branch;
+    std::tuple<Branches...> branches;
+
+    constexpr RuntimeConditionalSequence(uint32_t selected_branch_, std::tuple<Branches...> branches_) noexcept;
+
+    template <uint32_t SlotBase, uint32_t PrevA, uint32_t PrevB, uint32_t PrevP, bool PackHetero>
+    ALWI void apply(
+        uint32_t i_flat,
+        uint32_t ht,
+        uint32_t wt,
+        uint32_t inner_count,
+        uint32_t chain_lane_width,
+        uint32_t Ht,
+        uint32_t Wt) const;
+
+private:
+    template <
+        std::size_t BranchIndex,
+        uint32_t SlotBase,
+        uint32_t PrevA,
+        uint32_t PrevB,
+        uint32_t PrevP,
+        bool PackHetero>
+    ALWI void apply_selected(
+        uint32_t i_flat,
+        uint32_t ht,
+        uint32_t wt,
+        uint32_t inner_count,
+        uint32_t chain_lane_width,
+        uint32_t Ht,
+        uint32_t Wt) const;
+};
+
+/// Open ordered conditional. It is already a valid chain element with an implicit
+/// empty else, and may be extended with `.else_if(...)` or `.otherwise(...)`.
+template <class... Branches>
+struct RuntimeIfBuilder : RuntimeConditionalSequence<Branches...> {
+    using Base = RuntimeConditionalSequence<Branches...>;
+
+    constexpr RuntimeIfBuilder(uint32_t selected_branch_, std::tuple<Branches...> branches_) noexcept;
+
+    template <class... Elements>
+    ALWI auto else_if(bool condition, Elements... elements) const;
+
+    template <class... Elements>
+    ALWI auto otherwise(Elements... elements) const;
+};
+
+/// Start an ordered, exclusive runtime if / else-if / else chain. The result may
+/// be used directly, in which case an unmatched condition performs no element work.
+template <class... Elements>
+ALWI auto runtime_if(bool condition, Elements... elements);
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp
@@ -30,9 +30,10 @@
  * branch wins. Every branch is one chain position, so one runtime decision guards
  * the whole element sequence.
  *
- * Runtime-conditional sequences deliberately support only DEST-only operations
- * and caller-managed CB readers. Writers and driver-managed waits/pops are rejected:
- * their lifecycle cannot be conservatively planned across a disabled branch.
+ * Runtime-conditional sequences deliberately support only non-PRNG DEST-only
+ * operations and caller-managed CB readers. Writers, PRNG seeders, and
+ * driver-managed waits/pops are rejected: their one-time setup or lifecycle
+ * cannot be conservatively planned across a disabled branch.
  */
 
 namespace compute_kernel_lib {
@@ -59,7 +60,7 @@ struct RuntimeConditionalBranch {
     static_assert(sizeof...(Elements) > 0, "A runtime conditional branch requires at least one element");
     static_assert(
         (runtime_conditional_element_supported<Elements>() && ...),
-        "Runtime conditional elements must be DEST-only or use caller-managed input lifecycles");
+        "Runtime conditional elements must be non-PRNG DEST-only or use caller-managed input lifecycles");
 
     std::tuple<Elements...> elements;
 

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.inl
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file optional.inl
+ * @brief Implementation of compile-time optional and runtime-conditional elements.
+ *
+ * Included from `optional.hpp`. Do NOT include directly.
+ */
+
+namespace compute_kernel_lib {
+namespace detail {
+
+template <class Inner>
+constexpr bool runtime_conditional_element_supported() {
+    if constexpr (is_runtime_conditional_op_v<Inner> || is_cb_writer_op_v<Inner>) {
+        return false;
+    } else if constexpr (is_dest_only_op_v<Inner>) {
+        return true;
+    } else if constexpr (is_binary_fpu_op_v<Inner>) {
+        return !Inner::uses_dest_accumulation && Inner::AWait == WaitPolicy::None && Inner::APop == PopPolicy::None &&
+               (Inner::same_dfb || (Inner::BWait == WaitPolicy::None && Inner::BPop == PopPolicy::None));
+    } else if constexpr (is_cb_reader_op_v<Inner>) {
+        return Inner::Wait == WaitPolicy::None && Inner::Pop == PopPolicy::None;
+    } else {
+        return false;
+    }
+}
+
+template <
+    uint32_t SlotBase,
+    uint32_t PrevA,
+    uint32_t PrevB,
+    uint32_t PrevP,
+    bool PackHetero,
+    class... Elements,
+    std::size_t... Is>
+ALWI void apply_runtime_branch(
+    const RuntimeConditionalBranch<Elements...>& branch,
+    std::index_sequence<Is...>,
+    uint32_t i_flat,
+    uint32_t ht,
+    uint32_t wt,
+    uint32_t inner_count,
+    uint32_t chain_lane_width,
+    uint32_t Ht,
+    uint32_t Wt) {
+    // Runtime sequences cannot be boot-hoisted: the selected branch owns each
+    // element's transition + init immediately before that element executes. ChainTraits
+    // computes the branch-local previous-CB table once; a missing branch-local predecessor
+    // inherits the previous CB at the outer conditional's position.
+    (elem_apply_compute(
+         select_element<
+             participates_in_compute_v<Elements>,
+             ComputeFacts<
+                 true,
+                 true,
+                 SlotBase,
+                 ChainTraits<Elements...>::prev.srca[Is] == NO_PREV_DFB ? PrevA
+                                                                        : ChainTraits<Elements...>::prev.srca[Is],
+                 ChainTraits<Elements...>::prev.srcb[Is] == NO_PREV_DFB ? PrevB
+                                                                        : ChainTraits<Elements...>::prev.srcb[Is],
+                 ChainTraits<Elements...>::prev.pack[Is] == NO_PREV_DFB ? PrevP
+                                                                        : ChainTraits<Elements...>::prev.pack[Is],
+                 PackHetero>>(std::get<Is>(branch.elements)),
+         i_flat,
+         ht,
+         wt,
+         inner_count,
+         inner_count,
+         chain_lane_width,
+         Ht,
+         Wt),
+     ...);
+}
+
+}  // namespace detail
+
+template <class... Branches>
+constexpr RuntimeConditionalSequence<Branches...>::RuntimeConditionalSequence(
+    uint32_t selected_branch_, std::tuple<Branches...> branches_) noexcept :
+    selected_branch(selected_branch_), branches(branches_) {}
+
+template <class... Branches>
+template <uint32_t SlotBase, uint32_t PrevA, uint32_t PrevB, uint32_t PrevP, bool PackHetero>
+ALWI void RuntimeConditionalSequence<Branches...>::apply(
+    uint32_t i_flat,
+    uint32_t ht,
+    uint32_t wt,
+    uint32_t inner_count,
+    uint32_t chain_lane_width,
+    uint32_t Ht,
+    uint32_t Wt) const {
+    apply_selected<0, SlotBase, PrevA, PrevB, PrevP, PackHetero>(i_flat, ht, wt, inner_count, chain_lane_width, Ht, Wt);
+}
+
+template <class... Branches>
+template <std::size_t BranchIndex, uint32_t SlotBase, uint32_t PrevA, uint32_t PrevB, uint32_t PrevP, bool PackHetero>
+ALWI void RuntimeConditionalSequence<Branches...>::apply_selected(
+    uint32_t i_flat,
+    uint32_t ht,
+    uint32_t wt,
+    uint32_t inner_count,
+    uint32_t chain_lane_width,
+    uint32_t Ht,
+    uint32_t Wt) const {
+    if constexpr (BranchIndex < sizeof...(Branches)) {
+        if (selected_branch == BranchIndex) {
+            const auto& branch = std::get<BranchIndex>(branches);
+            detail::apply_runtime_branch<SlotBase, PrevA, PrevB, PrevP, PackHetero>(
+                branch,
+                std::make_index_sequence<std::tuple_size_v<decltype(branch.elements)>>{},
+                i_flat,
+                ht,
+                wt,
+                inner_count,
+                chain_lane_width,
+                Ht,
+                Wt);
+        } else {
+            apply_selected<BranchIndex + 1, SlotBase, PrevA, PrevB, PrevP, PackHetero>(
+                i_flat, ht, wt, inner_count, chain_lane_width, Ht, Wt);
+        }
+    }
+}
+
+template <class... Branches>
+constexpr RuntimeIfBuilder<Branches...>::RuntimeIfBuilder(
+    uint32_t selected_branch_, std::tuple<Branches...> branches_) noexcept :
+    Base(selected_branch_, branches_) {}
+
+template <class... Branches>
+template <class... Elements>
+ALWI auto RuntimeIfBuilder<Branches...>::else_if(bool condition, Elements... elements) const {
+    static_assert(sizeof...(Elements) > 0, "else_if requires at least one chain element");
+    using Branch = detail::RuntimeConditionalBranch<Elements...>;
+    constexpr uint32_t unmatched = sizeof...(Branches);
+    const uint32_t next_selected =
+        this->selected_branch == unmatched ? (condition ? unmatched : unmatched + 1) : this->selected_branch;
+    return RuntimeIfBuilder<Branches..., Branch>{
+        next_selected, std::tuple_cat(this->branches, std::tuple<Branch>{Branch{elements...}})};
+}
+
+template <class... Branches>
+template <class... Elements>
+ALWI auto RuntimeIfBuilder<Branches...>::otherwise(Elements... elements) const {
+    if constexpr (sizeof...(Elements) == 0) {
+        return RuntimeConditionalSequence<Branches...>{this->selected_branch, this->branches};
+    } else {
+        using Branch = detail::RuntimeConditionalBranch<Elements...>;
+        return RuntimeConditionalSequence<Branches..., Branch>{
+            this->selected_branch, std::tuple_cat(this->branches, std::tuple<Branch>{Branch{elements...}})};
+    }
+}
+
+template <class... Elements>
+ALWI auto runtime_if(bool condition, Elements... elements) {
+    static_assert(sizeof...(Elements) > 0, "runtime_if requires at least one chain element");
+    using Branch = detail::RuntimeConditionalBranch<Elements...>;
+    return RuntimeIfBuilder<Branch>{condition ? 0u : 1u, std::tuple<Branch>{Branch{elements...}}};
+}
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.inl
@@ -15,7 +15,7 @@ namespace detail {
 
 template <class Inner>
 constexpr bool runtime_conditional_element_supported() {
-    if constexpr (is_runtime_conditional_op_v<Inner> || is_cb_writer_op_v<Inner>) {
+    if constexpr (is_runtime_conditional_op_v<Inner> || is_cb_writer_op_v<Inner> || is_prng_seed_op_v<Inner>) {
         return false;
     } else if constexpr (is_dest_only_op_v<Inner>) {
         return true;

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file fill.hpp
+ * @brief Fill chain elements — FillScalar, FillInt, FillBitcast.
+ *
+ * These elements write a constant into a DEST slot. They derive `FillTileTag` (rooted in
+ * `DestOnlyTag`) so trait sweeps that look at CB consumers / CB producers correctly skip them.
+ * Each overrides `exec(uint32_t)` directly to capture the runtime constant.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <Dst DstSlot>
+struct FillScalar;
+template <DataFormat DF, Dst DstSlot>
+struct FillInt;
+template <Dst DstSlot>
+struct FillBitcast;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.inl
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of fill.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/fill.h"
+
+namespace compute_kernel_lib {
+
+template <Dst DstSlot>
+struct FillScalar : FillTileTag, UnaryOp<FillScalar<DstSlot>, DstSlot> {
+    float value;
+    constexpr explicit FillScalar(float v) noexcept : value(v) {}
+    constexpr FillScalar() noexcept : value(0.0f) {}
+
+    static ALWI void init() { fill_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { fill_tile(to_u32(DstSlot) + slot_offset, value); }
+};
+
+template <DataFormat DF, Dst DstSlot>
+struct FillInt : FillTileTag, UnaryOp<FillInt<DF, DstSlot>, DstSlot> {
+    uint32_t value;
+    constexpr explicit FillInt(uint32_t v) noexcept : value(v) {}
+    constexpr FillInt() noexcept : value(0) {}
+
+    // fill_tile_int shares the same init as fill_tile (no separate `_int_init`).
+    static ALWI void init() { fill_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        fill_tile_int<DF>(to_u32(DstSlot) + slot_offset, value);
+    }
+};
+
+template <Dst DstSlot>
+struct FillBitcast : FillTileTag, UnaryOp<FillBitcast<DstSlot>, DstSlot> {
+    uint32_t bits;
+    constexpr explicit FillBitcast(uint32_t b) noexcept : bits(b) {}
+    constexpr FillBitcast() noexcept : bits(0) {}
+
+    static ALWI void init() { fill_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        fill_tile_bitcast(to_u32(DstSlot) + slot_offset, bits);
+    }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file rand.hpp
+ * @brief Rand chain element — RandTile.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <Dst DstSlot>
+struct RandTile;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.inl
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of rand.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/rand.h"
+
+namespace compute_kernel_lib {
+
+/// RandTile chain element.
+///
+/// `rand_tile_init(seed, stream_id)` is rand's per-op SFPU init (it seeds and domain-separates the PRNG) — the rand
+/// analogue of every other op's `*_tile_init`, except it takes the runtime seed. So
+/// `init()` is a normal instance method (non-static, like `exec`) that reads the
+/// element's `seed_` and `stream_id_`; the chain dispatches init on the instance, emitting it once at
+/// boot-hoist — the once-per-kernel seeding the kernel used to do out-of-band. The
+/// per-instance `from` / `scale` (uniform [from, from+scale] range), `seed`, and `stream_id` are all
+/// passed at construction (same pattern as `Dropout<Slot>`).
+///
+/// @code
+///   eltwise_chain(IterationShape::tiles(num_tiles),
+///       RandTile<Dst::D0>{from, scale, get_arg_val<uint32_t>(0), get_arg_val<uint32_t>(1)},
+///       PackTile<output(cb_out, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
+/// @endcode
+template <Dst DstSlot>
+struct RandTile : RandTileTag, UnaryOp<RandTile<DstSlot>, DstSlot> {
+    /// Runtime payload — `from`/`scale` define the uniform [from, from+scale] range;
+    /// `seed` seeds the PRNG once at init and `stream_id` domain-separates per-core work ranges.
+    uint32_t from_;
+    uint32_t scale_;
+    uint32_t seed_;
+    uint32_t stream_id_;
+
+    constexpr RandTile(uint32_t f, uint32_t s, uint32_t seed, uint32_t stream_id = 0) noexcept :
+        from_(f), scale_(s), seed_(seed), stream_id_(stream_id) {}
+    constexpr RandTile() noexcept : from_(0), scale_(0), seed_(0), stream_id_(0) {}
+
+    ALWI void init() const { rand_tile_init(seed_, stream_id_); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        rand_tile(to_u32(DstSlot) + slot_offset, from_, scale_);
+    }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/ternary/ternary.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/ternary/ternary.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file ternary.hpp
+ * @brief Chain-family ternary SFPU op structs — Lerp, SnakeBeta (static) and
+ *        Addcmul, Addcdiv (runtime scalar `value`).
+ *
+ * These are `eltwise_chain` family elements (DestOnlyTag + `exec(i, slot_offset)`). All
+ * four wrap a 4-DEST-arg LLK `op_tile<DF>(in0, in1, in2, out)`; addcmul/addcdiv
+ * additionally take a runtime `value` (uint32 bits).
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+// Chain-family ternary SFPU op structs (definitions in ternary.inl).
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst In2 = Dst::D2, Dst Out = Dst::D0>
+struct Lerp;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst In2 = Dst::D2, Dst Out = Dst::D0>
+struct SnakeBeta;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst In2 = Dst::D2, Dst Out = Dst::D0>
+struct Addcmul;
+template <DataFormat DF, Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst In2 = Dst::D2, Dst Out = Dst::D0>
+struct Addcdiv;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/ternary/ternary.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/ternary/ternary.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/ternary/ternary.inl
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of ternary.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/lerp.h"
+#include "api/compute/eltwise_unary/snake_beta.h"
+#include "api/compute/eltwise_unary/addcmul.h"
+#include "api/compute/eltwise_unary/addcdiv.h"
+
+namespace compute_kernel_lib {
+
+// Lerp — y = start + weight * (end - start). lerp_tile<DF>(start, end, weight, out).
+template <DataFormat DF, Dst In0, Dst In1, Dst In2, Dst Out>
+struct Lerp : TernaryOp<Lerp<DF, In0, In1, In2, Out>, In0, In1, In2, Out> {
+    static ALWI void init() { lerp_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        lerp_tile<DF>(
+            to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(In2) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// SnakeBeta — snake_beta_tile<DF>(x, alpha, beta, out).
+template <DataFormat DF, Dst In0, Dst In1, Dst In2, Dst Out>
+struct SnakeBeta : TernaryOp<SnakeBeta<DF, In0, In1, In2, Out>, In0, In1, In2, Out> {
+    static ALWI void init() { snake_beta_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        snake_beta_tile<DF>(
+            to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(In2) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// Addcmul — out = in0 + value * (in1 * in2). addcmul_tile<DF>(in0, in1, in2, out, value).
+// Runtime `value` (uint32 bits) => instance exec, like FillScalar.
+template <DataFormat DF, Dst In0, Dst In1, Dst In2, Dst Out>
+struct Addcmul : TernaryOp<Addcmul<DF, In0, In1, In2, Out>, In0, In1, In2, Out> {
+    uint32_t value;
+    constexpr explicit Addcmul(uint32_t v) noexcept : value(v) {}
+    constexpr Addcmul() noexcept : value(0) {}
+    static ALWI void init() { addcmul_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        addcmul_tile<DF>(
+            to_u32(In0) + slot_offset,
+            to_u32(In1) + slot_offset,
+            to_u32(In2) + slot_offset,
+            to_u32(Out) + slot_offset,
+            value);
+    }
+};
+
+// Addcdiv — out = in0 + value * (in1 / in2). addcdiv_tile<DF>(in0, in1, in2, out, value).
+template <DataFormat DF, Dst In0, Dst In1, Dst In2, Dst Out>
+struct Addcdiv : TernaryOp<Addcdiv<DF, In0, In1, In2, Out>, In0, In1, In2, Out> {
+    uint32_t value;
+    constexpr explicit Addcdiv(uint32_t v) noexcept : value(v) {}
+    constexpr Addcdiv() noexcept : value(0) {}
+    static ALWI void init() { addcdiv_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        addcdiv_tile<DF>(
+            to_u32(In0) + slot_offset,
+            to_u32(In1) + slot_offset,
+            to_u32(In2) + slot_offset,
+            to_u32(Out) + slot_offset,
+            value);
+    }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file activations.hpp
+ * @brief Activation SFPU op structs for the eltwise chain.
+ *
+ * Wraps `relu_tile`, `sigmoid_tile`, `tanh_tile`, `gelu_tile`, `elu_tile`, `selu_tile`,
+ * `hardsigmoid_tile`, `hardtanh_tile`, `hardmish_tile`, `softsign_tile`, `softplus_tile`,
+ * `prelu_tile`, `mish_tile`, `silu_tile`, etc.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/op_params.hpp"  // Approx
+
+namespace compute_kernel_lib {
+
+// Simple unary activations.
+template <Dst Slot = Dst::D0>
+struct Relu;
+template <Dst Slot = Dst::D0>
+struct Sigmoid;
+template <Dst Slot = Dst::D0>
+struct Tanh;
+template <Dst Slot = Dst::D0>
+struct Gelu;
+
+// Derivatives — Approx::Exact (default) / Approx::Fast.
+template <Approx fast = Approx::Exact, Dst Slot = Dst::D0>
+struct TanhDerivative;
+template <Approx fast = Approx::Exact, Dst Slot = Dst::D0>
+struct GeluDerivative;
+
+// Binary-in-DEST.
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct Logsigmoid;
+
+// More unary activations.
+template <Dst Slot = Dst::D0>
+struct Hardsigmoid;
+template <Dst Slot = Dst::D0>
+struct Softsign;
+template <Dst Slot = Dst::D0>
+struct Hardmish;
+
+// Activations with runtime parameters.
+template <Dst Slot = Dst::D0>
+struct Hardtanh;
+template <Dst Slot = Dst::D0>
+struct Elu;
+template <Dst Slot = Dst::D0>
+struct Selu;
+template <Dst Slot = Dst::D0>
+struct Softplus;
+template <Dst Slot = Dst::D0>
+struct Prelu;
+template <Dst Slot = Dst::D0>
+struct LeakyRelu;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.inl
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of activations.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/compute_kernel_api.h"         // sigmoid_tile, tanh_tile (also gelu fallback)
+#include "api/compute/eltwise_unary/activations.h"  // hardsigmoid, softsign, softshrink, hardshrink, celu
+#include "api/compute/eltwise_unary/elu.h"
+#include "api/compute/eltwise_unary/gelu.h"
+#include "api/compute/eltwise_unary/hardmish.h"
+#include "api/compute/eltwise_unary/tanh_derivative.h"  // TanhDerivative
+#include "api/compute/logsigmoid.h"                     // Logsigmoid (binary in-DEST)
+#include "api/compute/eltwise_unary/hardtanh.h"
+#include "api/compute/eltwise_unary/prelu.h"
+#include "api/compute/eltwise_unary/relu.h"
+#include "api/compute/eltwise_unary/selu.h"
+#include "api/compute/eltwise_unary/softplus.h"
+
+namespace compute_kernel_lib {
+
+template <Dst Slot>
+struct Relu : UnaryOp<Relu<Slot>, Slot> {
+    static ALWI void init() { relu_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { relu_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Sigmoid : UnaryOp<Sigmoid<Slot>, Slot> {
+    static ALWI void init() { sigmoid_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { sigmoid_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Tanh : UnaryOp<Tanh<Slot>, Slot> {
+    static ALWI void init() { tanh_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { tanh_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Gelu : UnaryOp<Gelu<Slot>, Slot> {
+    static ALWI void init() { gelu_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { gelu_tile(to_u32(Slot) + slot_offset); }
+};
+
+/// d/dx(tanh) = sech²(x). LLK uses `fast_and_approx` bool template param;
+/// surfaced as `Approx::Exact` (default) / `Approx::Fast` in chain style.
+template <Approx fast, Dst Slot>
+struct TanhDerivative : UnaryOp<TanhDerivative<fast, Slot>, Slot> {
+    static ALWI void init() { tanh_derivative_tile_init<static_cast<bool>(fast)>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        tanh_derivative_tile<static_cast<bool>(fast)>(to_u32(Slot) + slot_offset);
+    }
+};
+
+/// d/dx(gelu). Same Approx pattern as TanhDerivative.
+template <Approx fast, Dst Slot>
+struct GeluDerivative : UnaryOp<GeluDerivative<fast, Slot>, Slot> {
+    static ALWI void init() { gelu_derivative_tile_init<static_cast<bool>(fast)>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        gelu_derivative_tile<static_cast<bool>(fast)>(to_u32(Slot) + slot_offset);
+    }
+};
+
+/// Logsigmoid binary-in-DEST: logsigmoid_tile(In0, In1, Out) where caller
+/// has loaded x into D[In0] and exp(-x) into D[In1]; result placed in D[Out].
+/// Modelled as BinaryOp (3-DEST, no CB sources).
+template <Dst In0, Dst In1, Dst Out>
+struct Logsigmoid : BinaryOp<Logsigmoid<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { logsigmoid_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        logsigmoid_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+template <Dst Slot>
+struct Hardsigmoid : UnaryOp<Hardsigmoid<Slot>, Slot> {
+    static ALWI void init() { hardsigmoid_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { hardsigmoid_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Softsign : UnaryOp<Softsign<Slot>, Slot> {
+    static ALWI void init() { softsign_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { softsign_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Hardmish : UnaryOp<Hardmish<Slot>, Slot> {
+    static ALWI void init() { hardmish_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { hardmish_tile(to_u32(Slot) + slot_offset); }
+};
+
+// Hardtanh — runtime min/max via ctor; overrides exec(uint32_t).
+template <Dst Slot>
+struct Hardtanh : UnaryOp<Hardtanh<Slot>, Slot> {
+    uint32_t min_param;
+    uint32_t max_param;
+    constexpr Hardtanh(uint32_t lo, uint32_t hi) noexcept : min_param(lo), max_param(hi) {}
+    constexpr Hardtanh() noexcept : min_param(0), max_param(0) {}
+
+    static ALWI void init() { hardtanh_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        hardtanh_tile(to_u32(Slot) + slot_offset, min_param, max_param);
+    }
+};
+
+// Elu — runtime alpha.
+template <Dst Slot>
+struct Elu : UnaryOp<Elu<Slot>, Slot> {
+    uint32_t alpha;
+    constexpr explicit Elu(uint32_t a) noexcept : alpha(a) {}
+    constexpr Elu() noexcept : alpha(0) {}
+
+    static ALWI void init() { elu_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { elu_tile(to_u32(Slot) + slot_offset, alpha); }
+};
+
+template <Dst Slot>
+struct Selu : UnaryOp<Selu<Slot>, Slot> {
+    uint32_t scale;
+    uint32_t alpha;
+    constexpr Selu(uint32_t s, uint32_t a) noexcept : scale(s), alpha(a) {}
+    constexpr Selu() noexcept : scale(0), alpha(0) {}
+    static ALWI void init() { selu_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { selu_tile(to_u32(Slot) + slot_offset, scale, alpha); }
+};
+
+template <Dst Slot>
+struct Softplus : UnaryOp<Softplus<Slot>, Slot> {
+    uint32_t beta;
+    uint32_t beta_recip;
+    uint32_t threshold;
+    constexpr Softplus(uint32_t b, uint32_t br, uint32_t t) noexcept : beta(b), beta_recip(br), threshold(t) {}
+    constexpr Softplus() noexcept : beta(0), beta_recip(0), threshold(0) {}
+    static ALWI void init() { softplus_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        softplus_tile(to_u32(Slot) + slot_offset, beta, beta_recip, threshold);
+    }
+};
+
+template <Dst Slot>
+struct Prelu : UnaryOp<Prelu<Slot>, Slot> {
+    uint32_t param0;
+    constexpr explicit Prelu(uint32_t p) noexcept : param0(p) {}
+    constexpr Prelu() noexcept : param0(0) {}
+    static ALWI void init() { prelu_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { prelu_tile(to_u32(Slot) + slot_offset, param0); }
+};
+
+// LeakyRelu — runtime slope.
+template <Dst Slot>
+struct LeakyRelu : UnaryOp<LeakyRelu<Slot>, Slot> {
+    uint32_t slope;
+    constexpr explicit LeakyRelu(uint32_t s) noexcept : slope(s) {}
+    constexpr LeakyRelu() noexcept : slope(0) {}
+    static ALWI void init() { leaky_relu_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { leaky_relu_tile(to_u32(Slot) + slot_offset, slope); }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file math.hpp
+ * @brief Math SFPU op structs for the eltwise chain — Exp, Log, Sqrt, Rsqrt, Power, ...
+ *
+ * Each op derives from `UnaryOp<Self, Slot>` (CRTP) and supplies static `init()` + `exec_impl()`.
+ * Template parameters carry approx / legacy / fast-and-approx mode + DEST slot at compile time.
+ * Runtime-param ops (Power, Rpow) override `exec(uint32_t)` directly to capture instance state.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/op_params.hpp"  // Approx, Legacy
+
+namespace compute_kernel_lib {
+
+// ---- Exp ----
+template <Approx approx = Approx::Exact, Dst Slot = Dst::D0>
+struct Exp;
+
+// ---- Log ----
+template <Approx fast = Approx::Exact, Dst Slot = Dst::D0>
+struct Log;
+
+// ---- Sqrt ----
+template <Approx fast = Approx::Exact, Dst Slot = Dst::D0>
+struct Sqrt;
+
+// ---- Recip (1/x) ----
+template <Dst Slot = Dst::D0>
+struct Recip;
+
+// ---- Rsqrt ----
+template <Approx fast = Approx::Exact, Legacy legacy = Legacy::Off, Dst Slot = Dst::D0>
+struct Rsqrt;
+
+// ---- Cbrt ----
+template <Dst Slot = Dst::D0>
+struct Cbrt;
+
+// ---- Log1p ----
+template <Approx fast = Approx::Fast, Dst Slot = Dst::D0>
+struct Log1p;
+
+// ---- Power ----
+template <Dst Slot = Dst::D0>
+struct Power;
+
+// ---- Rpow ----
+template <Dst Slot = Dst::D0>
+struct Rpow;
+
+// ---- Cumsum ----
+template <Dst Slot = Dst::D0>
+struct Cumsum;
+
+// ---- PowerIterative ----
+template <Dst Slot = Dst::D0>
+struct PowerIterative;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.inl
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of math.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/exp.h"
+#include "api/compute/eltwise_unary/sqrt.h"
+#include "api/compute/eltwise_unary/recip.h"
+#include "api/compute/eltwise_unary/rsqrt.h"
+#include "api/compute/eltwise_unary/cbrt.h"
+#include "api/compute/eltwise_unary/log1p.h"
+#include "api/compute/eltwise_unary/rpow.h"
+#include "api/compute/cumsum.h"              // Cumsum
+#include "api/compute/compute_kernel_api.h"  // log_tile / log_tile_init / power_tile
+
+namespace compute_kernel_lib {
+
+// ---- Exp ----
+template <Approx approx, Dst Slot>
+struct Exp : UnaryOp<Exp<approx, Slot>, Slot> {
+    static ALWI void init() { exp_tile_init<approx == Approx::Fast>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { exp_tile<approx == Approx::Fast>(to_u32(Slot) + slot_offset); }
+};
+
+// ---- Log ----
+template <Approx fast, Dst Slot>
+struct Log : UnaryOp<Log<fast, Slot>, Slot> {
+    static ALWI void init() { log_tile_init<fast == Approx::Fast>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { log_tile<fast == Approx::Fast>(to_u32(Slot) + slot_offset); }
+};
+
+// ---- Sqrt ----
+template <Approx fast, Dst Slot>
+struct Sqrt : UnaryOp<Sqrt<fast, Slot>, Slot> {
+    static ALWI void init() { sqrt_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { sqrt_tile<fast == Approx::Fast>(to_u32(Slot) + slot_offset); }
+};
+
+// ---- Recip (1/x) ----
+template <Dst Slot>
+struct Recip : UnaryOp<Recip<Slot>, Slot> {
+    static ALWI void init() { recip_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { recip_tile(to_u32(Slot) + slot_offset); }
+};
+
+// ---- Rsqrt — Approx (Fast/Exact) and Legacy (On/Off). Templated on both.
+template <Approx fast, Legacy legacy, Dst Slot>
+struct Rsqrt : UnaryOp<Rsqrt<fast, legacy, Slot>, Slot> {
+    static ALWI void init() { rsqrt_tile_init<legacy == Legacy::On>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        rsqrt_tile<legacy == Legacy::On, fast == Approx::Fast>(to_u32(Slot) + slot_offset);
+    }
+};
+
+// ---- Cbrt ----
+template <Dst Slot>
+struct Cbrt : UnaryOp<Cbrt<Slot>, Slot> {
+    static ALWI void init() { cbrt_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { cbrt_tile(to_u32(Slot) + slot_offset); }
+};
+
+// ---- Log1p — fast (approximate) vs exact mode selected by template ----
+template <Approx fast, Dst Slot>
+struct Log1p : UnaryOp<Log1p<fast, Slot>, Slot> {
+    static ALWI void init() { log1p_tile_init<fast == Approx::Fast>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { log1p_tile<fast == Approx::Fast>(to_u32(Slot) + slot_offset); }
+};
+
+// ---- Power — runtime exponent. ----
+template <Dst Slot>
+struct Power : UnaryOp<Power<Slot>, Slot> {
+    uint32_t exponent;
+    constexpr explicit Power(uint32_t e) noexcept : exponent(e) {}
+    constexpr Power() noexcept : exponent(0) {}
+    static ALWI void init() { power_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { power_tile(to_u32(Slot) + slot_offset, exponent); }
+};
+
+// ---- Rpow — base^x, runtime base. ----
+template <Dst Slot>
+struct Rpow : UnaryOp<Rpow<Slot>, Slot> {
+    uint32_t base;
+    constexpr explicit Rpow(uint32_t b) noexcept : base(b) {}
+    constexpr Rpow() noexcept : base(0) {}
+    static ALWI void init() { rpow_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { rpow_tile(to_u32(Slot) + slot_offset, base); }
+};
+
+// ---- Cumsum — columnwise cumulative sum (in-DEST). ----
+// LLK `cumsum_tile(idst, first)` where `first` resets the accumulator for the first row tile.
+// Modelled as a unary op with a single bool param `first` — a FIXED instance field applied
+// identically on every tile of the walk (exec ignores the tile index). So one Cumsum element is
+// correct only when every tile is a fresh row (`first=true`, default); a genuine multi-tile column
+// cumsum (first=true on ht=0, false after) is NOT expressible as a single chain element.
+template <Dst Slot>
+struct Cumsum : UnaryOp<Cumsum<Slot>, Slot> {
+    bool first;
+    constexpr explicit Cumsum(bool f = true) noexcept : first(f) {}
+    static ALWI void init() { cumsum_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { cumsum_tile(to_u32(Slot) + slot_offset, first); }
+};
+
+// ---- PowerIterative — positive-integer exponent via iterative multiply. ----
+// Distinct LLK from Power: power_iterative_tile uses an iterative loop; faster for
+// small integer exponents. Only supports positive integer scalars.
+template <Dst Slot>
+struct PowerIterative : UnaryOp<PowerIterative<Slot>, Slot> {
+    uint32_t exponent;
+    constexpr explicit PowerIterative(uint32_t e) noexcept : exponent(e) {}
+    constexpr PowerIterative() noexcept : exponent(0) {}
+    static ALWI void init() { power_iterative_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        power_iterative_tile(to_u32(Slot) + slot_offset, exponent);
+    }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file misc.hpp
+ * @brief Misc / utility SFPU op structs — Identity, Negative, Typecast, Sign, Abs, Square.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <Dst Slot = Dst::D0>
+struct Identity;
+
+template <Dst Slot = Dst::D0>
+struct Negative;
+
+template <Dst Slot = Dst::D0>
+struct Abs;
+
+template <Dst Slot = Dst::D0>
+struct Sign;
+
+template <Dst Slot = Dst::D0>
+struct Square;
+
+// CopyDest — copy a tile's values from one DEST slot to another (no defaults).
+template <Dst In, Dst Out, DataFormat DF = DataFormat::Invalid>
+struct CopyDest;
+
+// Typecast — compile-time in/out dtype encoded as numeric IDs.
+template <uint32_t InDF, uint32_t OutDF, Dst Slot = Dst::D0>
+struct Typecast;
+
+// Mask / MaskPosInf.
+template <DataFormat DF = DataFormat::Float16_b, Dst DataSlot = Dst::D0>
+struct Mask;
+
+template <Dst DataSlot = Dst::D0>
+struct MaskPosInf;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp
@@ -27,8 +27,9 @@ struct Sign;
 template <Dst Slot = Dst::D0>
 struct Square;
 
-// CopyDest — copy a tile's values from one DEST slot to another (no defaults).
-template <Dst In, Dst Out, DataFormat DF = DataFormat::Invalid>
+// CopyDest — copy a tile's values from one DEST slot to another. The LLK data
+// format is explicit because format-agnostic copying is deprecated.
+template <Dst In, Dst Out, DataFormat DF>
 struct CopyDest;
 
 // Typecast — compile-time in/out dtype encoded as numeric IDs.

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.inl
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of misc.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/identity.h"
+#include "api/compute/eltwise_unary/negative.h"
+#include "api/compute/eltwise_unary/typecast.h"
+#include "api/compute/mask.h"
+#include "api/compute/copy_dest_values.h"    // CopyDest (DST -> DST)
+#include "api/compute/compute_kernel_api.h"  // sign_tile, abs_tile, square_tile fallbacks
+
+namespace compute_kernel_lib {
+
+template <Dst Slot>
+struct Identity : UnaryOp<Identity<Slot>, Slot> {
+    static ALWI void init() { identity_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { identity_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Negative : UnaryOp<Negative<Slot>, Slot> {
+    static ALWI void init() { negative_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { negative_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Abs : UnaryOp<Abs<Slot>, Slot> {
+    static ALWI void init() { abs_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { abs_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Sign : UnaryOp<Sign<Slot>, Slot> {
+    static ALWI void init() { sign_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { sign_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Square : UnaryOp<Square<Slot>, Slot> {
+    static ALWI void init() { square_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { square_tile(to_u32(Slot) + slot_offset); }
+};
+
+// CopyDest — copy a tile's values from one DEST slot to another (copy_dest_values).
+// Two slots (In -> Out), no CB. Uses the un-templated copy_dest_values(in, out)
+// overload, which the build permits via -Wno-error=deprecated-declarations.
+template <Dst In, Dst Out, DataFormat DF>
+struct CopyDest : DestOnlyTag {
+    static constexpr uint32_t lane_width = (to_u32(In) > to_u32(Out) ? to_u32(In) : to_u32(Out)) + 1;
+    static ALWI void init() { copy_dest_values_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        if constexpr (DF == DataFormat::Invalid) {
+            copy_dest_values(to_u32(In) + slot_offset, to_u32(Out) + slot_offset);
+        } else {
+            copy_dest_values<DF>(to_u32(In) + slot_offset, to_u32(Out) + slot_offset);
+        }
+    }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { exec_impl(slot_offset); }
+};
+
+// Typecast — compile-time in/out dtype encoded as numeric IDs (uint32_t form expected by LLK).
+template <uint32_t InDF, uint32_t OutDF, Dst Slot>
+struct Typecast : UnaryOp<Typecast<InDF, OutDF, Slot>, Slot> {
+    static ALWI void init() { typecast_tile_init<InDF, OutDF>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { typecast_tile<InDF, OutDF>(to_u32(Slot) + slot_offset); }
+};
+
+// Mask — bakes the fixed `mask_tile` LLK contract (mask lives at DataSlot+1) into
+// the type. Caller pre-loads data into DataSlot and mask into DataSlot+1; the
+// op writes the masked result back into DataSlot. Compile-time `static_assert` rejects
+// `DataSlot == D_LAST` (no slot for the mask tile).
+//
+// LLK supports `DataFormat::Float16`, `DataFormat::Float16_b`, and `DataFormat::Int32`.
+template <DataFormat DF, Dst DataSlot>
+struct Mask : BinaryOp<Mask<DF, DataSlot>, DataSlot, static_cast<Dst>(to_u32(DataSlot) + 1), DataSlot> {
+    static_assert(
+        to_u32(DataSlot) + 1 < DEST_AUTO_LIMIT,
+        "Mask: DataSlot + 1 exceeds DEST_AUTO_LIMIT (mask tile lives at DataSlot + 1).");
+    static ALWI void init() { mask_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        mask_tile(to_u32(DataSlot) + slot_offset, to_u32(DataSlot) + 1 + slot_offset, DF);
+    }
+};
+
+// MaskPosInf — same LLK contract as Mask (data at DataSlot, mask at DataSlot+1) but
+// masks each element with +inf instead of 0. Shares mask_tile_init.
+template <Dst DataSlot>
+struct MaskPosInf : BinaryOp<MaskPosInf<DataSlot>, DataSlot, static_cast<Dst>(to_u32(DataSlot) + 1), DataSlot> {
+    static_assert(
+        to_u32(DataSlot) + 1 < DEST_AUTO_LIMIT,
+        "MaskPosInf: DataSlot + 1 exceeds DEST_AUTO_LIMIT (mask tile lives at DataSlot + 1).");
+    static ALWI void init() { mask_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        mask_posinf_tile(to_u32(DataSlot) + slot_offset, to_u32(DataSlot) + 1 + slot_offset);
+    }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.inl
@@ -46,18 +46,14 @@ struct Square : UnaryOp<Square<Slot>, Slot> {
 };
 
 // CopyDest — copy a tile's values from one DEST slot to another (copy_dest_values).
-// Two slots (In -> Out), no CB. Uses the un-templated copy_dest_values(in, out)
-// overload, which the build permits via -Wno-error=deprecated-declarations.
+// Two slots (In -> Out), no CB. The LLK's DataFormat-templated overload is
+// required so integer and floating-point DEST values preserve their representation.
 template <Dst In, Dst Out, DataFormat DF>
 struct CopyDest : DestOnlyTag {
     static constexpr uint32_t lane_width = (to_u32(In) > to_u32(Out) ? to_u32(In) : to_u32(Out)) + 1;
     static ALWI void init() { copy_dest_values_init(); }
     static ALWI void exec_impl(uint32_t slot_offset) {
-        if constexpr (DF == DataFormat::Invalid) {
-            copy_dest_values(to_u32(In) + slot_offset, to_u32(Out) + slot_offset);
-        } else {
-            copy_dest_values<DF>(to_u32(In) + slot_offset, to_u32(Out) + slot_offset);
-        }
+        copy_dest_values<DF>(to_u32(In) + slot_offset, to_u32(Out) + slot_offset);
     }
     ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { exec_impl(slot_offset); }
 };

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file predicates.hpp
+ * @brief Predicate / comparison-to-zero / classify SFPU op structs.
+ *
+ * Eqz, Nez, Ltz, Lez, Gtz, Gez, Isinf, Isnan, Isfinite, Isposinf, Isneginf,
+ * LogicalNot, plus runtime-param unary comparisons (UnaryEq/Ne/Gt/Ge/Lt/Le).
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+// Comparison-to-zero / classify unary predicates.
+template <Dst Slot = Dst::D0>
+struct Eqz;
+template <Dst Slot = Dst::D0>
+struct Nez;
+template <Dst Slot = Dst::D0>
+struct Ltz;
+template <Dst Slot = Dst::D0>
+struct Lez;
+template <Dst Slot = Dst::D0>
+struct Gtz;
+template <Dst Slot = Dst::D0>
+struct Gez;
+template <Dst Slot = Dst::D0>
+struct Isinf;
+template <Dst Slot = Dst::D0>
+struct Isnan;
+template <Dst Slot = Dst::D0>
+struct Isfinite;
+template <Dst Slot = Dst::D0>
+struct Isposinf;
+template <Dst Slot = Dst::D0>
+struct Isneginf;
+template <DataFormat DF, Dst Slot = Dst::D0>
+struct LogicalNot;
+
+// Runtime-param scalar comparisons.
+template <Dst Slot = Dst::D0>
+struct UnaryEq;
+template <Dst Slot = Dst::D0>
+struct UnaryNe;
+template <Dst Slot = Dst::D0>
+struct UnaryGt;
+template <Dst Slot = Dst::D0>
+struct UnaryGe;
+template <Dst Slot = Dst::D0>
+struct UnaryLt;
+template <Dst Slot = Dst::D0>
+struct UnaryLe;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.inl
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of predicates.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/comp.h"
+#include "api/compute/eltwise_unary/isinf_isnan.h"
+#include "api/compute/eltwise_unary/logical_not.h"
+
+namespace compute_kernel_lib {
+
+#define ELTWISE_DECLARE_UNARY(Name, fn)                                                             \
+    template <Dst Slot>                                                                             \
+    struct Name : UnaryOp<Name<Slot>, Slot> {                                                       \
+        static ALWI void init() { fn##_tile_init(); }                                               \
+        static ALWI void exec_impl(uint32_t slot_offset) { fn##_tile(to_u32(Slot) + slot_offset); } \
+    };
+
+ELTWISE_DECLARE_UNARY(Eqz, eqz)
+ELTWISE_DECLARE_UNARY(Nez, nez)
+ELTWISE_DECLARE_UNARY(Ltz, ltz)
+ELTWISE_DECLARE_UNARY(Lez, lez)
+ELTWISE_DECLARE_UNARY(Gtz, gtz)
+ELTWISE_DECLARE_UNARY(Gez, gez)
+ELTWISE_DECLARE_UNARY(Isinf, isinf)
+ELTWISE_DECLARE_UNARY(Isnan, isnan)
+ELTWISE_DECLARE_UNARY(Isfinite, isfinite)
+ELTWISE_DECLARE_UNARY(Isposinf, isposinf)
+ELTWISE_DECLARE_UNARY(Isneginf, isneginf)
+// LogicalNot — needs a DataFormat template arg; declared with explicit template.
+template <DataFormat DF, Dst Slot>
+struct LogicalNot : UnaryOp<LogicalNot<DF, Slot>, Slot> {
+    static ALWI void init() { logical_not_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { logical_not_tile<DF>(to_u32(Slot) + slot_offset); }
+};
+
+#undef ELTWISE_DECLARE_UNARY
+
+// Runtime-param scalar comparisons. Override exec(uint32_t) directly to capture param0.
+#define ELTWISE_DECLARE_UNARY_PARAM(Name, fn)                                                                         \
+    template <Dst Slot>                                                                                               \
+    struct Name : UnaryOp<Name<Slot>, Slot> {                                                                         \
+        uint32_t param0;                                                                                              \
+        constexpr explicit Name(uint32_t p) noexcept : param0(p) {}                                                   \
+        constexpr Name() noexcept : param0(0) {}                                                                      \
+        static ALWI void init() { fn##_tile_init(); }                                                                 \
+        ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { fn##_tile(to_u32(Slot) + slot_offset, param0); } \
+    };
+
+ELTWISE_DECLARE_UNARY_PARAM(UnaryEq, unary_eq)
+ELTWISE_DECLARE_UNARY_PARAM(UnaryNe, unary_ne)
+ELTWISE_DECLARE_UNARY_PARAM(UnaryGt, unary_gt)
+ELTWISE_DECLARE_UNARY_PARAM(UnaryGe, unary_ge)
+ELTWISE_DECLARE_UNARY_PARAM(UnaryLt, unary_lt)
+ELTWISE_DECLARE_UNARY_PARAM(UnaryLe, unary_le)
+
+#undef ELTWISE_DECLARE_UNARY_PARAM
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/rounding.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/rounding.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+template <Dst Slot = Dst::D0>
+struct Floor;
+template <Dst Slot = Dst::D0>
+struct Ceil;
+template <Dst Slot = Dst::D0>
+struct Trunc;
+template <Dst Slot = Dst::D0>
+struct Frac;
+// Round — runtime decimals.
+template <Dst Slot = Dst::D0>
+struct Round;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/rounding.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/rounding.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/rounding.inl
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of rounding.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/rounding.h"
+
+namespace compute_kernel_lib {
+
+template <Dst Slot>
+struct Floor : UnaryOp<Floor<Slot>, Slot> {
+    static ALWI void init() { rounding_op_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { floor_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Ceil : UnaryOp<Ceil<Slot>, Slot> {
+    static ALWI void init() { rounding_op_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { ceil_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Trunc : UnaryOp<Trunc<Slot>, Slot> {
+    static ALWI void init() { rounding_op_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { trunc_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Frac : UnaryOp<Frac<Slot>, Slot> {
+    static ALWI void init() { rounding_op_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { frac_tile(to_u32(Slot) + slot_offset); }
+};
+
+// Round — runtime decimals.
+template <Dst Slot>
+struct Round : UnaryOp<Round<Slot>, Slot> {
+    int32_t decimals;
+    constexpr explicit Round(int32_t d) noexcept : decimals(d) {}
+    constexpr Round() noexcept : decimals(0) {}
+    static ALWI void init() { rounding_op_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { round_tile(to_u32(Slot) + slot_offset, decimals); }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file scalar.hpp
+ * @brief Scalar-parameter SFPU op structs — Threshold, Clamp, AddUnary, SubUnary, MulUnary,
+ *        DivUnary, RsubUnary, RdivUnary, Dropout.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+// Threshold — runtime threshold + value.
+template <Dst Slot = Dst::D0>
+struct Threshold;
+
+// Clamp — runtime min/max.
+template <Dst Slot = Dst::D0>
+struct Clamp;
+
+// X-macro-generated binop-with-scalar wrappers.
+template <Dst Slot = Dst::D0>
+struct AddUnary;
+
+template <Dst Slot = Dst::D0>
+struct SubUnary;
+
+template <Dst Slot = Dst::D0>
+struct MulUnary;
+
+template <Dst Slot = Dst::D0>
+struct DivUnary;
+
+template <Dst Slot = Dst::D0>
+struct RsubUnary;
+
+// Dropout — runtime probability + scale_factor.
+template <Dst Slot = Dst::D0>
+struct Dropout;
+
+// RdivUnary — own header with its own init.
+template <Dst Slot = Dst::D0>
+struct RdivUnary;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.inl
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of scalar.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/threshold.h"
+#include "api/compute/eltwise_unary/clamp.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_unary/rdiv.h"
+#include "api/compute/eltwise_unary/dropout.h"  // Dropout
+
+namespace compute_kernel_lib {
+
+// Threshold — runtime threshold + value.
+template <Dst Slot>
+struct Threshold : UnaryOp<Threshold<Slot>, Slot> {
+    uint32_t threshold;
+    uint32_t value;
+    constexpr Threshold(uint32_t t, uint32_t v) noexcept : threshold(t), value(v) {}
+    constexpr Threshold() noexcept : threshold(0), value(0) {}
+    static ALWI void init() { threshold_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        threshold_tile(to_u32(Slot) + slot_offset, threshold, value);
+    }
+};
+
+// Clamp — runtime min/max.
+template <Dst Slot>
+struct Clamp : UnaryOp<Clamp<Slot>, Slot> {
+    uint32_t min_param;
+    uint32_t max_param;
+    constexpr Clamp(uint32_t lo, uint32_t hi) noexcept : min_param(lo), max_param(hi) {}
+    constexpr Clamp() noexcept : min_param(0), max_param(0) {}
+    static ALWI void init() { clamp_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        clamp_tile(to_u32(Slot) + slot_offset, min_param, max_param);
+    }
+};
+
+// Generic binop-with-scalar wrappers — share `binop_with_scalar_tile_init`.
+#define ELTWISE_DECLARE_BINOP_SCALAR(Name, fn)                                                                 \
+    template <Dst Slot>                                                                                        \
+    struct Name : UnaryOp<Name<Slot>, Slot> {                                                                  \
+        uint32_t param0;                                                                                       \
+        constexpr explicit Name(uint32_t p) noexcept : param0(p) {}                                            \
+        constexpr Name() noexcept : param0(0) {}                                                               \
+        static ALWI void init() { binop_with_scalar_tile_init(); }                                             \
+        ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { fn(to_u32(Slot) + slot_offset, param0); } \
+    };
+
+ELTWISE_DECLARE_BINOP_SCALAR(AddUnary, add_unary_tile)
+ELTWISE_DECLARE_BINOP_SCALAR(SubUnary, sub_unary_tile)
+ELTWISE_DECLARE_BINOP_SCALAR(MulUnary, mul_unary_tile)
+ELTWISE_DECLARE_BINOP_SCALAR(DivUnary, div_unary_tile)
+ELTWISE_DECLARE_BINOP_SCALAR(RsubUnary, rsub_unary_tile)
+
+// Dropout — runtime probability + scale_factor + seed (all packed u32 bits).
+// `dropout_kernel_init(seed)` is dropout's per-op SFPU init (it seeds the PRNG); it's
+// the dropout analogue of every other op's `*_tile_init`, except it takes the runtime
+// seed. So `init()` here is a normal instance method (non-static, like `exec`) that reads
+// the struct's `seed` — the chain dispatches init on the instance, so this just works.
+// The chain emits it once (boot-hoist), the once-per-kernel seeding the original kernel
+// did out-of-band.
+template <Dst Slot>
+struct Dropout : PrngSeedTag, UnaryOp<Dropout<Slot>, Slot> {
+    uint32_t probability;
+    uint32_t scale_factor;
+    uint32_t seed;
+    constexpr Dropout(uint32_t p, uint32_t s, uint32_t seed_) noexcept : probability(p), scale_factor(s), seed(seed_) {}
+    constexpr Dropout() noexcept : probability(0), scale_factor(0), seed(0) {}
+    ALWI void init() const { dropout_kernel_init(seed); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const {
+        dropout_tile(to_u32(Slot) + slot_offset, probability, scale_factor);
+    }
+};
+
+// rdiv is in its own header with its own init.
+template <Dst Slot>
+struct RdivUnary : UnaryOp<RdivUnary<Slot>, Slot> {
+    uint32_t param0;
+    constexpr explicit RdivUnary(uint32_t p) noexcept : param0(p) {}
+    constexpr RdivUnary() noexcept : param0(0) {}
+    static ALWI void init() { rdiv_tile_init(); }
+    ALWI void exec(uint32_t /*i*/, uint32_t slot_offset) const { rdiv_tile(to_u32(Slot) + slot_offset, param0); }
+};
+
+#undef ELTWISE_DECLARE_BINOP_SCALAR
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file special.hpp
+ * @brief Special-function SFPU op structs — Erf / Erfc / Erfinv / I0 / I1 / Lgamma / Digamma /
+ *        Where. (TanhDerivative lives in activations.hpp.)
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/op_params.hpp"  // Approx
+
+namespace compute_kernel_lib {
+
+// Erf / Erfc
+template <Approx fast = Approx::Fast, Dst Slot = Dst::D0>
+struct Erf;
+
+template <Dst Slot = Dst::D0>
+struct Erfc;
+
+// X-macro-generated unary special functions.
+template <Dst Slot = Dst::D0>
+struct Erfinv;
+
+template <Dst Slot = Dst::D0>
+struct I0;
+
+template <Dst Slot = Dst::D0>
+struct I1;
+
+template <Dst Slot = Dst::D0>
+struct Digamma;
+
+// Where — ternary y = where(cond, a, b).
+template <DataFormat DF, Dst Cond = Dst::D0, Dst A = Dst::D1, Dst B = Dst::D2, Dst Out = Dst::D0>
+struct Where;
+
+// lgamma family.
+template <Dst Slot = Dst::D0>
+struct LgammaStirling;
+
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst Out = Dst::D0>
+struct LgammaStirlingFloat;
+
+template <Dst In0 = Dst::D0, Dst In1 = Dst::D1, Dst In2 = Dst::D2, Dst Out = Dst::D0>
+struct LgammaAdjusted;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.inl
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of special.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/erf_erfc.h"
+#include "api/compute/eltwise_unary/erfinv.h"
+#include "api/compute/eltwise_unary/i0.h"
+#include "api/compute/eltwise_unary/i1.h"
+#include "api/compute/eltwise_unary/digamma.h"
+#include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/lgamma.h"
+
+namespace compute_kernel_lib {
+
+// Erf / Erfc — fast_and_approx template param.
+template <Approx fast, Dst Slot>
+struct Erf : UnaryOp<Erf<fast, Slot>, Slot> {
+    static ALWI void init() { erf_tile_init<fast == Approx::Fast>(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { erf_tile<fast == Approx::Fast>(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst Slot>
+struct Erfc : UnaryOp<Erfc<Slot>, Slot> {
+    static ALWI void init() { erfc_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { erfc_tile(to_u32(Slot) + slot_offset); }
+};
+
+#define ELTWISE_DECLARE_UNARY(Name, fn)                                                             \
+    template <Dst Slot>                                                                             \
+    struct Name : UnaryOp<Name<Slot>, Slot> {                                                       \
+        static ALWI void init() { fn##_tile_init(); }                                               \
+        static ALWI void exec_impl(uint32_t slot_offset) { fn##_tile(to_u32(Slot) + slot_offset); } \
+    };
+
+ELTWISE_DECLARE_UNARY(Erfinv, erfinv)
+ELTWISE_DECLARE_UNARY(I0, i0)
+ELTWISE_DECLARE_UNARY(I1, i1)
+ELTWISE_DECLARE_UNARY(Digamma, digamma)
+
+#undef ELTWISE_DECLARE_UNARY
+
+// Where — ternary y = where(cond, a, b). DEST-only chain element with compile-time
+// slot binding. Out may alias an input (a/b) — TernaryOp does not enforce slot-distinctness.
+template <DataFormat DF, Dst Cond, Dst A, Dst B, Dst Out>
+struct Where : TernaryOp<Where<DF, Cond, A, B, Out>, Cond, A, B, Out> {
+    static ALWI void init() { where_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        where_tile<DF>(
+            to_u32(Cond) + slot_offset, to_u32(A) + slot_offset, to_u32(B) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// lgamma family (DEST-internal SFPU). Three forms used by the lgamma kernels:
+//   - LgammaStirling      unary   : lgamma_stirling_tile(idst)
+//   - LgammaStirlingFloat binary  : lgamma_stirling_float_tile(x, log_z, out)
+//   - LgammaAdjusted      4-slot  : lgamma_adjusted_tile(stirling, logsin, x, out)
+// ---------------------------------------------------------------------------
+
+template <Dst Slot>
+struct LgammaStirling : UnaryOp<LgammaStirling<Slot>, Slot> {
+    static ALWI void init() { lgamma_stirling_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) { lgamma_stirling_tile(to_u32(Slot) + slot_offset); }
+};
+
+template <Dst In0, Dst In1, Dst Out>
+struct LgammaStirlingFloat : BinaryOp<LgammaStirlingFloat<In0, In1, Out>, In0, In1, Out> {
+    static ALWI void init() { lgamma_stirling_float_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        lgamma_stirling_float_tile(to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+// lgamma_adjusted_tile takes 4 explicit DEST args (stirling, logsin, x, out); Out
+// may alias an input (the kernel uses (D0,D1,D2,D0)).
+template <Dst In0, Dst In1, Dst In2, Dst Out>
+struct LgammaAdjusted : TernaryOp<LgammaAdjusted<In0, In1, In2, Out>, In0, In1, In2, Out> {
+    static ALWI void init() { lgamma_adjusted_tile_init(); }
+    static ALWI void exec_impl(uint32_t slot_offset) {
+        lgamma_adjusted_tile(
+            to_u32(In0) + slot_offset, to_u32(In1) + slot_offset, to_u32(In2) + slot_offset, to_u32(Out) + slot_offset);
+    }
+};
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/trig.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/trig.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file trig.hpp
+ * @brief Trigonometric SFPU op structs.
+ *
+ * Sin, Cos, Tan, Asin, Acos, Atan, Sinh, Cosh, Asinh, Acosh, Atanh.
+ */
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace compute_kernel_lib {
+
+// Trigonometric SFPU op structs (definitions in trig.inl).
+template <Dst Slot = Dst::D0>
+struct Sin;
+template <Dst Slot = Dst::D0>
+struct Cos;
+template <Dst Slot = Dst::D0>
+struct Tan;
+template <Dst Slot = Dst::D0>
+struct Asin;
+template <Dst Slot = Dst::D0>
+struct Acos;
+template <Dst Slot = Dst::D0>
+struct Atan;
+template <Dst Slot = Dst::D0>
+struct Sinh;
+template <Dst Slot = Dst::D0>
+struct Cosh;
+template <Dst Slot = Dst::D0>
+struct Asinh;
+template <Dst Slot = Dst::D0>
+struct Acosh;
+template <Dst Slot = Dst::D0>
+struct Atanh;
+
+}  // namespace compute_kernel_lib
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/trig.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/trig.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/unary/trig.inl
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Implementation detail of trig.hpp — full op-struct definitions live here. The public
+// header forward-declares these structs and includes this file at its tail.
+
+#include "api/compute/eltwise_unary/trigonometry.h"
+
+namespace compute_kernel_lib {
+
+#define ELTWISE_DECLARE_UNARY(Name, fn)                                                             \
+    template <Dst Slot>                                                                             \
+    struct Name : UnaryOp<Name<Slot>, Slot> {                                                       \
+        static ALWI void init() { fn##_tile_init(); }                                               \
+        static ALWI void exec_impl(uint32_t slot_offset) { fn##_tile(to_u32(Slot) + slot_offset); } \
+    };
+
+ELTWISE_DECLARE_UNARY(Sin, sin)
+ELTWISE_DECLARE_UNARY(Cos, cos)
+ELTWISE_DECLARE_UNARY(Tan, tan)
+ELTWISE_DECLARE_UNARY(Asin, asin)
+ELTWISE_DECLARE_UNARY(Acos, acos)
+ELTWISE_DECLARE_UNARY(Atan, atan)
+ELTWISE_DECLARE_UNARY(Sinh, sinh)
+ELTWISE_DECLARE_UNARY(Cosh, cosh)
+ELTWISE_DECLARE_UNARY(Asinh, asinh)
+ELTWISE_DECLARE_UNARY(Acosh, acosh)
+ELTWISE_DECLARE_UNARY(Atanh, atanh)
+
+#undef ELTWISE_DECLARE_UNARY
+
+}  // namespace compute_kernel_lib

--- a/ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp
@@ -31,7 +31,7 @@ FORCE_INLINE volatile tt_l1_ptr uint32_t* addr_to_l1_ptr(uint32_t addr) {
 }
 
 /**
- * @brief Create NOC source/destination args for a local L1 address on this core
+ * @brief Create NOC source args for a local L1 address on this core
  *
  * @param addr L1 memory address
  * @param noc_id NOC index (defaults to the current core's noc_index)

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/accumulation.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/accumulation.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Accumulation scenarios. CT args:
+// [mode, tiles_per_output, block_size, caller_managed, num_outputs, whole_shape]
+// mode 0 accumulates in DEST; mode 1 accumulates through an L1 output CB.
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t mode = get_compile_time_arg_val(0);
+    constexpr uint32_t n = get_compile_time_arg_val(1);
+    constexpr uint32_t block_size = get_compile_time_arg_val(2);
+    constexpr bool caller_managed = get_compile_time_arg_val(3) != 0;
+    constexpr uint32_t num_outputs = get_compile_time_arg_val(4);
+    constexpr bool whole_shape = get_compile_time_arg_val(5) != 0;
+    static_assert(mode < 2);
+    static_assert(n > 0);
+
+    using namespace compute_kernel_lib;
+    if constexpr (mode == 0) {
+        constexpr uint32_t cb_a = tt::CBIndex::c_0;
+        constexpr uint32_t cb_b = tt::CBIndex::c_1;
+        constexpr uint32_t cb_out = tt::CBIndex::c_16;
+        static_assert(block_size > 0);
+        static_assert(num_outputs > 0);
+        compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+
+        using PerRowAccumulate = BinaryFpu<
+            BinaryFpuOp::Add,
+            input(cb_a, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+            input(cb_b, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+            Dst::D0,
+            DestAccumulation::PerRow>;
+        using PerRowManagedPack = PackTile<output(
+            cb_out,
+            ReservePolicy::PerOuter,
+            PushPolicy::PerOuter,
+            DataFormatReconfig::Enabled,
+            TileAddressing::Direct,
+            DestAccumulation::PerRow)>;
+        using PerRowCallerPack = PackTile<output(
+            cb_out,
+            ReservePolicy::None,
+            PushPolicy::None,
+            DataFormatReconfig::Enabled,
+            TileAddressing::Direct,
+            DestAccumulation::PerRow)>;
+        using WholeShapeAccumulate = BinaryFpu<
+            BinaryFpuOp::Add,
+            input(cb_a, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+            input(cb_b, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+            Dst::D0,
+            DestAccumulation::WholeShape>;
+        using WholeShapeManagedPack = PackTile<output(
+            cb_out,
+            ReservePolicy::PerOuter,
+            PushPolicy::PerOuter,
+            DataFormatReconfig::Enabled,
+            TileAddressing::Direct,
+            DestAccumulation::WholeShape)>;
+        using WholeShapeCallerPack = PackTile<output(
+            cb_out,
+            ReservePolicy::None,
+            PushPolicy::None,
+            DataFormatReconfig::Enabled,
+            TileAddressing::Direct,
+            DestAccumulation::WholeShape)>;
+
+        CircularBuffer output_buffer(cb_out);
+        if constexpr (whole_shape) {
+            if constexpr (caller_managed) {
+                output_buffer.reserve_back(1);
+                eltwise_chain(
+                    IterationShape::grid(num_outputs, n).block_size(block_size),
+                    WholeShapeAccumulate{},
+                    WholeShapeCallerPack{});
+                output_buffer.push_back(1);
+            } else {
+                eltwise_chain(
+                    IterationShape::grid(num_outputs, n).block_size(block_size),
+                    WholeShapeAccumulate{},
+                    WholeShapeManagedPack{});
+            }
+        } else {
+            if constexpr (caller_managed) {
+                output_buffer.reserve_back(num_outputs);
+                eltwise_chain(
+                    IterationShape::grid(num_outputs, n).block_size(block_size),
+                    PerRowAccumulate{},
+                    PerRowCallerPack{});
+                output_buffer.push_back(num_outputs);
+            } else {
+                eltwise_chain(
+                    IterationShape::grid(num_outputs, n).block_size(block_size),
+                    PerRowAccumulate{},
+                    PerRowManagedPack{});
+            }
+        }
+    } else {
+        constexpr uint32_t cb_in = tt::CBIndex::c_0;
+        constexpr uint32_t cb_acc = tt::CBIndex::c_15;
+        constexpr uint32_t cb_out = tt::CBIndex::c_16;
+        static_assert(n > 1);
+        compute_kernel_hw_startup(cb_in, cb_acc);
+
+        CircularBuffer accumulator(cb_acc);
+        using ManagedPack = PackTile<output(
+            cb_acc,
+            ReservePolicy::OneUpfront,
+            PushPolicy::OneAtEnd,
+            DataFormatReconfig::Disabled,
+            TileAddressing::Direct,
+            DestAccumulation::Disabled,
+            L1Accumulation::Enabled)>;
+        using CallerPack = PackTile<output(
+            cb_acc,
+            ReservePolicy::None,
+            PushPolicy::None,
+            DataFormatReconfig::Disabled,
+            TileAddressing::Direct,
+            DestAccumulation::Disabled,
+            L1Accumulation::Enabled)>;
+
+        if constexpr (caller_managed) {
+            accumulator.reserve_back(1);
+            eltwise_chain(
+                IterationShape::tiles(n),
+                CopyTile<input(cb_in, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled)>{},
+                CallerPack{});
+            accumulator.push_back(1);
+        } else {
+            eltwise_chain(
+                IterationShape::tiles(n),
+                CopyTile<input(cb_in, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled)>{},
+                ManagedPack{});
+        }
+        eltwise_chain(IterationShape::one_tile(), CopyTile<input(cb_acc)>{}, PackTile<output(cb_out)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/bcast_binary_add.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/bcast_binary_add.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Operand broadcast suite: A + B with a hardware broadcast on B. BroadcastDim controls the
+// INTRA-tile replication (mirrors ckernel::BroadcastType: COL=1, ROW=2, SCALAR=3):
+//   ROW    -> B row 0 down all rows   -> out[r][c] = A[r][c] + B[0][c]
+//   COL    -> B col 0 across all cols -> out[r][c] = A[r][c] + B[r][0]
+//   SCALAR -> B element [0][0]        -> out[r][c] = A[r][c] + B[0][0]
+// The caller does only the dim-agnostic hw init (compute_kernel_hw_startup); the chain emits the
+// broadcast init AND compute itself from BroadcastDim. A random B makes ROW vs COL differ, so an
+// axis swap fails PCC.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t dim = get_compile_time_arg_val(1);  // 1=Col, 2=Row, 3=Scalar (ckernel values)
+
+    using namespace compute_kernel_lib;
+
+    compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+
+    if constexpr (dim == 2) {
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(
+                    cb_b, BroadcastDim::Row, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled)>{},
+            PackTile<output(cb_out, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
+    } else if constexpr (dim == 1) {
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(
+                    cb_b, BroadcastDim::Col, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled)>{},
+            PackTile<output(cb_out, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
+    } else {  // dim == 3 -> Scalar
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(
+                    cb_b,
+                    BroadcastDim::Scalar,
+                    WaitPolicy::PerTile,
+                    PopPolicy::PerTile,
+                    DataFormatReconfig::Disabled)>{},
+            PackTile<output(cb_out, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Block-capable exp(x): a Bulk + Block reader stages the window upfront so the chain processes
+// block_size tiles per inner iter across DEST lanes. block_size is a compile-time arg.
+//
+// Blocking is a loop-structure optimization — it must NOT change the per-tile result, so exp(x) is
+// identical across block_size; larger blocks should cut loop/DEST-sync overhead (the perf signal).
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t blk = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    using SafeBlockedInput =
+        CopyTile<input(cb_in, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block), Dst::D0>;
+    using UnsafeBlockedInput = CopyTile<input(cb_in, WaitPolicy::Upfront, PopPolicy::PerTile), Dst::D0>;
+    using SafeBlockedOutput = PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>;
+    using UnsafeBlockedOutput = PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::PerTile)>;
+    static_assert(chain_supports_block_v<EltwiseChain<SafeBlockedInput, Exp<>, SafeBlockedOutput>>);
+    static_assert(!chain_supports_block_v<EltwiseChain<UnsafeBlockedInput, Exp<>, SafeBlockedOutput>>);
+    static_assert(!chain_supports_block_v<EltwiseChain<SafeBlockedInput, Exp<>, UnsafeBlockedOutput>>);
+    eltwise_chain(
+        IterationShape::tiles(n).block_size(blk),
+        CopyTile<input(cb_in, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block), Dst::D0>{},
+        Exp<>{},
+        PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_chunked.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_chunked.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Block-capable exp(in) via a CHUNKED reader: waits/pops block_size tiles per chunk, so the CB
+// holds only ~block_size pages regardless of n. Unlike block_exp.cpp (Bulk+Block), this lets the
+// perf sweep run very large n without exhausting L1 while still exercising the block path.
+//
+// CT args: [n, block_size]. Host sizes cb_in/cb_out to a small multiple of block_size.
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t blk = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    eltwise_chain(
+        IterationShape::tiles(n).block_size(blk),
+        CopyTile<input(cb_in, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block), Dst::D0>{},
+        Exp<>{},
+        PackTile<output(cb_out, ReservePolicy::PerBlockSize, PushPolicy::PerBlockSize)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_chunked_fixed_tail.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_chunked_fixed_tail.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Block-capable exp(in) covering both valid-tail and fixed-size physical-tail synchronization.
+//
+// Each row has `Wt` valid tiles. The reader and writer exchange round_up(Wt, block_size)
+// pages per row in FullBlock mode, but the chain executes only Ht*Wt tiles. ValidTiles mode
+// instead exchanges only the logical remainder. Neither mode adds padding math.
+//
+// CT args: [Ht, Wt, block_size, synchronize_full_block].
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t block_size = get_compile_time_arg_val(2);
+    constexpr bool synchronize_full_block = get_compile_time_arg_val(3) != 0;
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    constexpr auto tail_sync = synchronize_full_block ? BlockTailSync::FullBlock : BlockTailSync::ValidTiles;
+    if constexpr (Ht == 1) {
+        eltwise_chain(
+            IterationShape::tiles(Wt).block_size(block_size, tail_sync),
+            CopyTile<
+                input(cb_in, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block),
+                Dst::D0>{},
+            Exp<>{},
+            PackTile<output(cb_out, ReservePolicy::PerBlockSize, PushPolicy::PerBlockSize)>{});
+    } else {
+        eltwise_chain(
+            IterationShape::grid(Ht, Wt).block_size(block_size, tail_sync),
+            CopyTile<
+                input(cb_in, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block),
+                Dst::D0>{},
+            Exp<>{},
+            PackTile<output(cb_out, ReservePolicy::PerBlockSize, PushPolicy::PerBlockSize)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_multislot_tail.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/block_exp_multislot_tail.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// A block-capable Exp chain that deliberately uses D1.  Its per-lane DEST footprint is two
+// slots (D0 is unused but reserved by the lane layout), making a four-tile block the half-sync
+// BF16 capacity boundary.  The Python test drives a partial final block through this path.
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t block_size = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    eltwise_chain(
+        IterationShape::tiles(n).block_size(block_size),
+        CopyTile<input(cb_in, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block), Dst::D1>{},
+        Exp<Approx::Exact, Dst::D1>{},
+        PackTile<output(cb_out, ReservePolicy::PerBlockSize, PushPolicy::PerBlockSize), Dst::D1>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/dest_reuse_param.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/dest_reuse_param.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DestReuseBinary matrix: reuse-direction x op. Stage 1 (fixed) D0 = A + B; stage 2 feeds DEST(D0)
+// and CB C into the FPU per ReuseType:
+//   DEST_TO_SRCA -> (A+B) op C     DEST_TO_SRCB -> C op (A+B)
+// For Sub the two directions differ, so the matrix proves DEST is routed to the correct unpack lane.
+//
+// CT args: [n, reuse (0=SRCA,1=SRCB), op (0=Add,1=Sub,2=Mul)].
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_c = tt::CBIndex::c_2;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t reuse = get_compile_time_arg_val(1);
+    constexpr uint32_t op = get_compile_time_arg_val(2);
+
+    using namespace compute_kernel_lib;
+    constexpr DestReuseType R = (reuse == 0) ? DestReuseType::DEST_TO_SRCA : DestReuseType::DEST_TO_SRCB;
+    constexpr BinaryFpuOp OP = (op == 0) ? BinaryFpuOp::Add : ((op == 1) ? BinaryFpuOp::Sub : BinaryFpuOp::Mul);
+
+    using CbOnSrcA = DestReuseBinary<BinaryFpuOp::Add, input(cb_c), DestReuseType::DEST_TO_SRCB>;
+    using CbOnSrcB = DestReuseBinary<BinaryFpuOp::Add, input(cb_c), DestReuseType::DEST_TO_SRCA>;
+    using ReconfigDisabled = DestReuseBinary<
+        BinaryFpuOp::Add,
+        input(cb_c, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+        DestReuseType::DEST_TO_SRCA>;
+    static_assert(CbOnSrcA::reconfig_srca_dfb == cb_c && CbOnSrcA::reconfig_srcb_dfb == NO_PREV_DFB);
+    static_assert(CbOnSrcB::reconfig_srca_dfb == NO_PREV_DFB && CbOnSrcB::reconfig_srcb_dfb == cb_c);
+    static_assert(
+        ReconfigDisabled::reconfig_srca_dfb == NO_PREV_DFB && ReconfigDisabled::reconfig_srcb_dfb == NO_PREV_DFB);
+
+    compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+
+    eltwise_chain(
+        IterationShape::tiles(n),
+        BinaryFpu<BinaryFpuOp::Add, input(cb_a), input(cb_b)>{},
+        DestReuseBinary<OP, input(cb_c), R>{},
+        PackTile<output(cb_out)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/fused_chain.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/fused_chain.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Realistic fused chain for the PerBlockSize-vs-Bulk perf comparison: out = exp(A + B) * C
+// (BinaryFpu add -> Exp -> DestReuseBinary mul, all in D0).
+//
+// Both lifecycles keep a BOUNDED CB (footprint set by `batch`/`block_size`, not N), so N scales to
+// thousands:
+//   - Bulk (life=0):    outer loop over `batch`-tile windows, a re-initialised Bulk chain per batch.
+//   - PerBlockSize (life=1): one chain over all N, waiting/popping once per block-size group (no re-init).
+//
+// CT args: [n, block_size, life, batch].
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_c = tt::CBIndex::c_2;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+
+    using FastExpD1 = compute_kernel_lib::Exp<compute_kernel_lib::Approx::Fast, compute_kernel_lib::Dst::D1>;
+    static_assert(FastExpD1::lane_width == 2);
+    constexpr uint32_t blk = get_compile_time_arg_val(1);
+    constexpr uint32_t life = get_compile_time_arg_val(2);   // 0 = Bulk (batched), 1 = PerBlockSize
+    constexpr uint32_t batch = get_compile_time_arg_val(3);  // Bulk batch window (tiles per chain call)
+
+    compute_kernel_hw_startup(cb_a, cb_b, cb_out);  // one boot covers every batch
+
+    using namespace compute_kernel_lib;
+    if constexpr (life == 0) {  // Bulk, batched over the whole N with a bounded `batch` window
+        for (uint32_t off = 0; off < n; off += batch) {
+            eltwise_chain(
+                IterationShape::tiles(batch).block_size(blk),
+                BinaryFpu<
+                    BinaryFpuOp::Add,
+                    input(cb_a, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+                    input(cb_b, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block)>{},
+                Exp<>{},
+                DestReuseBinary<
+                    BinaryFpuOp::Mul,
+                    input(cb_c, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+                    DestReuseType::DEST_TO_SRCA>{},
+                PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+        }
+    } else {  // PerBlockSize: single call over all N, bounded CB via per-block-size wait/pop
+        eltwise_chain(
+            IterationShape::tiles(n).block_size(blk),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block),
+                input(cb_b, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block)>{},
+            Exp<>{},
+            DestReuseBinary<
+                BinaryFpuOp::Mul,
+                input(cb_c, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block),
+                DestReuseType::DEST_TO_SRCA>{},
+            PackTile<output(cb_out, ReservePolicy::PerBlockSize, PushPolicy::PerBlockSize)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/hoist.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/hoist.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Equivalent exp(x) chains under three setup placements:
+//   0: one multi-tile call, so the chain hoists uniform setup;
+//   1: one single-tile call per tile, so each call emits setup;
+//   2: raw LLK setup followed by InitReconfigOwner::Caller.
+//
+// CT args: [n, mode].
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t mode = get_compile_time_arg_val(1);
+    static_assert(mode < 3);
+
+    using namespace compute_kernel_lib;
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    if constexpr (mode == 0) {
+        eltwise_chain(IterationShape::tiles(n), CopyTile<input(cb_in)>{}, Exp<>{}, PackTile<output(cb_out)>{});
+    } else if constexpr (mode == 1) {
+        for (uint32_t i = 0; i < n; ++i) {
+            eltwise_chain(IterationShape::one_tile(), CopyTile<input(cb_in)>{}, Exp<>{}, PackTile<output(cb_out)>{});
+        }
+    } else {
+        copy_tile_init(cb_in);
+        exp_tile_init();
+        eltwise_chain<InitReconfigOwner::Caller>(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_in, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled)>{},
+            Exp<>{},
+            PackTile<output(cb_out, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/index_2d.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/index_2d.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Inter-tile index test (the InputTileMapping *index* axis, not broadcast).
+// 2D grid(Ht, Wt) add: out(ht,wt) = A(ht,wt) + B tile selected by B's index mode.
+//   A: Block -> tile ht*Wt + wt (full walk)
+//   B: Row   -> tile wt (one per COLUMN, Wt tiles)    Col -> tile ht (one per ROW, Ht tiles)
+// BroadcastDim::None (plain tile add), so the only variable is which B tile is read — a Row<->Col
+// swap reads a different tile and fails PCC. Row/Col need a non-streaming lifecycle (Bulk).
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t mode = get_compile_time_arg_val(2);  // 1 = Col index, 2 = Row index
+
+    compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+
+    using namespace compute_kernel_lib;
+    if constexpr (mode == 2) {  // Row index on B
+        eltwise_chain(
+            IterationShape::grid(Ht, Wt),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+                input(cb_b, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Row)>{},
+            PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+    } else {  // Col index on B
+        eltwise_chain(
+            IterationShape::grid(Ht, Wt),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block),
+                input(cb_b, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Col)>{},
+            PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/misc_elements.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/misc_elements.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Small element scenarios that do not justify separate kernel files:
+//   0: ternary Where over three input CBs;
+//   1: one ReLU pack plus one unmodified pack.
+//
+// CT args: [n, mode].
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_c = tt::CBIndex::c_2;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t mode = get_compile_time_arg_val(1);
+    static_assert(mode < 2);
+
+    using namespace compute_kernel_lib;
+    if constexpr (mode == 0) {
+        compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_a)>{},
+            CopyTile<input(cb_b), Dst::D1>{},
+            CopyTile<input(cb_c), Dst::D2>{},
+            Where<DataFormat::Float16_b, Dst::D0, Dst::D1, Dst::D2, Dst::D0>{},
+            PackTile<output(cb_out)>{});
+    } else {
+        constexpr uint32_t cb_linear = tt::CBIndex::c_17;
+        compute_kernel_hw_startup(cb_a, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_a)>{},
+            PackTile<output(
+                cb_out,
+                ReservePolicy::PerTile,
+                PushPolicy::PerTile,
+                DataFormatReconfig::Enabled,
+                TileAddressing::Direct,
+                DestAccumulation::Disabled,
+                L1Accumulation::Disabled,
+                PackRelu::Zero)>{},
+            PackTile<output(cb_linear)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/misc_elements.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/misc_elements.cpp
@@ -5,12 +5,14 @@
 // Small element scenarios that do not justify separate kernel files:
 //   0: ternary Where over three input CBs;
 //   1: one ReLU pack plus one unmodified pack.
+//   2: int32 CopyDest from D0 to D1.
 //
 // CT args: [n, mode].
 
 #include <cstdint>
 
 #include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp"
 
 void kernel_main() {
@@ -20,7 +22,7 @@ void kernel_main() {
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t n = get_compile_time_arg_val(0);
     constexpr uint32_t mode = get_compile_time_arg_val(1);
-    static_assert(mode < 2);
+    static_assert(mode < 3);
 
     using namespace compute_kernel_lib;
     if constexpr (mode == 0) {
@@ -32,7 +34,7 @@ void kernel_main() {
             CopyTile<input(cb_c), Dst::D2>{},
             Where<DataFormat::Float16_b, Dst::D0, Dst::D1, Dst::D2, Dst::D0>{},
             PackTile<output(cb_out)>{});
-    } else {
+    } else if constexpr (mode == 1) {
         constexpr uint32_t cb_linear = tt::CBIndex::c_17;
         compute_kernel_hw_startup(cb_a, cb_out);
         eltwise_chain(
@@ -48,5 +50,12 @@ void kernel_main() {
                 L1Accumulation::Disabled,
                 PackRelu::Zero)>{},
             PackTile<output(cb_linear)>{});
+    } else {
+        compute_kernel_hw_startup(cb_a, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_a), Dst::D0>{},
+            CopyDest<Dst::D0, Dst::D1, DataFormat::Int32>{},
+            PackTile<output(cb_out), Dst::D1>{});
     }
 }

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/optional.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/optional.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Optional element scenarios. CT args: [n, scenario, enabled].
+// scenario 0 gates a unary, 1 gates a pack, and 2 runs runtime conditionals.
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t scenario = get_compile_time_arg_val(1);
+    constexpr bool enabled = get_compile_time_arg_val(2) != 0;
+    static_assert(scenario < 3);
+
+    using namespace compute_kernel_lib;
+    compute_kernel_hw_startup(cb_in, cb_out);
+    if constexpr (scenario == 0) {
+        eltwise_chain(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_in)>{},
+            Optional<enabled, Negative<Dst::D0>>{},
+            PackTile<output(cb_out)>{});
+    } else if constexpr (scenario == 1) {
+        constexpr uint32_t cb_out_2 = tt::CBIndex::c_17;
+        eltwise_chain(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_in)>{},
+            PackTile<output(cb_out)>{},
+            Optional<enabled, PackTile<output(cb_out_2)>>{});
+    } else {
+        const uint32_t mode = get_arg_val<uint32_t>(0);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_in)>{},
+            runtime_if(mode == 0, Negative<Dst::D0>{})
+                .else_if(mode == 1, Square<Dst::D0>{}, Negative<Dst::D0>{})
+                .otherwise(CopyDest<Dst::D0, Dst::D0>{}),
+            runtime_if(mode == 2, Abs<Dst::D0>{}),
+            runtime_if(mode == 3, Negative<Dst::D0>{}, Abs<Dst::D0>{}),
+            runtime_if(mode == 4, Square<Dst::D0>{}),
+            runtime_if(mode == 5, Square<Dst::D0>{}).else_if(mode == 6, Negative<Dst::D0>{}),
+            PackTile<output(cb_out)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/optional.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/optional.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
             CopyTile<input(cb_in)>{},
             runtime_if(mode == 0, Negative<Dst::D0>{})
                 .else_if(mode == 1, Square<Dst::D0>{}, Negative<Dst::D0>{})
-                .otherwise(CopyDest<Dst::D0, Dst::D0>{}),
+                .otherwise(CopyDest<Dst::D0, Dst::D0, DataFormat::Float16_b>{}),
             runtime_if(mode == 2, Abs<Dst::D0>{}),
             runtime_if(mode == 3, Negative<Dst::D0>{}, Abs<Dst::D0>{}),
             runtime_if(mode == 4, Square<Dst::D0>{}),

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/reader_2_asym.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/reader_2_asym.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Asymmetric 2-input reader: pushes n0 tiles to CB c_0 and n1 tiles to CB c_1.
+// Needed for inter-tile index tests where the broadcast operand has fewer tiles than the
+// full operand (Row index: c_1 has Wt tiles; Col index: c_1 has Ht tiles).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    const uint32_t n0 = get_arg_val<uint32_t>(2);
+    const uint32_t n1 = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb0 = 0;
+    constexpr uint32_t cb1 = 1;
+
+    constexpr auto src0_args = TensorAccessorArgs<0>();
+    constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+
+    const uint32_t bytes0 = get_local_cb_interface(cb0).fifo_page_size;
+    const uint32_t bytes1 = get_local_cb_interface(cb1).fifo_page_size;
+
+    const auto s0 = TensorAccessor(src0_args, src0_addr);
+    const auto s1 = TensorAccessor(src1_args, src1_addr);
+
+    Noc noc;
+    CircularBuffer c0(cb0), c1(cb1);
+    constexpr uint32_t onetile = 1;
+
+    // Push c_1 FIRST: it's the held/upfront operand and the chain needs it resident before it drains
+    // the streaming c_0. Filling a small c_0 first would block reserve_back before c_1 is pushed -> deadlock.
+    for (uint32_t i = 0; i < n1; ++i) {
+        c1.reserve_back(onetile);
+        noc.async_read(s1, c1, bytes1, {.page_id = i}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        c1.push_back(onetile);
+    }
+    for (uint32_t i = 0; i < n0; ++i) {
+        c0.reserve_back(onetile);
+        noc.async_read(s0, c0, bytes0, {.page_id = i}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        c0.push_back(onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/strided_tile_range.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/strided_tile_range.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t input_stride = get_compile_time_arg_val(2);
+    constexpr uint32_t output_stride = get_compile_time_arg_val(3);
+    constexpr uint32_t input_base = get_compile_time_arg_val(4);
+    constexpr uint32_t output_base = get_compile_time_arg_val(5);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    cb_wait_front(cb_in, Ht * input_stride);
+    cb_reserve_back(cb_out, Ht * output_stride);
+
+    using namespace compute_kernel_lib;
+    eltwise_chain(
+        IterationShape::grid(Ht, Wt),
+        CopyTile<input(
+            cb_in,
+            WaitPolicy::None,
+            PopPolicy::None,
+            InputTileMapping::Block,
+            DataFormatReconfig::Disabled,
+            TileAddressing::Strided)>{StridedTileRange{input_base, input_stride}},
+        PackTile<output(
+            cb_out, ReservePolicy::None, PushPolicy::None, DataFormatReconfig::Disabled, TileAddressing::Strided)>{
+            StridedTileRange{output_base, output_stride}});
+
+    cb_pop_front(cb_in, Ht * input_stride);
+    cb_push_back(cb_out, Ht * output_stride);
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/tile_addressing.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/tile_addressing.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tile-offset index test (the TileAddressing axis): identity copy with a Block walker at tile `base + i`
+// (TileAddressing::Offset); the chain inflates its wait/pop counts by `base` and reads tiles [base, base+n).
+// `base` is a runtime ctor arg. output[i] must equal input[base+i] — a dropped base add reads tile 0
+// and mismatches. TileAddressing::Offset requires a Bulk-family lifecycle (CopyTile static_assert), so uses Bulk.
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    const uint32_t base = get_arg_val<uint32_t>(0);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    eltwise_chain(
+        IterationShape::tiles(n),
+        CopyTile<
+            input(
+                cb_in,
+                WaitPolicy::Upfront,
+                PopPolicy::AtEnd,
+                InputTileMapping::Block,
+                DataFormatReconfig::Enabled,
+                TileAddressing::Offset),
+            Dst::D0>{base},
+        PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/unary_bcast.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/unary_bcast.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// UnaryBcast coverage for each hardware broadcast dimension. The element owns
+// the per-op short init; compute_kernel_hw_startup owns engine-wide setup.
+
+#include <cstdint>
+
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/broadcast/bcast.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t dim = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    if constexpr (dim == 0) {
+        unary_bcast<BroadcastDim::None, input(cb_in), output(cb_out)>(IterationShape::tiles(n));
+    } else if constexpr (dim == 1) {
+        unary_bcast<BroadcastDim::Col, input(cb_in), output(cb_out)>(IterationShape::tiles(n));
+    } else if constexpr (dim == 2) {
+        unary_bcast<BroadcastDim::Row, input(cb_in), output(cb_out)>(IterationShape::tiles(n));
+    } else {
+        unary_bcast<BroadcastDim::Scalar, input(cb_in), output(cb_out)>(IterationShape::tiles(n));
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/held_b.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/held_b.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Lifecycle / CB-synchronization suite.
+//
+// out[i] = A[i] + B[0] over n tiles: A streams (chain owns wait+pop); B is a single held tile reused
+// every iter on a selectable wait/pop pair. The chain emits exactly the CB edges its pair
+// declares; this kernel supplies the rest. A miscount hangs (wait/pop never satisfied) or reads a
+// stale tile, so each case asserts BOTH no-hang and correct values.
+//
+//   life  lifecycle        chain emits (for B)         caller supplies
+//   0     Bulk             wait 1 upfront + pop 1 end   nothing
+//   1     HeldBulk         wait 1 upfront, no pop       pop 1 after
+//   2     HeldStream       wait 1 / iter, no pop        pop 1 after
+//   3     CallerManaged    nothing                      wait 1 before, pop 1 after
+//   4     DeferredPop      no wait, pop 1 at end        wait 1 before
+//
+// B uses InputTileMapping::Scalar (re-read at relative tile 0 each iter) — the held-operand pattern.
+
+#include <cstdint>
+// chain.hpp first: it pulls in the compute API (PACK/UNPACK macros + llk decls) that
+// circular_buffer.h depends on. Reversing the order fails to compile.
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t life = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+
+    using namespace compute_kernel_lib;
+    CircularBuffer cb_b_obj(cb_b);
+
+    // A: streaming. B: held single tile (Scalar index, relative tile 0). Output: streaming.
+    auto pack = PackTile<output(cb_out, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{};
+
+    if constexpr (life == 0) {  // Bulk — chain owns both edges
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(cb_b, WaitPolicy::Upfront, PopPolicy::AtEnd, DataFormatReconfig::Disabled)>{},
+            pack);
+    } else if constexpr (life == 1) {  // HeldBulk — chain waits upfront, caller pops after
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(cb_b, WaitPolicy::Upfront, PopPolicy::None, DataFormatReconfig::Disabled)>{},
+            pack);
+        cb_b_obj.pop_front(1);
+    } else if constexpr (life == 2) {  // HeldStream — chain waits per-iter, caller pops after
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(cb_b, WaitPolicy::PerTile, PopPolicy::None, DataFormatReconfig::Disabled)>{},
+            pack);
+        cb_b_obj.pop_front(1);
+    } else if constexpr (life == 3) {  // CallerManaged — chain emits nothing for B
+        cb_b_obj.wait_front(1);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(cb_b, WaitPolicy::None, PopPolicy::None, DataFormatReconfig::Disabled)>{},
+            pack);
+        cb_b_obj.pop_front(1);
+    } else {  // life == 4: DeferredPop — caller waits before, chain pops at end
+        cb_b_obj.wait_front(1);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            BinaryFpu<
+                BinaryFpuOp::Add,
+                input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+                input(cb_b, WaitPolicy::None, PopPolicy::AtEnd, DataFormatReconfig::Disabled)>{},
+            pack);
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/inplace_chain.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/inplace_chain.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// In-place chain lifecycle: the chain reads AND writes the SAME CB (cb_x), overwriting a resident
+// buffer with no second CB. Run under --dev. CT args: [n, life, blk].
+//
+// Hazard: CB self-deadlock — the packer's reserve can't succeed while the reader's tiles still
+// occupy cb_x. Per-iter order is wait->read->POP then RESERVE->pack->push, so in-place is safe ONLY
+// when the output reserves incrementally (per-tile/chunk) AND the input pops incrementally. The
+// `life` cases are exactly the safe pairs; each must pass (no-hang + correct values):
+//   0  BulkDrain + Streaming (Scalar)   wait all n upfront, then pop1/reserve1/push1 per tile
+//   1  PerBlockSize + PerBlockSize (Block) wait/pop K, then reserve/push K, per block-size group
+//   2  Streaming + Streaming (Scalar)   wait1/pop1, then reserve1/push1, per tile
+// Any upfront-reserve output (Bulk / ReserveAllPush*) would deadlock and is deliberately not built.
+// In-place safety is a pure function of the input wait/pop and output reserve/push pairing; the compute
+// elements between read and pack (DestReuseBinary, SFPU ops, ...) are DEST-internal and don't affect
+// it — every case here holds the compute constant (Exp) and varies only the lifecycle pair.
+//
+// 3 stages keep the writer off cb_x: stage 0 Bulk-fills cb_x from the reader, stage A is the
+// in-place transform under test, stage B Bulk-copies cb_x to cb_out for the writer.
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_src = tt::CBIndex::c_0;   // reader fills this
+    constexpr uint32_t cb_x = tt::CBIndex::c_1;     // the in-place buffer (read AND written by stage A)
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;  // writer drains this
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t life = get_compile_time_arg_val(1);
+    constexpr uint32_t blk = get_compile_time_arg_val(2);  // block_size for the PerBlockSize case
+
+    compute_kernel_hw_startup(cb_src, cb_out);
+
+    using namespace compute_kernel_lib;
+
+    // Stage 0: Bulk-fill cb_x from the reader; after this cb_x is owned entirely by compute.
+    eltwise_chain(
+        IterationShape::tiles(n),
+        CopyTile<input(cb_src, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block), Dst::D0>{},
+        PackTile<output(cb_x, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+
+    // Stage A: exp(x) IN PLACE on cb_x (read cb_x -> DEST -> exp -> pack cb_x). THE CASE UNDER TEST.
+    if constexpr (life == 0) {
+        // Front rotation: pop frees the front tile, reserve reuses it. Scalar reads the current front.
+        eltwise_chain(
+            IterationShape::tiles(n),
+            CopyTile<input(cb_x, WaitPolicy::Upfront, PopPolicy::PerTile), Dst::D0>{},
+            Exp<>{},
+            PackTile<output(cb_x)>{});
+    } else if constexpr (life == 1) {
+        // Chunk lockstep: pop/reserve K per chunk. Block index walks the K-tile front window.
+        eltwise_chain(
+            IterationShape::tiles(n).block_size(blk),
+            CopyTile<
+                input(cb_x, WaitPolicy::PerBlockSize, PopPolicy::PerBlockSize, InputTileMapping::Block),
+                Dst::D0>{},
+            Exp<>{},
+            PackTile<output(cb_x, ReservePolicy::PerBlockSize, PushPolicy::PerBlockSize)>{});
+    } else {  // life == 2
+        // Per-tile rotation: like life 0 but the wait is per-tile too.
+        eltwise_chain(IterationShape::tiles(n), CopyTile<input(cb_x)>{}, Exp<>{}, PackTile<output(cb_x)>{});
+    }
+
+    // Stage B: copy cb_x -> cb_out (plain Bulk copy) so the DRAM writer drains cb_out, never cb_x.
+    eltwise_chain(
+        IterationShape::tiles(n),
+        CopyTile<input(cb_x, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block), Dst::D0>{},
+        PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/out_lifecycle.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/lifecycle/out_lifecycle.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Output-lifecycle / CB-synchronization suite (output side).
+//
+// Identity copy out[i] = A[i] over n tiles; input streams. The output PackTile uses a selectable
+// reserve/push pair; the chain emits the edges it declares and this kernel supplies the
+// rest. A reserve/push miscount hangs the writer or overwrites an unpushed tile, so each case
+// asserts no-hang AND correct values.
+//
+//   life  reserve/push pair      chain emits                          caller supplies
+//   0     Streaming              reserve 1 + push 1 / iter            nothing
+//   1     Bulk                   reserve n upfront + push n at end     nothing
+//   2     ReserveAllPushPerTile  reserve n upfront, push 1 / iter      nothing
+//   3     CallerManaged          pack only (no reserve / no push)      reserve n before, push n after
+//   4     ReserveNonePushEnd      push n at end                         reserve n before
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t life = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    CircularBuffer cb_out_obj(cb_out);
+    auto in = CopyTile<input(cb_in, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled), Dst::D0>{};
+
+    if constexpr (life == 0) {
+        eltwise_chain(
+            IterationShape::tiles(n),
+            in,
+            PackTile<output(cb_out, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
+    } else if constexpr (life == 1) {
+        eltwise_chain(
+            IterationShape::tiles(n),
+            in,
+            PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd, DataFormatReconfig::Disabled)>{});
+    } else if constexpr (life == 2) {
+        eltwise_chain(
+            IterationShape::tiles(n),
+            in,
+            PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
+    } else if constexpr (life == 3) {
+        cb_out_obj.reserve_back(n);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            in,
+            PackTile<output(cb_out, ReservePolicy::None, PushPolicy::None, DataFormatReconfig::Disabled)>{});
+        cb_out_obj.push_back(n);
+    } else {
+        cb_out_obj.reserve_back(n);
+        eltwise_chain(
+            IterationShape::tiles(n),
+            in,
+            PackTile<output(cb_out, ReservePolicy::None, PushPolicy::AtEnd, DataFormatReconfig::Disabled)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/block_clamp.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/block_clamp.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Out-of-bounds block_size probe: block-capable identity copy (Bulk + Block reader).
+//
+// block_size is a RUNTIME IterationShape field, so it can't be static_asserted; the chain clamps it
+// to chain_max_block_v = DEST_AUTO_LIMIT / chain_lane_width. An oversized block_size can't overflow
+// DEST — it only changes loop iteration count, not coverage. So {1, 4, 1000} must all reproduce the
+// input exactly (the driving pytest feeds those).
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t n = get_compile_time_arg_val(0);
+    constexpr uint32_t blk = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    eltwise_chain(
+        IterationShape::tiles(n).block_size(blk),
+        CopyTile<input(cb_in, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block), Dst::D0>{},
+        PackTile<output(cb_out, ReservePolicy::Upfront, PushPolicy::AtEnd)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/convenience_arity.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/convenience_arity.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Negative wrapper probes. The wrappers own a fixed number of CopyTile loads,
+// so their SFPU operation must consume the matching number of DEST operands.
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
+
+namespace compute_kernel_lib {
+
+struct TestUnary : UnaryOp<TestUnary, Dst::D0> {
+    static ALWI void init() {}
+    static ALWI void exec_impl(uint32_t) {}
+};
+
+struct TestBinary : BinaryOp<TestBinary, Dst::D0, Dst::D1, Dst::D0> {
+    static ALWI void init() {}
+    static ALWI void exec_impl(uint32_t) {}
+};
+
+}  // namespace compute_kernel_lib
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t total_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t mode = get_compile_time_arg_val(1);
+    static_assert(mode < 2);
+
+    compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+
+    using namespace compute_kernel_lib;
+    if constexpr (mode == 0) {
+        unary<TestBinary, input(cb_a), output(cb_out)>(IterationShape::tiles(total_tiles));
+    } else {
+        binary_sfpu<TestUnary, input(cb_a), input(cb_b), output(cb_out)>(IterationShape::tiles(total_tiles));
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/dst_slot.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/dst_slot.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Out-of-bounds DST probe: identity copy through a single DEST slot (slot index is a CT arg).
+//
+// Every chain element static_asserts `to_u32(slot) < DEST_AUTO_LIMIT`, which depends on the compute
+// config (half/full sync × fp32_dest_acc): half-sync bf16=8/fp32=4, full-sync bf16=16/fp32=8. The
+// driving pytest picks (slot, sync, fp32_acc) so a legal slot compiles and reproduces the input,
+// and an over-limit slot FAILS to compile with "DEST slot exceeds DEST_AUTO_LIMIT".
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t total_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t slot = get_compile_time_arg_val(1);
+    constexpr auto Slot = static_cast<compute_kernel_lib::Dst>(slot);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    compute_kernel_lib::eltwise_chain(
+        compute_kernel_lib::IterationShape::tiles(total_tiles),
+        compute_kernel_lib::CopyTile<compute_kernel_lib::input(cb_in), Slot>{},
+        compute_kernel_lib::PackTile<compute_kernel_lib::output(cb_out), Slot>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/prng_seed.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/prng_seed.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Negative PRNG probe: RandTile and Dropout both seed the one hardware PRNG,
+// so two independently seeded elements must be rejected at compile time.
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t total_tiles = get_compile_time_arg_val(0);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    eltwise_chain(
+        IterationShape::tiles(total_tiles),
+        CopyTile<input(cb_in), Dst::D0>{},
+        RandTile<Dst::D0>{0, 1, 17, 0},
+        Dropout<Dst::D1>{1, 1, 29},
+        PackTile<output(cb_out)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/runtime_prng.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/runtime_prng.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// A PRNG seeder cannot be guarded by runtime_if: the chain seeds PRNG state once
+// before its walk, while a conditional branch is selected within that walk.
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t total_tiles = get_compile_time_arg_val(0);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    eltwise_chain(
+        IterationShape::tiles(total_tiles),
+        CopyTile<input(cb_in), Dst::D0>{},
+        runtime_if(true, RandTile<Dst::D0>{0, 1, 17, 0}),
+        PackTile<output(cb_out)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/shared_cb_lifecycle.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/shared_cb_lifecycle.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Negative lifecycle probe: a staged CB-window owner cannot share the CB with
+// another reader that pops it.  The compile-time order argument exercises both
+// directions of the collision check.
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t total_tiles = get_compile_time_arg_val(0);
+    constexpr bool owner_first = get_compile_time_arg_val(1) != 0;
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    using namespace compute_kernel_lib;
+    using WindowOwner = CopyTile<input(cb_in, WaitPolicy::Upfront, PopPolicy::AtEnd, InputTileMapping::Block), Dst::D0>;
+    using PeerPopper =
+        CopyTile<input(cb_in, WaitPolicy::PerTile, PopPolicy::PerTile, InputTileMapping::Scalar), Dst::D1>;
+
+    if constexpr (owner_first) {
+        eltwise_chain(IterationShape::tiles(total_tiles), WindowOwner{}, PeerPopper{}, PackTile<output(cb_out)>{});
+    } else {
+        eltwise_chain(IterationShape::tiles(total_tiles), PeerPopper{}, WindowOwner{}, PackTile<output(cb_out)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/unclassified_element.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/oob/unclassified_element.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Negative classification probe: a plausible-looking element that forgot to inherit a kind tag
+// (CB reader / CB writer / DEST-only). Without the exhaustive-classification static_assert it
+// would compile and flow through every chain stage as a silently inert position; the driving
+// pytest asserts the chain instead FAILS to compile with "every element must carry exactly one
+// kind tag".
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace {
+
+struct RogueElement {
+    static void init() {}
+    void exec(uint32_t /*i*/, uint32_t /*ht*/, uint32_t /*wt*/, uint32_t /*slot_offset*/) const {}
+};
+
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t total_tiles = get_compile_time_arg_val(0);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+
+    compute_kernel_lib::eltwise_chain(
+        compute_kernel_lib::IterationShape::tiles(total_tiles),
+        compute_kernel_lib::CopyTile<compute_kernel_lib::input(cb_in)>{},
+        RogueElement{},
+        compute_kernel_lib::PackTile<compute_kernel_lib::output(cb_out)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/outer_stream/chain_outer_stream.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/outer_stream/chain_outer_stream.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Functional validation for PerTile + Col — a streamed column/outer-axis broadcast.
+//
+// BinaryFpu(cb_a, cb_b) -> PackTile(cb_out) over grid(Ht, Wt):
+//   cb_a: Streaming + Scalar — full Ht*Wt walk, one tile per (ht, wt), popped per tile.
+//   cb_b: PerTile + Col — ONE tile per row: waited at row entry, read at front index 0 across the
+//         row's Wt cols, and popped at row exit. Producer feeds a shallow 2-deep CB (O(1) L1) instead
+//         of the Ht-deep window an upfront + Col operand needs.
+//   cb_out: PerTile output — one result tile per (ht, wt), unaffected by the streamed input lifecycle.
+// Net: out[ht*Wt + wt] = cb_a[ht*Wt + wt] + cb_b[ht].
+
+#include <cstdint>
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+namespace ckl = compute_kernel_lib;
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+
+    compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+
+    ckl::eltwise_chain(
+        ckl::IterationShape::grid(Ht, Wt),
+        ckl::BinaryFpu<
+            ckl::BinaryFpuOp::Add,
+            ckl::input(cb_a, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::input(
+                cb_b,
+                ckl::WaitPolicy::PerTile,
+                ckl::PopPolicy::PerTile,
+                ckl::InputTileMapping::Col,
+                ckl::DataFormatReconfig::Disabled)>{},
+        ckl::PackTile<ckl::output(cb_out)>{});
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/outer_stream/reader_a_full_b_per_row.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/outer_stream/reader_a_full_b_per_row.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Feeds the PerTile + Col streamed-column lifecycle scenario:
+//   cb_a (c_0): the full Ht*Wt walk, one tile per (ht, wt), pushed in order.
+//   cb_b (c_1): ONE tile per row (b[ht]), pushed at the top of each row so it is present when
+//               the compute kernel starts that row. cb_b stays shallow (2-deep) — the producer
+//               never stages the whole column, which is the point of streamed Col.
+// Runtime args: a_addr, b_addr, Ht, Wt. Page bytes come from each CB's configured page size.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src0_addr = get_arg_val<uint32_t>(0);  // a: Ht*Wt tiles
+    const uint32_t src1_addr = get_arg_val<uint32_t>(1);  // b: Ht tiles (one per row)
+    const uint32_t Ht = get_arg_val<uint32_t>(2);
+    const uint32_t Wt = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb0 = 0;
+    constexpr uint32_t cb1 = 1;
+
+    constexpr auto src0_args = TensorAccessorArgs<0>();
+    constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+
+    const uint32_t bytes0 = get_local_cb_interface(cb0).fifo_page_size;
+    const uint32_t bytes1 = get_local_cb_interface(cb1).fifo_page_size;
+
+    const auto s0 = TensorAccessor(src0_args, src0_addr);
+    const auto s1 = TensorAccessor(src1_args, src1_addr);
+
+    Noc noc;
+    CircularBuffer c0(cb0), c1(cb1);
+
+    constexpr uint32_t onetile = 1;
+    uint32_t a_id = 0;
+    for (uint32_t ht = 0; ht < Ht; ++ht) {
+        // One b tile for this row.
+        c1.reserve_back(onetile);
+        noc.async_read(s1, c1, bytes1, {.page_id = ht}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        c1.push_back(onetile);
+        // Wt a tiles for this row.
+        for (uint32_t wt = 0; wt < Wt; ++wt) {
+            c0.reserve_back(onetile);
+            noc.async_read(s0, c0, bytes0, {.page_id = a_id}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            c0.push_back(onetile);
+            ++a_id;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig/reader_inputs.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig/reader_inputs.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Streams the same tile range from one to four tensors into CBs c_0..c_3.
+// The input count is a compile-time argument; TensorAccessorArgs follow it.
+
+#include <cstdint>
+
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+
+template <uint32_t NumInputs>
+void read_inputs() {
+    static_assert(NumInputs >= 1 && NumInputs <= 4);
+    constexpr uint32_t one_tile = 1;
+    Noc noc;
+
+    if constexpr (NumInputs == 1) {
+        const uint32_t src0_addr = get_arg_val<uint32_t>(0);
+        const uint32_t num_tiles = get_arg_val<uint32_t>(1);
+        const uint32_t start_id = get_arg_val<uint32_t>(2);
+        constexpr auto src0_args = TensorAccessorArgs<1>();
+        const auto src0 = TensorAccessor(src0_args, src0_addr);
+        const uint32_t bytes0 = get_local_cb_interface(0).fifo_page_size;
+        CircularBuffer cb0(0);
+        for (uint32_t i = start_id; i < start_id + num_tiles; ++i) {
+            cb0.reserve_back(one_tile);
+            noc.async_read(src0, cb0, bytes0, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb0.push_back(one_tile);
+        }
+    } else if constexpr (NumInputs == 2) {
+        const uint32_t src0_addr = get_arg_val<uint32_t>(0);
+        const uint32_t src1_addr = get_arg_val<uint32_t>(1);
+        const uint32_t num_tiles = get_arg_val<uint32_t>(2);
+        const uint32_t start_id = get_arg_val<uint32_t>(3);
+        constexpr auto src0_args = TensorAccessorArgs<1>();
+        constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+        const auto src0 = TensorAccessor(src0_args, src0_addr);
+        const auto src1 = TensorAccessor(src1_args, src1_addr);
+        const uint32_t bytes0 = get_local_cb_interface(0).fifo_page_size;
+        const uint32_t bytes1 = get_local_cb_interface(1).fifo_page_size;
+        CircularBuffer cb0(0), cb1(1);
+        for (uint32_t i = start_id; i < start_id + num_tiles; ++i) {
+            cb0.reserve_back(one_tile);
+            cb1.reserve_back(one_tile);
+            noc.async_read(src0, cb0, bytes0, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read(src1, cb1, bytes1, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb0.push_back(one_tile);
+            cb1.push_back(one_tile);
+        }
+    } else if constexpr (NumInputs == 3) {
+        const uint32_t src0_addr = get_arg_val<uint32_t>(0);
+        const uint32_t src1_addr = get_arg_val<uint32_t>(1);
+        const uint32_t src2_addr = get_arg_val<uint32_t>(2);
+        const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+        const uint32_t start_id = get_arg_val<uint32_t>(4);
+        constexpr auto src0_args = TensorAccessorArgs<1>();
+        constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+        constexpr auto src2_args = TensorAccessorArgs<src1_args.next_compile_time_args_offset()>();
+        const auto src0 = TensorAccessor(src0_args, src0_addr);
+        const auto src1 = TensorAccessor(src1_args, src1_addr);
+        const auto src2 = TensorAccessor(src2_args, src2_addr);
+        const uint32_t bytes0 = get_local_cb_interface(0).fifo_page_size;
+        const uint32_t bytes1 = get_local_cb_interface(1).fifo_page_size;
+        const uint32_t bytes2 = get_local_cb_interface(2).fifo_page_size;
+        CircularBuffer cb0(0), cb1(1), cb2(2);
+        for (uint32_t i = start_id; i < start_id + num_tiles; ++i) {
+            cb0.reserve_back(one_tile);
+            cb1.reserve_back(one_tile);
+            cb2.reserve_back(one_tile);
+            noc.async_read(src0, cb0, bytes0, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read(src1, cb1, bytes1, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read(src2, cb2, bytes2, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb0.push_back(one_tile);
+            cb1.push_back(one_tile);
+            cb2.push_back(one_tile);
+        }
+    } else {
+        const uint32_t src0_addr = get_arg_val<uint32_t>(0);
+        const uint32_t src1_addr = get_arg_val<uint32_t>(1);
+        const uint32_t src2_addr = get_arg_val<uint32_t>(2);
+        const uint32_t src3_addr = get_arg_val<uint32_t>(3);
+        const uint32_t num_tiles = get_arg_val<uint32_t>(4);
+        const uint32_t start_id = get_arg_val<uint32_t>(5);
+        constexpr auto src0_args = TensorAccessorArgs<1>();
+        constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+        constexpr auto src2_args = TensorAccessorArgs<src1_args.next_compile_time_args_offset()>();
+        constexpr auto src3_args = TensorAccessorArgs<src2_args.next_compile_time_args_offset()>();
+        const auto src0 = TensorAccessor(src0_args, src0_addr);
+        const auto src1 = TensorAccessor(src1_args, src1_addr);
+        const auto src2 = TensorAccessor(src2_args, src2_addr);
+        const auto src3 = TensorAccessor(src3_args, src3_addr);
+        const uint32_t bytes0 = get_local_cb_interface(0).fifo_page_size;
+        const uint32_t bytes1 = get_local_cb_interface(1).fifo_page_size;
+        const uint32_t bytes2 = get_local_cb_interface(2).fifo_page_size;
+        const uint32_t bytes3 = get_local_cb_interface(3).fifo_page_size;
+        CircularBuffer cb0(0), cb1(1), cb2(2), cb3(3);
+        for (uint32_t i = start_id; i < start_id + num_tiles; ++i) {
+            cb0.reserve_back(one_tile);
+            cb1.reserve_back(one_tile);
+            cb2.reserve_back(one_tile);
+            cb3.reserve_back(one_tile);
+            noc.async_read(src0, cb0, bytes0, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read(src1, cb1, bytes1, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read(src2, cb2, bytes2, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read(src3, cb3, bytes3, {.page_id = i}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb0.push_back(one_tile);
+            cb1.push_back(one_tile);
+            cb2.push_back(one_tile);
+            cb3.push_back(one_tile);
+        }
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t num_inputs = get_compile_time_arg_val(0);
+    read_inputs<num_inputs>();
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig/scenarios.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig/scenarios.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Data-format reconfiguration scenarios:
+//   0: both operands rotate with previous formats;
+//   1: first binary operation configures both operands;
+//   2: srcA rotates while srcB is first-use;
+//   3: srcA-only rotation;
+//   4: heterogeneous pack outputs;
+//   5: repeated streaming reads from one CB.
+//
+// CT args: [num_tiles, mode].
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_a = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b = tt::CBIndex::c_1;
+    constexpr uint32_t cb_c = tt::CBIndex::c_2;
+    constexpr uint32_t cb_d = tt::CBIndex::c_3;
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t mode = get_compile_time_arg_val(1);
+    static_assert(mode < 6);
+
+    using namespace compute_kernel_lib;
+    if constexpr (mode == 0) {
+        compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(num_tiles),
+            BinaryFpu<BinaryFpuOp::Add, input(cb_a), input(cb_b)>{},
+            BinaryFpu<BinaryFpuOp::Add, input(cb_c), input(cb_d)>{},
+            PackTile<output(cb_out)>{});
+    } else if constexpr (mode == 1) {
+        constexpr InputSpec default_input = input(cb_a);
+        constexpr OutputSpec default_output = output(cb_out);
+        static_assert(default_input.cb_id == cb_a);
+        static_assert(default_input.wait == WaitPolicy::PerTile);
+        static_assert(default_input.pop == PopPolicy::PerTile);
+        static_assert(default_input.mapping == InputTileMapping::Scalar);
+        static_assert(default_input.addressing == TileAddressing::Direct);
+        static_assert(default_input.reconfig == DataFormatReconfig::Enabled);
+        static_assert(default_output.reserve == ReservePolicy::PerTile);
+        static_assert(default_output.push == PushPolicy::PerTile);
+        static_assert(default_output.cb_id == cb_out);
+        static_assert(default_output.reconfig == DataFormatReconfig::Enabled);
+        static_assert(default_output.relu == PackRelu::Disabled);
+        static_assert(default_output.l1_accumulation == L1Accumulation::Disabled);
+        static_assert(default_output.dest_accumulation == DestAccumulation::Disabled);
+        static_assert(default_output.addressing == TileAddressing::Direct);
+
+        using SrcAOnly = BinaryFpu<
+            BinaryFpuOp::Add,
+            input(cb_a),
+            input(cb_b, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled)>;
+        using SrcBOnly = BinaryFpu<
+            BinaryFpuOp::Add,
+            input(cb_a, WaitPolicy::PerTile, PopPolicy::PerTile, DataFormatReconfig::Disabled),
+            input(cb_b)>;
+        static_assert(SrcAOnly::reconfig_srca_dfb == cb_a && SrcAOnly::reconfig_srcb_dfb == NO_PREV_DFB);
+        static_assert(SrcBOnly::reconfig_srca_dfb == NO_PREV_DFB && SrcBOnly::reconfig_srcb_dfb == cb_b);
+
+        compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(num_tiles),
+            BinaryFpu<BinaryFpuOp::Add, input(cb_a), input(cb_b)>{},
+            PackTile<output(cb_out)>{});
+    } else if constexpr (mode == 2) {
+        compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(num_tiles),
+            CopyTile<input(cb_a)>{},
+            BinaryFpu<BinaryFpuOp::Add, input(cb_b), input(cb_c), Dst::D1>{},
+            AddBinary<Dst::D0, Dst::D1, Dst::D0>{},
+            PackTile<output(cb_out)>{});
+    } else if constexpr (mode == 3) {
+        compute_kernel_hw_startup(cb_a, cb_b, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(num_tiles),
+            CopyTile<input(cb_a)>{},
+            CopyTile<input(cb_b)>{},
+            PackTile<output(cb_out)>{});
+    } else if constexpr (mode == 4) {
+        constexpr uint32_t cb_out_2 = tt::CBIndex::c_17;
+        compute_kernel_hw_startup(cb_a, cb_a, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(num_tiles),
+            CopyTile<input(cb_a)>{},
+            PackTile<output(cb_out)>{},
+            PackTile<output(cb_out_2)>{});
+    } else {
+        compute_kernel_hw_startup(cb_a, cb_a, cb_out);
+        eltwise_chain(
+            IterationShape::tiles(num_tiles),
+            CopyTile<input(cb_a)>{},
+            CopyTile<input(cb_a)>{},
+            CopyTile<input(cb_a)>{},
+            PackTile<output(cb_out)>{});
+    }
+}

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig/writer_2_outputs.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/reconfig/writer_2_outputs.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Writes num_tiles tiles from CBs c_16, c_17 to 2 output tensors.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t dst0_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst1_addr = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t start_id = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb0 = 16;
+    constexpr uint32_t cb1 = 17;
+
+    constexpr auto dst0_args = TensorAccessorArgs<0>();
+    constexpr auto dst1_args = TensorAccessorArgs<dst0_args.next_compile_time_args_offset()>();
+
+    const uint32_t bytes0 = get_local_cb_interface(cb0).fifo_page_size;
+    const uint32_t bytes1 = get_local_cb_interface(cb1).fifo_page_size;
+
+    const auto s0 = TensorAccessor(dst0_args, dst0_addr);
+    const auto s1 = TensorAccessor(dst1_args, dst1_addr);
+
+    Noc noc;
+    CircularBuffer c0(cb0), c1(cb1);
+
+    constexpr uint32_t onetile = 1;
+    for (uint32_t i = start_id; i < start_id + num_tiles; ++i) {
+        c0.wait_front(onetile);
+        c1.wait_front(onetile);
+        noc.async_write(c0, s0, bytes0, {}, {.page_id = i});
+        noc.async_write(c1, s1, bytes1, {}, {.page_id = i});
+        noc.async_writes_flushed();
+        c0.pop_front(onetile);
+        c1.pop_front(onetile);
+    }
+    noc.async_write_barrier();
+}


### PR DESCRIPTION
# [llk_helper_library] 1/8 eltwise helpers: framework and validation matrix

## Summary

This is PR 1 of the split of #49991. It introduces the foundational typed
description for element-wise L1 → L1 compute stages, together with its device
validation matrix and CI registration. Follow-up PRs migrate production
kernels to the framework; this PR intentionally does not change those kernels.

Instead of each compute kernel repeating DEST synchronization, DFB
wait/pop/reserve/push, per-operation initialization, data-format
reconfiguration, and tile loops, a caller describes:

- how the loop walks tiles;
- which DFBs provide and receive data;
- which operations run, in order; and
- who owns each part of the DFB lifecycle.

The helper validates that description at compile time and emits the LLK
operations formerly written by hand. Engine-wide
`compute_kernel_hw_startup(...)` remains a separate caller-owned step.

```cpp
eltwise_chain(
    IterationShape::tiles(num_tiles),
    CopyTile<input(in, WaitPolicy::PerTile, PopPolicy::PerTile)>{},
    PackTile<output(out, ReservePolicy::PerTile, PushPolicy::PerTile)>{});
```

## What changed

- Adds `eltwise/core/chain.inl`: variadic chain execution, DFB lifecycle
  scheduling, DEST synchronization, data-format reconfiguration, and
  compile-time validation.
- Adds the public chain and convenience APIs, including `IterationShape`,
  explicit input/output lifecycle policies, and common named chain forms.
- Adds operation adapters for unary, binary SFPU, broadcast, ternary, fill,
  and random operations.
- Adds compile-time `Optional<condition, Element>` support.
- Adds device-backed kernel-lib coverage for lifecycle ownership, blocking,
  DEST accumulation, indexing, reconfiguration, optional elements,
  out-of-bounds validation, and skip-compute behavior.
- Registers the functional kernel-lib suite in the ops-unit-test pipeline and
  makes `kernel_lib` selectable in L2 Nightly. The two realtime-profiler perf
  files are intentionally excluded from the functional pytest entry.
- Updates kernel-lib CMake/source wiring and the package source manifest for
  the new helper headers.

## API checkpoints for reviewers

- `IterationShape` describes loop execution, not necessarily the number of
  input or output tiles. The supported forms are `tiles(n)`, `grid(h, w)`, and
  `one_tile()`.
- Blocking is fluent via `.block_size(block_size)`. Valid tiles synchronize at
  the default tail; `BlockTailSync::FullBlock` names the padded physical-block
  contract where needed.
- `BinaryFpu` is ordered as `BinaryFpu<Op, srcA, srcB, ...>`. Its supported
  broadcast is attached to the `srcB` input specification.
- DFB lifecycle policies remain explicit on `input(...)` and `output(...)`.
- The framework is deliberately limited to L1 → L1 stages. Stateful or
  otherwise specialized loops remain appropriate where a chain would force an
  unnecessary DEST → L1 → DEST round trip.

## Scope and follow-ups

This PR is the foundation of the #49991 split. The subsequent PRs contain the
eltwise/generator, copy/data-movement, experimental, normalization, Moreh,
Moreh-training, and TT-Train migrations. Keeping those migrations out of this
PR makes the API and validation matrix independently reviewable.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:astancov/eltwise_helper_migration_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:astancov/eltwise_helper_migration_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=astancov/eltwise_helper_migration_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:astancov/eltwise_helper_migration_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:astancov/eltwise_helper_migration_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=astancov/eltwise_helper_migration_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:astancov/eltwise_helper_migration_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=astancov/eltwise_helper_migration_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:astancov/eltwise_helper_migration_1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=astancov/eltwise_helper_migration_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:astancov/eltwise_helper_migration_1)