### PR TITLE
[Performance] GLM-5.2 sparse MLA matmul tuning

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -21,7 +21,8 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.mla.mla_config import get_indexer_key_chunk
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tt.mla.mla_config import get_indexer_key_chunk, get_matmul_config
 from models.demos.deepseek_v3_d_p.tt.mla.rope import interleaved_perm_matrix
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
@@ -615,6 +616,23 @@ class TtIndexer:
             input_batch_index=cache_batch_idx if index_kbuf.shape[0] > 1 else 0,
         )
 
+    def _resolve_mm_cfg(self, weight_name: str, seq_len_local: int) -> dict | None:
+        """Return the model-gated Blackhole config for an indexer matmul."""
+        if not is_blackhole():
+            return None
+        entry = get_matmul_config(weight_name, seq_len_local)
+        candidates = entry if isinstance(entry, list) else [entry]
+        return next(
+            (
+                cfg
+                for cfg in candidates
+                if cfg is not None
+                and cfg.get("num_heads") in (None, self.config.num_attention_heads)
+                and cfg.get("q_lora_rank") in (None, getattr(self.config, "q_lora_rank", None))
+            ),
+            None,
+        )
+
     def write_k(
         self,
         hidden_states,
@@ -637,11 +655,13 @@ class TtIndexer:
         ``actual_end`` (end of the chunk's real tokens) clamps the write to them, so a chunk padding past
         the cache end needs only its real tokens to fit. forward() reads back the same prefix
         (``valid_pos``)."""
+        wk_cfg = self._resolve_mm_cfg("indexer.wk", seq_len)
         k = ttnn.linear(
             hidden_states,
             self._idx_wk,
             compute_kernel_config=self.default_compute_kernel_config,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=wk_cfg["out_mem_config"] if wk_cfg is not None else ttnn.DRAM_MEMORY_CONFIG,
+            **({"program_config": wk_cfg["program_config"]} if wk_cfg is not None else {}),
         )  # per-chip partial [1, 1, S/sp, D_idx]
         k = self._tp_rs_ag(k)  # all-reduce over TP
         k = ttnn.layer_norm(
@@ -660,12 +680,14 @@ class TtIndexer:
         # compacted stride (_index_cache_layers) so it matches the cache_batch_idx computed in forward().
         cache_layer_idx = self._cache_slot(cache_layer_idx)
         k = self._bc_rope_pe(k, rope_tensors, start_pos)  # [1, 1, S/sp, D_idx] bf16
+        k_hadamard_cfg = self._resolve_mm_cfg("indexer.k_hadamard", seq_len)
         k_h = ttnn.matmul(
             k,
             self._index_hadamard,
             dtype=ttnn.bfloat16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             compute_kernel_config=self.default_compute_kernel_config,
+            **({"program_config": k_hadamard_cfg["program_config"]} if k_hadamard_cfg is not None else {}),
         )
         ttnn.deallocate(k)
         k = k_h
@@ -744,11 +766,13 @@ class TtIndexer:
         )
 
         # Q stem: the shared q_a latent (qr) -> indexer wq_b.
+        wq_b_cfg = self._resolve_mm_cfg("indexer.wq_b", seq_len)
         q = ttnn.linear(
             qr,
             self._idx_wq_b,
             compute_kernel_config=self.default_compute_kernel_config,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=wq_b_cfg["out_mem_config"] if wq_b_cfg is not None else ttnn.DRAM_MEMORY_CONFIG,
+            **({"program_config": wq_b_cfg["program_config"]} if wq_b_cfg is not None else {}),
             # Preserve the unquantized values through Hadamard, then materialize BFP8 once below.
             dtype=ttnn.bfloat16,
         )  # [1, 1, S/sp, H_idx*D_idx] — ALL heads (wq_b replicated); queries stay SP-sharded (rotation-safe)
@@ -757,23 +781,27 @@ class TtIndexer:
         )  # [1, H_idx, S/sp, D_idx] — all heads resident
         # block-cyclic indexed rope (same op/tables as the key rope + MLA q_pe)
         q_dev = self._bc_rope_pe(q, rope_tensors, start_pos)
+        q_hadamard_cfg = self._resolve_mm_cfg("indexer.q_hadamard", seq_len)
         q_h = ttnn.matmul(
             q_dev,
             self._index_hadamard,
             dtype=ttnn.bfloat8_b,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             compute_kernel_config=self.default_compute_kernel_config,
+            **({"program_config": q_hadamard_cfg["program_config"]} if q_hadamard_cfg is not None else {}),
         )
         ttnn.deallocate(q_dev)
         q_dev = q_h
 
         # weights_proj: device stem -> FULL all-reduce over tp (all H_idx heads, matching the replicated
         # wq_b heads) -> scale -> [1, 1, S/sp, H_idx].
+        wproj_cfg = self._resolve_mm_cfg("indexer.weights_proj", seq_len)
         wts = ttnn.linear(
             hidden_states,
             self._idx_wproj,
             compute_kernel_config=self.default_compute_kernel_config,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=wproj_cfg["out_mem_config"] if wproj_cfg is not None else ttnn.DRAM_MEMORY_CONFIG,
+            **({"program_config": wproj_cfg["program_config"]} if wproj_cfg is not None else {}),
         )
         # H_idx=32 doesn't divide evenly into tile-sized TP=4 shards (8 < tile width), so _tp_rs_ag's
         # dim-3 reduce-scatter would hit ttnn's composite fallback (~30 extra tilize/pad/slice ops, see

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -26,6 +26,11 @@ import ttnn
 # Available core grid is 12x10, but due to di/dt and throttling problems, use 11x10 temporarily
 COMPUTE_GRID = (11, 10)
 
+# GLM-5.1/5.2 share the 64-head, q_lora_rank=2048 geometry. These tags keep
+# their 640-token configs separate from Kimi and DeepSeek variants sharing the same slot.
+_GLM_TAGS = {"num_heads": 64, "q_lora_rank": 2048, "chunked_only": True}
+_GLM_INDEXER_TAGS = {"num_heads": 64, "q_lora_rank": 2048}
+
 MLA_MATMUL_CONFIG = {
     # hidden_states @ q_a_proj_weight
     "q_a_proj": {
@@ -62,6 +67,23 @@ MLA_MATMUL_CONFIG = {
                     out_subblock_w=5,
                     per_core_M=2,
                     per_core_N=5,
+                    transpose_mcast=False,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+                "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_dtype": ttnn.bfloat16,
+            },
+            {
+                **_GLM_TAGS,
+                "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=COMPUTE_GRID,
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=6,
+                    per_core_M=2,
+                    per_core_N=6,
                     transpose_mcast=False,
                     fuse_batch=False,
                     fused_activation=None,
@@ -148,6 +170,23 @@ MLA_MATMUL_CONFIG = {
                 "out_mem_config": ttnn.L1_MEMORY_CONFIG,
                 "out_dtype": ttnn.bfloat16,
             },
+            {
+                **_GLM_TAGS,
+                "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=COMPUTE_GRID,
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=6,
+                    per_core_M=2,
+                    per_core_N=12,
+                    transpose_mcast=False,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "act_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_dtype": ttnn.bfloat16,
+            },
         ],
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -217,6 +256,20 @@ MLA_MATMUL_CONFIG = {
                     per_core_N=16,
                 ),
                 "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+                "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_dtype": ttnn.bfloat16,
+            },
+            {
+                **_GLM_TAGS,
+                "program_config": ttnn.MatmulMultiCoreReuseProgramConfig(
+                    compute_with_storage_grid_size=COMPUTE_GRID,
+                    in0_block_w=6,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    per_core_M=5,
+                    per_core_N=16,
+                ),
+                "act_mem_config": ttnn.L1_MEMORY_CONFIG,
                 "out_mem_config": ttnn.L1_MEMORY_CONFIG,
                 "out_dtype": ttnn.bfloat16,
             },
@@ -303,6 +356,23 @@ MLA_MATMUL_CONFIG = {
                 "out_mem_config": ttnn.L1_MEMORY_CONFIG,
                 "out_dtype": ttnn.bfloat16,
             },
+            {
+                **_GLM_TAGS,
+                "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=COMPUTE_GRID,
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=2,
+                    per_core_M=2,
+                    per_core_N=2,
+                    transpose_mcast=False,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "act_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_dtype": ttnn.bfloat16,
+            },
         ],
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -370,6 +440,20 @@ MLA_MATMUL_CONFIG = {
                     per_core_N=4,
                 ),
                 "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+                "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_dtype": ttnn.bfloat8_b,
+            },
+            {
+                **_GLM_TAGS,
+                "program_config": ttnn.MatmulMultiCoreReuseProgramConfig(
+                    compute_with_storage_grid_size=COMPUTE_GRID,
+                    in0_block_w=2,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    per_core_M=5,
+                    per_core_N=8,
+                ),
+                "act_mem_config": ttnn.L1_MEMORY_CONFIG,
                 "out_mem_config": ttnn.L1_MEMORY_CONFIG,
                 "out_dtype": ttnn.bfloat8_b,
             },
@@ -450,6 +534,23 @@ MLA_MATMUL_CONFIG = {
                 "out_mem_config": ttnn.L1_MEMORY_CONFIG,
                 "out_dtype": ttnn.bfloat16,
             },
+            {
+                **_GLM_TAGS,
+                "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=COMPUTE_GRID,
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=6,
+                    per_core_M=2,
+                    per_core_N=18,
+                    transpose_mcast=False,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+                "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+                "out_dtype": ttnn.bfloat16,
+            },
         ],
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -482,6 +583,96 @@ MLA_MATMUL_CONFIG = {
             "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
             "out_mem_config": ttnn.DRAM_MEMORY_CONFIG,
             "out_dtype": ttnn.bfloat16,
+        },
+    },
+    # GLM DSA indexer projections and normalized H128 transforms at local sequence length 640.
+    "indexer.wq_b": {
+        640: {
+            **_GLM_INDEXER_TAGS,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=8,
+                out_subblock_h=1,
+                out_subblock_w=6,
+                per_core_M=2,
+                per_core_N=12,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+            "act_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
+    },
+    "indexer.wk": {
+        640: {
+            **_GLM_INDEXER_TAGS,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=8,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=1,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+            "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+            "out_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
+    },
+    "indexer.weights_proj": {
+        640: {
+            **_GLM_INDEXER_TAGS,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=8,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=1,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+            "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+            # Main's TP all-reduce path feeds this directly to high_bw_all_gather, which requires DRAM.
+            "out_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
+    },
+    "indexer.k_hadamard": {
+        640: {
+            **_GLM_INDEXER_TAGS,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=4,
+                out_subblock_h=2,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=1,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+        },
+    },
+    "indexer.q_hadamard": {
+        640: {
+            **_GLM_INDEXER_TAGS,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=2,
+                out_subblock_h=2,
+                out_subblock_w=4,
+                per_core_M=8,
+                per_core_N=4,
+                fuse_batch=True,
+                mcast_in0=False,
+            ),
         },
     },
     # Kimi-K3 output gate: all-gathered hidden @ g_proj_weight, sigmoid fused. K = 7168 (K_t 224),

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -153,6 +153,7 @@ class TtDistributedRmsNorm(LightweightModule):
         stats_memcfg: ttnn.MemoryConfig = None,
         weight_cache_path: Optional[Path] = None,
         cache_name_prefix: Optional[str] = None,
+        output_memcfg: ttnn.MemoryConfig = None,
     ):
         """
         Initialize TtDistributedRmsNorm module.
@@ -168,6 +169,7 @@ class TtDistributedRmsNorm(LightweightModule):
             input_memcfg: Optional memory config for input (e.g., L1 sharded)
             sharded_progcfg: Optional sharded program config for layernorm
             stats_memcfg: Optional memory config for gathered stats (e.g., L1 sharded)
+            output_memcfg: Optional memory config for the normalized output
         """
         super().__init__()
         self.mesh_device = mesh_device
@@ -180,6 +182,7 @@ class TtDistributedRmsNorm(LightweightModule):
 
         # Memory configs (None = use DRAM interleaved)
         self.input_memcfg = input_memcfg
+        self.output_memcfg = output_memcfg
         self.sharded_progcfg = sharded_progcfg
         self.stats_memcfg = stats_memcfg
         self.weight_cache_path = weight_cache_path
@@ -273,6 +276,7 @@ class TtDistributedRmsNorm(LightweightModule):
                 epsilon=self.epsilon,
                 weight=self.weight,
                 program_config=self.sharded_progcfg,
+                memory_config=self.output_memcfg,
             )
 
         # Step 1: Pre-all-gather - each device computes local sum(x^2)
@@ -331,6 +335,7 @@ class TtDistributedRmsNorm(LightweightModule):
             epsilon=self.epsilon,
             weight=self.weight,
             dtype=ttnn.bfloat16,
+            memory_config=self.output_memcfg,
             program_config=self.sharded_progcfg,
         )
         if not use_high_bw_all_gather:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -12,6 +12,7 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import compute_constants, extract_mesh_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
@@ -302,6 +303,14 @@ class TtPrefillBlock(LightweightModule):
         )
 
         # --- Attention norm ---
+        use_glm52_l1_attn_norm = (
+            is_blackhole()
+            and is_chunked
+            and seq_len // mesh_device.shape[sp_axis] == 640
+            and config.num_attention_heads == 64
+            and config.q_lora_rank == 2048
+            and getattr(config, "indexer_types", None) is not None
+        )
         self.attn_norm = TtDistributedRmsNorm(
             mesh_device=mesh_device,
             emb_dim=emb_dim,
@@ -312,6 +321,7 @@ class TtPrefillBlock(LightweightModule):
             topology=tp_topology,
             weight_cache_path=weight_cache_path,
             cache_name_prefix=f"layer_{layer_idx}.attn_norm",
+            output_memcfg=ttnn.L1_MEMORY_CONFIG if use_glm52_l1_attn_norm else None,
         )
 
         # --- MLA ---


### PR DESCRIPTION
### PR Category

Performance

### Summary

Tune all 11 `ttnn.linear` and `ttnn.matmul` operations used by the Blackhole GLM-5.2 chunked sparse-MLA path at local sequence length 640, including the recently added DSA indexer projections and H128 Hadamard transforms.

The program configurations are gated by architecture, model geometry, and chunk shape so other models and shapes keep their existing paths. This also allows distributed RMSNorm to place the normalized attention hidden state directly in interleaved L1 for the same workload, avoiding a copy before its four direct matmul consumers.

Realtime-profiler results on an 8-chip Blackhole LoudBox with the scaled-FP8 warm configuration:

| Metric | Baseline | Optimized | Change |
|---|---:|---:|---:|
| 11 sparse-MLA matmuls | 1.014 ms | 0.442 ms | -56.4% |
| Sparse-MLA layer | 4.210 ms | 3.526 ms | -16.2% |

The baseline was `origin/main` at `f6deef232f7`. The sparse-MLA perf test constructs its input in DRAM, so these figures isolate the matmul configuration changes.

Matmul fidelity and tensor dtypes are unchanged; all 11 operations continue to use HiFi2.

### Additional model CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/glm52_mm_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/glm52_mm_optimization)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/glm52_mm_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/glm52_mm_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/glm52_mm_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/glm52_mm_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/glm52_mm_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/glm52_mm_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/glm52_mm_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/glm52_mm_optimization)