### PR TITLE
[skip-ci] Cherry-pick #54154 to stable: add ops-test-categories input

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -91,12 +91,15 @@ ttnn:
     wh_galaxy: 120
     bh_galaxy: 40
     bh_p100: 805
-    bh_p150b_civ2: 1045
-    wh_n150_civ2: 1215
+    bh_p150b_civ2: 840
+    wh_n150_civ2: 1010
     wh_n300_civ2: 1180
     bh_p150b_civ2_viommu: 115
     bh_p300: 60
     bh_quietbox_2: 60
+  package_and_release:
+    wh_n150_civ2: 205
+    bh_p150b_civ2: 205
   e2e:
     wh_llmbox: 90
     wh_galaxy: 0

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -21,6 +21,18 @@ on:
         type: string
         default: ''
         description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
+      tests-yaml-path:
+        required: false
+        type: string
+        default: ./tests/pipeline_reorg/ops_unit_tests.yaml
+        description: "Test list to load. Pipelines that own a disjoint slice of the ops suites pass their own yaml."
+      budget-subheading:
+        required: false
+        type: string
+        default: "unit"
+        description: "Key under each team in .github/time_budget.yaml to verify against.
+          Pipelines that run this workflow at different frequencies pass different keys so
+          their budgets are tracked separately (e.g. package_and_release vs the nightly unit)."
       enable-llk-asserts:
         required: false
         type: boolean
@@ -41,7 +53,7 @@ jobs:
     outputs:
       matrix: ${{ steps.filter-categories.outputs.matrix }}
     env:
-      TESTS_YAML_PATH: ./tests/pipeline_reorg/ops_unit_tests.yaml
+      TESTS_YAML_PATH: ${{ inputs.tests-yaml-path }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,7 +71,7 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "unit"
+            "${{ inputs.budget-subheading }}"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
@@ -72,6 +84,8 @@ jobs:
         run: |
           matrix='${{ steps.build-matrix.outputs.matrix }}'
           categories='${{ inputs.additional_test_categories }}'
+          # The comparison is exact between commas, strip whitespace first.
+          categories="${categories//[[:space:]]/}"
           filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
           {
             echo "matrix<<EOF"

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -27,6 +27,11 @@ on:
         required: false
         default: ""
         type: string
+      ops-test-categories:
+        description: "Categories from ops_pnr_tests.yaml to run (comma-separated)."
+        required: false
+        default: ""
+        type: string
 
   schedule:
     # Create dev every day at EOD of PST Mon-Fri + night of Sunday to kick off
@@ -53,6 +58,12 @@ env:
   #     SHA3
   DEFAULT_IGNORE_COMMITS: >-
     72e9419a1be562889e1f008cf3e2db495f9e0aa9
+  # Ops unit-test categories every release runs; the ops-test-categories dispatch UI input
+  # overrides this when set, and falls back here when left empty. Keep this value itself
+  # non-empty: the filter matches category names exactly, so an empty list would match
+  # nothing and skip the job. A new category also needs a timeout in ops_pnr_tests.yaml.
+  DEFAULT_OPS_TEST_CATEGORIES: >-
+    matmul,fused,reduction,moreh
 
 # Some explanation:
 # is-release-candidate is always true, unless the workflow is manually dispatched on a tag
@@ -67,6 +78,7 @@ jobs:
       is-release-candidate: ${{ steps.get-is-release-candidate-and-tag-type.outputs.is-release-candidate }}
       tag-type: ${{ steps.get-is-release-candidate-and-tag-type.outputs.tag-type }}
       default-ignore-commits: ${{ steps.set-defaults.outputs.ignore-commits }}
+      default-ops-test-categories: ${{ steps.set-defaults.outputs.ops-test-categories }}
     steps:
       - name: Set default values
         id: set-defaults
@@ -74,6 +86,7 @@ jobs:
         # (i.e., in `uses:` with `with:`), so we must expose env values via job outputs.
         run: |
           echo "ignore-commits=${{ env.DEFAULT_IGNORE_COMMITS }}" >> "$GITHUB_OUTPUT"
+          echo "ops-test-categories=${{ env.DEFAULT_OPS_TEST_CATEGORIES }}" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
@@ -161,6 +174,7 @@ jobs:
       tag-version: ${{ needs.create-tag.outputs.version }}
       is-release-candidate: ${{ needs.release-precheck.outputs.is-release-candidate }}
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
+      ops-test-categories: ${{ inputs.ops-test-categories || needs.release-precheck.outputs.default-ops-test-categories }}
 
   publish-to-pypi:
     needs: [build-test-publish, create-tag]
@@ -654,7 +668,8 @@ jobs:
             {
               "release-type": "rc",
               "dry-run": "${{ inputs.dry-run || 'false' }}",
-              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}"
+              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}",
+              "ops-test-categories": "${{ inputs.ops-test-categories || '' }}"
             }
       - name: Log no action needed
         if: ${{ steps.check-new-commits.outputs.has-new-commits == 'false' }}
@@ -682,5 +697,6 @@ jobs:
             {
               "release-type": "prod",
               "dry-run": "${{ inputs.dry-run || 'false' }}",
-              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}"
+              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}",
+              "ops-test-categories": "${{ inputs.ops-test-categories || '' }}"
             }

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -28,7 +28,7 @@ on:
         default: ""
         type: string
       ops-test-categories:
-        description: "Categories from ops_pnr_tests.yaml to run (comma-separated)."
+        description: "Categories from ops_pnr_tests.yaml to run (comma-separated, e.g. matmul,fused,reduction,moreh)."
         required: false
         default: ""
         type: string

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         default: ""
         type: string
+      ops-test-categories:
+        description: "Categories to run from ops_pnr_tests.yaml (comma-separated)."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -137,6 +142,23 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: wh_n150,bh_p150
+
+  ttnn-ops-unit-tests:
+    needs: [build-artifact]
+    if: ${{ inputs.tag-version != '' && inputs.platform == inputs.main-platform }}
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit
+    uses: ./.github/workflows/ops-unit-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enabled-skus: wh_n150_civ2,bh_p150b_civ2
+      additional_test_categories: ${{ inputs.ops-test-categories }}
+      tests-yaml-path: ./tests/pipeline_reorg/ops_pnr_tests.yaml
+      budget-subheading: package_and_release
 
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
   # expected-jobs is the union of single-host and exabox multihost legs so a

--- a/tests/pipeline_reorg/ops_pnr_tests.yaml
+++ b/tests/pipeline_reorg/ops_pnr_tests.yaml
@@ -1,0 +1,50 @@
+# This file defines the test matrix for the ops unit tests that run in
+# package-and-release.
+#
+# Same schema and same impl workflow (ops-unit-tests-impl.yaml) as
+# ops_unit_tests.yaml; in consequence each (test, sku) leg has exactly
+# one owning pipeline and one time budget.
+
+- name: ttnn release matmul tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 50
+    bh_p150b_civ2:
+      timeout: 50
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: matmul
+
+- name: ttnn release fused tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 65
+    bh_p150b_civ2:
+      timeout: 65
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: fused
+
+- name: ttnn release reduction tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/reduction -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 45
+    bh_p150b_civ2:
+      timeout: 45
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: reduction
+
+- name: ttnn release moreh tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 45
+    bh_p150b_civ2:
+      timeout: 45
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: moreh

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -39,13 +39,9 @@
   ai_summary:
     authoritative_job_status: true
   skus:
-    wh_n150_civ2:
-      timeout: 50
     wh_n300_civ2:
       timeout: 50
     bh_p100:
-      timeout: 50
-    bh_p150b_civ2:
       timeout: 50
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
@@ -54,13 +50,9 @@
 - name: ttnn nightly fused tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
-    wh_n150_civ2:
-      timeout: 65
     wh_n300_civ2:
       timeout: 65
     bh_p100:
-      timeout: 65
-    bh_p150b_civ2:
       timeout: 65
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
@@ -71,13 +63,9 @@
   ai_summary:
     authoritative_job_status: true
   skus:
-    wh_n150_civ2:
-      timeout: 45
     wh_n300_civ2:
       timeout: 45
     bh_p100:
-      timeout: 45
-    bh_p150b_civ2:
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
@@ -234,13 +222,9 @@
 - name: ttnn nightly moreh tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
-    wh_n150_civ2:
-      timeout: 45
     wh_n300_civ2:
       timeout: 45
     bh_p100:
-      timeout: 45
-    bh_p150b_civ2:
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn


### PR DESCRIPTION
### PR Category
CI/Infrastructure

### Summary

Cherry-picks #54154 (and its follow-up #55341) from `main` onto `stable` so that the
`ops-test-categories` workflow input exists on `stable`.

Without this, the self-dispatch steps in `package-and-release.yaml` fail:

```
Error: Unexpected inputs provided: ["ops-test-categories"]
```

`trigger-rc-after-*` dispatches `package-and-release.yaml` with `ref: stable`, and
`trigger-prod-after-rc-success` dispatches it with `ref: <RC tag>` (a tag cut from
`stable`). GitHub validates `workflow_dispatch` inputs against the workflow file **at
the target ref**, and `stable` predates #54154, so it does not declare
`ops-test-categories`. The `|| ''` fallback does not help — the key is still present in
the dispatch payload, and unknown keys are rejected regardless of value.

### What's changed

Straight cherry-pick of both commits, no manual edits:

- `6c180e3ec87` — #54154, applies to `stable` with no conflicts
- `d9925d38c93` — #55341, description-only follow-up

All six files come along deliberately. Taking only `package-and-release.yaml` would move
the failure one level down, since `stable`'s `release-build-test-publish.yaml` would then
reject the input it is handed.

### Notes for reviewers

- **`time_budget.yaml` vs the stable-only hotfix.** #55092 is on `stable` but not on
  `main`. It does not touch the two keys this cherry-pick edits — they were still at
  their pre-#54154 values (`bh_p150b_civ2: 1045`, `wh_n150_civ2: 1215`), so they land on
  exactly main's numbers with 205 min per SKU moved to the new `ttnn.package_and_release`
  key. #55092's other bumps are preserved.
- **The `ops_unit_tests.yaml` SKU removal is inert here.** It drops
  `wh_n150_civ2`/`bh_p150b_civ2` from four suites, but `tt-metal-l2-nightly.yaml` runs on
  cron (default branch only) plus manual dispatch, so nothing on `stable` reads that file
  on a schedule.
- Verified that after the cherry-pick, all of `ops-unit-tests-impl.yaml`,
  `release-build-test-publish.yaml`, `ops_pnr_tests.yaml` and `ops_unit_tests.yaml` are
  byte-identical to `main`. Remaining `package-and-release.yaml` divergence from `main` is
  pre-existing and untouched (`stable` has `pypa/gh-action-pypi-publish@v1.13.0` where
  `main` pins the SHA).
- Not verified on device: whether the new `ttnn-ops-unit-tests` job passes within the
  205 min budget on an actual release run. That was validated on `main` in #54154.
