### PR TITLE
SpxTP migration table for GLM5.2

### DIFF
--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -19,6 +19,7 @@ WARMUP_CHUNKS=10
 PCC_THRESHOLD=0.85
 RUNNER_ENV=""
 PRODUCER_ENV=""
+TP_SHARD_KV_DEFAULT=0
 
 case "${MODEL}" in
   kimi27)
@@ -32,6 +33,7 @@ case "${MODEL}" in
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/glm52_prefill_runner_kv}"
     MGD="${MGD_DIR}/glm52_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/glm52.json"
+    TP_SHARD_KV_DEFAULT=1
     RUNNER_ENV="export PREFILL_LAYER_ACK_D2H=1;"
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}'; \
         export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k;"
@@ -107,6 +109,7 @@ python3 "${TTRUN_PY}" \
     export PREFILL_MANIFEST='${MANIFEST}'; \
     export PREFILL_FABRIC_MODE=2d; \
     export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
+    export PREFILL_TP_SHARD_KV=${PREFILL_TP_SHARD_KV:-${TP_SHARD_KV_DEFAULT}}; \
     export PREFILL_SYNC_PER_CHUNK=1; \
     export PREFILL_TIMING_DIR='${TIMING_DIR}'; \
     export PREFILL_ENABLE_MIGRATION=1; \

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -1231,3 +1231,81 @@ def test_glm52_index_cache_pipeline_stage_addresses():
     mismatched = {k: (merged[k], golden[k]) for k in golden if merged[k] != golden[k]}
     assert not mismatched, f"{len(mismatched)} entries mismapped, e.g. {list(mismatched.items())[:2]}"
     logger.info(f"[glm52] merged 2-stage index-cache table matches the per-rank walk over {len(merged)} entries")
+
+
+def test_glm52_tp_sharded_pipeline_stage_addresses():
+    rows, cols, sp_axis, tp_axis = 8, 4, 0, 1
+    num_users, seq_len, num_banks = 2, 2 * PREFILL_CHUNK_TOKENS, BH_NUM_DRAM_BANKS
+    CHUNK_SIZE_BYTES = 19584
+    stage_ranges = [(0, 18), (18, 20)]
+    num_layers = sum(count for _, count in stage_ranges)
+    base_addrs = [0x1000_0000, 0x2000_0000]
+    tokens_per_device = PREFILL_CHUNK_TOKENS // (rows * cols)
+
+    def stage(rank, first_layer, count):
+        return {
+            "rank": rank,
+            "first_layer": first_layer,
+            "count": count,
+            "base_addr": base_addrs[rank],
+            "num_banks": num_banks,
+            "host_tag": 0xABC0000 + rank,
+            "fnids": [[ttnn.FabricNodeId(ttnn.MeshId(rank), r * cols + c) for c in range(cols)] for r in range(rows)],
+        }
+
+    def populate(stage_layout, tp):
+        config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+        config.num_layers = num_layers
+        table = _RecordingKvChunkAddressTable()
+        populate_kv_chunk_address_table_kimi(
+            lookup_table=table,
+            config=config,
+            mesh_device=None,
+            mesh_shape=(rows, cols),
+            seq_len=seq_len,
+            sp_axis=sp_axis,
+            tt_kvpe_cache=None,
+            chunk_size_bytes=CHUNK_SIZE_BYTES,
+            num_users=num_users,
+            stage_layout=stage_layout,
+            tp_axis=tp,
+        )
+        return table.entries
+
+    layout = [stage(rank, first, count) for rank, (first, count) in enumerate(stage_ranges)]
+
+    golden = {}
+    for rank, (first_layer, count) in enumerate(stage_ranges):
+        solo = populate([stage(rank, 0, count)], tp_axis)
+        golden.update({(cid, layer + first_layer, pos, slot): v for (cid, layer, pos, slot), v in solo.items()})
+
+    merged = populate(layout, tp_axis)
+    assert merged.keys() == golden.keys(), (
+        f"merged table covers {len(merged)} entries vs {len(golden)} golden — the stages do not tile "
+        f"the cache (layers {sorted({k[1] for k in merged})} vs {sorted({k[1] for k in golden})})"
+    )
+    mismatched = {k: (merged[k], golden[k]) for k in golden if merged[k] != golden[k]}
+    assert not mismatched, f"{len(mismatched)} entries mismapped, e.g. {list(mismatched.items())[:2]}"
+
+    replicated = populate(layout, None)
+    assert merged.keys() == replicated.keys(), (
+        f"TP-sharded table covers {len(merged)} entries vs {len(replicated)} TP-replicated — dedup must "
+        f"not change the position set"
+    )
+
+    for (_, layer, position, _), (noc_addr, size_bytes, group) in merged.items():
+        rank = 0 if layer < stage_ranges[0][1] else 1
+        offset_in_chunk = position % PREFILL_CHUNK_TOKENS
+        row = offset_in_chunk // (PREFILL_CHUNK_TOKENS // rows)
+        col = (offset_in_chunk % (PREFILL_CHUNK_TOKENS // rows)) // tokens_per_device
+        assert group == ((rank, row * cols + col),), (
+            f"layer {layer} position {position} is owned by {group}, expected the single device "
+            f"(mesh {rank}, chip {row * cols + col}) that holds that 32-token shard"
+        )
+        assert size_bytes == CHUNK_SIZE_BYTES
+        assert (noc_addr & 0xFFFFFFFF) >= base_addrs[rank], (
+            f"layer {layer} addresses {noc_addr & 0xFFFFFFFF:#x}, below stage {rank}'s base "
+            f"{base_addrs[rank]:#x} — the stage's base address did not reach the walk"
+        )
+
+    logger.info(f"[glm52] merged 2-stage TP-sharded table matches the per-rank walk over {len(merged)} entries")

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -129,8 +129,8 @@ def build_and_serialize_kv_chunk_table(
 
     ``tp_shard_kv`` (KV dedup): the table addresses each (row, col) device individually instead of one
     group per SP row. MUST match the layout the caches were allocated with, or every address is wrong.
-    Merged (KVPE + index) table only, and single-stage only (no PP). ``tp_axis`` names the TP mesh axis
-    in either case — it is the dflash head-count geometry and is not itself the dedup switch."""
+    Merged (KVPE + index) table only. ``tp_axis`` names the TP mesh axis in either case — it is the
+    dflash head-count geometry and is not itself the dedup switch."""
     assert chunk_size_global == PREFILL_CHUNK_TOKENS, (
         f"create_kv_chunk_address_table_kimi assumes a block-cyclic period of "
         f"PREFILL_CHUNK_TOKENS={PREFILL_CHUNK_TOKENS}, but chunk_size_global={chunk_size_global}. "

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -525,10 +525,10 @@ def populate_kv_chunk_address_table_kimi(
         )
         return layer_rows[dense_layer]
 
-    if tp_axis is None and stage_layout is not None:
-        # ---- SP-only / TP-replicated, stage_layout-driven path (PP-capable, #48826). ----
+    if stage_layout is not None:
+        # ---- stage_layout-driven path (PP-capable, #48826). ----
         # Per-stage device groups + host tags are built inside the stage loop below (one group per
-        # (stage, SP row)); no rank-local single-stage device-group pass here — the multi-stage merge
+        # (stage, SP row, TP col)); no rank-local single-stage device-group pass here — the multi-stage merge
         # supersedes it, and a rank-local set_fabric_node_host(localhost) would fight the per-stage host.
         rows = mesh_shape[0]
 
@@ -542,9 +542,23 @@ def populate_kv_chunk_address_table_kimi(
             f"not a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
         )
 
+        if tp_axis is not None:
+            assert sp_axis == 0 and tp_axis == 1, (
+                f"TP-sharded KV chunk table requires the production (sp_axis=0, tp_axis=1) layout, "
+                f"got sp_axis={sp_axis}, tp_axis={tp_axis}"
+            )
+        tp_factor = mesh_shape[tp_axis] if tp_axis is not None else 1
+        tokens_per_device = tokens_per_chunk_local // tp_factor
+        assert (
+            tokens_per_chunk_local % tp_factor == 0
+        ), f"tokens_per_chunk_local ({tokens_per_chunk_local}) must be divisible by tp ({tp_factor})"
+        assert (
+            tokens_per_device % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0
+        ), f"tokens_per_device ({tokens_per_device}) must be a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
+
         # tt-blaze-style merge: for every STAGE place its layers' chunks on ITS mesh at ITS base addr.
-        # Within a stage we replay the original single-stage build exactly (one device group per SP row, an
-        # independent bank round-robin per row sequencing slot -> local layer -> chunk), but write to the
+        # Within a stage we replay the original single-stage build exactly (an independent bank
+        # round-robin per addressed device sequencing slot -> local layer -> chunk), but write to the
         # GLOBAL layer index (first_layer + local_layer) so every stage lands in one table.
         for stage in stage_layout:
             dram_bank_base_addr = stage["base_addr"]
@@ -554,31 +568,35 @@ def populate_kv_chunk_address_table_kimi(
             count = stage["count"]
             stage_fnids = stage["fnids"]
             for row in range(rows):
-                # Data is replicated across each TP column, so one device group per (stage, SP row).
-                fnids_row = stage_fnids[row]
-                group_idx = lookup_table.add_device_group(fnids_row)
-                for fid in fnids_row:
-                    lookup_table.set_fabric_node_host(fid, host_name=host_name)
-                curr_bank_id = 0
-                curr_bank_offset = 0
-                for slot in range(num_users):
-                    for local_layer in range(count):
-                        global_layer = first + local_layer
-                        for seq_chunk in range(num_chunks_per_seq_len):
-                            chunk_token_start = seq_chunk * PREFILL_CHUNK_TOKENS + row * tokens_per_chunk_local
-                            chunk_token_end = chunk_token_start + tokens_per_chunk_local
-                            for position in range(
-                                chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
-                            ):
-                                location = ttnn.experimental.disaggregation.KvCacheLocation()
-                                location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
-                                location.size_bytes = chunk_size_bytes
-                                location.device_group_index = group_idx
-                                lookup_table.set(_table_row(global_layer), position, slot, location, config_id)
+                row_groups = [[fid] for fid in stage_fnids[row]] if tp_axis is not None else [stage_fnids[row]]
+                for col, fnids_dev in enumerate(row_groups):
+                    group_idx = lookup_table.add_device_group(fnids_dev)
+                    for fid in fnids_dev:
+                        lookup_table.set_fabric_node_host(fid, host_name=host_name)
+                    curr_bank_id = 0
+                    curr_bank_offset = 0
+                    for slot in range(num_users):
+                        for local_layer in range(count):
+                            global_layer = first + local_layer
+                            for seq_chunk in range(num_chunks_per_seq_len):
+                                chunk_token_start = (
+                                    seq_chunk * PREFILL_CHUNK_TOKENS
+                                    + row * tokens_per_chunk_local
+                                    + col * tokens_per_device
+                                )
+                                chunk_token_end = chunk_token_start + tokens_per_device
+                                for position in range(
+                                    chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+                                ):
+                                    location = ttnn.experimental.disaggregation.KvCacheLocation()
+                                    location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
+                                    location.size_bytes = chunk_size_bytes
+                                    location.device_group_index = group_idx
+                                    lookup_table.set(_table_row(global_layer), position, slot, location, config_id)
 
-                                curr_bank_id = (curr_bank_id + 1) % num_dram_banks
-                                if curr_bank_id == 0:
-                                    curr_bank_offset += chunk_size_bytes
+                                    curr_bank_id = (curr_bank_id + 1) % num_dram_banks
+                                    if curr_bank_id == 0:
+                                        curr_bank_offset += chunk_size_bytes
         return lookup_table
 
     # ---- Legacy single-stage path (direct call, stage_layout is None). ----
@@ -622,12 +640,6 @@ def populate_kv_chunk_address_table_kimi(
         assert sp_axis == 0 and tp_axis == 1, (
             f"TP-sharded KV chunk table requires the production (sp_axis=0, tp_axis=1) layout, "
             f"got sp_axis={sp_axis}, tp_axis={tp_axis}"
-        )
-        # This path ignores stage_layout and derives everything from THIS rank's cache/mesh, so a
-        # multi-stage (PP) layout would silently produce a table covering only one rank's own layers.
-        assert stage_layout is None or len(stage_layout) == 1, (
-            f"TP-sharded KV chunk table is single-stage only: got a {len(stage_layout)}-stage layout. "
-            f"The TP-sharded branch does not merge per-stage layer ranges / base addresses."
         )
     tp_factor = mesh_shape[tp_axis] if tp_axis is not None else 1
     tokens_per_device = tokens_per_chunk_local // tp_factor  # 160 for 5k chunks on tp=4


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/actions/runs/33879954402

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/kv-chunk-table-tp-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/kv-chunk-table-tp-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/kv-chunk-table-tp-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/kv-chunk-table-tp-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/kv-chunk-table-tp-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/kv-chunk-table-tp-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/kv-chunk-table-tp-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/kv-chunk-table-tp-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/kv-chunk-table-tp-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/kv-chunk-table-tp-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/kv-chunk-table-tp-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/kv-chunk-table-tp-pp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/kv-chunk-table-tp-pp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/kv-chunk-table-tp-pp)