### PR TITLE
[Test Only] Determinism tests for the compressed matmul kernels (DRAM, L1 and expert)

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/compressed_determinism_utils.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/compressed_determinism_utils.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the compressed-matmul determinism tests.
+
+The compressed matmul kernels take a per-tile format assignment, and the tests that hunt
+for non-determinism need to state that assignment exactly rather than let
+``CompressedTensorAssigner`` derive it from the data. These helpers build such an
+assignment, quantize a host golden to match it, and localize a bitwise failure.
+
+Used by the DRAM streaming tests (``test_dram_matmul_custom_compressed``), the L1
+single-kernel tests (``test_matmul_custom_compressed``) and the expert matmul tests
+(``per_core_allocation/test_matmul_expert``).
+"""
+
+import os
+
+import numpy as np
+import torch
+
+from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import COMPRESSED_FORMATS, ttnn_quantize_fn
+
+FMT_TO_IDX = {fmt: idx for idx, fmt in enumerate(COMPRESSED_FORMATS)}
+IDX_TO_FMT = {idx: fmt for fmt, idx in FMT_TO_IDX.items()}
+
+# Re-runs per determinism case. Raise for a soak:
+#   COMPRESSED_MM_DETERMINISM_ITERS=500 pytest ...
+DET_ITERS = int(os.environ.get("COMPRESSED_MM_DETERMINISM_ITERS", "50"))
+
+# --- Kimi K2.7-Code production format mix ----------------------------------------------
+#
+# Measured over all 384 experts x 3 projections of layer 1 of the shipped
+# target_3_5_32x32_native map (3.5 b/e): bfp4 54.95 %, bfp2 41.08 %, bfp0 3.96 %, bfp8 0 %.
+# The uniform patterns below give bfp0 roughly eight times its production share, so a mix
+# drawn at these ratios is the one that resembles what the model actually streams.
+K27_FORMATS = ["bfp4", "bfp2", "bfp0"]
+K27_FORMAT_RATIOS = [0.5495, 0.4108, 0.0396]
+# Same mix as relative weights, for the helpers that take a {format: weight} dict.
+K27_FORMAT_WEIGHTS = {"bfp4": 0.5495, "bfp2": 0.4108, "bfp0": 0.0396}
+
+K27_HIDDEN = 7168
+K27_MOE_INTERMEDIATE = 2048
+K27_MOE_TP = 8
+K27_PER_DEVICE_MOE_N = K27_MOE_INTERMEDIATE // K27_MOE_TP  # 256
+
+PATTERNS = ["alternate", "pairs", "blocks", "random", "ratios"]
+
+
+def build_stream_format_pattern(num_tiles, formats, pattern, period=2, seed=0, ratios=None):
+    """Build a per-tile format code sequence, in the order the kernel consumes the tiles.
+
+    The compute kernel reads tiles in pairs, so where a format change lands relative to a
+    pair boundary is what ``pattern`` controls:
+
+    - ``"alternate"``: the format changes at every tile, so one half of the changes fall
+                       *inside* a pair.
+    - ``"pairs"``:     the format changes every 2 tiles, so each pair holds one format and
+                       changes only ever land on a pair boundary.
+    - ``"blocks"``:    the format changes every ``period`` tiles (pass the subblock size to
+                       keep each streamed subblock single-format).
+    - ``"random"``:    a seeded draw from ``formats`` at equal probability.
+    - ``"ratios"``:    a seeded draw at the probabilities in ``ratios`` (see
+                       ``K27_FORMAT_RATIOS``).
+
+    Args:
+        num_tiles: length of the sequence.
+        formats: format names to use, e.g. ``["bfp4", "bfp2"]``.
+        pattern: one of ``PATTERNS``.
+        period: run length for ``pattern="blocks"``.
+        seed: RNG seed for the two drawn patterns.
+        ratios: per-format probabilities for ``pattern="ratios"``, in the order of ``formats``.
+
+    Returns:
+        int8 array of length ``num_tiles`` holding COMPRESSED_FORMATS indices.
+    """
+    codes = np.array([FMT_TO_IDX[f] for f in formats], dtype=np.int8)
+    i = np.arange(num_tiles)
+    if pattern == "alternate":
+        return codes[i % len(codes)]
+    if pattern == "pairs":
+        return codes[(i // 2) % len(codes)]
+    if pattern == "blocks":
+        assert period >= 1, f"period must be >= 1, got {period}"
+        return codes[(i // period) % len(codes)]
+    if pattern == "random":
+        return codes[np.random.default_rng(seed).integers(0, len(codes), size=num_tiles)]
+    if pattern == "ratios":
+        assert ratios is not None, 'pattern="ratios" needs a ratios argument'
+        assert len(ratios) == len(formats), f"ratios ({len(ratios)}) must match formats ({len(formats)})"
+        p = np.asarray(ratios, dtype=np.float64)
+        return codes[np.random.default_rng(seed).choice(len(codes), size=num_tiles, p=p / p.sum())]
+    raise ValueError(f"Unknown pattern: {pattern!r}, expected one of {PATTERNS}")
+
+
+def quantize_per_tile(tensor_f32, assignment, tile_w=32):
+    """Host golden: quantize each tile with the format that ``assignment`` gives it.
+
+    BFP block exponents are tile-aligned, so quantizing the whole tensor once per format and
+    then selecting per tile matches quantizing tile by tile, and is far faster.
+    """
+    out = tensor_f32.clone()
+    codes = np.repeat(np.repeat(assignment, tile_w, axis=0), tile_w, axis=1)
+    codes = torch.from_numpy(codes.astype(np.int16))
+    for fmt, code in FMT_TO_IDX.items():
+        sel = codes == code
+        if not bool(sel.any()):
+            continue
+        out = torch.where(sel, ttnn_quantize_fn(tensor_f32, fmt), out)
+    return out
+
+
+def assert_tile_counts(counts, assignment, formats):
+    """Check that the packed tensor holds exactly the assignment's mix, tile for tile."""
+    for fmt in FMT_TO_IDX:
+        expected = int((assignment == FMT_TO_IDX[fmt]).sum())
+        assert counts.get(fmt, 0) == expected, f"format {fmt}: packed {counts.get(fmt, 0)} tiles, expected {expected}"
+    for fmt in formats:
+        assert counts.get(fmt, 0) > 0, f"format {fmt} was requested but no tile uses it: {counts}"
+
+
+def describe_mismatch(output, reference, assignment=None, per_core_n_tiles=None, tile_w=32):
+    """Localize a determinism failure to cores, tile columns and tile formats."""
+    diff = output != reference
+    parts = [
+        f"{int(diff.sum())} / {diff.numel()} elements differ",
+        f"max |diff| = {(output.float() - reference.float()).abs().max().item()}",
+    ]
+    bad_cols = torch.nonzero(diff.any(dim=0).flatten()).flatten().tolist()
+    bad_tile_cols = sorted({c // tile_w for c in bad_cols})
+    if per_core_n_tiles:
+        parts.append(f"core(s) {sorted({tc // per_core_n_tiles for tc in bad_tile_cols})}")
+    if assignment is not None:
+        fmts = sorted({IDX_TO_FMT[int(c)] for tc in bad_tile_cols for c in np.unique(assignment[:, tc])})
+        parts.append(f"formats in affected columns: {fmts}")
+    parts.append(f"first affected tile columns: {bad_tile_cols[:16]}")
+    return "; ".join(parts)
+
+
+def assert_bitwise_stable(run_once, iterations, *, context="", assignment=None, per_core_n_tiles=None, reference=None):
+    """Call ``run_once()`` ``iterations`` times and require a bitwise equal result every time.
+
+    ``run_once`` returns a torch tensor. ``reference`` seeds the comparison; when it is None
+    the first call's result becomes the reference. Every divergence is collected, because how
+    often it happens and whether it always hits the same tiles is the useful part.
+    """
+    divergences = []
+    for i in range(iterations):
+        output = run_once()
+        if reference is None:
+            reference = output.clone()
+            continue
+        if not torch.equal(output, reference):
+            divergences.append(f"  iteration {i}: {describe_mismatch(output, reference, assignment, per_core_n_tiles)}")
+    if divergences:
+        detail = "\n".join(divergences[:10])
+        raise AssertionError(
+            f"Output is not bitwise stable over {iterations} runs"
+            f"{f' ({context})' if context else ''}: {len(divergences)} differ.\n{detail}"
+        )
+    return reference

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_matmul_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_matmul_expert.py
@@ -21,6 +21,11 @@ from models.demos.deepseek_v3_b1.micro_ops.matmul_expert.op import (
     create_dram_expert_tensors_multi_device,
     encode_expert_indices,
 )
+from models.demos.deepseek_v3_b1.tests.unit_tests.compressed_determinism_utils import (
+    DET_ITERS,
+    K27_FORMAT_WEIGHTS,
+    K27_FORMATS,
+)
 from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
 
 
@@ -1108,6 +1113,31 @@ def _build_sram_fmt_data(sram_cts, mesh_device, sram_core_grid, sram_k_per_core,
 # ---------------------------------------------------------------------------
 
 
+def _assert_expert_stable(launch, result, sram_out_tensor, iterations):
+    """Re-run the expert matmul and require the DRAM and SRAM outputs to stay bitwise equal.
+
+    Nothing is rebuilt between runs, so a difference means the device gives two answers for
+    one program and one set of inputs. The SRAM output is included because the hot-expert
+    matmul is a separate kernel from the DRAM one and can be unstable on its own.
+    """
+    named = [("dram", result)] + ([("sram", sram_out_tensor)] if sram_out_tensor is not None else [])
+    reference = {name: ttnn.to_torch(t).clone() for name, t in named}
+    divergences = []
+    for i in range(1, iterations + 1):
+        launch()
+        for name, t in named:
+            got = ttnn.to_torch(t)
+            if not torch.equal(got, reference[name]):
+                diff = got != reference[name]
+                divergences.append(
+                    f"  run {i} [{name}]: {int(diff.sum())} / {diff.numel()} elements differ, "
+                    f"max |diff| = {(got.float() - reference[name].float()).abs().max().item()}"
+                )
+    assert not divergences, "Output is not bitwise stable over {} re-runs:\n{}".format(
+        iterations, "\n".join(divergences[:10])
+    )
+
+
 def _run_standard(
     mesh_device,
     M,
@@ -1132,6 +1162,7 @@ def _run_standard(
     k_parallel_per_bank=1,
     num_loop_iters=1,
     primary_at_last_offset=False,
+    determinism_iterations=0,
 ):
     """Standard path: WIDTH_SHARDED SRAM, per-expert output slices on compute_core_grid."""
     cores_per_dram_bank = n_parallel_per_bank * k_parallel_per_bank
@@ -1300,34 +1331,40 @@ def _run_standard(
         if has_sram
         else (None, None, None, None, None)
     )
-    result = ExpertKernel.op(
-        a_tensor,
-        sram_cts,
-        dram_cts,
-        out_tensor,
-        index_tensor,
-        num_active_experts=num_active_experts,
-        subblock_k=subblock_k,
-        subblock_n=subblock_n,
-        dram_core_grid=dram_core_grid,
-        dram_meta_tensors=dram_meta_tensors,
-        dram_per_core_n=dram_per_core_N,
-        has_sram=has_sram,
-        sram_core_grid=sram_core_grid,
-        sram_fmt_tensor=sram_fmt_tensor,
-        sram_base_addr_tensor=sram_base_addr_tensor,
-        sram_fmt_l1_addrs=sram_fmt_l1_addrs,
-        sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
-        sram_k_offsets=sram_k_offsets,
-        n_parallel_per_bank=n_parallel_per_bank,
-        k_parallel_per_bank=k_parallel_per_bank,
-        sram_per_core_n=sram_per_core_N,
-        sram_k_per_core=Kt,
-        sram_output_tensor=sram_out_tensor,
-        dram_fuse_silu=dram_fuse_silu,
-        tp_expert=tp_expert,
-        num_loop_iters=num_loop_iters,
-    )
+
+    def _launch():
+        return ExpertKernel.op(
+            a_tensor,
+            sram_cts,
+            dram_cts,
+            out_tensor,
+            index_tensor,
+            num_active_experts=num_active_experts,
+            subblock_k=subblock_k,
+            subblock_n=subblock_n,
+            dram_core_grid=dram_core_grid,
+            dram_meta_tensors=dram_meta_tensors,
+            dram_per_core_n=dram_per_core_N,
+            has_sram=has_sram,
+            sram_core_grid=sram_core_grid,
+            sram_fmt_tensor=sram_fmt_tensor,
+            sram_base_addr_tensor=sram_base_addr_tensor,
+            sram_fmt_l1_addrs=sram_fmt_l1_addrs,
+            sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
+            sram_k_offsets=sram_k_offsets,
+            n_parallel_per_bank=n_parallel_per_bank,
+            k_parallel_per_bank=k_parallel_per_bank,
+            sram_per_core_n=sram_per_core_N,
+            sram_k_per_core=Kt,
+            sram_output_tensor=sram_out_tensor,
+            dram_fuse_silu=dram_fuse_silu,
+            tp_expert=tp_expert,
+            num_loop_iters=num_loop_iters,
+        )
+
+    result = _launch()
+    if determinism_iterations:
+        _assert_expert_stable(_launch, result, sram_out_tensor, determinism_iterations)
     if active_sram:
         _validate_sram_output(
             sram_out_tensor,
@@ -1382,6 +1419,7 @@ def _run_accum(
     fmt_ratios=None,
     num_loop_iters=1,
     primary_at_last_offset=False,
+    determinism_iterations=0,
 ):
     """Accumulation path: WIDTH_SHARDED SRAM, expert outputs summed in-place.
 
@@ -1538,34 +1576,40 @@ def _run_accum(
         if has_sram
         else (None, None, None, None, None)
     )
-    result = ExpertKernel.op(
-        a_tensor,
-        sram_cts,
-        dram_cts,
-        out_tensor,
-        index_tensor,
-        num_active_experts=num_active_experts,
-        subblock_k=subblock_k,
-        subblock_n=subblock_n,
-        dram_core_grid=dram_core_grid,
-        dram_meta_tensors=dram_meta_tensors,
-        dram_per_core_n=dram_per_core_N,
-        has_sram=has_sram,
-        sram_core_grid=sram_core_grid,
-        sram_fmt_tensor=sram_fmt_tensor,
-        sram_base_addr_tensor=sram_base_addr_tensor,
-        sram_fmt_l1_addrs=sram_fmt_l1_addrs,
-        sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
-        sram_k_offsets=sram_k_offsets,
-        n_parallel_per_bank=n_parallel_per_bank,
-        accum_experts=True,
-        sram_per_core_n=sram_per_core_N,
-        sram_k_per_core=Kt,
-        sram_output_tensor=sram_out_tensor,
-        tp_expert=tp_expert,
-        num_loop_iters=num_loop_iters,
-        primary_at_last_offset=primary_at_last_offset,
-    )
+
+    def _launch():
+        return ExpertKernel.op(
+            a_tensor,
+            sram_cts,
+            dram_cts,
+            out_tensor,
+            index_tensor,
+            num_active_experts=num_active_experts,
+            subblock_k=subblock_k,
+            subblock_n=subblock_n,
+            dram_core_grid=dram_core_grid,
+            dram_meta_tensors=dram_meta_tensors,
+            dram_per_core_n=dram_per_core_N,
+            has_sram=has_sram,
+            sram_core_grid=sram_core_grid,
+            sram_fmt_tensor=sram_fmt_tensor,
+            sram_base_addr_tensor=sram_base_addr_tensor,
+            sram_fmt_l1_addrs=sram_fmt_l1_addrs,
+            sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
+            sram_k_offsets=sram_k_offsets,
+            n_parallel_per_bank=n_parallel_per_bank,
+            accum_experts=True,
+            sram_per_core_n=sram_per_core_N,
+            sram_k_per_core=Kt,
+            sram_output_tensor=sram_out_tensor,
+            tp_expert=tp_expert,
+            num_loop_iters=num_loop_iters,
+            primary_at_last_offset=primary_at_last_offset,
+        )
+
+    result = _launch()
+    if determinism_iterations:
+        _assert_expert_stable(_launch, result, sram_out_tensor, determinism_iterations)
     if active_sram:
         _validate_sram_output_accum(
             sram_out_tensor,
@@ -1617,6 +1661,7 @@ def _run_slice_k(
     k_parallel_per_bank=1,
     num_loop_iters=1,
     primary_at_last_offset=False,
+    determinism_iterations=0,
 ):
     """K-sliced path: HEIGHT_SHARDED SRAM, separate output grids."""
     cores_per_dram_bank = n_parallel_per_bank * k_parallel_per_bank
@@ -1757,34 +1802,40 @@ def _run_slice_k(
         if has_sram
         else (None, None, None, None, None)
     )
-    result = ExpertKernel.op(
-        a_tensor,
-        sram_cts,
-        dram_cts,
-        out_tensor,
-        index_tensor,
-        num_active_experts=num_active_experts,
-        subblock_k=subblock_k,
-        subblock_n=subblock_n,
-        dram_core_grid=dram_core_grid,
-        dram_meta_tensors=dram_meta_tensors,
-        dram_per_core_n=dram_per_core_N,
-        has_sram=has_sram,
-        sram_core_grid=sram_core_grid,
-        sram_fmt_tensor=sram_fmt_tensor,
-        sram_base_addr_tensor=sram_base_addr_tensor,
-        sram_fmt_l1_addrs=sram_fmt_l1_addrs,
-        sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
-        sram_k_offsets=sram_k_offsets,
-        n_parallel_per_bank=n_parallel_per_bank,
-        k_parallel_per_bank=k_parallel_per_bank,
-        sram_per_core_n=sram_per_core_N,
-        sram_k_per_core=sram_k_per_core,
-        sram_output_tensor=sram_out_tensor,
-        dram_fuse_silu=dram_fuse_silu,
-        tp_expert=tp_expert,
-        num_loop_iters=num_loop_iters,
-    )
+
+    def _launch():
+        return ExpertKernel.op(
+            a_tensor,
+            sram_cts,
+            dram_cts,
+            out_tensor,
+            index_tensor,
+            num_active_experts=num_active_experts,
+            subblock_k=subblock_k,
+            subblock_n=subblock_n,
+            dram_core_grid=dram_core_grid,
+            dram_meta_tensors=dram_meta_tensors,
+            dram_per_core_n=dram_per_core_N,
+            has_sram=has_sram,
+            sram_core_grid=sram_core_grid,
+            sram_fmt_tensor=sram_fmt_tensor,
+            sram_base_addr_tensor=sram_base_addr_tensor,
+            sram_fmt_l1_addrs=sram_fmt_l1_addrs,
+            sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
+            sram_k_offsets=sram_k_offsets,
+            n_parallel_per_bank=n_parallel_per_bank,
+            k_parallel_per_bank=k_parallel_per_bank,
+            sram_per_core_n=sram_per_core_N,
+            sram_k_per_core=sram_k_per_core,
+            sram_output_tensor=sram_out_tensor,
+            dram_fuse_silu=dram_fuse_silu,
+            tp_expert=tp_expert,
+            num_loop_iters=num_loop_iters,
+        )
+
+    result = _launch()
+    if determinism_iterations:
+        _assert_expert_stable(_launch, result, sram_out_tensor, determinism_iterations)
     if active_sram:
         _validate_sram_output_slice_k(
             sram_out_tensor,
@@ -1844,6 +1895,7 @@ def _run_hybrid_expert_multi_device(
     k_parallel_per_bank=1,
     num_loop_iters=1,
     primary_at_last_offset=False,
+    determinism_iterations=0,
 ):
     """Dispatcher: delegate to the appropriate variant.
 
@@ -1893,6 +1945,7 @@ def _run_hybrid_expert_multi_device(
             k_parallel_per_bank=k_parallel_per_bank,
             num_loop_iters=num_loop_iters,
             primary_at_last_offset=primary_at_last_offset,
+            determinism_iterations=determinism_iterations,
         )
     elif accum_experts:
         _run_accum(
@@ -1917,6 +1970,7 @@ def _run_hybrid_expert_multi_device(
             fmt_ratios,
             num_loop_iters=num_loop_iters,
             primary_at_last_offset=primary_at_last_offset,
+            determinism_iterations=determinism_iterations,
         )
     else:
         _run_standard(
@@ -1943,6 +1997,7 @@ def _run_hybrid_expert_multi_device(
             k_parallel_per_bank=k_parallel_per_bank,
             num_loop_iters=num_loop_iters,
             primary_at_last_offset=primary_at_last_offset,
+            determinism_iterations=determinism_iterations,
         )
 
 
@@ -2873,4 +2928,101 @@ def test_matmul_expert_bspm_sparse_activation(bh_2d_mesh_device):
         bspm_expert_configs=[(0, 0), (1, 0), (2, 0), (3, 0)],  # 4 registered experts
         active_expert_ids=[0, 2],  # sparse: only experts 0 and 2 selected this step
         pcc_threshold=0.90,
+    )
+
+
+# ======================================================================================
+# Bitwise determinism
+# ======================================================================================
+#
+# The cases above check accuracy with PCC. PCC cannot see an unstable kernel, because each
+# run is compared with the golden and not with the other runs. These cases run the same
+# program repeatedly and require the output to stay bitwise equal.
+#
+# Both compressed matmuls are covered. The DRAM one streams the cold experts, and the SRAM
+# one holds the hot experts in L1; _assert_expert_stable compares both outputs. The K2.7
+# decode run uses both, and it loads the hot experts K-sliced, which is the slice-K path.
+
+
+@pytest.mark.parametrize(
+    "formats,fmt_ratios",
+    [(["bfp4"], None), (K27_FORMATS, K27_FORMAT_WEIGHTS)],
+    ids=["bfp4_only", "k27_bspm_mix"],
+)
+def test_hybrid_expert_determinism_standard(device, formats, fmt_ratios):
+    """Gate/up shape, 2 SRAM + 2 DRAM experts, all active. bfp4_only is the control."""
+    _run_hybrid_expert_multi_device(
+        device,
+        M=1,
+        K=7168,
+        N=256,
+        num_experts=4,
+        sram_expert_ids=[0, 2],
+        dram_expert_ids=[1, 3],
+        active_expert_ids=[0, 1, 2, 3],
+        formats_per_device=[formats],
+        sram_n_parallel=8,
+        fmt_ratios=fmt_ratios,
+        determinism_iterations=DET_ITERS,
+    )
+
+
+@pytest.mark.parametrize(
+    "formats,fmt_ratios",
+    [(["bfp4"], None), (K27_FORMATS, K27_FORMAT_WEIGHTS)],
+    ids=["bfp4_only", "k27_bspm_mix"],
+)
+def test_hybrid_expert_determinism_accum(device, formats, fmt_ratios):
+    """Down-proj shape with accumulation over experts, 3 SRAM + 5 DRAM, 4 active."""
+    _run_hybrid_expert_multi_device(
+        device,
+        M=1,
+        K=256,
+        N=7168,
+        num_experts=8,
+        sram_expert_ids=[1, 4, 6],
+        dram_expert_ids=[0, 2, 3, 5, 7],
+        active_expert_ids=[0, 1, 4, 7],
+        formats_per_device=[formats],
+        sram_n_parallel=56,
+        num_subblocks_k=1,
+        accum_experts=True,
+        fmt_ratios=fmt_ratios,
+        determinism_iterations=DET_ITERS,
+    )
+
+
+@pytest.mark.requires_grid_size((12, 10))
+@pytest.mark.parametrize(
+    "formats,fmt_ratios",
+    [(["bfp4"], None), (K27_FORMATS, K27_FORMAT_WEIGHTS)],
+    ids=["bfp4_only", "k27_bspm_mix"],
+)
+def test_hybrid_expert_determinism_slice_k_gate_grid(device, formats, fmt_ratios):
+    """The production gate-proj layout: K-sliced SRAM experts on the irregular A-core grid.
+
+    This is how the decode run loads its hot experts, and the SRAM cores overlap the DRAM
+    bank cores, so it also covers the per-core push/pop on that overlap.
+    """
+    a_cores, _ = _build_ab_grids(device)
+    _run_hybrid_expert_multi_device(
+        device,
+        M=1,
+        K=7168,
+        N=256,
+        num_experts=8,
+        sram_expert_ids=[2, 5],
+        dram_expert_ids=list(range(8)),
+        active_expert_ids=list(range(8)),
+        formats_per_device=[formats],
+        sram_cores_override=a_cores,
+        sram_k_parallel=8,
+        sram_n_parallel=8,
+        dram_fuse_silu=True,
+        num_subblocks_n=1,
+        n_parallel_per_bank=1,
+        k_parallel_per_bank=2,
+        fmt_distribution="uniform",
+        fmt_ratios=fmt_ratios,
+        determinism_iterations=DET_ITERS,
     )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -23,8 +23,20 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, CompressedTensorAssigner
-from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import ttnn_quantize_fn
 from models.demos.deepseek_v3_b1.micro_ops.dram_streaming_matmul_compressed.op import DRAMStreamingMatmulCompressed
+from models.demos.deepseek_v3_b1.tests.unit_tests.compressed_determinism_utils import (
+    DET_ITERS,
+    FMT_TO_IDX,
+    K27_FORMAT_RATIOS,
+    K27_FORMATS,
+    K27_HIDDEN,
+    K27_MOE_INTERMEDIATE,
+    K27_PER_DEVICE_MOE_N,
+    assert_tile_counts,
+    build_stream_format_pattern,
+    describe_mismatch,
+    quantize_per_tile,
+)
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_dram_streaming_matmul import shuffle_tensor_tiles
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_matmul_custom_compressed import scale_tiles_for_mixed_formats
 from models.demos.deepseek_v3_b1.weights.transforms.moe import shuffle_dram_assignment as _shuffle_dram_assignment
@@ -886,93 +898,31 @@ def test_dram_matmul_bspm_cache_roundtrip(device, tmp_path):
 # per-core metadata and re-allocates the in1 CB backing tensor on every call, so each
 # iteration is a full host-side program build + device run, not a replay of one program.
 
-_FMT_TO_IDX = {fmt: idx for idx, fmt in enumerate(["bfp8", "bfp4", "bfp2", "bfp0"])}
+# ======================================================================================
+# Determinism tests with an explicitly specified tile-format distribution
+# ======================================================================================
+#
+# The tests above get their tile formats from CompressedTensorAssigner, which picks a
+# format per tile from the data. That makes the bfp4/bfp2/bfp0 mix data-dependent and
+# unrepeatable across shapes, which is no good for chasing non-determinism.
+#
+# The helpers in compressed_determinism_utils let a test state the format of every tile
+# directly. This file adds the one piece specific to the DRAM path: lifting a stream-order
+# pattern into the tile order that the shuffled DRAM tensor uses.
+#
+# Note on what an iteration covers: DRAMStreamingMatmulCompressed.op() rebuilds its
+# per-core metadata and re-allocates the in1 CB backing tensor on every call, so each
+# iteration is a full host-side program build + device run, not a replay of one program.
+#
+# Two knobs used by the tt-blaze port of this kernel have no equivalent in
+# DRAMStreamingMatmulCompressed, so the tests here cannot reproduce them:
+# k_parallel_per_bank=2 (gate/up split K across the two cores in a bank; the metal op only
+# splits N) and subblock_n=2 (down groups two N columns per streamed block; the metal op
+# walks one N column at a time). Both change the DRAM stream order, so they are a genuine
+# coverage gap on the metal op, not an oversight here. They are covered on the blaze side.
 
-# Shape used by the determinism tests — the DeepSeek R1 expert gate_proj shape, matching
-# the mixed-format tests above. Override for a quicker local run.
+# Shape used by the general determinism tests. Override for a quicker local run.
 _DET_M, _DET_K, _DET_N = 1, 7168, 2048
-
-# Iterations per case. Bump for a longer soak: DRAM_MM_DETERMINISM_ITERS=500 pytest ...
-_DET_ITERS = int(os.environ.get("DRAM_MM_DETERMINISM_ITERS", "50"))
-
-# --- Kimi K2.7-Code production configuration -------------------------------------
-#
-# Taken from a real 16-host K2.7-Code decode run (tt-blaze `blaze.models.cli`, BSPM
-# `target_3_5_32x32_native`). Blaze runs its own port of this kernel rather than
-# DRAMStreamingMatmulCompressed, but both consume the same per-tile format metadata and
-# the same DRAM stream order, so the shapes and the format mix carry over.
-#
-# The K2.7 MoE makes three DRAM compressed-matmul calls per layer, at two distinct
-# geometries (moe_intermediate 2048 is TP-sharded over 8 devices):
-#   gate, up:  K=7168, N=256  per device, subblock_k=56, one N tile column per core
-#   down:      K=256,  N=7168 per device, subblock_k=8,  14 N tile columns per core
-#
-# Two blaze-side knobs have no equivalent in DRAMStreamingMatmulCompressed, so the tests
-# below cannot reproduce them: k_parallel_per_bank=2 (gate/up split K across the two cores
-# in a bank; the metal op only splits N) and subblock_n=2 (down groups two N columns per
-# streamed block; the metal op walks one N column at a time). Both change the DRAM stream
-# order, so they are a genuine coverage gap on the metal op, not an oversight here.
-_K27_HIDDEN = 7168
-_K27_MOE_INTERMEDIATE = 2048
-_K27_MOE_TP = 8
-_K27_PER_DEVICE_MOE_N = _K27_MOE_INTERMEDIATE // _K27_MOE_TP  # 256
-
-# Measured over all 384 experts x 3 projections of layer 1 of the shipped
-# target_3_5_32x32_native map: bfp4 54.95 %, bfp2 41.08 %, bfp0 3.96 %, bfp8 0 %.
-# The uniform "alternate"/"random" patterns give bfp0 ~8x its production share, so a mix
-# drawn at these ratios is the one that resembles what the model actually streams.
-_K27_FORMATS = ["bfp4", "bfp2", "bfp0"]
-_K27_FORMAT_RATIOS = [0.5495, 0.4108, 0.0396]
-
-
-def build_stream_format_pattern(num_stream_tiles, formats, pattern, period=2, seed=0, ratios=None):
-    """Build the per-tile format code sequence for one DRAM shard, in kernel stream order.
-
-    Stream order within a shard is column-major: for each N column, the Kt tiles are
-    contiguous. Tiles are consumed by the compute kernel in pairs (see ``pack_tile_pairs``),
-    so where a format change lands relative to a pair boundary is what the ``pattern``
-    argument controls:
-
-    - ``"alternate"``: format changes on every tile — half the changes fall *inside* a pair.
-    - ``"pairs"``:     format changes every 2 tiles — each pair is homogeneous, changes only
-                       ever land on a pair boundary.
-    - ``"blocks"``:    format changes every ``period`` tiles (pass ``period=subblock_k`` to
-                       keep each streamed subblock single-format).
-    - ``"random"``:    seeded i.i.d. draw from ``formats``, uniform.
-    - ``"ratios"``:    seeded i.i.d. draw from ``formats`` at the probabilities in ``ratios``.
-                       Use it to match a real BSPM allocation's format mix (see
-                       ``_K27_FORMAT_RATIOS``); the uniform patterns above over-represent
-                       whichever format production uses least.
-
-    Args:
-        num_stream_tiles: Kt * per_N_tiles for one DRAM shard.
-        formats: format names to cycle through, e.g. ``["bfp4", "bfp2"]``.
-        pattern: one of "alternate", "pairs", "blocks", "random", "ratios".
-        period: run length for ``pattern="blocks"``.
-        seed: RNG seed for ``pattern="random"`` and ``pattern="ratios"``.
-        ratios: per-format probabilities for ``pattern="ratios"``, same order as ``formats``.
-
-    Returns:
-        int8 array of length ``num_stream_tiles`` holding COMPRESSED_FORMATS indices.
-    """
-    codes = np.array([_FMT_TO_IDX[f] for f in formats], dtype=np.int8)
-    i = np.arange(num_stream_tiles)
-    if pattern == "alternate":
-        return codes[i % len(codes)]
-    if pattern == "pairs":
-        return codes[(i // 2) % len(codes)]
-    if pattern == "blocks":
-        assert period >= 1, f"period must be >= 1, got {period}"
-        return codes[(i // period) % len(codes)]
-    if pattern == "random":
-        return codes[np.random.default_rng(seed).integers(0, len(codes), size=num_stream_tiles)]
-    if pattern == "ratios":
-        assert ratios is not None, 'pattern="ratios" needs a ratios argument'
-        assert len(ratios) == len(formats), f"ratios ({len(ratios)}) must match formats ({len(formats)})"
-        p = np.asarray(ratios, dtype=np.float64)
-        p = p / p.sum()
-        return codes[np.random.default_rng(seed).choice(len(codes), size=num_stream_tiles, p=p)]
-    raise ValueError(f"Unknown pattern: {pattern}")
 
 
 def stream_pattern_to_logical_assignment(stream_codes, kt, per_n_tiles, num_banks):
@@ -1014,42 +964,6 @@ def stream_pattern_to_logical_assignment(stream_codes, kt, per_n_tiles, num_bank
     return logical, shuffled
 
 
-def quantize_per_tile(tensor_f32, logical_assignment, tile_w=32):
-    """Host golden: quantize/dequantize each tile with the format its assignment names.
-
-    BFP block exponents are tile-aligned, so quantizing the whole tensor once per format
-    and then selecting per tile is equivalent to quantizing tile by tile, and far faster.
-    """
-    out = tensor_f32.clone()
-    mask_codes = np.repeat(np.repeat(logical_assignment, tile_w, axis=0), tile_w, axis=1)
-    mask_codes = torch.from_numpy(mask_codes.astype(np.int16))
-    for fmt, code in _FMT_TO_IDX.items():
-        sel = mask_codes == code
-        if not bool(sel.any()):
-            continue
-        out = torch.where(sel, ttnn_quantize_fn(tensor_f32, fmt), out)
-    return out
-
-
-def _describe_mismatch(output, reference, logical_assignment, per_core_n_tiles, tile_w=32):
-    """Localize a determinism failure to cores / tile columns / tile formats."""
-    diff = output != reference
-    bad_cols = torch.nonzero(diff.any(dim=0).flatten()).flatten().tolist()
-    bad_tile_cols = sorted({c // tile_w for c in bad_cols})
-    bad_cores = sorted({tc // per_core_n_tiles for tc in bad_tile_cols})
-    idx_to_fmt = {v: k for k, v in _FMT_TO_IDX.items()}
-    fmts_in_bad_cols = sorted(
-        {idx_to_fmt[int(code)] for tc in bad_tile_cols for code in np.unique(logical_assignment[:, tc])}
-    )
-    return (
-        f"{int(diff.sum())} / {diff.numel()} elements differ, "
-        f"max |diff| = {(output.float() - reference.float()).abs().max().item()}; "
-        f"{len(bad_tile_cols)} tile column(s) affected on core(s) {bad_cores}; "
-        f"formats present in affected columns: {fmts_in_bad_cols}; "
-        f"first affected tile columns: {bad_tile_cols[:16]}"
-    )
-
-
 def _run_determinism_case(
     device,
     formats,
@@ -1077,7 +991,7 @@ def _run_determinism_case(
     ``formats`` then only says which formats must be present.
     """
     tile_w = 32
-    num_iterations = num_iterations or _DET_ITERS
+    num_iterations = num_iterations or DET_ITERS
 
     primary_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
     num_banks = len(primary_cores_list)
@@ -1144,12 +1058,8 @@ def _run_determinism_case(
     # The requested mix must actually be on device, tile for tile.
     counts = ct.tile_counts
     total = logical_assignment.size
-    logger.info(f"tile counts: {counts} ({ {f: f'{100 * counts.get(f, 0) / total:.2f}%' for f in _FMT_TO_IDX} })")
-    for fmt in _FMT_TO_IDX:
-        expected = int((logical_assignment == _FMT_TO_IDX[fmt]).sum())
-        assert counts.get(fmt, 0) == expected, f"format {fmt}: packed {counts.get(fmt, 0)} tiles, expected {expected}"
-    for fmt in formats:
-        assert counts.get(fmt, 0) > 0, f"format {fmt} was requested but no tile uses it: {counts}"
+    logger.info(f"tile counts: {counts} ({ {f: f'{100 * counts.get(f, 0) / total:.2f}%' for f in FMT_TO_IDX} })")
+    assert_tile_counts(counts, logical_assignment, formats)
 
     # --- Golden, quantized with the same per-tile formats ---------------------------
     torch_expected = (torch_a.float() @ quantize_per_tile(torch_b, logical_assignment)).bfloat16()[..., :N]
@@ -1215,7 +1125,7 @@ def _run_determinism_case(
             assert passing, f"Iteration {i}: PCC vs golden failed: {pcc_message}"
             reference = output.clone()
         elif not torch.equal(output, reference):
-            divergences.append((i, _describe_mismatch(output, reference, logical_assignment, per_core_n_tiles)))
+            divergences.append((i, describe_mismatch(output, reference, logical_assignment, per_core_n_tiles)))
             # Keep going: how often it diverges, and whether it is always the same tiles,
             # is the interesting part.
 
@@ -1296,8 +1206,8 @@ def test_dram_matmul_compressed_determinism_4cores(device, formats):
 
 _K27_PROJ_CONFIGS = {
     # proj: (K, N, subblock_k, cores_per_bank) -> per_core_N tiles on an 8-bank part
-    "gate_up": (_K27_HIDDEN, _K27_PER_DEVICE_MOE_N, 56, 1),  # 1 N tile column per core
-    "down": (_K27_PER_DEVICE_MOE_N, _K27_HIDDEN, 8, 2),  # 14 N tile columns per core
+    "gate_up": (K27_HIDDEN, K27_PER_DEVICE_MOE_N, 56, 1),  # 1 N tile column per core
+    "down": (K27_PER_DEVICE_MOE_N, K27_HIDDEN, 8, 2),  # 14 N tile columns per core
 }
 
 
@@ -1307,13 +1217,13 @@ def test_dram_matmul_compressed_determinism_k27_production(device, proj):
     K, N, subblock_k, cores_per_bank = _K27_PROJ_CONFIGS[proj]
     _run_determinism_case(
         device,
-        _K27_FORMATS,
+        K27_FORMATS,
         "ratios",
         K=K,
         N=N,
         subblock_k=subblock_k,
         cores_per_bank=cores_per_bank,
-        ratios=_K27_FORMAT_RATIOS,
+        ratios=K27_FORMAT_RATIOS,
     )
 
 
@@ -1328,7 +1238,7 @@ def test_dram_matmul_compressed_determinism_k27_production_alternating(device, p
     K, N, subblock_k, cores_per_bank = _K27_PROJ_CONFIGS[proj]
     _run_determinism_case(
         device,
-        _K27_FORMATS,
+        K27_FORMATS,
         "alternate",
         K=K,
         N=N,
@@ -1370,11 +1280,11 @@ def _load_k27_bspm_assignment(proj, kt, tiles_w, require_formats, max_experts_sc
 
     tile_w = 32
     if proj == "gate_up":
-        proj_idx, full_rows, full_cols = 0, _K27_HIDDEN // tile_w, _K27_MOE_INTERMEDIATE // tile_w
+        proj_idx, full_rows, full_cols = 0, K27_HIDDEN // tile_w, K27_MOE_INTERMEDIATE // tile_w
     else:
-        proj_idx, full_rows, full_cols = 2, _K27_MOE_INTERMEDIATE // tile_w, _K27_HIDDEN // tile_w
+        proj_idx, full_rows, full_cols = 2, K27_MOE_INTERMEDIATE // tile_w, K27_HIDDEN // tile_w
 
-    wanted = [_FMT_TO_IDX[f] for f in require_formats]
+    wanted = [FMT_TO_IDX[f] for f in require_formats]
     for expert_idx in range(max_experts_scanned):
         full = load_bspm_for_expert(
             str(bspm_path), expert_idx=expert_idx, proj_idx=proj_idx, tile_rows=full_rows, tile_cols=full_cols
@@ -1398,11 +1308,11 @@ def test_dram_matmul_compressed_determinism_k27_bspm(device, proj):
     num_banks = device.dram_grid_size().x
     n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks * cores_per_bank)
     assignment = _load_k27_bspm_assignment(
-        proj, kt=K // tile_w, tiles_w=n_padded // tile_w, require_formats=_K27_FORMATS
+        proj, kt=K // tile_w, tiles_w=n_padded // tile_w, require_formats=K27_FORMATS
     )
     _run_determinism_case(
         device,
-        _K27_FORMATS,
+        K27_FORMATS,
         "bspm",
         K=K,
         N=N,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -13,13 +13,17 @@ Key difference from test_matmul_custom_compressed.py (L1 version):
 B lives in DRAM and is streamed in variable-size subblocks.
 """
 
+import os
+
 import numpy as np
+import pytest
 import torch
 from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, CompressedTensorAssigner
+from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import ttnn_quantize_fn
 from models.demos.deepseek_v3_b1.micro_ops.dram_streaming_matmul_compressed.op import DRAMStreamingMatmulCompressed
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_dram_streaming_matmul import shuffle_tensor_tiles
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_matmul_custom_compressed import scale_tiles_for_mixed_formats
@@ -863,3 +867,546 @@ def test_dram_matmul_bspm_cache_roundtrip(device, tmp_path):
     passing, pcc = comp_pcc(out_miss, out_hit, 0.99)
     logger.info("Cache roundtrip PCC (miss vs hit): {}", pcc)
     assert passing, f"Cache roundtrip PCC too low: {pcc} — miss and hit CompressedTensors disagree"
+
+
+# ======================================================================================
+# Determinism tests with an explicitly specified tile-format distribution
+# ======================================================================================
+#
+# The tests above get their tile formats from CompressedTensorAssigner, which picks a
+# format per tile from the data. That makes the bfp4/bfp2/bfp0 mix data-dependent and
+# unrepeatable across shapes, which is no good for chasing non-determinism.
+#
+# The helpers below let a test state the format of every tile directly, in the order the
+# kernel streams them, so a specific format-transition pattern (e.g. bfp4 <-> bfp2 on
+# adjacent tiles, i.e. within one metadata pair) can be reproduced exactly and then run
+# many times looking for bitwise divergence.
+#
+# Note on what an iteration covers: DRAMStreamingMatmulCompressed.op() rebuilds its
+# per-core metadata and re-allocates the in1 CB backing tensor on every call, so each
+# iteration is a full host-side program build + device run, not a replay of one program.
+
+_FMT_TO_IDX = {fmt: idx for idx, fmt in enumerate(["bfp8", "bfp4", "bfp2", "bfp0"])}
+
+# Shape used by the determinism tests — the DeepSeek R1 expert gate_proj shape, matching
+# the mixed-format tests above. Override for a quicker local run.
+_DET_M, _DET_K, _DET_N = 1, 7168, 2048
+
+# Iterations per case. Bump for a longer soak: DRAM_MM_DETERMINISM_ITERS=500 pytest ...
+_DET_ITERS = int(os.environ.get("DRAM_MM_DETERMINISM_ITERS", "50"))
+
+# --- Kimi K2.7-Code production configuration -------------------------------------
+#
+# Taken from a real 16-host K2.7-Code decode run (tt-blaze `blaze.models.cli`, BSPM
+# `target_3_5_32x32_native`). Blaze runs its own port of this kernel rather than
+# DRAMStreamingMatmulCompressed, but both consume the same per-tile format metadata and
+# the same DRAM stream order, so the shapes and the format mix carry over.
+#
+# The K2.7 MoE makes three DRAM compressed-matmul calls per layer, at two distinct
+# geometries (moe_intermediate 2048 is TP-sharded over 8 devices):
+#   gate, up:  K=7168, N=256  per device, subblock_k=56, one N tile column per core
+#   down:      K=256,  N=7168 per device, subblock_k=8,  14 N tile columns per core
+#
+# Two blaze-side knobs have no equivalent in DRAMStreamingMatmulCompressed, so the tests
+# below cannot reproduce them: k_parallel_per_bank=2 (gate/up split K across the two cores
+# in a bank; the metal op only splits N) and subblock_n=2 (down groups two N columns per
+# streamed block; the metal op walks one N column at a time). Both change the DRAM stream
+# order, so they are a genuine coverage gap on the metal op, not an oversight here.
+_K27_HIDDEN = 7168
+_K27_MOE_INTERMEDIATE = 2048
+_K27_MOE_TP = 8
+_K27_PER_DEVICE_MOE_N = _K27_MOE_INTERMEDIATE // _K27_MOE_TP  # 256
+
+# Measured over all 384 experts x 3 projections of layer 1 of the shipped
+# target_3_5_32x32_native map: bfp4 54.95 %, bfp2 41.08 %, bfp0 3.96 %, bfp8 0 %.
+# The uniform "alternate"/"random" patterns give bfp0 ~8x its production share, so a mix
+# drawn at these ratios is the one that resembles what the model actually streams.
+_K27_FORMATS = ["bfp4", "bfp2", "bfp0"]
+_K27_FORMAT_RATIOS = [0.5495, 0.4108, 0.0396]
+
+
+def build_stream_format_pattern(num_stream_tiles, formats, pattern, period=2, seed=0, ratios=None):
+    """Build the per-tile format code sequence for one DRAM shard, in kernel stream order.
+
+    Stream order within a shard is column-major: for each N column, the Kt tiles are
+    contiguous. Tiles are consumed by the compute kernel in pairs (see ``pack_tile_pairs``),
+    so where a format change lands relative to a pair boundary is what the ``pattern``
+    argument controls:
+
+    - ``"alternate"``: format changes on every tile — half the changes fall *inside* a pair.
+    - ``"pairs"``:     format changes every 2 tiles — each pair is homogeneous, changes only
+                       ever land on a pair boundary.
+    - ``"blocks"``:    format changes every ``period`` tiles (pass ``period=subblock_k`` to
+                       keep each streamed subblock single-format).
+    - ``"random"``:    seeded i.i.d. draw from ``formats``, uniform.
+    - ``"ratios"``:    seeded i.i.d. draw from ``formats`` at the probabilities in ``ratios``.
+                       Use it to match a real BSPM allocation's format mix (see
+                       ``_K27_FORMAT_RATIOS``); the uniform patterns above over-represent
+                       whichever format production uses least.
+
+    Args:
+        num_stream_tiles: Kt * per_N_tiles for one DRAM shard.
+        formats: format names to cycle through, e.g. ``["bfp4", "bfp2"]``.
+        pattern: one of "alternate", "pairs", "blocks", "random", "ratios".
+        period: run length for ``pattern="blocks"``.
+        seed: RNG seed for ``pattern="random"`` and ``pattern="ratios"``.
+        ratios: per-format probabilities for ``pattern="ratios"``, same order as ``formats``.
+
+    Returns:
+        int8 array of length ``num_stream_tiles`` holding COMPRESSED_FORMATS indices.
+    """
+    codes = np.array([_FMT_TO_IDX[f] for f in formats], dtype=np.int8)
+    i = np.arange(num_stream_tiles)
+    if pattern == "alternate":
+        return codes[i % len(codes)]
+    if pattern == "pairs":
+        return codes[(i // 2) % len(codes)]
+    if pattern == "blocks":
+        assert period >= 1, f"period must be >= 1, got {period}"
+        return codes[(i // period) % len(codes)]
+    if pattern == "random":
+        return codes[np.random.default_rng(seed).integers(0, len(codes), size=num_stream_tiles)]
+    if pattern == "ratios":
+        assert ratios is not None, 'pattern="ratios" needs a ratios argument'
+        assert len(ratios) == len(formats), f"ratios ({len(ratios)}) must match formats ({len(formats)})"
+        p = np.asarray(ratios, dtype=np.float64)
+        p = p / p.sum()
+        return codes[np.random.default_rng(seed).choice(len(codes), size=num_stream_tiles, p=p)]
+    raise ValueError(f"Unknown pattern: {pattern}")
+
+
+def stream_pattern_to_logical_assignment(stream_codes, kt, per_n_tiles, num_banks):
+    """Lift a per-shard stream-order format sequence to a logical ``(Kt, tiles_w)`` assignment.
+
+    ``CompressedTensor`` wants the assignment in the same tile order as the tensor it is
+    handed, and the DRAM tests hand it ``shuffle_tensor_tiles(...)`` output. Rather than
+    reason about that permutation by hand, run the tile *indices* through the same
+    ``shuffle_dram_assignment`` permutation the BSPM path uses and scatter through it.
+
+    ``stream_codes`` is applied identically to every DRAM shard, so all cores see the same
+    format sequence and only their weight data differs.
+
+    Returns:
+        ``(logical, shuffled)`` int8 ``(Kt, tiles_w)`` arrays. Pass ``shuffled`` to
+        ``CompressedTensor.from_bspm`` alongside the shuffled tensor; ``logical`` is the
+        one to use when building a host-side golden.
+    """
+    tiles_w = per_n_tiles * num_banks
+    assert len(stream_codes) == kt * per_n_tiles, f"expected {kt * per_n_tiles} codes, got {len(stream_codes)}"
+
+    # perm[k, n] = logical flat tile index that ends up at shuffled position (k, n).
+    idx_grid = np.arange(kt * tiles_w, dtype=np.int32).reshape(kt, tiles_w)
+    perm = _shuffle_dram_assignment(idx_grid, num_banks)
+
+    logical_flat = np.zeros(kt * tiles_w, dtype=np.int8)
+    for b in range(num_banks):
+        cols = slice(b * per_n_tiles, (b + 1) * per_n_tiles)
+        logical_flat[perm[:, cols].ravel()] = stream_codes
+    logical = logical_flat.reshape(kt, tiles_w)
+
+    shuffled = _shuffle_dram_assignment(logical, num_banks)
+    # Self-check: the pattern must come back out in stream order exactly as specified,
+    # otherwise the test is measuring a different tile distribution than it claims to.
+    for b in range(num_banks):
+        cols = slice(b * per_n_tiles, (b + 1) * per_n_tiles)
+        got = shuffled[:, cols].ravel()
+        assert np.array_equal(got, stream_codes), f"stream-order round-trip mismatch on bank {b}"
+    return logical, shuffled
+
+
+def quantize_per_tile(tensor_f32, logical_assignment, tile_w=32):
+    """Host golden: quantize/dequantize each tile with the format its assignment names.
+
+    BFP block exponents are tile-aligned, so quantizing the whole tensor once per format
+    and then selecting per tile is equivalent to quantizing tile by tile, and far faster.
+    """
+    out = tensor_f32.clone()
+    mask_codes = np.repeat(np.repeat(logical_assignment, tile_w, axis=0), tile_w, axis=1)
+    mask_codes = torch.from_numpy(mask_codes.astype(np.int16))
+    for fmt, code in _FMT_TO_IDX.items():
+        sel = mask_codes == code
+        if not bool(sel.any()):
+            continue
+        out = torch.where(sel, ttnn_quantize_fn(tensor_f32, fmt), out)
+    return out
+
+
+def _describe_mismatch(output, reference, logical_assignment, per_core_n_tiles, tile_w=32):
+    """Localize a determinism failure to cores / tile columns / tile formats."""
+    diff = output != reference
+    bad_cols = torch.nonzero(diff.any(dim=0).flatten()).flatten().tolist()
+    bad_tile_cols = sorted({c // tile_w for c in bad_cols})
+    bad_cores = sorted({tc // per_core_n_tiles for tc in bad_tile_cols})
+    idx_to_fmt = {v: k for k, v in _FMT_TO_IDX.items()}
+    fmts_in_bad_cols = sorted(
+        {idx_to_fmt[int(code)] for tc in bad_tile_cols for code in np.unique(logical_assignment[:, tc])}
+    )
+    return (
+        f"{int(diff.sum())} / {diff.numel()} elements differ, "
+        f"max |diff| = {(output.float() - reference.float()).abs().max().item()}; "
+        f"{len(bad_tile_cols)} tile column(s) affected on core(s) {bad_cores}; "
+        f"formats present in affected columns: {fmts_in_bad_cols}; "
+        f"first affected tile columns: {bad_tile_cols[:16]}"
+    )
+
+
+def _run_determinism_case(
+    device,
+    formats,
+    pattern,
+    *,
+    M=_DET_M,
+    K=_DET_K,
+    N=_DET_N,
+    cores_per_bank=1,
+    subblock_k=None,
+    num_iterations=None,
+    pcc_threshold=0.98,
+    seed=0,
+    ratios=None,
+    logical_assignment=None,
+):
+    """Run the DRAM compressed matmul ``num_iterations`` times with a fixed, explicitly
+    specified tile-format distribution and assert every run is bitwise identical.
+
+    Correctness against a host golden (quantized with the same per-tile formats) is checked
+    once, on the first compared iteration — a stable but wrong result is not a pass.
+
+    ``logical_assignment`` replaces the generated pattern with a caller-supplied
+    ``(Kt, tiles_w)`` assignment in logical tile order — pass a real BSPM map here.
+    ``formats`` then only says which formats must be present.
+    """
+    tile_w = 32
+    num_iterations = num_iterations or _DET_ITERS
+
+    primary_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+    num_banks = len(primary_cores_list)
+
+    compute_cores_list = [
+        ttnn.CoreCoord(c.x + offset, c.y) for c in primary_cores_list for offset in range(cores_per_bank)
+    ]
+    num_cores = len(compute_cores_list)
+
+    n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks * cores_per_bank)
+    per_core_N = n_padded // (num_banks * cores_per_bank)
+    per_core_n_tiles = per_core_N // tile_w
+    total_N_per_bank = per_core_N * cores_per_bank
+    per_n_tiles = total_N_per_bank // tile_w
+
+    Kt = K // tile_w
+    if subblock_k is None:
+        subblock_k = Kt // 4 if Kt > 8 else Kt
+    if subblock_k % 2 != 0:
+        subblock_k = max(2, subblock_k - 1)
+    assert Kt % subblock_k == 0, f"Kt ({Kt}) must be divisible by subblock_k ({subblock_k})"
+
+    logger.info(
+        f"determinism: formats={formats} pattern={pattern} M={M} K={K} N={N} n_padded={n_padded} "
+        f"Kt={Kt} subblock_k={subblock_k} cores_per_bank={cores_per_bank} num_cores={num_cores} "
+        f"iterations={num_iterations}"
+    )
+
+    # --- Explicit tile distribution -------------------------------------------------
+    if logical_assignment is None:
+        stream_codes = build_stream_format_pattern(
+            Kt * per_n_tiles, formats, pattern, period=subblock_k, seed=seed, ratios=ratios
+        )
+        logical_assignment, shuffled_assignment = stream_pattern_to_logical_assignment(
+            stream_codes, Kt, per_n_tiles, num_banks
+        )
+    else:
+        expected_shape = (Kt, per_n_tiles * num_banks)
+        assert (
+            logical_assignment.shape == expected_shape
+        ), f"logical_assignment must be {expected_shape}, got {logical_assignment.shape}"
+        shuffled_assignment = _shuffle_dram_assignment(logical_assignment, num_banks)
+
+    torch.manual_seed(seed)
+    torch_a = torch.randn((M, K), dtype=torch.bfloat16)
+    torch_b = torch.randn((K, n_padded)).float()
+    torch_b_shuffled = shuffle_tensor_tiles(torch_b, tile_w, num_banks)
+
+    dram_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+            )
+        ]
+    )
+    b_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_grid, [K, total_N_per_bank], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    ct = CompressedTensor.from_bspm(torch_b_shuffled, shuffled_assignment, device=device, memory_config=b_mem_config)
+
+    # The requested mix must actually be on device, tile for tile.
+    counts = ct.tile_counts
+    total = logical_assignment.size
+    logger.info(f"tile counts: {counts} ({ {f: f'{100 * counts.get(f, 0) / total:.2f}%' for f in _FMT_TO_IDX} })")
+    for fmt in _FMT_TO_IDX:
+        expected = int((logical_assignment == _FMT_TO_IDX[fmt]).sum())
+        assert counts.get(fmt, 0) == expected, f"format {fmt}: packed {counts.get(fmt, 0)} tiles, expected {expected}"
+    for fmt in formats:
+        assert counts.get(fmt, 0) > 0, f"format {fmt} was requested but no tile uses it: {counts}"
+
+    # --- Golden, quantized with the same per-tile formats ---------------------------
+    torch_expected = (torch_a.float() @ quantize_per_tile(torch_b, logical_assignment)).bfloat16()[..., :N]
+
+    # --- Device tensors, allocated once and reused across iterations ----------------
+    a_tile = ttnn.Tile([M, tile_w])
+    compute_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in compute_cores_list]
+    )
+    ttnn_a = ttnn.from_torch(
+        torch_a.repeat(num_cores, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(compute_core_grid, [M, K], ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+        tile=a_tile,
+    )
+
+    out_tile = ttnn.Tile([M, tile_w])
+    out_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(compute_core_grid, [M, per_core_N], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    host_zeros = ttnn.from_torch(
+        torch.zeros((M, n_padded), dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, tile=out_tile
+    )
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, n_padded), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=out_mem_config,
+        tile=out_tile,
+    )
+
+    def run_once():
+        # Re-zero so a partially-written output cannot masquerade as a stable one by
+        # inheriting the previous iteration's values.
+        ttnn.copy_host_to_device_tensor(host_zeros, ttnn_output)
+        result = DRAMStreamingMatmulCompressed.op(
+            ttnn_a, ct, ttnn_output, subblock_k=subblock_k, cores_per_bank=cores_per_bank
+        )
+        return ttnn.to_torch(result)[..., :N]
+
+    # Warm-up: first call also compiles/uploads, so keep it out of the compared set.
+    run_once()
+
+    reference = None
+    divergences = []
+    for i in range(num_iterations):
+        output = run_once()
+        assert not torch.isnan(output.float()).any(), f"Iteration {i}: output contains NaN"
+        assert not torch.all(output == 0), f"Iteration {i}: output is all zeros"
+
+        if reference is None:
+            passing, pcc_message = comp_pcc(torch_expected, output, pcc_threshold)
+            logger.info(f"PCC vs per-tile-quantized golden: {pcc_message}")
+            assert passing, f"Iteration {i}: PCC vs golden failed: {pcc_message}"
+            reference = output.clone()
+        elif not torch.equal(output, reference):
+            divergences.append((i, _describe_mismatch(output, reference, logical_assignment, per_core_n_tiles)))
+            # Keep going: how often it diverges, and whether it is always the same tiles,
+            # is the interesting part.
+
+    if divergences:
+        detail = "\n".join(f"  iter {i}: {msg}" for i, msg in divergences[:10])
+        raise AssertionError(
+            f"Non-deterministic output: {len(divergences)} / {num_iterations - 1} iterations differ from "
+            f"iteration 0 (formats={formats}, pattern={pattern}, cores_per_bank={cores_per_bank}, "
+            f"subblock_k={subblock_k}).\n{detail}"
+        )
+
+    logger.info(f"✓ {num_iterations} iterations bitwise identical (formats={formats}, pattern={pattern})")
+
+
+# --- Format-mix sweep: is a bfp4 <-> bfp2 transition what breaks determinism? ---
+#
+# "alternate" is the harshest pattern — the format changes on every tile, so half the
+# changes land inside a metadata pair. The single-format cases are the controls: if they
+# are stable and the mixed ones are not, the transition itself is implicated.
+
+
+@pytest.mark.parametrize(
+    "formats",
+    [
+        ["bfp4", "bfp2", "bfp0"],
+        ["bfp4", "bfp0"],
+        ["bfp2", "bfp0"],
+        ["bfp4", "bfp2"],
+        ["bfp4"],
+        ["bfp2"],
+    ],
+    ids=["bfp4_bfp2_bfp0", "bfp4_bfp0", "bfp2_bfp0", "bfp4_bfp2", "bfp4_only", "bfp2_only"],
+)
+def test_dram_matmul_compressed_determinism_format_mix(device, formats):
+    """Fixed alternating tile distribution, repeated many times; output must be bitwise stable."""
+    _run_determinism_case(device, formats, "alternate")
+
+
+# --- Where does the format change land? ---
+#
+# Each two-format mix, varying only how often the format changes: every tile (inside a
+# pair), every pair, or every subblock. Narrows a failure to intra-pair, inter-pair, or
+# subblock-boundary handling. bfp0 is worth its own rows here because a bfp0 tile takes
+# the zero-tile address rather than a real DRAM offset, so a bfp4/bfp0 or bfp2/bfp0
+# transition exercises different metadata than a bfp4/bfp2 one.
+
+
+@pytest.mark.parametrize("pattern", ["alternate", "pairs", "blocks", "random"])
+@pytest.mark.parametrize(
+    "formats",
+    [["bfp4", "bfp2"], ["bfp4", "bfp0"], ["bfp2", "bfp0"]],
+    ids=["bfp4_bfp2", "bfp4_bfp0", "bfp2_bfp0"],
+)
+def test_dram_matmul_compressed_determinism_transition_pattern(device, formats, pattern):
+    """Two-format mix with the format transitions placed at different granularities."""
+    _run_determinism_case(device, formats, pattern)
+
+
+# --- Multi-core per bank: adds the semaphore handoff between cores sharing a bank ---
+
+
+@pytest.mark.parametrize(
+    "formats",
+    [["bfp4", "bfp2", "bfp0"], ["bfp4", "bfp2"], ["bfp4", "bfp0"], ["bfp2", "bfp0"]],
+    ids=["bfp4_bfp2_bfp0", "bfp4_bfp2", "bfp4_bfp0", "bfp2_bfp0"],
+)
+def test_dram_matmul_compressed_determinism_4cores(device, formats):
+    """Same alternating distribution with 4 cores per bank, so pipelined DRAM reads are in play."""
+    _run_determinism_case(device, formats, "alternate", cores_per_bank=4)
+
+
+# --- Kimi K2.7-Code production geometry and format mix ---
+#
+# The cases above all run K=7168, N=2048, 8 N tile columns per core. Neither K2.7 MoE
+# projection has that shape: gate/up gives each core a SINGLE N tile column, and down runs
+# a short K (8 tiles) against a wide N. Both change how the kernel walks its metadata, so
+# they are worth their own rows.
+
+_K27_PROJ_CONFIGS = {
+    # proj: (K, N, subblock_k, cores_per_bank) -> per_core_N tiles on an 8-bank part
+    "gate_up": (_K27_HIDDEN, _K27_PER_DEVICE_MOE_N, 56, 1),  # 1 N tile column per core
+    "down": (_K27_PER_DEVICE_MOE_N, _K27_HIDDEN, 8, 2),  # 14 N tile columns per core
+}
+
+
+@pytest.mark.parametrize("proj", ["gate_up", "down"])
+def test_dram_matmul_compressed_determinism_k27_production(device, proj):
+    """K2.7 per-device MoE geometry, with the format mix drawn at the shipped BSPM's ratios."""
+    K, N, subblock_k, cores_per_bank = _K27_PROJ_CONFIGS[proj]
+    _run_determinism_case(
+        device,
+        _K27_FORMATS,
+        "ratios",
+        K=K,
+        N=N,
+        subblock_k=subblock_k,
+        cores_per_bank=cores_per_bank,
+        ratios=_K27_FORMAT_RATIOS,
+    )
+
+
+@pytest.mark.parametrize("proj", ["gate_up", "down"])
+def test_dram_matmul_compressed_determinism_k27_production_alternating(device, proj):
+    """K2.7 geometry with the harshest distribution instead of the realistic one.
+
+    The ratios draw leaves long single-format runs, so it rarely puts a bfp4 tile next to a
+    bfp2 one inside a pair. This row keeps the production shape and forces that transition
+    on every tile.
+    """
+    K, N, subblock_k, cores_per_bank = _K27_PROJ_CONFIGS[proj]
+    _run_determinism_case(
+        device,
+        _K27_FORMATS,
+        "alternate",
+        K=K,
+        N=N,
+        subblock_k=subblock_k,
+        cores_per_bank=cores_per_bank,
+    )
+
+
+# --- The real BSPM map, not a generated pattern ---
+
+
+def _load_k27_bspm_assignment(proj, kt, tiles_w, require_formats, max_experts_scanned=32):
+    """Load one expert projection from the shipped K2.7 map, cropped to a per-device slice.
+
+    Set K27_BSPM_DIR to the target_3_5_32x32_native root (the directory holding layer_*/).
+
+    The map stores every projection at full, un-TP-sharded size, and its header carries no
+    tile dimensions, so the projection shape has to be supplied. gate/up are [HIDDEN,
+    MOE_INTERMEDIATE] and TP-shard along N; down is [MOE_INTERMEDIATE, HIDDEN] and shards
+    along K. Either way the leading slice is what one device streams.
+
+    The allocator spends its budget per expert, so the mix in one device's slice varies a
+    lot: expert 0 of layer 1 is entirely bfp4 in both projections, and only about a quarter
+    of the 384 experts use all three formats in their leading slice. This scans for the
+    first expert that does, and reports which one it picked.
+    """
+    import pytest as _pytest
+
+    bspm_dir = os.environ.get("K27_BSPM_DIR")
+    if not bspm_dir:
+        _pytest.skip("K27_BSPM_DIR not set")
+    from pathlib import Path
+
+    from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_expert
+
+    bspm_path = Path(bspm_dir) / "layer_1" / "precision_map_B_3.5.bspm"
+    if not bspm_path.exists():
+        _pytest.skip(f"BSPM file not found: {bspm_path}")
+
+    tile_w = 32
+    if proj == "gate_up":
+        proj_idx, full_rows, full_cols = 0, _K27_HIDDEN // tile_w, _K27_MOE_INTERMEDIATE // tile_w
+    else:
+        proj_idx, full_rows, full_cols = 2, _K27_MOE_INTERMEDIATE // tile_w, _K27_HIDDEN // tile_w
+
+    wanted = [_FMT_TO_IDX[f] for f in require_formats]
+    for expert_idx in range(max_experts_scanned):
+        full = load_bspm_for_expert(
+            str(bspm_path), expert_idx=expert_idx, proj_idx=proj_idx, tile_rows=full_rows, tile_cols=full_cols
+        )
+        assert full.shape == (full_rows, full_cols), f"BSPM map is {full.shape}, expected {(full_rows, full_cols)}"
+        assert full.shape[0] >= kt and full.shape[1] >= tiles_w, f"BSPM map {full.shape} too small for {(kt, tiles_w)}"
+        sliced = np.ascontiguousarray(full[:kt, :tiles_w])
+        if all(int((sliced == code).sum()) > 0 for code in wanted):
+            logger.info(f"K2.7 BSPM {proj}: using layer 1 expert {expert_idx}")
+            return sliced
+    _pytest.skip(
+        f"no expert below {max_experts_scanned} has all of {require_formats} in its {proj} slice of {bspm_path}"
+    )
+
+
+@pytest.mark.parametrize("proj", ["gate_up", "down"])
+def test_dram_matmul_compressed_determinism_k27_bspm(device, proj):
+    """K2.7 production geometry driven by the real shipped BSPM codes, not a generated pattern."""
+    K, N, subblock_k, cores_per_bank = _K27_PROJ_CONFIGS[proj]
+    tile_w = 32
+    num_banks = device.dram_grid_size().x
+    n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks * cores_per_bank)
+    assignment = _load_k27_bspm_assignment(
+        proj, kt=K // tile_w, tiles_w=n_padded // tile_w, require_formats=_K27_FORMATS
+    )
+    _run_determinism_case(
+        device,
+        _K27_FORMATS,
+        "bspm",
+        K=K,
+        N=N,
+        subblock_k=subblock_k,
+        cores_per_bank=cores_per_bank,
+        logical_assignment=assignment,
+    )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul_custom_compressed.py
@@ -22,6 +22,16 @@ from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, Comp
 from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_expert
 from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import COMPRESSED_FORMATS, ttnn_quantize_fn
 from models.demos.deepseek_v3_b1.micro_ops.matmul_custom_compressed.op import MatmulCustomCompressed
+from models.demos.deepseek_v3_b1.tests.unit_tests.compressed_determinism_utils import (
+    DET_ITERS,
+    K27_FORMAT_RATIOS,
+    K27_FORMATS,
+    K27_HIDDEN,
+    K27_PER_DEVICE_MOE_N,
+    assert_bitwise_stable,
+    build_stream_format_pattern,
+    quantize_per_tile,
+)
 
 
 def scale_tiles_for_mixed_formats(b_torch, formats):
@@ -101,6 +111,7 @@ def _run_matmul_custom_compressed_with_assignment(
     assignment,
     num_cores=1,
     pcc_threshold=0.98,
+    determinism_iterations=0,
 ):
     """Helper: run custom compressed A @ decompress(B_compressed).
 
@@ -191,6 +202,17 @@ def _run_matmul_custom_compressed_with_assignment(
     passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
     logger.info(pcc_message)
     assert passing, pcc_message
+
+    if determinism_iterations:
+        assert_bitwise_stable(
+            lambda: ttnn.to_torch(MatmulCustomCompressed.op(ttnn_a, ct, ttnn_output, impl=impl)),
+            determinism_iterations,
+            context=f"impl={impl}, M={M}, K={K}, N={N}, num_cores={num_cores}",
+            assignment=assignment,
+            per_core_n_tiles=n_per_core // 32,
+            reference=output_torch.clone(),
+        )
+
     return passing, pcc_message
 
 
@@ -602,3 +624,151 @@ def test_matmul_custom_compressed_bspm_mixed_budget(device):
     assert passing_bfp4, f"Uniform BFP4 PCC too low: {pcc_bfp4}"
     # BFP4-only must be at least as good as the mixed 3.5 b/e (allow 1% tolerance for rng variance)
     assert float(pcc_bfp4) >= float(pcc_35) - 0.01, f"Uniform BFP4 PCC ({pcc_bfp4}) should be >= 3.5 b/e PCC ({pcc_35})"
+
+
+# ======================================================================================
+# Determinism, with an explicitly specified tile-format distribution
+# ======================================================================================
+#
+# The cases above take their tile formats from CompressedTensorAssigner, so the mix follows
+# the data and a test cannot state it. These cases set the format of every tile, run the
+# kernel many times, and require a bitwise equal output every time. PCC cannot see an
+# unstable kernel, because each run is compared with the golden and not with the other runs.
+#
+# The implementations do not all accept every mix. The rules below are the ones the
+# parametrization of test_matmul_custom_compressed_single_core already applies, kept in one
+# predicate so an invalid combination fails with a clear message instead of a device error.
+
+# K2.7-Code per-device gate/up shape. bfp0 needs a runtime barrier implementation, and this
+# shape has no room for a constexpr one, so the mixed cases run on "runtime barrier".
+_DET_SHAPE = (1, K27_HIDDEN, K27_PER_DEVICE_MOE_N)
+# Narrower shape for the implementation sweep: the constexpr variants unroll the per-tile
+# format metadata, and 224 x 8 tiles overflows the kernel config buffer.
+_DET_IMPL_SHAPE = (1, K27_HIDDEN, 64)
+
+
+def _impl_rejects(impl, formats, shape):
+    """Return why this implementation cannot take this mix and shape, or None if it can."""
+    if ("bfp2" in formats or "bfp0" in formats) and "barrier" not in impl:
+        return "bfp2/bfp0 need barrier synchronization"
+    if "bfp0" in formats and "constexpr" in impl:
+        return "bfp0 does not work with the constexpr implementations"
+    if shape == (1, 7168, 256) and "constexpr" in impl:
+        return "not enough program memory for a constexpr implementation at this shape"
+    return None
+
+
+def _barrier_impls_for(formats, shape):
+    """The implementations that accept this mix and shape, as pytest ids."""
+    return [i for i in IMPLEMENTATIONS if _impl_rejects(i, formats, shape) is None]
+
+
+def _run_determinism_case(
+    device,
+    impl,
+    formats,
+    pattern,
+    *,
+    shape=_DET_SHAPE,
+    num_cores=1,
+    ratios=None,
+    seed=0,
+    pcc_threshold=0.98,
+    iterations=None,
+):
+    """Build a weight tensor with a stated per-tile format mix, then check bitwise stability.
+
+    The weights are quantized on the host with the same per-tile formats before they go to the
+    device, so the golden is exact for the mix and the first run is checked for correctness as
+    well: a stable but wrong result is not a pass.
+    """
+    M, K, N = shape
+    reason = _impl_rejects(impl, formats, shape)
+    assert reason is None, f"impl {impl!r} cannot take formats {formats} at {shape}: {reason}"
+
+    tile_w = 32
+    kt, nt = K // tile_w, N // tile_w
+    codes = build_stream_format_pattern(kt * nt, formats, pattern, period=kt, seed=seed, ratios=ratios)
+    assignment = codes.reshape(kt, nt)
+
+    torch.manual_seed(seed)
+    torch_a = torch.randn((M, K), dtype=torch.bfloat16)
+    torch_b = quantize_per_tile(torch.randn((K, N)).float(), assignment)
+
+    _run_matmul_custom_compressed_with_assignment(
+        device,
+        M,
+        K,
+        N,
+        impl,
+        torch_a,
+        torch_b,
+        assignment,
+        num_cores=num_cores,
+        pcc_threshold=pcc_threshold,
+        determinism_iterations=iterations or DET_ITERS,
+    )
+
+
+@pytest.mark.parametrize(
+    "formats",
+    [
+        ["bfp4", "bfp2", "bfp0"],
+        ["bfp4", "bfp0"],
+        ["bfp2", "bfp0"],
+        ["bfp4", "bfp2"],
+        ["bfp4"],
+        ["bfp2"],
+    ],
+    ids=["bfp4_bfp2_bfp0", "bfp4_bfp0", "bfp2_bfp0", "bfp4_bfp2", "bfp4_only", "bfp2_only"],
+)
+def test_matmul_custom_compressed_determinism_format_mix(device, formats):
+    """Alternating tile distribution, repeated many times, on the runtime barrier implementation.
+
+    The two single-format rows are the controls: if they stay stable and a mixed row does
+    not, the format change is the cause.
+    """
+    _run_determinism_case(device, "runtime barrier", formats, "alternate")
+
+
+@pytest.mark.parametrize("impl", _barrier_impls_for(["bfp4", "bfp2"], _DET_IMPL_SHAPE))
+def test_matmul_custom_compressed_determinism_impl(device, impl):
+    """Every implementation that accepts a bfp4/bfp2 mix, against a format change at each tile.
+
+    These are separate compute-kernel code paths for the same matmul, and the per-tile format
+    metadata is what they handle differently.
+    """
+    _run_determinism_case(device, impl, ["bfp4", "bfp2"], "alternate", shape=_DET_IMPL_SHAPE)
+
+
+@pytest.mark.parametrize("pattern", ["alternate", "pairs", "blocks", "random"])
+def test_matmul_custom_compressed_determinism_transition_pattern(device, pattern):
+    """bfp4/bfp2 with the format transitions at different granularities.
+
+    Narrows a failure to handling inside a pair, between pairs, or at a block boundary.
+    """
+    _run_determinism_case(device, "runtime barrier", ["bfp4", "bfp2"], pattern)
+
+
+def test_matmul_custom_compressed_determinism_k27_mix(device):
+    """K2.7 per-device gate/up shape with the shipped map's format ratios."""
+    _run_determinism_case(device, "runtime barrier", K27_FORMATS, "ratios", ratios=K27_FORMAT_RATIOS)
+
+
+@pytest.mark.parametrize("num_cores", [2, 13, 32])
+def test_matmul_custom_compressed_determinism_multicore(device, num_cores):
+    """The K2.7 mix spread over several cores, so each core holds its own N slice."""
+    if num_cores == 32:
+        # Same known failure that test_matmul_custom_compressed_multicore skips: a runtime
+        # implementation on 32 cores with anything but plain bfp8 gives a PCC error. The
+        # output comes back constant, so there is nothing to compare for stability.
+        pytest.skip("FIXME: PCC ERROR (runtime impl, 32 cores, non-bfp8 formats)")
+    _run_determinism_case(
+        device,
+        "runtime barrier",
+        K27_FORMATS,
+        "ratios",
+        shape=(1, K27_HIDDEN, 64 * num_cores),
+        num_cores=num_cores,
+        ratios=K27_FORMAT_RATIOS,
+    )


### PR DESCRIPTION
### PR Category

Test Only

### Summary

This PR adds 51 determinism cases for the compressed matmul kernels. Each case sets the format of every tile, runs the kernel many times, and compares each output bitwise with the first output. No test did this before.

The tests answer a question about the kernels. The question was whether a change between bfp4 and bfp2 makes the output unstable.

Three kernels are covered:

| Kernel | Weights | Test file | Cases |
|---|---|---|---:|
| `dram_streaming_matmul_compressed` | DRAM | `test_dram_matmul_custom_compressed.py` | 28 |
| `matmul_custom_compressed` | L1 | `test_matmul_custom_compressed.py` | 17 |
| `matmul_expert` (SRAM and DRAM halves) | L1 and DRAM | `per_core_allocation/test_matmul_expert.py` | 6 |

The existing mixed-format tests take their tile formats from `CompressedTensorAssigner`. That component selects a format from the data. Thus the mix of bfp4, bfp2 and bfp0 changes with the data, and a test cannot set it. The new helpers in `compressed_determinism_utils.py` set the format of each tile directly.

**Results.** All cases pass. A longer run of 200 iterations for each case also passes. The output stays bitwise equal. The hypothesis does not occur in these conditions. This is not a proof that the kernels are stable. Refer to the limits below.

### What the tests contain

**New module `compressed_determinism_utils.py`**

- `build_stream_format_pattern` gives the format of each tile in the sequence in which the kernel reads the tiles. It has five patterns. `alternate` changes the format at each tile, so one half of the changes fall inside a metadata pair. `pairs` changes the format only at a pair boundary. `blocks` changes it only at a subblock boundary. `random` selects formats at equal probability. `ratios` selects formats at given probabilities.
- `quantize_per_tile` makes a host reference that uses the same format for each tile.
- `assert_bitwise_stable` and `describe_mismatch` run the comparison and report the cores, the tile columns and the tile formats of a failure.
- The Kimi K2.7-Code constants. The shipped map `target_3_5_32x32_native` contains bfp4 54.95 %, bfp2 41.08 %, bfp0 3.96 % and bfp8 0 %. This is measured over all 384 experts and all 3 projections of layer 1. The `alternate` and `random` patterns give bfp0 approximately eight times its true part, so the `ratios` pattern is the one that resembles the model.

**DRAM streaming matmul (28 cases)**

Six format mixes, three two-format mixes against four transition patterns, four mixes with four cores for each DRAM bank, and the K2.7 per-device geometry. The K2.7 cases also run from the real codes of the shipped map. Set `K27_BSPM_DIR` to use them; they skip if the variable is absent.

**Standalone L1 matmul (17 cases)**

Six format mixes, four transition patterns, three core counts, the K2.7 mix, and each implementation that accepts a mix. The implementations are separate compute-kernel code paths, and the per-tile format metadata is what they handle differently.

**Expert matmul (6 cases)**

The standard, the accumulate and the K-sliced paths, each with a single-format control and the K2.7 mix. The check compares the SRAM output as well as the DRAM output, because the hot-expert matmul is a separate kernel from the cold-expert one.

Set `COMPRESSED_MM_DETERMINISM_ITERS` to change the number of runs. The default is 50.

### Results on a Blackhole loudbox

| Run | Result | Time |
|---|---|---|
| DRAM and L1 determinism | 44 passed, 1 skipped | 72 s |
| Expert determinism (own session) | 6 passed | 15 s |
| Expert file, single device, no benchmark | 14 passed, 2 skipped | 99 s |
| Soak at 200 runs for each case | 44 passed, 1 skipped; then 6 passed | 113 s + 16 s |

### Notes for reviewers

**The expert tests need their own pytest session.** `per_core_allocation/conftest.py` sets `TT_METAL_ALLOCATOR_MODE_HYBRID` in a module-scoped fixture. That is too late if another file already opened the device, and the run stops with `Per-core allocation requires AllocatorMode::HYBRID`. This is not new. `test_hybrid_expert_1sram_1dram`, which this PR does not touch, fails the same way. The PR leaves it alone, but a reader who runs the three files together will meet it.

**The full expert file takes more than 60 minutes.** The multi-device cases and the benchmark cases hold that time. The single-device subset above takes 99 s.

**One case is skipped for a known error.** `test_matmul_custom_compressed_multicore` already skips a runtime implementation on 32 cores with anything but plain bfp8, because the output comes back constant. The new 32-core case reuses that skip and points to it. This PR does not find a new fault there.

**Two knobs of the tt-blaze port have no equivalent here.** The blaze DRAM matmul can divide K between the two cores of a bank, and can group two N columns in each block. `DRAMStreamingMatmulCompressed` does neither. Both change the DRAM read order. tenstorrent/tt-blaze#3928 covers them.

**The tests do not cover these conditions.**

- Each case keeps one device open. A fault that needs a device to open again stays invisible.
- The weights stay the same in all runs of a case. Only the formats change. A fault that depends on the weight values stays invisible.
- `op()` makes new metadata at each call, so the runs do not replay one program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/compressed-dram-matmul-determinism-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/compressed-dram-matmul-determinism-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/compressed-dram-matmul-determinism-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/compressed-dram-matmul-determinism-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/compressed-dram-matmul-determinism-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/compressed-dram-matmul-determinism-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/compressed-dram-matmul-determinism-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/compressed-dram-matmul-determinism-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/compressed-dram-matmul-determinism-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/compressed-dram-matmul-determinism-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/compressed-dram-matmul-determinism-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/compressed-dram-matmul-determinism-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/compressed-dram-matmul-determinism-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/compressed-dram-matmul-determinism-tests)