### PR TITLE
BMM kernels: remove inline ISA, gate unsupported SFPU off on Quasar

### DIFF
--- a/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/activations.h
@@ -6,16 +6,19 @@
 
 #include "api/compute/common_globals.h"
 #if defined(TRISC_MATH) || defined(TRISC_PACK)
+#ifndef ARCH_QUASAR
 #include "ckernel_sfpu_softsign.h"
 #include "ckernel_sfpu_softshrink.h"
 #include "ckernel_sfpu_hardshrink.h"
 #include "ckernel_sfpu_celu.h"
 #include "ckernel_sfpu_activations.h"
+#endif
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #endif
 
 namespace ckernel {
 
+#ifndef ARCH_QUASAR
 // clang-format off
 /**
 * Performs element-wise hardsigmoid operation. The DST
@@ -174,5 +177,6 @@ ALWI void hardshrink_tile(uint32_t idst, uint32_t param0) {
  * Please refer to documentation for any_init.
  */
 ALWI void hardshrink_tile_init() { MATH(SFPU_UNARY_INIT(hardshrink)); }
+#endif  // !ARCH_QUASAR
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/hardtanh.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/hardtanh.h
@@ -6,12 +6,15 @@
 
 #include "api/compute/common_globals.h"
 #if defined(TRISC_MATH) || defined(TRISC_PACK)
+#ifndef ARCH_QUASAR
 #include "ckernel_sfpu_hardtanh.h"
+#endif
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #endif
 
 namespace ckernel {
 
+#ifndef ARCH_QUASAR
 // clang-format off
  /**
  * Performs element-wise hardtanh operation. The DST
@@ -58,5 +61,6 @@ ALWI void hardtanh_tile_pack(uint32_t idst, uint32_t param0, uint32_t param1) {
 ALWI void hardtanh_tile_init() { MATH(SFPU_UNARY_INIT(hardtanh)); }
 
 ALWI void hardtanh_tile_init_pack() { PACK(SFPU_UNARY_INIT(hardtanh)); }
+#endif  // !ARCH_QUASAR
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
@@ -6,12 +6,15 @@
 
 #include "api/compute/common_globals.h"
 #if defined(TRISC_MATH) || defined(TRISC_PACK)
+#ifndef ARCH_QUASAR
 #include "ckernel_sfpu_selu.h"
+#endif
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #endif
 
 namespace ckernel {
 
+#ifndef ARCH_QUASAR
 // clang-format off
 /**
  * Performs element-wise computation of selu = scale * (max(0,x) + min(0, alpha * (exp(x)-1))), where x is each
@@ -60,5 +63,6 @@ ALWI void selu_tile_pack(uint32_t idst, uint32_t scale, uint32_t alpha) {
 ALWI void selu_tile_init() { MATH(SFPU_UNARY_INIT(selu)); }
 
 ALWI void selu_tile_init_pack() { PACK(SFPU_UNARY_INIT(selu)); }
+#endif  // !ARCH_QUASAR
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
@@ -25,6 +25,11 @@ struct ActivationInitHelper {
             ACT == KernelActivation::HARDSIGMOID || ACT == KernelActivation::HARDTANH ||
             ACT == KernelActivation::SELU || ACT == KernelActivation::SOFTPLUS,
         "Unsupported KernelActivation type for fused activation init");
+#ifdef ARCH_QUASAR
+    static_assert(
+        ACT == KernelActivation::NONE,
+        "Fused SFPU activations run on the packer; Quasar SFPU from pack is not supported.");
+#endif
 
     FORCE_INLINE static void init() {
         if constexpr (ACT == KernelActivation::SILU) {
@@ -66,6 +71,11 @@ struct ActivationApplyHelper {
     static_assert(
         ACT != KernelActivation::SOFTPLUS || PARAM0 != 0,
         "SOFTPLUS PARAM0 (beta) must be non-zero to avoid division by zero");
+#ifdef ARCH_QUASAR
+    static_assert(
+        ACT == KernelActivation::NONE,
+        "Fused SFPU activations run on the packer; Quasar SFPU from pack is not supported.");
+#endif
 
     FORCE_INLINE static void apply(uint32_t tile_index) {
         if constexpr (ACT == KernelActivation::SILU) {
@@ -103,6 +113,12 @@ struct ActivationApplyHelper {
 
 template <KernelActivation ACT, uint32_t PARAM0 = 0, uint32_t PARAM1 = 0, uint32_t PARAM2 = 0>
 FORCE_INLINE void apply_activation_from_pack(uint32_t out_subblock_num_tiles) {
+#ifdef ARCH_QUASAR
+    static_assert(
+        ACT == KernelActivation::NONE,
+        "Fused SFPU activations run on the packer; Quasar SFPU from pack is not supported.");
+    (void)out_subblock_num_tiles;
+#else
     PACK(TTI_SEMWAIT(
         p_stall::STALL_TDMA | p_stall::STALL_CFG, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_ZERO));
 
@@ -115,4 +131,5 @@ FORCE_INLINE void apply_activation_from_pack(uint32_t out_subblock_num_tiles) {
 
     // Wait for SFPU completion before packing
     PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
@@ -32,6 +32,7 @@ struct ActivationInitHelper {
 #endif
 
     FORCE_INLINE static void init() {
+#ifndef ARCH_QUASAR
         if constexpr (ACT == KernelActivation::SILU) {
             silu_tile_init_pack();
         } else if constexpr (ACT == KernelActivation::TANH) {
@@ -54,6 +55,7 @@ struct ActivationInitHelper {
         } else if constexpr (ACT == KernelActivation::SOFTPLUS) {
             softplus_tile_init_pack();
         }
+#endif
     }
 };
 
@@ -78,6 +80,9 @@ struct ActivationApplyHelper {
 #endif
 
     FORCE_INLINE static void apply(uint32_t tile_index) {
+#ifdef ARCH_QUASAR
+        (void)tile_index;
+#else
         if constexpr (ACT == KernelActivation::SILU) {
             silu_tile_pack(tile_index);
         } else if constexpr (ACT == KernelActivation::TANH) {
@@ -108,6 +113,7 @@ struct ActivationApplyHelper {
             // PARAM0 is beta, PARAM2 beta reciprocal, PARAM1 is threshold
             softplus_tile_pack(tile_index, PARAM0, PARAM2, PARAM1);
         }
+#endif
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -278,12 +278,12 @@ void kernel_main() {
 #ifdef PACK_RELU
                 // for each batch we start with relu disabled so that intermediate results are not relu'd
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
                 }
 #endif
 
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
-                    PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                    pack_reconfig_data_format(mm_partials_cb_id);
                 }
 
                 for (uint32_t block = 0; block < num_blocks_inner_dim; block++) {
@@ -292,22 +292,22 @@ void kernel_main() {
 #if not defined FUSE_BIAS and defined PACK_RELU
                     if (last_out) {
                         // if last block we pack the final result with relu enabled
-                        PACK((llk_pack_relu_config(ReluConfig::zero())));
+                        pack_relu_config(ReluConfig::zero());
                     }
 #endif
 
                     if constexpr (in0_transpose_tile) {
                         reconfig_data_format_srca(in1_cb_id, in0_transpose_cb_id);
                         transpose_init(in0_transpose_cb_id);
-                        PACK((pack_reconfig_data_format(in0_cb_id)));
+                        pack_reconfig_data_format(in0_cb_id);
 #ifdef PACKER_L1_ACC
-                        PACK((llk_pack_reconfig_l1_acc(0)));
+                        pack_reconfig_l1_acc(0);
 #endif
                         transpose_tile_block<in0_block_num_tiles>(in0_transpose_cb_id, in0_cb_id);
                         reconfig_data_format_srca(in0_transpose_cb_id, in1_cb_id);
                         matmul_block_init(
                             in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
-                        PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                        pack_reconfig_data_format(mm_partials_cb_id);
                     }
 
                     in0_cb.wait_front(in0_block_num_tiles);
@@ -384,18 +384,18 @@ void kernel_main() {
 #endif
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                                PACK((pack_reconfig_data_format(mm_out_cb_id)));
+                                pack_reconfig_data_format(mm_out_cb_id);
 #endif
 
 #ifdef PACKER_L1_ACC
 #ifdef FUSE_BIAS
                                 if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                    pack_reconfig_l1_acc(0);
                                 } else {
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 }
 #else
-                                PACK((llk_pack_reconfig_l1_acc(0)));
+                                pack_reconfig_l1_acc(0);
 #endif
 #endif
                                 uint32_t start_dst_index = 0;
@@ -411,13 +411,13 @@ void kernel_main() {
 
 #ifdef PACKER_L1_ACC
                                 if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                    pack_reconfig_l1_acc(0);
                                 } else if (block == 1) {
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 } else if (in0_transpose_tile) {
                                     // For each block, l1_acc would have been enabled during the
                                     // transpose stage. So let us put it back here.
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 }
 #endif
 
@@ -480,13 +480,13 @@ void kernel_main() {
 #ifdef FUSE_BIAS
 #ifdef PACK_RELU
                 // if last block we pack the final result with relu enabled
-                PACK((llk_pack_relu_config(ReluConfig::zero())));
+                pack_relu_config(ReluConfig::zero());
 #endif
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                PACK((pack_reconfig_data_format(out_cb_id)));
+                pack_reconfig_data_format(out_cb_id);
 #endif
 #ifdef PACKER_L1_ACC
-                PACK((llk_pack_reconfig_l1_acc(0)));
+                pack_reconfig_l1_acc(0);
 #endif
                 reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
                 if constexpr (row_broadcast_bias) {
@@ -558,15 +558,15 @@ void kernel_main() {
 #endif  // FUSE_BIAS
                 if constexpr (untilize_out) {
 #ifdef PACK_RELU
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
 #endif  // PACK_RELU
 #ifndef FUSE_BIAS
                     reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                    PACK((pack_reconfig_data_format(out_cb_id)));
+                    pack_reconfig_data_format(out_cb_id);
 #endif
 #ifdef PACKER_L1_ACC
-                    PACK((llk_pack_reconfig_l1_acc(0)));
+                    pack_reconfig_l1_acc(0);
 #endif
 #endif  // FUSE_BIAS
                     pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -535,24 +535,11 @@ void kernel_main() {
                         untilize_mode_out_cb.reserve_back(out_subblock_num_tiles);
 
 #ifdef SFPU_ACTIVATION
-                        PACK(TTI_SEMWAIT(
-                            p_stall::STALL_TDMA | p_stall::STALL_CFG,
-                            semaphore::t6_sem(semaphore::MATH_PACK),
-                            p_stall::STALL_ON_ZERO));
-
-                        // Flip destination register offset for PACKER access
-                        PACK(TT_SETC16(
-                            DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
-
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            ActivationApplyHelper<
-                                activation_type,
-                                activation_param0,
-                                activation_param1,
-                                activation_param2>::apply(i);
-                        }
-
-                        PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+                        apply_activation_from_pack<
+                            activation_type,
+                            activation_param0,
+                            activation_param1,
+                            activation_param2>(out_subblock_num_tiles);
 #else
                         tile_regs_wait();
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -283,12 +283,12 @@ void kernel_main() {
 #ifdef PACK_RELU
         // for each batch we start we relu disabled so that intermediate results are not relu'd
         if constexpr (batch > 1) {
-            PACK((llk_pack_relu_config(ReluConfig::none())));
+            pack_relu_config(ReluConfig::none());
         }
 #endif
 
         if constexpr (batch > 1) {
-            PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+            pack_reconfig_data_format(mm_partials_cb_id);
         }
 
         // Wait to receive in1
@@ -311,7 +311,7 @@ void kernel_main() {
 #if not defined FUSE_BIAS and defined PACK_RELU
             if (last_out) {
                 // if last block we pack the final result with relu enabled
-                PACK((llk_pack_relu_config(ReluConfig::zero())));
+                pack_relu_config(ReluConfig::zero());
             }
 #endif
 
@@ -405,12 +405,12 @@ void kernel_main() {
 #endif
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
-                        PACK((pack_reconfig_data_format(mm_out_cb_id)));
+                        pack_reconfig_data_format(mm_out_cb_id);
 #endif
 
 #ifdef PACKER_L1_ACC
 
-                        PACK((llk_pack_reconfig_l1_acc(0)));
+                        pack_reconfig_l1_acc(0);
 #endif
 
                         uint32_t start_dst_index = 0;
@@ -434,9 +434,9 @@ void kernel_main() {
 
 #ifdef PACKER_L1_ACC
                         if (block == 0) {  // no accumulation for first iteration
-                            PACK((llk_pack_reconfig_l1_acc(0)));
+                            pack_reconfig_l1_acc(0);
                         } else if (block == 1) {
-                            PACK((llk_pack_reconfig_l1_acc(1)));
+                            pack_reconfig_l1_acc(1);
                         }
 #endif
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -546,24 +546,11 @@ void kernel_main() {
                         untilize_mode_out_dfb.reserve_back(out_subblock_num_tiles);
 
 #ifdef SFPU_ACTIVATION
-                        PACK(TTI_SEMWAIT(
-                            p_stall::STALL_TDMA | p_stall::STALL_CFG,
-                            semaphore::t6_sem(semaphore::MATH_PACK),
-                            p_stall::STALL_ON_ZERO));
-
-                        // Flip destination register offset for PACKER access
-                        PACK(TT_SETC16(
-                            DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
-
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            ActivationApplyHelper<
-                                activation_type,
-                                activation_param0,
-                                activation_param1,
-                                activation_param2>::apply(i);
-                        }
-
-                        PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+                        apply_activation_from_pack<
+                            activation_type,
+                            activation_param0,
+                            activation_param1,
+                            activation_param2>(out_subblock_num_tiles);
 #else
                         tile_regs_wait();
 #endif


### PR DESCRIPTION
### PR Category
Bug fix, Cleanup

### Issue 
https://github.com/tenstorrent/tt-metal/issues/54329

### Summary
- Remove inline ISA register pokes (`TTI_SEMWAIT` / `TT_SETC16` / `TTI_STALLWAIT`) from the
  BMM compute kernels by moving the packer-thread SFPU activation sequence into
  `apply_activation_from_pack<>` in `bmm_fused_activation.hpp`.
- Convert direct LLK calls in those kernels to their Compute API equivalents:
  `PACK((llk_pack_relu_config(...)))` → `pack_relu_config(...)`,
  `PACK((llk_pack_reconfig_l1_acc(n)))` → `pack_reconfig_l1_acc(n)`,
  `PACK((pack_reconfig_data_format(x)))` → `pack_reconfig_data_format(x)`.
- Guard off the activations that Quasar cannot run, in `activations.h`, `hardtanh.h` and
  `selu.h`. This covers both the pack-thread variants (Quasar has no pack-thread SFPU) and the
  **math-thread ops that are simply unimplemented there** — `softsign_tile`, `celu_tile`,
  `softshrink_tile`, `hardshrink_tile`, `hardsigmoid_tile`, `hardtanh_tile`, `selu_tile`. None of
  `ckernel_sfpu_{activations,hardtanh,selu,celu,softsign,softshrink,hardshrink}.h` exist under
  `hw/ckernels/quasar`, so the whole declaration is guarded, matching the existing convention for
  ops absent on an arch (for instance `pack_rows*` in `pack.h`).
- Make `bmm_fused_activation.hpp` fail with a clear `static_assert` on Quasar rather than
  undeclared-function errors. The method bodies are guarded too — the non-dependent calls inside
  them break parsing before the assert can fire.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/resnet_cleanup_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/resnet_cleanup_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/resnet_cleanup_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/resnet_cleanup_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/resnet_cleanup_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/resnet_cleanup_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/resnet_cleanup_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/resnet_cleanup_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/resnet_cleanup_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/resnet_cleanup_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/resnet_cleanup_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/resnet_cleanup_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/resnet_cleanup_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/resnet_cleanup_v3)