### PR TITLE
sim: make CQ wait clock pumping configurable

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -189,4 +189,40 @@ TEST_F(TdpLimitEnvFixture, CPU_MalformedEnvVarThrows) {
     EXPECT_ANY_THROW(llrt::RunTimeOptions());
 }
 
+constexpr const char* kSimulatorCqWaitClocksEnvVar = "TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS";
+
+class SimulatorCqWaitClocksEnvFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const char* previous = getenv(kSimulatorCqWaitClocksEnvVar);
+        previous_ = previous != nullptr ? std::optional<std::string>(previous) : std::nullopt;
+    }
+
+    void TearDown() override {
+        if (previous_.has_value()) {
+            setenv(kSimulatorCqWaitClocksEnvVar, previous_->c_str(), /*overwrite=*/1);
+        } else {
+            unsetenv(kSimulatorCqWaitClocksEnvVar);
+        }
+    }
+
+private:
+    std::optional<std::string> previous_;
+};
+
+TEST_F(SimulatorCqWaitClocksEnvFixture, CPU_ParsesPositiveDecimalValue) {
+    unsetenv(kSimulatorCqWaitClocksEnvVar);
+    EXPECT_EQ(llrt::RunTimeOptions().get_simulator_cq_wait_clocks(), 1u);
+
+    setenv(kSimulatorCqWaitClocksEnvVar, "64", /*overwrite=*/1);
+    EXPECT_EQ(llrt::RunTimeOptions().get_simulator_cq_wait_clocks(), 64u);
+}
+
+TEST_F(SimulatorCqWaitClocksEnvFixture, CPU_RejectsInvalidValues) {
+    for (const char* value : {"", "0", "-1", "0x40", "12abc", "4294967296"}) {
+        setenv(kSimulatorCqWaitClocksEnvVar, value, /*overwrite=*/1);
+        EXPECT_ANY_THROW(llrt::RunTimeOptions()) << "value: " << value;
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -50,6 +50,15 @@ bool wrap_ge(uint32_t a, uint32_t b) {
     return diff >= 0;
 }
 
+void advance_simulator_cq_wait(MetalContext& ctx, uint32_t device_id) {
+    if (!ctx.rtoptions().get_simulator_enabled()) {
+        return;
+    }
+    for (uint32_t i = 0; i < ctx.rtoptions().get_simulator_cq_wait_clocks(); ++i) {
+        ctx.get_cluster().advance_device_execution(device_id);
+    }
+}
+
 // Cancellable timeout wrapper: invokes on_timeout() before throwing and waits for task to exit
 // Please note that the FuncBody is going to loop until the FuncWait returns false.
 // GetProgress is optional - if provided, timeout only triggers if BOTH wait_condition is true AND no progress made
@@ -710,8 +719,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         auto fetch_operation_body = [&]() {
             ctx.get_cluster().read_core(&fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
-            // Yield to clock the simulator when running on TTSim; no-op on real hardware.
-            ctx.get_cluster().advance_device_execution(this->device_id);
+            advance_simulator_cq_wait(ctx, this->device_id);
         };
 
         // Condition to check if should continue waiting
@@ -769,8 +777,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
         write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->context_id, this->device_id, cq_id, this->cq_size);
         write_ptr = write_ptr_and_toggle & 0x7fffffff;
         write_toggle = write_ptr_and_toggle >> 31;
-        // Yield to clock the simulator when running on TTSim; no-op on real hardware.
-        tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().advance_device_execution(this->device_id);
+        advance_simulator_cq_wait(tt::tt_metal::MetalContext::instance(this->context_id), this->device_id);
     };
 
     // Condition to check if the operation should continue

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -286,15 +286,16 @@ bool is_env_enabled(const char* value) { return value && value[0] == '1'; }
 uint32_t parse_uint32_env(const char* name, const char* value) {
     TT_FATAL(value != nullptr && value[0] != '\0', "{} must not be empty", name);
     std::string text(value);
-    TT_FATAL(text[0] != '-', "{} must be a non-negative integer, got '{}'", name, text);
+    TT_FATAL(text[0] != '-', "{} must be a positive decimal integer, got '{}'", name, text);
     size_t parse_pos = 0;
     unsigned long long parsed = 0;
     try {
-        parsed = std::stoull(text, &parse_pos, 0);
+        parsed = std::stoull(text, &parse_pos, 10);
     } catch (const std::exception& e) {
-        TT_FATAL(false, "{} must be a non-negative integer, got '{}': {}", name, text, e.what());
+        TT_FATAL(false, "{} must be a positive decimal integer, got '{}': {}", name, text, e.what());
     }
     TT_FATAL(parse_pos == text.size(), "{} has trailing characters in '{}'", name, text);
+    TT_FATAL(parsed > 0, "{} must be greater than zero", name);
     TT_FATAL(parsed <= std::numeric_limits<uint32_t>::max(), "{} exceeds uint32_t max: {}", name, text);
     return static_cast<uint32_t>(parsed);
 }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -118,6 +118,7 @@ enum class EnvVarID {
     TT_METAL_DISABLE_SFPLOADMACRO,                      // Disable use of SFPLOADMACRO instructions
     TT_METAL_DRAM_BACKED_CQ,                            // Store command queues in device DRAM
     TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,            // Simulator tensor preload bypasses FD CQ copies
+    TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS,                  // Simulator clocks to pump from CQ wait loops
     TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES,  // Override Blackhole DRAM programmable cores
     TT_METAL_MEASURE_DFB_INIT_TIME,  // Temporary DFB init rdcycle instrumentation (deprecate once device profiler
                                      // covers this).
@@ -281,6 +282,22 @@ std::string normalize_path(const char* path, const std::string& subdir = "") {
 
 // Helper function to check if environment variable value is "1" (enabled)
 bool is_env_enabled(const char* value) { return value && value[0] == '1'; }
+
+uint32_t parse_uint32_env(const char* name, const char* value) {
+    TT_FATAL(value != nullptr && value[0] != '\0', "{} must not be empty", name);
+    std::string text(value);
+    TT_FATAL(text[0] != '-', "{} must be a non-negative integer, got '{}'", name, text);
+    size_t parse_pos = 0;
+    unsigned long long parsed = 0;
+    try {
+        parsed = std::stoull(text, &parse_pos, 0);
+    } catch (const std::exception& e) {
+        TT_FATAL(false, "{} must be a non-negative integer, got '{}': {}", name, text, e.what());
+    }
+    TT_FATAL(parse_pos == text.size(), "{} has trailing characters in '{}'", name, text);
+    TT_FATAL(parsed <= std::numeric_limits<uint32_t>::max(), "{} exceeds uint32_t max: {}", name, text);
+    return static_cast<uint32_t>(parsed);
+}
 
 std::string trim_copy(const std::string& input) {
     auto first = std::find_if_not(input.begin(), input.end(), [](unsigned char ch) { return std::isspace(ch); });
@@ -850,6 +867,14 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Usage: export TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1
         case EnvVarID::TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES:
             this->simulator_direct_tensor_writes = is_env_enabled(value);
+            break;
+
+        // TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS
+        // Number of simulator clocks to pump from each CQ wait loop iteration.
+        // Default: 1 (preserve existing simulator behavior)
+        // Usage: export TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS=64
+        case EnvVarID::TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS:
+            this->simulator_cq_wait_clocks = parse_uint32_env("TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS", value);
             break;
 
         // TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -389,6 +389,9 @@ class RunTimeOptions {
     // Bypass FD CQ payload copies for simulator tensor preloads (TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1)
     bool simulator_direct_tensor_writes = false;
 
+    // Number of simulator clocks to pump from CQ wait loops.
+    uint32_t simulator_cq_wait_clocks = 1;
+
     // To be used for NUMA node based thread binding
     bool numa_based_affinity = false;
 
@@ -933,6 +936,8 @@ public:
     void set_dram_backed_cq(bool enable) { dram_backed_cq = enable; }
 
     bool get_simulator_direct_tensor_writes() const { return simulator_direct_tensor_writes; }
+
+    uint32_t get_simulator_cq_wait_clocks() const { return simulator_cq_wait_clocks; }
 
     std::optional<uint32_t> get_fabric_router_sync_timeout_ms() const { return fabric_router_sync_timeout_ms; }
 


### PR DESCRIPTION
## Summary

Make simulator progress during command-queue waits configurable while preserving the existing one-clock default:

- centralize simulator-only CQ clock advancement;
- add `TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS` with strict unsigned parsing;
- use the configured clock count in reserve-back and completion-front wait loops; and
- pin the validated CRAQ-compatible UMD candidate for end-to-end testing.

This is the replacement for closed PR #55460. The integration branch was rebuilt on current Metal `main` after `main` advanced, so the old PR head is intentionally not reused.

## Validation

- `git diff --check`
- Release artifact and wheel build passed on the prior candidate
- Metal PR CI is being rerun on the rebuilt current-main candidate
- CRAQ-Sim P150 and H2D/D2H gates are being run with exact dependency SHAs

## Dependency chain

- UMD: `76058cabad01aa104cba5b2505cacc9e028e50e5` (PR #3385)
- Metal candidate: `10353cf444454547849fba41799b070a0d0db864`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/craq-sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/craq-sim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/craq-sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/craq-sim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/craq-sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/craq-sim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/craq-sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/craq-sim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/craq-sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/craq-sim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/craq-sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/craq-sim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/craq-sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/craq-sim)