### PR TITLE
Speeding up DEVICE_PRINT tests

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -351,7 +351,7 @@ protected:
         }
     }
 
-    static std::string DevicePrintConfigFingerprint() {
+    std::string DevicePrintConfigFingerprint() const {
         const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
         const auto targets = rtoptions.get_feature_targets(tt::llrt::RunTimeDebugFeatureDprint);
         std::string fingerprint = fmt::format(
@@ -361,6 +361,11 @@ protected:
             targets.one_file_per_risc,
             targets.prepend_device_core_risc,
             rtoptions.get_checkpoint_enabled());
+        fingerprint += fmt::format(
+            " l1_small={} trace_region={} dispatch_full_us={}",
+            l1_small_size_,
+            trace_region_size_,
+            rtoptions.get_device_print_dispatch_full_us());
         fingerprint += " chip_ids=[";
         for (int chip_id : targets.chip_ids) {
             fingerprint += fmt::format("{},", chip_id);

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -40,6 +40,11 @@ protected:
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
 
     void SetUp() override {
+        TT_FATAL(
+            !get_shared_devices().initialized,
+            "Shared DEVICE_PRINT devices are still open. A DevicePrint suite must release them in "
+            "TearDownTestSuite before a per-test fixture opens its own devices.");
+
         std::vector<ChipId> ids;
         for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
             ids.push_back(id);
@@ -255,10 +260,21 @@ protected:
 };
 
 class DevicePrintFixture : public DebugToolsMeshFixture {
+public:
+    static constexpr uint32_t kTestDispatchFullUs = 2000;
+
+    static void TearDownTestSuite() { ReleaseSharedDevices(); }
+
+    void RequestFreshDevicesAfterThisTest() { request_fresh_devices_ = true; }
+
 protected:
     int memfd_ = -1;
+    bool request_fresh_devices_{};
     tt::llrt::TargetSelection dprint_previous_targets_{};
     bool test_mode_previous_{};
+    uint32_t dispatch_full_us_previous_{};
+    bool dispatch_full_us_lowered_{};
+    inline static std::string shared_devices_fingerprint_;
 
     void SetUp() override {
         // Save previous DPRINT / test-mode state so TearDown can restore it. TearDown runs even
@@ -295,26 +311,109 @@ protected:
         rtoptions.set_test_mode_enabled(true);
         rtoptions.set_watcher_enabled(false);
 
-        ExtraSetUp();
+        dispatch_full_us_previous_ = rtoptions.get_device_print_dispatch_full_us();
+        dispatch_full_us_lowered_ = (getenv("TT_METAL_DEVICE_PRINT_DISPATCH_FULL_US") == nullptr);
+        if (dispatch_full_us_lowered_) {
+            rtoptions.set_device_print_dispatch_full_us(kTestDispatchFullUs);
+        }
 
-        // Parent class initializes devices and any necessary flags
-        DebugToolsMeshFixture::SetUp();
+        ExtraSetUp();
+        AcquireSharedDevices();
+
+        if (const auto& dprint_server = MetalContext::instance().dprint_server()) {
+            dprint_server->reset_for_new_run();
+        }
     }
 
     void TearDown() override {
-        // Parent class tears down devices
-        DebugToolsMeshFixture::TearDown();
+        auto& shared = get_shared_devices();
+        const auto& dprint_server = MetalContext::instance().dprint_server();
+        if (HasFailure() || request_fresh_devices_ || (dprint_server && dprint_server->hang_detected())) {
+            shared.needs_recovery = true;
+        }
+        request_fresh_devices_ = false;
+        this->devices_.clear();
+        this->id_to_device_.clear();
+
         ExtraTearDown();
 
         auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
         rtoptions.set_feature_targets(tt::llrt::RunTimeDebugFeatureDprint, dprint_previous_targets_);
         rtoptions.set_test_mode_enabled(test_mode_previous_);
         rtoptions.set_watcher_enabled(watcher_previous_enabled);
+        if (dispatch_full_us_lowered_) {
+            rtoptions.set_device_print_dispatch_full_us(dispatch_full_us_previous_);
+        }
 
         if (memfd_ >= 0) {
             close(memfd_);
             memfd_ = -1;
         }
+    }
+
+    static std::string DevicePrintConfigFingerprint() {
+        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        const auto targets = rtoptions.get_feature_targets(tt::llrt::RunTimeDebugFeatureDprint);
+        std::string fingerprint = fmt::format(
+            "enabled={} all_chips={} one_file_per_risc={} prepend={} checkpoint={}",
+            targets.enabled,
+            targets.all_chips,
+            targets.one_file_per_risc,
+            targets.prepend_device_core_risc,
+            rtoptions.get_checkpoint_enabled());
+        fingerprint += " chip_ids=[";
+        for (int chip_id : targets.chip_ids) {
+            fingerprint += fmt::format("{},", chip_id);
+        }
+        fingerprint += "] mesh_coords=[";
+        for (const auto& [row, col] : targets.mesh_coords) {
+            fingerprint += fmt::format("({},{}),", row, col);
+        }
+        fingerprint += "] all_cores=[";
+        for (const auto& [core_type, debug_class] : targets.all_cores) {
+            fingerprint += fmt::format("{}:{},", static_cast<int>(core_type), debug_class);
+        }
+        fingerprint += "] cores=[";
+        for (const auto& [core_type, core_coords] : targets.cores) {
+            fingerprint += fmt::format("{}:", static_cast<int>(core_type));
+            for (const auto& core : core_coords) {
+                fingerprint += fmt::format("{}-{};", core.x, core.y);
+            }
+        }
+        fingerprint += "]";
+        return fingerprint;
+    }
+
+    void AcquireSharedDevices() {
+        auto& shared = get_shared_devices();
+        const std::string fingerprint = DevicePrintConfigFingerprint();
+        if (shared.initialized && (shared.needs_recovery || fingerprint != shared_devices_fingerprint_)) {
+            ReleaseSharedDevices();
+        }
+        if (!shared.initialized) {
+            create_shared_devices(l1_small_size_, trace_region_size_);
+            shared_devices_fingerprint_ = fingerprint;
+            log_info(tt::LogTest, "DEVICE_PRINT: opened shared devices for config {}", fingerprint);
+        }
+        this->id_to_device_ = shared.id_to_device;
+        this->devices_ = shared.devices;
+
+        this->DetectDispatchMode();
+        this->arch_ = tt::tt_metal::MetalContext::instance().get_cluster().arch();
+        init_max_cbs();
+    }
+
+    static void ReleaseSharedDevices() {
+        auto& shared = get_shared_devices();
+        if (!shared.initialized) {
+            shared_devices_fingerprint_.clear();
+            return;
+        }
+
+        destroy_shared_devices();
+
+        // Deliberately NOT calling MetalContext::teardown() here.
+        shared_devices_fingerprint_.clear();
     }
 
     // Override this function in child classes for additional setup commands between DPRINT setup

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
@@ -41,8 +41,17 @@ constexpr uint32_t NUM_CORES = 2;
 // Fixture: DevicePrintFixture with checkpoint enabled
 class DevicePrintCheckpointTest : public DevicePrintFixture {
 protected:
-    void ExtraSetUp() override { tt::tt_metal::MetalContext::instance().rtoptions().set_checkpoint_enabled(true); }
-    void ExtraTearDown() override { tt::tt_metal::MetalContext::instance().rtoptions().set_checkpoint_enabled(false); }
+    void ExtraSetUp() override {
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        checkpoint_previous_ = rtoptions.get_checkpoint_enabled();
+        rtoptions.set_checkpoint_enabled(true);
+    }
+    void ExtraTearDown() override {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_checkpoint_enabled(checkpoint_previous_);
+    }
+
+private:
+    bool checkpoint_previous_{};
 };
 
 // Helper: create standard DRAM buffers, CBs, and run program on single core

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
@@ -102,6 +102,7 @@ TEST_F(DevicePrintFixture, IdleEthTestPrint) {
         log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
+    this->RequestFreshDevicesAfterThisTest();
     for (auto& mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
         // Skip if no ethernet cores on this device

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
@@ -75,6 +75,7 @@ void ConfigureDevicePrintForCoord(
     rtopts.set_feature_prepend_device_core_risc(kDprint, true);
     rtopts.set_feature_mesh_coords(kDprint, {{row, col}});
     rtopts.set_feature_all_chips(kDprint, false);
+    rtopts.resolve_mesh_coords_to_chip_ids(MetalContext::instance().get_system_mesh());
 }
 
 // Builds a MeshWorkload where each device DEVICE_PRINTs its global mesh coordinate (row, col).
@@ -168,15 +169,11 @@ void RunAllChipsVerificationTest(
 }  // namespace
 
 void DevicePrintMeshCoordsFixture::ExtraSetUp() {
-    // Teardown forces MetalContext to re-initialize (including resolve_mesh_coords_to_chip_ids)
-    // when devices are opened by DebugToolsMeshFixture::SetUp().  Re-apply rtoptions afterwards
-    // because ParseAllFeatureEnv resets them to defaults on re-initialization.
-    MetalContext::instance().teardown();
     CMAKE_UNIQUE_NAMESPACE::ConfigureDevicePrintForCoord(
         MetalContext::instance().rtoptions(), dprint_file_name, target_coord.first, target_coord.second);
 }
 
-void DevicePrintMeshCoordsFixture::ExtraTearDown() { MetalContext::instance().teardown(); }
+void DevicePrintMeshCoordsFixture::ExtraTearDown() {}
 
 // Test 1: Only the device at mesh coord (0,0) should produce DEVICE_PRINT output.
 TEST_F(DevicePrintMeshCoordsFixture, TensixTestDevicePrintMeshCoordsFiltersCorrectDevice) {

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
@@ -42,10 +42,6 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_chip_ids(
             tt::llrt::RunTimeDebugFeatureDprint, {});
     }
-    void ExtraTearDown() override {
-        MetalContext::instance()
-            .teardown();  // Teardown dprint server so we can re-init later with all devices enabled again
-    }
 };
 
 namespace {

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
@@ -42,8 +42,6 @@ void RunTest(DevicePrintFixture* fixture, const std::shared_ptr<distributed::Mes
     uint32_t delay_cycles = clk_mhz * 4000000;  // 4 seconds
     const std::vector<uint32_t> args = {delay_cycles, xy_start.x, xy_start.y};
     fixture->RunProgram(mesh_device, "tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp", args);
-    // Close system instantly after running to attempt to cut off prints.
-    fixture->TearDownTestSuite();
 
     // Check the print log against expected output.
     vector<std::string> expected_output;

--- a/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
@@ -10,6 +10,7 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include "internal/debug/watcher_common.h"
 #include "internal/hw_thread.h"
+#include "api/debug/device_print.h"
 
 #if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
@@ -112,6 +113,7 @@ void __attribute__((noinline)) Application(void) {
     }
     WAYPOINT("RED");
 
+    DEVICE_PRINT_INITIALIZE_LOCK();
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
     DeviceProfilerInit();
     while (routing_info->routing_enabled) {
@@ -141,6 +143,7 @@ void __attribute__((noinline)) Application(void) {
                 WAYPOINT("D");
             }
             mailboxes->go_messages[0].signal = RUN_MSG_DONE;
+            DEVICE_PRINT_KERNEL_FINISHED();
 
             if (launch_msg_address->kernel_config.mode == DISPATCH_MODE_DEV) {
                 launch_msg_address->kernel_config.enables = 0;

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -546,15 +546,17 @@ void DPrintServer::Impl::print_buffer_data(
                 risc_data.warned_missing_parser = true;
                 log_warning(
                     tt::LogMetal,
-                    "DEVICE_PRINT: dropping messages from device {} core ({},{}) risc {}: no ELF parser "
-                    "resolved (is_kernel={}, info_id={}). The core is printing but never announced its "
-                    "kernel id; its firmware may be missing DEVICE_PRINT_KERNEL_FINISHED().",
+                    "DEVICE_PRINT: dropping messages from device {} core ({},{}) risc {}: no {} ELF "
+                    "parser resolved (info_id={}). {}",
                     device_id,
                     logical_core.coord.x,
                     logical_core.coord.y,
                     header->risc_id,
-                    header->is_kernel,
-                    header->info_id);
+                    header->is_kernel ? "kernel" : "firmware",
+                    header->info_id,
+                    header->is_kernel ? "The core is printing but never announced its kernel id; its firmware may be "
+                                        "missing DEVICE_PRINT_KERNEL_FINISHED()."
+                                      : "The firmware ELF could not be found for this risc.");
             }
 
             // Move to the next message
@@ -1345,6 +1347,7 @@ void DPrintServer::Impl::reset_for_new_run() {
         risc_data.kernel_elf_path.clear();
         risc_data.kernel_elf_parser.reset();
         risc_data.last_loaded_kernel_id = -1;
+        risc_data.warned_missing_parser = false;
     }
 }  // reset_for_new_run
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -173,6 +173,7 @@ public:
     void attach_devices();
     void detach_devices();
     void clear_log_file();
+    void reset_for_new_run();
     bool reads_dispatch_cores(ChipId device_id) { return device_reads_dispatch_cores_[device_id]; }
     bool hang_detected() { return server_killed_due_to_hang_; }
 
@@ -260,6 +261,7 @@ private:
         std::string message_buffer;
         std::optional<std::string> line_prefix;
         int last_loaded_kernel_id = -1;
+        bool warned_missing_parser = false;
     };
 
     std::map<RiscKey, RiscData, RiscKeyComparator> risc_data_;
@@ -300,6 +302,11 @@ private:
 
     ofstream* outfile_ = nullptr;  // non-cout
     ostream* stream_ = nullptr;    // either == outfile_ or is &cout
+    std::mutex print_state_lock_;
+
+    // Opens (or re-opens) the output stream(s) per the current RTOptions.
+    // REQUIRES print_state_lock_ to be held.
+    void reconfigure_output();
 
     // For printing each risc's dprint to a separate file, a map from {device id, core, risc index} to files.
     std::map<RiscKey, ofstream*, RiscKeyComparator> risc_to_file_stream_;
@@ -535,6 +542,19 @@ void DPrintServer::Impl::print_buffer_data(
                         }
                     }
                 }
+            } else if (!risc_data.warned_missing_parser) {
+                risc_data.warned_missing_parser = true;
+                log_warning(
+                    tt::LogMetal,
+                    "DEVICE_PRINT: dropping messages from device {} core ({},{}) risc {}: no ELF parser "
+                    "resolved (is_kernel={}, info_id={}). The core is printing but never announced its "
+                    "kernel id; its firmware may be missing DEVICE_PRINT_KERNEL_FINISHED().",
+                    device_id,
+                    logical_core.coord.x,
+                    logical_core.coord.y,
+                    header->risc_id,
+                    header->is_kernel,
+                    header->info_id);
             }
 
             // Move to the next message
@@ -950,12 +970,7 @@ DPrintServer::Impl::Impl(
     }
 
     // Set the output stream according to RTOptions, either a file name or stdout if none specified.
-    std::filesystem::path output_dir(env_.get_rtoptions().get_logs_dir() + logfile_path);
-    std::filesystem::create_directories(output_dir);
-    if (!file_name.empty() && !one_file_per_risc) {
-        outfile_ = new ofstream(file_name);
-    }
-    stream_ = outfile_ ? outfile_ : &std::cout;
+    reconfigure_output();
 
     // Spin off the thread that runs the print server.
     print_server_thread_ = new std::thread([this] { poll_print_data(); });
@@ -1284,17 +1299,54 @@ void DPrintServer::Impl::detach_device(ChipId device_id) {
 }  // detach_device
 
 void DPrintServer::Impl::clear_log_file() {
+    std::lock_guard lock(print_state_lock_);
+    reconfigure_output();
+}  // clear_log_file
+
+void DPrintServer::Impl::reconfigure_output() {
+    // Close previous file
     if (outfile_) {
-        auto& rtoptions = env_.get_rtoptions();
-        // Just close the file and re-open it (without append) to clear it.
         outfile_->close();
         delete outfile_;
-
-        string file_name = rtoptions.get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
-        outfile_ = new ofstream(file_name);
-        stream_ = outfile_ ? outfile_ : &std::cout;
+        outfile_ = nullptr;
     }
-}  // clear_log_file
+
+    // Configure for new state
+    auto& rtoptions = env_.get_rtoptions();
+    const bool one_file_per_risc = rtoptions.get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint);
+    string file_name = rtoptions.get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
+    std::filesystem::path output_dir(rtoptions.get_logs_dir() + logfile_path);
+    std::filesystem::create_directories(output_dir);
+
+    if (!file_name.empty() && !one_file_per_risc) {
+        outfile_ = new ofstream(file_name);
+    }
+    stream_ = outfile_ ? outfile_ : &std::cout;
+}  // reconfigure_output
+
+void DPrintServer::Impl::reset_for_new_run() {
+    std::lock_guard lock(print_state_lock_);
+
+    reconfigure_output();
+
+    // Clean up existing per-risc file streams.
+    for (auto& [risc_key, risc_stream] : risc_to_file_stream_) {
+        if (risc_stream != nullptr) {
+            risc_stream->close();
+            delete risc_stream;
+        }
+    }
+    risc_to_file_stream_.clear();
+
+    // Reset per-risc decode state.
+    for (auto& [risc_key, risc_data] : risc_data_) {
+        risc_data.message_buffer.clear();
+        risc_data.line_prefix.reset();
+        risc_data.kernel_elf_path.clear();
+        risc_data.kernel_elf_parser.reset();
+        risc_data.last_loaded_kernel_id = -1;
+    }
+}  // reset_for_new_run
 
 void DPrintServer::Impl::poll_print_data() {
     // Give the print server thread a reasonable name.
@@ -1317,13 +1369,16 @@ void DPrintServer::Impl::poll_print_data() {
 
         // Flag for whether any new print data was found in this round of polling.
         bool new_data_this_iter = false;
-        for (auto& device_and_cores : device_to_core_range_copy) {
-            ChipId device_id = device_and_cores.first;
-            new_data_this_iter |= poll_device_print_data(device_id, device_and_cores.second);
+        {
+            std::lock_guard state_lock(print_state_lock_);
+            for (auto& device_and_cores : device_to_core_range_copy) {
+                ChipId device_id = device_and_cores.first;
+                new_data_this_iter |= poll_device_print_data(device_id, device_and_cores.second);
 
-            // If this read detected a print hang, stop processing prints.
-            if (server_killed_due_to_hang_) {
-                return;
+                // If this read detected a print hang, stop processing prints.
+                if (server_killed_due_to_hang_) {
+                    return;
+                }
             }
         }
 
@@ -1423,6 +1478,7 @@ void DPrintServer::await() { impl_->await(); }
 void DPrintServer::attach_devices() { impl_->attach_devices(); }
 void DPrintServer::detach_devices() { impl_->detach_devices(); }
 void DPrintServer::clear_log_file() { impl_->clear_log_file(); }
+void DPrintServer::reset_for_new_run() { impl_->reset_for_new_run(); }
 bool DPrintServer::reads_dispatch_cores(ChipId device_id) { return impl_->reads_dispatch_cores(device_id); }
 bool DPrintServer::hang_detected() { return impl_->hang_detected(); }
 std::vector<umd::CoreDescriptor> DPrintServer::get_print_cores(ChipId device_id) const {

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -54,6 +54,10 @@ public:
     // Clears the log file of a currently-running print server.
     void clear_log_file();
 
+    // Prepares a long-lived print server to serve a fresh run (i.e. the next test in a suite that
+    // shares one set of open devices).
+    void reset_for_new_run();
+
     bool reads_dispatch_cores(ChipId device_id);
 
     // Returns the list of cores the print server polls for the given device.


### PR DESCRIPTION
Reducing number of times device needs to be (re)initialized. Test execution time went from `85.1s` to `17.1s` when kernels are already compiled. If kernel cache is empty `180s` down to `99s`.
Fixing small bug in `erisc.cc`, added DEVICE_PRINT initialization and deinitialization.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/speedup_device_print_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/speedup_device_print_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/speedup_device_print_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/speedup_device_print_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/speedup_device_print_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/speedup_device_print_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/speedup_device_print_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/speedup_device_print_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/speedup_device_print_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/speedup_device_print_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/speedup_device_print_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/speedup_device_print_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/speedup_device_print_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/speedup_device_print_tests)