### PR TITLE
[Cleanup] Remove llk api hw config calls for BH in binary_ng/ and experimental/quasar/binary_ng

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
@@ -61,9 +61,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -64,9 +64,6 @@ void kernel_main() {
         exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
         PREPROCESS(LHS, CircularBuffer(cb_pre_lhs), exp_cb_post_lhs, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_lhs.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -68,9 +68,6 @@ ALWI void process_tile(
         exp_cb_raw_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
         PREPROCESS(OTHER_OP, CircularBuffer(cb_llk_post), exp_cb_post_other, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_other.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
@@ -61,9 +61,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -81,7 +81,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -92,7 +92,6 @@ void kernel_main() {
         exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         PREPROCESS(LHS, CircularBuffer(cb_pre_lhs), exp_cb_post_lhs, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_lhs.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -89,7 +89,6 @@ ALWI void process_tile(
         exp_cb_raw_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         PREPROCESS(OTHER_OP, CircularBuffer(cb_llk_post), exp_cb_post_other, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_other.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -81,7 +81,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -69,7 +69,6 @@ void kernel_main() {
         exp_dfb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         exp_dfb_out.reserve_back(num_tiles_per_cycle);
         exp_dfb_llk_post.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -71,7 +71,6 @@ ALWI void process_tile(
         exp_dfb_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(CB_OTHER);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         exp_dfb_out.reserve_back(num_tiles_per_cycle);
         exp_dfb_llk_post.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_col_bcast_dfb.cpp
@@ -91,9 +91,7 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_bcast_dfb.cpp
@@ -98,9 +98,7 @@ void kernel_main() {
         dfb_bcast.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
         // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without
         // this the gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out)
         // writes the wrong buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_row_col_bcast_dfb.cpp
@@ -104,9 +104,7 @@ ALWI void process_tile(
         dfb_raw_row.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
         // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this
         // the gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the
         // wrong buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_scalar_bcast_dfb.cpp
@@ -94,9 +94,7 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_col_bcast_dfb.cpp
@@ -117,9 +117,7 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_bcast_dfb.cpp
@@ -136,9 +136,7 @@ void kernel_main() {
         dfb_bcast.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
         // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without
         // this the gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out)
         // writes the wrong buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_row_col_bcast_dfb.cpp
@@ -126,9 +126,7 @@ ALWI void process_tile(
         dfb_raw_row.pop_front(num_tiles_per_cycle);
 
         pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
         // Retarget the packer destination ring back to dfb_out for the binary-op pack below (see above).
         pack_init(dfb_out_id);
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_scalar_bcast_dfb.cpp
@@ -119,9 +119,7 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(dfb_llk_post_id, dfb_out_id);
-#if defined(ARCH_BLACKHOLE)
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out_id)));
-#elif defined(ARCH_QUASAR)
+#ifdef ARCH_QUASAR
     // Retarget the packer destination ring back to dfb_out for the binary-op pack below; without this the
     // gasket-only pack_reconfig above leaves the ring on llk_post and pack_tile(0, out) writes the wrong
     // buffer (the ~constant-output symptom). Mirrors eltwise_utils_dfb.hpp.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast.cpp
@@ -59,9 +59,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -65,9 +65,6 @@ void kernel_main() {
         exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
         PREPROCESS(LHS, DataflowBuffer(cb_pre_lhs), exp_cb_post_lhs, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_lhs.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -69,9 +69,6 @@ ALWI void process_tile(
         exp_cb_raw_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
         PREPROCESS(OTHER_OP, DataflowBuffer(cb_llk_post), exp_cb_post_other, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_other.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast.cpp
@@ -59,9 +59,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
-#endif
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -79,7 +79,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -93,7 +93,6 @@ void kernel_main() {
         exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         PREPROCESS(LHS, DataflowBuffer(cb_pre_lhs), exp_cb_post_lhs, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_lhs.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -90,7 +90,6 @@ ALWI void process_tile(
         exp_cb_raw_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_raw_other);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         PREPROCESS(OTHER_OP, DataflowBuffer(cb_llk_post), exp_cb_post_other, exp_cb_out, num_tiles_per_cycle);
         exp_cb_post_other.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -79,7 +79,6 @@ ALWI void process_tile(
     tile_regs_release();
 
     pack_reconfig_data_format(cb_llk_post, cb_out);
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
     PREPROCESS(
         BCAST_OP,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -70,7 +70,6 @@ void kernel_main() {
         exp_cb_bcast.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         exp_cb_out.reserve_back(num_tiles_per_cycle);
         exp_cb_llk_post.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -72,7 +72,6 @@ ALWI void process_tile(
         exp_cb_other.pop_front(num_tiles_per_cycle);
         // unary_bcast_uninit<BroadcastType::ROW>(CB_OTHER);
         pack_reconfig_data_format(cb_llk_post, cb_out);
-        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
 
         exp_cb_out.reserve_back(num_tiles_per_cycle);
         exp_cb_llk_post.wait_front(num_tiles_per_cycle);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_qsr/compute/eltwise_binary_no_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_qsr/compute/eltwise_binary_no_bcast_dfb.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_post_rhs_id, dfb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))


### PR DESCRIPTION
### PR Category
Cleanup

### Issue
https://github.com/tenstorrent/tt-metal/issues/54329

### Summary
- Remove llk api `pack_hw_configure` calls from `/experimental/quasar/binary_ng` and `ttnn/operations/eltwise/binary_ng` compute kernels.
- Converts one leftover `llk_pack_relu_config` call to compute api call `pack_relu_config`.

These pack_hw_configure calls were added to compensate for the packer being left misconfigured inside process_tile. At that time `unary_bcast_init<BCAST>(cb_bcast, cb_llk_post)` was used, which would execute `PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)))` . So the packer was configured for `cb_llk_post`, and on BH that reached `pack_tile(0, cb_out)` with `cb_llk_post`'s geometry still programmed.

Since then the 2-arg `unary_bcast_init<>(cb_in, cb_out)` call site was migrated to the 1-arg `unary_bcast_init<>(cb_in)` plus a `compute_kernel_hw_startup at kernel start. The 1- arg `unary_bcast_init` does not contain any PACK(); calls. So it is safe to remove the BH specific hw config calls.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/remove_hw_config_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/remove_hw_config_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/remove_hw_config_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/remove_hw_config_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/remove_hw_config_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/remove_hw_config_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/remove_hw_config_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/remove_hw_config_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/remove_hw_config_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/remove_hw_config_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/remove_hw_config_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/remove_hw_config_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/remove_hw_config_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/remove_hw_config_bh)