### PR TITLE
add blaze to metal  p and r

### DIFF
--- a/.github/workflows/blaze-merge-gate.yaml
+++ b/.github/workflows/blaze-merge-gate.yaml
@@ -157,7 +157,7 @@ jobs:
             exit 1
           fi
           if ! gh api "repos/${BLAZE_REPO}/actions/workflows/${BLAZE_WORKFLOW}" --jq .id >/dev/null 2>&1; then
-            echo "::error::TT_BLAZE_PAT can read ${BLAZE_REPO} but not ${BLAZE_WORKFLOW}. That is an Actions-permission gap, not a missing file: a fine-grained PAT needs Actions: Read and write (plus Metadata: Read); a classic PAT needs the 'repo' and 'workflow' scopes."
+            echo "::error::TT_BLAZE_PAT can read ${BLAZE_REPO} but not ${BLAZE_WORKFLOW}. That is an Actions-permission gap, not a missing file: a fine-grained PAT needs Actions: Read and write (plus Metadata: Read); a classic PAT needs the 'repo' scope for a private repository."
             echo "- ❌ tt-blaze — TT_BLAZE_PAT lacks Actions access on ${BLAZE_REPO}" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi

--- a/.github/workflows/blaze-merge-gate.yaml
+++ b/.github/workflows/blaze-merge-gate.yaml
@@ -62,10 +62,9 @@ on:
         default: main
       wait-timeout-minutes:
         description: >-
-          How long to wait for the tt-blaze run. 3 hours: tt-blaze's full merge
-          gate is a silicon matrix (unit + P150 + craq-sim + every gate-tier BH
-          Loudbox bucket), and the bulk of the wall clock is queue time for free
-          P150 / BH Loudbox runners rather than the tests themselves.
+          How long to wait for the tt-blaze run. Includes 1 hour of running the gate
+          and 2 hours to find runners, though most cases should find runners within 30 min
+          given blaze stats, especially at night. Internal timeouts make it fail fast on hangs.
         required: false
         type: number
         default: 180
@@ -263,8 +262,12 @@ jobs:
       # Cancelling this run (or the release pipeline around it) stops this job but
       # not the run it started, which would otherwise keep occupying constrained
       # P150/Loudbox runners for hours on behalf of a release nobody is cutting.
-      - name: Cancel the tt-blaze run if this job was cancelled
-        if: cancelled() && env.BLAZE_RUN_ID != ''
+      #
+      # failure() is here for the TIMEOUT path specifically: giving up on the wait
+      # exits 1, which is not cancelled(), so without this a timed-out gate leaves
+      # the blaze run holding those runners with nobody watching it anymore.
+      - name: Cancel the tt-blaze run if this job was cancelled or timed out
+        if: (cancelled() || failure()) && env.BLAZE_RUN_ID != ''
         env:
           GH_TOKEN: ${{ secrets.TT_BLAZE_PAT }}
         shell: bash

--- a/.github/workflows/blaze-merge-gate.yaml
+++ b/.github/workflows/blaze-merge-gate.yaml
@@ -1,0 +1,273 @@
+name: Blaze Merge Gate
+
+# Runs tt-blaze's ENTIRE merge gate (its ci.yaml) against the tt-metal build this
+# release pipeline just produced, so a tt-metal change that breaks tt-blaze is
+# caught while the release is being cut rather than by the next uplift.
+#
+# Scope is tt-blaze's whole gate -- unit + P150 + craq-sim + every gate-tier BH
+# Loudbox bucket -- because nothing downstream waits on this job: it hangs off
+# release-build-test-publish.yaml's `build-artifact` and runs alongside the
+# release demo tests. tt-blaze's ci.yaml defaults every bucket selector to "run
+# all", so the dispatch below passes only the plumbing inputs and gets the full
+# gate. (Earlier revisions of this workflow ran one Loudbox bucket because they
+# sat in tt-metal's merge queue and could not hold it for hours.)
+#
+# tt-blaze cannot build tt-metal itself -- its CI consumes prebuilt tarball+wheel
+# artifacts. So this workflow does NOT hand tt-blaze a branch to go resolve: it
+# hands over `metal-run-id`, the id of the top-level run whose `build-artifact`
+# job has already published the tarball and wheel for this exact commit. tt-blaze's
+# download-build-artifact.yaml takes that run id verbatim and skips pin
+# resolution entirely. `metal-ref` then moves tt-blaze's tt-metal submodule to the
+# same commit, so JIT-compiled kernels and the linked libraries come from one
+# tt-metal rather than two.
+#
+# The release build is tracy=false, so tt-blaze runs against the plain variant
+# (its pin-driven runs are profiler-only). The gate-tier tests that touch tracy at
+# all today do so defensively (an `import tracy` in a try/except, a
+# TT_METAL_DEVICE_PROFILER env probe), so widening the scope to the whole gate is
+# safe -- but a blaze test that comes to REQUIRE tracy at runtime cannot run here,
+# and would show up as a failure of this job rather than of anything in tt-metal.
+#
+# Auth: dispatching and polling a workflow in another repo needs a PAT with
+# `actions: write` (dispatch, cancel) and `actions: read` (poll) on
+# tenstorrent/tt-blaze, stored in THIS repo as the `TT_BLAZE_PAT` secret. The
+# default GITHUB_TOKEN is scoped to tt-metal and cannot dispatch tt-blaze.
+#
+# `gh workflow run` returns no run id, so the run is correlated by echoing a
+# unique `dispatch-id` into tt-blaze's `run-name` and matching it back. That token
+# is also tt-blaze's concurrency key, which is what keeps concurrent dispatches
+# from cancelling each other's blaze run.
+
+on:
+  workflow_call:
+    inputs:
+      metal-run-id:
+        description: >-
+          Run id holding the tt-metal build artifacts tt-blaze should test
+          against. Normally `github.run_id` -- artifacts belong to the TOP-LEVEL
+          run, so that is the right value even from a nested reusable workflow.
+        required: true
+        type: string
+      metal-ref:
+        description: >-
+          tt-metal commit those artifacts were built from. tt-blaze checks its
+          tt-metal submodule out here. Must be a commit fetchable from
+          tenstorrent/tt-metal for as long as the blaze run lasts.
+        required: true
+        type: string
+      blaze-ref:
+        description: "tt-blaze branch/tag/SHA to run the gate from."
+        required: false
+        type: string
+        default: main
+      wait-timeout-minutes:
+        description: >-
+          How long to wait for the tt-blaze run. 3 hours: tt-blaze's full merge
+          gate is a silicon matrix (unit + P150 + craq-sim + every gate-tier BH
+          Loudbox bucket), and the bulk of the wall clock is queue time for free
+          P150 / BH Loudbox runners rather than the tests themselves.
+        required: false
+        type: number
+        default: 180
+    outputs:
+      blaze-run-url:
+        description: "URL of the tt-blaze run this gate waited on (empty if none was ever found)."
+        value: ${{ jobs.blaze-ci.outputs.blaze-run-url }}
+    secrets:
+      TT_BLAZE_PAT:
+        description: "PAT with actions:read+write on tenstorrent/tt-blaze."
+        required: true
+
+jobs:
+  blaze-ci:
+    name: tt-blaze CI (full merge gate)
+    runs-on: ubuntu-latest
+    # The 3-hour deadline plus slack: the poll loop must outlive its own deadline
+    # so it can report WHY it gave up. If the runner killed it first, the failure
+    # would read as an infra timeout instead of "no Loudbox came free".
+    timeout-minutes: 195
+    outputs:
+      blaze-run-url: ${{ steps.dispatch.outputs.blaze-run-url }}
+    env:
+      BLAZE_REPO: tenstorrent/tt-blaze
+      BLAZE_WORKFLOW: ci.yaml
+    steps:
+      - name: Dispatch tt-blaze ci.yaml and wait for it
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.TT_BLAZE_PAT }}
+          METAL_RUN_ID: ${{ inputs.metal-run-id }}
+          METAL_REF: ${{ inputs.metal-ref }}
+          BLAZE_REF: ${{ inputs.blaze-ref }}
+          TIMEOUT_MINUTES: ${{ inputs.wait-timeout-minutes }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          POLL_SECONDS=60
+          # A dispatched run is not immediately visible to `gh run list`. Until this
+          # is up, "no matching run" means "not indexed yet", not "dispatch failed".
+          GRACE_SECONDS=300
+          # Below this job's fixed 195-minute cap, with room for the loop to report
+          # a timeout instead of the runner killing it mid-wait. Raising the
+          # deadline past this means raising `timeout-minutes` above too.
+          MAX_WAIT_MINUTES=180
+
+          # `number` inputs are not integer inputs -- 1.5 reaches the arithmetic
+          # below and fails there as a bare bash syntax error naming nothing.
+          if [[ ! "${TIMEOUT_MINUTES:-}" =~ ^[0-9]+$ ]] || [ "$TIMEOUT_MINUTES" -lt 1 ]; then
+            echo "::error::wait-timeout-minutes must be a positive whole number of minutes (got '${TIMEOUT_MINUTES:-}')."
+            exit 1
+          fi
+          if [ "$TIMEOUT_MINUTES" -gt "$MAX_WAIT_MINUTES" ]; then
+            echo "::error::wait-timeout-minutes=${TIMEOUT_MINUTES} exceeds ${MAX_WAIT_MINUTES}. This job's timeout-minutes caps it, so a longer deadline would be cut short by the runner instead of reported here -- raise timeout-minutes in this workflow alongside it."
+            exit 1
+          fi
+
+          # Unique per run AND per re-run of that run, so a re-run never latches
+          # onto the blaze run its previous attempt started.
+          DISPATCH_ID="metal-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "dispatch-id: ${DISPATCH_ID}"
+
+          # Scope: tt-blaze's WHOLE merge gate. Its `bh-loudbox-run-all` and
+          # `p150-run-all` selectors both default to true, so passing only the
+          # plumbing inputs below is what asks for every gate-tier bucket. To
+          # narrow it again, pass the `bh-loudbox-*` / `p150-*` booleans from
+          # tt-blaze's ci.yaml explicitly.
+          # Preflight the token before dispatching. tt-blaze is PRIVATE, and
+          # GitHub answers 404 (never 403) for anything a token cannot see there,
+          # so `gh workflow run` reports a missing workflow when the real fault is
+          # a PAT that cannot read the repo. These two probes separate the cases so
+          # the log names the actual problem.
+          # Probe 1: is the credential live at all? Separated from the repo probe
+          # because "expired/revoked token" and "valid token that cannot see
+          # tt-blaze" have completely different fixes but look identical once the
+          # repo lookup 404s.
+          if ! PAT_LOGIN=$(gh api user --jq .login 2>/dev/null) || [ -z "$PAT_LOGIN" ]; then
+            echo "::error::TT_BLAZE_PAT is not a usable credential -- GitHub rejected it outright (401 Bad credentials), so this is not about repo access. It is expired, revoked, or was stored with stray whitespace/quotes when the secret was set. Reissue it and update the secret in ${GITHUB_REPOSITORY}."
+            echo "- ❌ tt-blaze — TT_BLAZE_PAT rejected (bad credentials)" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          # Not a secret; naming it turns "wrong account / stale bot" into a
+          # one-line diagnosis instead of a hunt.
+          echo "TT_BLAZE_PAT authenticates as: ${PAT_LOGIN}"
+
+          if ! gh api "repos/${BLAZE_REPO}" --jq .full_name >/dev/null 2>&1; then
+            echo "::error::TT_BLAZE_PAT is valid (authenticates as '${PAT_LOGIN}') but cannot see ${BLAZE_REPO}. ${BLAZE_REPO} is private, so GitHub answers 404 rather than 403 for anything this token is not entitled to. Either '${PAT_LOGIN}' has no access to ${BLAZE_REPO}, or the token is scoped away from it: a fine-grained PAT must list ${BLAZE_REPO} in its selected repositories AND be approved by the tenstorrent org (pending approval also reads as 404); a classic PAT needs the 'repo' scope to see private repos at all."
+            echo "- ❌ tt-blaze — TT_BLAZE_PAT ('${PAT_LOGIN}') cannot see ${BLAZE_REPO}" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          if ! gh api "repos/${BLAZE_REPO}/actions/workflows/${BLAZE_WORKFLOW}" --jq .id >/dev/null 2>&1; then
+            echo "::error::TT_BLAZE_PAT can read ${BLAZE_REPO} but not ${BLAZE_WORKFLOW}. That is an Actions-permission gap, not a missing file: a fine-grained PAT needs Actions: Read and write (plus Metadata: Read); a classic PAT needs the 'repo' and 'workflow' scopes."
+            echo "- ❌ tt-blaze — TT_BLAZE_PAT lacks Actions access on ${BLAZE_REPO}" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          # Dispatching needs actions:WRITE, which neither probe above proves --
+          # both are reads. A 403 here (rather than 404) means the token can see
+          # Actions but not trigger them.
+          if ! gh workflow run "$BLAZE_WORKFLOW" \
+            --repo "$BLAZE_REPO" \
+            --ref "$BLAZE_REF" \
+            -f metal-run-id="$METAL_RUN_ID" \
+            -f metal-ref="$METAL_REF" \
+            -f dispatch-id="$DISPATCH_ID"; then
+            echo "::error::Dispatch of ${BLAZE_WORKFLOW} on ${BLAZE_REPO}@${BLAZE_REF} failed. The token can read the workflow (checked above), so the usual causes are: no actions:write on ${BLAZE_REPO}; ${BLAZE_REF} does not carry every input passed here (an input this workflow sends but ${BLAZE_REF}'s ci.yaml does not declare is rejected outright -- the tt-blaze side must land FIRST); or ${BLAZE_REF} does not exist."
+            echo "- ❌ tt-blaze — dispatch rejected" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "Dispatched ${BLAZE_REPO} ${BLAZE_WORKFLOW} on ${BLAZE_REF} (full merge gate)"
+          echo "  tt-metal commit:  ${METAL_REF}"
+          echo "  tt-metal build:   https://github.com/${GITHUB_REPOSITORY}/actions/runs/${METAL_RUN_ID}"
+
+          started=$(date +%s)
+          deadline=$(( started + TIMEOUT_MINUTES * 60 ))
+          run_id=""
+          run_url=""
+
+          while :; do
+            elapsed=$(( $(date +%s) - started ))
+
+            if [ -z "$run_id" ]; then
+              # Correlate on the token echoed into tt-blaze's run-name. Matching on
+              # "newest dispatch" instead would be wrong: the release pipeline is
+              # dispatched on a schedule AND by hand, so two runs can be dispatching
+              # onto the same ref at once.
+              #
+              # `displayTitle` is where a computed `run-name` lands; `name` is the
+              # workflow's own name. Both are searched so this keeps working if gh
+              # ever changes which one carries it.
+              run_id=$(gh run list --repo "$BLAZE_REPO" --workflow "$BLAZE_WORKFLOW" \
+                         --event workflow_dispatch --limit 100 \
+                         --json databaseId,displayTitle,name \
+                         --jq "[.[] | select(((.displayTitle // \"\") + \" \" + (.name // \"\")) | contains(\"${DISPATCH_ID}\"))] | .[0].databaseId // empty" \
+                       2>/dev/null || echo "")
+
+              if [ -z "$run_id" ]; then
+                if [ "$elapsed" -gt "$GRACE_SECONDS" ]; then
+                  echo "::error::Dispatched ${BLAZE_REPO} ${BLAZE_WORKFLOW} but no run carrying '${DISPATCH_ID}' appeared within ${elapsed}s. Most likely ${BLAZE_REF} does not echo dispatch-id into run-name (the tt-blaze side of this plumbing is missing or older than this workflow)."
+                  echo "- ❌ tt-blaze — dispatched run never appeared" >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
+                fi
+                echo "waiting for the dispatched run to be indexed (${elapsed}s)"
+                sleep "$POLL_SECONDS"
+                continue
+              fi
+
+              run_url="https://github.com/${BLAZE_REPO}/actions/runs/${run_id}"
+              echo "tt-blaze run: ${run_url}"
+              echo "blaze-run-url=${run_url}" >> "$GITHUB_OUTPUT"
+              # Read by the cancel step below, which runs only if THIS job is
+              # cancelled and so cannot rely on any of the locals here.
+              echo "BLAZE_RUN_ID=${run_id}" >> "$GITHUB_ENV"
+              echo "- ⏳ tt-blaze — [run ${run_id}](${run_url})" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            read -r status conclusion <<< "$(gh run view "$run_id" --repo "$BLAZE_REPO" \
+                                               --json status,conclusion \
+                                               --jq '"\(.status) \(.conclusion // "-")"')"
+
+            if [ "$status" = "completed" ]; then
+              case "$conclusion" in
+                success)
+                  echo "✅ tt-blaze CI passed: ${run_url}"
+                  echo "- ✅ tt-blaze — [run ${run_id}](${run_url})" >> "$GITHUB_STEP_SUMMARY"
+                  exit 0
+                  ;;
+                skipped)
+                  # Every job guarded off (eg. a "[SKIP CI]" title on the blaze
+                  # side). Nothing ran, so there is nothing to fail on.
+                  echo "::notice::tt-blaze CI was skipped: ${run_url}"
+                  echo "- ⏭️ tt-blaze — skipped ([run ${run_id}](${run_url}))" >> "$GITHUB_STEP_SUMMARY"
+                  exit 0
+                  ;;
+                *)
+                  echo "::error::tt-blaze CI concluded '${conclusion}' — this tt-metal change breaks tt-blaze, or the blaze run itself is broken. ${run_url}"
+                  echo "- ❌ tt-blaze — \`${conclusion}\` ([run ${run_id}](${run_url}))" >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
+                  ;;
+              esac
+            fi
+
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out after ${TIMEOUT_MINUTES} min with the tt-blaze run still '${status}'. Raise wait-timeout-minutes or check runner availability. ${run_url}"
+              echo "- ⏱️ tt-blaze — timed out after ${TIMEOUT_MINUTES} min ([run ${run_id}](${run_url}))" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+
+            echo "tt-blaze run ${run_id}: ${status} (${elapsed}s elapsed)"
+            sleep "$POLL_SECONDS"
+          done
+
+      # Cancelling this run (or the release pipeline around it) stops this job but
+      # not the run it started, which would otherwise keep occupying constrained
+      # P150/Loudbox runners for hours on behalf of a release nobody is cutting.
+      - name: Cancel the tt-blaze run if this job was cancelled
+        if: cancelled() && env.BLAZE_RUN_ID != ''
+        env:
+          GH_TOKEN: ${{ secrets.TT_BLAZE_PAT }}
+        shell: bash
+        run: |
+          echo "Cancelling tt-blaze run ${BLAZE_RUN_ID}"
+          gh run cancel "$BLAZE_RUN_ID" --repo "$BLAZE_REPO" || true

--- a/.github/workflows/blaze-merge-gate.yaml
+++ b/.github/workflows/blaze-merge-gate.yaml
@@ -77,6 +77,9 @@ on:
         description: "PAT with actions:read+write on tenstorrent/tt-blaze."
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   blaze-ci:
     name: tt-blaze CI (full merge gate)

--- a/.github/workflows/blaze-merge-gate.yaml
+++ b/.github/workflows/blaze-merge-gate.yaml
@@ -235,11 +235,9 @@ jobs:
                   exit 0
                   ;;
                 skipped)
-                  # Every job guarded off (eg. a "[SKIP CI]" title on the blaze
-                  # side). Nothing ran, so there is nothing to fail on.
-                  echo "::notice::tt-blaze CI was skipped: ${run_url}"
-                  echo "- ⏭️ tt-blaze — skipped ([run ${run_id}](${run_url}))" >> "$GITHUB_STEP_SUMMARY"
-                  exit 0
+                  echo "::error::tt-blaze CI was skipped, so the required merge-gate validation did not run. ${run_url}"
+                  echo "- ❌ tt-blaze — skipped; no validation ran ([run ${run_id}](${run_url}))" >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
                   ;;
                 *)
                   echo "::error::tt-blaze CI concluded '${conclusion}' — this tt-metal change breaks tt-blaze, or the blaze run itself is broken. ${run_url}"

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -160,6 +160,50 @@ jobs:
       tests-yaml-path: ./tests/pipeline_reorg/ops_pnr_tests.yaml
       budget-subheading: package_and_release
 
+  # ===========================================================================
+  # Team: blaze
+  # test list: owned by tenstorrent/tt-blaze (its ci.yaml), not by this repo
+  # ===========================================================================
+  #
+  # Runs tt-blaze's FULL merge gate against this release build, so a tt-metal
+  # change that breaks tt-blaze surfaces while the release is being cut instead of
+  # at the next uplift. Deliberately unconditional -- every run of Package and
+  # release gets it, no path filter and no tag-version guard: the whole point is
+  # that the release the downstream repo will uplift to has been proven against
+  # that repo's own gate.
+  #
+  # tt-blaze does not build tt-metal, so it is handed THIS run's id: `build-artifact`
+  # above published the tarball and wheel there, and tt-blaze consumes them directly
+  # instead of resolving from its tt-metal pin. See blaze-merge-gate.yaml.
+  #
+  # Hangs off `build-artifact` only -- NOT the release tests -- so the blaze gate
+  # runs alongside release-demo-tests rather than after them. It waits on
+  # tt-blaze's constrained P150/BH Loudbox pool for up to 3 hours, so serializing
+  # it behind the demo tests would add those hours to every nightly.
+  #
+  # Restricted to the main-platform leg of the caller's matrix: tt-blaze consumes
+  # the 22.04/Release tarball specifically (its download-artifacts-from-run action
+  # pins that in the artifact name), and the other legs of this matrix publish
+  # tarballs it cannot use. If main-platform ever moves off 22.04 this fails loudly
+  # on "no plain 22.04/Release build artifact" rather than silently skipping.
+  blaze-merge-gate:
+    needs: [build-artifact]
+    if: ${{ inputs.platform == inputs.main-platform }}
+    permissions:
+      contents: read
+    # TT_BLAZE_PAT -- the default GITHUB_TOKEN cannot dispatch another repo.
+    secrets: inherit
+    uses: ./.github/workflows/blaze-merge-gate.yaml
+    with:
+      # Artifacts belong to the TOP-LEVEL run, so `build-artifact`'s tarball and
+      # wheel are on the Package and release run id even though this is nested.
+      metal-run-id: ${{ github.run_id }}
+      # The commit `build-artifact` compiled. tt-blaze checks its tt-metal
+      # submodule out here so its JIT-compiled kernels match the libraries it
+      # links against.
+      metal-ref: ${{ github.sha }}
+      blaze-ref: main
+
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
   # expected-jobs is the union of single-host and exabox multihost legs so a
   # missing ai_job_summary artifact is reconciled as INFRA_FAILURE.

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -192,7 +192,8 @@ jobs:
     permissions:
       contents: read
     # TT_BLAZE_PAT -- the default GITHUB_TOKEN cannot dispatch another repo.
-    secrets: inherit
+    secrets:
+      TT_BLAZE_PAT: ${{ secrets.TT_BLAZE_PAT }}
     uses: ./.github/workflows/blaze-merge-gate.yaml
     with:
       # Artifacts belong to the TOP-LEVEL run, so `build-artifact`'s tarball and
@@ -202,9 +203,7 @@ jobs:
       # submodule out here so its JIT-compiled kernels match the libraries it
       # links against.
       metal-ref: ${{ github.sha }}
-      # TEMP FOR TEST RUN -- REVERT TO `main` BEFORE MERGING. Points at the
-      # tt-blaze branch carrying the guard removals, without which this gate
-      # reports green having run the Loudbox buckets only.
+      # Run tt-blaze's full merge gate from its main branch.
       blaze-ref: main
 
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -202,7 +202,10 @@ jobs:
       # submodule out here so its JIT-compiled kernels match the libraries it
       # links against.
       metal-ref: ${{ github.sha }}
-      blaze-ref: main
+      # TEMP FOR TEST RUN -- REVERT TO `main` BEFORE MERGING. Points at the
+      # tt-blaze branch carrying the guard removals, without which this gate
+      # reports green having run the Loudbox buckets only.
+      blaze-ref: jvega/metal_p_and_r
 
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
   # expected-jobs is the union of single-host and exabox multihost legs so a

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -205,7 +205,7 @@ jobs:
       # TEMP FOR TEST RUN -- REVERT TO `main` BEFORE MERGING. Points at the
       # tt-blaze branch carrying the guard removals, without which this gate
       # reports green having run the Loudbox buckets only.
-      blaze-ref: jvega/metal_p_and_r
+      blaze-ref: main
 
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
   # expected-jobs is the union of single-host and exabox multihost legs so a


### PR DESCRIPTION
This PR adds blaze testing to the P&R workflow which acts as step 1 of our uplift effort as described below. The workflow run is the blaze merge gate which is guaranteed to be passing on the prior uplifted version of metal main with current main and hence errors only exist in regressions in main that break blaze such as API changes or new bugs on the core APIs blaze uses. 

The approach is:

A PAT was added as a tt-metal secret to give metadata and actions R/W access to blaze workflows. Then from metal what I am doing is from a ubuntu runner issuing a gh command to launch the blaze merge gate workflow and then poll completion reporting whether the blaze workflow passed, failed, or hung, and mirroring that result on the P&R workflow in metal. I also gave that workflow on the blaze side priority access to runners to not slow down metal. 

To save on compile time this waits until the compilation and wheel is completed on P&R before issuing the gh command and on the blaze side it imports the wheel produced in this metal run where we pass the appropriate information (metal-run-id, metal-ref, dispatch-id) in the gh command so that blaze that also has a PAT to read and write from metal  can quickly get the P&R run and download its products within a few seconds allowing it to run without re-compiling metal. Timeouts in blaze are also scaled appropriately as this PR causes a tt-metal cache miss on the targeted runner as it is a version of metal blaze is not actively using. Furthermore quick fail timeouts on a per pytest basis are added on the tt-blaze test so if something hangs we don't have to wait for the long timeout.

A caveat is the runner timeout here must include queue time of obtaining a runner in blaze hence why it is large but hitting that is unlikely given normal queue times in blaze are averaging 26 minutes for priority runners.

Sample run below

https://github.com/tenstorrent/tt-metal/actions/runs/33798336923/job/100813922334

The uplift effort is described below:

Creating a uplift candidate
Full blaze merge gate to be run in metal's nightly P&R workflow running metal main with blaze main combination
Regressions are metal-based or a combination of metal and blaze (e.g. API changes) as the test must already be green on blaze side with prior packaged main

Sanity or metal merge gate pipeline for micro issues
Reactive, currently empty but will be populated as P&R issues are resolved and "weak points" are identified
Metal-only test of LLKs, APIs, etc affecting blaze

This creates an “uplift candidate” which is the most recent green run on the blaze portion of P&R

Uplifting
Runs on the current “uplift candidate” with the intent to promote it to blaze metal pin
Runs cluster level tests to ensure they do not break before bringing metal into blaze
As frequent as machines allow on multi-galaxy systems
If it passes, uplift candidate becomes the new pinned metal in Blaze

Ownership

I (Juan Camilo Vega) will own fixing if this job goes red

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jvega/add_blaze_to_p_and_R)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jvega/add_blaze_to_p_and_R)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jvega/add_blaze_to_p_and_R)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jvega/add_blaze_to_p_and_R)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jvega/add_blaze_to_p_and_R)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jvega/add_blaze_to_p_and_R)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jvega/add_blaze_to_p_and_R)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jvega/add_blaze_to_p_and_R)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jvega/add_blaze_to_p_and_R)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jvega/add_blaze_to_p_and_R)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jvega/add_blaze_to_p_and_R)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jvega/add_blaze_to_p_and_R)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jvega/add_blaze_to_p_and_R)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jvega/add_blaze_to_p_and_R)