### PR TITLE
[llk_helper_library] 2/8 eltwise helpers: migrate eltwise and generator kernels

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1765,6 +1765,23 @@ def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, 
     assert_allclose(output_tensor, golden_tensor, rtol=1e-05, atol=atol)
 
 
+@pytest.mark.parametrize("torch_dtype,ttnn_dtype", [(torch.int32, ttnn.int32), (torch.uint32, ttnn.uint32)])
+def test_unary_hardswish_integer_releases_every_input_tile(torch_dtype, ttnn_dtype, device):
+    """The integer path is hardsigmoid-only, but must still pop all input pages across a multi-tile tensor."""
+    grid = device.compute_with_storage_grid_size()
+    # The input CB holds two tiles. Give at least one worker three tiles so a missing pop blocks its reader.
+    num_tiles = 2 * grid.x * grid.y + 1
+    input_data = torch.zeros((1, 1, 32, 32 * num_tiles), dtype=torch_dtype)
+    input_tensor = ttnn.from_torch(input_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.to_torch(ttnn.hardswish(input_tensor), dtype=torch_dtype)
+    # Integer hardswish preserves the existing integer-path contract: the hardsigmoid result is
+    # packed as Float32 bits. hardsigmoid(0) is 0.5f == 0x3f000000.
+    golden = torch.full_like(input_data, 0x3F000000)
+
+    assert torch.equal(output, golden)
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -2580,6 +2597,20 @@ def test_unary_logit_edge_cases(input_shape, torch_dtype, ttnn_dtype, device, ep
             assert_with_ulp(output_tensor[finite_mask], golden_tensor[finite_mask], ulp_threshold=1)
     else:
         assert torch.allclose(output_tensor, golden_tensor, equal_nan=True, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("eps", [None, 0.25])
+def test_unary_logit_streams_temporary_tiles(device, eps):
+    grid = device.compute_with_storage_grid_size()
+    # The temporary CB holds two tiles. Give at least one worker three tiles to exercise producer/consumer streaming.
+    num_tiles = 2 * grid.x * grid.y + 1
+    in_data = torch.full((1, 1, 32, 32 * num_tiles), 0.5, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.to_torch(ttnn.logit(input_tensor, eps=eps))
+    golden_tensor = ttnn.get_golden_function(ttnn.logit)(in_data, eps=eps)
+
+    assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp
@@ -25,9 +25,9 @@
  * --------------------
  * The chain never issues engine-wide ("BIG") init. The caller owns `compute_kernel_hw_startup`
  * (plus `compute_kernel_hw_startup` / `mm_init` / `reduce_init` when the kernel mixes those
- * primitives). The chain owns only per-element init — `*_tile_init`, `init_bcast`,
- * `copy_tile_init` / `copy_tile_to_dst_init_short`, the `reconfig_data_format_*` fold, and the
- * dst-sync lifecycle. Do not add a `*_with_init` wrapper that folds `compute_kernel_hw_startup`
+ * primitives). The chain owns only per-element init — `*_tile_init`, `init_bcast`, `copy_init`,
+ * and the `reconfig_data_format_*` fold and dst-sync lifecycle.
+ * Do not add a `*_with_init` wrapper that folds `compute_kernel_hw_startup`
  * into the chain: it is only correct for single-stage kernels and breaks multi-stage / mid-loop
  * ones.
  *

--- a/ttnn/cpp/ttnn/kernel_lib/eltwise/core/chain.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/eltwise/core/chain.inl
@@ -537,8 +537,8 @@ inline constexpr bool is_fpu_kind_op_v =
     is_binary_fpu_op_v<T> || is_dest_reuse_binary_op_v<T> || is_unary_bcast_op_v<T>;
 
 /// MATH-MOP-touching element predicate. Groups every element whose init
-/// programs the MATH MOP / ADDR_MOD_0..3 lane: `CopyTile` (via
-/// `copy_tile_to_dst_init_short`) and the FPU-kind ops (`BinaryFpu`,
+/// programs the MATH MOP / ADDR_MOD_0..3 lane: `CopyTile` (via `copy_init`)
+/// and the FPU-kind ops (`BinaryFpu`,
 /// `DestReuseBinary`, `UnaryBcast`). The hoist gate requires all such
 /// elements in a chain (including the CopyTile-versus-FPU init clash) to be
 /// the same instantiated type — otherwise the boot-time fold leaves only the
@@ -913,7 +913,7 @@ struct detail::CopyTileImpl : InputStream, CopyTileTag {
     constexpr explicit CopyTileImpl(StridedTileRange range) noexcept : Base(range) {}
 
     // ---- chain pipeline hooks ----
-    static ALWI void init() { copy_tile_init(Cb); }
+    static ALWI void init() { copy_init(Cb); }
 
     ALWI void exec(uint32_t i_flat, uint32_t ht, uint32_t wt, uint32_t slot_offset) const {
         const uint32_t in_idx = tile_base_value<Addressing>(tile_base) +
@@ -2605,7 +2605,7 @@ ALWI void hoist_compute_init_one(SelectedElement<E, TransitionFacts<PrevA, PrevB
 //   - Helper does NOT wrap any "BIG init" (`compute_kernel_hw_startup`,
 //     `compute_kernel_hw_startup`, `mm_init`, `reduce_init`).
 //   - Helper owns per-element init only — `add_init`, `*_tile_init`,
-//     `init_bcast`, `copy_tile_to_dst_init_short`, `reconfig_data_format_*`,
+//     `init_bcast`, `copy_init`, `reconfig_data_format_*`,
 //     `tile_regs_*` lifecycle.
 //   - Per `compute_kernel_hw_startup.h:26-30`, mid-`MAIN()` boot is undefined.
 //     Multi-stage kernels are the only exception (one boot per stage,

--- a/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/hoist.cpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tests/eltwise/chain/axes/hoist.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
             eltwise_chain(IterationShape::one_tile(), CopyTile<input(cb_in)>{}, Exp<>{}, PackTile<output(cb_out)>{});
         }
     } else {
-        copy_tile_init(cb_in);
+        copy_init(cb_in);
         exp_tile_init();
         eltwise_chain<InitReconfigOwner::Caller>(
             IterationShape::tiles(n),

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/compute_bernoulli.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/compute_bernoulli.cpp
@@ -2,24 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/rand.h"
-#include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.hpp"
 
 void kernel_main() {
-    constexpr std::uint32_t intermed_cb_id = get_compile_time_arg_val(0);
+    using namespace compute_kernel_lib;
 
-    const std::uint32_t seed = get_arg_val<std::uint32_t>(0);
-    const std::uint32_t start_id = get_arg_val<std::uint32_t>(1);
-    const std::uint32_t num_tiles = get_arg_val<std::uint32_t>(2);
-    const std::uint32_t end_id = start_id + num_tiles;
+    constexpr uint32_t intermed_dfb_id = get_compile_time_arg_val(0);
 
-    CircularBuffer cb_intermed(intermed_cb_id);
+    compute_kernel_hw_startup(intermed_dfb_id, intermed_dfb_id);
 
-    compute_kernel_hw_startup(intermed_cb_id, intermed_cb_id);
-    copy_init(intermed_cb_id);
+    const uint32_t seed = get_arg_val<uint32_t>(0);
+    const uint32_t start_id = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
     // rand_tile's internal interval is inclusive. Use the largest FP32 value
     // below 1.0 so that Bernoulli's `random < probability` comparison still
@@ -27,18 +24,8 @@ void kernel_main() {
     constexpr std::uint32_t rand_from = 0;
     constexpr std::uint32_t rand_scale = 0x3F7FFFFFU;
 
-    rand_tile_init(seed, start_id);
-    for (std::uint32_t i = start_id; i < end_id; ++i) {
-        cb_intermed.reserve_back(1);
-
-        tile_regs_acquire();
-        rand_tile(0, rand_from, rand_scale);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile(0, intermed_cb_id, 0);
-        tile_regs_release();
-
-        cb_intermed.push_back(1);
-    }
+    eltwise_chain(
+        IterationShape::tiles(num_tiles),
+        RandTile<Dst::D0>{rand_from, rand_scale, seed, start_id},
+        PackTile<output(intermed_dfb_id, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1315,18 +1315,28 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
         reader_defines["BCAST_LLK"] = "0";
     }
 
+    const bool fill_with_value_int = b_dtype == DataType::INT32 || b_dtype == DataType::UINT32;
     if (op_type == BinaryOpType::WHERE_TTS || op_type == BinaryOpType::WHERE_TST) {
         // Add common fill defines
         compute_kernel_defines["FILL_LLK"] = "fill_tile";
         if (b_dtype == DataType::INT32) {
             compute_kernel_defines["FILL_LLK"] = "fill_tile_int<DataFormat::Int32>";
-            compute_kernel_defines["FILL_WITH_VALUE_INT"] = "1";
         } else if (b_dtype == DataType::UINT32) {
             compute_kernel_defines["FILL_LLK"] = "fill_tile_int<DataFormat::UInt32>";
-            compute_kernel_defines["FILL_WITH_VALUE_INT"] = "1";
         } else {
             compute_kernel_defines["FILL_WITH_VALUE_FLOAT"] = "1";
         }
+        if (fill_with_value_int && compute_kernel != CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeNoBcast) {
+            compute_kernel_defines["FILL_WITH_VALUE_INT"] = "1";
+        }
+        // where_tile<DataFormat::X> selector — mirrors get_sfpu_init_fn(WHERE, a_dtype)
+        // in binary_ng_utils.cpp so the eltwise_chain `Where` element can pick the
+        // exact same DataFormat the legacy BINARY_SFPU_OP macro baked in.
+        const char* where_df = (a_dtype == DataType::INT32)     ? "Int32"
+                               : (a_dtype == DataType::UINT32)  ? "UInt32"
+                               : (a_dtype == DataType::FLOAT32) ? "Float32"
+                                                                : "Float16_b";
+        compute_kernel_defines["WHERE_DATA_FORMAT"] = where_df;
     }
     compute_kernel_defines["WHERE_TTS"] = (op_type == BinaryOpType::WHERE_TTS) ? "1" : "0";
     compute_kernel_defines["WHERE_TST"] = (op_type == BinaryOpType::WHERE_TST) ? "1" : "0";
@@ -1336,7 +1346,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_device_cores;
     compute_desc.defines = {compute_kernel_defines.begin(), compute_kernel_defines.end()};
-    compute_desc.compile_time_args = {num_tiles_per_cycle};
+    compute_desc.compile_time_args = {num_tiles_per_cycle, static_cast<uint32_t>(fill_with_value_int)};
     compute_desc.config = ComputeConfigDescriptor{
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .unpack_to_dest_mode = {unpack_to_dest_mode.begin(), unpack_to_dest_mode.end()},

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
@@ -4,79 +4,67 @@
 
 #include <cstdint>
 
-#include "api/compute/eltwise_unary/where.h"
-#include "api/compute/eltwise_unary/fill.h"
-#include "eltwise_utils_common.hpp"
-#include "eltwise_utils_sfpu.hpp"
+#include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp"    // Where
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp"  // FillBitcast / FillInt
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"    // Optional
+
+namespace ckl = compute_kernel_lib;
+
+constexpr bool kIsInt = get_compile_time_arg_val(1) == 1;
+constexpr bool kIsFloat = !kIsInt;
+
+constexpr DataFormat kWhereDF = DataFormat::WHERE_DATA_FORMAT;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t scalar_value = get_arg_val<uint32_t>(3);
-    const auto scalar_val = reinterpret_cast<const float*>(&scalar_value);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
 
-    DataflowBuffer dfb_in0(tt::CBIndex::c_0);
-    DataflowBuffer dfb_in1(tt::CBIndex::c_1);
-    DataflowBuffer dfb_out(tt::CBIndex::c_2);
+    constexpr auto dfb_cond_id = tt::CBIndex::c_0;
+    constexpr auto dfb_tensor_id = tt::CBIndex::c_1;
+    constexpr auto dfb_out_id = tt::CBIndex::c_2;
 
-    compute_kernel_hw_startup(dfb_in0.get_id(), dfb_out.get_id());
-    copy_init(dfb_in0.get_id());
-    BINARY_SFPU_INIT
-
-    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        dfb_in0.wait_front(num_tiles_per_cycle);
-        dfb_in1.wait_front(num_tiles_per_cycle);
-        dfb_out.reserve_back(num_tiles_per_cycle);
-
-        tile_regs_acquire();
-        copy_init(dfb_in0.get_id());
-        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            copy_tile(dfb_in0.get_id(), i, i * 3);
-        }
-        copy_init(dfb_in1.get_id());
-        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            // TTS: tensor is true value, goes to dst_reg 1
 #if WHERE_TTS
-            copy_tile(dfb_in1.get_id(), i, i * 3 + 1);  // Copy true tensor to dst_reg 1
-            fill_tile_init();
-            // TTS: scalar is false value, goes to dst_reg 2
-#ifdef FILL_WITH_VALUE_FLOAT
-            FILL_LLK(i * 3 + 2, *scalar_val);
-#endif
-#ifdef FILL_WITH_VALUE_INT
-            FILL_LLK(i * 3 + 2, scalar_value);
-#endif
-#endif
-
-// TST: tensor is false value, goes to dst_reg 2
-#if WHERE_TST
-            copy_tile(dfb_in1.get_id(), i, i * 3 + 2);  // Copy false tensor to dst_reg 2
-            fill_tile_init();
-            // TST: scalar is true value, goes to dst_reg 1
-#ifdef FILL_WITH_VALUE_FLOAT
-            FILL_LLK(i * 3 + 1, *scalar_val);
-#endif
-#ifdef FILL_WITH_VALUE_INT
-            FILL_LLK(i * 3 + 1, scalar_value);
-#endif
+    // TTS: tensor is true value, goes to dst_reg 1
+    // TTS: scalar is false value, goes to dst_reg 2
+    constexpr auto kTensorSlot = ckl::Dst::D1;
+    constexpr auto kFillSlot = ckl::Dst::D2;
+#else
+    // TST: tensor is false value, goes to dst_reg 2
+    // TST: scalar is true value, goes to dst_reg 1
+    constexpr auto kTensorSlot = ckl::Dst::D2;
+    constexpr auto kFillSlot = ckl::Dst::D1;
 #endif
 
-            BINARY_SFPU_OP(i * 3, i * 3 + 1, i * 3 + 2, i * 3);
-        }
+    compute_kernel_hw_startup(dfb_cond_id, dfb_tensor_id, dfb_out_id);
 
-        tile_regs_commit();
-
-        tile_regs_wait();
-        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
-            pack_tile(i * 3, dfb_out.get_id());
-        }
-        tile_regs_release();
-
-        dfb_out.push_back(num_tiles_per_cycle);
-        dfb_in0.pop_front(num_tiles_per_cycle);
-        dfb_in1.pop_front(num_tiles_per_cycle);
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles).block_size(num_tiles_per_cycle),
+        // cond -> D0 (block read, init_short for dfb_cond_id).
+        ckl::CopyTile<
+            ckl::input(
+                dfb_cond_id, ckl::WaitPolicy::PerBlockSize, ckl::PopPolicy::PerBlockSize, ckl::InputTileMapping::Block),
+            ckl::Dst::D0>{},
+        // tensor -> D1 (TTS) / D2 (TST) (block read, init_short for dfb_tensor_id).
+        ckl::CopyTile<
+            ckl::input(
+                dfb_tensor_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block),
+            kTensorSlot>{},
+        // scalar fill -> the other slot. Inactive flavor folds to a no-op.
+        ckl::Optional<kIsInt, ckl::FillInt<kWhereDF, kFillSlot>>{scalar_value},
+        ckl::Optional<kIsFloat, ckl::FillBitcast<kFillSlot>>{scalar_value},
+        // where(D0, D1, D2) -> D0.
+        ckl::Where<kWhereDF, ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D0>{},
+        ckl::PackTile<ckl::output(
+            dfb_out_id,
+            ckl::ReservePolicy::PerBlockSize,
+            ckl::PushPolicy::PerBlockSize,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu.cpp
@@ -4,66 +4,47 @@
 
 #include <cstdint>
 
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.hpp"  // MulUnary
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"
+
+namespace ckl = compute_kernel_lib;
+
+inline void run_addcmul(uint32_t num_tiles, uint32_t scalar_arg) {
+    constexpr auto dfb_in0_id = tt::CBIndex::c_0;
+    constexpr auto dfb_in1_id = tt::CBIndex::c_1;
+    constexpr auto dfb_in2_id = tt::CBIndex::c_2;
+    constexpr auto dfb_out_id = tt::CBIndex::c_3;
+
+    // output = input_a + value * input_b * input_c
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        // (input_b * input_c)
+        ckl::BinaryFpu<
+            ckl::BinaryFpuOp::Mul,
+            ckl::input(
+                dfb_in1_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::input(
+                dfb_in2_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled)>{},
+        // Step 2: (input_b * input_c) * value -> DST[0]
+        ckl::runtime_if(scalar_arg != 1u, ckl::MulUnary<ckl::Dst::D0>{scalar_arg}),  // DST[0] * scalar -> DST[0]
+        // Now wait for input_a (only when we need it)
+        // Step 3: Load A and add with result DST[0] + dfb_in0_id -> DST[0]
+        ckl::DestReuseBinary<ckl::BinaryFpuOp::Add, ckl::input(dfb_in0_id), ckl::DestReuseType::DEST_TO_SRCA>{},
+        ckl::PackTile<ckl::output(
+            dfb_out_id, ckl::ReservePolicy::PerTile, ckl::PushPolicy::PerTile, ckl::DataFormatReconfig::Disabled)>{});
+}
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t scalar_arg = get_arg_val<uint32_t>(3);
+    constexpr auto dfb_in1_id = tt::CBIndex::c_1;
+    constexpr auto dfb_in2_id = tt::CBIndex::c_2;
+    constexpr auto dfb_out_id = tt::CBIndex::c_3;
 
-    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
-    const bool scalar_is_not_1 = scalar_arg != 1u;
+    compute_kernel_hw_startup(dfb_in1_id, dfb_in2_id, dfb_out_id);
 
-    DataflowBuffer dfb_in0(tt::CBIndex::c_0);  // input_a
-    DataflowBuffer dfb_in1(tt::CBIndex::c_1);  // input_b
-    DataflowBuffer dfb_in2(tt::CBIndex::c_2);  // input_c
-    DataflowBuffer dfb_out(tt::CBIndex::c_3);
-
-    // output = input_a + value * input_b * input_c
-    compute_kernel_hw_startup(dfb_in1.get_id(), dfb_in2.get_id(), dfb_out.get_id());
-
-    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        // Wait for input_b and input_c first (needed for first computation)
-        dfb_in1.wait_front(num_tiles_per_cycle);
-        dfb_in2.wait_front(num_tiles_per_cycle);
-
-        tile_regs_acquire();
-
-        // (input_b * input_c)
-        mul_init(dfb_in1.get_id(), dfb_in2.get_id());
-        mul_tiles(dfb_in1.get_id(), dfb_in2.get_id(), 0, 0, 0);
-
-        // Done with dfb_in1 and dfb_in2, pop them early for pipeline efficiency
-        dfb_in1.pop_front(num_tiles_per_cycle);
-        dfb_in2.pop_front(num_tiles_per_cycle);
-
-        // Step 2: (input_b * input_c) * value -> DST[0]
-        if (scalar_is_not_1) {
-            binop_with_scalar_tile_init();
-            mul_unary_tile(0, scalar_arg);  // DST[0] * scalar -> DST[0]
-        }
-
-        // Now wait for input_a (only when we need it)
-        dfb_in0.wait_front(num_tiles_per_cycle);
-
-        // Step 3: Load A and add with result DST[0] + dfb_in0 -> DST[0]
-        add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(dfb_in0.get_id());
-        add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
-            dfb_in0.get_id(), 0, 0);
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        // Reserve output buffer only when ready to write
-        dfb_out.reserve_back(num_tiles_per_cycle);
-
-        // Pack the result from DST[0] to output
-        pack_tile(0, dfb_out.get_id());
-
-        tile_regs_release();
-
-        dfb_out.push_back(num_tiles_per_cycle);
-        dfb_in0.pop_front(num_tiles_per_cycle);
-    }
+    run_addcmul(num_tiles, scalar_arg);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
@@ -4,64 +4,58 @@
 
 #include <cstdint>
 
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/fill.h"
-#include "api/compute/mul_int_sfpu.h"
-#include "api/compute/add_int_sfpu.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp"  // FillInt
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/int.hpp"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t scalar_arg = get_arg_val<uint32_t>(3);
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
 
-    DataflowBuffer dfb_in0(tt::CBIndex::c_0);  // input_a
-    DataflowBuffer dfb_in1(tt::CBIndex::c_1);  // input_b
-    DataflowBuffer dfb_in2(tt::CBIndex::c_2);  // input_c
-    DataflowBuffer dfb_out(tt::CBIndex::c_3);
+    constexpr auto dfb_in0_id = tt::CBIndex::c_0;
+    constexpr auto dfb_in1_id = tt::CBIndex::c_1;
+    constexpr auto dfb_in2_id = tt::CBIndex::c_2;
+    constexpr auto dfb_out_id = tt::CBIndex::c_3;
 
-    compute_kernel_hw_startup(dfb_in0.get_id(), dfb_out.get_id());
-    copy_init(dfb_in0.get_id());
+    compute_kernel_hw_startup(dfb_in0_id, dfb_out_id);
 
-    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        dfb_in0.wait_front(num_tiles_per_cycle);
-        dfb_in1.wait_front(num_tiles_per_cycle);
-        dfb_in2.wait_front(num_tiles_per_cycle);
-
-        dfb_out.reserve_back(num_tiles_per_cycle);
-
-        tile_regs_acquire();
-
-        copy_init(dfb_in0.get_id());
-        copy_tile(dfb_in0.get_id(), 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
-
-        copy_init(dfb_in1.get_id());
-        copy_tile(dfb_in1.get_id(), 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
-
-        copy_init(dfb_in2.get_id());
-        copy_tile(dfb_in2.get_id(), 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
-
-        fill_tile_init();
-        fill_tile_int<ADDCMUL_DATA_FORMAT>(3, scalar_arg);
-
-        mul_int_tile_init<ADDCMUL_DATA_FORMAT>();
-        mul_int_tile<ADDCMUL_DATA_FORMAT>(3, 1, 3);
-        mul_int_tile<ADDCMUL_DATA_FORMAT>(3, 2, 2);
-
-        add_int_tile_init();
-        add_int_tile<ADDCMUL_DATA_FORMAT>(0, 2, 0);
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, dfb_out.get_id());
-
-        tile_regs_release();
-
-        dfb_out.push_back(num_tiles_per_cycle);
-        dfb_in0.pop_front(num_tiles_per_cycle);
-        dfb_in1.pop_front(num_tiles_per_cycle);
-        dfb_in2.pop_front(num_tiles_per_cycle);
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles).block_size(num_tiles_per_cycle),
+        ckl::CopyTile<
+            ckl::input(
+                dfb_in0_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::CopyTile<
+            ckl::input(
+                dfb_in1_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        ckl::CopyTile<
+            ckl::input(
+                dfb_in2_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D2>{},
+        ckl::FillInt<ADDCMUL_DATA_FORMAT, ckl::Dst::D3>{scalar_arg},
+        ckl::MulIntBinary<ADDCMUL_DATA_FORMAT, ckl::Dst::D3, ckl::Dst::D1, ckl::Dst::D3>{},  // D3 = scalar*in1
+        ckl::MulIntBinary<ADDCMUL_DATA_FORMAT, ckl::Dst::D3, ckl::Dst::D2, ckl::Dst::D2>{},  // D2 = D3*in2
+        ckl::AddIntBinary<ADDCMUL_DATA_FORMAT, ckl::Dst::D0, ckl::Dst::D2, ckl::Dst::D0>{},  // D0 = in0 + D2
+        ckl::PackTile<ckl::output(
+            dfb_out_id,
+            ckl::ReservePolicy::PerBlockSize,
+            ckl::PushPolicy::PerBlockSize,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
@@ -3,39 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/compute/common.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/convenience.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_input = tt::CBIndex::c_0;
-    constexpr auto cb_output = tt::CBIndex::c_2;
+    constexpr auto dfb_input_id = tt::CBIndex::c_0;
+    constexpr auto dfb_output_id = tt::CBIndex::c_2;
 
-    DataflowBuffer dfb_in(cb_input);
-    DataflowBuffer dfb_out(cb_output);
+    compute_kernel_hw_startup(dfb_input_id, dfb_output_id);
 
-    compute_kernel_hw_startup(cb_input, cb_output);
-    copy_init(cb_input);
-
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        tile_regs_acquire();
-
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-
-        copy_tile(cb_input, 0, 0);
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_output);
-
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
-
-        tile_regs_release();
-    }
+    compute_kernel_lib::copy<
+        compute_kernel_lib::input(
+            dfb_input_id,
+            compute_kernel_lib::WaitPolicy::PerTile,
+            compute_kernel_lib::PopPolicy::PerTile,
+            compute_kernel_lib::DataFormatReconfig::Disabled),
+        compute_kernel_lib::output(
+            dfb_output_id,
+            compute_kernel_lib::ReservePolicy::PerTile,
+            compute_kernel_lib::PushPolicy::PerTile,
+            compute_kernel_lib::DataFormatReconfig::Disabled)>(compute_kernel_lib::IterationShape::tiles(num_tiles));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel.cpp
@@ -3,58 +3,53 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/compute/common.h"
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/compute/eltwise_unary/activations.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp"  // Hardsigmoid
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"  // Optional
+
+namespace ckl = compute_kernel_lib;
+
+constexpr bool kIsFloat32 = get_compile_time_arg_val(0) == 1;
+constexpr bool kIsInt = get_compile_time_arg_val(1) == 1;
+constexpr bool kIsFloat = !kIsFloat32 && !kIsInt;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_input = tt::CBIndex::c_0;
-    constexpr auto cb_output = tt::CBIndex::c_2;
+    constexpr auto dfb_input_id = tt::CBIndex::c_0;
+    constexpr auto dfb_output_id = tt::CBIndex::c_2;
 
-    DataflowBuffer dfb_in(cb_input);
-    DataflowBuffer dfb_out(cb_output);
+    compute_kernel_hw_startup(dfb_input_id, dfb_output_id);
 
-    compute_kernel_hw_startup(cb_input, cb_output);
-    copy_init(cb_input);
-
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        tile_regs_acquire();
-
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 0);
-        copy_tile(cb_input, 0, 1);
-
-        hardsigmoid_tile_init();
-        hardsigmoid_tile(0);
-
-#ifdef INP_FLOAT32
-        mul_binary_tile_init();
-        mul_binary_tile(0, 1, 0);
-#endif
-#ifdef INP_FLOAT
-        mul_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_input);
-        mul_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_input, 0, 0);
-#endif
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_output);
-
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
-
-        tile_regs_release();
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        ckl::CopyTile<
+            ckl::input(
+                dfb_input_id,
+                ckl::WaitPolicy::PerTile,
+                kIsInt ? ckl::PopPolicy::PerTile : ckl::PopPolicy::None,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::Hardsigmoid<ckl::Dst::D0>{},
+        ckl::Optional<
+            kIsFloat32,
+            ckl::CopyTile<
+                ckl::input(
+                    dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+                ckl::Dst::D1>>{},
+        ckl::Optional<kIsFloat32, ckl::MulBinary<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D0>>{},
+        ckl::Optional<
+            kIsFloat,
+            ckl::DestReuseBinary<
+                ckl::BinaryFpuOp::Mul,
+                ckl::input(
+                    dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+                ckl::DestReuseType::DEST_TO_SRCA>>{},
+        ckl::PackTile<ckl::output(
+            dfb_output_id,
+            ckl::ReservePolicy::PerTile,
+            ckl::PushPolicy::PerTile,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_fast_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_fast_kernel.cpp
@@ -3,107 +3,67 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/compute/common.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/eltwise_unary/binop_with_scalar.h"
-#include "api/compute/eltwise_unary/lgamma.h"
-#include "api/compute/eltwise_unary/fill.h"
-#include "api/compute/eltwise_unary/rounding.h"
-#include "api/compute/eltwise_unary/trigonometry.h"
-#include "api/compute/eltwise_unary/where.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp"  // FillScalar
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp"   // Where, LgammaStirling, LgammaAdjusted
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/trig.hpp"      // Sin
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/rounding.hpp"  // Floor, Frac
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"      // Abs
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"      // Log
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_input = tt::CBIndex::c_0;
-    constexpr auto cb_output = tt::CBIndex::c_2;
-
+    constexpr auto dfb_input_id = tt::CBIndex::c_0;
+    constexpr auto dfb_output_id = tt::CBIndex::c_2;
     constexpr float M_PI = 3.14159265358979323846f;
 
-    DataflowBuffer dfb_in(cb_input);
-    DataflowBuffer dfb_out(cb_output);
+    compute_kernel_hw_startup(dfb_input_id, dfb_output_id);
 
-    compute_kernel_hw_startup(cb_input, cb_output);
-    copy_init(cb_input);
-
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        tile_regs_acquire();
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-
-        // copy input to dst 0 and 1
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 0);  // x
-        copy_tile(cb_input, 0, 1);  // x
-
-        // tile 0 = res_stirling
-        lgamma_stirling_tile_init();
-        lgamma_stirling_tile(0);
-
-        // fill tile 2 with M_PI
-        fill_tile_init();
-        fill_tile(2, M_PI);
-
-        // tile 1 = frac (x)
-        rounding_op_tile_init();
-        frac_tile(1);
-
-        // tile 1 = frac (x) * M_PI
-        mul_binary_tile_init();
-        mul_binary_tile(1, 2, 1);
-
-        // tile 1 =  sin(frac (x) * M_PI)
-        sin_tile_init();
-        sin_tile(1);
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 2);  // x
-        copy_tile(cb_input, 0, 3);  // x
-
-        // tile 3 = floor(x)
-        rounding_op_tile_init();
-        floor_tile(3);
-
-        // tile 2 = ( x == floor(x)) condition
-        eq_binary_tile_init();
-        eq_binary_tile(2, 3, 2);
-
-        // fill tile 3 with 0.0f
-        fill_tile_init();
-        fill_tile(3, 0.0f);
-
-        // tile 1 = 0 if x == floor(x), otherwise sin(frac (x) * M_PI)
-        where_tile_init();
-        where_tile<DataFormat::Float16_b>(2, 3, 1, 1);
-
-        // abs(integer adjusted sin(frac (x) * M_PI))
-        abs_tile_init();
-        abs_tile(1);
-
-        // log|sin(pi*x)|. Zero sin(pi*x) at integers handled
-        log_tile_init();
-        log_tile(1);
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 2);  // x
-
-        lgamma_adjusted_tile_init();
-        lgamma_adjusted_tile(0, 1, 2, 0);
-
-        tile_regs_commit();
-
-        tile_regs_wait();
-
-        pack_tile(0, cb_output);
-
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
-
-        tile_regs_release();
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        // x -> D0 (owns the wait), x -> D1.
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        // D0 = stirling(x)
+        ckl::LgammaStirling<ckl::Dst::D0>{},
+        // D2 = M_PI ; D1 = sin(frac(x) * M_PI)
+        ckl::FillScalar<ckl::Dst::D2>{M_PI},
+        ckl::Frac<ckl::Dst::D1>{},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1>{},
+        ckl::Sin<ckl::Dst::D1>{},
+        // reload x -> D2, D3 ; D3 = floor(x) ; D2 = (x == floor(x))
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D2>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D3>{},
+        ckl::Floor<ckl::Dst::D3>{},
+        ckl::EqBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
+        // D3 = 0 ; D1 = where(cond=D2, a=0, b=sin) -> 0 at integers else sin
+        ckl::FillScalar<ckl::Dst::D3>{0.0f},
+        ckl::Where<DataFormat::Float16_b, ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D1, ckl::Dst::D1>{},
+        // D1 = log|D1|
+        ckl::Abs<ckl::Dst::D1>{},
+        ckl::Log<ckl::Approx::Exact, ckl::Dst::D1>{},
+        // reload x -> D2 (owns the pop) ; D0 = adjusted(stirling=D0, logsin=D1, x=D2)
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D2>{},
+        ckl::LgammaAdjusted<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D0>{},
+        ckl::PackTile<ckl::output(
+            dfb_output_id,
+            ckl::ReservePolicy::PerTile,
+            ckl::PushPolicy::PerTile,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/lgamma_kernel.cpp
@@ -3,137 +3,82 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/compute/common.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/eltwise_unary/binop_with_scalar.h"
-#include "api/compute/eltwise_unary/lgamma.h"
-#include "api/compute/eltwise_unary/fill.h"
-#include "api/compute/eltwise_unary/rounding.h"
-#include "api/compute/eltwise_unary/trigonometry.h"
-#include "api/compute/eltwise_unary/where.h"
-#include "api/compute/eltwise_unary/comp.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp"  // FillScalar
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/extended.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/predicates.hpp"  // Ltz
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp"     // Where, LgammaStirlingFloat, LgammaAdjusted
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/trig.hpp"        // Sin
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/rounding.hpp"    // Floor, Frac
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"        // Abs
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"        // Log
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_input = tt::CBIndex::c_0;
-    constexpr auto cb_output = tt::CBIndex::c_2;
-
+    constexpr auto dfb_input_id = tt::CBIndex::c_0;
+    constexpr auto dfb_output_id = tt::CBIndex::c_2;
     constexpr float M_PI = 3.14159265358979323846f;
 
-    DataflowBuffer dfb_in(cb_input);
-    DataflowBuffer dfb_out(cb_output);
+    compute_kernel_hw_startup(dfb_input_id, dfb_output_id);
 
-    compute_kernel_hw_startup(cb_input, cb_output);
-    copy_init(cb_input);
-
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        tile_regs_acquire();
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-
-        // copy input to dst 0 and 1
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 0);  // x
-        copy_tile(cb_input, 0, 1);  // x
-
-        fill_tile_init();
-        fill_tile(2, 0.5f);
-
-        // x - 0.5
-        sub_binary_tile_init();
-        sub_binary_tile(1, 2, 1);
-
-        // (x - 0.5) < 0
-        ltz_tile_init();
-        ltz_tile(1);
-
-        fill_tile_init();
-        fill_tile(2, 1.0f);
-
-        // 1 - x
-        sub_binary_tile_init();
-        sub_binary_tile(2, 0, 2);
-
-        // tile 1 = z = (x < 0.5) ? 1-x : x
-        where_tile_init();
-        where_tile<DataFormat::Float32>(1, 2, 0, 1);
-
-        // log z
-        log_tile_init<false>();
-        log_tile<false>(1);
-
-        // tile 0 = res_stirling
-        lgamma_stirling_float_tile_init();
-        lgamma_stirling_float_tile(0, 1, 0);  // x, log_z
-
-        // fill tile 2 with M_PI
-        fill_tile_init();
-        fill_tile(2, M_PI);
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 1);  // x
-
-        // tile 1 = frac (x)
-        rounding_op_tile_init();
-        frac_tile(1);
-
-        // tile 1 = frac (x) * M_PI
-        mul_binary_tile_init();
-        mul_binary_tile(1, 2, 1);
-
-        // tile 1 =  sin(frac (x) * M_PI)
-        sin_tile_init();
-        sin_tile(1);
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 2);  // x
-        copy_tile(cb_input, 0, 3);  // x
-
-        // tile 3 = floor(x)
-        rounding_op_tile_init();
-        floor_tile(3);
-
-        // tile 2 = ( x == floor(x)) condition
-        eq_binary_tile_init();
-        eq_binary_tile(2, 3, 2);
-
-        // fill tile 3 with 0.0f
-        fill_tile_init();
-        fill_tile(3, 0.0f);
-
-        // tile 1 = 0 if x == floor(x), otherwise sin(frac (x) * M_PI)
-        where_tile_init();
-        where_tile<DataFormat::Float32>(2, 3, 1, 1);
-
-        // abs(integer adjusted sin(frac (x) * M_PI))
-        abs_tile_init();
-        abs_tile(1);
-
-        // log|sin(pi*x)|. Zero sin(pi*x) at integers handled
-        log_tile_init();
-        log_tile(1);
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 2);  // x
-
-        lgamma_adjusted_tile_init();
-        lgamma_adjusted_tile(0, 1, 2, 0);
-
-        tile_regs_commit();
-
-        tile_regs_wait();
-
-        pack_tile(0, cb_output);
-
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
-
-        tile_regs_release();
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        // x -> D0 (owns the wait), x -> D1.
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        // D2 = 0.5 ; D1 = x - 0.5 ; D1 = (x-0.5 < 0)
+        ckl::FillScalar<ckl::Dst::D2>{0.5f},
+        ckl::SubBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1>{},
+        ckl::Ltz<ckl::Dst::D1>{},
+        // D2 = 1.0 ; D2 = 1 - x
+        ckl::FillScalar<ckl::Dst::D2>{1.0f},
+        ckl::SubBinary<ckl::Dst::D2, ckl::Dst::D0, ckl::Dst::D2>{},
+        // D1 = z = where(cond=D1, a=1-x, b=x)
+        ckl::Where<DataFormat::Float32, ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D0, ckl::Dst::D1>{},
+        // D1 = log z
+        ckl::Log<ckl::Approx::Exact, ckl::Dst::D1>{},
+        // D0 = stirling(x=D0, log_z=D1)
+        ckl::LgammaStirlingFloat<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D0>{},
+        // D2 = M_PI ; reload x -> D1 ; D1 = sin(frac(x) * M_PI)
+        ckl::FillScalar<ckl::Dst::D2>{M_PI},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        ckl::Frac<ckl::Dst::D1>{},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1>{},
+        ckl::Sin<ckl::Dst::D1>{},
+        // reload x -> D2, D3 ; D3 = floor(x) ; D2 = (x == floor(x))
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D2>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D3>{},
+        ckl::Floor<ckl::Dst::D3>{},
+        ckl::EqBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
+        // D3 = 0 ; D1 = where(cond=D2, a=0, b=sin) -> 0 at integers else sin
+        ckl::FillScalar<ckl::Dst::D3>{0.0f},
+        ckl::Where<DataFormat::Float32, ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D1, ckl::Dst::D1>{},
+        // D1 = log|D1|
+        ckl::Abs<ckl::Dst::D1>{},
+        ckl::Log<ckl::Approx::Exact, ckl::Dst::D1>{},
+        // reload x -> D2 (owns the pop) ; D0 = adjusted(stirling=D0, logsin=D1, x=D2)
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D2>{},
+        ckl::LgammaAdjusted<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D0>{},
+        ckl::PackTile<ckl::output(
+            dfb_output_id,
+            ckl::ReservePolicy::PerTile,
+            ckl::PushPolicy::PerTile,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logit_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logit_kernel.cpp
@@ -2,79 +2,65 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/compute/common.h"
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/eltwise_unary/clamp.h"
-#include "api/compute/eltwise_unary/rsub.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"    // Log
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/scalar.hpp"  // Clamp, RsubUnary
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"  // Optional
+
+namespace ckl = compute_kernel_lib;
 
 // Formula: logit(x) = log(x/(1-x)) -- calls clamp, rsub, div, and log tiles.
+
+constexpr bool kDoClamp = get_compile_time_arg_val(0) == 1;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t packed_scalar1 = get_arg_val<uint32_t>(1);
     const uint32_t packed_scalar2 = get_arg_val<uint32_t>(2);
 
-    constexpr auto cb_input = tt::CBIndex::c_0;
-    constexpr auto cb_output = tt::CBIndex::c_2;
-    constexpr auto cb_tmp0 = tt::CBIndex::c_1;
+    constexpr auto dfb_input_id = tt::CBIndex::c_0;
+    constexpr auto dfb_tmp0_id = tt::CBIndex::c_1;
+    constexpr auto dfb_output_id = tt::CBIndex::c_2;
 
-    DataflowBuffer dfb_in(cb_input);
-    DataflowBuffer dfb_out(cb_output);
-    DataflowBuffer dfb_tmp(cb_tmp0);
+    // The legacy kernel boots unpack from the input and pack for the final output once;
+    // tmp0 has the same element format and is only an in-kernel handoff.
+    compute_kernel_hw_startup(dfb_input_id, dfb_output_id);
 
-    compute_kernel_hw_startup(cb_input, cb_output);
-    copy_init(cb_input);
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-        dfb_tmp.reserve_back(1);
+    // The temporary DFB holds only two tiles, and this kernel is both its producer and consumer.
+    // Produce and consume one tile at a time: separating the two stages deadlocks once the producer fills the DFB.
+    for (uint32_t tile = 0; tile < num_tiles; ++tile) {
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<
+                ckl::input(
+                    dfb_input_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+                ckl::Dst::D0>{},
+            ckl::Optional<kDoClamp, ckl::Clamp<ckl::Dst::D0>>{packed_scalar1, packed_scalar2},
+            ckl::PackTile<ckl::output(
+                dfb_tmp0_id,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckl::DataFormatReconfig::Disabled)>{});
 
-        tile_regs_acquire();
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 0);
-#ifdef CLAMP
-        clamp_tile_init();
-        clamp_tile(0, packed_scalar1, packed_scalar2);
-#endif
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_tmp0);
-        tile_regs_release();
-
-        dfb_tmp.push_back(1);
-        dfb_tmp.wait_front(1);
-
-        tile_regs_acquire();
-
-        copy_init(cb_tmp0);
-        copy_tile(cb_tmp0, 0, 0);
-        copy_tile(cb_tmp0, 0, 1);
-
-        rsub_tile_init();
-        rsub_tile(0, 0x3F800000u);  // 1.0 - x
-
-        div_binary_tile_init();
-        div_binary_tile(1, 0, 0);
-
-        log_tile_init();
-        log_tile(0);
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_output);
-        tile_regs_release();
-
-        dfb_tmp.pop_front(1);
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
+        ckl::eltwise_chain(
+            ckl::IterationShape::one_tile(),
+            ckl::CopyTile<
+                ckl::input(
+                    dfb_tmp0_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+                ckl::Dst::D0>{},
+            ckl::CopyTile<
+                ckl::input(
+                    dfb_tmp0_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+                ckl::Dst::D1>{},
+            ckl::RsubUnary<ckl::Dst::D0>{0x3F800000u},  // 1.0 - x
+            ckl::DivBinary<ckl::Dst::D1, ckl::Dst::D0, ckl::Dst::D0>{},
+            ckl::Log<ckl::Approx::Exact, ckl::Dst::D0>{},
+            ckl::PackTile<ckl::output(
+                dfb_output_id,
+                ckl::ReservePolicy::PerTile,
+                ckl::PushPolicy::PerTile,
+                ckl::DataFormatReconfig::Disabled)>{});
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
@@ -3,53 +3,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/compute/common.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/eltwise_unary/exp.h"
-#include "api/compute/logsigmoid.h"
-#include "api/compute/eltwise_unary/negative.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/math.hpp"         // Exp
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"         // Negative
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp"  // Logsigmoid
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_input = tt::CBIndex::c_0;
-    constexpr auto cb_output = tt::CBIndex::c_2;
+    constexpr auto dfb_input_id = tt::CBIndex::c_0;
+    constexpr auto dfb_output_id = tt::CBIndex::c_2;
 
-    DataflowBuffer dfb_in(cb_input);
-    DataflowBuffer dfb_out(cb_output);
+    compute_kernel_hw_startup(dfb_input_id, dfb_output_id);
 
-    compute_kernel_hw_startup(cb_input, cb_output);
-    copy_init(cb_input);
-
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-
-        tile_regs_acquire();
-
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 0);
-        copy_tile(cb_input, 0, 1);
-
-        negative_tile_init();
-        negative_tile(1);
-
-        exp_tile_init<true>();
-        exp_tile<true>(1);
-
-        logsigmoid_tile_init();
-        logsigmoid_tile(0, 1, 0);
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_output);
-        tile_regs_release();
-
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        ckl::Negative<ckl::Dst::D1>{},
+        ckl::Exp<ckl::Approx::Fast, ckl::Dst::D1>{},
+        ckl::Logsigmoid<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D0>{},
+        ckl::PackTile<ckl::output(
+            dfb_output_id,
+            ckl::ReservePolicy::PerTile,
+            ckl::PushPolicy::PerTile,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
@@ -3,61 +3,56 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/compute/common.h"
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/eltwise_unary/fill.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/special.hpp"    // Where
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp"  // FillBitcast / FillInt
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/core/optional.hpp"    // Optional
+
+namespace ckl = compute_kernel_lib;
+
+#if defined(INP_INT32)
+constexpr auto kWhereDF = DataFormat::Int32;
+#elif defined(INP_UINT32)
+constexpr auto kWhereDF = DataFormat::UInt32;
+#elif defined(INP_FLOAT32)
+constexpr auto kWhereDF = DataFormat::Float32;
+#else
+// The legacy kernel used Float16_b for BF16 and both BFP input dtypes.
+constexpr auto kWhereDF = DataFormat::Float16_b;
+#endif
+
+constexpr bool kIsInt = kWhereDF == DataFormat::Int32 || kWhereDF == DataFormat::UInt32;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t packed_scalar1 = get_arg_val<uint32_t>(1);
     const uint32_t packed_scalar2 = get_arg_val<uint32_t>(2);
-    const auto true_value = reinterpret_cast<const float*>(&packed_scalar1);
-    const auto false_value = reinterpret_cast<const float*>(&packed_scalar2);
 
-    constexpr auto cb_input = tt::CBIndex::c_0;
-    constexpr auto cb_output = tt::CBIndex::c_2;
+    constexpr auto dfb_input_id = tt::CBIndex::c_0;
+    constexpr auto dfb_output_id = tt::CBIndex::c_2;
 
-    DataflowBuffer dfb_in(cb_input);
-    DataflowBuffer dfb_out(cb_output);
+    compute_kernel_hw_startup(dfb_input_id, dfb_output_id);
 
-    compute_kernel_hw_startup(cb_input, cb_output);
-    copy_init(cb_input);
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-        tile_regs_acquire();
-        copy_init(cb_input);
-        copy_tile(cb_input, 0, 0);
-
-        fill_tile_init();
-#if defined(INP_INT32)
-        fill_tile_int<DataFormat::Int32>(1, packed_scalar1);
-        fill_tile_int<DataFormat::Int32>(2, packed_scalar2);
-#endif
-#if defined(INP_UINT32)
-        fill_tile_int<DataFormat::UInt32>(1, packed_scalar1);
-        fill_tile_int<DataFormat::UInt32>(2, packed_scalar2);
-#endif
-#if defined(INP_FLOAT) || defined(INP_FLOAT32)
-        fill_tile(1, *true_value);
-        fill_tile(2, *false_value);
-#endif
-#ifndef SFPU_OP_CHAIN_0
-#error "where_tss_kernel requires SFPU_OP_CHAIN_0 to be defined via get_block_defines"
-#endif
-        SFPU_OP_CHAIN_0
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_output);
-        tile_regs_release();
-
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
-    }
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        // cond -> D0. Single DFB read: Streaming (wait 1 / pop 1 per iter), Scalar index.
+        ckl::CopyTile<
+            ckl::input(
+                dfb_input_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        // true_value -> D1 (inactive flavor folds to a FillTileTag no-op).
+        // kWhereDF carries main's #48602 fix: Int32 for int32 inputs, UInt32 for uint32 inputs.
+        ckl::Optional<kIsInt, ckl::FillInt<kWhereDF, ckl::Dst::D1>>{packed_scalar1},
+        ckl::Optional<!kIsInt, ckl::FillBitcast<ckl::Dst::D1>>{packed_scalar1},
+        // false_value -> D2.
+        ckl::Optional<kIsInt, ckl::FillInt<kWhereDF, ckl::Dst::D2>>{packed_scalar2},
+        ckl::Optional<!kIsInt, ckl::FillBitcast<ckl::Dst::D2>>{packed_scalar2},
+        // where(D0, D1, D2) -> D0.
+        ckl::Where<kWhereDF, ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D0>{},
+        ckl::PackTile<ckl::output(
+            dfb_output_id,
+            ckl::ReservePolicy::PerTile,
+            ckl::PushPolicy::PerTile,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -35,14 +35,10 @@ void apply_input_dtype_defines(DataType dtype, std::map<std::string, std::string
     }
 }
 
-void pack_first_op_scalars(
-    const EltwiseUnaryWithParam& op,
-    DataType input_dtype,
-    uint32_t& packed_scalar1,
-    uint32_t& packed_scalar2,
-    std::map<std::string, std::string>& unary_defines) {
+bool pack_first_op_scalars(
+    const EltwiseUnaryWithParam& op, DataType input_dtype, uint32_t& packed_scalar1, uint32_t& packed_scalar2) {
     if (op.empty()) {
-        return;
+        return false;
     }
     switch (op.type()) {
         case UnaryOpType::WHERE_TSS:
@@ -78,12 +74,13 @@ void pack_first_op_scalars(
                 }
                 packed_scalar1 = pack_scalar_runtime_arg_impl(lo, input_dtype);
                 packed_scalar2 = pack_scalar_runtime_arg_impl(hi, input_dtype);
-                unary_defines["CLAMP"] = "clamp_tile";
+                return true;
             }
             break;
         }
         default: break;
     }
+    return false;
 }
 
 bool needs_tmp0_cb(UnaryOpType t) { return t == UnaryOpType::LOGIT; }
@@ -420,8 +417,8 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
     const bool math_approx_mode = false;
     std::map<std::string, std::string> unary_defines = get_block_defines(ops_chain, "0", "0", input.dtype());
     CMAKE_UNIQUE_NAMESPACE::apply_input_dtype_defines(input.dtype(), unary_defines);
-    CMAKE_UNIQUE_NAMESPACE::pack_first_op_scalars(
-        ops_chain[0], input.dtype(), packed_scalar1, packed_scalar2, unary_defines);
+    const bool logit_clamp_enabled =
+        CMAKE_UNIQUE_NAMESPACE::pack_first_op_scalars(ops_chain[0], input.dtype(), packed_scalar1, packed_scalar2);
 
     const std::string compute_path = fmt::format(
         "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/{}",
@@ -509,6 +506,15 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
     compute_desc.kernel_source = compute_path;
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_device_cores;
+    if (ops_chain[0].type() == UnaryOpType::HARDSWISH) {
+        compute_desc.compile_time_args = {
+            static_cast<uint32_t>(unary_defines.contains("INP_FLOAT32")),
+            static_cast<uint32_t>(unary_defines.contains("INP_INT32") || unary_defines.contains("INP_UINT32")),
+        };
+    } else if (ops_chain[0].type() == UnaryOpType::LOGIT) {
+        compute_desc.compile_time_args = {static_cast<uint32_t>(logit_clamp_enabled)};
+    }
+    compute_desc.compile_time_args.push_back(static_cast<uint32_t>(cb_data_format));
     compute_desc.defines = {unary_defines.begin(), unary_defines.end()};
     compute_desc.config = ComputeConfigDescriptor{
         .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
@@ -595,9 +601,8 @@ void UnaryDeviceOperation::ProgramFactory::override_runtime_arguments(
     // A changed split can flip a core between noop and active, so write every slot create_descriptor
     // writes rather than only the ones that usually move -- otherwise a flipped core keeps stale args.
     uint32_t packed_scalar1 = 0, packed_scalar2 = 0;
-    std::map<std::string, std::string> unused_defines;
     CMAKE_UNIQUE_NAMESPACE::pack_first_op_scalars(
-        operation_attributes.op_chain[0], input.dtype(), packed_scalar1, packed_scalar2, unused_defines);
+        operation_attributes.op_chain[0], input.dtype(), packed_scalar1, packed_scalar2);
 
     enumerate_core_rt_args(
         operation_attributes, tensor_args, output, [&](const CoreRtArgs& w, const RmChunkConstants& kc) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/gelu_bw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/gelu_bw_program_factory.cpp
@@ -128,9 +128,9 @@ tt::tt_metal::ProgramDescriptor GeluBwProgramFactory::create_descriptor(
     }
     std::map<std::string, std::string> compute_defines;
     if (fp32_dest_acc_en) {
-        compute_defines["COPY_DEST_VALUES"] = "copy_dest_values<DataFormat::Float32>";
+        compute_defines["COPY_DEST_DATA_FORMAT"] = "DataFormat::Float32";
     } else {
-        compute_defines["COPY_DEST_VALUES"] = "copy_dest_values<DataFormat::Float16_b>";
+        compute_defines["COPY_DEST_DATA_FORMAT"] = "DataFormat::Float16_b";
     }
 
     if (output.dtype() == DataType::BFLOAT16) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_poly.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_poly.cpp
@@ -2,62 +2,53 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Compute kernel for GELU backward using polynomial-based GELU derivative
-// Uses Sollya-derived minimax polynomials for high accuracy (Max ULP = 1)
-
 #include <cstdint>
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/common.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/binary_bitwise_sfpu.h"
-#include "api/compute/binary_shift.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/compute/eltwise_unary/gelu.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp"  // GeluDerivative
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
 
+namespace ckl = compute_kernel_lib;
+
+// GELU backward using the exact (non-tanh) piecewise derivative: Sollya-fitted core and corrected negative tail.
+// Uses Sollya-derived minimax polynomials for high accuracy (Max ULP = 1)
 void kernel_main() {
-    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t per_core_tile_cnt = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_grad_out = tt::CBIndex::c_0;
-    constexpr auto cb_input = tt::CBIndex::c_1;
-    constexpr auto cb_grad_in = tt::CBIndex::c_2;
+    constexpr auto dfb_grad_out_id = tt::CBIndex::c_0;
+    constexpr auto dfb_input_id = tt::CBIndex::c_1;
+    constexpr auto dfb_grad_in_id = tt::CBIndex::c_2;
 
-    CircularBuffer cb_grad_out_cb(cb_grad_out);
-    CircularBuffer cb_input_cb(cb_input);
-    CircularBuffer cb_grad_in_cb(cb_grad_in);
+    compute_kernel_hw_startup(dfb_grad_out_id, dfb_grad_in_id);
 
-    compute_kernel_hw_startup(cb_grad_out, cb_grad_in);
-    copy_init(cb_grad_out);
-    gelu_derivative_tile_init<false>();
-    mul_binary_tile_init();
+    const auto shape = ckl::IterationShape::tiles(per_core_tile_cnt);
 
-    // Per-tile canonical pattern: acquire → compute → commit → wait → pack → release
     // Multi-tile batching in dest is not possible here because gelu_derivative_tile
     // uses additional dest registers as scratch during polynomial evaluation.
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_grad_in_cb.reserve_back(1);
-        cb_grad_out_cb.wait_front(1);
-        cb_input_cb.wait_front(1);
-
-        tile_regs_acquire();
-
-        copy_tile(cb_grad_out, 0, 0);    // dest[0] = grad_out
-        copy_tile(cb_input, 0, 1);       // dest[1] = input
-        gelu_derivative_tile<false>(1);  // dest[1] = GELU'(input)
-        mul_binary_tile(0, 1, 0);        // dest[0] = grad_out * GELU'(input)
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_grad_in);
-
-        tile_regs_release();
-
-        cb_grad_out_cb.pop_front(1);
-        cb_input_cb.pop_front(1);
-        cb_grad_in_cb.push_back(1);
-    }
+    ckl::eltwise_chain(
+        shape,
+        // dest[0] = grad_out
+        ckl::CopyTile<
+            ckl::input(
+                dfb_grad_out_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::CopyTile<
+            ckl::input(
+                dfb_input_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        ckl::GeluDerivative<ckl::Approx::Exact, ckl::Dst::D1>{},     // dest[1] = GELU'(input)
+        ckl::MulBinary<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D0>{},  // dest[0] = grad_out * GELU'(input)
+        ckl::PackTile<ckl::output(
+            dfb_grad_in_id,
+            ckl::ReservePolicy::PerBlockSize,
+            ckl::PushPolicy::PerBlockSize,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_tanh.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_tanh.cpp
@@ -2,121 +2,91 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-
-#include "api/compute/common.h"
+#include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/binary_bitwise_sfpu.h"
-#include "api/compute/binary_shift.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/compute/copy_dest_values.h"
-#include "api/compute/eltwise_unary/fill.h"
-#include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
 
+namespace ckl = compute_kernel_lib;
+
+// GELU'(x) = 0.5*(1+tanh(z)) + 0.5*beta*x*(1+3*kappa*x^2)*(1-tanh(z)^2),
+// where z = beta*(x+kappa*x^3); output = grad_out*GELU'(x).
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_grad_out = tt::CBIndex::c_0;
-    constexpr auto cb_input = tt::CBIndex::c_1;
-    constexpr auto cb_grad_in = tt::CBIndex::c_2;
-
-    CircularBuffer cb_grad_out_cb(cb_grad_out);
-    CircularBuffer cb_input_cb(cb_input);
-    CircularBuffer cb_grad_in_cb(cb_grad_in);
+    constexpr auto dfb_grad_out_id = tt::CBIndex::c_0;
+    constexpr auto dfb_input_id = tt::CBIndex::c_1;
+    constexpr auto dfb_grad_in_id = tt::CBIndex::c_2;
 
     constexpr float kSqrt2 = 1.41421356237309504880f;          // sqrt(2)
     constexpr float kTwoOverSqrtPi = 1.12837916709551257390f;  // 2/sqrt(pi)
     constexpr float kBeta = kSqrt2 * kTwoOverSqrtPi * 0.5f;
     constexpr float kKappa = 0.044715f;
 
-    compute_kernel_hw_startup(cb_grad_out, cb_grad_in);
-    copy_init(cb_grad_out);
-    add_binary_tile_init();
-    mul_binary_tile_init();
-    square_tile_init();
-    tanh_tile_init();
-    sub_binary_tile_init();
+    compute_kernel_hw_startup(dfb_grad_out_id, dfb_grad_in_id);
 
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_grad_in_cb.reserve_back(1);
-        cb_grad_out_cb.wait_front(1);
-        cb_input_cb.wait_front(1);
-
-        tile_regs_acquire();
-
-        copy_tile(cb_grad_out, 0, 0);
-        copy_tile(cb_input, 0, 1);
-        copy_tile(cb_input, 0, 2);  // tile[2] = x
-        copy_tile(cb_input, 0, 5);  // tile[5] = x
-
-        // tile[1] = x³
-        square_tile(1);            // tile[1] = x²
-        mul_binary_tile(1, 2, 1);  // tile[1] = x² * x = x³
-
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        ckl::CopyTile<
+            ckl::input(
+                dfb_grad_out_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D2>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D5>{},
+        ckl::Square<ckl::Dst::D1>{},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1>{},
         // tile[1] = kKappa * x³
-        fill_tile(3, kKappa);
-        mul_binary_tile(1, 3, 1);
-
+        ckl::FillScalar<ckl::Dst::D3>{kKappa},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1>{},
         // tile[1] = x + kKappa * x³
-        add_binary_tile<BF16_ROUNDING_MODE>(1, 2, 1);
-
+        ckl::AddBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1, BF16_ROUNDING_MODE>{},
         // tile[1] = kBeta * (x + kKappa * x³) = inner
-        fill_tile(3, kBeta);
-        mul_binary_tile(1, 3, 1);
-
+        ckl::FillScalar<ckl::Dst::D3>{kBeta},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1>{},
         // tile[1] = tanh(inner)
-        tanh_tile_init();
-        tanh_tile(1);
-        COPY_DEST_VALUES(1, 4);  // tile[4] = tanh(inner)
-
+        ckl::Tanh<ckl::Dst::D1>{},
+        ckl::CopyDest<ckl::Dst::D1, ckl::Dst::D4, COPY_DEST_DATA_FORMAT>{},  // tile[4] = tanh(inner)
         // CDF term: tile[1] = 0.5 * (1 + tanh)
-        fill_tile(3, 1.0f);
-        add_binary_tile<BF16_ROUNDING_MODE>(1, 3, 1);  // tile[1] = 1 + tanh
-        fill_tile(3, 0.5f);
-        mul_binary_tile(1, 3, 1);  // tile[1] = 0.5*(1 + tanh) = CDF term
-
+        ckl::FillScalar<ckl::Dst::D3>{1.0f},
+        ckl::AddBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1, BF16_ROUNDING_MODE>{},
+        ckl::FillScalar<ckl::Dst::D3>{0.5f},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1>{},  // tile[1] = 0.5*(1 + tanh) = CDF term
         // sech²: tile[4] = 1 - tanh²
-        square_tile(4);  // tile[4] = tanh²
-        fill_tile(3, 1.0f);
-        sub_binary_tile<BF16_ROUNDING_MODE>(3, 4, 3);  // tile[3] = 1 - tanh²
-        COPY_DEST_VALUES(3, 4);    // tile[4] = sech²
-
+        ckl::Square<ckl::Dst::D4>{},
+        ckl::FillScalar<ckl::Dst::D3>{1.0f},
+        ckl::SubBinary<ckl::Dst::D3, ckl::Dst::D4, ckl::Dst::D3, BF16_ROUNDING_MODE>{},
+        ckl::CopyDest<ckl::Dst::D3, ckl::Dst::D4, COPY_DEST_DATA_FORMAT>{},
         // PDF term: 0.5 * kBeta * x * (1 + 3*kKappa*x²) * sech²
         // tile[2] still = x, need x²
-        fill_tile(3, kKappa * 3.0f);
-        square_tile(2);            // tile[2] = x²
-        mul_binary_tile(2, 3, 2);  // tile[2] = 3*kKappa * x²
-        fill_tile(3, 1.0f);
-        add_binary_tile<BF16_ROUNDING_MODE>(2, 3, 2);  // tile[2] = 1 + 3*kKappa*x²
-
+        ckl::FillScalar<ckl::Dst::D3>{kKappa * 3.0f},
+        ckl::Square<ckl::Dst::D2>{},
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},  // tile[2] = 3*kKappa * x²
+        ckl::FillScalar<ckl::Dst::D3>{1.0f},
+        ckl::AddBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2, BF16_ROUNDING_MODE>{},  // tile[2] = 1 + 3*kKappa*x²
         // tile[2] = sech² * (1 + 3*kKappa*x²)
-        mul_binary_tile(2, 4, 2);
-
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D4, ckl::Dst::D2>{},
         // tile[2] = kBeta/2 * sech² * (1 + 3*kKappa*x²)
-        fill_tile(3, kBeta / 2.0f);
-        mul_binary_tile(2, 3, 2);
-
+        ckl::FillScalar<ckl::Dst::D3>{kBeta / 2.0f},
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
         // tile[2] = x * kBeta/2 * sech² * (1 + 3*kKappa*x²) = PDF term
-        COPY_DEST_VALUES(5, 3);  // tile[3] = x (saved in tile[5])
-        mul_binary_tile(2, 3, 2);
-
+        ckl::CopyDest<ckl::Dst::D5, ckl::Dst::D3, COPY_DEST_DATA_FORMAT>{},  // tile[3] = x (saved in tile[5])
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
         // result = grad * (CDF_term + PDF_term)
-        add_binary_tile<BF16_ROUNDING_MODE>(1, 2, 1);  // tile[1] = CDF + PDF
-        mul_binary_tile(0, 1, 0);  // tile[0] = grad * (CDF + PDF)
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_grad_in);
-
-        tile_regs_release();
-
-        cb_grad_out_cb.pop_front(1);
-        cb_input_cb.pop_front(1);
-        cb_grad_in_cb.push_back(1);
-    }
+        ckl::AddBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1, BF16_ROUNDING_MODE>{},
+        ckl::MulBinary<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D0>{},  // tile[0] = grad * (CDF + PDF)
+        ckl::PackTile<ckl::output(
+            dfb_grad_in_id,
+            ckl::ReservePolicy::PerTile,
+            ckl::PushPolicy::PerTile,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_tanh_fp32.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_tanh_fp32.cpp
@@ -2,122 +2,90 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Same tanh-approximation GELU backward formula as eltwise_bw_gelu_tanh.cpp, restricted to
-// 4 live DST tiles (0-3) instead of 6.
+// GELU'(x) = 0.5*(1+tanh(z)) + 0.5*beta*x*(1+3*kappa*x^2)*(1-tanh(z)^2),
+// where z = beta*(x+kappa*x^3); output = grad_out*GELU'(x). This version is restricted
+// to four live DST tiles (0-3).
 
-#include <cstdint>
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-
-#include "api/compute/common.h"
+#include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/binary_bitwise_sfpu.h"
-#include "api/compute/binary_shift.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/compute/copy_dest_values.h"
-#include "api/compute/eltwise_unary/fill.h"
-#include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/fill.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/misc.hpp"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_grad_out = tt::CBIndex::c_0;
-    constexpr auto cb_input = tt::CBIndex::c_1;
-    constexpr auto cb_grad_in = tt::CBIndex::c_2;
-
-    CircularBuffer cb_grad_out_cb(cb_grad_out);
-    CircularBuffer cb_input_cb(cb_input);
-    CircularBuffer cb_grad_in_cb(cb_grad_in);
+    constexpr auto dfb_grad_out_id = tt::CBIndex::c_0;
+    constexpr auto dfb_input_id = tt::CBIndex::c_1;
+    constexpr auto dfb_grad_in_id = tt::CBIndex::c_2;
 
     constexpr float kSqrt2 = 1.41421356237309504880f;          // sqrt(2)
     constexpr float kTwoOverSqrtPi = 1.12837916709551257390f;  // 2/sqrt(pi)
     constexpr float kBeta = kSqrt2 * kTwoOverSqrtPi * 0.5f;
     constexpr float kKappa = 0.044715f;
 
-    compute_kernel_hw_startup(cb_grad_out, cb_grad_in);
-    copy_init(cb_grad_out);
-    add_binary_tile_init();
-    mul_binary_tile_init();
-    square_tile_init();
-    tanh_tile_init();
-    sub_binary_tile_init();
+    compute_kernel_hw_startup(dfb_grad_out_id, dfb_grad_in_id);
 
-    for (uint32_t i = 0; i < num_tiles; ++i) {
-        cb_grad_in_cb.reserve_back(1);
-        cb_grad_out_cb.wait_front(1);
-        cb_input_cb.wait_front(1);
-
-        tile_regs_acquire();
-
-        copy_tile(cb_input, 0, 1);
-        copy_tile(cb_input, 0, 2);  // tile[2] = x
-
-        // tile[1] = x^3
-        square_tile(1);
-        mul_binary_tile(1, 2, 1);
-
+    ckl::eltwise_chain(
+        ckl::IterationShape::tiles(num_tiles),
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::None, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D2>{},
+        ckl::Square<ckl::Dst::D1>{},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1>{},
         // tile[1] = 0.044715 * x^3
-        fill_tile(3, kKappa);
-        mul_binary_tile(1, 3, 1);
-
+        ckl::FillScalar<ckl::Dst::D3>{kKappa},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1>{},
         // tile[1] = x + 0.044715 * x^3
-        add_binary_tile(1, 2, 1);
-
+        ckl::AddBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1>{},
         // tile[1] = sqrt(2/π) * (x + 0.044715 * x^3)
-        fill_tile(3, kBeta);
-        mul_binary_tile(1, 3, 1);
-
+        ckl::FillScalar<ckl::Dst::D3>{kBeta},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1>{},
         // tile[1] = tanh(sqrt(2/π) * (x + 0.044715 * x^3))
-        tanh_tile_init();
-        tanh_tile(1);
-        COPY_DEST_VALUES(1, 0);  // copy tanh result to tile[0]
-
+        ckl::Tanh<ckl::Dst::D1>{},
+        ckl::CopyDest<ckl::Dst::D1, ckl::Dst::D0, COPY_DEST_DATA_FORMAT>{},  // copy tanh result to tile[0]
         // CDF term: tile[1] = 0.5 * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))
-        fill_tile(3, 1.0f);
-        add_binary_tile(1, 3, 1);
-        fill_tile(3, 0.5f);
-        mul_binary_tile(1, 3, 1);
-
-        // tile[0] = 1 - tanh^2
-        square_tile(0);
-        fill_tile(3, 1.0f);
-        sub_binary_tile(3, 0, 0);
-
+        ckl::FillScalar<ckl::Dst::D3>{1.0f},
+        ckl::AddBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1>{},
+        ckl::FillScalar<ckl::Dst::D3>{0.5f},
+        ckl::MulBinary<ckl::Dst::D1, ckl::Dst::D3, ckl::Dst::D1>{},
+        ckl::Square<ckl::Dst::D0>{},
+        ckl::FillScalar<ckl::Dst::D3>{1.0f},
+        ckl::SubBinary<ckl::Dst::D3, ckl::Dst::D0, ckl::Dst::D0>{},
         // tile[2] = (1 + 0.134145 * x**2)
-        fill_tile(3, kKappa * 3.0f);
-        square_tile(2);            // x^2
-        mul_binary_tile(2, 3, 2);  // 0.134145 * x**2
-        fill_tile(3, 1.0f);
-        add_binary_tile(2, 3, 2);  // 1 + 0.134145 * x**2
-
+        ckl::FillScalar<ckl::Dst::D3>{kKappa * 3.0f},
+        ckl::Square<ckl::Dst::D2>{},
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
+        ckl::FillScalar<ckl::Dst::D3>{1.0f},
+        ckl::AddBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
         // PDF term: tile[2] = 0.5 * sqrt(2/π) * (1 + 0.134145 * x^2) * (1 - tanh^2)
-        mul_binary_tile(2, 0, 2);
-        fill_tile(3, kBeta / 2.0f);
-        mul_binary_tile(2, 3, 2);
-
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D0, ckl::Dst::D2>{},
+        ckl::FillScalar<ckl::Dst::D3>{kBeta / 2.0f},
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
         // tile[0] is free now (tanh/sech² no longer needed): load grad_out.
-        copy_tile(cb_grad_out, 0, 0);
-
+        ckl::CopyTile<
+            ckl::input(
+                dfb_grad_out_id, ckl::WaitPolicy::PerTile, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
         // tile[2] = x * pdf term. Re-read x from the CB
-        copy_tile(cb_input, 0, 3);
-        mul_binary_tile(2, 3, 2);
-
+        ckl::CopyTile<
+            ckl::input(dfb_input_id, ckl::WaitPolicy::None, ckl::PopPolicy::PerTile, ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D3>{},
+        ckl::MulBinary<ckl::Dst::D2, ckl::Dst::D3, ckl::Dst::D2>{},
         // result: tile[1] = cdf_term + x * pdf_term
-        add_binary_tile(1, 2, 1);
+        ckl::AddBinary<ckl::Dst::D1, ckl::Dst::D2, ckl::Dst::D1>{},
         // tile[0] = grad * (cdf_term + x * pdf_term)
-        mul_binary_tile(0, 1, 0);
-
-        tile_regs_commit();
-        tile_regs_wait();
-
-        pack_tile(0, cb_grad_in);
-
-        tile_regs_release();
-
-        cb_grad_out_cb.pop_front(1);
-        cb_input_cb.pop_front(1);
-        cb_grad_in_cb.push_back(1);
-    }
+        ckl::MulBinary<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D0>{},
+        ckl::PackTile<ckl::output(
+            dfb_grad_in_id,
+            ckl::ReservePolicy::PerTile,
+            ckl::PushPolicy::PerTile,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/kernels/compute/eltwise_bw_tanh_deriv.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/kernels/compute/eltwise_bw_tanh_deriv.cpp
@@ -2,60 +2,52 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Compute kernel for tanh backward using sech²(x) = 4·exp(-2|x|) / (1 + exp(-2|x|))²
-// Avoids catastrophic cancellation in the naive 1 - tanh²(x) formula.
+// Uses sech^2(x) = 4*exp(-2*abs(x)) / (1+exp(-2*abs(x)))^2 to avoid catastrophic
+// cancellation in the naive 1-tanh(x)^2 formula.
 
 #include <cstdint>
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/common.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/tanh_derivative.h"
-#include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/compute_kernel_api.h"
-#include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/unary/activations.hpp"  // TanhDerivative
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/binary/sfpu/basic.hpp"
+
+namespace ckl = compute_kernel_lib;
 
 void kernel_main() {
-    uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
-    uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
+    uint32_t per_core_tile_cnt = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_grad_out = tt::CBIndex::c_0;
-    constexpr auto cb_input = tt::CBIndex::c_1;
-    constexpr auto cb_grad_in = tt::CBIndex::c_2;
+    constexpr auto dfb_grad_out_id = tt::CBIndex::c_0;
+    constexpr auto dfb_input_id = tt::CBIndex::c_1;
+    constexpr auto dfb_grad_in_id = tt::CBIndex::c_2;
 
-    DataflowBuffer exp_dfb_grad_out(cb_grad_out);
-    DataflowBuffer exp_dfb_input(cb_input);
-    DataflowBuffer exp_dfb_grad_in(cb_grad_in);
+    compute_kernel_hw_startup(dfb_grad_out_id, dfb_grad_in_id);
 
-    compute_kernel_hw_startup(cb_grad_out, cb_grad_in);
-    copy_init(cb_grad_out);
-    tanh_derivative_tile_init<false>();
-    mul_binary_tile_init();
+    const auto shape = ckl::IterationShape::tiles(per_core_tile_cnt);
 
-    for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
-        exp_dfb_grad_in.reserve_back(per_core_block_size);
-        exp_dfb_grad_out.wait_front(per_core_block_size);
-        exp_dfb_input.wait_front(per_core_block_size);
-
-        for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            tile_regs_acquire();
-
-            copy_tile(cb_grad_out, i, 0);    // dest[0] = grad_out
-            copy_tile(cb_input, i, 1);       // dest[1] = input
-            tanh_derivative_tile<false>(1);  // dest[1] = sech²(input)
-            mul_binary_tile(0, 1, 0);        // dest[0] = grad_out * sech²(input)
-
-            tile_regs_commit();
-            tile_regs_wait();
-
-            pack_tile(0, cb_grad_in);
-
-            tile_regs_release();
-        }
-
-        exp_dfb_grad_out.pop_front(per_core_block_size);
-        exp_dfb_input.pop_front(per_core_block_size);
-        exp_dfb_grad_in.push_back(per_core_block_size);
-    }
+    ckl::eltwise_chain(
+        shape,
+        // dest[0] = grad_out
+        ckl::CopyTile<
+            ckl::input(
+                dfb_grad_out_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D0>{},
+        ckl::CopyTile<
+            ckl::input(
+                dfb_input_id,
+                ckl::WaitPolicy::PerBlockSize,
+                ckl::PopPolicy::PerBlockSize,
+                ckl::InputTileMapping::Block,
+                ckl::DataFormatReconfig::Disabled),
+            ckl::Dst::D1>{},
+        ckl::TanhDerivative<ckl::Approx::Exact, ckl::Dst::D1>{},     // dest[1] = sech²(input)
+        ckl::MulBinary<ckl::Dst::D0, ckl::Dst::D1, ckl::Dst::D0>{},  // dest[0] = grad_out * sech²(input)
+        ckl::PackTile<ckl::output(
+            dfb_grad_in_id,
+            ckl::ReservePolicy::PerBlockSize,
+            ckl::PushPolicy::PerBlockSize,
+            ckl::DataFormatReconfig::Disabled)>{});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_program_factory.cpp
@@ -146,8 +146,7 @@ ProgramDescriptor TanhBwProgramFactory::create_descriptor(
         reader_desc.emplace_runtime_args(
             core, {src0_buffer, src1_buffer, num_tiles_per_core, num_tiles_written, 0u, 0u, num_cores_y});
 
-        compute_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{num_tiles_per_core, 1});
+        compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{num_tiles_per_core});
 
         writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
 

--- a/ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/rand.h"
-#include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/api/chain.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/eltwise/generators/rand.hpp"  // RandTile (owns rand_tile_init via init())
 
 void kernel_main() {
-    constexpr uint32_t output_cb_id = get_compile_time_arg_val(0);
+    using namespace compute_kernel_lib;
+
+    constexpr uint32_t output_dfb_id = get_compile_time_arg_val(0);
 
     const uint32_t seed = get_arg_val<uint32_t>(0);
     union {
@@ -26,25 +29,11 @@ void kernel_main() {
     }
     const uint32_t start_id = get_arg_val<uint32_t>(3);
     const uint32_t num_tiles = get_arg_val<uint32_t>(4);
-    const uint32_t end_id = start_id + num_tiles;
 
-    CircularBuffer cb_output(output_cb_id);
+    compute_kernel_hw_startup(output_dfb_id, output_dfb_id);
 
-    compute_kernel_hw_startup(output_cb_id, output_cb_id);
-    copy_init(output_cb_id);
-
-    rand_tile_init(seed, start_id);
-    for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_output.reserve_back(1);
-
-        tile_regs_acquire();
-        rand_tile(0, f2u_lower_bound.u, f2u_scale.u);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile(0, output_cb_id, 0);
-        tile_regs_release();
-
-        cb_output.push_back(1);
-    }
+    eltwise_chain(
+        IterationShape::tiles(num_tiles),
+        RandTile<Dst::D0>{f2u_lower_bound.u, f2u_scale.u, seed, start_id},
+        PackTile<output(output_dfb_id, ReservePolicy::PerTile, PushPolicy::PerTile, DataFormatReconfig::Disabled)>{});
 }


### PR DESCRIPTION
# [llk_helper_library] 2/8 eltwise helpers: migrate eltwise and generator kernels

## Summary

This is PR 2 of the #49991 split and depends on #55446 (PR 1, the helper
framework). It migrates selected existing L1 → L1 eltwise and random-generator
compute kernels to `eltwise_chain`, retaining their existing TTNN APIs and
kernel behavior.

Each migration replaces handwritten DFB lifecycle code, operation
initialization, DEST management, and tile loops with an explicit chain. As in
PR 1, `compute_kernel_hw_startup(...)` remains caller-owned.

## Migrated kernels

- Random generators: Bernoulli and uniform use `RandTile` and an explicit
  output lifecycle.
- Unary kernels: identity, hardswish, lgamma (regular and fast), logit, and
  logsigmoid.
- `where` paths: binary no-broadcast and unary TSS variants.
- Ternary addc/addcmul variants, including the runtime conditional multiply
  when the scalar differs from one.
- Unary backward kernels: GELU (polynomial, tanh, and FP32-tanh variants) and
  tanh derivative.

## Migration details

- DFB wait/pop/reserve/push ownership is represented directly on each chain
  input and output. Operations that read one input into multiple DEST slots
  retain their staged wait/pop behavior.
- The binary `where` factory passes the selected input data format to the
  chain element, matching the legacy `where_tile` initialization. Integer
  fill handling remains limited to the paths that require it.
- The unary factory makes Logit's clamp decision a compile-time argument and
  passes the input data format needed by migrated unary kernels.
- Logit retains its two-stage temporary-DFB pipeline. Its producer and
  consumer are deliberately interleaved one tile at a time because the
  temporary DFB can hold only two tiles; separating those stages can deadlock.
- The new unary regression test gives at least one worker more tiles than the
  temporary DFB can hold, covering this streaming behavior for Logit with and
  without `eps`.

## Review guide

Suggested review order:

1. `compute_bernoulli.cpp` and `compute_uniform.cpp` for the smallest
   generator migrations.
2. `hardswish_kernel.cpp` and `logit_kernel.cpp` for unary chains, optional
   clamp behavior, and the temporary-DFB handoff.
3. `eltwise_where_no_bcast.cpp` and `ternary_addc_ops_fpu.cpp` for
   data-format selection, runtime conditions, delayed input consumption, and
   DEST reuse.
4. `eltwise_bw_gelu_tanh.cpp` for the larger multi-DEST backward chain.

## Scope

This PR does not modify the helper framework introduced in PR 1 and does not
include copy/data-movement, experimental, normalization, Moreh, Moreh-training,
or TT-Train migrations. Those remain in subsequent split PRs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:astancov/eltwise_helper_migration_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:astancov/eltwise_helper_migration_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=astancov/eltwise_helper_migration_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:astancov/eltwise_helper_migration_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=astancov/eltwise_helper_migration_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:astancov/eltwise_helper_migration_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=astancov/eltwise_helper_migration_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:astancov/eltwise_helper_migration_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=astancov/eltwise_helper_migration_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:astancov/eltwise_helper_migration_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=astancov/eltwise_helper_migration_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:astancov/eltwise_helper_migration_2)