### PR TITLE
allocate max users at max_seq_len in prefill runner

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -190,7 +190,7 @@ shield:
     wh_n150: 100
     bh_p150: 60
   demo:
-    bh_sc4: 35
+    bh_sc4: 50
 
 scaleout:
   merge_gate:

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -12,9 +12,7 @@ MANIFEST_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests
 MGD_DIR="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration/ci"
 
 CHUNK_SIZE=5120
-MAX_SEQ_LEN=256000
 GOLDEN_LEN=56320
-REAL_CHUNKS=$((MAX_SEQ_LEN / CHUNK_SIZE))
 WARMUP_CHUNKS=10
 PCC_THRESHOLD=0.85
 RUNNER_ENV=""
@@ -26,6 +24,8 @@ case "${MODEL}" in
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/prefill_runner_kv}"
     MGD="${MGD_DIR}/kimi27_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/kimi27.json"
+    MAX_SEQ_LEN=256000
+    NUM_USERS_DEFAULT=86
     RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized; export PREFILL_USE_TRACE=1; export PREFILL_LAYER_ACK_D2H=1;"
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}';"
     ;;
@@ -33,6 +33,8 @@ case "${MODEL}" in
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/glm52_prefill_runner_kv}"
     MGD="${MGD_DIR}/glm52_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/glm52.json"
+    MAX_SEQ_LEN=1049600
+    NUM_USERS_DEFAULT=28
     TP_SHARD_KV_DEFAULT=1
     RUNNER_ENV="export PREFILL_LAYER_ACK_D2H=1;"
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}'; \
@@ -43,6 +45,8 @@ case "${MODEL}" in
     exit 2
     ;;
 esac
+
+REAL_CHUNKS=$((MAX_SEQ_LEN / CHUNK_SIZE))
 
 mkdir -p "${PIPELINE_DIR}"
 TTRUN_DIR="${TTRUN_DIR:-/etc/ttop}"
@@ -109,6 +113,7 @@ python3 "${TTRUN_PY}" \
     export PREFILL_MANIFEST='${MANIFEST}'; \
     export PREFILL_FABRIC_MODE=2d; \
     export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
+    export PREFILL_NUM_USERS=${PREFILL_NUM_USERS:-${NUM_USERS_DEFAULT}}; \
     export PREFILL_TP_SHARD_KV=${PREFILL_TP_SHARD_KV:-${TP_SHARD_KV_DEFAULT}}; \
     export PREFILL_SYNC_PER_CHUNK=1; \
     export PREFILL_TIMING_DIR='${TIMING_DIR}'; \

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -25,6 +25,9 @@ case "${MODEL}" in
     MGD="${MGD_DIR}/kimi27_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/kimi27.json"
     MAX_SEQ_LEN=256000
+    # Users are bounded by per-bank KV capacity, and that bound has to be bisected, not computed --
+    # the arithmetic bound overshoots ~20% once weights and transients are counted. The OOM edge sits
+    # just above this and wanders between ranks, so re-bisect before raising it.
     NUM_USERS_DEFAULT=86
     RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized; export PREFILL_USE_TRACE=1; export PREFILL_LAYER_ACK_D2H=1;"
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}';"
@@ -34,6 +37,8 @@ case "${MODEL}" in
     MGD="${MGD_DIR}/glm52_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/glm52.json"
     MAX_SEQ_LEN=1049600
+    # Same per-bank capacity bound, relaxed by the TP KV dedup below. The sparse KV format moves it
+    # a long way (SP x TP fits 34 at bf16, 56 at fp8), so this sits well under the edge, not on it.
     NUM_USERS_DEFAULT=28
     TP_SHARD_KV_DEFAULT=1
     RUNNER_ENV="export PREFILL_LAYER_ACK_D2H=1;"

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -740,9 +740,10 @@
   test_group: module
   skus:
     bh_sc4:
-      # Measured test step 8.5 min at 50 chunks; headroom for the up-to-120s producer connect plus
-      # model-load/NFS variance on a 4-galaxy run. Must match the shield/demo budget.
-      timeout: 15
+      # Mesh bringup, weight load and the staggered device teardown dominate the step; the chunk loop
+      # is a couple of minutes of it. Budget covers those plus the up-to-120s producer connect.
+      # Must match the shield/demo budget.
+      timeout: 20
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield
   sp_config: sc4
@@ -753,7 +754,7 @@
 # its 21 `full` layers), and the pipeline split is layer-aware (18/20/20/20, snapped to `full` starts).
 # Both caches are PCC'd: the producer gates on min(config 0, config 1), so this is the only leg that
 # covers the merged multi-cache KV chunk table and the per-stage index-cache numbering.
-- name: "(GLM-5.2-744B) disaggregated prefill KV accuracy 55k@5k + perf 250k@5k, SC4"
+- name: "(GLM-5.2-744B) disaggregated prefill KV accuracy 55k@5k + perf 1M@5k, SC4"
   cmd: |
     set -euo pipefail
     export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
@@ -767,10 +768,11 @@
   test_group: module
   skus:
     bh_sc4:
-      # Measured test step 9 min: weight load from the warm 8x4 cache, then 50 chunks over 78 layers
-      # plus both-cache UMD readback. The extra 5 min over the Kimi entry is cold-cache weight-load
-      # insurance. Counts against the shield/demo budget together with the Kimi entry.
-      timeout: 20
+      # 1M at 28 users reaches a PCC verdict in ~16.5 min -- 215 chunks at ~2.3s each, since the
+      # lightning indexer scores the whole prefix and so grows with depth, plus a 143M-entry KV chunk
+      # table for rank 0 to merge and serialize -- and then spends ~7 min unwinding the mesh.
+      # Counts against the shield/demo budget together with the Kimi entry.
+      timeout: 30
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield
   sp_config: sc4


### PR DESCRIPTION
CI run with reverted main-breaking culprits

https://github.com/tenstorrent/tt-metal/actions/runs/34105698965

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-ci-max-users)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-ci-max-users)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-ci-max-users)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-ci-max-users)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-ci-max-users)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-ci-max-users)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-ci-max-users)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-ci-max-users)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-ci-max-users)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-ci-max-users)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-ci-max-users)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-ci-max-users)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-ci-max-users)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-ci-max-users)