### PR TITLE
[skip ci] Disable 2 tests in DispatchTelemetryHostL1WaitTest in merge gate

### DIFF
--- a/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
@@ -13,6 +13,7 @@
   skus:
     wh_n300_civ2:
       timeout: 15
+      # Issue: https://github.com/tenstorrent/tt-metal/issues/55429
       cmd: /usr/bin/tt-metalium-validation-smoke --gtest_filter='-*CPU_*:DispatchTelemetryHostL1WaitTest.ReadInfoFromSeparateProcessWhileDeviceInUse:DispatchTelemetryHostL1WaitTest.DispatchCoreEfficiencyAndUtilization'
     wh_llmbox_civ2_viommu:
       timeout: 15

--- a/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
@@ -13,6 +13,7 @@
   skus:
     wh_n300_civ2:
       timeout: 15
+      cmd: /usr/bin/tt-metalium-validation-smoke --gtest_filter='-*CPU_*:DispatchTelemetryHostL1WaitTest.ReadInfoFromSeparateProcessWhileDeviceInUse:DispatchTelemetryHostL1WaitTest.DispatchCoreEfficiencyAndUtilization'
     wh_llmbox_civ2_viommu:
       timeout: 15
     bh_p150b_civ2_viommu:


### PR DESCRIPTION
### Summary
Disable 2 tests in DispatchTelemetryHostL1WaitTest in merge gate

### Notes for reviewers
The 2 below tests have regressed/become flaky in merge gate

- `DispatchTelemetryHostL1WaitTest.ReadInfoFromSeparateProcessWhileDeviceInUse`
- `DispatchTelemetryHostL1WaitTest.DispatchCoreEfficiencyAndUtilization`

Failures on recent commits

https://github.com/tenstorrent/tt-metal/actions/runs/33880260666/job/101049839305#step:13:3269
https://github.com/tenstorrent/tt-metal/actions/runs/33866629497/job/101004955405#step:13:3269
https://github.com/tenstorrent/tt-metal/actions/runs/33829615577/job/100891142534#step:13:3269
https://github.com/tenstorrent/tt-metal/actions/runs/33765093663/job/100684191853#step:13:3199


Disabling them to prevent rejecting PRs incorrectly

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kkabilar-disable-mgate-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kkabilar-disable-mgate-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kkabilar-disable-mgate-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kkabilar-disable-mgate-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kkabilar-disable-mgate-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kkabilar-disable-mgate-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kkabilar-disable-mgate-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kkabilar-disable-mgate-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kkabilar-disable-mgate-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kkabilar-disable-mgate-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kkabilar-disable-mgate-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kkabilar-disable-mgate-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kkabilar-disable-mgate-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kkabilar-disable-mgate-test)