### PR TITLE
[Bug Fix] Hash Tensor Specs in I2S 

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
@@ -317,13 +317,9 @@ def test_interleaved_to_sharded_rejects_pure_nd(device, tensor_shape, nd_shard_s
 def test_interleaved_to_sharded_rejects_pure_nd_with_preallocated_output(
     device, tensor_shape, nd_shard_shape, nd_shard_grid, output_shard_shape, output_shard_grid, expect_error
 ):
-    """A pure-ND output config must be rejected even when the caller supplies a pre-allocated output.
+    """A pure-ND output config must be rejected even when a pre-allocated output is supplied.
 
-    validate_inputs used to derive its ND normalization from compute_output_specs(attrs, tensor_args),
-    and that returns the caller's own spec verbatim when a pre-allocated output is present. The ND
-    rejection therefore tested the pre-allocated tensor's (2D) layout instead of the computed one, and
-    the memory-config comparison below it degenerated into comparing that tensor against itself, so
-    this call was accepted rather than rejected.
+    validate_inputs used to read the ND check off the caller's own spec, so this was wrongly accepted.
     """
     nd_shard_spec = ttnn.NdShardSpec(nd_shard_shape, nd_shard_grid, orientation=ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
@@ -332,8 +328,7 @@ def test_interleaved_to_sharded_rejects_pure_nd_with_preallocated_output(
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
 
-    # Deliberately valid on its own terms -- matching shape, dtype and layout -- so that the ND output
-    # config is the only thing left for the op to object to.
+    # Valid on its own terms, so the ND output config is the only thing left to object to.
     preallocated_output = ttnn.allocate_tensor_on_device(
         ttnn_input_tensor.shape,
         ttnn_input_tensor.dtype,

--- a/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
@@ -298,3 +298,53 @@ def test_interleaved_to_sharded_rejects_pure_nd(device, tensor_shape, nd_shard_s
 
     with expect_error(RuntimeError, r"interleaved_to_sharded does not support ND sharding"):
         ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)
+
+
+@pytest.mark.parametrize(
+    "tensor_shape, nd_shard_shape, nd_shard_grid, output_shard_shape, output_shard_grid",
+    [
+        # Same pure-ND config as above, paired with a legal 2D-sharded pre-allocated output:
+        # 6*32 = 192 rows of 64, height-sharded 32 rows per core across 6 cores.
+        [
+            [6, 32, 64],
+            [3, 32, 32],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+        ],
+    ],
+)
+def test_interleaved_to_sharded_rejects_pure_nd_with_preallocated_output(
+    device, tensor_shape, nd_shard_shape, nd_shard_grid, output_shard_shape, output_shard_grid, expect_error
+):
+    """A pure-ND output config must be rejected even when the caller supplies a pre-allocated output.
+
+    validate_inputs used to derive its ND normalization from compute_output_specs(attrs, tensor_args),
+    and that returns the caller's own spec verbatim when a pre-allocated output is present. The ND
+    rejection therefore tested the pre-allocated tensor's (2D) layout instead of the computed one, and
+    the memory-config comparison below it degenerated into comparing that tensor against itself, so
+    this call was accepted rather than rejected.
+    """
+    nd_shard_spec = ttnn.NdShardSpec(nd_shard_shape, nd_shard_grid, orientation=ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
+
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
+
+    # Deliberately valid on its own terms -- matching shape, dtype and layout -- so that the ND output
+    # config is the only thing left for the op to object to.
+    preallocated_output = ttnn.allocate_tensor_on_device(
+        ttnn_input_tensor.shape,
+        ttnn_input_tensor.dtype,
+        ttnn_input_tensor.layout,
+        device,
+        ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(output_shard_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+    )
+
+    with expect_error(RuntimeError, r"interleaved_to_sharded does not support ND sharding"):
+        ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config, preallocated_output=preallocated_output)

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -35,7 +35,12 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     // Use the normalized memory config for validation so that convertible ND specs are accepted.
     auto resolved_output_mem_config = output_mem_config;
     if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
-        auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+        // Normalize from the input alone. compute_output_specs returns the caller's own spec verbatim
+        // when a pre-allocated output is supplied, so passing tensor_args through would make the
+        // rejection below test the caller's layout instead of the computed one, and would reduce the
+        // memory-config comparison further down to comparing the tensor against itself.
+        auto output_spec =
+            compute_output_specs(operation_attributes, tensor_args_t{input_tensor, /*output_tensor=*/std::nullopt});
         if (output_spec.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
             return {
                 false,
@@ -143,20 +148,35 @@ ttsl::hash::hash_t InterleavedToShardedDeviceOperation::compute_program_hash(
     const auto& input_tensor = tensor_args.input_tensor;
     // keep_l1_aligned is deliberately absent: the factory hardcodes it to true and never reads the
     // attribute, so keying on it would split the cache between byte-identical programs.
-    return tt::tt_metal::operation::hash_operation<InterleavedToShardedDeviceOperation>(
-        operation_attributes.output_mem_config,
-        operation_attributes.output_dtype,
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        input_tensor.layout(),
-        // Both shapes are needed. The row-major branch of the factory takes the reader's row stride
-        // from logical_shape()[-1] and the last core's shard height from logical_volume(), and
-        // neither is patched on a cache hit. Padded shape alone does not pin those: an interleaved
-        // input's alignment is unconstrained (validate_alignment_rm only checks the width alignment
-        // of a sharded tensor), so a logical [1, 1, 32, 60] with Alignment{64} and a logical
-        // [1, 1, 32, 64] with the default alignment both pad to [1, 1, 32, 64].
-        input_tensor.logical_shape(),
-        input_tensor.padded_shape());
+    //
+    // Tensors are keyed as whole TensorSpecs rather than as a projection of selected fields, because a
+    // Metal 2.0 port declares one TensorParameter per tensor from its TensorSpec, and on a cache hit
+    // ValidateTensorArgs REJECTS -- it does not rebuild -- a tensor whose spec differs from the one
+    // baked in at program creation, comparing dtype, page config, memory config and alignment exactly.
+    // Under a projection, two tensors differing only in a dropped field would share a key, hit, and
+    // then throw from report_tensor_arg_mismatch; hashing the spec wholesale keeps the key and that
+    // accept/reject predicate in agreement by construction.
+    //
+    // The spec also subsumes the shape terms this key used to carry explicitly: TensorSpec hashes as
+    // (logical_shape, tensor_layout) and padded_shape is a pure function of that pair, so both the tile
+    // branch's padded reads and the row-major branch's logical reads (the reader's row stride from
+    // logical_shape()[-1], the last core's shard height from logical_volume(), neither patched on a
+    // cache hit) stay pinned. What it adds over the projection is alignment, which the shape pair does
+    // not determine -- a TILE input with logical [1, 1, 64, 64] passes validate_alignment_tile with
+    // either Alignment{32, 32} or Alignment{64, 64}, and both pad to [1, 1, 64, 64].
+    auto hash = tt::tt_metal::operation::hash_operation<InterleavedToShardedDeviceOperation>(
+        operation_attributes.output_mem_config, operation_attributes.output_dtype, input_tensor.tensor_spec());
+
+    // The factory derives its shard spec, core ranges, CB sizes and every per-core index from the
+    // output tensor, so the output spec has to be keyed too. When absent it needs no term of its own:
+    // compute_output_specs then builds it from the input's logical shape and layout plus the two
+    // attributes above, all already hashed. When supplied by the caller it does, because validate_inputs
+    // pins only its logical shape, memory config, dtype, layout and tile -- not its alignment, which
+    // validate_alignment_rm leaves free for a height-sharded row-major tensor.
+    if (tensor_args.output_tensor.has_value()) {
+        hash = ttsl::hash::hash_objects(hash, tensor_args.output_tensor->tensor_spec());
+    }
+    return hash;
 }
 
 Tensor interleaved_to_sharded(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -35,10 +35,8 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     // Use the normalized memory config for validation so that convertible ND specs are accepted.
     auto resolved_output_mem_config = output_mem_config;
     if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
-        // Normalize from the input alone. compute_output_specs returns the caller's own spec verbatim
-        // when a pre-allocated output is supplied, so passing tensor_args through would make the
-        // rejection below test the caller's layout instead of the computed one, and would reduce the
-        // memory-config comparison further down to comparing the tensor against itself.
+        // Normalize from the input alone: with a pre-allocated output, compute_output_specs just hands
+        // back the caller's own spec, so the checks below would end up testing that tensor against itself.
         auto output_spec =
             compute_output_specs(operation_attributes, tensor_args_t{input_tensor, /*output_tensor=*/std::nullopt});
         if (output_spec.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
@@ -149,30 +147,14 @@ ttsl::hash::hash_t InterleavedToShardedDeviceOperation::compute_program_hash(
     // keep_l1_aligned is deliberately absent: the factory hardcodes it to true and never reads the
     // attribute, so keying on it would split the cache between byte-identical programs.
     //
-    // Tensors are keyed as whole TensorSpecs rather than as a projection of selected fields, because a
-    // Metal 2.0 port declares one TensorParameter per tensor from its TensorSpec, and on a cache hit
-    // ValidateTensorArgs REJECTS -- it does not rebuild -- a tensor whose spec differs from the one
-    // baked in at program creation, comparing dtype, page config, memory config and alignment exactly.
-    // Under a projection, two tensors differing only in a dropped field would share a key, hit, and
-    // then throw from report_tensor_arg_mismatch; hashing the spec wholesale keeps the key and that
-    // accept/reject predicate in agreement by construction.
-    //
-    // The spec also subsumes the shape terms this key used to carry explicitly: TensorSpec hashes as
-    // (logical_shape, tensor_layout) and padded_shape is a pure function of that pair, so both the tile
-    // branch's padded reads and the row-major branch's logical reads (the reader's row stride from
-    // logical_shape()[-1], the last core's shard height from logical_volume(), neither patched on a
-    // cache hit) stay pinned. What it adds over the projection is alignment, which the shape pair does
-    // not determine -- a TILE input with logical [1, 1, 64, 64] passes validate_alignment_tile with
-    // either Alignment{32, 32} or Alignment{64, 64}, and both pad to [1, 1, 64, 64].
+    // Key on the whole TensorSpec instead of picking out fields: once this is ported to Metal 2.0, a
+    // cache hit is rejected outright if any spec field differs, and alignment is the one the old
+    // shape pair left free. The spec still covers the shapes that used to be hashed explicitly.
     auto hash = tt::tt_metal::operation::hash_operation<InterleavedToShardedDeviceOperation>(
         operation_attributes.output_mem_config, operation_attributes.output_dtype, input_tensor.tensor_spec());
 
-    // The factory derives its shard spec, core ranges, CB sizes and every per-core index from the
-    // output tensor, so the output spec has to be keyed too. When absent it needs no term of its own:
-    // compute_output_specs then builds it from the input's logical shape and layout plus the two
-    // attributes above, all already hashed. When supplied by the caller it does, because validate_inputs
-    // pins only its logical shape, memory config, dtype, layout and tile -- not its alignment, which
-    // validate_alignment_rm leaves free for a height-sharded row-major tensor.
+    // The factory reads its shard spec, core ranges and CB sizes off the output, so key that too --
+    // but only when the caller supplies one, since otherwise it's derived from what's already hashed.
     if (tensor_args.output_tensor.has_value()) {
         hash = ttsl::hash::hash_objects(hash, tensor_args.output_tensor->tensor_spec());
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -34,7 +34,12 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     // Use the normalized memory config for validation so that convertible ND specs are accepted.
     auto resolved_output_mem_config = output_mem_config;
     if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
-        auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+        // Normalize from the input alone. compute_output_specs returns the caller's own spec verbatim
+        // when a pre-allocated output is supplied, so passing tensor_args through would make the
+        // rejection below test the caller's layout instead of the computed one, and would reduce the
+        // memory-config comparison further down to comparing the tensor against itself.
+        auto output_spec =
+            compute_output_specs(operation_attributes, tensor_args_t{input_tensor, /*output_tensor=*/std::nullopt});
         if (output_spec.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
             return {
                 false,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -34,10 +34,8 @@ std::pair<bool, std::string> InterleavedToShardedDeviceOperation::validate_input
     // Use the normalized memory config for validation so that convertible ND specs are accepted.
     auto resolved_output_mem_config = output_mem_config;
     if (output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {
-        // Normalize from the input alone. compute_output_specs returns the caller's own spec verbatim
-        // when a pre-allocated output is supplied, so passing tensor_args through would make the
-        // rejection below test the caller's layout instead of the computed one, and would reduce the
-        // memory-config comparison further down to comparing the tensor against itself.
+        // Normalize from the input alone: with a pre-allocated output, compute_output_specs just hands
+        // back the caller's own spec, so the checks below would end up testing that tensor against itself.
         auto output_spec =
             compute_output_specs(operation_attributes, tensor_args_t{input_tensor, /*output_tensor=*/std::nullopt});
         if (output_spec.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -32,13 +32,9 @@ struct InterleavedToShardedDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    // Deliberately no compute_program_hash. This op declares its TensorParameters with default
-    // relaxations, so a cache hit is accepted only if the whole TensorSpec matches -- alignment
-    // included -- and the framework default hash is already exactly that strict: it reflects each
-    // Tensor as (storage, tensor_spec), TensorSpec as (logical_shape, tensor_layout), and
-    // TensorLayout as (dtype, page_config, memory_config, alignment). A hand-written projection of
-    // those fields is what let the unported sibling key two alignment-differing inputs the same, so
-    // overriding here would only reintroduce the ability to drift from the accept/reject predicate.
+    // No compute_program_hash on purpose: the framework default already keys on the full TensorSpec,
+    // which is exactly the strict match this op's TensorParameters require. Overriding it would only
+    // risk drifting from that again.
 };
 
 Tensor interleaved_to_sharded(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -31,6 +31,14 @@ struct InterleavedToShardedDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    // Deliberately no compute_program_hash. This op declares its TensorParameters with default
+    // relaxations, so a cache hit is accepted only if the whole TensorSpec matches -- alignment
+    // included -- and the framework default hash is already exactly that strict: it reflects each
+    // Tensor as (storage, tensor_spec), TensorSpec as (logical_shape, tensor_layout), and
+    // TensorLayout as (dtype, page_config, memory_config, alignment). A hand-written projection of
+    // those fields is what let the unported sibling key two alignment-differing inputs the same, so
+    // overriding here would only reintroduce the ability to drift from the accept/reject predicate.
 };
 
 Tensor interleaved_to_sharded(


### PR DESCRIPTION
### Summary

Two changes to `interleaved_to_sharded` to finalise it for Metal 2.0 porting. One is a pre-port hardening, the other is a live validation fix.

**1. Key the op on whole `TensorSpec`s instead of a five-field projection.** 
The old hash had `(dtype, memory_config, layout, logical_shape, padded_shape)`, omitting`alignment`.
So two tensors can share both shapes and differ in alignment (a TILE input with logical `[1, 1, 64, 64]` passes `validate_alignment_tile` with either `Alignment{32, 32}` or `Alignment{64, 64}`). 

Note that this is not a detectable issue today, it's only one after this gets ported to Metal 2.0.

There's no issue today because the op builds a `ProgramDescriptor` and declares no `TensorParameter`, so `ValidateTensorArgs` never runs on it, and with both shapes already keyed those two inputs produce byte-identical programs. After the op gets ported though, a `TensorParameter` is declared from a `TensorSpec` and compares `tensor_layout()`, alignment included, exactly under every relaxation. That means the cache hit will be rejected by `report_tensor_arg_mismatch`. Hashing the spec wholesale keeps the key and that accept/reject predicate in agreement by construction, avoiding that potential validation crash.

**2. Fix `validate_inputs` deriving its ND normalisation from `compute_output_specs(attrs, tensor_args)`.**
Compute output specs returns the caller's own spec verbatim when a pre-allocated output is supplied, so the ND sharded rejection tested the caller's layout instead of the computed one, and the memory-config
comparison below it degenerated into comparing the tensor against itself. 

That meant a pure-ND `output_mem_config` paired with a legally 2D-sharded pre-allocated output would be accepted, since they aren't compared against each other.

The `validate_inputs` fix is mirrored into the `experimental/quasar` sibling, which carried a
verbatim copy. Its hash needs no change — it declares no `compute_program_hash`, and the
framework default already reflects each `Tensor` as `(storage, tensor_spec)`, exactly the strict
comparison its `TensorParameter`s require; a comment now records that.

### Testing

- `test_interleaved_to_sharded_rejects_pure_nd_with_preallocated_output` — new regression test
  for change 2; fails before, passes after. Not yet run on silicon.
- No test accompanies change 1. The colliding pair is not constructible from Python (all three
  `ttnn.TensorSpec` constructors use the three-argument `TensorLayout`, which always computes the
  default alignment; `Alignment` has no bindings at all), and it has no observable failure in
  either op today, so such a test would pass before and after.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/I2S_Hash_Update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/I2S_Hash_Update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/I2S_Hash_Update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/I2S_Hash_Update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/I2S_Hash_Update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/I2S_Hash_Update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/I2S_Hash_Update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/I2S_Hash_Update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/I2S_Hash_Update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/I2S_Hash_Update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/I2S_Hash_Update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/I2S_Hash_Update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/I2S_Hash_Update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/I2S_Hash_Update)