### PR TITLE
KDA: enable Fabric2D support

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
+++ b/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
@@ -120,19 +120,28 @@ def tp_axis_is_wrapped(mesh_device) -> bool:
     The mesh graph descriptor cannot answer this: it is absent whenever the graph came from
     auto-discovery, which is the one path that substitutes a fabric for the requested one.
     Routing tables are always populated, and they are what the collective actually consumes,
-    so a wrap is detected by where a route goes rather than by what the topology claims. The
-    far peer sits one hop behind on a ring and `cols - 1` hops ahead on a line.
+    so a wrap is detected by where the opened mesh maps its TP endpoints. A straight torus has
+    the same forwarding direction from column 0 to the last column as from column 1 to column 0.
+    A 1xN view over a 2D system mesh can instead close through a direct perimeter edge.
     """
     _, cols = tuple(mesh_device.shape)
     mesh_shapes = ttnn.get_physical_mesh_shapes()
     assert len(mesh_shapes) == 1, f"expected a single local mesh, got {mesh_shapes}"
-    mesh_id = ttnn.MeshId(next(iter(mesh_shapes)))
+    _, physical_cols = next(iter(mesh_shapes.values()))
 
-    def direction(src, dst):
-        node = lambda col: ttnn.FabricNodeId(mesh_id, col)  # noqa: E731 -- row 0, so chip id is the column
-        value = ttnn.get_eth_forwarding_direction(node(src), node(dst))
-        assert value is not None, f"no TP route from column {src} to {dst}"
+    def node(col):
+        return mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(0, col))
+
+    def direction(src_col, dst_col):
+        value = ttnn.get_eth_forwarding_direction(node(src_col), node(dst_col))
+        assert value is not None, f"no TP route from column {src_col} to {dst_col}"
         return value
+
+    first, last = node(0), node(cols - 1)
+    first_row, first_col = divmod(first.chip_id, physical_cols)
+    last_row, last_col = divmod(last.chip_id, physical_cols)
+    if abs(first_row - last_row) + abs(first_col - last_col) == 1:
+        return True
 
     return direction(0, cols - 1) == direction(1, 0)
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
@@ -9,6 +9,7 @@ import torch
 
 import ttnn
 from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import collect_mesh_accuracy_and_determinism_results
 from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_equal
@@ -18,7 +19,7 @@ pytestmark = [
     pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
     pytest.mark.parametrize(
         "device_params",
-        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        [fabric2d_device_params()],
         indirect=True,
     ),
 ]

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
@@ -12,6 +12,8 @@ from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import collect_mesh_accuracy_and_determinism_results
 from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.tt_transformers.tt.ccl import TT_CCL
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_equal
 
 pytestmark = [
@@ -77,9 +79,16 @@ def test_exchange_convolution_carry_preserves_causal_carries(
     state_dims[tensor_parallel_axis] = 2
     qkv_tt = _to_device(qkv, mesh_device, tuple(qkv_dims))
     state_tt = _to_device(external, mesh_device, tuple(state_dims))
+    tt_ccl = TT_CCL(mesh_device)
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor]:
-        return exchange_convolution_carry(qkv_tt, state_tt, sequence_parallel_axis=sp_axis)
+        return exchange_convolution_carry(
+            qkv_tt,
+            state_tt,
+            sequence_parallel_axis=sp_axis,
+            topology=per_axis_topology()[sp_axis],
+            tt_ccl=tt_ccl,
+        )
 
     (entry_tt, final_tt), mismatch_markers = collect_mesh_accuracy_and_determinism_results(run)
     actual_entries = _sp_carries(entry_tt, mesh_device, sp_axis, tensor_parallel_axis)

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
@@ -18,11 +18,17 @@ from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import ass
 
 pytestmark = [
     run_for_blackhole(),
-    pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
     pytest.mark.parametrize(
-        "device_params",
-        [fabric2d_device_params()],
-        indirect=True,
+        "mesh_device,device_params",
+        [
+            pytest.param(
+                (2, 4),
+                fabric2d_device_params(),
+                marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+                id="fabric2d-mesh-2x4",
+            )
+        ],
+        indirect=["mesh_device", "device_params"],
     ),
 ]
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
@@ -19,6 +19,8 @@ from models.demos.deepseek_v3_d_p.tests.kda.utils import (
 )
 from models.demos.deepseek_v3_d_p.tt.kda import recurrence
 from models.demos.deepseek_v3_d_p.tt.kda.config import KDARecurrenceProgramConfig
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.tt_transformers.tt.ccl import TT_CCL
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
     assert_accurate,
     assert_bit_identical,
@@ -57,6 +59,8 @@ def _run_recurrence(
             local_scan_strategy=local_scan_strategy,
         ),
         sequence_parallel_axis=None,
+        topology=ttnn.Topology.Linear,
+        tt_ccl=None,
     )
     return executor(q=q, k=k, v=v, gate=gate, beta=beta, initial_state=state)
 
@@ -281,6 +285,8 @@ def _distributed_recurrence_case(
         mesh_device,
         KDARecurrenceProgramConfig(summary_group_chunks=8),
         sequence_parallel_axis=sp_axis,
+        topology=per_axis_topology()[sp_axis],
+        tt_ccl=TT_CCL(mesh_device),
     )
     return executor, inputs, expected_output.to(torch.bfloat16), expected_state, sp_axis
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
@@ -11,6 +11,7 @@ import torch
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda.ops import kda_recurrent_reference
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     collect_mesh_accuracy_and_determinism_results,
     compare_cpu_device,
@@ -297,7 +298,7 @@ def _run_distributed_recurrence(
 @pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric2d_device_params()],
     indirect=True,
 )
 @pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
@@ -333,7 +334,7 @@ def test_distributed_recurrence_matches_serial_and_is_deterministic(
 @pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric2d_device_params()],
     indirect=True,
 )
 @pytest.mark.parametrize("tensor_parallel_axis", [0, 1])

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
@@ -19,6 +19,7 @@ from models.demos.deepseek_v3_d_p.tests.kda.utils import (
 )
 from models.demos.deepseek_v3_d_p.tt.kda import recurrence
 from models.demos.deepseek_v3_d_p.tt.kda.config import KDARecurrenceProgramConfig
+from models.demos.deepseek_v3_d_p.tt.kda.recurrence import KDASequenceParallel
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import TT_CCL
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
@@ -58,9 +59,7 @@ def _run_recurrence(
             summary_group_chunks=summary_group_chunks,
             local_scan_strategy=local_scan_strategy,
         ),
-        sequence_parallel_axis=None,
-        topology=ttnn.Topology.Linear,
-        tt_ccl=None,
+        sequence_parallel=None,
     )
     return executor(q=q, k=k, v=v, gate=gate, beta=beta, initial_state=state)
 
@@ -284,9 +283,11 @@ def _distributed_recurrence_case(
     executor = recurrence.KDARecurrence(
         mesh_device,
         KDARecurrenceProgramConfig(summary_group_chunks=8),
-        sequence_parallel_axis=sp_axis,
-        topology=per_axis_topology()[sp_axis],
-        tt_ccl=TT_CCL(mesh_device),
+        sequence_parallel=KDASequenceParallel(
+            axis=sp_axis,
+            topology=per_axis_topology()[sp_axis],
+            tt_ccl=TT_CCL(mesh_device),
+        ),
     )
     return executor, inputs, expected_output.to(torch.bfloat16), expected_state, sp_axis
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
@@ -301,11 +301,17 @@ def _run_distributed_recurrence(
     return output, new_state
 
 
-@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 @pytest.mark.parametrize(
-    "device_params",
-    [fabric2d_device_params()],
-    indirect=True,
+    "mesh_device,device_params",
+    [
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-mesh-2x4",
+        )
+    ],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
 def test_distributed_recurrence_matches_serial_and_is_deterministic(
@@ -337,11 +343,17 @@ def test_distributed_recurrence_matches_serial_and_is_deterministic(
     assert_accurate(expected_state, actual_state, name=f"{label} state")
 
 
-@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 @pytest.mark.parametrize(
-    "device_params",
-    [fabric2d_device_params()],
-    indirect=True,
+    "mesh_device,device_params",
+    [
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-mesh-2x4",
+        )
+    ],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
 def test_distributed_recurrence_trace_replay_matches_eager(

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
@@ -9,6 +9,7 @@ import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
 from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import random_weights
 from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
 from models.demos.deepseek_v3_d_p.tt.kda.weights import load_kda_weights
@@ -38,7 +39,7 @@ def _tp_rank(physical_index: int, mesh_columns: int, tensor_parallel_axis: int) 
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric2d_device_params()],
     indirect=True,
 )
 def test_device_weight_placement(
@@ -133,7 +134,7 @@ def test_device_weight_placement(
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric2d_device_params()],
     indirect=True,
 )
 def test_tp_layer_with_nonsquare_state_matches_reference(mesh_device: ttnn.MeshDevice) -> None:

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
@@ -13,6 +13,7 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_p
 from models.demos.deepseek_v3_d_p.tests.kda.utils import random_weights
 from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
 from models.demos.deepseek_v3_d_p.tt.kda.weights import load_kda_weights
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import TT_CCL
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_equal
 
@@ -153,7 +154,13 @@ def test_tp_layer_with_nonsquare_state_matches_reference(mesh_device: ttnn.MeshD
     )
     golden_output, golden_state = kda_forward_reference(hidden, state_dict, config)
 
-    layer = ttKDA(mesh_device, config, state_dict, tt_ccl=TT_CCL(mesh_device))
+    layer = ttKDA(
+        mesh_device,
+        config,
+        state_dict,
+        tt_ccl=TT_CCL(mesh_device),
+        topology=per_axis_topology(),
+    )
     initial_state = layer.allocate_state(batch_size=1)
     hidden_tt = ttnn.from_torch(
         hidden,

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
@@ -9,7 +9,7 @@ import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
 from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import random_weights
 from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
 from models.demos.deepseek_v3_d_p.tt.kda.weights import load_kda_weights
@@ -30,18 +30,31 @@ def _tp_rank(physical_index: int, mesh_columns: int, tensor_parallel_axis: int) 
 
 
 @pytest.mark.parametrize(
-    "mesh_device,tensor_parallel_axis",
+    "mesh_device,tensor_parallel_axis,device_params",
     [
-        pytest.param((1, 8), 1, id="tp8-1d"),
-        pytest.param((2, 4), 0, id="tp2-axis0"),
-        pytest.param((2, 4), 1, id="tp4-axis1"),
+        pytest.param(
+            (1, 8),
+            1,
+            torus_x_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 8), topology="ring"),
+            id="tp8-torus-x",
+        ),
+        pytest.param(
+            (2, 4),
+            0,
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="tp2-axis0-fabric-2d",
+        ),
+        pytest.param(
+            (2, 4),
+            1,
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="tp4-axis1-fabric-2d",
+        ),
     ],
-    indirect=["mesh_device"],
-)
-@pytest.mark.parametrize(
-    "device_params",
-    [fabric2d_device_params()],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
 def test_device_weight_placement(
     mesh_device: ttnn.MeshDevice,
@@ -132,11 +145,17 @@ def test_device_weight_placement(
             )
 
 
-@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "device_params",
-    [fabric2d_device_params()],
-    indirect=True,
+    "mesh_device,device_params",
+    [
+        pytest.param(
+            (1, 8),
+            torus_x_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 8), topology="ring"),
+            id="tp8-torus-x",
+        )
+    ],
+    indirect=["mesh_device", "device_params"],
 )
 def test_tp_layer_with_nonsquare_state_matches_reference(mesh_device: ttnn.MeshDevice) -> None:
     config = KDAConfig(

--- a/models/demos/deepseek_v3_d_p/tests/kda/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/conftest.py
@@ -7,9 +7,21 @@ from pathlib import Path
 
 import pytest
 
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import assert_requested_tp_wrap_was_realized
+
 
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "perf: mark explicit KDA performance tests")
+
+
+@pytest.fixture(autouse=True)
+def guard_the_requested_wrap(request: pytest.FixtureRequest):
+    """Fail when a requested TP torus was silently realized without its wrap."""
+    if "mesh_device" not in request.fixturenames:
+        yield
+        return
+    assert_requested_tp_wrap_was_realized(request.getfixturevalue("mesh_device"))
+    yield
 
 
 @pytest.fixture

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
@@ -30,18 +30,34 @@ _PCC_THRESHOLD = 0.9995
 
 
 @pytest.mark.parametrize(
-    "mesh_device,tensor_parallel_axis,device_params",
+    "mesh_device,tensor_parallel_axis,device_params,sequence",
     [
+        pytest.param(
+            (1, 8),
+            1,
+            fabric2d_device_params(),
+            128,
+            id="SP1xTP8-fabric-2d",
+        ),
         pytest.param(
             (2, 4),
             1,
             fabric2d_device_params(),
+            _SEQUENCE,
             id="SP2xTP4-fabric-2d",
+        ),
+        pytest.param(
+            (2, 4),
+            0,
+            fabric2d_device_params(),
+            128,
+            id="SP4xTP2-fabric-2d",
         ),
         pytest.param(
             (8, 4),
             1,
             torus_xy_device_params(),
+            _SEQUENCE,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="SP8xTP4-torus-xy",
         ),
@@ -52,12 +68,13 @@ def test_synthetic_kimi_k3_accuracy_and_determinism(
     mesh_device: ttnn.MeshDevice,
     tensor_parallel_axis: int,
     device_params: dict,
+    sequence: int,
 ) -> None:
     """Gate K3 dimensions against Torch and compare three device runs bit-for-bit."""
     mesh_shape = tuple(mesh_device.shape)
     sequence_parallel_axis = 1 - tensor_parallel_axis
     layout = f"SP{mesh_shape[sequence_parallel_axis]}xTP{mesh_shape[tensor_parallel_axis]}"
-    case = make_synthetic_kimi_k3_test_case(sequence=_SEQUENCE)
+    case = make_synthetic_kimi_k3_test_case(sequence=sequence)
     reference_start = time.perf_counter()
     golden_output, golden_state = kda_forward_reference(case.hidden, case.state_dict, case.config)
     reference_seconds = time.perf_counter() - reference_start
@@ -78,7 +95,7 @@ def test_synthetic_kimi_k3_accuracy_and_determinism(
     state = KdaState(recurrent=recurrent, convolution=convolution)
     try:
         pcc = check_kimi_k3_accuracy(
-            f"Synthetic Kimi-K3 T=5120 {layout}",
+            f"Synthetic Kimi-K3 T={sequence} {layout}",
             case,
             golden_output,
             golden_state,
@@ -96,7 +113,7 @@ def test_synthetic_kimi_k3_accuracy_and_determinism(
             + json.dumps(
                 {
                     "layout": layout,
-                    "sequence": _SEQUENCE,
+                    "sequence": sequence,
                     "weights": "deterministic synthetic",
                     "reference": "independent pure-Torch FP32 CPU reference",
                     "cpu_reference_seconds": reference_seconds,

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
@@ -13,7 +13,7 @@ import pytest
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     check_kimi_k3_accuracy,
     collect_mesh_accuracy_and_determinism_results,
@@ -35,8 +35,8 @@ _PCC_THRESHOLD = 0.9995
         pytest.param(
             (2, 4),
             1,
-            fabric_1d_device_params(),
-            id="SP2xTP4-fabric-1d",
+            fabric2d_device_params(),
+            id="SP2xTP4-fabric-2d",
         ),
         pytest.param(
             (8, 4),
@@ -116,9 +116,9 @@ def test_synthetic_kimi_k3_accuracy_and_determinism(
 @pytest.mark.parametrize(
     "mesh_device,tensor_parallel_axis,device_params,sequence",
     [
-        pytest.param((1, 8), 1, fabric_1d_device_params(), 128, id="SP1xTP8"),
-        pytest.param((2, 4), 1, fabric_1d_device_params(), 128, id="SP2xTP4"),
-        pytest.param((2, 4), 0, fabric_1d_device_params(), 128, id="SP4xTP2"),
+        pytest.param((1, 8), 1, fabric2d_device_params(), 128, id="SP1xTP8-fabric-2d"),
+        pytest.param((2, 4), 1, fabric2d_device_params(), 128, id="SP2xTP4-fabric-2d"),
+        pytest.param((2, 4), 0, fabric2d_device_params(), 128, id="SP4xTP2-fabric-2d"),
         pytest.param(
             (8, 4),
             1,

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
@@ -13,7 +13,11 @@ import pytest
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     check_kimi_k3_accuracy,
     collect_mesh_accuracy_and_determinism_results,
@@ -35,15 +39,17 @@ _PCC_THRESHOLD = 0.9995
         pytest.param(
             (1, 8),
             1,
-            fabric2d_device_params(),
+            torus_x_device_params(),
             128,
-            id="SP1xTP8-fabric-2d",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 8), topology="ring"),
+            id="SP1xTP8-torus-x",
         ),
         pytest.param(
             (2, 4),
             1,
             fabric2d_device_params(),
             _SEQUENCE,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="SP2xTP4-fabric-2d",
         ),
         pytest.param(
@@ -51,6 +57,7 @@ _PCC_THRESHOLD = 0.9995
             0,
             fabric2d_device_params(),
             128,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="SP4xTP2-fabric-2d",
         ),
         pytest.param(
@@ -133,16 +140,37 @@ def test_synthetic_kimi_k3_accuracy_and_determinism(
 @pytest.mark.parametrize(
     "mesh_device,tensor_parallel_axis,device_params,sequence",
     [
-        pytest.param((1, 8), 1, fabric2d_device_params(), 128, id="SP1xTP8-fabric-2d"),
-        pytest.param((2, 4), 1, fabric2d_device_params(), 128, id="SP2xTP4-fabric-2d"),
-        pytest.param((2, 4), 0, fabric2d_device_params(), 128, id="SP4xTP2-fabric-2d"),
+        pytest.param(
+            (1, 8),
+            1,
+            torus_x_device_params(),
+            128,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 8), topology="ring"),
+            id="SP1xTP8-torus-x",
+        ),
+        pytest.param(
+            (2, 4),
+            1,
+            fabric2d_device_params(),
+            128,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="SP2xTP4-fabric-2d",
+        ),
+        pytest.param(
+            (2, 4),
+            0,
+            fabric2d_device_params(),
+            128,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="SP4xTP2-fabric-2d",
+        ),
         pytest.param(
             (8, 4),
             1,
             torus_xy_device_params(),
             512,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="SP8xTP4",
+            id="SP8xTP4-torus-xy",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_contract.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_contract.py
@@ -11,6 +11,7 @@ import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    LINEAR_TOPOLOGY,
     collect_mesh_accuracy_and_determinism_results,
     make_small_kda_test_config,
     random_weights,
@@ -60,7 +61,7 @@ def test_layer_matches_reference_and_is_deterministic(device: ttnn.Device) -> No
         torch.bfloat16
     )
     golden_output, golden_state = kda_forward_reference(hidden, weights, config)
-    layer = ttKDA(device, config, weights)
+    layer = ttKDA(device, config, weights, topology=LINEAR_TOPOLOGY)
     hidden_tt = _hidden_to_device(hidden, device)
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
@@ -87,7 +88,7 @@ def test_layer_matches_reference_and_is_deterministic(device: ttnn.Device) -> No
 
 def test_allocate_state_contract(device: ttnn.Device) -> None:
     config = make_small_kda_test_config()
-    layer = ttKDA(device, config, random_weights(config))
+    layer = ttKDA(device, config, random_weights(config), topology=LINEAR_TOPOLOGY)
     first = layer.allocate_state()
     second = layer.allocate_state()
 
@@ -102,7 +103,7 @@ def test_forward_contract(device: ttnn.Device) -> None:
     weights = random_weights(config)
     hidden = torch.randn(1, 64, config.hidden_size, generator=torch.Generator().manual_seed(109)).to(torch.bfloat16)
     golden_output, golden_state = kda_forward_reference(hidden, weights, config)
-    layer = ttKDA(device, config, weights)
+    layer = ttKDA(device, config, weights, topology=LINEAR_TOPOLOGY)
     input_state = layer.allocate_state()
     input_recurrent_before = ttnn.to_torch(input_state.recurrent)
     input_convolution_before = ttnn.to_torch(input_state.convolution)
@@ -145,6 +146,55 @@ def test_forward_contract(device: ttnn.Device) -> None:
 
 
 @pytest.mark.parametrize(
+    "sp_axis,tp_axis,expected_sp,expected_tp",
+    [
+        pytest.param(0, 1, ttnn.Topology.Linear, ttnn.Topology.Ring, id="sp0-tp1"),
+        pytest.param(1, 0, ttnn.Topology.Ring, ttnn.Topology.Linear, id="sp1-tp0"),
+    ],
+)
+def test_layer_selects_topology_by_physical_axis(
+    device: ttnn.Device,
+    sp_axis: int,
+    tp_axis: int,
+    expected_sp: ttnn.Topology,
+    expected_tp: ttnn.Topology,
+) -> None:
+    config = make_small_kda_test_config()
+    layer = ttKDA(
+        device,
+        config,
+        random_weights(config),
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        topology=(ttnn.Topology.Linear, ttnn.Topology.Ring),
+    )
+
+    assert layer.sp_ccl_topology == expected_sp
+    assert layer.tp_ccl_topology == expected_tp
+
+
+def test_layer_requires_topology(device: ttnn.Device, expect_error) -> None:
+    config = make_small_kda_test_config()
+    with expect_error(TypeError, "topology"):
+        ttKDA(device, config, random_weights(config))
+
+
+@pytest.mark.parametrize(
+    "topology",
+    [
+        pytest.param(ttnn.Topology.Linear, id="scalar"),
+        pytest.param((ttnn.Topology.Linear,), id="short-tuple"),
+        pytest.param((ttnn.Topology.Linear, ttnn.Topology.Linear, ttnn.Topology.Linear), id="long-tuple"),
+        pytest.param((ttnn.Topology.Linear, "Ring"), id="invalid-member"),
+    ],
+)
+def test_layer_rejects_malformed_topology(topology: object, device: ttnn.Device, expect_error) -> None:
+    config = make_small_kda_test_config()
+    with expect_error(ValueError, "2-tuple of ttnn.Topology"):
+        ttKDA(device, config, random_weights(config), topology=topology)
+
+
+@pytest.mark.parametrize(
     "case",
     [
         pytest.param("axes", id="sp-and-tp-axes-must-be-distinct"),
@@ -159,11 +209,11 @@ def test_layer_rejects_invalid_construction(case: str, device: ttnn.Device, expe
 
     if case == "axes":
         with expect_error(ValueError, "requires distinct 2D SP/TP axes"):
-            ttKDA(device, config, state_dict, sp_axis=0, tp_axis=0)
+            ttKDA(device, config, state_dict, sp_axis=0, tp_axis=0, topology=LINEAR_TOPOLOGY)
     elif case == "weight_sources":
-        weights = ttKDA(device, config, state_dict).weights
+        weights = ttKDA(device, config, state_dict, topology=LINEAR_TOPOLOGY).weights
         with expect_error(ValueError, "either constructed KDAWeights or host state_dict"):
-            ttKDA(device, config, state_dict, weights=weights)
+            ttKDA(device, config, state_dict, weights=weights, topology=LINEAR_TOPOLOGY)
     elif case == "grouped_nonsquare":
         nonsquare_config = replace(config, head_v_dim=64)
         base_program_config = KDAProgramConfig()
@@ -172,9 +222,15 @@ def test_layer_rejects_invalid_construction(case: str, device: ttnn.Device, expe
             recurrence=replace(base_program_config.recurrence, local_scan_strategy="grouped"),
         )
         with expect_error(ValueError, "grouped KDA affine prefix currently requires K == V"):
-            ttKDA(device, nonsquare_config, random_weights(nonsquare_config), program_config=program_config)
+            ttKDA(
+                device,
+                nonsquare_config,
+                random_weights(nonsquare_config),
+                program_config=program_config,
+                topology=LINEAR_TOPOLOGY,
+            )
     else:
-        layer = ttKDA(device, config, state_dict)
+        layer = ttKDA(device, config, state_dict, topology=LINEAR_TOPOLOGY)
         with expect_error(ValueError, "batch_size=1"):
             layer.allocate_state(batch_size=2)
 
@@ -193,7 +249,7 @@ def test_layer_rejects_invalid_construction(case: str, device: ttnn.Device, expe
 )
 def test_layer_rejects_invalid_forward(case: str, device: ttnn.Device, expect_error) -> None:
     config = make_small_kda_test_config()
-    layer = ttKDA(device, config, random_weights(config))
+    layer = ttKDA(device, config, random_weights(config), topology=LINEAR_TOPOLOGY)
     hidden_shape = (1, 32, config.hidden_size)
     state = layer.allocate_state()
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_contract.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_contract.py
@@ -173,31 +173,23 @@ def test_layer_selects_topology_by_physical_axis(
     assert layer.tp_ccl_topology == expected_tp
 
 
-def test_layer_requires_topology(device: ttnn.Device, expect_error) -> None:
-    config = make_small_kda_test_config()
-    with expect_error(TypeError, "topology"):
-        ttKDA(device, config, random_weights(config))
-
-
-@pytest.mark.parametrize(
-    "topology",
-    [
-        pytest.param(ttnn.Topology.Linear, id="scalar"),
-        pytest.param((ttnn.Topology.Linear,), id="short-tuple"),
-        pytest.param((ttnn.Topology.Linear, ttnn.Topology.Linear, ttnn.Topology.Linear), id="long-tuple"),
-        pytest.param((ttnn.Topology.Linear, "Ring"), id="invalid-member"),
-    ],
-)
-def test_layer_rejects_malformed_topology(topology: object, device: ttnn.Device, expect_error) -> None:
-    config = make_small_kda_test_config()
-    with expect_error(ValueError, "2-tuple of ttnn.Topology"):
-        ttKDA(device, config, random_weights(config), topology=topology)
+_MALFORMED_TOPOLOGIES = {
+    "topology_scalar": ttnn.Topology.Linear,
+    "topology_short": (ttnn.Topology.Linear,),
+    "topology_long": (ttnn.Topology.Linear, ttnn.Topology.Linear, ttnn.Topology.Linear),
+    "topology_member": (ttnn.Topology.Linear, "Ring"),
+}
 
 
 @pytest.mark.parametrize(
     "case",
     [
         pytest.param("axes", id="sp-and-tp-axes-must-be-distinct"),
+        pytest.param("topology_missing", id="topology-is-required"),
+        pytest.param("topology_scalar", id="topology-rejects-a-bare-topology"),
+        pytest.param("topology_short", id="topology-rejects-a-1-tuple"),
+        pytest.param("topology_long", id="topology-rejects-a-3-tuple"),
+        pytest.param("topology_member", id="topology-rejects-a-non-topology-member"),
         pytest.param("weight_sources", id="weight-sources-are-mutually-exclusive"),
         pytest.param("grouped_nonsquare", id="grouped-scan-requires-square-state"),
         pytest.param("batch_state", id="state-allocation-requires-batch-one"),
@@ -210,6 +202,12 @@ def test_layer_rejects_invalid_construction(case: str, device: ttnn.Device, expe
     if case == "axes":
         with expect_error(ValueError, "requires distinct 2D SP/TP axes"):
             ttKDA(device, config, state_dict, sp_axis=0, tp_axis=0, topology=LINEAR_TOPOLOGY)
+    elif case == "topology_missing":
+        with expect_error(TypeError, "topology"):
+            ttKDA(device, config, state_dict)
+    elif case in _MALFORMED_TOPOLOGIES:
+        with expect_error(ValueError, "2-tuple of ttnn.Topology"):
+            ttKDA(device, config, state_dict, topology=_MALFORMED_TOPOLOGIES[case])
     elif case == "weight_sources":
         weights = ttKDA(device, config, state_dict, topology=LINEAR_TOPOLOGY).weights
         with expect_error(ValueError, "either constructed KDAWeights or host state_dict"):

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
@@ -11,6 +11,7 @@ import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
 from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     collect_mesh_accuracy_and_determinism_results,
     random_weights,
@@ -28,7 +29,7 @@ pytestmark = [
     pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
     pytest.mark.parametrize(
         "device_params",
-        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        [fabric2d_device_params()],
         indirect=True,
     ),
 ]

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
@@ -21,6 +21,7 @@ from models.demos.deepseek_v3_d_p.tests.kda.utils import (
 )
 from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, KDARecurrenceProgramConfig
 from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import TT_CCL
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate
 
@@ -87,6 +88,7 @@ def test_sp_group_divisor_fallback_matches_reference(
         sp_axis=sp_axis,
         tp_axis=tensor_parallel_axis,
         program_config=program_config,
+        topology=per_axis_topology(),
     )
     initial_state = layer.allocate_state(batch_size=1)
     hidden_tt = _to_sp_input(hidden, mesh_device, sp_axis)
@@ -179,6 +181,7 @@ def test_sp_segmented_prefill_matches_one_shot(
         program_config=KDAProgramConfig(
             recurrence=KDARecurrenceProgramConfig(summary_group_chunks=summary_group_chunks)
         ),
+        topology=per_axis_topology(),
     )
 
     one_shot_input_state = layer.allocate_state(batch_size=1)
@@ -286,6 +289,7 @@ def test_sp_minimal_group_matches_reference_and_is_deterministic(
         sp_axis=sp_axis,
         tp_axis=tensor_parallel_axis,
         program_config=KDAProgramConfig(recurrence=KDARecurrenceProgramConfig(summary_group_chunks=1)),
+        topology=per_axis_topology(),
     )
     hidden_tt = _to_sp_input(hidden, mesh_device, sp_axis)
     tp_size = tuple(mesh_device.shape)[tensor_parallel_axis]

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
@@ -27,11 +27,17 @@ from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import ass
 
 pytestmark = [
     run_for_blackhole(),
-    pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
     pytest.mark.parametrize(
-        "device_params",
-        [fabric2d_device_params()],
-        indirect=True,
+        "mesh_device,device_params",
+        [
+            pytest.param(
+                (2, 4),
+                fabric2d_device_params(),
+                marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+                id="fabric2d-mesh-2x4",
+            )
+        ],
+        indirect=["mesh_device", "device_params"],
     ),
 ]
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_stateful.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_stateful.py
@@ -8,7 +8,7 @@ import torch
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
-from models.demos.deepseek_v3_d_p.tests.kda.utils import make_small_kda_test_config, random_weights
+from models.demos.deepseek_v3_d_p.tests.kda.utils import LINEAR_TOPOLOGY, make_small_kda_test_config, random_weights
 from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_bit_identical
 
@@ -38,7 +38,7 @@ def test_segmented_prefill_matches_reference_and_reuses_program(
     golden_first, golden_state = kda_forward_reference(hidden[:, :32], weights, config)
     golden_second, golden_state = kda_forward_reference(hidden[:, 32:], weights, config, golden_state)
 
-    layer = ttKDA(device, config, weights)
+    layer = ttKDA(device, config, weights, topology=LINEAR_TOPOLOGY)
     state = layer.allocate_state()
     actual_first, state = _forward(layer, hidden[:, :32], state)
     cache_entries_after_first = device.num_program_cache_entries()
@@ -76,7 +76,7 @@ def test_trace_replay_matches_eager_without_mutating_input_state(device: ttnn.De
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    layer = ttKDA(device, config, random_weights(config))
+    layer = ttKDA(device, config, random_weights(config), topology=LINEAR_TOPOLOGY)
 
     with ttnn.manage_config("throw_exception_on_fallback", True):
         eager_output, _ = layer.forward(hidden_tt, layer.allocate_state())

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
@@ -234,7 +234,7 @@ def _assert_synthetic_performance(layout: str, median_wall_ms: float) -> None:
     )
 
 
-@pytest.mark.parametrize("layout", ["SP2xTP4", "SP8xTP4"])
+@pytest.mark.parametrize("layout", ["SP1xTP8", "SP2xTP4", "SP4xTP2", "SP8xTP4"])
 def test_synthetic_performance_uses_two_sided_margin(layout, monkeypatch, expect_error) -> None:
     monkeypatch.setenv("KDA_PERF_SKU", _PERF_SKU)
     reference_ms = _synthetic_perf_reference_ms(layout)
@@ -506,7 +506,9 @@ def test_kimi_k3_layer_1_perf(
 @pytest.mark.parametrize(
     "mesh_device,tensor_parallel_axis,device_params",
     [
+        pytest.param((1, 8), 1, fabric2d_device_params(), id="SP1xTP8-fabric-2d"),
         pytest.param((2, 4), 1, fabric2d_device_params(), id="SP2xTP4-fabric-2d"),
+        pytest.param((2, 4), 0, fabric2d_device_params(), id="SP4xTP2-fabric-2d"),
         pytest.param(
             (8, 4),
             1,

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
@@ -23,7 +23,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import KDAReferenceState, kda_forward_reference
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import KIMI_K3_FIRST_KDA_LAYER
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     KimiK3TestCase,
@@ -48,12 +48,12 @@ _PCC_THRESHOLD = 0.9995
 _CPU_REFERENCE_CACHE_VERSION = 4
 _PERF_SKU = "bh_loudbox"
 _PERF_MARGIN = 0.03
-# LoudBox calibration at 350413d7a98e (2026-08-31): median across five independent
-# sessions, each using the median of five warm synchronized 10-replay samples.
+# Throwaway Fabric2D prototype baselines from one session on bh-lb-42 (2026-09-04).
+# A proper implementation must recalibrate with five independent sessions.
 _PERF_REFERENCE_MS = {
-    "SP1xTP8": 9.597,
-    "SP2xTP4": 9.539,
-    "SP4xTP2": 9.991,
+    "SP1xTP8": 11.062,
+    "SP2xTP4": 9.890,
+    "SP4xTP2": 10.055,
 }
 # Blackhole Galaxy SP8xTP4 calibration at c4f8ddd0e377 (2026-09-02): median
 # of five warm synchronized 10-replay samples on the high-power CI lane.
@@ -401,15 +401,7 @@ def _trace_wall_samples_ms(
 @pytest.mark.parametrize(
     "device_params",
     [
-        # FABRIC_2D follow-up: SP1xTP8 hangs with a device timeout and failed
-        # Ethernet-core recovery. SP2xTP4/SP4xTP2 were correct but 0.05%/0.10%
-        # slower than FABRIC_1D; do not enable 2D until the SP1 failure is fixed.
-        pytest.param(
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            },
-            id="fabric_1d",
-        ),
+        pytest.param(fabric2d_device_params(), id="fabric_2d"),
     ],
     indirect=True,
 )
@@ -514,7 +506,7 @@ def test_kimi_k3_layer_1_perf(
 @pytest.mark.parametrize(
     "mesh_device,tensor_parallel_axis,device_params",
     [
-        pytest.param((2, 4), 1, fabric_1d_device_params(), id="SP2xTP4-fabric-1d"),
+        pytest.param((2, 4), 1, fabric2d_device_params(), id="SP2xTP4-fabric-2d"),
         pytest.param(
             (8, 4),
             1,

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
@@ -48,12 +48,15 @@ _PCC_THRESHOLD = 0.9995
 _CPU_REFERENCE_CACHE_VERSION = 4
 _PERF_SKU = "bh_loudbox"
 _PERF_MARGIN = 0.03
-# Throwaway Fabric2D prototype baselines from one session on bh-lb-42 (2026-09-04).
-# A proper implementation must recalibrate with five independent sessions.
+# Fabric2D calibration at da25439f8c3 on bh-lb-42 (2026-09-04): median of
+# five independent process/device sessions, each containing five 10-replay samples.
+# Session medians: SP1xTP8=[11.067, 11.057, 11.051, 11.059, 11.048],
+# SP2xTP4=[9.922, 9.921, 9.925, 9.920, 9.915],
+# SP4xTP2=[10.259, 10.261, 10.257, 10.255, 10.251].
 _PERF_REFERENCE_MS = {
-    "SP1xTP8": 11.062,
-    "SP2xTP4": 9.890,
-    "SP4xTP2": 10.055,
+    "SP1xTP8": 11.057,
+    "SP2xTP4": 9.921,
+    "SP4xTP2": 10.257,
 }
 # Blackhole Galaxy SP8xTP4 calibration at c4f8ddd0e377 (2026-09-02): median
 # of five warm synchronized 10-replay samples on the high-power CI lane.

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
@@ -23,7 +23,11 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import KDAReferenceState, kda_forward_reference
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import KIMI_K3_FIRST_KDA_LAYER
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     KimiK3TestCase,
@@ -48,13 +52,15 @@ _PCC_THRESHOLD = 0.9995
 _CPU_REFERENCE_CACHE_VERSION = 4
 _PERF_SKU = "bh_loudbox"
 _PERF_MARGIN = 0.03
-# Fabric2D calibration at da25439f8c3 on bh-lb-42 (2026-09-04): median of
+# SP1xTP8 retains the TP-ring regression target calibrated at 350413d7a98e
+# (2026-08-31). The TorusX Fabric2D profile restores that physical topology;
+# recalibrate only after measuring it across independent hardware sessions.
+# Unwrapped Fabric2D calibration at da25439f8c3 on bh-lb-42 (2026-09-04):
 # five independent process/device sessions, each containing five 10-replay samples.
-# Session medians: SP1xTP8=[11.067, 11.057, 11.051, 11.059, 11.048],
-# SP2xTP4=[9.922, 9.921, 9.925, 9.920, 9.915],
+# Session medians: SP2xTP4=[9.922, 9.921, 9.925, 9.920, 9.915],
 # SP4xTP2=[10.259, 10.261, 10.257, 10.255, 10.251].
 _PERF_REFERENCE_MS = {
-    "SP1xTP8": 11.057,
+    "SP1xTP8": 9.597,
     "SP2xTP4": 9.921,
     "SP4xTP2": 10.257,
 }
@@ -396,17 +402,31 @@ def _trace_wall_samples_ms(
 
 
 @pytest.mark.parametrize(
-    "mesh_device,tensor_parallel_axis",
-    [((1, 8), 1), ((2, 4), 1), ((2, 4), 0)],
-    indirect=["mesh_device"],
-    ids=["SP1xTP8", "SP2xTP4", "SP4xTP2"],
-)
-@pytest.mark.parametrize(
-    "device_params",
+    "mesh_device,tensor_parallel_axis,device_params",
     [
-        pytest.param(fabric2d_device_params(), id="fabric_2d"),
+        pytest.param(
+            (1, 8),
+            1,
+            torus_x_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 8), topology="ring"),
+            id="SP1xTP8-torus-x",
+        ),
+        pytest.param(
+            (2, 4),
+            1,
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="SP2xTP4-fabric-2d",
+        ),
+        pytest.param(
+            (2, 4),
+            0,
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="SP4xTP2-fabric-2d",
+        ),
     ],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
 def test_kimi_k3_layer_1_perf(
     mesh_device: ttnn.MeshDevice,
@@ -509,9 +529,27 @@ def test_kimi_k3_layer_1_perf(
 @pytest.mark.parametrize(
     "mesh_device,tensor_parallel_axis,device_params",
     [
-        pytest.param((1, 8), 1, fabric2d_device_params(), id="SP1xTP8-fabric-2d"),
-        pytest.param((2, 4), 1, fabric2d_device_params(), id="SP2xTP4-fabric-2d"),
-        pytest.param((2, 4), 0, fabric2d_device_params(), id="SP4xTP2-fabric-2d"),
+        pytest.param(
+            (1, 8),
+            1,
+            torus_x_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 8), topology="ring"),
+            id="SP1xTP8-torus-x",
+        ),
+        pytest.param(
+            (2, 4),
+            1,
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="SP2xTP4-fabric-2d",
+        ),
+        pytest.param(
+            (2, 4),
+            0,
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="SP4xTP2-fabric-2d",
+        ),
         pytest.param(
             (8, 4),
             1,

--- a/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
@@ -11,7 +11,7 @@ import torch
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import kda_state_dict_sha256
-from models.demos.deepseek_v3_d_p.tests.kda.utils import make_small_kda_test_config, random_weights
+from models.demos.deepseek_v3_d_p.tests.kda.utils import LINEAR_TOPOLOGY, make_small_kda_test_config, random_weights
 from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, KDARecurrenceProgramConfig
 from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
 from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights, load_kda_weights
@@ -106,13 +106,21 @@ def test_cached_and_in_memory_layers_match(device: ttnn.Device, tmp_path: Path) 
     cache_prefix = "layer_0.kda"
     KDAWeights.build_ttnn_cache(state_dict, tmp_path, cache_prefix, config, device)
 
-    in_memory_layer = ttKDA(device, config, state_dict)
+    in_memory_layer = ttKDA(device, config, state_dict, topology=LINEAR_TOPOLOGY)
     cached_layer = ttKDA(
         device,
         config,
         weights=KDAWeights.from_cache(tmp_path, cache_prefix, config, device),
+        topology=LINEAR_TOPOLOGY,
     )
-    cache_only_layer = ttKDA(device, config, None, weight_cache_path=tmp_path, layer_idx=0)
+    cache_only_layer = ttKDA(
+        device,
+        config,
+        None,
+        weight_cache_path=tmp_path,
+        layer_idx=0,
+        topology=LINEAR_TOPOLOGY,
+    )
     outputs = {
         "in-memory": _forward(in_memory_layer, hidden, in_memory_layer.allocate_state()),
         "preloaded-cache": _forward(cached_layer, hidden, cached_layer.allocate_state()),
@@ -127,9 +135,16 @@ def test_cached_and_in_memory_layers_match(device: ttnn.Device, tmp_path: Path) 
 def test_program_config_resolution(device: ttnn.Device) -> None:
     config = make_small_kda_test_config()
     program_config = replace(KDAProgramConfig(), qkv_channel_chunk_size=128)
-    layer = ttKDA(device, config, random_weights(config), program_config=program_config)
+    layer = ttKDA(
+        device,
+        config,
+        random_weights(config),
+        program_config=program_config,
+        topology=LINEAR_TOPOLOGY,
+    )
 
     assert layer.qkv_convolution_program_config.channel_chunk_size == 96
+    assert layer.sp_ccl_topology == ttnn.Topology.Linear
     assert layer.tp_ccl_topology == ttnn.Topology.Linear
 
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
@@ -126,11 +126,11 @@ def test_cached_and_in_memory_layers_match(device: ttnn.Device, tmp_path: Path) 
 @pytest.mark.use_module_device
 def test_program_config_resolution(device: ttnn.Device) -> None:
     config = make_small_kda_test_config()
-    program_config = replace(KDAProgramConfig(), qkv_channel_chunk_size=128, tp_ccl_topology=ttnn.Topology.Ring)
+    program_config = replace(KDAProgramConfig(), qkv_channel_chunk_size=128)
     layer = ttKDA(device, config, random_weights(config), program_config=program_config)
 
     assert layer.qkv_convolution_program_config.channel_chunk_size == 96
-    assert layer.tp_ccl_topology == ttnn.Topology.Ring
+    assert layer.tp_ccl_topology == ttnn.Topology.Linear
 
 
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/test_infrastructure.py
@@ -144,8 +144,6 @@ def test_program_config_resolution(device: ttnn.Device) -> None:
     )
 
     assert layer.qkv_convolution_program_config.channel_chunk_size == 96
-    assert layer.sp_ccl_topology == ttnn.Topology.Linear
-    assert layer.tp_ccl_topology == ttnn.Topology.Linear
 
 
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/kda/utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/utils.py
@@ -25,8 +25,11 @@ from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import (
 from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, kimi_k3_program_config
 from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
 from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import TT_CCL
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate
+
+LINEAR_TOPOLOGY = (ttnn.Topology.Linear, ttnn.Topology.Linear)
 
 
 @dataclass(frozen=True)
@@ -349,6 +352,7 @@ def make_kimi_k3_device_case(
         sp_axis=sequence_parallel_axis,
         tp_axis=tensor_parallel_axis,
         program_config=selected_program_config,
+        topology=per_axis_topology(),
     )
     return layer, hidden
 

--- a/models/demos/deepseek_v3_d_p/tests/kda/utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/utils.py
@@ -331,11 +331,7 @@ def make_kimi_k3_device_case(
             mesh_shape=tuple(mesh_device.shape),
         ),
     )
-    default_program_config = kimi_k3_program_config(
-        tp_ccl_topology=(
-            ttnn.Topology.Ring if tuple(mesh_device.shape)[sequence_parallel_axis] == 1 else ttnn.Topology.Linear
-        )
-    )
+    default_program_config = kimi_k3_program_config()
     selected_program_config = program_config or default_program_config
     if summary_group_chunks is not None:
         selected_program_config = replace(

--- a/models/demos/deepseek_v3_d_p/tt/kda/config.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/config.py
@@ -50,7 +50,6 @@ class KDAProgramConfig:
     recurrence: KDARecurrenceProgramConfig = field(default_factory=KDARecurrenceProgramConfig)
     # Ceiling: the effective chunk is the largest TP-local channel divisor no greater than this value.
     qkv_channel_chunk_size: int = 768
-    tp_ccl_topology: ttnn.Topology = ttnn.Topology.Linear
     gated_rms_output_dtype: ttnn.DataType = ttnn.float32
     output_projection_math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.HiFi4
 
@@ -64,15 +63,14 @@ class KDAProgramConfig:
             raise ValueError("gated_rms_output_dtype must be ttnn.float32 or ttnn.bfloat16")
 
 
-def kimi_k3_program_config(*, tp_ccl_topology: ttnn.Topology) -> KDAProgramConfig:
-    """Return the production K3 program configuration with caller-owned per-axis CCL topology."""
+def kimi_k3_program_config() -> KDAProgramConfig:
+    """Return the production K3 program configuration."""
     return KDAProgramConfig(
         # Scan policy is fixed at construction. Direct scan avoids summary overhead for shorter fixed
         # sequences; grouped scan trades P local scans of N/P chunks plus a log2(P) prefix for summary
         # overhead and requires batch_heads * P worker owners. K3 at T=5120 uses grouped scan.
         recurrence=KDARecurrenceProgramConfig(local_scan_strategy="grouped", summary_group_chunks=20),
         qkv_channel_chunk_size=512,
-        tp_ccl_topology=tp_ccl_topology,
         gated_rms_output_dtype=ttnn.bfloat16,
         output_projection_math_fidelity=ttnn.MathFidelity.HiFi2,
     )

--- a/models/demos/deepseek_v3_d_p/tt/kda/convolution.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/convolution.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import ttnn
+from models.tt_transformers.tt.ccl import TT_CCL
 
 
 def exchange_convolution_carry(
@@ -12,6 +13,8 @@ def exchange_convolution_carry(
     initial_carry: ttnn.Tensor,
     *,
     sequence_parallel_axis: int,
+    topology: ttnn.Topology,
+    tt_ccl: TT_CCL,
 ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
     """Return partition entry carries and the replicated final stream carry.
 
@@ -40,10 +43,14 @@ def exchange_convolution_carry(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     tiled_tail = ttnn.to_layout(padded_tail, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    gathered_tails = ttnn.all_gather(
+    gathered_tails = ttnn.experimental.all_gather_async(
         tiled_tail,
         dim=1,
+        multi_device_global_semaphore=tt_ccl.get_and_cycle_ag_semaphore_handles(sequence_parallel_axis),
+        barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(sequence_parallel_axis),
+        num_links=tt_ccl.get_num_links(sequence_parallel_axis),
         cluster_axis=sequence_parallel_axis,
+        topology=topology,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 

--- a/models/demos/deepseek_v3_d_p/tt/kda/kda.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/kda.py
@@ -22,7 +22,6 @@ from models.demos.deepseek_v3_d_p.tt.kda.config import (
 from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
 from models.demos.deepseek_v3_d_p.tt.kda.recurrence import KDARecurrence
 from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights, load_kda_weights
-from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import TT_CCL
 
 
@@ -87,13 +86,23 @@ class ttKDA:
         tp_axis: int = 1,
         program_config: KDAProgramConfig | None = None,
         weights: KDAWeights | None = None,
+        *,
+        topology: tuple[ttnn.Topology, ttnn.Topology],
     ) -> None:
         if tp_axis not in (0, 1) or sp_axis not in (0, 1) or sp_axis == tp_axis:
             raise ValueError(f"KDA requires distinct 2D SP/TP axes, got SP={sp_axis}, TP={tp_axis}")
+        if (
+            not isinstance(topology, tuple)
+            or len(topology) != 2
+            or not all(isinstance(axis_topology, ttnn.Topology) for axis_topology in topology)
+        ):
+            raise ValueError("KDA topology must be a 2-tuple of ttnn.Topology values ordered by physical mesh axis")
         program_config = program_config or KDAProgramConfig()
         self.device = mesh_device
         self.tensor_parallel_axis = tp_axis
         self.sequence_parallel_axis = sp_axis
+        self.sp_ccl_topology = topology[self.sequence_parallel_axis]
+        self.tp_ccl_topology = topology[self.tensor_parallel_axis]
         self.sequence_parallel_size = (
             tuple(mesh_device.shape)[self.sequence_parallel_axis] if isinstance(mesh_device, ttnn.MeshDevice) else 1
         )
@@ -102,8 +111,6 @@ class ttKDA:
         )
         if uses_grouped_scan and config.head_k_dim != config.head_v_dim:
             raise ValueError("grouped KDA affine prefix currently requires K == V")
-        # Throwaway Fabric2D prototype: topology is a fact of the active fabric, not a tuning knob.
-        self.tp_ccl_topology = per_axis_topology()[self.tensor_parallel_axis]
         self.gated_rms_output_dtype = program_config.gated_rms_output_dtype
         if weights is not None and state_dict is not None:
             raise ValueError("pass either constructed KDAWeights or host state_dict, not both")
@@ -132,8 +139,8 @@ class ttKDA:
         self.qkv_convolution_program_config = ttnn.QkvCausalConv1dSiluProgramConfig(
             channel_chunk_size=qkv_channel_chunk_size
         )
-        if self.tensor_parallel_size > 1 and tt_ccl is None:
-            raise ValueError("tt_ccl is required for tensor-parallel KDA")
+        if (self.tensor_parallel_size > 1 or self.sequence_parallel_size > 1) and tt_ccl is None:
+            raise ValueError("tt_ccl is required for multi-device KDA collectives")
         self.tt_ccl = tt_ccl
         # Ordinary matmuls (input and decay projections) keep packer L1 accumulation.
         self.compute_config = ttnn.init_device_compute_kernel_config(
@@ -155,6 +162,8 @@ class ttKDA:
             mesh_device,
             program_config.recurrence,
             sequence_parallel_axis=(self.sequence_parallel_axis if self.sequence_parallel_size > 1 else None),
+            topology=self.sp_ccl_topology,
+            tt_ccl=self.tt_ccl,
         )
         self.output_projection_compute_config = ttnn.init_device_compute_kernel_config(
             mesh_device.arch(),
@@ -241,6 +250,8 @@ class ttKDA:
                 qkv_row_major,
                 state_row_major,
                 sequence_parallel_axis=self.sequence_parallel_axis,
+                topology=self.sp_ccl_topology,
+                tt_ccl=self.tt_ccl,
             )
         else:
             new_state = ttnn.slice(

--- a/models/demos/deepseek_v3_d_p/tt/kda/kda.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/kda.py
@@ -22,6 +22,7 @@ from models.demos.deepseek_v3_d_p.tt.kda.config import (
 from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
 from models.demos.deepseek_v3_d_p.tt.kda.recurrence import KDARecurrence
 from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights, load_kda_weights
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import TT_CCL
 
 
@@ -101,7 +102,8 @@ class ttKDA:
         )
         if uses_grouped_scan and config.head_k_dim != config.head_v_dim:
             raise ValueError("grouped KDA affine prefix currently requires K == V")
-        self.tp_ccl_topology = program_config.tp_ccl_topology
+        # Throwaway Fabric2D prototype: topology is a fact of the active fabric, not a tuning knob.
+        self.tp_ccl_topology = per_axis_topology()[self.tensor_parallel_axis]
         self.gated_rms_output_dtype = program_config.gated_rms_output_dtype
         if weights is not None and state_dict is not None:
             raise ValueError("pass either constructed KDAWeights or host state_dict, not both")
@@ -369,7 +371,7 @@ class ttKDA:
             compute_kernel_config=self.output_projection_compute_config,
         )
         if self.tensor_parallel_size > 1:
-            cluster_axis = None if self.sequence_parallel_size == 1 else self.tensor_parallel_axis
+            cluster_axis = self.tensor_parallel_axis
             output = ttnn.experimental.reduce_scatter_minimal_async(
                 output,
                 dim=-1,

--- a/models/demos/deepseek_v3_d_p/tt/kda/kda.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/kda.py
@@ -20,7 +20,7 @@ from models.demos.deepseek_v3_d_p.tt.kda.config import (
     KDAProgramConfig,
 )
 from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
-from models.demos.deepseek_v3_d_p.tt.kda.recurrence import KDARecurrence
+from models.demos.deepseek_v3_d_p.tt.kda.recurrence import KDARecurrence, KDASequenceParallel
 from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights, load_kda_weights
 from models.tt_transformers.tt.ccl import TT_CCL
 
@@ -161,9 +161,15 @@ class ttKDA:
         self.recurrence = KDARecurrence(
             mesh_device,
             program_config.recurrence,
-            sequence_parallel_axis=(self.sequence_parallel_axis if self.sequence_parallel_size > 1 else None),
-            topology=self.sp_ccl_topology,
-            tt_ccl=self.tt_ccl,
+            sequence_parallel=(
+                KDASequenceParallel(
+                    axis=self.sequence_parallel_axis,
+                    topology=self.sp_ccl_topology,
+                    tt_ccl=self.tt_ccl,
+                )
+                if self.sequence_parallel_size > 1
+                else None
+            ),
         )
         self.output_projection_compute_config = ttnn.init_device_compute_kernel_config(
             mesh_device.arch(),

--- a/models/demos/deepseek_v3_d_p/tt/kda/recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/recurrence.py
@@ -23,6 +23,7 @@ from models.demos.deepseek_v3_d_p.tt.kda.config import (
     KDA_RECURRENT_STATE_DTYPE,
     KDARecurrenceProgramConfig,
 )
+from models.tt_transformers.tt.ccl import TT_CCL
 
 
 def _group_summary_memory_config(device: ttnn.Device, group_heads: int, key_dim: int) -> ttnn.MemoryConfig:
@@ -220,6 +221,8 @@ def _distributed_affine_prefix(
     initial_state: ttnn.Tensor,
     *,
     sequence_parallel_axis: int,
+    topology: ttnn.Topology,
+    tt_ccl: TT_CCL,
     compute_config: ttnn.DeviceComputeKernelConfig,
 ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
     """Compose SP partition affine summaries and return entry/final carries."""
@@ -239,10 +242,14 @@ def _distributed_affine_prefix(
     transport_a = ttnn.reshape(transport_a, (1, batch_heads, key_dim, key_dim))
     transport_b = ttnn.reshape(transport_b, (1, batch_heads, key_dim, value_dim))
     packed = ttnn.concat([transport_a, transport_b], dim=3, memory_config=output_memory)
-    gathered = ttnn.all_gather(
+    gathered = ttnn.experimental.all_gather_async(
         packed,
         dim=0,
+        multi_device_global_semaphore=tt_ccl.get_and_cycle_ag_semaphore_handles(sequence_parallel_axis),
+        barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(sequence_parallel_axis),
+        num_links=tt_ccl.get_num_links(sequence_parallel_axis),
         cluster_axis=sequence_parallel_axis,
+        topology=topology,
         memory_config=output_memory,
     )
 
@@ -321,6 +328,8 @@ def _scan_grouped_chunks(
     *,
     summary_group_chunks: int,
     sequence_parallel_axis: int | None,
+    topology: ttnn.Topology,
+    tt_ccl: TT_CCL | None,
     compute_config: _RecurrenceComputeConfig,
 ) -> _ScanResult:
     group_chunks = _effective_summary_group_chunks(geometry.num_chunks, summary_group_chunks)
@@ -338,6 +347,7 @@ def _scan_grouped_chunks(
     prefix_initial_state = initial_state
     prefix_memory_config = KDA_LOCAL_PREFIX_MEMORY_CONFIG
     if sequence_parallel_axis is not None:
+        assert tt_ccl is not None
         partition_a, partition_b = ttnn.experimental.kda.reduce_affine_transforms(
             summary_a,
             summary_b,
@@ -350,6 +360,8 @@ def _scan_grouped_chunks(
             partition_b,
             initial_state,
             sequence_parallel_axis=sequence_parallel_axis,
+            topology=topology,
+            tt_ccl=tt_ccl,
             compute_config=compute_config.affine_prefix,
         )
         prefix_memory_config = KDA_DISTRIBUTED_PREFIX_MEMORY_CONFIG
@@ -385,7 +397,11 @@ class KDARecurrence:
         program_config: KDARecurrenceProgramConfig,
         *,
         sequence_parallel_axis: int | None,
+        topology: ttnn.Topology,
+        tt_ccl: TT_CCL | None,
     ) -> None:
+        if sequence_parallel_axis is not None and tt_ccl is None:
+            raise ValueError("tt_ccl is required for sequence-parallel KDA recurrence")
         preparation = ttnn.init_device_compute_kernel_config(
             device.arch(),
             math_fidelity=ttnn.MathFidelity.HiFi4,
@@ -412,6 +428,8 @@ class KDARecurrence:
         )
         self._summary_group_chunks = program_config.summary_group_chunks
         self._sequence_parallel_axis = sequence_parallel_axis
+        self._topology = topology
+        self._tt_ccl = tt_ccl
         self._use_grouped_scan = sequence_parallel_axis is not None or program_config.local_scan_strategy == "grouped"
 
     def __call__(
@@ -447,6 +465,8 @@ class KDARecurrence:
                 geometry,
                 summary_group_chunks=self._summary_group_chunks,
                 sequence_parallel_axis=self._sequence_parallel_axis,
+                topology=self._topology,
+                tt_ccl=self._tt_ccl,
                 compute_config=self._compute_config,
             )
         else:

--- a/models/demos/deepseek_v3_d_p/tt/kda/recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/recurrence.py
@@ -26,6 +26,20 @@ from models.demos.deepseek_v3_d_p.tt.kda.config import (
 from models.tt_transformers.tt.ccl import TT_CCL
 
 
+@dataclass(frozen=True)
+class KDASequenceParallel:
+    """A sequence-parallel axis together with the transport its collectives run on.
+
+    A sequence-parallel recurrence needs all three; a single-partition recurrence needs
+    none. Keeping them in one value means a caller cannot name an axis without a
+    transport, or pick a topology for an axis that was never split.
+    """
+
+    axis: int
+    topology: ttnn.Topology
+    tt_ccl: TT_CCL
+
+
 def _group_summary_memory_config(device: ttnn.Device, group_heads: int, key_dim: int) -> ttnn.MemoryConfig:
     grid = device.compute_with_storage_grid_size()
     capacity = grid.x * grid.y
@@ -220,17 +234,17 @@ def _distributed_affine_prefix(
     transform_b: ttnn.Tensor,
     initial_state: ttnn.Tensor,
     *,
-    sequence_parallel_axis: int,
-    topology: ttnn.Topology,
-    tt_ccl: TT_CCL,
+    sequence_parallel: KDASequenceParallel,
     compute_config: ttnn.DeviceComputeKernelConfig,
 ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
     """Compose SP partition affine summaries and return entry/final carries."""
     shape = tuple(transform_a.shape)
 
+    axis = sequence_parallel.axis
+    tt_ccl = sequence_parallel.tt_ccl
     mesh_device = transform_a.device()
     mesh_shape = tuple(mesh_device.shape)
-    sp_size = mesh_shape[sequence_parallel_axis]
+    sp_size = mesh_shape[axis]
     batch_heads, key_dim = shape[0], shape[1]
     value_dim = transform_b.shape[-1]
     output_memory = KDA_OUTPUT_MEMORY_CONFIG
@@ -245,11 +259,11 @@ def _distributed_affine_prefix(
     gathered = ttnn.experimental.all_gather_async(
         packed,
         dim=0,
-        multi_device_global_semaphore=tt_ccl.get_and_cycle_ag_semaphore_handles(sequence_parallel_axis),
-        barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(sequence_parallel_axis),
-        num_links=tt_ccl.get_num_links(sequence_parallel_axis),
-        cluster_axis=sequence_parallel_axis,
-        topology=topology,
+        multi_device_global_semaphore=tt_ccl.get_and_cycle_ag_semaphore_handles(axis),
+        barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(axis),
+        num_links=tt_ccl.get_num_links(axis),
+        cluster_axis=axis,
+        topology=sequence_parallel.topology,
         memory_config=output_memory,
     )
 
@@ -294,7 +308,7 @@ def _distributed_affine_prefix(
     entry_state = ttnn.mesh_partition(
         replicated_entries,
         dim=0,
-        cluster_axis=sequence_parallel_axis,
+        cluster_axis=axis,
         memory_config=output_memory,
     )
     final_state = ttnn.to_memory_config(carry, output_memory)
@@ -327,9 +341,7 @@ def _scan_grouped_chunks(
     geometry: _RecurrenceGeometry,
     *,
     summary_group_chunks: int,
-    sequence_parallel_axis: int | None,
-    topology: ttnn.Topology,
-    tt_ccl: TT_CCL | None,
+    sequence_parallel: KDASequenceParallel | None,
     compute_config: _RecurrenceComputeConfig,
 ) -> _ScanResult:
     group_chunks = _effective_summary_group_chunks(geometry.num_chunks, summary_group_chunks)
@@ -346,8 +358,7 @@ def _scan_grouped_chunks(
 
     prefix_initial_state = initial_state
     prefix_memory_config = KDA_LOCAL_PREFIX_MEMORY_CONFIG
-    if sequence_parallel_axis is not None:
-        assert tt_ccl is not None
+    if sequence_parallel is not None:
         partition_a, partition_b = ttnn.experimental.kda.reduce_affine_transforms(
             summary_a,
             summary_b,
@@ -359,9 +370,7 @@ def _scan_grouped_chunks(
             partition_a,
             partition_b,
             initial_state,
-            sequence_parallel_axis=sequence_parallel_axis,
-            topology=topology,
-            tt_ccl=tt_ccl,
+            sequence_parallel=sequence_parallel,
             compute_config=compute_config.affine_prefix,
         )
         prefix_memory_config = KDA_DISTRIBUTED_PREFIX_MEMORY_CONFIG
@@ -380,7 +389,7 @@ def _scan_grouped_chunks(
         (geometry.batch_heads, geometry.num_chunks, geometry.chunk_size, geometry.value_dim),
     )
 
-    if sequence_parallel_axis is not None:
+    if sequence_parallel is not None:
         return _ScanResult(output=output, final_state=distributed_final_state)
     return _ScanResult(
         output=output,
@@ -396,12 +405,8 @@ class KDARecurrence:
         device: ttnn.Device | ttnn.MeshDevice,
         program_config: KDARecurrenceProgramConfig,
         *,
-        sequence_parallel_axis: int | None,
-        topology: ttnn.Topology,
-        tt_ccl: TT_CCL | None,
+        sequence_parallel: KDASequenceParallel | None,
     ) -> None:
-        if sequence_parallel_axis is not None and tt_ccl is None:
-            raise ValueError("tt_ccl is required for sequence-parallel KDA recurrence")
         preparation = ttnn.init_device_compute_kernel_config(
             device.arch(),
             math_fidelity=ttnn.MathFidelity.HiFi4,
@@ -427,10 +432,8 @@ class KDARecurrence:
             scan=scan,
         )
         self._summary_group_chunks = program_config.summary_group_chunks
-        self._sequence_parallel_axis = sequence_parallel_axis
-        self._topology = topology
-        self._tt_ccl = tt_ccl
-        self._use_grouped_scan = sequence_parallel_axis is not None or program_config.local_scan_strategy == "grouped"
+        self._sequence_parallel = sequence_parallel
+        self._use_grouped_scan = sequence_parallel is not None or program_config.local_scan_strategy == "grouped"
 
     def __call__(
         self,
@@ -464,9 +467,7 @@ class KDARecurrence:
                 state,
                 geometry,
                 summary_group_chunks=self._summary_group_chunks,
-                sequence_parallel_axis=self._sequence_parallel_axis,
-                topology=self._topology,
-                tt_ccl=self._tt_ccl,
+                sequence_parallel=self._sequence_parallel,
                 compute_config=self._compute_config,
             )
         else:


### PR DESCRIPTION
## Summary

- Require explicit per-axis KDA collective topology.
- Use the canonical profiles: LoudBox SP1xTP8 TorusX/ring, SP2xTP4 and SP4xTP2 Fabric2D/linear, and Galaxy SP8xTP4 TorusXY/ring.
- Detect when a requested TP wrap was not realized.

## TP-wrap detection

LoudBox exposes a 2D physical mesh, but `SystemMesh` maps a logical 1x8 mesh around its perimeter. Auto-discovery can therefore label the system graph `MESH` even though the opened 1x8 mesh has a direct physical edge between its TP endpoints.

The old guard constructed Fabric node IDs from logical columns, so it missed that mapped closing edge. `tp_axis_is_wrapped()` now resolves the opened mesh's actual Fabric node IDs, recognizes adjacent mapped endpoints, and retains the route-direction check for straight torus layouts.

## Performance

Measured on an 8xP150 LoudBox (`bh-lb-42`):

| Layout | PR7 | Current reference | Fresh HEAD |
| --- | ---: | ---: | ---: |
| SP1xTP8 TorusX | 9.597 ms | 9.597 ms | 9.704 ms (+1.11%) |
| SP2xTP4 Fabric2D | 9.539 ms | 9.921 ms | 9.932 ms (+0.11%) |
| SP4xTP2 Fabric2D | 9.991 ms | 10.257 ms | 10.265 ms (+0.08%) |
| Galaxy SP8xTP4 TorusXY | 3.963 ms | 3.963 ms | 3.994 ms (+0.79%) |

All results were measured at `e7909fcf884`. SP1xTP8 is the median of five 10-replay samples (`9.704, 9.694, 9.703, 9.713, 9.726 ms`); SP2xTP4 and SP4xTP2 are medians across five independent process/device sessions using the same sampling. Galaxy CI measured `3.955, 3.949, 4.008, 4.007, 3.994 ms`. Each layout passes its symmetric 3% gate. SP1xTP8 TP reduce-scatter measured 1.047 ms. The previous linear-TP SP1xTP8 configuration measured 11.057 ms (+15.2% versus PR7); restoring the perimeter ring removes that regression.

## Validation

- LoudBox SP1xTP8 accuracy and determinism: passed; output PCC `0.999952`, recurrent PCC `0.999790`, convolution PCC `0.999997`, bit-identical across 3 repetitions.
- LoudBox synthetic performance: SP1xTP8 `9.704 ms`, SP2xTP4 `9.932 ms`, and SP4xTP2 `10.265 ms`; all passed.
- Galaxy SP8xTP4 accuracy, determinism, and `3.994 ms` performance: passed.
- Targeted pre-commit, `py_compile`, and `git diff --check`: passed. Python-only change; no build required.

## Test plan

Triggered from `e7909fcf884`. Pills show workflow status and link to the corresponding run.

[![LoudBox KDA topology matrix](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/test-dispatch.yaml?branch=momcilo%2Fkda_2dfab&event=workflow_dispatch&label=LoudBox%20KDA%20topology%20matrix&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/runs/34464155922)
[![LoudBox hosted KDA gates](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/blackhole-e2e-tests.yaml?branch=momcilo%2Fkda_2dfab&event=workflow_dispatch&label=LoudBox%20hosted%20KDA%20gates&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/runs/34464153957)
[![Galaxy KDA accuracy and performance](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/blaze-models-prefill-tests.yaml?branch=momcilo%2Fkda_2dfab&event=workflow_dispatch&label=Galaxy%20KDA%20accuracy%20%2B%20performance&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/runs/34464155779)

- LoudBox topology matrix: SP1xTP8, SP2xTP4, and SP4xTP2 accuracy, determinism, and performance.
- LoudBox hosted: standard SP2xTP4 accuracy and performance gates.
- Galaxy: SP8xTP4 accuracy, determinism, and performance.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=momcilo/kda_2dfab)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:momcilo/kda_2dfab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=momcilo/kda_2dfab)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:momcilo/kda_2dfab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=momcilo/kda_2dfab)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:momcilo/kda_2dfab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=momcilo/kda_2dfab)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:momcilo/kda_2dfab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=momcilo/kda_2dfab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:momcilo/kda_2dfab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=momcilo/kda_2dfab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:momcilo/kda_2dfab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=momcilo/kda_2dfab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:momcilo/kda_2dfab)
