### PR TITLE
BGE-M3: use the data-parallel serving path from the vLLM wrapper

### DIFF
--- a/models/demos/wormhole/bge_m3/demo/generator_vllm.py
+++ b/models/demos/wormhole/bge_m3/demo/generator_vllm.py
@@ -71,6 +71,11 @@ class BgeM3ForEmbedding:
         self.models = None
         self.data_parallel = None
         self.submeshes = None
+        # Set by _initialize_model once the mesh is known.
+        self._data_parallel = False
+        # Long-lived device tensors plus the trace that replays over them.
+        self._traced_inputs = None
+        self._traced_output = None
         self.state_dict = None
         self.tokenizer = None
         # Cache for mean-pool helper tensors keyed by (batch, seq) to avoid per-step
@@ -88,7 +93,7 @@ class BgeM3ForEmbedding:
         tt_data_parallel=1,
         optimizations: Optional[str] = None,
         vllm_config=None,
-        dtype=ttnn.bfloat16,
+        dtype=ttnn.bfloat8_b,
         **kwargs,
     ) -> "BgeM3ForEmbedding":
         if optimizations is not None:
@@ -116,10 +121,28 @@ class BgeM3ForEmbedding:
             **kwargs,
         )
 
+    def _mesh_is_dp2(self) -> bool:
+        """True when the device is the 2-chip mesh that the serving path needs.
+
+        ModelArgs rejects data_parallel on any other mesh, so a single chip and a
+        larger mesh both keep the base path.
+        """
+        try:
+            return self.device.get_num_devices() == 2 and tuple(self.device.shape) == (2, 1)
+        except AttributeError:
+            return False
+
     def _initialize_model(self) -> None:
         if self._is_initialized and self.model is not None:
             return
 
+        # Data parallel needs the 2-chip mesh, 8192 tokens, and batch 12. ModelArgs
+        # reads these and selects the serving modules.
+        self._data_parallel = (
+            self._mesh_is_dp2()
+            and self.max_seq_len == BGE_M3_LONG_SEQ_LEN
+            and int(self.max_batch_size) == BGE_M3_LONG_SEQ_CHUNK
+        )
         self.model_args, self.model, self.state_dict = create_tt_model(
             mesh_device=self.device,
             max_batch_size=self.max_batch_size,
@@ -127,6 +150,7 @@ class BgeM3ForEmbedding:
             dtype=self.dtype,
             state_dict=self.state_dict,
             hf_model_name=self.model_name,
+            data_parallel=self._data_parallel,
         )
         self.tokenizer = self.model_args.tokenizer
         self._is_initialized = True
@@ -145,8 +169,12 @@ class BgeM3ForEmbedding:
         position_ids: Optional[torch.Tensor] = None,
         *,
         padded_batch_size: int,
+        padded_seq_len: Optional[int] = None,
     ) -> dict[str, Optional[torch.Tensor]]:
-        padded_seq_len = _get_padded_seq_len(input_ids.shape[1])
+        # The caller passes a length when the shape is fixed, as the data-parallel
+        # path is. Otherwise pad to the next supported length.
+        if padded_seq_len is None:
+            padded_seq_len = _get_padded_seq_len(input_ids.shape[1])
 
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
@@ -184,6 +212,198 @@ class BgeM3ForEmbedding:
 
         return padded_inputs
 
+    def _to_device_dp(self, tensor: torch.Tensor, *, on_device: bool = True) -> ttnn.Tensor:
+        """Split a host tensor over the mesh on the batch dimension.
+
+        The batch 12 request becomes 6 rows per chip. Each chip then runs a full
+        replica over the whole sequence and uses no collectives.
+
+        ``on_device`` False keeps the result in host storage, which
+        ``copy_host_to_device_tensor`` requires when it refills a traced buffer.
+        """
+        kwargs = {"mesh_mapper": ttnn.ShardTensorToMesh(self.device, dim=0)}
+        if on_device:
+            kwargs.update(device=self.device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return ttnn.from_torch(
+            tensor.to(torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            **kwargs,
+        )
+
+    def _pool_helper_tensor(self, host: torch.Tensor) -> ttnn.Tensor:
+        """Stage one mean-pool helper, sharded to match the output rows."""
+        return ttnn.from_torch(
+            host,
+            device=self.device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.device, dim=0),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _refill_pool_helpers(self, attention_mask: torch.Tensor) -> None:
+        """Rewrite the mean-pool helpers for the current valid lengths.
+
+        The helpers are allocated once, before the trace capture, because a device
+        allocation during a live trace is unsafe. Their contents still depend on the
+        request: reusing the lengths from the capture pools later requests over the
+        wrong token span.
+        """
+        keep = attention_mask.to(torch.bfloat16)
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(
+                keep.unsqueeze(-1),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.device, dim=0),
+            ),
+            self._pool_mask,
+        )
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(
+                keep.sum(dim=1, keepdim=True).clamp(min=1.0).unsqueeze(-1),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.device, dim=0),
+            ),
+            self._pool_counts,
+        )
+
+    def _capture_trace(self, staged: dict[str, torch.Tensor]) -> None:
+        """Stage the inputs once, then record one forward over them.
+
+        Replay overwrites these same buffers, so they must outlive the capture.
+        The trace covers the whole mesh operation, the batch split included.
+        """
+        device_inputs = {
+            "input_ids": self._to_device_dp(staged["input_ids"]),
+            "token_type_ids": self._to_device_dp(staged["token_type_ids"]),
+            "position_ids": self._to_device_dp(staged["position_ids"]),
+            # The kernels read per-request valid lengths and build only the
+            # boundary mask tiles. A dense [B, 1, S, S] mask costs about 1.5 GiB here.
+            "attention_mask": self._to_device_dp(staged["valid_lengths"]),
+        }
+        warmup = self.model(**device_inputs)
+        ttnn.synchronize_device(self.device)
+        ttnn.deallocate(warmup)
+
+        # Allocate the pooling helpers now. Allocating a device buffer while a trace
+        # is live is unsafe, and Metal warns about it, so nothing may allocate after
+        # capture. Both helpers shard on the batch dimension to match the output, and
+        # _refill_pool_helpers rewrites them for every later request.
+        self._pool_mask = self._pool_helper_tensor(
+            torch.zeros_like(staged["attention_mask_2d"], dtype=torch.bfloat16).unsqueeze(-1)
+        )
+        self._pool_counts = self._pool_helper_tensor(
+            torch.ones((staged["attention_mask_2d"].shape[0], 1, 1), dtype=torch.bfloat16)
+        )
+        self._refill_pool_helpers(staged["attention_mask_2d"])
+
+        self._traced_output = self.model.capture_trace(**device_inputs, mesh_device=self.device, cq_id=0)
+        self._traced_inputs = device_inputs
+
+    def _forward_chunk_traced(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        token_type_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        *,
+        chunk_batch_size: int,
+    ) -> dict[str, torch.Tensor]:
+        """Replay the captured trace on new inputs."""
+        # _pad_inputs returns None for either id tensor when the caller omits it, but
+        # the trace records a fixed set of buffers, so both must exist.
+        if token_type_ids is None:
+            token_type_ids = torch.zeros_like(input_ids)
+        if position_ids is None:
+            nonpad = attention_mask.to(torch.long)
+            position_ids = torch.cumsum(nonpad, dim=1) * nonpad + int(self.tokenizer.pad_token_id)
+        staged = {
+            "input_ids": input_ids,
+            "token_type_ids": token_type_ids,
+            "position_ids": position_ids,
+            "valid_lengths": attention_mask.sum(dim=1, keepdim=True),
+            "attention_mask_2d": attention_mask,
+        }
+        if self._traced_inputs is None:
+            self._capture_trace(staged)
+        else:
+            for name, source_key in (
+                ("input_ids", "input_ids"),
+                ("token_type_ids", "token_type_ids"),
+                ("position_ids", "position_ids"),
+                ("attention_mask", "valid_lengths"),
+            ):
+                ttnn.copy_host_to_device_tensor(
+                    self._to_device_dp(staged[source_key], on_device=False), self._traced_inputs[name]
+                )
+            # The mean-pool helpers hold the valid lengths, so they follow the inputs.
+            self._refill_pool_helpers(attention_mask)
+
+        self.model.execute_trace(blocking=True)
+
+        # Pool on the chip that holds the rows. Reading the whole hidden state instead
+        # would move about 400 MB per request over PCIe and cost more than the forward.
+        hidden = self._traced_output
+        if len(hidden.shape) == 4:
+            hidden = ttnn.squeeze(hidden, dim=1)
+        if self.sentence_pooling_method == "cls":
+            pooled_tt = ttnn.slice(hidden, [0, 0, 0], [hidden.shape[0], 1, hidden.shape[2]])
+        else:
+            masked = ttnn.multiply(hidden, self._pool_mask)
+            pooled_tt = ttnn.div(ttnn.sum(masked, dim=1, keepdim=True), self._pool_counts)
+            ttnn.deallocate(masked)
+
+        # Only [B, 1, D] crosses PCIe now.
+        composer = ttnn.ConcatMesh2dToTensor(self.device, dims=(0, 2), mesh_shape=(2, 1))
+        pooled = ttnn.to_torch(pooled_tt, mesh_composer=composer).to(torch.float32)
+        ttnn.deallocate(pooled_tt)
+        pooled = pooled.reshape(-1, self.model_args.dim)[: input_ids.shape[0]]
+        if self.normalize_embeddings:
+            pooled = torch.nn.functional.normalize(pooled, p=2, dim=-1)
+        if self.return_sparse or self.return_colbert:
+            raise NotImplementedError(
+                "The traced data-parallel path returns dense vectors only. "
+                "Ask for sparse or colbert vectors on the base path."
+            )
+        return {"dense_vecs": pooled[:chunk_batch_size]}
+
+    def _pool_outputs_host(self, hidden, input_ids, attention_mask, chunk_batch_size):
+        """Pool one forward output on the host.
+
+        Mirrors the device heads in _pool_outputs. The traced path uses this one,
+        because a device allocation during a live trace is unsafe.
+        """
+        return_dict = {}
+        if self.return_dense:
+            if self.sentence_pooling_method == "cls":
+                pooled = hidden[:, 0, :]
+            else:
+                keep = attention_mask.to(hidden.dtype).unsqueeze(-1)
+                pooled = (hidden * keep).sum(dim=1) / keep.sum(dim=1).clamp(min=1.0)
+            if self.normalize_embeddings:
+                pooled = torch.nn.functional.normalize(pooled, p=2, dim=-1)
+            return_dict["dense_vecs"] = pooled[:chunk_batch_size]
+        if self.return_sparse or self.return_colbert:
+            raise NotImplementedError(
+                "The traced data-parallel path returns dense vectors only. "
+                "Ask for sparse or colbert vectors on the base path."
+            )
+        return return_dict
+
+    def _pool_outputs(self, output, input_ids, attention_mask, chunk_batch_size):
+        """Run the requested pooling heads over one forward output."""
+        return_dict = {}
+        if self.return_dense:
+            return_dict["dense_vecs"] = self._dense_embedding(output, attention_mask)[:chunk_batch_size]
+        if self.return_sparse:
+            return_dict["sparse_vecs"] = self._sparse_embedding(output, input_ids)[:chunk_batch_size]
+        if self.return_colbert:
+            return_dict["colbert_vecs"] = self._colbert_embedding(output, attention_mask)[:chunk_batch_size]
+        return return_dict
+
     def _forward_chunk(
         self,
         input_ids: torch.Tensor,
@@ -203,15 +423,7 @@ class BgeM3ForEmbedding:
         if output.layout != ttnn.TILE_LAYOUT:
             output = ttnn.to_layout(output, ttnn.TILE_LAYOUT)
 
-        return_dict = {}
-        if self.return_dense:
-            return_dict["dense_vecs"] = self._dense_embedding(output, attention_mask)[:chunk_batch_size]
-        if self.return_sparse:
-            return_dict["sparse_vecs"] = self._sparse_embedding(output, input_ids)[:chunk_batch_size]
-        if self.return_colbert:
-            return_dict["colbert_vecs"] = self._colbert_embedding(output, attention_mask)[:chunk_batch_size]
-
-        return return_dict
+        return self._pool_outputs(output, input_ids, attention_mask, chunk_batch_size)
 
     def _get_or_build_mean_pool_helpers(
         self,
@@ -393,6 +605,12 @@ class BgeM3ForEmbedding:
         self._validate_request(batch_size, padded_seq_len)
         self._initialize_model()
 
+        # The data-parallel modules are built for one shape and reject any other, so
+        # every request pads up to it. A short request costs a full forward, which is
+        # what makes this configuration a fixed-shape serving path.
+        if self._data_parallel:
+            padded_seq_len = BGE_M3_LONG_SEQ_LEN
+
         target_padded_batch_size = get_target_padded_batch_size(batch_size, padded_seq_len)
         chunk_outputs = []
         for start, end in iter_execution_ranges(batch_size, padded_seq_len):
@@ -402,9 +620,19 @@ class BgeM3ForEmbedding:
                 token_type_ids=_slice_optional_batch_tensor(token_type_ids, start, end),
                 position_ids=_slice_optional_batch_tensor(position_ids, start, end),
                 padded_batch_size=target_padded_batch_size,
+                padded_seq_len=padded_seq_len,
             )
+            # The serving modules need the exact B12/S8192 shard, and the trace needs
+            # one fixed shape. A shorter request, such as the one-prompt warmup, keeps
+            # the eager path.
+            traced_shape = (
+                self._data_parallel
+                and target_padded_batch_size == BGE_M3_LONG_SEQ_CHUNK
+                and padded_seq_len == BGE_M3_LONG_SEQ_LEN
+            )
+            forward_chunk = self._forward_chunk_traced if traced_shape else self._forward_chunk
             chunk_outputs.append(
-                self._forward_chunk(
+                forward_chunk(
                     input_ids=padded_inputs["input_ids"],
                     attention_mask=padded_inputs["attention_mask"],
                     token_type_ids=padded_inputs["token_type_ids"],
@@ -446,9 +674,12 @@ def register_model() -> None:
 # HELPER FUNCTIONS
 ########################################################
 
-# Long-sequence path uses fixed 16-wide device execution regardless of max_batch_size.
+# The long-sequence path runs a fixed 12-wide device execution, whatever
+# max_batch_size says. ModelArgs turns on the data-parallel serving modules only at
+# batch 12 over 8192 tokens (model_config.py), so any other width drops to the base
+# path. The mesh mapper then gives each chip 6 rows.
 BGE_M3_LONG_SEQ_LEN = 8192
-BGE_M3_LONG_SEQ_CHUNK = 16
+BGE_M3_LONG_SEQ_CHUNK = 12
 # Short-sequence multi-request path pads to 32 rows for device execution.
 BGE_M3_SHORT_SEQ_PADDED_BATCH = 32
 
@@ -471,8 +702,8 @@ def get_target_padded_batch_size(original_batch_size: int, padded_seq_len: int) 
 
 def get_execution_chunk_size(original_batch_size: int, padded_seq_len: int) -> int:
     """
-    Number of real batch rows per forward. For long sequences, fixed at 16; tail
-    chunks still pad to get_target_padded_batch_size (16).
+    Number of real batch rows per forward. For long sequences, fixed at 12; tail
+    chunks still pad to get_target_padded_batch_size (12).
     """
     if is_long_seq_8192(padded_seq_len):
         return BGE_M3_LONG_SEQ_CHUNK

--- a/models/demos/wormhole/bge_m3/demo/generator_vllm.py
+++ b/models/demos/wormhole/bge_m3/demo/generator_vllm.py
@@ -74,8 +74,11 @@ class BgeM3ForEmbedding:
         # Set by _initialize_model once the mesh is known.
         self._data_parallel = False
         # Long-lived device tensors plus the trace that replays over them.
+        # release() frees all of them.
         self._traced_inputs = None
         self._traced_output = None
+        self._pool_mask = None
+        self._pool_counts = None
         self.state_dict = None
         self.tokenizer = None
         # Cache for mean-pool helper tensors keyed by (batch, seq) to avoid per-step
@@ -230,6 +233,30 @@ class BgeM3ForEmbedding:
             layout=ttnn.ROW_MAJOR_LAYOUT,
             **kwargs,
         )
+
+    def release(self) -> None:
+        """Free the trace and the device tensors that outlive one request.
+
+        A caller that unloads or rebuilds this wrapper must call this before the
+        mesh closes. The trace holds a region of device memory, and the input and
+        pooling buffers stay allocated between requests, so dropping the Python
+        reference alone leaks both. Calling this twice is safe.
+        """
+        if self.model is not None:
+            self.model.release_trace()
+        for tensor in (self._pool_mask, self._pool_counts):
+            if tensor is not None:
+                ttnn.deallocate(tensor)
+        self._pool_mask = None
+        self._pool_counts = None
+        for tensor in (self._traced_inputs or {}).values():
+            ttnn.deallocate(tensor)
+        self._traced_inputs = None
+        self._traced_output = None
+        for mask_tt, counts_tt, _signature in self._mean_pool_cache.values():
+            ttnn.deallocate(mask_tt)
+            ttnn.deallocate(counts_tt)
+        self._mean_pool_cache.clear()
 
     def _pool_helper_tensor(self, host: torch.Tensor) -> ttnn.Tensor:
         """Stage one mean-pool helper, sharded to match the output rows."""
@@ -613,8 +640,9 @@ class BgeM3ForEmbedding:
                 padded_seq_len=padded_seq_len,
             )
             # The serving modules need the exact B12/S8192 shard, and the trace needs
-            # one fixed shape. A shorter request, such as the one-prompt warmup, keeps
-            # the eager path.
+            # one fixed shape. Data-parallel requests already pad to that shape above,
+            # so they all replay the trace, including a one-prompt warmup. Every other
+            # configuration keeps the eager path.
             traced_shape = (
                 self._data_parallel
                 and target_padded_batch_size == BGE_M3_LONG_SEQ_CHUNK

--- a/models/demos/wormhole/bge_m3/demo/generator_vllm.py
+++ b/models/demos/wormhole/bge_m3/demo/generator_vllm.py
@@ -349,12 +349,20 @@ class BgeM3ForEmbedding:
         hidden = self._traced_output
         if len(hidden.shape) == 4:
             hidden = ttnn.squeeze(hidden, dim=1)
+        # The base path also serves last_token, and it raises on anything it does
+        # not know. Match that, or a request for another method returns a mean
+        # embedding and reports success.
         if self.sentence_pooling_method == "cls":
             pooled_tt = ttnn.slice(hidden, [0, 0, 0], [hidden.shape[0], 1, hidden.shape[2]])
-        else:
+        elif self.sentence_pooling_method == "mean":
             masked = ttnn.multiply(hidden, self._pool_mask)
             pooled_tt = ttnn.div(ttnn.sum(masked, dim=1, keepdim=True), self._pool_counts)
             ttnn.deallocate(masked)
+        else:
+            raise NotImplementedError(
+                f"The traced data-parallel path serves cls and mean pooling. "
+                f"Ask for {self.sentence_pooling_method} on the base path."
+            )
 
         # Only [B, 1, D] crosses PCIe now.
         composer = ttnn.ConcatMesh2dToTensor(self.device, dims=(0, 2), mesh_shape=(2, 1))
@@ -369,29 +377,6 @@ class BgeM3ForEmbedding:
                 "Ask for sparse or colbert vectors on the base path."
             )
         return {"dense_vecs": pooled[:chunk_batch_size]}
-
-    def _pool_outputs_host(self, hidden, input_ids, attention_mask, chunk_batch_size):
-        """Pool one forward output on the host.
-
-        Mirrors the device heads in _pool_outputs. The traced path uses this one,
-        because a device allocation during a live trace is unsafe.
-        """
-        return_dict = {}
-        if self.return_dense:
-            if self.sentence_pooling_method == "cls":
-                pooled = hidden[:, 0, :]
-            else:
-                keep = attention_mask.to(hidden.dtype).unsqueeze(-1)
-                pooled = (hidden * keep).sum(dim=1) / keep.sum(dim=1).clamp(min=1.0)
-            if self.normalize_embeddings:
-                pooled = torch.nn.functional.normalize(pooled, p=2, dim=-1)
-            return_dict["dense_vecs"] = pooled[:chunk_batch_size]
-        if self.return_sparse or self.return_colbert:
-            raise NotImplementedError(
-                "The traced data-parallel path returns dense vectors only. "
-                "Ask for sparse or colbert vectors on the base path."
-            )
-        return return_dict
 
     def _pool_outputs(self, output, input_ids, attention_mask, chunk_batch_size):
         """Run the requested pooling heads over one forward output."""

--- a/models/demos/wormhole/bge_m3/demo/generator_vllm.py
+++ b/models/demos/wormhole/bge_m3/demo/generator_vllm.py
@@ -344,6 +344,16 @@ class BgeM3ForEmbedding:
 
         self.model.execute_trace(blocking=True)
 
+        if self.return_sparse or self.return_colbert:
+            raise NotImplementedError(
+                "The traced data-parallel path returns dense vectors only. "
+                "Ask for sparse or colbert vectors on the base path."
+            )
+        if not self.return_dense:
+            # The base path returns the heads the caller asks for, and an empty
+            # result when it asks for none. Match that, and skip the pooling.
+            return {}
+
         # Pool on the chip that holds the rows. Reading the whole hidden state instead
         # would move about 400 MB per request over PCIe and cost more than the forward.
         hidden = self._traced_output
@@ -371,11 +381,6 @@ class BgeM3ForEmbedding:
         pooled = pooled.reshape(-1, self.model_args.dim)[: input_ids.shape[0]]
         if self.normalize_embeddings:
             pooled = torch.nn.functional.normalize(pooled, p=2, dim=-1)
-        if self.return_sparse or self.return_colbert:
-            raise NotImplementedError(
-                "The traced data-parallel path returns dense vectors only. "
-                "Ask for sparse or colbert vectors on the base path."
-            )
         return {"dense_vecs": pooled[:chunk_batch_size]}
 
     def _pool_outputs(self, output, input_ids, attention_mask, chunk_batch_size):

--- a/models/demos/wormhole/bge_m3/demo/generator_vllm.py
+++ b/models/demos/wormhole/bge_m3/demo/generator_vllm.py
@@ -8,6 +8,7 @@ from typing import Iterator, Optional
 
 import torch
 import transformers
+from ttnn.device import is_wormhole_b0 as ttnn_is_wormhole_b0
 
 import ttnn
 from models.common.auto_compose import to_torch_auto_compose
@@ -125,15 +126,20 @@ class BgeM3ForEmbedding:
         )
 
     def _mesh_is_dp2(self) -> bool:
-        """True when the device is the 2-chip mesh that the serving path needs.
+        """True when the device is the 2-chip Wormhole mesh that the serving path needs.
 
         ModelArgs rejects data_parallel on any other mesh, so a single chip and a
-        larger mesh both keep the base path.
+        larger mesh both keep the base path. The shape alone does not name the card,
+        so ask for Wormhole as well: the S8192 programs and encoder SDPA target the
+        N300, and another 2-chip card keeps the base path.
         """
-        try:
-            return self.device.get_num_devices() == 2 and tuple(self.device.shape) == (2, 1)
-        except AttributeError:
+        if self.device is None:
             return False
+        return (
+            self.device.get_num_devices() == 2
+            and tuple(self.device.shape) == (2, 1)
+            and ttnn_is_wormhole_b0(self.device)
+        )
 
     def _initialize_model(self) -> None:
         if self._is_initialized and self.model is not None:
@@ -340,6 +346,17 @@ class BgeM3ForEmbedding:
         chunk_batch_size: int,
     ) -> dict[str, torch.Tensor]:
         """Replay the captured trace on new inputs."""
+        # The kernel takes one valid length per row and rebuilds a prefix mask from
+        # it, so a mask that keeps its tokens elsewhere would attend to the wrong
+        # ones while pooling still reads the mask as given. The base path takes the
+        # whole mask, but it needs a model built without data_parallel, because the
+        # JiT modules expect the sharded batch.
+        if not _mask_is_prefix(attention_mask):
+            raise NotImplementedError(
+                "The traced data-parallel path takes an attention mask that keeps its "
+                "tokens in one run from index 0. Left padding and holes need a model "
+                "built with data_parallel=False."
+            )
         # _pad_inputs returns None for either id tensor when the caller omits it, but
         # the trace records a fixed set of buffers, so both must exist.
         if token_type_ids is None:
@@ -784,6 +801,21 @@ def _slice_optional_batch_tensor(
     if tensor.shape[0] == 1:
         return tensor
     return tensor[start:end]
+
+
+def _mask_is_prefix(attention_mask: torch.Tensor) -> bool:
+    """True when every row keeps its tokens in one run that starts at index 0.
+
+    The traced path sends one valid length per row, and the kernel rebuilds a prefix
+    mask from it. That count cannot express left padding or a hole, so [0, 0, 1, 1]
+    and [1, 1, 0, 0] reach the kernel as the same mask while pooling still reads the
+    original. Such a request attends to the wrong tokens, so it keeps the base path,
+    which takes the whole mask.
+    """
+    keep = attention_mask.to(torch.bool)
+    lengths = keep.sum(dim=1, keepdim=True)
+    prefix = torch.arange(keep.shape[1], device=keep.device).unsqueeze(0) < lengths
+    return bool(torch.equal(keep, prefix))
 
 
 def _concatenate_chunk_outputs(chunk_outputs: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:

--- a/models/demos/wormhole/bge_m3/tests/pcc/generator_vllm_dp.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/generator_vllm_dp.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Traced data-parallel path of the BGE-M3 serving wrapper, on a 1x2 N300.
+
+The tier-2 command names its files one by one, and this one is not on that list.
+It needs two chips, and the registered BGE-M3 tests run on a single card. Run it
+by hand:
+
+    TT_VISIBLE_DEVICES=0 HF_MODEL=BAAI/bge-m3 \
+    pytest models/demos/wormhole/bge_m3/tests/pcc/generator_vllm_dp.py -s
+
+``tests/pcc/model_dp.py`` drives ``BgeM3Model`` directly. These tests drive
+``BgeM3ForEmbedding``, the class vLLM and tt-media-server load, so they cover the
+wrapper: trace capture, buffer refill, batch sharding, on-device pooling, and
+replay.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ttnn
+from models.demos.wormhole.bge_m3.demo.generator_vllm import BgeM3ForEmbedding
+
+MODEL_ID = "BAAI/bge-m3"
+DP_BATCH_SIZE = 12
+DP_SEQ_LEN = 8192
+EMBED_DIM = 1024
+
+# Cosine against the HF reference. The serving path runs BF8 weights with BF4 K
+# and V, so it does not match HF to PCC 0.99. model_dp.py gates the numerics;
+# this bound catches a wrong mask or a stale buffer, which move it far more.
+COSINE_FLOOR = 0.90
+
+MESH_PARAMS = pytest.mark.parametrize("mesh_device", [(2, 1)], indirect=True, ids=["dp2_n300"])
+DEVICE_PARAMS = pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 50_000_000}],
+    indirect=True,
+)
+
+
+@pytest.fixture(scope="module")
+def prompts():
+    """Twelve prompts of different lengths, so every row has its own valid length."""
+    base = [
+        "Artificial intelligence changes how people work with computers.",
+        "Quantum computing solves problems that classical machines cannot.",
+        "Machine learning finds patterns in very large collections of data.",
+        "Renewable energy costs fall every year across most markets.",
+        "The library held thousands of manuscripts from many centuries.",
+        "Neural networks learn a representation from examples alone.",
+    ]
+    return [text * (1 + index % 3) for index, text in enumerate(base * 2)]
+
+
+@pytest.fixture(scope="module")
+def encoded(prompts):
+    transformers = pytest.importorskip("transformers")
+    tokenizer = transformers.AutoTokenizer.from_pretrained(MODEL_ID)
+    return tokenizer(
+        prompts,
+        padding="max_length",
+        truncation=True,
+        max_length=DP_SEQ_LEN,
+        return_tensors="pt",
+    )
+
+
+@pytest.fixture(scope="module")
+def reference(encoded):
+    """Mean-pooled HF output for the same tokens."""
+    transformers = pytest.importorskip("transformers")
+    hf_model = transformers.AutoModel.from_pretrained(MODEL_ID, torch_dtype=torch.float32).eval()
+    with torch.no_grad():
+        hidden = hf_model(
+            input_ids=encoded["input_ids"],
+            attention_mask=encoded["attention_mask"],
+        ).last_hidden_state
+    keep = encoded["attention_mask"].unsqueeze(-1).to(hidden.dtype)
+    return (hidden * keep).sum(dim=1) / keep.sum(dim=1).clamp(min=1.0)
+
+
+def _build(mesh_device, **kwargs):
+    return BgeM3ForEmbedding(
+        device=mesh_device,
+        max_batch_size=DP_BATCH_SIZE,
+        max_seq_len=DP_SEQ_LEN,
+        dtype=ttnn.bfloat8_b,
+        **kwargs,
+    )
+
+
+def _fixed_length_batch(valid_length):
+    """One batch where every row holds ``valid_length`` real tokens."""
+    input_ids = torch.zeros((DP_BATCH_SIZE, DP_SEQ_LEN), dtype=torch.long)
+    attention_mask = torch.zeros((DP_BATCH_SIZE, DP_SEQ_LEN), dtype=torch.long)
+    torch.manual_seed(valid_length)
+    for row in range(DP_BATCH_SIZE):
+        input_ids[row, :valid_length] = torch.randint(5, 1000, (valid_length,))
+        attention_mask[row, :valid_length] = 1
+    return input_ids, attention_mask
+
+
+@MESH_PARAMS
+@DEVICE_PARAMS
+def test_wrapper_dp2_matches_hf(mesh_device, encoded, reference, reset_seeds):
+    """The wrapper selects the data-parallel path and agrees with HF."""
+    assert tuple(mesh_device.shape) == (2, 1)
+
+    model = _build(mesh_device)
+    try:
+        first = model.forward(
+            input_ids=encoded["input_ids"],
+            attention_mask=encoded["attention_mask"],
+        )["dense_vecs"]
+
+        assert model._data_parallel, "the wrapper did not select the data-parallel path"
+        assert model._traced_inputs is not None, "the wrapper did not capture a trace"
+        assert first.shape == (DP_BATCH_SIZE, EMBED_DIM)
+        assert torch.isfinite(first).all(), "the embeddings hold non-finite values"
+
+        cosine = F.cosine_similarity(first.float(), reference, dim=-1)
+        print(f"GATE_COSINE_WRAPPER_DP2 mean={cosine.mean():.6f} min={cosine.min():.6f}")
+        assert cosine.min() > COSINE_FLOOR, f"cosine against HF fell to {cosine.min():.4f}"
+    finally:
+        model.release()
+
+
+@MESH_PARAMS
+@DEVICE_PARAMS
+def test_replay_follows_the_valid_lengths(mesh_device, reset_seeds):
+    """A second request with different valid lengths pools over its own tokens.
+
+    The pooling helpers hold the valid length of each row. An earlier version built
+    them once at capture, so this second request reused the first request's lengths
+    and pooled over the wrong span. The trace replay must refill them.
+    """
+    model = _build(mesh_device)
+    try:
+        short_ids, short_mask = _fixed_length_batch(64)
+        long_ids, long_mask = _fixed_length_batch(2048)
+
+        # Capture on the short batch, then replay on the long one.
+        model.forward(input_ids=short_ids, attention_mask=short_mask)
+        after_long = model.forward(input_ids=long_ids, attention_mask=long_mask)["dense_vecs"].clone()
+
+        # A fresh wrapper pools the long batch with no earlier state to inherit.
+        model.release()
+        reference_model = _build(mesh_device)
+        try:
+            expected = reference_model.forward(input_ids=long_ids, attention_mask=long_mask)["dense_vecs"].clone()
+        finally:
+            reference_model.release()
+
+        cosine = F.cosine_similarity(after_long.float(), expected.float(), dim=-1)
+        print(f"GATE_COSINE_REPLAY_LENGTHS min={cosine.min():.6f}")
+        assert (
+            cosine.min() > 0.999
+        ), f"replay pooled over the wrong tokens: cosine {cosine.min():.4f} against a fresh wrapper"
+    finally:
+        model.release()
+
+
+@MESH_PARAMS
+@DEVICE_PARAMS
+def test_release_frees_the_trace(mesh_device, reset_seeds):
+    """release() returns the trace region, so the wrapper can be rebuilt."""
+    input_ids, attention_mask = _fixed_length_batch(128)
+
+    for _ in range(3):
+        model = _build(mesh_device)
+        output = model.forward(input_ids=input_ids, attention_mask=attention_mask)["dense_vecs"]
+        assert output.shape == (DP_BATCH_SIZE, EMBED_DIM)
+        assert model._traced_inputs is not None
+
+        model.release()
+        assert model._traced_inputs is None
+        assert model._pool_mask is None
+        assert model._pool_counts is None
+        model.release()  # calling it twice is safe
+
+
+@MESH_PARAMS
+@DEVICE_PARAMS
+def test_heads_match_the_base_path(mesh_device, expect_error, reset_seeds):
+    """The traced path returns the heads the caller asks for, and rejects the rest."""
+    input_ids, attention_mask = _fixed_length_batch(64)
+
+    model = _build(mesh_device, return_dense=False)
+    try:
+        assert model.forward(input_ids=input_ids, attention_mask=attention_mask) == {}
+    finally:
+        model.release()
+
+    for method in ("cls", "mean"):
+        model = _build(mesh_device, sentence_pooling_method=method)
+        try:
+            output = model.forward(input_ids=input_ids, attention_mask=attention_mask)["dense_vecs"]
+            assert output.shape == (DP_BATCH_SIZE, EMBED_DIM), method
+            assert torch.isfinite(output).all(), method
+        finally:
+            model.release()
+
+    # The base path serves last_token. The traced path must say so, not return a
+    # mean embedding and report success.
+    model = _build(mesh_device, sentence_pooling_method="last_token")
+    try:
+        with expect_error(NotImplementedError, "cls and mean"):
+            model.forward(input_ids=input_ids, attention_mask=attention_mask)
+    finally:
+        model.release()
+
+    for return_head in ("return_sparse", "return_colbert"):
+        model = _build(mesh_device, **{return_head: True})
+        try:
+            with expect_error(NotImplementedError, "dense vectors only"):
+                model.forward(input_ids=input_ids, attention_mask=attention_mask)
+        finally:
+            model.release()

--- a/models/demos/wormhole/bge_m3/tests/pcc/generator_vllm_dp.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/generator_vllm_dp.py
@@ -165,6 +165,40 @@ def test_replay_follows_the_valid_lengths(mesh_device, reset_seeds):
 
 @MESH_PARAMS
 @DEVICE_PARAMS
+def test_rejects_a_non_prefix_mask(mesh_device, expect_error, reset_seeds):
+    """A mask that does not start at index 0 must raise, not answer wrongly.
+
+    The kernel takes one valid length per row, so it cannot tell [0, 0, 1, 1] from
+    [1, 1, 0, 0]. Pooling still reads the mask as given, and the two answers differ
+    by cosine 0.05, so the wrapper rejects the request.
+    """
+    model = _build(mesh_device)
+    try:
+        prefix_ids, prefix_mask = _fixed_length_batch(64)
+        model.forward(input_ids=prefix_ids, attention_mask=prefix_mask)
+
+        # The same tokens and the same count, moved off index 0.
+        offset_ids = torch.roll(prefix_ids, shifts=64, dims=1)
+        offset_mask = torch.roll(prefix_mask, shifts=64, dims=1)
+        with expect_error(NotImplementedError, "one run from index 0"):
+            model.forward(input_ids=offset_ids, attention_mask=offset_mask)
+
+        # A hole inside the run is refused as well.
+        holed_mask = prefix_mask.clone()
+        holed_mask[:, 10] = 0
+        with expect_error(NotImplementedError, "one run from index 0"):
+            model.forward(input_ids=prefix_ids, attention_mask=holed_mask)
+
+        # The refusal leaves the wrapper usable.
+        again = model.forward(input_ids=prefix_ids, attention_mask=prefix_mask)["dense_vecs"]
+        assert again.shape == (DP_BATCH_SIZE, EMBED_DIM)
+        assert torch.isfinite(again).all()
+    finally:
+        model.release()
+
+
+@MESH_PARAMS
+@DEVICE_PARAMS
 def test_release_frees_the_trace(mesh_device, reset_seeds):
     """release() returns the trace region, so the wrapper can be rebuilt."""
     input_ids, attention_mask = _fixed_length_batch(128)

--- a/models/demos/wormhole/bge_m3/tt/custom_ops/encoder_sdpa/kernels/writer.cpp
+++ b/models/demos/wormhole/bge_m3/tt/custom_ops/encoder_sdpa/kernels/writer.cpp
@@ -218,7 +218,11 @@ void kernel_main() {
                 valid_Sqt,
                 windowed_valid_Skt,
                 k_num_chunks,
-                cu_window_seqlens_eles);
+                cu_window_seqlens_eles,
+                // q_tok_offset. Upstream added this for chunked prefill, where a q
+                // chunk starts partway into the sequence. This op always starts at
+                // token 0, and use_windowed_mask is 0, so the generator is discarded.
+                0);
 
             // Determine how many rows of OUT will be written. Both start and end rows are
             // capped by valid_Sqt, since Sq padding is independent of Sk padding.


### PR DESCRIPTION
### Ticket

N/A

### Problem

`BgeM3ForEmbedding` is the class that vLLM and tt-media-server both load to
serve `BAAI/bge-m3`. It did not use the data-parallel serving path that this
repo already ships, so a server request ran the base path and never reached the
B12/S8192 modules.

Two things stopped it:

- `_initialize_model` called `create_tt_model` without `data_parallel`, so
  `ModelArgs` left `use_jit` False and the serving modules never loaded.
- `BGE_M3_LONG_SEQ_CHUNK` was 16, but the `use_jit` gate needs exactly 12.
  Passing `data_parallel` alone would still not have selected them.

The wrapper also ran an eager forward for every request. The serving forward is
one fixed shape, so it is a candidate for a captured trace, and each request was
paying dispatch cost instead.

### Fix

- Set the long-sequence chunk to 12, the width `ModelArgs` reads.
- Pass `data_parallel` when the device is the 2-chip mesh.
- Shard the inputs on the batch dimension with `ShardTensorToMesh`, so each chip
  runs 6 of the 12 rows.
- Capture one trace over the fixed shape and replay it. The replay refills the
  same input buffers, because a trace binds to the buffers it recorded.
- Default the vLLM entry point to `bfloat8_b`. The loader passes no dtype, so
  the model built in `bfloat16` and missed the serving path.

Three problems came out of that work.

**Every data-parallel request pads to the serving shape.** The modules reject any
other shard. The one-prompt warmup that tt-media-server sends failed with
`expected per-shard tile shape (1536,32,96)`. A short request now costs a full
forward, which is what a fixed-shape serving path does.

**Pooling runs on device.** Reading the whole hidden state to the host moves
about 400 MB per request. Host pooling measured 2840 ms against 988 ms on
device.

**The pooling buffers hold the valid length of each row.** They are allocated
before the capture, because a device allocation during a live trace is unsafe,
and refilled on every replay. The first version allocated them once at capture,
so any later request with different lengths pooled over the wrong token span.

### Kernel build fix

A second commit repairs the kernel build against current `main`. Upstream added
a ninth argument, `q_tok_offset`, to `windowed_generate_if_enabled` for chunked
prefill, and the build failed with `no matching function for call`.

This op always starts at token 0 and sets `use_windowed_mask` to 0, so
`if constexpr` discards the generator body. Passing 0 is correct.

### Checklist

Measured on one N300 (Wormhole, 2 chips), batch 12 over 8192 tokens:

| Metric | Value |
| --- | --- |
| Forward | 987.6 ms, 12.1 embeddings/s |
| PCC against HF, unmasked | 0.8643948911304122 |
| PCC against HF, masked CLS | 0.9352450285992435 |
| Cosine against HF, real prompts | mean 0.9494, min 0.9342 |
| Tier 2 unit tests | 62 passed |
| Tier 2 demo tests | 12 passed |

Both PCC values match the numbers before this change, to every digit.

### Notes for reviewers

1. The traced path returns dense vectors only, and raises for the sparse and
   colbert heads. tt-media-server reads `dense_vecs`, so it is unaffected. Every
   shape other than the data-parallel one keeps the eager path.

2. Trace replay binds to the buffers it recorded, so a caller must serialize
   access. Two threads inside one replay overwrite each other and return
   non-finite embeddings. The matching tt-inference-server change holds a lock
   around the forward for this reason.

3. `q_tok_offset` is the second time an upstream signature change broke these
   kernels, after the SFPU re-sync in #54669. The `encoder_sdpa` kernels are a
   copy of `ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/`, so this
   will keep happening. I would still like input on whether they should include
   the ttnn headers instead.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gtobarTT/bge_m3_vllm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gtobarTT/bge_m3_vllm_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gtobarTT/bge_m3_vllm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gtobarTT/bge_m3_vllm_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gtobarTT/bge_m3_vllm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gtobarTT/bge_m3_vllm_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gtobarTT/bge_m3_vllm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gtobarTT/bge_m3_vllm_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gtobarTT/bge_m3_vllm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gtobarTT/bge_m3_vllm_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gtobarTT/bge_m3_vllm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gtobarTT/bge_m3_vllm_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gtobarTT/bge_m3_vllm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gtobarTT/bge_m3_vllm_fix)