### PR TITLE
[Cleanup] Port Slice to Metal 2.0

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
@@ -5,29 +5,32 @@
 import pytest
 import ttnn
 
-# The layernorm factories a fusion branch drives directly.
-_LAYERNORM_FACTORIES = (
+# The factories a fusion branch drives directly. Each entry is one that has migrated to Metal 2.0
+# (or is on its way there); the guard below is keyed on the method, not on this list, so an entry
+# that still has `create_descriptor` costs nothing.
+_BRANCH_FACTORIES = (
     ttnn.LayerNormMultiCoreProgramFactory,
     ttnn.LayerNormShardedProgramFactory,
+    ttnn.SliceTileProgramFactory,
 )
 
 
 @pytest.fixture(autouse=True)
-def _skip_branches_needing_layernorm_descriptors(monkeypatch):
-    """Skip tests that ask a layernorm factory for a ``create_descriptor`` it no longer has.
+def _skip_branches_needing_descriptors(monkeypatch):
+    """Skip tests that ask a factory for a ``create_descriptor`` it no longer has.
 
     A fusion branch drives a factory's ``create_descriptor`` and consumes the ``ProgramDescriptor``
-    it returns; both layernorm factories now produce a ``ProgramSpec``, which no branch can consume
-    yet. Standing in for the missing method, rather than marking whole tests, skips only the tests
-    that actually reach the ``create_descriptor`` call, and will become a no-op once a factory
+    it returns; a factory ported to Metal 2.0 produces a ``ProgramSpec`` instead, which no branch can
+    consume yet. Standing in for the missing method, rather than marking whole tests, skips only the
+    tests that actually reach the ``create_descriptor`` call, and will become a no-op once a factory
     exposes it again. Issue #54365.
     """
-    missing = [factory for factory in _LAYERNORM_FACTORIES if not hasattr(factory, "create_descriptor")]
+    missing = [factory for factory in _BRANCH_FACTORIES if not hasattr(factory, "create_descriptor")]
     if not missing:
         return
 
     def _no_descriptor(*_args, **_kwargs):
-        pytest.skip("layernorm factories produce a ProgramSpec; a fusion branch needs a ProgramDescriptor")
+        pytest.skip("factory produces a ProgramSpec; a fusion branch needs a ProgramDescriptor")
 
     for factory in missing:
         monkeypatch.setattr(factory, "create_descriptor", staticmethod(_no_descriptor), raising=False)

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -13,6 +13,9 @@
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
 
 namespace ttnn::operations::ccl {
 namespace detail {
@@ -29,6 +32,10 @@ uint32_t get_cluster_axis_index(
 namespace {
 
 using SliceOp = ttnn::prim::SliceDeviceOperation;
+
+// MeshPartition drives slice's program factories directly rather than going through TTNN's
+// dispatcher, so it builds and refreshes their programs itself. Every slice factory now speaks the
+// Metal 2.0 spec API, so both sites go through MakeProgramFromSpec / UpdateProgramRunArgs.
 
 // Helper function to compute slice parameters for a given mesh coordinate
 auto compute_slice_parameters(
@@ -128,8 +135,11 @@ MeshPartitionDeviceOperation::MeshPartition::create_at(
     Program program = std::visit(
         [&](auto&& factory) -> Program {
             using Factory = std::decay_t<decltype(factory)>;
-            auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
-            return Program{descriptor};
+            auto* mesh_device = slice_tensor_args.input.device();
+            auto artifacts = Factory::create_program_artifacts(slice_attrs, slice_tensor_args, tensor_return_value);
+            Program spec_program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+            tt::tt_metal::experimental::SetProgramRunArgs(spec_program, artifacts.run_params);
+            return spec_program;
         },
         program_factory);
 
@@ -149,11 +159,18 @@ void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
         auto [slice_attrs, slice_tensor_args] =
             compute_slice_parameters(operation_attributes, tensor_args, mesh_coordinate);
 
-        // Re-apply this coord's per-dispatch state to the cached Program, through the same patch the
-        // slice op uses -- addresses only. CB total_size/page_size are not re-applied on a hit, so any
-        // sizing that varies across calls must be in compute_program_hash().
-        ttnn::prim::patch_slice_program_addresses(
-            program, shared_variables.slice_program_factory, slice_attrs, slice_tensor_args, tensor_return_value);
+        // Re-apply this coord's per-dispatch state to the cached Program. Addresses only; DFB
+        // sizing is not re-applied on a hit, so any sizing that varies across calls must be in
+        // compute_program_hash().
+        std::visit(
+            [&](auto&& factory) {
+                using Factory = std::decay_t<decltype(factory)>;
+                tt::tt_metal::experimental::UpdateProgramRunArgs(
+                    program,
+                    Factory::override_runtime_arguments(
+                        slice_attrs, slice_tensor_args, tensor_return_value, mesh_coordinate));
+            },
+            shared_variables.slice_program_factory);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_BRIEF.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_BRIEF.md
@@ -1,0 +1,298 @@
+# Metal 2.0 Port Brief — `ttnn/cpp/ttnn/operations/data_movement/slice`
+
+> Audit cleared all gates. This is your actionable input; the full record is in `METAL2_PREPORT_AUDIT.md`.
+
+**Gates cleared:** Device 2.0 ✓ · Features ✓ · TTNN factory concept ✓ · Offset base pointers ✓ · TensorAccessor 3rd arg ✓
+
+**Recipe docs:** `4bd4bf42bfe 2026-09-03 docs(metal_2.0): state the offset-base wall as a category, not as slice's current state` *(carry this line into the port report's Provenance section)*
+
+> **Read this first — the port is incremental, and part of it is already done.** On
+> `akertesz/slice-test` (PR #55433, draft) **two of the five factories are already ported** to
+> `CustomProgramSpecFactoryConcept`: `SliceTileProgramFactory` (`8c8b9eea947`) and
+> `SliceTileTensorArgsProgramFactory` (`aafc364bc0c`). The framework **dispatches per-factory**, so the
+> op builds and runs with its factories on mixed concepts — you do not have to convert all five in one
+> change, and this brief should not be read as requiring that. Reported verification for the first:
+> Wormhole n150, legality checks forced on, `test_slice.py` 448 passed / 38 skipped, matching baseline.
+> That branch also carries its own audit/brief/plan/report set. It cites recipe `1167faf7b42` against
+> this brief's `4bd4bf42bfe` — but the later date is a divergent branch, and on content **this brief
+> ran on the newer audit recipe**. The entire doc-tree delta between the two is one hunk in
+> `metal2_audit.md`'s offset-base-pointer section; **`metal2_port.md` is byte-identical**, so the port
+> recipe you follow is the same either way. Reconcile the documents before starting — see
+> `METAL2_PREPORT_AUDIT.md` → *Post-audit reconciliation*, which also explains the one substantive
+> finding difference (that branch already dropped the `TensorAccessor` 3rd args).
+
+**Scope:** one DeviceOperation, **five** program factories, **nine** slice-owned kernels + **one**
+cross-family donor kernel, **seven** CBs, **twelve** tensor bindings. Two kernel files in the op
+directory are **unreferenced** and out of scope — do not touch
+`device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp` or
+`device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp`.
+
+Which factory serves which config (`device/slice_device_operation.cpp:309-341`) — you need this to read
+the per-config dispositions below:
+
+| Config | Factory |
+|---|---|
+| `use_tensor_args == true` (TILE only) | `SliceTileTensorArgs` |
+| RM, HEIGHT-sharded in **and** out, no step, W-begin L1-aligned | `SliceRmSharded` |
+| RM, any `step != 1` | `SliceRmStride` (rank ≤ 4 and rank > 4 bind **different** kernels) |
+| RM, otherwise (interleaved **or** BLOCK/WIDTH-sharded) | `SliceRm` |
+| TILE, otherwise | `SliceTile` |
+
+## TTNN factory analysis
+
+These facts feed the port's TTNN ProgramFactory wiring (→ `ttnn_factory.md`). Carry them forward:
+
+- **Current concept:** `descriptor` — all five factories declare
+  `static tt::tt_metal::ProgramDescriptor create_descriptor(const SliceParams&, const SliceInputs&, Tensor&)`
+  (`device/slice_program_factory_rm.hpp:26` and the four peers).
+- **Op-owned tensors:** none.
+- **Target concept:** **`CustomProgramSpecFactoryConcept`** (no op-owned tensors) — selected by
+  `Override runtime args method? == yes`, and confirmed by the readiness sheet's own `Porting Target`
+  cell. All five factories define `override_runtime_arguments`:
+  `…_rm.cpp:396`, `…_rm_sharded.cpp:415`, `…_rm_stride.cpp:178`, `…_tile.cpp:189`,
+  `…_tile_tensor_args.cpp:195`. **Translate** these into `ProgramRunArgs`-returning methods; do not
+  delete them.
+- **`override_runtime_arguments` is unusual in shape — read this before you start on it.** All five
+  one-line methods delegate to a single shared implementation,
+  `patch_slice_program_addresses` (`device/slice_program_factory_rm_sharded.cpp:354-413`), which
+  branches on the factory type and reaches **three different** refresh mechanisms:
+  - `SliceRmSharded` → `apply_descriptor_runtime_args` over a CB-address-only descriptor, matching the
+    two borrowed CBs **positionally** (src0, then c_16) — `:362-368`. Keep that order in the spec.
+  - `SliceRm` / `SliceRmStride` → `patch_slot0`, a positional `GetRuntimeArgs` rewrite of arg slot 0,
+    skipping cores whose slot holds 0 — `:372-380, 389`.
+  - `SliceTile` / `SliceTileTensorArgs` → `apply_dynamic_runtime_args` over a `DynamicRuntimeArg`
+    vector — `:394-409`, with the per-core half built by `slice_tile_dynamic_args`
+    (`device/slice_program_factory_tile.cpp:198-281`), which **re-derives the work split** and must keep
+    matching `create_descriptor`'s.
+  All of that collapses once the tensors are typed bindings that the framework refreshes — most of
+  what the function does is re-point addresses. The residue that genuinely belongs in the translated
+  method is the tile factories' per-core scalar re-emission (`start_id`, `num_tiles`, `id_per_dim`,
+  and the writer's `num_tiles` / `start_id`), which exists to fix #52651 (a divergent-partition hit
+  leaving `num_pages = 0`). Note `tt::tt_metal::apply_dynamic_runtime_args` / `DynamicRuntimeArg` here
+  is a **helper API**, not the deprecated device-op `get_dynamic_runtime_args` hook — the op has no
+  such hook.
+- **Custom hash:** present at `device/slice_device_operation.cpp:343`. **Leave it exactly as it is** —
+  no rewrite, no trimming. It is deliberately over-keyed (see its comment at `:344-348` and issues
+  `#53997` / `#47602`), and several factory comments depend on that keying being in place.
+- **Pybound `create_descriptor` — delete it:** `slice_nanobind.cpp:168-179`, on `SliceTileProgramFactory`.
+  This is a user-visible API change; give it its own entry in the port report. Leave the device-op's
+  `create_output_tensors` / `compute_output_specs` bindings (`:156-166`) and the `SliceParams` /
+  `SliceInputs` struct bindings (`:138-154`) alone — those are not descriptor internals.
+- **Gate-cleared, confirmed absent** (each would have blocked this brief): a `TensorParameter relaxation`
+  that is neither `none` nor an analysis pointer (the cell reads **`none`** on all five rows) ·
+  `get_dynamic_runtime_args` (the deprecated hook). A custom hash, an `override_runtime_arguments`, and
+  a pybound `create_descriptor` are **not** in this list: none of them gate, and all three are present
+  here.
+
+## Construct — to do
+
+**Tensor bindings** (12 — ten Case 1, two clean; **no Case 2 anywhere**, so no
+`get_bank_base_address` bridge is needed):
+
+- `SliceRm` · **`input`** — **Case 1**. Delivered today as a `Buffer*` binding at reader RTA 0
+  (`…_rm.cpp:377`); kernel builds `TensorAccessor(src_args, src_addr, padded_stick_size)`
+  (`slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:43`). → express as
+  `TensorParameter` / `TensorBinding`; kernel uses `TensorAccessor(tensor::<name>)`. The RTA-0 address
+  and the `TensorAccessorArgs` CTA plumbing (`…_rm.cpp:336`) both disappear. **Drop the 3rd arg** — see
+  below.
+- `SliceRm` · **`output`** — **Case 1**. `Buffer*` @ writer RTA 0 (`…_rm.cpp:385`) →
+  `TensorAccessor(dst_args, dst_addr, page_size_override)`
+  (`slice_writer_unary_stick_layout_interleaved_start_id.cpp:32`). Same treatment; **drop the 3rd arg**.
+- `SliceRmSharded` · **`input`** — **clean** (borrowed-memory DFB read). There is **no address arg and
+  no `TensorAccessor`** in this factory. CB `c_0` is borrowed from `input.buffer()`
+  (`…_rm_sharded.cpp:282,290`) and the kernel reads through it. → port via
+  `DataflowBufferSpec::borrowed_from`. No binding work item.
+- `SliceRmSharded` · **`output`** — **clean**, same shape: CB `c_16` borrowed from `output.buffer()`
+  (`…_rm_sharded.cpp:294,302`) → `borrowed_from`.
+- `SliceRmStride` · **`input`** — **Case 1**. `Buffer*` @ reader RTA 0 (`…_rm_stride.cpp:128` for the
+  4D path, `:147` for ND) → `TensorAccessor(src_args, src_addr)`
+  (`reader_multicore_slice_4d.cpp:89`, `reader_multicore_slice_nd.cpp:94`). **No 3rd arg** — nothing to
+  drop.
+- `SliceRmStride` · **`output`** — **Case 1**. `Buffer*` @ writer RTA 0 (`:136` / `:160`) →
+  `TensorAccessor(dst_args, dst_addr)` (`writer_multicore_slice_4d.cpp:72`, and the ND peer).
+- `SliceTile` · **`input`** — **Case 1**, and note it rides a **CRTA**, not an RTA: `Buffer*` pushed
+  into `emplace_common_runtime_args` at `…_tile.cpp:143` → `get_common_arg_val<uint32_t>(0)`
+  (`reader_unary_unpad_dims_interleaved_start_id.cpp:15`) → `TensorAccessor(src_args, src_addr)` (`:26`).
+- `SliceTile` · **`output`** — **Case 1**. `Buffer*` @ writer RTA 0 (`…_tile.cpp:180`) →
+  `TensorAccessor(dst_args, dst_addr)` (slice's own
+  `writer_unary_interleaved_start_id.cpp:36`).
+- `SliceTileTensorArgs` · **`input`** / **`start_tensor`** / **`end_tensor`** — **three Case 1
+  bindings**, all on CRTAs 0/1/2 (`…_tile_tensor_args.cpp:182,183,184`), each with its **own**
+  `TensorAccessorArgs` block chained by `next_compile_time_args_offset()`
+  (`reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:17-19`) and its own accessor
+  (`:33,44,45`). Bind all three; the chained-offset CTA arithmetic disappears with them.
+- `SliceTileTensorArgs` · **`output`** — **Case 1**. `Buffer*` @ writer RTA 0
+  (`…_tile_tensor_args.cpp:151,168`), consumed by the **donor** kernel (see *Watch for*).
+
+None of the twelve is the silent-wrong stale-address hazard: every one already arrives as a `Buffer*`
+binding, which the framework patches on cache hits. This is routine port work, not a correctness fix.
+
+**TensorParameter relaxation:** **`none`.** Apply no relaxation. In particular do **not** set
+`dynamic_tensor_shape` for the two 3rd-arg drops below — they are Class 2, not Class 1. *(Confirmed by
+the op owner, 2026-09-04: the readiness sheet's `Provisional relaxation finding` cell reading
+`needs fix, then none` is **stale** — the relaxations are fine and the value is `none`. Ignore that
+cell; do not go looking for a pending fix.)*
+
+**TensorAccessor 3rd arg:** drop the redundant page-size argument at **exactly two** sites, both in
+`SliceRm`:
+
+- `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:43` — drop `padded_stick_size` (RTA 1);
+  the host-side source is `slice_program_factory_rm.cpp:86`.
+- `slice_writer_unary_stick_layout_interleaved_start_id.cpp:32` — drop `page_size_override` (RTA 7);
+  host-side source `slice_program_factory_rm.cpp:155`.
+
+Both are **Class 2** — the value equals what Metal 2.0 supplies implicitly, so this is a pure no-op.
+The other ten accessors in the op pass no 3rd argument.
+
+> **Update: this item is already done on `akertesz/slice-test` (PR #55433), commit `87bd11a885e`.** It
+> drops both 3rd args, removes the two now-dead host RTAs, and reindexes both kernels — exactly as
+> specified below. If you are porting on top of that branch, **verify and skip**; the text is kept for
+> a port that starts from an unpatched tree.
+>
+> The safety question is settled, so do not re-litigate it: for a BLOCK/WIDTH-sharded RM tensor the
+> dropped value is `buffer->page_size()` while the implicit one is `buffer->aligned_page_size()`, and
+> those coincide only when `shard_W · element_size` is alignment-aligned — but
+> `has_subaligned_shard_row` (`slice.cpp:47-57`) plus `needs_rm_composite_input` / `_output`
+> (`:60-86`) reshard any tensor that would violate that, so `SliceRmProgramFactory` never sees one via
+> `ttnn::slice`. PR #55433 also adds `check_accessor_page_size` (`c65cafac4ee`), a `TT_FATAL` in
+> `create_descriptor` that pins the invariant for the one route bypassing that guard
+> (`MeshPartition`). **Carry that assertion into the ported factory** — the spec path is exactly such a
+> bypass-visible route, and Metal 2.0 offers no page-size override to fall back on.
+
+Once the args are gone, `padded_stick_size` / `page_size_override` become dead RTAs. Remove them from
+the host arg lists too (`…_rm.cpp:91` and `:165`), and mind that both kernels read a **fixed positional
+run** — every later index shifts.
+
+**CB endpoints:** four of seven CBs are already legal 1:1; three need a self-loop. Nothing needs the
+multi-binding advanced option, nothing is dead, nothing is config-conditional.
+
+| Factory / config | CB | Do this |
+|---|---|---|
+| `SliceRm` | `c_0` (`…_rm.cpp:322`) | **plain 1:1** — reader PRODUCER, writer CONSUMER. No action beyond the ordinary binding. |
+| `SliceRmSharded` | `c_0`, borrowed from `input.buffer()` (`…_rm_sharded.cpp:282,290`) | **self-loop** — one toucher, and it is *sync-free*: the reader only calls `dfb_in.get_write_ptr()` (`slice_reader_…_rm_sharded.cpp:41`), no FIFO ops at all. Bind the reader **PRODUCER and CONSUMER**. Legal on Gen1 for DM; record the Quasar debt. |
+| `SliceRmSharded` | `c_16`, borrowed from `output.buffer()` (`:294,302`) | **self-loop** — one toucher, locked producer (`reserve_back` `:40` / `push_back` `:89`), nothing drains it. Bind the reader PRODUCER **and** CONSUMER. |
+| `SliceRmStride` (rank ≤ 4) | `c_0` (`…_rm_stride.cpp:69`) | **plain 1:1** — `reader_multicore_slice_4d` PRODUCER, `writer_multicore_slice_4d` CONSUMER. |
+| `SliceRmStride` (rank > 4) | `c_0` (same descriptor, different kernels) | **plain 1:1** — `reader_multicore_slice_nd` / `writer_multicore_slice_nd`. |
+| `SliceTile` | `c_0` (`…_tile.cpp:53-60`) | **plain 1:1**. |
+| `SliceTileTensorArgs` | `c_0` (`…_tile_tensor_args.cpp:56`) | **plain 1:1** — slice reader PRODUCER, **donor** writer CONSUMER. |
+| `SliceTileTensorArgs` | `c_1`, the start/end staging scratchpad (`…_tile_tensor_args.cpp:65`) | **self-loop** — one toucher that already holds both roles: the reader runs `reserve_back`/`push_back`/`wait_front`/`pop_front` twice over it (`…_tensor_args.cpp:52-59,66,69-76,83`). Bind the reader PRODUCER **and** CONSUMER; the kernel body is unchanged. |
+
+**RTA / CRTA varargs:** six kernels carry genuine variable-count blocks. Reach for the vararg mechanism
+on these; **name everything else.**
+
+| Kernel | Vararg site | What it is |
+|---|---|---|
+| `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | `:32-34` — `get_arg_addr(14)` | three `num_dims`-length blocks (`num_unpadded_sticks`, `num_padded_sticks`, `id_per_dim`); `num_dims` is **RTA 4**, a runtime value |
+| `slice_reader_unary_unpad_dims_rm_sharded.cpp` | `:26-30` — `get_arg_addr(1)`, `get_arg_addr(1 + num_cores_read*2)`, `get_arg_addr(1 + num_cores_read*3)`, `chunk_start_id + 1` | noc-x/y pairs + per-core chunk descriptors, all sized off runtime `num_cores_read` (RTA 0). **The trickiest one in the op** — see the aliasing warning below |
+| `reader_multicore_slice_nd.cpp` | `:73-87` | **five** consecutive `tensor_rank`-length blocks (`input_dims`, `output_dims`, `slice_starts`, `slice_ends`, `slice_steps`) |
+| `writer_multicore_slice_nd.cpp` | `:73` | one `tensor_rank`-length block (`output_dims`) |
+| `reader_unary_unpad_dims_interleaved_start_id.cpp` | `:17-18` — `get_common_arg_addr(1)`; `:23` — `get_arg_addr(2)` | a `2·num_dims` **CRTA** block **and** a `num_dims` **RTA** block. `num_dims` is a CTA (`:13`) — still a vararg: it varies across instantiations |
+| `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | `:25-26` — `get_common_arg_addr(3)`; `:92` — `get_common_arg_addr(3 + 2*num_dims)`; `:31` — `get_arg_addr(2)` | two CRTA blocks (the second at a **computed** start offset) + one RTA block |
+
+**Name these — they are not varargs:** `reader_multicore_slice_4d.cpp:52-77` is a fixed run of **25**
+distinct fields via `rt_args_idx++`, and `writer_multicore_slice_4d.cpp:52-61` is **9**. A sequential
+counter over a fixed set is legacy positional plumbing, not a loop. Same for every scalar that precedes
+a vararg block (`src_addr`, `num_dims`, `start_id`, `num_tiles`, `tensor_rank`, `element_size`,
+`num_rows_for_this_core`, `start_row_for_this_core`) and for the `SliceRm` writer's entire 11-arg set —
+don't let those ride the varargs.
+
+**No CTA varargs.** Every `get_compile_time_arg_val` in the op uses a literal constant index, so
+`KernelAdvancedOptions::compile_time_varargs` is not needed anywhere.
+
+## Watch for
+
+- **CB endpoints (multi-binding):** **none.** No CB reaches ≥3 touchers or doubles a FIFO role, and the
+  hidden-second-writer face is structurally impossible here — **the op declares no semaphores at all**,
+  so there is nothing to coordinate a raw co-fill. Every `get_write_ptr()` / `get_read_ptr()` in the op
+  was attributed to a kernel that already holds that CB's role. Do not set the flag anywhere.
+- **Cross-op / shared kernels:**
+  - `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` — the **borrowed**
+    donor bound by `SliceTileTensorArgs` (`…_tile_tensor_args.cpp:133`). **A `_metal2` fork already
+    exists beside it** at
+    `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp` — a true
+    locational sibling, not an `experimental/quasar/` copy. → **Rung 1: bind it, don't re-fork.** Its
+    interface is now *your* constraint, and it fits without change: DFB **`dfb::out`**, tensor
+    **`tensor::dst`**, named args **`args::num_pages`**, **`args::start_id`** — which is exactly the
+    `{dst_buffer, num_tiles_per_core, num_tiles_written}` the factory supplies today. It gates
+    `#ifdef OUT_SHARDED` / `#ifdef BACKWARDS`; slice sets **no** `defines`, so neither fires, same as
+    now. Do **not** edit that fork — it already has consumers. Do not add the pointer comment to the
+    legacy original either; it already has one.
+  - **Sunset list** (coordination and tracking only — **not** authorization to convert the legacy
+    eltwise copy in place): ≥15 factories still bind that path, including `data_movement/concat`,
+    `data_movement/reshape_on_device`, five `data_movement/tilize` factories,
+    `eltwise/unary_backward/tanh_bw`, `embedding`, `examples/example` (×2),
+    `experimental/matmul/attn_matmul`, `experimental/transformer/nlp_concat_heads` (+ `_boltz`).
+    Tracked as **issue #52228**, which also records a **duplicate** fork at
+    `copy/typecast/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp` — bind the
+    eltwise-sited one, not that. Record the still-unmigrated set in the port report so the eventual
+    last port can see it was last.
+  - **Slice's own `device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` is neither borrowed
+    nor lent** — `SliceTileProgramFactory` is its only binder, verified tree-wide. **Convert it in
+    place; no fork.** And resist redirecting `SliceTile` onto the shared `_metal2` fork instead: slice's
+    copy exists precisely because it takes its DFB index from a **named** CTA
+    (`get_named_compile_time_arg_val("dfb_id_out")`, `…_tile.cpp:161`) so the fusion infrastructure can
+    remap it — a capability the shared fork does not have. Collapsing them would be a functional change.
+- **RTA varargs:** the six sites in the table above — reach for the vararg mechanism rather than trying
+  to name each element; name the fixed 4D runs.
+- **`ccl/mesh_partition` calls slice's `create_descriptor` from outside the op directory — your
+  signature change breaks its build.**
+  `ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp` calls
+  `SliceOp::validate_on_program_cache_miss` and `SliceOp::select_program_factory` (`:126-127`), then
+  `Factory::create_descriptor(...)` on the selected slice factory (`:131`), and refreshes through
+  `ttnn::prim::patch_slice_program_addresses` (`:155`) — which is *deliberately* shared for this
+  purpose (see `device/slice_program_factory_rm_sharded.cpp:350-353` and
+  `mesh_partition_device_operation.hpp:47`). That op is `legacy (MeshWorkload)` with
+  `Is able to port? = no`, so it cannot co-migrate, and fixing it is **outside your scope**. The audit
+  routes the decision to the ops team.
+
+  > **Update: resolved and implemented on `akertesz/slice-test` (PR #55433), commit `8c8b9eea947`** —
+  > you do **not** need to stop here, and you should not re-solve it. That commit adds
+  > `template <typename T> concept IsSliceSpecFactory = requires { &T::create_program_artifacts; };`
+  > to `mesh_partition_program_factory.cpp` and branches both call sites on it: `create_at` builds a
+  > spec factory through `MakeProgramFromSpec` + `SetProgramRunArgs`, and `override_runtime_arguments`
+  > routes it through `UpdateProgramRunArgs(program, Factory::override_runtime_arguments(...))`; the
+  > descriptor path is untouched for the factories still on it. Because the concept keys on the **entry
+  > point** rather than a factory-name list, **each further factory you port needs no edit there** —
+  > and the branch retires when the last one converts. Two caveats to carry into your port report: that
+  > out-of-op-directory change was **explicitly authorized by the invoker**, and it is **not
+  > run-verified** (MeshPartition's tests are t3000/TG-only).
+- **The `id_per_dim` vararg block is *written* by the kernel, not just read.**
+  `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:80`,
+  `reader_unary_unpad_dims_interleaved_start_id.cpp:45`,
+  `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:124` all do `id_per_dim[j]++` in place,
+  and the host seeds the block per core (`…_rm.cpp:153`, `…_tile.cpp:117-124`). Confirm the vararg
+  mechanism hands you a **writable** L1 view before assuming read-only; the dimension walk depends on
+  the mutation persisting across loop iterations.
+- **`slice_reader_unary_unpad_dims_rm_sharded.cpp` aliases two pointers one word apart into the same
+  interleaved stream.** `read_noc_x = get_arg_addr(1)` and `read_noc_y = get_arg_addr(2)` (`:26-27`)
+  read x and y out of a single interleaved x/y RTA run, both strided by 2 (`:85`). Preserve the layout
+  exactly; this is the easiest thing in the op to get subtly wrong when converting a block to varargs.
+- **`SliceRmSharded` reads *remote* cores' L1 at the address of its *own* borrowed CB.** The kernel
+  takes `l1_read_addr = dfb_in.get_write_ptr()` (`:41`) — a **local** pointer into its own borrowed
+  input CB — then uses that same value as the `.addr` of reads aimed at other cores (`:65`, `:76`).
+  That works only because a sharded CB sits at the same L1 offset on every core in the range. Keep
+  `c_0` bound `borrowed_from` the input so the invariant holds; it is not visible at the call site.
+- **Two kernels are already part-modernized — expect a binding-layer change, not an idiom rewrite.**
+  `reader_unary_unpad_dims_interleaved_start_id.cpp` already uses
+  `get_named_compile_time_arg_val("dfb_id_in")` (`:12`), takes its page size from
+  `dfb_in0.get_entry_size()` (`:33`) rather than `get_tile_size(cb)`, and passes the DFB object straight
+  into `noc.async_read(s0, dfb_in0, …)` (`:40`). Slice's own writer copy is the same shape. The host
+  already emits `named_compile_time_args` for both (`…_tile.cpp:139,161`).
+- **A Device 2.0 → Metal 2.0 breadcrumb in the donor: confirm, don't swap blind.** The *legacy* eltwise
+  donor reads its page size via `get_local_cb_interface(cb_id_out).fifo_page_size`
+  (`writer_unary_interleaved_start_id.cpp:27`) — a **sanctioned** free function, which is why the
+  Device 2.0 gate is green. Whitelist rule 7 moves such lookups onto the object, and the `_metal2` fork
+  **has already done it** (`dfb.get_entry_size()`). Since you are reusing the fork, there is nothing to
+  change; just don't mistake the legacy line for work you owe.
+- **`constexpr` vs `const` in the tensor-args reader.**
+  `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:15-16` declares `tile_width` and
+  `tile_height` as **`const`** (not `constexpr`) while reading them from `get_compile_time_arg_val(3)`
+  / `(4)`; every other CTA in that file is `constexpr`. That distinction decides token-form vs
+  member-getter — check which the named-CTA replacement needs before swapping.
+- **Do not "fix" what the audit flagged as pre-existing.** `METAL2_PREPORT_AUDIT.md` → *Misc anomalies*
+  lists genuine latent issues (a dead `compile_time_element_size` CTA in four kernels, dead RTAs in the
+  4D stride writer, an end tensor that `SliceTileTensorArgs` reads and discards, dead `#ifdef` branches
+  in slice's own writer copy). Those route to the ops team and are **not** in the port diff — the port
+  keeps binding and emitting them. In particular the **end tensor is still read** by the kernel
+  (`…_tensor_args.cpp:69-83`), so it stays a live `TensorParameter` binding even though its value is
+  unused.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_PLAN.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_PLAN.md
@@ -1,0 +1,506 @@
+# Port Plan — `data_movement/slice`
+
+Port plan for `ttnn/cpp/ttnn/operations/data_movement/slice`, ported from the TTNN
+**ProgramDescriptor** API (`create_descriptor`) to **Metal 2.0** (`create_program_artifacts`).
+Written during the inventory and planning steps; committed alongside the port for review.
+
+**Inputs consumed:** `METAL2_PREPORT_AUDIT.md` (GREEN) and `METAL2_PORT_BRIEF.md`, both in this
+directory.
+
+## Tree state this port starts from — read first
+
+The brief and the audit were written partly against **PR #55433 (`akertesz/slice-test`)**, where two
+factories were already ported and three ops-team pre-port fixes had landed. **None of that is in this
+tree.** Verified at `d1f66c276f2`:
+
+| Item the brief says is "already done on #55433" | State in this tree |
+|---|---|
+| `SliceTileProgramFactory` ported (`8c8b9eea947`) | **not present** — still `create_descriptor` |
+| `SliceTileTensorArgsProgramFactory` ported (`aafc364bc0c`) | **not present** |
+| `TensorAccessor` 3rd args dropped (`87bd11a885e`) | **not present** — both sites still pass one |
+| `check_accessor_page_size` `TT_FATAL` (`c65cafac4ee`) | **not present** |
+| `IsSliceSpecFactory` bridge in `ccl/mesh_partition` (`8c8b9eea947`) | **not present** |
+
+So this port runs the brief's *"a port that starts from an unpatched tree"* path throughout: it does
+the 3rd-arg drop itself, and it must re-establish the `ccl/mesh_partition` bridge before any factory
+can compile. See [Deferred / Flagged](#deferred--flagged).
+
+The op *does* carry `1b0d9d1258a [Bug Fix] Prepare Slice for Metal 2.0 Port (#55262)`, which is what
+cleared the audit's offset-base-pointer gate (the W-begin fold is split out into `src_offset_bytes`).
+
+---
+
+## Legacy Inventory
+
+### Legacy factory shape
+
+- **Concept:** `ProgramDescriptorFactoryConcept` — all five factories declare
+  `static tt::tt_metal::ProgramDescriptor create_descriptor(const SliceParams&, const SliceInputs&, Tensor&)`.
+- **Where the methods live:** in five factory structs held by
+  `SliceDeviceOperation::program_factory_t` (`device/slice_device_operation.hpp:36-41`). **Not** the
+  direct-descriptor shape, so `ttnn_factory.md` exception 3 does not apply.
+- **Variants:** five factories, selected by `select_program_factory`
+  (`device/slice_device_operation.cpp:309-341`):
+
+  | Config | Factory | File |
+  |---|---|---|
+  | `use_tensor_args == true` (TILE only) | `SliceTileTensorArgs` | `slice_program_factory_tile_tensor_args.cpp` |
+  | RM, HEIGHT-sharded in **and** out, no step, W-begin L1-aligned | `SliceRmSharded` | `slice_program_factory_rm_sharded.cpp` |
+  | RM, any `step != 1` | `SliceRmStride` (rank ≤ 4 and rank > 4 bind different kernels) | `slice_program_factory_rm_stride.cpp` |
+  | RM, otherwise (interleaved **or** BLOCK/WIDTH-sharded) | `SliceRm` | `slice_program_factory_rm.cpp` |
+  | TILE, otherwise | `SliceTile` | `slice_program_factory_tile.cpp` |
+
+- **Custom `compute_program_hash`:** **present** — declared `device/slice_device_operation.hpp:51`,
+  defined `device/slice_device_operation.cpp:343`. **Left intact.** It is deliberately over-keyed
+  (comment at `:344-348`, issues `#53997` / `#47602` / `#45144`); several factory comments depend on
+  that keying. No backdoor `attribute_values` / `to_hash` (grep: zero hits).
+- **`override_runtime_arguments`:** present on all five, each a one-line delegation to the shared
+  `patch_slice_program_addresses` (`slice_program_factory_rm_sharded.cpp:354-413`). This is the
+  target-concept selector → `CustomProgramSpecFactoryConcept`.
+- **`opt_level`:** `grep -n opt_level` over the five factory `.cpp`/`.hpp` → **zero hits**. Every
+  kernel is data-movement, so every resolved level is `O2`, which is also Metal 2.0's
+  `CompilerOptions` default. **No `opt_level` line is owed anywhere in this port** (there is not a
+  single compute kernel in the op).
+- **`defines`:** none set by any factory (confirms the donor's `OUT_SHARDED` / `BACKWARDS` and slice's
+  own writer's identical pair never fire).
+
+---
+
+### Variant: `SliceTile`
+
+#### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | CRTAs | defines | opt_level | config |
+|---|---|---|---|---|---|---|---|---|---|
+| reader | `slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp` | `all_cores` | `[0]=num_dims`, then `TensorAccessorArgs(src0)` | `dfb_id_in = 0` (`:139`) | `[0]=start_id, [1]=num_tiles, [2..2+num_dims)=id_per_dim` | `[0]=src0_buffer (Buffer*)`, `[1..1+2·num_dims)` = `num_unpadded_tiles_per_dim` ‖ `num_padded_tiles_per_dim` | none | O2 (unset, DM) | `ReaderConfigDescriptor{}` |
+| writer | `slice/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` (slice's **own** copy) | `all_cores` | `TensorAccessorArgs(dst)` from slot 0 | `dfb_id_out = 0` (`:161`) | `[0]=dst_buffer (Buffer*), [1]=num_tiles, [2]=start_id` | none | none | O2 (unset, DM) | `WriterConfigDescriptor{}` |
+
+#### CBs
+| index | total_size | core_ranges | data_format | page_size | tile |
+|---|---|---|---|---|---|
+| 0 | `2 · single_tile_size` | `all_cores` | `datatype_to_dataformat_converter(input.dtype())` | `single_tile_size` | unset |
+
+#### Semaphores
+none — the op declares no semaphores at all.
+
+#### Tensor accessors
+| host site | originating Tensor | arg slot (host) |
+|---|---|---|
+| `slice_program_factory_tile.cpp:65` (`TensorAccessorArgs(*src0_buffer)`) | `tensor_args.input` | reader **CRTA 0** (`:143`) |
+| `slice_program_factory_tile.cpp:152` (`TensorAccessorArgs(*dst_buffer)`) | `tensor_return_value` (output) | writer RTA 0 (`:180`) |
+
+#### Work split
+`split_work_to_cores(sub_core_grids | compute_with_storage_grid_size, num_unpadded_tiles)`
+→ `(num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2)`.
+Cores enumerated with `corerange_to_cores(all_cores)`; cores in neither group are **no-op cores** that
+still receive a zero-filled arg row.
+
+---
+
+### Variant: `SliceTileTensorArgs`
+
+#### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | CRTAs | defines | opt_level | config |
+|---|---|---|---|---|---|---|---|---|---|
+| reader | `slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | `all_cores` | `[0]=src0_cb_index, [1]=tensor_cb_index, [2]=num_dims, [3]=tile_width, [4]=tile_height`, then three chained `TensorAccessorArgs` (src, start, end) | none | `[0]=start_id, [1]=num_tiles, [2..2+num_dims)=id_per_dim` | `[0]=src_buffer, [1]=start_buffer, [2]=end_buffer` (all `Buffer*`), `[3..3+3·num_dims)` = `num_unpadded` ‖ `num_padded` ‖ `input_shape` | none | O2 | `ReaderConfigDescriptor{}` |
+| writer | `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` (**cross-family donor**) | `all_cores` | `[0]=src0_cb_index`, then `TensorAccessorArgs(dst)` | none | `[0]=dst_buffer, [1]=num_tiles, [2]=start_id` | none | none | O2 | `WriterConfigDescriptor{}` |
+
+#### CBs
+| index | total_size | core_ranges | data_format | page_size | tile |
+|---|---|---|---|---|---|
+| 0 | `2 · single_tile_size` | `all_cores` | input dtype | `single_tile_size` | unset |
+| 1 | `single_tile_size` | `all_cores` | input dtype | `single_tile_size` | unset |
+
+#### Tensor accessors
+| host site | originating Tensor | arg slot |
+|---|---|---|
+| `…_tile_tensor_args.cpp:82` | `tensor_args.input` | reader CRTA 0 (`:182`) |
+| `…_tile_tensor_args.cpp:83` | `tensor_args.start_tensor` | reader CRTA 1 (`:183`) |
+| `…_tile_tensor_args.cpp:84` | `tensor_args.end_tensor` | reader CRTA 2 (`:184`) |
+| `…_tile_tensor_args.cpp:87` | output | writer RTA 0 (`:151`, `:168`) |
+
+#### Work split
+Same shape as `SliceTile`, over `num_unpadded_tiles`, with `start_offset` hard-wired to `0`
+(`:129`) — the real offset is computed on-device from the start tensor.
+
+---
+
+### Variant: `SliceRm`
+
+#### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | CRTAs | defines | opt_level | config |
+|---|---|---|---|---|---|---|---|---|---|
+| reader | `slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | `all_cores` | `TensorAccessorArgs(src0)` from slot 0 | none | `[0]=src0_buffer`, `[1]=reader_page_size`, `[2]=unpadded_row_size_bytes`, `[3]=unpadded_row_size_bytes_offset`, `[4]=num_dims`, `[5]=misalignment`, `[6]=start_id`, `[7]=num_sticks_per_core`, `[8]=num_sticks_per_core_read`, `[9]=num_read_per_barrier`, `[10]=chunk_size`, `[11]=num_chunks_per_stick`, `[12]=last_chunk_size`, `[13]=begins_bytes−misalignment`, `[14..]` = `num_unpadded_sticks_per_dim` ‖ `num_padded_sticks_per_dim` ‖ `id_per_dim` (3 × `num_dims`) | none | none | O2 | `ReaderConfigDescriptor{}` |
+| writer | `slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp` | `all_cores` | `[0]=src0_cb_index`, then `TensorAccessorArgs(dst)` | none | `[0]=dst_buffer`, `[1]=stick_size`, `[2]=stick_size_offset`, `[3]=num_sticks_per_core`, `[4]=num_sticks_per_core_read`, `[5]=num_read_per_barrier`, `[6]=start_id`, `[7]=page_size_override`, `[8]=chunk_size`, `[9]=num_chunks_per_stick`, `[10]=last_chunk_size` | none | none | O2 | `WriterConfigDescriptor{}` |
+
+#### CBs
+| index | total_size | core_ranges | data_format | page_size | tile |
+|---|---|---|---|---|---|
+| 0 | `num_read_per_barrier · 2 · cb_page_size` | `all_cores` | input dtype | `sizing.cb_page_size` | unset |
+
+#### Tensor accessors
+| host site | originating Tensor | arg slot |
+|---|---|---|
+| `slice_program_factory_rm.cpp:336` | `tensor_args.input` | reader RTA 0 (`:377`) |
+| `slice_program_factory_rm.cpp:333` | output | writer RTA 0 (`:385`) |
+
+Both accessors pass a **3rd (page-size) argument** — the two Class-2 drop sites the brief names.
+
+#### Work split
+`split_work_to_cores(…, num_unpadded_sticks)`; per-core `num_sticks_per_core` is `0` for cores in
+neither group (still emitted, with a full arg row).
+
+---
+
+### Variant: `SliceRmStride`
+
+**Runtime kernel-source selection** on `input_shape.rank()`:
+
+| rank | reader source | writer source |
+|---|---|---|
+| ≤ 4 | `reader_multicore_slice_4d.cpp` | `writer_multicore_slice_4d.cpp` |
+| > 4 | `reader_multicore_slice_nd.cpp` | `writer_multicore_slice_nd.cpp` |
+
+Both pairs convert together — this factory is one atomic unit of four kernel entry points.
+
+#### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | opt_level | config |
+|---|---|---|---|---|---|---|
+| reader (4D) | `reader_multicore_slice_4d.cpp` | `all_cores` | `[0]=in_cb`, `[1]=element_size` (**dead**), then `TensorAccessorArgs(input)` | 25 fixed fields via `rt_args_idx++` — `src_addr`(Buffer*), `tensor_rank`, `input_w/h/d/n`, `output_w/h/d/n`, `slice_{start,end,step}_{w,h,d,n}`, `element_size`, `num_rows_for_this_core`, `start_row_for_this_core` | O2 | `ReaderConfigDescriptor{}` |
+| writer (4D) | `writer_multicore_slice_4d.cpp` | `all_cores` | `[0]=in_cb`, `[1]=element_size` (**dead**), then `TensorAccessorArgs(output)` | 9 fixed fields — `dst_addr`(Buffer*), `tensor_rank`, `output_w/h/d/n`, `element_size`, `num_rows_for_this_core`, `start_row_for_this_core` | O2 | `WriterConfigDescriptor{}` |
+| reader (ND) | `reader_multicore_slice_nd.cpp` | `all_cores` | same two + `TensorAccessorArgs(input)` | `src_addr`(Buffer*), `tensor_rank`, `element_size`, `num_rows_for_this_core`, `start_row_for_this_core`, then **five** `tensor_rank`-long blocks: `input_dims`, `output_dims`, `slice_starts`, `slice_ends`, `slice_steps` | O2 | `ReaderConfigDescriptor{}` |
+| writer (ND) | `writer_multicore_slice_nd.cpp` | `all_cores` | same two + `TensorAccessorArgs(output)` | `dst_addr`(Buffer*), `tensor_rank`, `element_size`, `num_rows_for_this_core`, `start_row_for_this_core`, then one `tensor_rank`-long `output_dims` block | O2 | `WriterConfigDescriptor{}` |
+
+#### CBs
+| index | total_size | core_ranges | data_format | page_size | tile |
+|---|---|---|---|---|---|
+| 0 | `2 · cb_page_size_aligned` | `all_cores` | input dtype | `round_up(input_w · element_size, max(src,dst) alignment)` | unset |
+
+#### Work split
+`split_work_to_cores(…, total_output_rows)`, but the per-core row counts are **not** taken from the
+returned group counts: the factory re-derives them as `base_rows_per_core = total_output_rows /
+num_cores` plus one extra row for the first `total_output_rows % num_cores` cores (`:101-102`,
+`:120-124`). Preserve exactly.
+
+---
+
+### Variant: `SliceRmSharded`
+
+#### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | opt_level | config |
+|---|---|---|---|---|---|---|
+| reader | `slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp` | `all_cores_unpadded` | `[0]=stick_size_unpadded`, `[1]=num_sticks_unpadded`, `[2]=src_stride_bytes`, `[3]=dst_stride_bytes`, `[4]=begins_bytes` | `[0]=num_cores_read`, then the data-directed gather plan: `2·num_cores_read` interleaved NoC (x,y), `num_cores_read` chunk counts, and a `(start_id, length)` pair per chunk | O2 | `ReaderConfigDescriptor{}` |
+
+**Only one kernel** in this factory — there is no writer.
+
+#### CBs
+| index | total_size | core_ranges | data_format | page_size | `.buffer` |
+|---|---|---|---|---|---|
+| 0 | `shard_height_padded · src_stride_bytes` | `all_cores_unpadded` | input dtype | `src_stride_bytes` | `input.buffer()` (**borrowed**) |
+| `c_16` (16) | `shard_height_unpadded · dst_stride_bytes` | `all_cores_unpadded` | output dtype | `dst_stride_bytes` | `output.buffer()` (**borrowed**) |
+
+Neither sets `address_offset`, and neither is a `GlobalCircularBuffer` — the plain borrowed-memory
+pattern → `DataflowBufferSpec::borrowed_from`.
+
+#### Tensor accessors
+**None.** This factory constructs no `TensorAccessor` and passes no address arg; both tensors reach
+the kernel only through the two borrowed DFBs.
+
+#### Work split
+Driven by the two shard specs, not `split_work_to_cores`: `num_cores_unpadded =
+output.shard_spec().num_cores()`, with the core order recomputed from `row_major` and the unpadded
+grid dimensions (`:335-341`).
+
+---
+
+### Shared kernels
+
+| kernel | relationship | `_metal2` fork beside it? | Rung |
+|---|---|---|---|
+| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` | **borrowed** by `SliceTileTensorArgs` (`…_tile_tensor_args.cpp:133`); ≥15 other binding factories | **yes** — `…/writer_unary_interleaved_start_id_metal2.cpp` | **Rung 1 — bind the existing fork, create nothing, edit nothing** |
+| `slice/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` (slice's own copy) | neither borrowed nor lent — `SliceTileProgramFactory` is its only binder | n/a | **Convert in place, no fork** |
+| slice's other seven referenced kernels | slice-owned, single-binder | n/a | Convert in place |
+
+**Fork's binding vocabulary (now this port's constraint, not a free choice):** DFB `dfb::out`
+(CONSUMER), tensor `tensor::dst`, named args `args::num_pages`, `args::start_id`; gated on
+`#ifdef OUT_SHARDED` / `#ifdef BACKWARDS`, neither of which slice sets. That is exactly the
+`{dst_buffer, num_tiles_per_core, num_tiles_written}` triple the factory supplies today.
+`ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp:208-220` is an
+in-tree consumer of the same fork and confirms the shape.
+
+Do **not** redirect `SliceTile` onto that fork: slice's own copy exists precisely because it takes its
+DFB index from a **named** CTA so the fusion infrastructure can remap it. Collapsing them would be a
+functional change.
+
+### Flags
+
+- **Unreferenced kernel files in the op directory, not audited and not touched:**
+  `device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp`,
+  `device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp`.
+- **`ccl/mesh_partition` is an out-of-directory *host* consumer** of `create_descriptor` and
+  `patch_slice_program_addresses`. See [Deferred / Flagged](#deferred--flagged).
+- **Pre-existing anomalies the audit lists under *Misc anomalies*** — dead
+  `compile_time_element_size` CTA in four stride kernels, dead RTAs in the 4D stride writer, the end
+  tensor that `SliceTileTensorArgs` reads and discards, dead `#ifdef` branches in slice's own writer
+  copy, `constexpr uint32_t start_offset = 0` in the tensor-args factory. **All preserved verbatim**;
+  the port keeps binding and emitting them.
+
+---
+
+## TTNN ProgramFactory
+
+- **Concept (inherited from audit):** **`CustomProgramSpecFactoryConcept`** — all five factories.
+  Selected by *"Override runtime args method? == yes"*, confirmed by the readiness sheet's
+  `Porting Target` cell. Each factory gains:
+  ```cpp
+  static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+      const SliceParams&, const SliceInputs&, Tensor&);
+  static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
+      const SliceParams&, const SliceInputs&, Tensor&,
+      const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
+  ```
+  and loses `create_descriptor` (mandatory: `ProgramDescriptorFactoryConcept` and
+  `ProgramSpecFactoryConcept` are mutually exclusive by construction —
+  `ttnn/api/ttnn/operation_concepts.hpp:120-136`).
+- **Custom `compute_program_hash`:** present at `device/slice_device_operation.cpp:343` — **left
+  exactly as it is.** Heads-up only; if a `TensorSpec` legality failure appears on the *second*
+  invocation of a test, this hash is the named suspect and the correct response is stop-and-report.
+- **Op-owned tensors:** **none.** No `create_workload_descriptor`, no `buffers` vector. The
+  `op_owned_tensors` field of `ProgramArtifacts` is omitted throughout.
+- **Implementation notes:**
+  - The `CustomProgramSpecMeshWorkloadFactoryAdapter` cache-hit path
+    (`ttnn/api/ttnn/mesh_device_operation_adapter.hpp:963-983`) calls **only**
+    `UpdateProgramRunArgs` with what the override returns — it does **not** also run the base
+    adapter's `UpdateTensorArgs`. So every `TensorParameter` bound to an io tensor must appear in the
+    override's `tensor_args`, or its address freezes at the cache-miss value. All five overrides
+    therefore return the factory's full `tensor_args` set.
+  - `patch_slice_program_addresses` and `slice_tile_dynamic_args` are **deleted** once the last
+    factory converts; their whole job (re-pointing addresses, re-emitting the tile factories' per-core
+    scalars) is subsumed by `TensorArgument` bindings plus the translated overrides.
+  - Spec resource names are declared **function-locally** in each factory: the five slice factory
+    `.cpp`s land in one unity-build translation unit, where anonymous namespaces merge and
+    file-scope `const KernelSpecName READER{"reader"}` in two files would collide. (This is the same
+    hazard `pad_rm_sharded_height_only_program_factory.cpp:22-23` documents for its seven factories,
+    which it solves with per-factory name prefixes.)
+
+---
+
+## Planned Spec Shape
+
+### Variant: `SliceTile`
+
+- **KernelSpecs (2):** `reader`, `writer` — 1:1 with the legacy `KernelDescriptor`s.
+- **DataflowBufferSpecs (1):** `src0` ← legacy CB 0. `entry_size = single_tile_size`,
+  `num_entries = 2`, `data_format_metadata = cb_data_format`.
+- **SemaphoreSpecs:** none.
+- **TensorParameters (2):** `input` ← `tensor_args.input.tensor_spec()`; `output` ←
+  `tensor_return_value.tensor_spec()`. No relaxations.
+- **WorkUnitSpecs (1):** `{reader, writer}` on `all_cores`.
+- **Bindings:** `src0` — reader PRODUCER (`in0`), writer CONSUMER (`out`). Plain 1:1.
+- **Varargs:** reader `num_runtime_varargs = num_dims` (`id_per_dim`);
+  `num_common_runtime_varargs = 2 · num_dims` (`num_unpadded_tiles_per_dim` ‖ `num_padded_tiles_per_dim`).
+
+### Variant: `SliceTileTensorArgs`
+
+- **KernelSpecs (2):** `reader` (own source), `writer` (**donor `_metal2` fork**).
+- **DataflowBufferSpecs (2):** `src0` ← CB 0 (`single_tile_size` × 2);
+  `tensor_stage` ← CB 1 (`single_tile_size` × 1).
+- **TensorParameters (4):** `input`, `start`, `end`, `output`.
+- **WorkUnitSpecs (1):** `{reader, writer}` on `all_cores`.
+- **Bindings:** `src0` — reader PRODUCER (`in0`), donor writer CONSUMER (`out`). `tensor_stage` —
+  reader **self-loop** (PRODUCER *and* CONSUMER, both `tensor_stage`).
+- **Varargs:** reader `num_runtime_varargs = num_dims`;
+  `num_common_runtime_varargs = 3 · num_dims`.
+
+### Variant: `SliceRm`
+
+- **KernelSpecs (2):** `reader`, `writer`.
+- **DataflowBufferSpecs (1):** `src0` ← CB 0. `entry_size = sizing.cb_page_size`,
+  `num_entries = 2 · sizing.num_read_per_barrier` (legacy `total_size = nrpb · 2 · page_size`).
+- **TensorParameters (2):** `input`, `output`.
+- **WorkUnitSpecs (1):** `{reader, writer}` on `all_cores`.
+- **Bindings:** `src0` — reader PRODUCER (`in0`), writer CONSUMER (`out0`). Plain 1:1.
+- **Varargs:** reader `num_runtime_varargs = 3 · num_dims`; writer none.
+
+### Variant: `SliceRmStride`
+
+- **KernelSpecs (2):** `reader`, `writer` — each with a runtime-selected `source` and a
+  rank-dependent `runtime_arg_schema` / vararg count.
+- **DataflowBufferSpecs (1):** `in_dfb` ← CB 0. `entry_size = cb_page_size_aligned`, `num_entries = 2`.
+- **TensorParameters (2):** `input`, `output`.
+- **WorkUnitSpecs (1):** `{reader, writer}` on `all_cores`.
+- **Bindings:** `in_dfb` — reader PRODUCER (`out`), writer CONSUMER (`in`). Plain 1:1 on both rank
+  paths. *(The accessor names read "backwards" because they are the kernels' own vocabulary: the
+  reader fills what it calls `dfb_out`, the writer drains what it calls `dfb_in`.)*
+- **Varargs:** ND path only — reader `num_runtime_varargs = 5 · tensor_rank`, writer
+  `num_runtime_varargs = tensor_rank`. 4D path: **zero** varargs; all 25 / 9 fields are named.
+
+### Variant: `SliceRmSharded`
+
+- **KernelSpecs (1):** `reader`.
+- **DataflowBufferSpecs (2):** `in_shard` ← CB 0, `borrowed_from = input`;
+  `out_shard` ← CB `c_16`, `borrowed_from = output`.
+- **TensorParameters (2):** `input`, `output` — declared **only** to back the two borrowed DFBs; no
+  kernel binds a `TensorAccessor` to either.
+- **WorkUnitSpecs (1):** `{reader}` on `all_cores_unpadded`.
+- **Bindings:** `in_shard` — reader **self-loop** (sync-free, raw `get_write_ptr()` peek only);
+  `out_shard` — reader **self-loop** (locked producer, nothing drains it).
+- **Varargs:** reader `num_runtime_varargs = max over nodes of (3·num_cores_read + 2·num_chunks)`,
+  zero-filled per node to that maximum (the kernel walks the block by the counts it reads out of it,
+  so the tail is never read).
+
+---
+
+## Preserved Multiplicity
+
+**none — no work-split multiplicity in legacy.** No factory pushes the same `kernel_source` into two
+`KernelDescriptor`s; every factory's reader and writer are distinct sources, and `SliceRmSharded` has
+a single kernel. (Confirms the audit's *dual-instance work-split hunt (face c): none*.)
+
+---
+
+## Dropped Plumbing
+
+### `SliceTile`
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `…_tile.cpp:143` (reader CRTA 0) | `reader_common.push_back(src0_buffer)` | `TensorBinding{input, "input"}` |
+| `…_tile.cpp:65` | `TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args)` | binding mechanism |
+| `…_tile.cpp:139` | `named_compile_time_args = {{"dfb_id_in", 0}}` | `DFBBinding{src0, "in0", PRODUCER}` |
+| `…_tile.cpp:64` (reader CTA 0) | positional `{num_dims}` | named `compile_time_args = {{"num_dims", …}}` |
+| `…_tile.cpp:180` (writer RTA 0) | `dst_buffer` in `emplace_runtime_args` | `TensorBinding{output, "dst"}` |
+| `…_tile.cpp:152` | `TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args)` | binding mechanism |
+| `…_tile.cpp:161` | `named_compile_time_args = {{"dfb_id_out", 0}}` | `DFBBinding{src0, "out", CONSUMER}` |
+| reader kernel `:14` | `constexpr auto src_args = TensorAccessorArgs<1>()` + `:15` `src_addr` CRTA read | `TensorAccessor(tensor::input)` |
+| writer kernel `:20` | `constexpr auto dst_args = TensorAccessorArgs<0>()` + `:15` `dst_addr` RTA read | `TensorAccessor(tensor::dst)` |
+
+### `SliceTileTensorArgs`
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `…_tensor_args.cpp:182,183,184` (reader CRTA 0/1/2) | three `Buffer*` pushes | `TensorBinding{input,"input"}`, `{start,"start"}`, `{end,"end"}` |
+| `…_tensor_args.cpp:82,83,84` | three chained `TensorAccessorArgs(...).append_to(...)` | binding mechanism |
+| reader kernel `:17-19` | `TensorAccessorArgs<5>()` → `next_compile_time_args_offset()` chain ×2 | three `TensorAccessor(tensor::…)` |
+| `…_tensor_args.cpp:81` CTA `[0]`,`[1]` | `src0_cb_index`, `tensor_cb_index` | `DFBBinding`s (`in0`, `tensor_stage`) |
+| `…_tensor_args.cpp:81` CTA `[2..4]` | positional `num_dims`, `tile_width`, `tile_height` | named CTAs |
+| `…_tensor_args.cpp:86` CTA `[0]` | `src0_cb_index` for the donor writer | `DFBBinding{src0, "out", CONSUMER}` |
+| `…_tensor_args.cpp:87` | `TensorAccessorArgs(*dst_buffer)` | `TensorBinding{output, "dst"}` (donor's name) |
+| `…_tensor_args.cpp:151,168` (writer RTA 0) | `dst_buffer` | same `TensorBinding` |
+
+### `SliceRm`
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `…_rm.cpp:377` (reader RTA 0) | `reader_args.push_back(src0_buffer)` | `TensorBinding{input, "input"}` |
+| `…_rm.cpp:336` | `TensorAccessorArgs(*src0_buffer).append_to(...)` | binding mechanism |
+| `…_rm.cpp:86` → reader RTA 1 | `reader_page_size` (`per_shard_page_size_bytes(...)`) — the accessor's **3rd argument** | **dropped**; the binding token supplies the aligned page size (Class 2) |
+| `…_rm.cpp:385` (writer RTA 0) | `writer_args.push_back(dst_buffer)` | `TensorBinding{output, "dst"}` |
+| `…_rm.cpp:333` | `TensorAccessorArgs(*dst_buffer).append_to(...)` | binding mechanism |
+| `…_rm.cpp:155` → writer RTA 7 | `writer_page_size` — the accessor's **3rd argument** | **dropped** (Class 2) |
+| `…_rm.cpp:332` writer CTA `[0]` | `src0_cb_index` | `DFBBinding{src0, "out0", CONSUMER}` |
+| reader kernel `:45` | `constexpr uint32_t dfb_id_in0 = 0;` (hardcoded magic index) | `DFBBinding{src0, "in0", PRODUCER}` |
+| reader kernel `:36`, writer `:30` | `TensorAccessorArgs<N>()` + address RTA reads | `TensorAccessor(tensor::…)` |
+| every remaining reader / writer RTA | positional `get_arg_val<uint32_t>(N)` | named `get_arg(args::…)` |
+
+### `SliceRmStride`
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `…_rm_stride.cpp:128,147` (reader RTA 0) | `input_buffer` | `TensorBinding{input, "src"}` |
+| `…_rm_stride.cpp:136,160` (writer RTA 0) | `output_buffer` | `TensorBinding{output, "dst"}` |
+| `…_rm_stride.cpp:80,83` | `TensorAccessorArgs(...).append_to(...)` ×2 | binding mechanism |
+| `…_rm_stride.cpp:79,82` CTA `[0]` | `in_cb` | `DFBBinding`s |
+| `…_rm_stride.cpp:79,82` CTA `[1]` | positional `element_size` (**dead** in all four kernels) | named CTA `compile_time_element_size` — **kept, still dead** (audit: preserve) |
+| all remaining fixed RTAs | positional `get_arg_val<uint32_t>(rt_args_idx++)` | named `get_arg(args::…)` |
+
+### `SliceRmSharded`
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `…_rm_sharded.cpp:290` | `CBDescriptor{.buffer = input.buffer()}` | `DataflowBufferSpec{.borrowed_from = input}` |
+| `…_rm_sharded.cpp:302` | `CBDescriptor{.buffer = output.buffer()}` | `DataflowBufferSpec{.borrowed_from = output}` |
+| `…_rm_sharded.cpp:364-366` | `apply_descriptor_runtime_args` over a CB-address-only descriptor, matched **positionally** | the two `TensorArgument`s in the override; the framework re-points each borrowed DFB from its backing tensor. **The positional CB order stops mattering** — the binding is by name. |
+| reader kernel `:32,33` | `constexpr auto dfb_in0 = tt::CBIndex::c_0; … c_16` (magic indices) | `dfb::in_shard`, `dfb::out_shard` |
+| reader kernel `:14-19` | five positional CTAs | five named CTAs |
+| reader kernel `:25` | `get_arg_val<uint32_t>(0)` | `get_arg(args::num_cores_read)` |
+| reader kernel `:26-30` | four aliased `get_arg_addr(...)` pointers into one interleaved block | one flat runtime-vararg block read through `get_vararg(base + i)` with explicit bases |
+
+**Not dropped anywhere:** no semaphore-ID RTAs (the op has none), no CTA varargs (every
+`get_compile_time_arg_val` index in the op is a literal), no Case-2 raw-pointer bindings.
+
+---
+
+## Applied Patterns
+
+- **Self-loop DFB binding** — `SliceTileTensorArgs`'s `tensor_stage` (one toucher already holding
+  both FIFO roles); `SliceRmSharded`'s `in_shard` (sync-free, raw peek only) and `out_shard` (locked
+  producer, nothing drains it). Three sites, matching the audit's census exactly. Re-derived from the
+  kernel-touch census rather than transcribed: `in_shard` — one toucher
+  (`slice_reader_…_rm_sharded.cpp:41` `get_write_ptr`, no FIFO ops); `out_shard` — one toucher
+  (`:40` `reserve_back`, `:42` `get_write_ptr`, `:89` `push_back`); `tensor_stage` — one toucher
+  running `reserve_back`/`push_back`/`wait_front`/`pop_front` twice (`…_tensor_args.cpp:52-59,66,69-76,83`).
+- **Borrowed-memory DFB** — `SliceRmSharded`'s two DFBs, `borrowed_from` the `input` / `output`
+  `TensorParameter`s. This also preserves the invariant the kernel silently depends on: it takes
+  `l1_read_addr = dfb_in.get_write_ptr()` — a *local* pointer — and uses it as the `.addr` of reads
+  aimed at *other* cores, which is only correct because a sharded DFB lands at the same L1 offset on
+  every core in the range.
+- **Shared kernel, rung 1 (reuse the existing `_metal2` fork)** — `SliceTileTensorArgs`'s writer binds
+  `eltwise/unary/…/writer_unary_interleaved_start_id_metal2.cpp`. No new file, no edit to the fork, no
+  pointer comment added to the legacy original (it already has one).
+- **Runtime kernel-source selection** — `SliceRmStride` picks its reader/writer pair by rank; all four
+  sources convert in this change.
+- **Removing a pybound legacy factory entry point** — `slice_nanobind.cpp:168-179` binds
+  `SliceTileProgramFactory::create_descriptor`; the port makes that method vanish, so the binding is
+  deleted. User-visible API change → its own port-report entry.
+- **Multi-binding advanced option** — **not used anywhere.** Re-derived: no DFB in this op reaches ≥3
+  touchers or doubles a FIFO role, and the hidden-co-filler face is structurally impossible (the op
+  declares no semaphores, so nothing could coordinate a raw co-fill).
+
+---
+
+## Deferred / Flagged
+
+1. **`ccl/mesh_partition` blocks the *first* factory port in this tree, and the fix is out-of-directory.**
+   `ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp` calls
+   `Factory::create_descriptor(...)` inside a `std::visit` over slice's `program_factory_t` (`:131`)
+   and refreshes through `ttnn::prim::patch_slice_program_addresses` (`:155`). Porting **any** slice
+   factory removes `create_descriptor` from that variant alternative and breaks the build. That op is
+   `legacy (MeshWorkload)` / `Is able to port? = no`, so it cannot co-migrate.
+
+   The audit closed this as *Questions* #3: **option (b) was chosen, implemented on `akertesz/slice-test`
+   (`8c8b9eea947`), and the out-of-op-directory change was explicitly authorized by the invoker.** The
+   design is specified there — a concept keyed on the *entry point*:
+   ```cpp
+   template <typename T>
+   concept IsSliceSpecFactory = requires { &T::create_program_artifacts; };
+   ```
+   with both call sites branched on it. This port **re-implements that authorized change** (it is
+   absent from this tree) rather than re-deciding it. Two caveats carried into the report: the edit is
+   outside the op directory, and it is **not run-verified** — MeshPartition's tests are t3000/TG-only.
+
+2. **`get_vararg()` is read-only, and three slice readers advance their `id_per_dim` block in place.**
+   `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:80`,
+   `reader_unary_unpad_dims_interleaved_start_id.cpp:45`,
+   `…_tensor_args.cpp:124` all do `id_per_dim[j]++`. `genfiles.cpp:441` emits only
+   `get_vararg(idx)` — a *value* getter — with no address form, so the host-seeded block cannot be
+   written back. The two tile readers take `num_dims` from a **CTA**, so the block copies into a
+   `uint32_t id_per_dim[num_dims]` local (the pattern `data_movement/pad` already established:
+   `reader_pad_tiled.cpp:22-32`). The **RM** reader takes `num_dims` from an **RTA**, so a
+   compile-time-sized local needs a bound: use `tensor_accessor::MAX_RANK` (8,
+   `tt_metal/hw/inc/internal/tensor/const.h:11`) — the accessor's own rank ceiling, already in scope
+   in these kernels — with a device `ASSERT`. This is the one place the port changes *where* a value
+   lives rather than how it is spelled; it is behaviour-identical because nothing reads the block back
+   from L1 after the kernel exits. Reported as a framework gap (a `get_vararg_addr(i)`).
+
+3. **`SliceRmSharded`'s vararg block length varies per node.** `num_cores_read` and the chunk count
+   are data-directed, but `KernelAdvancedOptions::num_runtime_varargs` is one number for the whole
+   KernelSpec. Declare the longest block and zero-fill the shorter ones; the kernel walks the block by
+   the counts it reads out of it, so the tail is never touched. (Same resolution
+   `pad_rm_sharded_height_only_program_factory.cpp:360-367` reached.)
+
+4. **Legacy cache-miss / cache-hit divergence in the tile factories, preserved.**
+   `create_descriptor` gives a no-op core writer args `{0, 0, 0}` (`…_tile.cpp:176`), while
+   `slice_tile_dynamic_args` re-emits that core's writer slot 2 as the *running* `num_tiles_written`
+   (`:274`) rather than 0. Also, `patch_slot0` deliberately skips slots holding 0, so a no-op core's
+   address slot keeps its zero across hits, whereas a `TensorBinding` patches every node uniformly.
+   Both differences are inert (`num_pages == 0`, so the writer loop never runs). **Preserved as-is**
+   and recorded in the port report — a port may not fix a latent inconsistency.
+
+5. **No new findings that contradict the audit.** The CB census, the vararg census, the "no Case 2
+   anywhere" finding, the `none` relaxation and the target concept all re-derived clean against this
+   tree.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_REPORT.md
@@ -1,0 +1,349 @@
+# Metal 2.0 Port Report — `data_movement/slice`
+
+*(Opened at the start of the port; friction captured as it happened, polished at the end.)*
+
+## Outcome
+
+**`PORTED`** — all five factories of `SliceDeviceOperation` converted to
+`CustomProgramSpecFactoryConcept`: `SliceRm`, `SliceRmSharded`, `SliceRmStride`, `SliceTile`,
+`SliceTileTensorArgs`. Nine slice-owned kernels converted in place; the cross-family donor reused via
+its existing `_metal2` fork (rung 1). Nothing left on the descriptor API, so
+`patch_slice_program_addresses` and `slice_tile_dynamic_args` are deleted outright.
+
+### Verification
+
+Metal 2.0 legality checks forced on at all nine `skip_validation` sites and **proven live** — 9254
+`METAL2_CHECKS_FORCED` markers in the final run — and Watcher on (`TT_METAL_WATCHER=10`) for every
+run. The final numbers were measured on the committed tree, with the forcing re-applied for the
+measurement and reverted afterwards; the diff contains none of that scaffolding.
+
+| Suite | Pre-port baseline | Post-port |
+|---|---|---|
+| `unit_tests/operations/data_movement/test_slice.py` | 445 passed, 38 skipped | **445 passed, 38 skipped** |
+| `nightly/…/test_slice_for_conv.py` + `test_universal_input_tm_slice.py` | not separately baselined | **321 passed, 4 skipped, 0 failed** |
+| C++ gtests | — | none exist for this op (see *Open items*) |
+
+Anti-pattern self-audit, over the op directory (**29 `.cpp`/`.hpp`/`.h` files scanned**, and 25 files
+in the change set for the diff-scoped checks) — every check zero over a non-zero denominator:
+
+| Check | Result |
+|---|---|
+| buffer address in run args (`->address()`, `emplace_runtime_args`, `Buffer*`) | 0 |
+| magic CB indices / `CBIndex::` in CTAs | 0 |
+| `TensorAccessorArgs<N>()` in ported kernels | 0 (4 hits total: 2 in the *unreferenced* kernels, 2 in comments in the off-limits device-op class) |
+| `cb`-shaped names (`[Cc][Bb]_`, `\bCB[A-Z]`, …) | 0 |
+| `.id` extraction at LLK call sites | 0 |
+| `allow_instance_multi_binding` | 0 |
+| positional `compile_time_args = {…}` | 0 |
+| `opt_level` | 0 — correct here: the op has **no compute kernel at all**, so every kernel's legacy resolved level is `O2`, which is also Metal 2.0's default. No `opt_level` line is owed. |
+| `hw_config` fidelity | all ten DM kernels resolve to the reader/writer defaults and use `create_reader_datamovement_config` / `create_writer_datamovement_config`; no custom `(processor, noc, noc_mode)` existed to reproduce |
+| forced-legality scaffolding in the diff | 0 files under `tt_metal/`, 0 marker hits |
+| ephemeral `.md` cited from code | 0 |
+| `TT_FATAL` / `TT_ASSERT` / `TT_THROW` census | one intended **+1** (`check_accessor_page_size`, mandated by the brief). One guard was lost in a first pass and **restored** (`TT_ASSERT(output.buffer() != nullptr)` in the tile factory) — the census is what caught it. |
+
+The device-operation class (`slice_device_operation.cpp`) and the op's top-level `slice.cpp` are
+**byte-identical** to pre-port.
+
+**One capability lost outside the op, with no test left red:** the brief-mandated removal of the
+pybound `SliceTileProgramFactory.create_descriptor` takes slice out of the descriptor-fusion path,
+which the port cannot repair (fusion merges `ProgramDescriptor`s; a ported factory has none). Six
+fusion tests are converted from failures to skips by the same guard layernorm's port uses, under
+issue #54365 — `0 failed, 50 passed, 75 skipped`. See *Handoff points* #1.
+
+**Bench caveat:** this machine's multi-chip ethernet topology defeats UMD's cluster discovery, so all
+runs used `TT_VISIBLE_DEVICES` to restrict to a single Wormhole card. That matches the
+single-device scope of the op's tests, but `ccl/mesh_partition` — which this port had to change —
+could not be exercised.
+
+## Provenance
+
+`git log -1 --format='%h %cs %s' -- docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/`
+prints **nothing** in this checkout: the recipe docs are not in this tree at all. They were consumed
+out-of-tree from `/localdev/edwinlee/metal2_port.md`, so the recipe version cannot be pinned by hash.
+
+- **Recipe docs (this port):** *unpinnable* — `/localdev/edwinlee/metal2_port.md`, 1200 lines,
+  consumed 2026-09-04. Its five `../shared/*.md` references (`port_patterns.md`,
+  `migration_guide.md`, `ttnn_factory.md`, `cb_dfb_api_whitelist.md`, `workspace_setup.md`) do not
+  exist in this tree or beside the recipe; the port worked from the declaring headers under
+  `tt_metal/api/tt-metalium/experimental/metal2_host_api/` instead.
+- **Audit docs (inherited):** `4bd4bf42bfe 2026-09-03 docs(metal_2.0): state the offset-base wall as a
+  category, not as slice's current state`
+- **Port base commit:** `d1f66c276f2` (branch `edwinlee/Port_Slice`); merge-base with `origin/main` is
+  `f2fc16b61aa`.
+
+## TTNN ProgramFactory
+
+- **Concept realized:** `CustomProgramSpecFactoryConcept` on **all five** factories, as the audit
+  chose. Each now defines `create_program_artifacts` returning `ProgramArtifacts` and
+  `override_runtime_arguments` returning `ProgramRunArgs`; `create_descriptor` is gone from all five.
+- **Op-owned tensors:** none — `ProgramArtifacts::op_owned_tensors` is omitted throughout.
+- **Custom `compute_program_hash`: left intact**, `device/slice_device_operation.cpp:343`. Not
+  rewritten, not trimmed, not re-derived. No `TensorSpec` legality failure appeared on any
+  second-or-later invocation, so the ops team's pre-port verdict on the hash holds.
+- **Pybind entry points removed:** one — `SliceTileProgramFactory.create_descriptor`, plus its two
+  Python re-exports. See *Handoff points* #1; it has live callers the port does not fix.
+- **Device-op-class edits the port forced:** none of the three documented exceptions applied. The
+  device-operation class itself (`slice_device_operation.cpp`) is **byte-identical**; the only edit to
+  `slice_device_operation.hpp` is the deletion of the `patch_slice_program_addresses` declaration,
+  whose definition the port removes.
+- **What collapsed.** `patch_slice_program_addresses`
+  (formerly `slice_program_factory_rm_sharded.cpp:354-413`) and `slice_tile_dynamic_args`
+  (formerly `slice_program_factory_tile.cpp:198-281`) are **both deleted**. Between them they held
+  three separate refresh mechanisms — `apply_descriptor_runtime_args` over a CB-address-only
+  descriptor, a positional `GetRuntimeArgs` slot-0 rewrite, and an `apply_dynamic_runtime_args`
+  vector — and all three were doing the same thing the typed bindings now do. What genuinely remained
+  (the tile factories' per-node scalar re-emission for #52651) is a dozen lines inside two
+  `override_runtime_arguments`, sharing one work-split helper with the cache-miss path so the two
+  cannot drift.
+- **Open items with the concept:** the `CustomProgramSpecMeshWorkloadFactoryAdapter` cache-hit path
+  (`ttnn/api/ttnn/mesh_device_operation_adapter.hpp:963-983`) applies **only** what the override
+  returns — it does not also run the base adapter's `UpdateTensorArgs`. Three of slice's five
+  factories need no per-dispatch scalars at all and exist on this concept purely to re-supply their
+  tensor bindings. That is correct but easy to get wrong (omit a binding and its address silently
+  freezes at the cache-miss value); a base-concept variant that still refreshed tensors would suit
+  those three better.
+
+## Handoff points
+
+### 1. Removed pybind surface — `SliceTileProgramFactory.create_descriptor`
+*Tagged: API surface: removed entry point. Owner: the descriptor-fusion team, under issue #54365.*
+
+The port replaces `create_descriptor` with `create_program_artifacts` on all five factories, so the
+`def_static` that bound it (`slice_nanobind.cpp:167-179`) had to go —
+`ProgramDescriptorFactoryConcept` and `ProgramSpecFactoryConcept` are mutually exclusive by
+construction (`ttnn/api/ttnn/operation_concepts.hpp:120-136`), so the method cannot stay on the
+factory at all.
+
+**The type itself stays bound.** `slice_nanobind.cpp` keeps an empty
+`nb::class_<SliceTileProgramFactory>` and both Python re-exports
+(`ttnn/ttnn/operations/data_movement.py:550`, `ttnn/ttnn/__init__.py:639`). That is deliberate and
+mirrors `layernorm_nanobind.cpp:339`, which is exactly the same shape: a factory that ported to Metal
+2.0, still bound, with no methods. It costs nothing and it means a caller gets a clear
+missing-*method* error rather than a missing-*symbol* one.
+
+**What genuinely cannot be preserved.** A fusion branch does not merely call `create_descriptor` — it
+consumes the `ProgramDescriptor` structurally: `fusion.py:805` iterates `op.descriptor.kernels` to
+group them by RISC type, `op_descriptor.py:227` hashes the descriptor, and codegen emits a *fused*
+`ProgramDescriptor`. A ported factory produces a `ProgramSpec`, which that pipeline cannot consume.
+No binding shape recovers this; the capability is gone until fusion learns to consume a spec. The
+affected consumer is `models/experimental/ops/descriptors/data_movement/slice.py:54`.
+
+**Resolution — the layernorm precedent, applied.** The fusion suite already handles exactly this: an
+autouse fixture in `tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py` stands a
+`pytest.skip` in for the missing `create_descriptor`, skipping only the tests that actually reach the
+call and self-retiring once a factory exposes one again. Slice is the second op through that door, so
+it is added to the fixture's tuple (renamed `_LAYERNORM_FACTORIES` → `_BRANCH_FACTORIES`, and the
+skip message generalized, since it is no longer layernorm-specific).
+
+| Suite | Before the guard | After |
+|---|---|---|
+| `…/parallel_sequential/test_parallel_sequential.py` + `…/demo/test_fused_demo.py` | 6 failed, 50 passed, 69 skipped | **0 failed, 50 passed, 75 skipped** |
+
+The six that convert to skips are `TestBranchingTopology::test_three_way_split_with_slice`,
+`TestBranchingTopology::test_nested_split_with_slice`,
+`TestParallelExecution::test_two_disjoint_trees_parallel`,
+`TestDocExample::test_matmul_slice_ln_rms_tree`,
+`TestAsymmetricBarrier::test_narrow_wide_with_slice`, and
+`TestPerfDemos::test_sharded_tree_ln_slice_matmul_slice_ln_fused[perf_mode=none]`.
+
+**Two notes for the owners.** The conftest edit is *outside the op directory* — sanctioned here only
+because it is the established mechanism for this exact event and issue #54365 already owns it; it
+should be reviewed by the fusion team rather than waved through with the port. And the coupling runs
+both ways: slice keeps its **own** copy of the unary writer specifically so the fusion infrastructure
+can remap the DFB index, so re-enabling these branches is worth real consideration rather than
+indefinite skipping.
+
+### 2. `ccl/mesh_partition` — out-of-op-directory edit, and it is now unconditional
+*Tagged: cross-op host coupling. Owner: ops team / TTNN.*
+
+`ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp` drives slice's
+factories directly and had to move with them, at both call sites (`create_at` and
+`override_runtime_arguments`). Three things to carry forward:
+
+- The change is **outside the porter's writeable surface**. It is taken here on the audit's record
+  that option (b) was chosen and *"explicitly authorized by the invoker"* (*Questions* #3) — the
+  branch that implemented it, PR #55433 `8c8b9eea947`, is **not in this tree**, so it was
+  re-implemented rather than inherited.
+- Because all five factories converted in this change, the `IsSliceSpecFactory` concept that made the
+  bridge incremental is **already retired**: both sites now go unconditionally through
+  `MakeProgramFromSpec` + `SetProgramRunArgs` and `UpdateProgramRunArgs`. That is the intended end
+  state, one step earlier than expected.
+- It remains **not run-verified**: MeshPartition's tests are t3000/TG-only and this bench is a single
+  Wormhole card. Unchanged from the audit's caveat.
+
+### 3. `get_vararg()` has no address form, and three readers write back into their vararg block
+*Tagged: API: missing accessor. Owner: the Metal 2.0 API team.*
+
+`tt_metal/jit_build/genfiles.cpp:441` emits only `get_vararg(idx)` / `get_common_vararg(idx)` — value
+getters. Three slice readers advance a host-seeded `id_per_dim` block in place, so the block must be
+copied into a kernel local and mutated there:
+
+- `reader_unary_unpad_dims_interleaved_start_id.cpp:26` and
+  `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:31` — `num_dims` is a CTA, so the
+  local is exactly sized.
+- `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:44` — `num_dims` is a **runtime** arg, so
+  no exactly-sized local is possible. Sized by `tensor_accessor::MAX_RANK`
+  (`tt_metal/hw/inc/internal/tensor/const.h:11`) with a device `ASSERT`. Promoting `num_dims` to a CTA
+  would have fixed it but changes compile/cache behaviour, which is not port work.
+
+`data_movement/pad` hit the same wall and resolved it the same way
+(`pad/device/kernels/dataflow/reader_pad_tiled.cpp:22-32`), so this is now two independent ports
+reporting it. A `get_vararg_addr(i)` — or the planned typed `std::array` arguments — removes the
+workaround and the `MAX_RANK` bound with it. This is the **only** place in this port where a value
+changes *where it lives* rather than how it is spelled; it is behaviour-identical because nothing
+reads the block back from L1 after the kernel exits.
+
+## Successes
+
+- **The recipe's insistence on forcing the legality checks paid for itself immediately.** The op's own
+  runtime config reports `validate_program_args=false` (visible in every `ttnn.CONFIG` dump in the
+  test logs), so on this bench the cache-hit validator would have been off for the whole port. Forcing
+  all nine `skip_validation` sites and proving it with the two `METAL2_CHECKS_FORCED` markers — both
+  present in every test run — is the difference between a verified port and a false green. *Recipe:
+  "Ensure the Metal 2.0 host-side legality checks are enabled."*
+
+- **"Re-derive the endpoint dispositions from the census, don't transcribe them" held up.** The brief
+  listed three self-loops; re-deriving each from the kernel-touch census reached the same three, and
+  more usefully it forced reading *why* `in_shard` is sync-free
+  (`slice_reader_unary_unpad_dims_rm_sharded.cpp:41` is a bare `get_write_ptr()` with no FIFO ops).
+  That is the same fact that makes the borrowed binding load-bearing for correctness, not just for
+  addressing — which is now written down at the DFB spec
+  (`slice_program_factory_rm_sharded.cpp:296-305`) instead of being invisible at the call site.
+
+- **The `Table`-is-not-a-vector warning fired correctly.** `runtime_arg_values` is keyed name-first,
+  then node, and every legacy loop here is node-first. `AddRuntimeArgsForNode` let all five factories
+  keep their existing per-core loops verbatim; inverting them by hand across ~40 arguments would have
+  been the single most error-prone edit in the port. *Recipe: `KernelSpec` ↔ `KernelRunArgs`.*
+
+- **The scope-discipline rule caught a real temptation.** The tile factories diverge between their
+  cache-miss and cache-hit paths for a no-op node's writer `start_id` (0 vs. the running tile count) —
+  inert, since `num_pages` is 0 there. It reads like a bug and is a one-line "fix". Preserved instead,
+  and written up below. Same for the dead `compile_time_element_size` CTA in four stride kernels and
+  the dead `old_src_tile_id` local, both of which the port carries forward unchanged.
+
+## Friction
+
+*(running notes)*
+
+- **Gap — the recipe's reference docs are not in this checkout.** `metal2_port.md` links
+  `../shared/port_patterns.md`, `../shared/migration_guide.md`, `../shared/ttnn_factory.md`,
+  `../shared/cb_dfb_api_whitelist.md` and `../shared/workspace_setup.md`; none exists in this tree or
+  beside the recipe at `/localdev/edwinlee/`. Worked from the declaring headers instead (which the
+  recipe itself recommends as the stronger reflex).
+
+- **Gap — the environment `workspace_setup.md` assumes was not present.** No `build_Release`, no
+  `python_env`, submodules uninitialized, and neither `clang-20` nor `g++-12` installed (no sudo).
+  `./build_metal.sh` fails at cmake configure. Resolved by building and testing inside the project's
+  own CI image, `ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64`.
+
+- **Gap — UMD cannot build a cluster descriptor on this bench, and nothing in the recipe covers it.**
+  Every device open (host *and* container, so not a Docker artifact) threw a bare
+  `std::out_of_range("unordered_map::at")` from
+  `tt::umd::TopologyDiscovery::fill_cluster_descriptor_info()` — no TT_FATAL, no message, no hint.
+  The eight Wormhole cards are individually healthy; it is the multi-chip ethernet map that fails.
+  `TT_VISIBLE_DEVICES=<n>` restricts discovery to one card and everything works, which is what the
+  whole verification run used. Worth a line in `workspace_setup.md`: *a device-open failure that
+  surfaces as `unordered_map::at` is a cluster-topology problem — retry with `TT_VISIBLE_DEVICES`
+  before suspecting the port.* Cost here: ~40 minutes.
+
+- **Gap — the `TensorAccessor` 3rd-arg Class-2 rule is stated as "the value equals what Metal 2.0
+  supplies implicitly", and on an interleaved accessor that is false while the drop is still safe.**
+  The brief calls both slice sites *"a pure no-op"* because the passed value equals the implicit one.
+  For the interleaved case it does not: `per_shard_page_size_bytes` returns the true logical row
+  (`common.cpp:782-792`), while the implicit value is that row rounded up to the allocator alignment.
+  They address identically only because an *interleaved* accessor realigns the value internally —
+  equivalence of effect, not of value. Writing the brief-mandated `check_accessor_page_size` guard as
+  the equality the brief describes made **24 of 483 tests fail** on the first full run, every one of
+  them an interleaved RM slice whose row bytes are not 32-aligned (e.g. `2 B` vs `32 B`, `126 B` vs
+  `128 B`). The guard is only meaningful where the accessor consumes the value verbatim, so it is now
+  scoped to sharded tensors (`slice_program_factory_rm.cpp:293-312`).
+
+  This is the concrete form of the gap the audit already predicted in its own *Recipe notes* #1 — that
+  the taxonomy has no row for `buffer->page_size()` on a sharded accessor, and that the two Class-2
+  clauses ("correct magnitude" vs "`== aligned_page_size`") come apart there. It is worth the
+  subject saying explicitly that the *equality* clause is a sharded-accessor test and the
+  *magnitude* clause is the interleaved one; stated as one rule it invites exactly this guard.
+
+- **Confusion — the brief describes a tree this port did not start from.** Its two "already done on
+  `akertesz/slice-test`, verify and skip" call-outs (the `TensorAccessor` 3rd-arg drop, the
+  `ccl/mesh_partition` bridge) are both *absent* here, and one of them is a hard build blocker for the
+  very first factory. The brief does say the text is kept "for a port that starts from an unpatched
+  tree", which is what saved it — but the tree state is worth an explicit *check this first* line
+  rather than a note attached to one item. See `METAL2_PORT_PLAN.md` → *Tree state this port starts
+  from*.
+
+## Open items for downstream
+
+### Shared kernel touches
+
+| Kernel | Relationship | Rung taken | Remaining unmigrated consumers |
+|---|---|---|---|
+| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` | **borrowed** by `SliceTileTensorArgs` | **Rung 1 — reused the existing `_metal2` fork beside it** (`…/writer_unary_interleaved_start_id_metal2.cpp`). No new file; the fork was not edited; no pointer comment added to the legacy original (it already has one). | see sunset list below |
+| `slice/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` (slice's own copy) | neither borrowed nor lent — `SliceTileProgramFactory` is its only binder | **converted in place, no fork** | none |
+| slice's other seven kernels | slice-owned, single-binder | converted in place | none |
+
+**Sunset list for the legacy eltwise copy** — coordination only, *not* authorization to convert it in
+place. Slice is now off that path, so it drops out of the consumer set. At least fifteen factories
+still bind it, among them `data_movement/concat`, `data_movement/reshape_on_device`, five
+`data_movement/tilize` factories, `eltwise/unary_backward/tanh_bw`, `embedding`,
+`examples/example` (×2), `experimental/matmul/attn_matmul`,
+`experimental/transformer/nlp_concat_heads` (+ `_boltz`). Tracked as **issue #52228**, which also
+records the duplicate fork at
+`copy/typecast/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp` — the
+eltwise-sited one is the one to bind.
+
+### Pre-existing findings, preserved not fixed
+
+Everything here is behaviour the port carried forward deliberately. Each is an ops-team question.
+
+1. **Cache-miss / cache-hit divergence in the tile factories.** For a node the work split left idle,
+   the build path emitted writer `start_id = 0` while the refresh path re-emitted the running tile
+   count. Inert — `num_pages` is 0 there, so the writer's loop never runs — but the two paths
+   genuinely disagreed. Preserved on both sides
+   (`slice_program_factory_tile.cpp:232-236` and `:266-271`, with the same split in
+   `…_tile_tensor_args.cpp`). A follow-up should just make the idle node's value 0 in both.
+   *Related:* the legacy `patch_slot0` deliberately skipped an arg slot holding 0, so an idle node's
+   address slot kept its zero across hits; a `TensorBinding` patches every node uniformly, so idle
+   nodes now receive the real address. Also inert, same reason.
+2. **Dead `compile_time_element_size` CTA** in all four stride kernels
+   (`reader_multicore_slice_4d.cpp:79`, `writer_multicore_slice_4d.cpp:63`,
+   `reader_multicore_slice_nd.cpp:65`, `writer_multicore_slice_nd.cpp:64`). Declared, never used; the
+   kernels use the runtime `element_size`. Still emitted by the host
+   (`slice_program_factory_rm_stride.cpp:98`). Kept, as the audit directs.
+3. **Dead RTAs in the 4D stride writer** — `output_h`, `output_d`, `output_n` are read and never used;
+   only `output_w` is. Still named and still emitted. Same for `tensor_rank` in that file.
+4. **`SliceTileTensorArgs` reads the end tensor and discards it.** The reader does a full DFB-staged
+   read into `end_indices`, which is `[[maybe_unused]]` and never read afterwards. The port keeps the
+   whole apparatus: the `end` `TensorParameter`, its binding, its accessor, and the staging round
+   trip — because the read still happens. If the tensor really is unnecessary, a binding, a DFB
+   round trip and an accessor can all go; that is an ops-team call, not a port one.
+5. **Dead `old_src_tile_id` local** at `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:117`
+   — assigned each iteration, never read. Preserved verbatim.
+6. **Dead preprocessor branches** — slice's own writer copy still gates on `#ifdef OUT_SHARDED` and
+   `#ifdef BACKWARDS`, and no slice factory sets any `defines`, so neither can fire. Preserved (and
+   the reused eltwise fork has the identical pair).
+7. **Stale comments in the off-limits device-op class.** `slice_device_operation.cpp:386` and `:412`
+   explain the hash's contents in terms of `TensorAccessorArgs` baked into the writer's compile-time
+   args. The mechanism is now the tensor binding, so the wording is stale — the *reasoning* still
+   holds (the accessor layout is still baked per cache entry, from the `TensorParameter` spec). Not
+   touched: that file is outside the port's writeable surface.
+
+### Test coverage notes
+
+- **The op has no C++ gtests.** `unit_tests_ttnn` and every sibling binary return zero tests for
+  `*Slice*`; the 67 hits in `unit_tests_ttnn_ccl` are CCL slice-helper tests, unrelated to this op.
+  Python is the whole safety net, which is worth knowing before the next structural change here.
+- **`ccl/mesh_partition` remains unexercised on this bench** (t3000/TG only), so the out-of-directory
+  change in *Handoff points* #2 is compile-verified only.
+- **Two unreferenced kernel files** remain in the op directory and were deliberately not touched or
+  audited: `device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp` and
+  `device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp`. They still contain legacy
+  `TensorAccessorArgs<N>()` / positional-CTA idioms, which is the only reason a tree-wide grep for
+  those patterns is non-zero after this port. If they are genuinely dead they should be deleted.
+
+### Per-op carry-over
+
+- `data_movement/pad` is the closest structural sibling (same sharded-gather reader shape, same
+  `id_per_dim` write-back, same borrowed-shard DFBs) and is already ported. Anyone porting a third op
+  in this family should read `pad`'s factories first — the two ports independently reached the same
+  answers on every shared construct, which is a good sign those answers are the intended ones.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PORT_REPORT.md
@@ -45,10 +45,11 @@ The device-operation class (`slice_device_operation.cpp`) and the op's top-level
 **byte-identical** to pre-port.
 
 **One capability lost outside the op, with no test left red:** the brief-mandated removal of the
-pybound `SliceTileProgramFactory.create_descriptor` takes slice out of the descriptor-fusion path,
-which the port cannot repair (fusion merges `ProgramDescriptor`s; a ported factory has none). Six
-fusion tests are converted from failures to skips by the same guard layernorm's port uses, under
-issue #54365 — `0 failed, 50 passed, 75 skipped`. See *Handoff points* #1.
+pybound `SliceTileProgramFactory.create_descriptor` takes slice out of the `OpDescriptor` path
+(`models/experimental/`), which the port cannot repair — that path needs a `ProgramDescriptor` object
+and a ported factory has none. Six tests are converted from failures to skips by the same guard
+layernorm's port uses, under issue #54365 — `0 failed, 50 passed, 75 skipped`. See
+*Handoff points* #1.
 
 **Bench caveat:** this machine's multi-chip ethernet topology defeats UMD's cluster discovery, so all
 runs used `TT_VISIBLE_DEVICES` to restrict to a single Wormhole card. That matches the
@@ -121,12 +122,21 @@ mirrors `layernorm_nanobind.cpp:339`, which is exactly the same shape: a factory
 2.0, still bound, with no methods. It costs nothing and it means a caller gets a clear
 missing-*method* error rather than a missing-*symbol* one.
 
-**What genuinely cannot be preserved.** A fusion branch does not merely call `create_descriptor` — it
-consumes the `ProgramDescriptor` structurally: `fusion.py:805` iterates `op.descriptor.kernels` to
-group them by RISC type, `op_descriptor.py:227` hashes the descriptor, and codegen emits a *fused*
-`ProgramDescriptor`. A ported factory produces a `ProgramSpec`, which that pipeline cannot consume.
-No binding shape recovers this; the capability is gone until fusion learns to consume a spec. The
-affected consumer is `models/experimental/ops/descriptors/data_movement/slice.py:54`.
+**What genuinely cannot be preserved.** The consumer does not merely *call* `create_descriptor`; it
+needs the returned `ProgramDescriptor` as an object. `OpDescriptor.launch()` hands it straight to
+`ttnn.generic_op` (`op_descriptor.py:334-338`); a *fused* tree goes further and consumes it
+structurally — `fusion.py:805` iterates `op.descriptor.kernels` to group them by RISC type,
+`op_descriptor.py:227` hashes it, and codegen emits a merged `ProgramDescriptor`. A ported factory
+produces a `ProgramSpec`, which neither path can consume. No binding shape recovers this.
+
+**Scope — wider than "fusion", but narrower than it first looks.** The entry point is
+`models/experimental/ops/descriptors/data_movement/slice.py:54`, and *both* its uses break: standalone
+`OpDescriptor.launch()`, and membership in a `Sequential` / `Parallel` tree (a "branch", in this
+infrastructure's terms, is one `OpDescriptor` inside such a tree — `fusion.py:441-458`). Against
+that: `Sequential` / `Parallel` are **already disabled by default** — `fusion.py:85-89` raises unless
+`TT_METAL_ENABLE_PARALLEL_SEQUENTIAL=1`, for the same *"until ProgramSpec is exposed to Python"*
+reason that #54365 tracks — and everything affected sits under `models/experimental/`. `ttnn.slice()`
+itself is untouched; it runs the spec path, which is what the 445 passing tests exercise.
 
 **Resolution — the layernorm precedent, applied.** The fusion suite already handles exactly this: an
 autouse fixture in `tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py` stands a

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PREPORT_AUDIT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PREPORT_AUDIT.md
@@ -1,0 +1,754 @@
+# Metal 2.0 Audit Findings — `ttnn/cpp/ttnn/operations/data_movement/slice`
+
+One DeviceOperation, five program factories (single bundled report; findings are attributed per factory
+throughout — see *Per-DeviceOperation / per-factory attribution*):
+
+- **`ttnn::prim::SliceDeviceOperation`** (`device/slice_device_operation.hpp:31`)
+  - `SliceRmProgramFactory` (`device/slice_program_factory_rm.cpp`)
+  - `SliceRmShardedProgramFactory` (`device/slice_program_factory_rm_sharded.cpp`)
+  - `SliceRmStrideProgramFactory` (`device/slice_program_factory_rm_stride.cpp`)
+  - `SliceTileProgramFactory` (`device/slice_program_factory_tile.cpp`)
+  - `SliceTileTensorArgsProgramFactory` (`device/slice_program_factory_tile_tensor_args.cpp`)
+
+**Kernels in scope** (every kernel a factory `kernel_source`s, own + donor):
+
+| Kernel | Factory | Owner |
+|---|---|---|
+| `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | Rm | slice |
+| `slice_writer_unary_stick_layout_interleaved_start_id.cpp` | Rm | slice |
+| `slice_reader_unary_unpad_dims_rm_sharded.cpp` | RmSharded | slice |
+| `reader_multicore_slice_4d.cpp` / `writer_multicore_slice_4d.cpp` | RmStride (rank ≤ 4) | slice |
+| `reader_multicore_slice_nd.cpp` / `writer_multicore_slice_nd.cpp` | RmStride (rank > 4) | slice |
+| `reader_unary_unpad_dims_interleaved_start_id.cpp` | Tile | slice |
+| `writer_unary_interleaved_start_id.cpp` (slice's own copy) | Tile | slice |
+| `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | TileTensorArgs | slice |
+| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` | TileTensorArgs | **eltwise/unary (cross-family donor)** |
+
+**Unreferenced kernel files in the op directory** (out of scope, contents not audited — listed only so a
+reader does not mistake them for live code): `device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp`,
+`device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp`. No factory names either file.
+
+**Scope:** TTNN op, Gen1 (WH/BH) target — within scope of `audit/metal2_audit.md`.
+
+**Recipe docs:** *not pinnable* — `git log -1 -- docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/`
+prints nothing in this checkout (that path does not exist here; `.../host_apis/` holds only
+`buffers/ device_management/ kernels/ profiler/ program/ runtime_args/`). The audit ran against
+`/localdev/edwinlee/metal2_audit.md`, an out-of-tree copy, so the guidance version cannot be recorded.
+
+**Reference data:** readiness sheet *"TTNN Operations analysis"* fetched 2026-09-01 (Drive
+`1KUMj8SyBGlNMZlLFgs1MbAZlO2g6EoUc4KaxSlcy8jw`, owner `dgomez@`, modifiedTime `2026-09-01T05:26:10Z`).
+Five slice rows, one per factory. The two dated triage analyses the recipe names as priors —
+`2026-07-19_offset_base_pointers.md` and `2026-07-06_tensor_accessor_3rd_arg_triage.md` — are **not present
+in this checkout and were not available**; both subjects below were therefore resolved from the code alone,
+per each subject's "your own scan is the source of truth" rule. The offset-base-pointer finding is
+independently corroborated by the sheet's `Known op issues` cell; the 3rd-argument finding has **no
+external corroboration** and should be read as a fresh classification (see *Questions*).
+
+---
+
+## Status summary
+
+| Field | Value |
+|---|---|
+| **Op directory** | `ttnn/cpp/ttnn/operations/data_movement/slice` |
+| **Overall** | **RED** — at op level, **no portable subset** (all five factories blocked) |
+| **DOps / Factories** | `SliceDeviceOperation` → `SliceRmProgramFactory`, `SliceRmShardedProgramFactory`, `SliceRmStrideProgramFactory`, `SliceTileProgramFactory`, `SliceTileTensorArgsProgramFactory` |
+| *Prereqs* — Device 2.0 (every kernel used) | **Yes — GREEN.** All nine referenced kernels (slice-owned + the eltwise/unary donor) are structurally Device 2.0: `Noc`, `DataflowBuffer`, `CoreLocalMem`, `TensorAccessor`. No CB-index-keyed free-function holdovers. |
+| *Prereqs* — Cross-op escapes | **Ok** (kernel-side ✓ clean) — **but see the host-side issue**: `ccl/mesh_partition` drives all five slice factories and `patch_slice_program_addresses` directly. Not a gate; a bundled-port coordination requirement. |
+| *Feature Support* — overall | **GREEN** — all three Appendix A entries `N/A` |
+| *Feature Support* — Variadic-CTA | Ok — no kernel reads a compile-time arg at a varying index |
+| *TTNN Readiness* — `Is able to port?` (the gate) | **No** — `no` on **all five** factory rows. Attributed: `TensorParameter relaxation` = `(legality - pending analysis)` (all 5) **and** `Known op issues` = `offset base ptr to TensorAccessor` (`SliceRmProgramFactory`) |
+| *TTNN Readiness* — Concept (current) | `descriptor` (all 5) — cross-check ✓ (`create_descriptor` returning `ProgramDescriptor` on each factory) |
+| *TTNN Readiness* — Secretly SPMD (WorkloadDescriptor only) | N/A (not `WorkloadDescriptor`) |
+| *TTNN Readiness* — Custom hash | **Yes** (not a gate; port leaves it intact): `device/slice_device_operation.cpp:302-354`. Cross-check ✓ |
+| *TTNN Readiness* — `get_dynamic_runtime_args` | **No** ✓ — no such hook on the DeviceOperation. Cross-check ✓ (comments still reference one — see *Misc anomalies*) |
+| *TTNN Readiness* — `override_runtime_arguments` | **Yes** (not a gate; selects `CustomProgramSpecFactoryConcept`) — all five factories: `slice_program_factory_rm.cpp:435`, `slice_program_factory_rm_sharded.cpp:418`, `slice_program_factory_rm_stride.cpp:178`, `slice_program_factory_tile.cpp:189`, `slice_program_factory_tile_tensor_args.cpp:195`. Cross-check ✓ |
+| *TTNN Readiness* — Pybind `create_descriptor` | **Yes** (not a gate; port deletes the binding): `slice_nanobind.cpp:164-176` (`SliceTileProgramFactory.create_descriptor`). Sheet value is the literal string `PR` on all five rows — see *Gate detail* |
+| *TTNN Readiness* — Op-owned tensors | No (sheet blank; consistent with `descriptor`) ✓ |
+| *TTNN Readiness* — Target concept | **`CustomProgramSpecFactoryConcept`** (all five) — matches the sheet's `Porting Target` |
+| *Port work* — Offset base pointer | **GATE** → ops team + framework/Audrey (**Type 2 — accessor-fed offset arg**), `SliceRmProgramFactory` only. The other four factories are clean on this gate. |
+| *Port work* — Tensor bindings (per binding) | ⚠ port work — 9 Case 1, 2 clean (borrowed-DFB), 1 gated upstream (the Type-2 base). No Case 2. |
+| *TTNN Readiness* — TensorParameter relaxation | `(legality - pending analysis)` on **all five** rows → **GATE** → ops team *(the known item the requester asked to set aside)* |
+| *Port work* — TensorAccessor 3rd arg | **Two sites, both in `SliceRmProgramFactory`'s kernels.** Class 2 (drop) under interleaved and HEIGHT_SHARDED; **Class 3 / Special → GATE** under BLOCK/WIDTH_SHARDED. |
+| *Port work* — CB endpoints | legal (4 CBs, plain 1:1) + **self-loop** ×3 (`RmSharded` c_0, `RmSharded` c_16, `TileTensorArgs` c_1). No dead CB, no multi-binding, no conditional DFB. |
+
+**CB endpoints** are dispositions, not gates: every out-of-window CB here resolves with a **self-loop**
+(one toucher). No CB needs the multi-binding advanced option, and none is dead.
+
+---
+
+## Result
+
+**RED at op level; no portable subset.** All five factory rows read `Is able to port? = no`, so there is no
+clean factory subset to carve out and **no porter brief is issued**.
+
+Four distinct gates are open. Two are the items the requester already knows about; **two more sit
+downstream of them**, and one of those is new information:
+
+| # | Gate | Scope | Owner | Known? |
+|---|---|---|---|---|
+| 1 | `TensorParameter relaxation` = `(legality - pending analysis)` — the hash/relaxation legality analysis | all 5 factories | ops team | **known** |
+| 2 | **Offset base pointer, Type 2** — `input.buffer()->address() + begins_bytes - misalignment` fed to a `TensorAccessor` as its base | `SliceRmProgramFactory` | ops team **+ framework/Audrey, flag early** | on the sheet as `Known op issues`; characterised here |
+| 3 | **`TensorAccessor` 3rd argument, Class 3 / Special** — a load-bearing per-shard page-size override that the Metal 2.0 binding model cannot express, and that conflates page *payload* with page *stride* | `SliceRmProgramFactory` (reader + writer) | ops team | **NEW — not on the sheet, no triage-doc coverage available** |
+| 4 | TTNN factory-concept gate (`Is able to port? = no`) — the roll-up of #1 and #2 | all 5 factories | TTNN / readiness-sheet owner (verdict); ops team (causes) | **known** |
+
+**Answer to "what else is downstream after the hashing/relaxation work?"** — three things, in descending
+order of risk:
+
+1. **Gate #3, the `TensorAccessor` 3rd-argument override** (below). This is the one item no existing
+   record covers. It is *not* the usual redundant page-size arg that drops mechanically: on
+   BLOCK/WIDTH-sharded row-major tensors the override is deliberately set to the per-shard payload width
+   so a shared helper can re-index shard-relative, and Metal 2.0 supplies `aligned_page_size` implicitly
+   with **no override API**. Resolving it also exposes what looks like a pre-existing payload-vs-stride
+   defect in `noc_async_{read,write}_sharded`.
+2. **`ccl/mesh_partition` is a host-side consumer of slice's factory API** — it calls all five
+   `create_descriptor`s and `patch_slice_program_addresses` directly and stores
+   `SliceDeviceOperation::program_factory_t` in its own `shared_variables_t`. The port changes the
+   factory entry point and deletes the patching shim, so mesh_partition breaks unless it is ported or
+   adapted in the same change. Not a gate under this recipe (which inventories *kernel* escapes only),
+   but it is a scheduling dependency, and mesh_partition is itself `legacy (MeshWorkload)` /
+   `Is able to port? = no` on the sheet.
+3. **The port is a `CustomProgramSpecFactoryConcept` translation of an unusually large patcher.**
+   `patch_slice_program_addresses` is a 60-line five-way `std::visit` shared across two ops, mixing
+   `GetRuntimeArgs` slot-poking, `apply_descriptor_runtime_args` on CB descriptors, and
+   `apply_dynamic_runtime_args`; it must become one `ProgramRunArgs`-returning method per factory.
+   Additionally, **every reader kernel reads variable-count RTA/CRTA blocks through
+   `get_arg_addr`/`get_common_arg_addr` pointers** (six vararg sites), and one of those blocks is
+   **mutated in place by the kernel** — which is also where a latent cache-hit bug lives (see
+   *Misc anomalies*).
+
+Everything else clears: **Device 2.0 is GREEN** for all nine kernels, **all three Appendix A features are
+absent**, **CB endpoint legality is clean** (three self-loops, nothing needing the multi-binding flag),
+and the kernel-side donor coupling is `✓ clean`.
+
+**Path forward.** None of the four gates is a missing Metal 2.0 feature. #1 and #2 are ops-team fixes on
+their own tracks; #3 needs an ops-team decision on the page-size override (and, if the alignment concern
+below is confirmed, a fix to the shared `noc_async_*_sharded` helpers); #4 lifts when #1–#3 do. The op is
+then re-audited.
+
+**Scoping-rule disclosure.** Both blocking causes are cleared on the **op-code side** (a relaxation/hash
+fix and an offset split both rewrite this code), so the recipe's *Red* scoping rule would have me **skip**
+the seven purely-informational subjects on a whole-op RED with no portable subset. I ran them **in full
+anyway**, because the requester explicitly asked what lies downstream of the known hash/relaxation work.
+Read the informational sections with that caveat: the RM reader/writer detail in particular will change
+when the offset split lands, so re-audit rather than porting from this document. Nothing was skipped.
+
+---
+
+## Gate detail
+
+### TTNN factory concept (`Is able to port?`) — **RED**, all five factories
+
+Sheet cell `Is able to port?` = `no` on every slice row. Two blocking columns explain it:
+
+| Blocking column | Value (verbatim) | Rows | Route |
+|---|---|---|---|
+| `TensorParameter relaxation` | `(legality - pending analysis)` | all 5 | **ops team** |
+| `Known op issues` | `offset base ptr to TensorAccessor` | `SliceRmProgramFactory` | **ops team + framework** |
+
+The `Provisional relaxation finding (Edwin)` column reads `needs fix, then none` on the
+`SliceRmProgramFactory` and `SliceTileProgramFactory` rows and is blank on the other three — recorded
+verbatim, not interpreted. This is an *attributed* `no`, not an unattributed one; the readiness-sheet
+owner needs no question on the verdict itself.
+
+**Lightweight cross-check — clean, with one observation.** Verified against the code:
+
+| Column | Sheet | Code | ✓ |
+|---|---|---|---|
+| `Concept` | `descriptor` | `create_descriptor` → `ProgramDescriptor` on all five factory `.hpp`s | ✓ |
+| `Custom hash` | `yes` | `SliceDeviceOperation::compute_program_hash`, `slice_device_operation.cpp:302` | ✓ |
+| `Runtime-args update (get_dynamic_runtime_args)` | `no` | no such hook on the DeviceOperation (grep clean; the adapter `static_assert`s it cannot coexist with `override_runtime_arguments`, `mesh_device_operation_adapter.hpp:509`) | ✓ |
+| `Override runtime args method?` | `yes` | all five factories define it (sites in the status summary) | ✓ |
+| `Pybind descriptor` | `PR` | `slice_nanobind.cpp:167` binds `SliceTileProgramFactory::create_descriptor` | see note |
+| `Op-owned tensors?` | blank | no `WorkloadDescriptor`, no `buffers` vector | ✓ |
+| Factory-set match | 5 rows | 5 factories in `program_factory_t` (`slice_device_operation.hpp:36-41`), names match one-for-one | ✓ |
+
+Cross-column invariants hold: `get_dynamic_runtime_args = no` on a `descriptor` concept ✓; no op-owned
+tensors on a `descriptor` row ✓; `Porting Target = CustomProgramSpecFactoryConcept` consistent with
+`Override runtime args method? = yes` ✓.
+
+Two observations that are **not** conflict claims — neither is in the recipe's cross-check set, and
+neither is offered as evidence the sheet is broken:
+
+- `Pybind descriptor` carries the literal string **`PR`** (not `yes`/`no`) on all five rows. The code has
+  exactly one pybound `create_descriptor`, on the Tile factory (`slice_nanobind.cpp:164-176`); the
+  nanobind file additionally exposes `SliceParams`, `SliceInputs` and `SliceDeviceOperation`'s
+  `create_output_tensors` / `compute_output_specs` (`slice_nanobind.cpp:134-163`). Recorded so the porter
+  knows which sites the deletion touches. Question for the sheet owner below.
+- `Smuggled pointer (raw buffer addr in RTA/CRTA)` = `no`, while `SliceRmProgramFactory` does put a
+  `buffer()->address()`-derived value on reader RTA 0. This **reconciles**: the column tracks the
+  *stale-pointer* hazard, and because the factory defines `override_runtime_arguments` the value is
+  re-emitted on every cache hit (`slice_program_factory_rm.cpp:389-390` → `:423`), so it is never stale.
+  The offset that rides along is what gates, and it is captured under `Known op issues`.
+
+### Device 2.0 (every kernel used) — **GREEN**
+
+Every kernel the op instantiates is structurally Device 2.0. No `InterleavedAddrGen` /
+`ShardedAddrGen` / `InterleavedAddrGenFast` / `InterleavedPow2AddrGen*`, no bare `noc_async_read` /
+`noc_async_write`, no `cb_reserve_back` / `cb_push_back` / `cb_wait_front` / `cb_pop_front`, no raw
+semaphore addresses, no `evil_set_*_ptr`. Every `get_write_ptr()` / `get_read_ptr()` in the op is a
+`DataflowBuffer` **method** on an in-scope wrapper (14 sites across 9 files), never the CB-index free
+function.
+
+Cross-op donor, also clear: `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`
+constructs a `DataflowBuffer` and a `Noc`, and reads its page size via
+`get_local_cb_interface(cb_id_out).fifo_page_size` (`:27`). `get_local_cb_interface(cb_id)` is on the
+audit's **sanctioned** free-function list, so this is **not** a holdover and does not knock the op out of
+Green — even though a wrapper is in scope and a wrapper method (`get_entry_size()`) exists. (Slice's own
+copy of that kernel already uses `dfb_out.get_entry_size()`,
+`device/kernels/dataflow/writer_unary_interleaved_start_id.cpp:26`.)
+
+No violations table — there are no violations.
+
+### Feature compatibility — **GREEN** (all entries `N/A`)
+
+| Feature | Status | Notes |
+|---|---|---|
+| GlobalCircularBuffer | N/A | No `GlobalCircularBuffer` type, `CreateGlobalCircularBuffer`, `global_circular_buffer.hpp` include, `CBDescriptor::global_circular_buffer` field, `remote_index(`, `remote_cb_*` identifier, `UpdateDynamicCircularBufferAddress`, or `num_global_cb_receivers` anywhere in the op. The two Buffer-backed CBs (`slice_program_factory_rm_sharded.cpp:290,302`) set only `.buffer` — the plain borrowed-memory pattern, which is a mechanical porting-recipe translation via `DataflowBufferSpec::borrowed_from`, not this entry. |
+| CBDescriptor `address_offset` (non-zero) | N/A | No `.address_offset`, `set_address_offset`, 4-arg `UpdateDynamicCircularBufferAddress`, or `cb_descriptor_from_sharded_tensor` in the op. The two `CBDescriptor`s that set `.buffer` leave `address_offset` defaulted to 0. (Note: the op's offset problem is a *host-folded pointer* — Type 2 below — **not** a CB `address_offset`; the two are different mechanisms and only the latter is this entry.) |
+| GlobalSemaphore | N/A | The op declares **no semaphores at all** — no `SemaphoreDescriptor`, no `CreateSemaphore`, no `GlobalSemaphore`, no `global_semaphore.hpp`. |
+
+Variadic CTA: no kernel calls `get_compile_time_arg_val` at a varying index — every CTA read is at a
+literal offset or a `TensorAccessorArgs<N>` constexpr chain.
+
+### Offset base pointers — **RED (Type 2 — accessor-fed offset arg)**, `SliceRmProgramFactory`
+
+**The fold** (`device/slice_program_factory_rm.cpp:43-50`):
+
+```cpp
+inline uint32_t slice_rm_reader_base_address(const Tensor& input, const ttnn::Shape& slice_start) {
+    const uint32_t begins_bytes = slice_start[-1] * input.element_size();
+    const auto src_buffer_alignment = input.buffer()->buffer_type() == BufferType::DRAM
+                                          ? ::hal::get_dram_alignment() : ::hal::get_l1_alignment();
+    const uint32_t misalignment = begins_bytes % src_buffer_alignment;
+    return input.buffer()->address() + begins_bytes - misalignment;   // :49  ← the fold
+}
+```
+
+Emitted as **reader RTA 0** at `slice_program_factory_rm.cpp:107`, and re-emitted on every cache hit at
+`:423` via `slice_rm_reader_dynamic_args` → `apply_dynamic_runtime_args` (`:389-390`).
+
+**The consumption — this is what makes it Type 2, not Type 1**
+(`device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:14,33,38`):
+
+```cpp
+const uint32_t src_addr = get_arg_val<uint32_t>(0);       // the base+offset value
+constexpr auto src_args = TensorAccessorArgs<0>();
+const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);   // ← offset IS the accessor base
+```
+
+The offset address is the `TensorAccessor`'s **base**, not a relocatable trailing `+` on a NoC address, so
+the mechanical Type-1 arg split does not apply. Metal 2.0's `TensorAccessor(tensor::name)` ctor takes the
+base implicitly from the binding's CRTA word and accepts **no** base override
+(`tt_metal/hw/inc/api/tensor/tensor_accessor.h:96-107` for the sharded specialisation, `:409-418` for the
+interleaved one — both delegate with the address only). There is no seam.
+
+- **Arg:** `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` — **reader RTA 0, role `src_addr`**.
+- **Offset expression:** `begins_bytes - misalignment`, where
+  `begins_bytes = slice_start[-1] * input.element_size()` and
+  `misalignment = begins_bytes % (DRAM ? dram_alignment : l1_alignment)`.
+  Deterministic from cache-miss inputs (`slice_start`, dtype, buffer type are all hashed), so this is a
+  real addressing pattern, not a one-off constant.
+- **Why the fold exists:** the kernel needs an *aligned* start below the requested byte offset, then
+  fixes up the residue on-device with a whole-stick `tt_memmove`
+  (`slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:97-101`), passing `misalignment` separately
+  as reader RTA 5. So the residue is *already* split out; only the aligned-multiple part is folded.
+- **Route:** **ops team** to refactor before the port, **and framework/Audrey — flag early.** The likely
+  shape (unsettled) is a plain `TensorAccessor` on the clean base plus kernel-side pointer manipulation,
+  weighed against a first-class tensor-view binding. The affected variant is row-major, matching the
+  recipe's characterisation of the wall as an RM phenomenon.
+
+**Other factories scanned — clean, and the reason each is clean matters:**
+
+| Factory | Address args | Verdict |
+|---|---|---|
+| `SliceRmShardedProgramFactory` | none — both tensors reach the kernel as borrowed-memory CBs (`.buffer = input.buffer()` / `output.buffer()`, `slice_program_factory_rm_sharded.cpp:290,302`). The width offset travels as a **separate CTA** (`begins_bytes`, `:310`) and is added kernel-side (`slice_reader_unary_unpad_dims_rm_sharded.cpp:69`). | ✓ clean — offset already split out |
+| `SliceRmStrideProgramFactory` | reader RTA 0 = `input_buffer`, writer RTA 0 = `output_buffer` — bare `Buffer*` bindings (`slice_program_factory_rm_stride.cpp:128,136,147,160`) | ✓ clean base |
+| `SliceTileProgramFactory` | reader CRTA 0 = `src0_buffer`, writer RTA 0 = `dst_buffer` (`slice_program_factory_tile.cpp:143,180`). The tile start offset rides a **clean tile-index scalar** (`start_offset` folded into `reader_args[0] = start_id`, `:97,119,125`) | ✓ clean base — the tiled variant the recipe predicts is unaffected |
+| `SliceTileTensorArgsProgramFactory` | reader CRTA 0/1/2 = `src_buffer` / `start_buffer` / `end_buffer`, writer RTA 0 = `dst_buffer` (`slice_program_factory_tile_tensor_args.cpp:182-184,151,168`). Start offset computed **on device** from the start tensor (`reader_..._tensor_args.cpp:85-112`) | ✓ clean base |
+
+No Type 1, no Type 3 (`address_offset`), no Type 4 (`ttnn::narrow` / interior-base `MeshBuffer::create`).
+Reconciliation against the checked-in triage doc was not possible (doc absent); this is a from-code scan
+of **every** address arg in all five factories, not a table lookup.
+
+### TensorAccessor 3rd argument — **RED (Class 3 / Special)** under B/W-sharding, Class 2 otherwise
+
+Only **two** accessors in the whole op pass a 3rd argument, and both belong to `SliceRmProgramFactory`.
+The other eleven `TensorAccessor` constructions in the op's kernels pass two arguments and are not this
+subject.
+
+| # | Site | Value | Host origin |
+|---|---|---|---|
+| A | `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:38` (`padded_stick_size`, reader RTA 1) | `per_shard_page_size_bytes(input, padded_row_size_bytes)` | `slice_program_factory_rm.cpp:102`, emitted `:108` |
+| B | `slice_writer_unary_stick_layout_interleaved_start_id.cpp:32` (`page_size_override`, writer RTA 7) | `per_shard_page_size_bytes(output, unpadded_row_size_bytes)` | `slice_program_factory_rm.cpp:171`, emitted `:181` |
+
+**Question 1 — sharded or interleaved?** Both. `SliceRmProgramFactory` is the catch-all row-major factory
+(`slice_device_operation.cpp:279-296`), so the same accessor is interleaved on some configs and sharded on
+others. The two specialisations read the argument differently, so the site must be classified per config.
+
+**Question 2 — magnitude.** `per_shard_page_size_bytes` (`data_movement/common/common.cpp:782-793`)
+returns three different things:
+
+| Input/output memory layout | Returned value | True `aligned_page_size` | Accessor specialisation | Class |
+|---|---|---|---|---|
+| Interleaved (DRAM or L1) | `row_bytes` = `padded_shape[-1] * E` = `buffer->page_size()` | `round_up(page_size, alignment)` | interleaved — realigns internally via `InterleavedAddrGen::aligned_page_size = align_power_of_2(page_size, allocator_alignment)` (`dataflow_api_addrgen.h:278-279`) | **2 — inert, drop** |
+| HEIGHT_SHARDED | `buffer()->aligned_page_size()` — *exactly* the default | same | sharded — verbatim | **2 — redundant, drop** |
+| **BLOCK_SHARDED / WIDTH_SHARDED** | `shard_spec.shape[1] * E` = `buffer->page_size()`, **unaligned** | `round_up(page_size, 16)` (L1) / DRAM alignment | **sharded — verbatim, no realignment net** | **3 / Special — GATE** |
+
+For row-major B/W-sharded tensors the buffer's page **is** the shard row
+(`page_config.cpp:111-118`: page width comes from the physical shard width; `tensor_layout.cpp:321-327`:
+the physical shard shape is the shard spec's shape unrounded), and the allocator strides pages at
+`align(page_size, alignment)` (`buffer.cpp:764`). The sharded `TensorAccessor` uses the passed value
+**verbatim** as that stride — `bank_start + bank_base_address + page_mapping.bank_page_offset *
+aligned_page_size + offset` (`tensor_accessor.h:307`). So whenever `shard_W * element_size` is not
+alignment-aligned, the accessor strides short and mis-addresses.
+
+**Why it is Special and not just a wrong value.** The override is *load-bearing by design*, and both
+kernels say so in comments (`..._rm_interleaved_start_id.cpp:36-37`,
+`..._stick_layout_...:20-21`): the value is consumed a second time inside the shared helpers
+`noc_async_read_sharded` / `noc_async_write_sharded`
+(`data_movement/common/kernels/common.hpp:375-409` / `:325-360`), which call
+`tensor.get_aligned_page_size()` (`:389` / `:340`) to split one logical row across shards:
+
+```cpp
+const uint32_t page_size = tensor.get_aligned_page_size();
+uint32_t sharded_src_id  = src_id * pages_per_row + offset / page_size;
+uint32_t sharded_offset  = offset % page_size;
+uint32_t read_size       = std::min(remaining, page_size - sharded_offset);   // ← wants the PAYLOAD size
+```
+
+The split arithmetic wants the page **payload** (`shard_W * E`); the accessor's addressing wants the page
+**stride** (`aligned_page_size`). One 3rd argument is being asked to be both. They coincide exactly when
+`shard_W * E % alignment == 0` — which is presumably why this has never been caught — and diverge
+otherwise. Metal 2.0 removes the override entirely (the binding-token ctors above supply
+`aligned_page_size` implicitly and offer no override), so the port cannot preserve today's behaviour on
+the B/W-sharded path even if that behaviour were correct.
+
+- **Class 2 (mechanical drop)** for interleaved and HEIGHT_SHARDED configs — both sites.
+- **Class 3 → GATE** for BLOCK_SHARDED / WIDTH_SHARDED configs, escalating to **Special** because the
+  intent (shard-relative payload paging) is not expressible through the binding model. Latent rather than
+  live: it is masked wherever the shard width happens to be alignment-aligned. I could not establish from
+  the code whether any shipped/tested config has `shard_W * element_size % 16 != 0`, so per the recipe's
+  "possibly-wrong-magnitude value gates" rule the site is **gated conservatively**.
+- **Route: ops team**, for both sites. The decision is theirs: confirm the override is redundant for
+  every reachable config (→ drops to Class 2 and the gate lifts), or fix the payload-vs-stride
+  conflation in the two shared `noc_async_*_sharded` helpers so the accessor can carry the true stride.
+  The helper fix is **outside the op** and would touch every data_movement caller of those helpers.
+
+No triage-doc cross-check was possible; this is a fresh classification. See *Questions*.
+
+### CB endpoints — **GATE-free**, all dispositions determined
+
+Device 2.0 is GREEN, so the census ran on intact Device-2.0 idioms — no deferral. Seven CB instances
+across the five factories; census per `(CB, config)`, per node:
+
+| Factory | CB | Touchers on a node | Verdict | Port-time resolution |
+|---|---|---|---|---|
+| `Rm` | `src0_cb_index = 0` (`slice_program_factory_rm.cpp:338-346`) | reader: `reserve_back`/`push_back` + own `get_write_ptr` peek → **1 locked producer**; writer: `wait_front`/`pop_front` + own `get_read_ptr` peek → **1 locked consumer** | **plain 1:1** | none — bind PRODUCER/CONSUMER as-is |
+| `RmSharded` | `c_0`, **borrowed from `input.buffer()`** (`:282-291`) | the single reader kernel, `get_write_ptr()` only (`slice_reader_..._rm_sharded.cpp:41`) — no FIFO ops → **1 role-free toucher** | **single-ended / sync-free** | **self-loop** — bind the reader PRODUCER **and** CONSUMER; plus `borrowed_from` the input |
+| `RmSharded` | `c_16`, **borrowed from `output.buffer()`** (`:294-303`) | the same single reader kernel: `reserve_back` / `get_write_ptr` / `push_back`, nothing drains (`:40-42,89`) → **1 locked producer** | **single-ended** | **self-loop**; plus `borrowed_from` the output |
+| `RmStride` | `in_cb = 0` (`slice_program_factory_rm_stride.cpp:69-77`) | reader (4d or nd) produces; writer (4d or nd) consumes | **plain 1:1** | none |
+| `Tile` | cb 0 (`slice_program_factory_tile.cpp:53-60`) | reader produces; writer consumes. Index reaches both kernels via `named_compile_time_args` `dfb_id_in` / `dfb_id_out` (`:139,161`) | **plain 1:1** | none |
+| `TileTensorArgs` | `src0_cb_index = 0` (`slice_program_factory_tile_tensor_args.cpp:56-64`) | reader produces; the **eltwise/unary donor** writer consumes | **plain 1:1** | none |
+| `TileTensorArgs` | `tensor_cb_index = 1` (`:65-73`) | the reader only, running a full `reserve_back`→`push_back`→`wait_front`→`pop_front` cycle twice as staging for the start/end tensors (`reader_..._tensor_args.cpp:52-83`) → **1 toucher, locked to both roles** | **single-ended (self-loop already in code)** | **self-loop** — bind the reader PRODUCER **and** CONSUMER |
+
+**Nothing here gates**, and the harder shapes are all absent:
+
+- **No dead CB.** Every allocated `buffer_index` is referenced by a bound kernel in every config;
+  each index was traced through its CTA / `named_compile_time_args` carrier to a real access.
+- **No hidden second writer.** Actively scanned every kernel that touches each CB for a
+  `get_write_ptr()` / `fifo_wr_ptr` write by a kernel that is not the CB's FIFO producer, gated by a
+  semaphore pair. There are **no semaphores anywhere in this op**, so the coordination mechanism that
+  face requires does not exist here.
+- **No multiple-readers face and no dual-instance work-split.** No factory pushes the same
+  `kernel_source` into two `KernelDescriptor`s; every kernel instance is unique per factory. No CB has
+  read sites in 2+ co-resident kernels beyond the ordinary producer/consumer pair.
+- **No config-dependent flip.** Each CB's census is the same across that factory's configs; no
+  conditional DFB is needed.
+
+One non-obvious `RmSharded` detail the porter should carry forward: `dfb_in.get_write_ptr()` (`:41`) is
+used as a **remote** L1 address — it is combined with *another core's* `noc_x`/`noc_y` (`:65,76`) to read
+that core's shard of the borrowed input buffer. That is legal precisely because the CB is
+`borrowed_from` the input buffer, so the local address is the same on every core the buffer occupies. It
+is a peek, not a second endpoint, and the census above already accounts for it.
+
+---
+
+## Port-work summary  *(would mirror the brief — no brief is issued)*
+
+- **Tensor bindings** (per binding, per factory):
+  - `Rm` / `input` — **gated upstream** as the Type-2 offset base; *not* a Case 1/2 item. Do not classify
+    it as Case 1 or the offset silently vanishes.
+  - `Rm` / `output` — **Case 1** (writer RTA 0 `Buffer*` → `TensorAccessor(dst_args, dst_addr, ...)`).
+  - `RmSharded` / `input` — **clean** (borrowed-memory DFB read; `borrowed_from` the input buffer).
+  - `RmSharded` / `output` — **clean** (borrowed-memory DFB write; `borrowed_from` the output buffer).
+  - `RmStride` / `input`, `output` — **Case 1** each.
+  - `Tile` / `input`, `output` — **Case 1** each.
+  - `TileTensorArgs` / `input`, `start_tensor`, `end_tensor`, `output` — **Case 1** each (four bindings).
+  - **No Case 2 anywhere** — no kernel does hand-rolled arithmetic on a tensor base pointer, so no
+    `get_bank_base_address` bridge is needed.
+  - Delivery mechanism note: except for the `Rm` reader base, every address arrives as a `Buffer*`
+    binding pushed into an `RTArgList` / common-arg list. Because each factory defines
+    `override_runtime_arguments`, the adapter **bypasses** `resolve_bindings`
+    (`mesh_device_operation_adapter.hpp:449-455`), so those `Buffer*` entries only place the initial
+    value at cache-miss time — `patch_slice_program_addresses` is what actually re-points them on a hit.
+    Both mechanisms must be accounted for when the bindings become typed.
+- **TensorParameter relaxation:** `(legality - pending analysis)` on all five factories — blocked, ops team.
+- **TensorAccessor 3rd arg:** two sites (`Rm` reader `:38`, `Rm` writer `:32`) — Class 2 drop for
+  interleaved / HEIGHT_SHARDED, **blocked** (Class 3/Special) for BLOCK/WIDTH_SHARDED.
+- **CB endpoints:** self-loop `(RmSharded c_0, all configs)`, `(RmSharded c_16, all configs)`,
+  `(TileTensorArgs c_1, all configs)`; the remaining four CBs are plain 1:1. No dead-CB drop, no
+  multi-binding flag, no conditional DFB.
+- **`override_runtime_arguments` → `ProgramRunArgs` translation** (the `CustomProgramSpecFactoryConcept`
+  work), five methods funnelling into one shared 63-line patcher
+  (`slice_program_factory_rm_sharded.cpp:354-416`) that mixes three distinct patching mechanisms:
+  `apply_descriptor_runtime_args` on CB-address-only descriptors (`:363-367`), a raw
+  `GetRuntimeArgs` slot-0 poke with a "skip if the slot holds 0" heuristic (`:372-381`), and
+  `apply_dynamic_runtime_args` (`:390,404,412`). `slice_tile_dynamic_args`
+  (`slice_program_factory_tile.cpp:198-281`) and `slice_rm_reader_dynamic_args`
+  (`slice_program_factory_rm.cpp:405-433`) each **re-derive the work split** to stay in lockstep with
+  `create_descriptor` — duplication the `ProgramRunArgs` form should be able to collapse.
+  `<tt-metalium/experimental/program_descriptor_patching.hpp>` is included by all five factory `.cpp`s
+  and is self-described as the shim that Metal 2.0 deletes (`:8-19` of that header), so the port removes
+  every one of these calls.
+
+---
+
+## Heads-ups  *(would mirror the brief — no brief is issued)*
+
+- **CB endpoints (multi-binding shapes to watch):** **none.** No CB in this op needs the multi-binding
+  advanced option; no hidden second writer exists (there are no semaphores to coordinate one). The three
+  out-of-window CBs are all one-toucher self-loops, listed in Port-work.
+- **Cross-op / shared kernels:**
+  - `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`
+    — instantiated by `SliceTileTensorArgsProgramFactory`
+    (`slice_program_factory_tile_tensor_args.cpp:133`). **A `_metal2` fork already exists beside it** at
+    `.../writer_unary_interleaved_start_id_metal2.cpp` — **bind that fork, do not create a second one.**
+    The legacy file's header comment names the sunset plan (issue **#52228**) and the consumer list.
+  - Broadly shared: ~25 other program factories instantiate the same legacy file (concat, tilize ×5,
+    transpose ×2, reshape_on_device, reduction ×4, matmul, embeddings, attn_matmul, nlp_concat_heads ×2,
+    gelu_bw, tanh_bw, examples ×2, plus tests and a programming example). That set is a
+    **sunset / coordination list, not authorization to convert the kernel in place.**
+  - Slice keeps its **own** copy of that kernel for the Tile factory
+    (`device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`) — same stem, different file,
+    slice-owned, no fork needed. Do not confuse the two; the Tile and TileTensorArgs factories point at
+    different files.
+  - **`ttnn/cpp/ttnn/operations/experimental/quasar/slice/` exists and is out of bounds.** It contains a
+    shortcut pre-port copy of this op (including a `slice_program_factory_rm_stride.cpp` that names the
+    same kernels). It is not a precedent, not a naming source, and not evidence that any construct here
+    is portable. Do not read it.
+- **RTA / CRTA varargs** — six genuine vararg sites; **prefer named args everywhere else**:
+  | Kernel | Site | Shape |
+  |---|---|---|
+  | `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | `:29-31` — three `num_dims`-length blocks via `get_arg_addr(13)`, `num_dims` from RTA 4 | RTA vararg |
+  | `slice_reader_unary_unpad_dims_rm_sharded.cpp` | `:26-30` — four blocks at **runtime-computed** offsets (`get_arg_addr(1 + num_cores_read * 2)`, `* 3`), variable count | RTA vararg (both recognition shapes) |
+  | `reader_unary_unpad_dims_interleaved_start_id.cpp` | `:17-18` — `2 * num_dims` CRTA block via `get_common_arg_addr(1)` | **CRTA** vararg (CTA-bounded still varies per instantiation) |
+  | `reader_unary_unpad_dims_interleaved_start_id.cpp` | `:23` — `num_dims`-length `id_per_dim` block via `get_arg_addr(2)` | RTA vararg |
+  | `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | `:25-26,31,91-92` — `3 * num_dims` CRTA span, one read at the runtime offset `get_common_arg_addr(3 + 2 * num_dims)`, plus the `id_per_dim` RTA block | CRTA + RTA vararg |
+  | `reader_multicore_slice_nd.cpp` / `writer_multicore_slice_nd.cpp` | reader `:73-88` (five `tensor_rank`-length blocks, running offset), writer `:73` (one block) — `tensor_rank` is an **RTA** | RTA vararg |
+  The two `*_4d.cpp` kernels are the counter-case: a fixed `rt_args_idx++` run over a constant field set
+  (`reader_multicore_slice_4d.cpp:52-77`, `writer_multicore_slice_4d.cpp:52-61`) → **name every one of
+  those**, they are not varargs.
+- **A vararg block is mutated in place by the kernel.** `id_per_dim` is written back into the runtime-arg
+  region as the reader walks dimensions — `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:76-78`,
+  `reader_unary_unpad_dims_interleaved_start_id.cpp:45-48`,
+  `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:124-127`, and the analogous `coords[]`
+  copy in `reader_multicore_slice_nd.cpp:103-105`. The arg region is being used as writable scratch that
+  must be re-initialised every dispatch. Confirm the vararg mechanism preserves that (and see the
+  related latent bug in *Misc anomalies* — do **not** carry today's behaviour forward as intended).
+- **`ccl/mesh_partition` is a second consumer of this op's factory API** — host-side, and the recipe's
+  coupling buckets do not cover it. `mesh_partition_program_factory.cpp:123-136` calls
+  `SliceOp::validate_on_program_cache_miss`, `SliceOp::select_program_factory` and then
+  `Factory::create_descriptor` for whichever slice factory is selected; `:149-156` calls
+  `ttnn::prim::patch_slice_program_addresses`; and `mesh_partition_device_operation.hpp:47-52` stores a
+  `prim::SliceDeviceOperation::program_factory_t` in its own `shared_variables_t`. Changing
+  `create_descriptor` → the spec entry point and deleting the patcher **breaks mesh_partition** unless it
+  is ported or adapted in the same change. mesh_partition is itself `legacy (MeshWorkload)` with
+  `Is able to port? = no` on the sheet, so the two cannot simply be ported together today.
+- **`const` vs `constexpr` at two CTA reads** — `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:15-16`
+  declares `tile_width` / `tile_height` as `const uint32_t` (not `constexpr`) from
+  `get_compile_time_arg_val`. That distinction decides token-form vs member-getter for the port; confirm
+  rather than swapping blind.
+- **`named_compile_time_args` is already in use** for CB indices on the Tile factory
+  (`slice_program_factory_tile.cpp:139,161` → `get_named_compile_time_arg_val("dfb_id_in"/"dfb_id_out")`),
+  with a stated fusion-remapping motive. Two of the op's kernels are therefore already part-modernised:
+  the port there is a binding-layer change, not an idiom rewrite. The other three factories still pass CB
+  indices positionally.
+
+---
+
+## Team-only
+
+### Out-of-directory coupling & donor shape
+
+**Op-level roll-up (function-call escape): `✓ clean.`** Exactly one out-of-directory header is included by
+the op's kernels, it is in-family, and every function it exposes to slice takes Device 2.0-native
+handles.
+
+| Op kernel | Donor file | Class | Status |
+|---|---|---|---|
+| `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | `ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp` | 5 — in-family shared | ✓ |
+| `slice_writer_unary_stick_layout_interleaved_start_id.cpp` | same | 5 | ✓ |
+| `reader_multicore_slice_4d.cpp` | same | 5 | ✓ |
+| `writer_multicore_slice_4d.cpp` | same | 5 | ✓ |
+| `reader_multicore_slice_nd.cpp` | same | 5 | ✓ |
+| `writer_multicore_slice_nd.cpp` | same | 5 | ✓ |
+| `slice_reader_unary_unpad_dims_rm_sharded.cpp` | *(none — `tt_metal/*` only)* | 1 | ✓ |
+| `reader_unary_unpad_dims_interleaved_start_id.cpp` | *(none)* | 1 | ✓ |
+| `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | *(none)* | 1 | ✓ |
+| `writer_unary_interleaved_start_id.cpp` (slice copy) | *(none)* | 1 | ✓ |
+| `eltwise/unary/.../writer_unary_interleaved_start_id.cpp` (donor) | *(none)* | 1 | ✓ |
+
+Every other include across all nine kernels resolves under `tt_metal/hw/inc/api/*`
+(`dataflow_api.h`, `noc.h`, `dataflow_buffer.h`, `core_local_mem.h`, `endpoints.h`,
+`tensor/noc_traits.h`) — bucket 1, no concern.
+
+**Per-call detail** (`data_movement/common/kernels/common.hpp`), three functions called:
+
+| Function | Signature shape | Status |
+|---|---|---|
+| `noc_async_read_sharded(Noc, uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size)` (`:375`) | **Shape 1** — `TensorAccessor<DSpec>` by value, plus a `Noc` | ✓ excellent — porter constructs `TensorAccessor(tensor::name)` and passes it |
+| `noc_async_write_sharded(...)` (`:325`) | **Shape 1** — same | ✓ excellent |
+| `tt_memmove<...>(Noc, uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t bytes)` (`:143`) | plain L1 addresses + `Noc`; no CB / semaphore / accessor handle | ✓ no bridge needed |
+
+No `uint32_t sem_id`, no `uint32_t`/`uint64_t` sem address, no `TensorAccessorArgs<N>` parameter, no CTA
+offset as NTTP, no old-style addr-gen, no `CircularBuffer&`, no `DataflowBuffer&` parameters. Nothing
+starred. The deprecated no-`Noc` overloads of both `noc_async_*_sharded` (`:363`, `:411`) exist in the
+donor but slice calls the `Noc`-first form everywhere.
+
+Note for the framework/ops discussion in *TensorAccessor 3rd argument*: these two helpers are the reason
+the 3rd-arg override exists, and their internal use of `get_aligned_page_size()` for **both** the page
+stride and the per-page payload size is where that gate's root cause sits. Fixing it there is a
+data_movement-wide change, not a slice change.
+
+**Borrowed kernel files (file-path instantiation):**
+
+| Kernel file | Owner | Also instantiated by | `_metal2` fork beside it? |
+|---|---|---|---|
+| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` | eltwise/unary (cross-family) | **broadly shared** — concat, tilize (×5), transpose (×2), reshape_on_device, reduction (×4, incl. welford), matmul multicore, embeddings fused, attn_matmul, nlp_concat_heads (×2), gelu_bw, tanh_bw, examples (×2), plus `tests/ttnn/.../test_generic_op.{cpp,py}`, `test_situ_glu_sfpu.py` and `tt_metal/programming_examples/matmul/matmul_multi_core` | **Yes** — `writer_unary_interleaved_start_id_metal2.cpp`, same directory. Bind it. |
+
+The other eight kernels are slice-owned and instantiated only by slice. Two further `_metal2` files with
+the same stem exist elsewhere and are **not** forks to reuse: one is typecast's own copy
+(`copy/typecast/device/kernels/dataflow/`), and two live under `experimental/quasar/**` (out of bounds by
+the locational test).
+
+**Host-side coupling (no recipe bucket — see *Recipe notes*):** `ccl/mesh_partition` consumes slice's
+factory API directly, detailed under *Heads-ups*. Separately, four ops call slice's pure host-side offset
+helpers `get_rm_start_offset` / `get_tiled_start_offset` (`slice_device_operation.hpp:23-25`):
+`experimental/padded_slice` (2 factories), `experimental/slice_write` (3 factories),
+`experimental/transformer/nlp_kv_cache_load_slice`. Those are scalar arithmetic functions untouched by the
+port — recorded for completeness, not a coupling risk.
+
+### Relaxation candidates (FALLIBLE — candidates to verify; the ops team owns the real analysis)
+
+Mined from `compute_program_hash` (`slice_device_operation.cpp:302-354`), which hashes the **full**
+input spec, the full output spec, the start-tensor spec when present, all slice params, `sub_core_grids`
+and `factory.index()`. Default strict is the safe reading; these are only observations:
+
+- The hash includes `input.memory_config()` and `output_spec.memory_config()` in full, and the factory's
+  correctness genuinely depends on the sharded-vs-interleaved distinction (the 3rd-arg finding above and
+  the `select_program_factory` height-sharded branch both key on it). So there is **no obvious
+  memory-config relaxation candidate** here.
+- Both `padded_shape` and `logical_shape` are hashed for input and output. The RM factory's CB sizing,
+  chunking and stride math derive from `padded_shape[-1]` and `slice_start[-1]` only
+  (`slice_program_factory_rm.cpp:205-303`), and the Tile factory's per-dim args derive from
+  `padded_shape` only — a `match_padded_shape`-style relaxation might be viable for the Tile factory, but
+  the RM factory also folds `element_size()` (i.e. dtype) into `begins_bytes`, and `sub_core_grids`
+  changes the work split. Fallible; the sheet's `(legality - pending analysis)` cell is the real analysis.
+- The comment at `:304-307` states the custom hash exists to *strengthen* distribution against
+  false cache hits ("weak distribution for small-integer shape sequences ... same pattern as concat fix
+  in PR #45144 (issue #47602)"), not to relax anything. If that reading holds, the relaxation column's
+  `needs fix, then none` provisional finding is consistent: this is a hash-correctness item, not a
+  genuine `TensorSpec` relaxation.
+
+### TTNN factory analysis (sheet-derived facts, with `file:line` evidence)
+
+- **Concept (current):** `descriptor`, all five factories. Each `.hpp` declares
+  `static ProgramDescriptor create_descriptor(const SliceParams&, const SliceInputs&, Tensor&)`.
+- **Op-owned tensors:** none — no `create_workload_descriptor`, no `WorkloadDescriptor`, no `buffers`
+  vector anywhere in the op.
+- **MeshWorkload need:** none. `select_program_factory` (`slice_device_operation.cpp:268-300`) picks one
+  single-program factory; `slice()` dispatches through `ttnn::device_operation::launch`
+  (`:381-384`). *(Note: `ccl/mesh_partition` wraps these same factories in a MeshWorkload of its own —
+  that need belongs to mesh_partition, not to slice.)*
+- **Custom hash:** `SliceDeviceOperation::compute_program_hash`, `slice_device_operation.cpp:302-354`.
+  **Not a gate**; the port leaves it exactly as it is. No backdoor `attribute_values` / `to_hash`
+  (sheet `no`, ✓ confirmed — `SliceParams` / `SliceInputs`, `slice_device_operation_types.hpp:13-28`,
+  declare neither).
+- **`get_dynamic_runtime_args`:** absent. The adapter's `static_assert`
+  (`mesh_device_operation_adapter.hpp:509-513`) makes it impossible to combine with the
+  `override_runtime_arguments` the op does define, so it cannot quietly return.
+- **`override_runtime_arguments`:** present on all five factories → target
+  **`CustomProgramSpecFactoryConcept`**. Sites: `slice_program_factory_rm.cpp:435`,
+  `slice_program_factory_rm_sharded.cpp:418`, `slice_program_factory_rm_stride.cpp:178`,
+  `slice_program_factory_tile.cpp:189`, `slice_program_factory_tile_tensor_args.cpp:195` — each a
+  one-line delegation to the shared `patch_slice_program_addresses`
+  (`slice_program_factory_rm_sharded.cpp:354-416`).
+- **Pybind `create_descriptor`:** `slice_nanobind.cpp:164-176` (`SliceTileProgramFactory`). Removing it
+  is a user-visible API change and gets its own entry in the eventual port report. Other risky pybinds in
+  the same function (`bind_slice_descriptor`, `:134-163`): `nb::class_` of `SliceParams` with
+  read-write access to every field, `nb::class_` of `SliceInputs`, and `nb::class_` of
+  `SliceDeviceOperation` exposing `create_output_tensors` / `compute_output_specs`.
+- **Target concept:** `CustomProgramSpecFactoryConcept`, no op-owned tensors — matches the sheet's
+  `Porting Target` on all five rows.
+- **Execution model:** `SPMD` on all five rows; consistent with the single-program `descriptor` shape.
+
+---
+
+## Misc anomalies  *(team-only, non-gating; route to the ops team — the port does not act on these)*
+
+1. **Latent cache-hit bug: the RM reader's `id_per_dim` block is never re-initialised.** The reader
+   increments `id_per_dim[]` in place inside the runtime-arg region
+   (`slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:31,74-82,104-112`), so after a dispatch the
+   block holds the walked-to values, not the per-core start values `create_descriptor` wrote
+   (`slice_program_factory_rm.cpp:169`). Because `SliceRmProgramFactory` defines
+   `override_runtime_arguments`, the adapter uses **neither** `resolve_bindings` **nor**
+   `get_dynamic_runtime_args` and the factory owns the whole re-derivation
+   (`mesh_device_operation_adapter.hpp:449-455`) — but `slice_rm_reader_dynamic_args`
+   (`slice_program_factory_rm.cpp:405-433`) re-emits **only reader arg 0**, and
+   `patch_slice_program_addresses` re-emits only writer slot 0 for this factory. Nothing restores
+   `id_per_dim`. A second dispatch that hits the cached program should therefore start its dimension
+   walk from stale indices and read the wrong sticks. The sibling factories do **not** have this hole:
+   `slice_tile_dynamic_args` explicitly re-emits reader slots `2 .. 2+num_dims`
+   (`slice_program_factory_tile.cpp:268-271`), covering both Tile and TileTensorArgs, and
+   `slice_reader_unary_unpad_dims_rm_sharded.cpp` never mutates its args. Worth a targeted
+   repeat-dispatch test on the RM path (rank ≥ 2, ≥ 2 dims walked, two invocations with the same shapes).
+2. **Stale comments describe a hook that does not exist.** Five comments name
+   `SliceDeviceOperation::get_dynamic_runtime_args` as the mechanism that re-emits the RM reader base —
+   `slice_program_factory_rm.cpp:41,42,105,106` and `slice_program_factory_rm.hpp:40`. There is no such
+   hook; the mechanism is `override_runtime_arguments` → `slice_rm_reader_dynamic_args` →
+   `apply_dynamic_runtime_args`. Adding the hook the comments describe would now trip the adapter's
+   `static_assert`. Also at `slice_program_factory_rm_sharded.cpp:278-279` a comment says "the framework
+   copies runtime args and patches dynamic CB addresses" on a cache hit — which is the
+   `resolve_bindings` path this op opts out of by defining `override_runtime_arguments`. Both readings
+   are actively misleading for anyone reasoning about item 1.
+3. **Dead CTA in all four `*_multicore_slice_*` kernels.** `compile_time_element_size =
+   get_compile_time_arg_val(1)` is declared and never used —
+   `reader_multicore_slice_4d.cpp:81`, `writer_multicore_slice_4d.cpp:65`,
+   `reader_multicore_slice_nd.cpp:66`, `writer_multicore_slice_nd.cpp:65`. The host passes
+   `element_size` as CTA 1 (`slice_program_factory_rm_stride.cpp:79,82`) **and** again as an RTA
+   (`:132,142,149,161`); only the RTA is read.
+4. **Dead locals.** `output_bytes_per_row`, `output_h`, `output_d`, `output_n` are computed/read and never
+   used in `reader_multicore_slice_4d.cpp:56-62,86`. `old_src_tile_id` is assigned and never used in
+   `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:115`. `writer_multicore_slice_nd.cpp:73`
+   uses `get_arg_addr(rt_args_idx++)` where the post-increment is pointless (no further reads).
+5. **The `end_tensor` binding feeds nothing.** `SliceTileTensorArgsProgramFactory` requires an
+   `end_tensor` (`slice_program_factory_tile_tensor_args.cpp:27,46`), allocates a `TensorAccessor` for it
+   and reads a full tile from it on device
+   (`reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:45,69-83`), but `end_indices` is
+   declared `[[maybe_unused]]` (`:49`) and never read after the copy loop (`:80-82`). The output extent
+   comes from host-computed `num_unpadded_tiles_per_dim` instead. A whole tensor binding, accessor,
+   staging CB round-trip and NOC read exist to populate a dead array. If that is intended (e.g. reserved
+   for a future dynamic-extent path) it deserves a comment; if not, the binding and the second staging
+   read can go.
+6. **Dead `#ifdef` paths in slice's own copy of the unary writer.**
+   `device/kernels/dataflow/writer_unary_interleaved_start_id.cpp:29,38` branch on `OUT_SHARDED` and
+   `BACKWARDS`. No slice factory sets `defines` on that `KernelDescriptor`
+   (`slice_program_factory_tile.cpp:154-162`), so `OUT_SHARDED` is never taken and `BACKWARDS` never
+   compiled. Carried over from the eltwise original.
+7. **The `patch_slot0` "skip if zero" heuristic is undocumented as a contract.**
+   `slice_program_factory_rm_sharded.cpp:370-381` writes the new address into arg slot 0 of every core's
+   arg vector *except* where the slot currently holds 0, on the premise that a zero slot marks a core
+   `create_descriptor` left zero-filled. That premise holds today (the no-op-core paths write
+   `{0u, 0u, 0u}`, e.g. `slice_program_factory_tile.cpp:176`,
+   `slice_program_factory_tile_tensor_args.cpp:151`), but it is a value-based sentinel standing in for
+   structural information the descriptor already has, applied uniformly across four factories with
+   different slot layouts. It is the kind of shim that quietly mis-fires if a factory ever writes a
+   non-zero placeholder or a legitimately-zero address.
+8. **Two unreferenced kernel files** in `device/kernels/dataflow/`:
+   `strided_slice_reader_rm_interleaved_nd.cpp` and `strided_slice_writer_rm_interleaved.cpp`. No factory
+   names either (the strided path uses the `*_multicore_slice_{4d,nd}.cpp` pair instead). Likely
+   superseded; candidates for deletion.
+
+---
+
+## Per-DeviceOperation / per-factory attribution
+
+One DeviceOperation, so the bundling is per factory. Findings differ materially between them:
+
+| Factory | `Is able to port?` | Gates open | 3rd arg | Offset base ptr | CB dispositions | Bindings |
+|---|---|---|---|---|---|---|
+| `SliceRmProgramFactory` | no | relaxation · **offset Type 2** · **3rd arg Class 3/S** | 2 sites | **Type 2 GATE** | 1× plain 1:1 | 1 Case 1, 1 gated |
+| `SliceRmShardedProgramFactory` | no | relaxation only | none | clean | 2× **self-loop** (both borrowed) | 2 clean |
+| `SliceRmStrideProgramFactory` | no | relaxation only | none | clean | 1× plain 1:1 | 2 Case 1 |
+| `SliceTileProgramFactory` | no | relaxation only | none | clean | 1× plain 1:1 | 2 Case 1 |
+| `SliceTileTensorArgsProgramFactory` | no | relaxation only | none | clean | 1× plain 1:1, 1× **self-loop** | 4 Case 1 |
+
+Shared across all five: `descriptor` → `CustomProgramSpecFactoryConcept`, the custom hash, the
+`override_runtime_arguments` / `patch_slice_program_addresses` translation, and the `ccl/mesh_partition`
+host-side coupling. If the relaxation gate clears **without** the offset and 3rd-arg gates clearing, the
+four non-`Rm` factories become a viable clean subset — that is the most likely next re-audit outcome and
+worth planning for.
+
+---
+
+## Questions for the user
+
+1. **Is the `TensorAccessor` 3rd-argument override on the RM path known to anyone?**
+   `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:38` and
+   `slice_writer_unary_stick_layout_interleaved_start_id.cpp:32` pass a per-shard page size that, on
+   BLOCK/WIDTH-sharded row-major tensors, is the page **payload** (`shard_W * element_size`) where the
+   sharded accessor uses the value verbatim as the page **stride** (`aligned_page_size`). It is not on
+   the readiness sheet (`Known op issues` names only the offset base pointer) and I could not consult
+   `2026-07-06_tensor_accessor_3rd_arg_triage.md`. Two things would settle the class: (a) does any
+   shipped or tested slice config have `shard_W * element_size % 16 != 0` on a B/W-sharded row-major
+   input **or** output? (b) is the payload-vs-stride conflation in
+   `data_movement/common/kernels/common.hpp:340,389` a known issue with an owner? If (a) is "no" for
+   every reachable config, both sites drop to Class 2 and this gate lifts.
+2. **`Pybind descriptor` = `PR` on all five slice rows.** The sheet uses the literal string `PR` where
+   other rows carry `yes`/`no`. The code has one pybound `create_descriptor`, on the Tile factory only
+   (`slice_nanobind.cpp:167`). Is `PR` "a PR is in flight to remove it", and does it apply to the whole
+   op or just the Tile row? Routed to the readiness-sheet owner as a question, not a defect claim —
+   `Pybind descriptor` is in the cross-check set, but a non-boolean value is a vocabulary question rather
+   than a code/sheet conflict.
+3. **Who owns adapting `ccl/mesh_partition`?** It calls all five slice `create_descriptor`s and
+   `patch_slice_program_addresses` directly and is itself `legacy (MeshWorkload)` /
+   `Is able to port? = no`. The slice port cannot land without either porting mesh_partition in the same
+   change or giving it an adapter, and mesh_partition is not portable today. This ordering constraint
+   should be settled before the slice port is scheduled, not discovered during it.
+
+---
+
+## Recipe notes
+
+1. **No bucket for a host-side factory-API borrower.** *Out-of-directory coupling* is defined entirely in
+   terms of kernels: `#include` escapes (the six donor classes) and file-path kernel instantiation. It has
+   nowhere to record that **another op family calls this op's `create_descriptor` and its cache-hit
+   patcher from host code** (`ccl/mesh_partition/device/mesh_partition_program_factory.cpp:123-156`,
+   `mesh_partition_device_operation.hpp:47-52`). That is arguably the single highest-impact coupling
+   finding in this audit — the port changes the exact API mesh_partition consumes — yet the subject's
+   report format (roll-up / summary table / per-call detail / borrowed kernel files) has no row for it and
+   its gating carve-out (a donor kernel on pre-Device-2.0 idioms) does not apply. I surfaced it under
+   *Heads-ups* and *Team-only* by analogy. Suggestion: add a fourth escape type — *host-side factory-API
+   consumer* — with an explicit "does the consumer's own readiness allow a bundled port?" question, since
+   the answer here (`no`) is a real scheduling constraint.
+2. **The 3rd-argument magnitude rule is written for interleaved accessors and misclassifies sharded ones.**
+   *Question 2* lists "`buffer->page_size()`, `tt::tile_size` / `get_tile_size(cb)` and
+   `aligned_page_size()`" together as **correct magnitude**. But the *Class 2* row admits only
+   "`== aligned_page_size`, **or** a correct-magnitude value on an *interleaved* accessor", and the
+   load-bearing-subtlety paragraph says sharded uses the value verbatim with no safety net. On a sharded
+   accessor `buffer->page_size()` and `aligned_page_size()` differ by the alignment round-up, and that
+   difference **does** mis-address — so following Question 2 literally yields Class 2 while following the
+   table yields Class 3. I resolved it toward the table (and the conservative-gating rule), but the two
+   passages contradict each other. Suggestion: split Question 2's correct-magnitude list by
+   specialisation, or state explicitly that on a sharded accessor `page_size()` is *not* interchangeable
+   with `aligned_page_size()`.
+3. **The taxonomy has no clean slot for "load-bearing override that is also arguably wrong."** The site
+   here is simultaneously Special (the intent — shard-relative payload paging — is inexpressible in the
+   binding model) and Class 3 (the value looks wrong for the accessor's own addressing). Both route to
+   the ops team, so the verdict is unaffected, but the class label had to be reported as "3 / Special"
+   rather than picked. A note that the classes are not mutually exclusive, and that reporting both is
+   fine when they route identically, would save the next auditor the same hesitation.
+4. **The *Red* scoping rule's "which side does it clear on?" test is hard to apply to a relaxation
+   verdict.** `(legality - pending analysis)` means the ops team will *analyse* and *possibly* fix. If
+   the analysis concludes "no relaxation needed, the hash was merely strong", the cell flips with the op's
+   code untouched (→ run the seven subjects); if it concludes "needs fix", the code changes (→ skip). The
+   provisional column here says `needs fix, then none`, which I took as op-code side. The rule assumes
+   the clearing side is knowable at audit time; for a pending-analysis cell it is knowable only
+   probabilistically. Suggestion: name the pending-relaxation case explicitly and say which way to lean
+   (running the subjects and disclosing the staleness risk seems cheaper than a second full pass).
+5. **Provenance is unpinnable when the recipe is consumed out-of-tree.** The `git log` command targets
+   `docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/`, which does not exist in this checkout;
+   the recipe I followed lives at an absolute path outside the repo. The fallback instruction ("record
+   that instead") works, but a version stamp inside the recipe document itself would survive being copied
+   out of the doc branch — which appears to be the normal way these audits are actually run.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PREPORT_AUDIT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/METAL2_PREPORT_AUDIT.md
@@ -1,7 +1,16 @@
 # Metal 2.0 Audit Findings — `ttnn/cpp/ttnn/operations/data_movement/slice`
 
-One DeviceOperation, five program factories (single bundled report; findings are attributed per factory
-throughout — see *Per-DeviceOperation / per-factory attribution*):
+> **Re-audit (2026-09-04) — the op is now GREEN.** Earlier audits of this op RED'd on the readiness
+> sheet's TTNN gate plus the offset-base-pointer and `TensorAccessor`-3rd-argument subjects. All three
+> have cleared: the sheet's `Is able to port?` now reads **`yes` on all five factory rows**, and the
+> from-code scan finds **no host-folded offset base** anywhere in the op. Both dated triage analyses
+> still list `slice`, and **both are stale for it** — each catalogues a construct the op no longer has.
+> Per each subject's *"your own scan is the source of truth"* rule, the from-code scan decides.
+> **A porter brief is issued:** `METAL2_PORT_BRIEF.md`, beside this file.
+
+One DeviceOperation, five program factories — a single bundled report (they share the device-op, the
+custom hash, the address-patching helper and, in part, their kernels). Findings are attributed per
+factory throughout; see *Per-DeviceOperation / per-factory attribution*.
 
 - **`ttnn::prim::SliceDeviceOperation`** (`device/slice_device_operation.hpp:31`)
   - `SliceRmProgramFactory` (`device/slice_program_factory_rm.cpp`)
@@ -10,7 +19,18 @@ throughout — see *Per-DeviceOperation / per-factory attribution*):
   - `SliceTileProgramFactory` (`device/slice_program_factory_tile.cpp`)
   - `SliceTileTensorArgsProgramFactory` (`device/slice_program_factory_tile_tensor_args.cpp`)
 
-**Kernels in scope** (every kernel a factory `kernel_source`s, own + donor):
+Factory selection (`device/slice_device_operation.cpp:309-341`) is what defines the *configs* this
+report classifies per-`(CB, config)` against:
+
+| Config | Selected factory |
+|---|---|
+| `use_tensor_args == true` (TILE only) | `SliceTileTensorArgs` |
+| RM, HEIGHT-sharded in **and** out, no step, W-begin L1-aligned | `SliceRmSharded` |
+| RM, any `step != 1` | `SliceRmStride` (rank ≤ 4 vs rank > 4 pick different kernels) |
+| RM, otherwise (interleaved **or** BLOCK/WIDTH-sharded) | `SliceRm` |
+| TILE, otherwise | `SliceTile` |
+
+**Kernels in scope** (every kernel a factory `kernel_source`s — own and donor):
 
 | Kernel | Factory | Owner |
 |---|---|---|
@@ -20,29 +40,31 @@ throughout — see *Per-DeviceOperation / per-factory attribution*):
 | `reader_multicore_slice_4d.cpp` / `writer_multicore_slice_4d.cpp` | RmStride (rank ≤ 4) | slice |
 | `reader_multicore_slice_nd.cpp` / `writer_multicore_slice_nd.cpp` | RmStride (rank > 4) | slice |
 | `reader_unary_unpad_dims_interleaved_start_id.cpp` | Tile | slice |
-| `writer_unary_interleaved_start_id.cpp` (slice's own copy) | Tile | slice |
+| `writer_unary_interleaved_start_id.cpp` (slice's **own** copy) | Tile | slice |
 | `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | TileTensorArgs | slice |
-| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` | TileTensorArgs | **eltwise/unary (cross-family donor)** |
+| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` | TileTensorArgs | **eltwise/unary — cross-family donor** |
 
 **Unreferenced kernel files in the op directory** (out of scope, contents not audited — listed only so a
-reader does not mistake them for live code): `device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp`,
-`device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp`. No factory names either file.
+reader does not mistake them for live code; verified unreferenced by a tree-wide filename grep):
+`device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp`,
+`device/kernels/dataflow/strided_slice_writer_rm_interleaved.cpp`.
 
-**Scope:** TTNN op, Gen1 (WH/BH) target — within scope of `audit/metal2_audit.md`.
+**Scope:** TTNN op, Gen1 (WH/BH) target — within scope of `metal2_audit.md`.
 
-**Recipe docs:** *not pinnable* — `git log -1 -- docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/`
-prints nothing in this checkout (that path does not exist here; `.../host_apis/` holds only
-`buffers/ device_management/ kernels/ profiler/ program/ runtime_args/`). The audit ran against
-`/localdev/edwinlee/metal2_audit.md`, an out-of-tree copy, so the guidance version cannot be recorded.
+**Recipe docs:** `4bd4bf42bfe 2026-09-03 docs(metal_2.0): state the offset-base wall as a category, not as slice's current state`
 
-**Reference data:** readiness sheet *"TTNN Operations analysis"* fetched 2026-09-01 (Drive
-`1KUMj8SyBGlNMZlLFgs1MbAZlO2g6EoUc4KaxSlcy8jw`, owner `dgomez@`, modifiedTime `2026-09-01T05:26:10Z`).
-Five slice rows, one per factory. The two dated triage analyses the recipe names as priors —
-`2026-07-19_offset_base_pointers.md` and `2026-07-06_tensor_accessor_3rd_arg_triage.md` — are **not present
-in this checkout and were not available**; both subjects below were therefore resolved from the code alone,
-per each subject's "your own scan is the source of truth" rule. The offset-base-pointer finding is
-independently corroborated by the sheet's `Known op issues` cell; the 3rd-argument finding has **no
-external corroboration** and should be read as a fresh classification (see *Questions*).
+*Provenance note:* the recipe was consumed out-of-tree from `/localdev/edwinlee/metal2_audit.md`. That
+file is **byte-identical** (`diff` clean) to
+`docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/audit/metal2_audit.md` on branch
+`akertesz/op-porting-recipe` in the doc-branch checkout at `/localdev/edwinlee/Port_Recipe`, so the hash
+above is a valid pin. Note this is a **newer recipe** than the prior audit ran against
+(`50e992a8ec2`), and the newest commit is specifically about this subject area.
+
+**Reference data.** Readiness sheet *"TTNN Operations analysis"* **fetched fresh this session** from
+Drive (`1KUMj8SyBGlNMZlLFgs1MbAZlO2g6EoUc4KaxSlcy8jw`, owner `dgomez@`) — 28 columns, 486 rows, five
+`data_movement/slice` rows (one per factory). Both dated triage analyses named by the recipe were
+available and are cross-referenced below: `analyses/2026-07-19_offset_base_pointers.md` and
+`analyses/2026-07-06_tensor_accessor_3rd_arg_triage.md`. **Both list `slice`; both are now stale for it.**
 
 ---
 
@@ -51,704 +73,680 @@ external corroboration** and should be read as a fresh classification (see *Ques
 | Field | Value |
 |---|---|
 | **Op directory** | `ttnn/cpp/ttnn/operations/data_movement/slice` |
-| **Overall** | **RED** — at op level, **no portable subset** (all five factories blocked) |
-| **DOps / Factories** | `SliceDeviceOperation` → `SliceRmProgramFactory`, `SliceRmShardedProgramFactory`, `SliceRmStrideProgramFactory`, `SliceTileProgramFactory`, `SliceTileTensorArgsProgramFactory` |
-| *Prereqs* — Device 2.0 (every kernel used) | **Yes — GREEN.** All nine referenced kernels (slice-owned + the eltwise/unary donor) are structurally Device 2.0: `Noc`, `DataflowBuffer`, `CoreLocalMem`, `TensorAccessor`. No CB-index-keyed free-function holdovers. |
-| *Prereqs* — Cross-op escapes | **Ok** (kernel-side ✓ clean) — **but see the host-side issue**: `ccl/mesh_partition` drives all five slice factories and `patch_slice_program_addresses` directly. Not a gate; a bundled-port coordination requirement. |
-| *Feature Support* — overall | **GREEN** — all three Appendix A entries `N/A` |
-| *Feature Support* — Variadic-CTA | Ok — no kernel reads a compile-time arg at a varying index |
-| *TTNN Readiness* — `Is able to port?` (the gate) | **No** — `no` on **all five** factory rows. Attributed: `TensorParameter relaxation` = `(legality - pending analysis)` (all 5) **and** `Known op issues` = `offset base ptr to TensorAccessor` (`SliceRmProgramFactory`) |
-| *TTNN Readiness* — Concept (current) | `descriptor` (all 5) — cross-check ✓ (`create_descriptor` returning `ProgramDescriptor` on each factory) |
-| *TTNN Readiness* — Secretly SPMD (WorkloadDescriptor only) | N/A (not `WorkloadDescriptor`) |
-| *TTNN Readiness* — Custom hash | **Yes** (not a gate; port leaves it intact): `device/slice_device_operation.cpp:302-354`. Cross-check ✓ |
-| *TTNN Readiness* — `get_dynamic_runtime_args` | **No** ✓ — no such hook on the DeviceOperation. Cross-check ✓ (comments still reference one — see *Misc anomalies*) |
-| *TTNN Readiness* — `override_runtime_arguments` | **Yes** (not a gate; selects `CustomProgramSpecFactoryConcept`) — all five factories: `slice_program_factory_rm.cpp:435`, `slice_program_factory_rm_sharded.cpp:418`, `slice_program_factory_rm_stride.cpp:178`, `slice_program_factory_tile.cpp:189`, `slice_program_factory_tile_tensor_args.cpp:195`. Cross-check ✓ |
-| *TTNN Readiness* — Pybind `create_descriptor` | **Yes** (not a gate; port deletes the binding): `slice_nanobind.cpp:164-176` (`SliceTileProgramFactory.create_descriptor`). Sheet value is the literal string `PR` on all five rows — see *Gate detail* |
-| *TTNN Readiness* — Op-owned tensors | No (sheet blank; consistent with `descriptor`) ✓ |
-| *TTNN Readiness* — Target concept | **`CustomProgramSpecFactoryConcept`** (all five) — matches the sheet's `Porting Target` |
-| *Port work* — Offset base pointer | **GATE** → ops team + framework/Audrey (**Type 2 — accessor-fed offset arg**), `SliceRmProgramFactory` only. The other four factories are clean on this gate. |
-| *Port work* — Tensor bindings (per binding) | ⚠ port work — 9 Case 1, 2 clean (borrowed-DFB), 1 gated upstream (the Type-2 base). No Case 2. |
-| *TTNN Readiness* — TensorParameter relaxation | `(legality - pending analysis)` on **all five** rows → **GATE** → ops team *(the known item the requester asked to set aside)* |
-| *Port work* — TensorAccessor 3rd arg | **Two sites, both in `SliceRmProgramFactory`'s kernels.** Class 2 (drop) under interleaved and HEIGHT_SHARDED; **Class 3 / Special → GATE** under BLOCK/WIDTH_SHARDED. |
-| *Port work* — CB endpoints | legal (4 CBs, plain 1:1) + **self-loop** ×3 (`RmSharded` c_0, `RmSharded` c_16, `TileTensorArgs` c_1). No dead CB, no multi-binding, no conditional DFB. |
+| **Overall** | **GREEN** — every gate cleared; brief issued |
+| **DOps / Factories** | `SliceDeviceOperation` → `SliceRm`, `SliceRmSharded`, `SliceRmStride`, `SliceTile`, `SliceTileTensorArgs` |
+| *Prereqs* — Device 2.0 (every kernel used) | **Yes** ✓ — all 9 kernel files + the in-family helper header are structurally Device 2.0; zero holdovers |
+| *Prereqs* — Cross-op escapes | **Ok** ✓ — one in-family helper header (all call shapes ✓), one cross-family donor kernel with a `_metal2` fork already checked in |
+| *Feature Support* — overall | **GREEN** — no Appendix A entry fires |
+| *Feature Support* — Variadic-CTA | Ok — every `get_compile_time_arg_val` index is a literal constant; no CTA vararg |
+| *TTNN Readiness* — `Is able to port?` (the gate) | **Yes** ✓ — `yes` on all five factory rows; primary cross-check clean |
+| *TTNN Readiness* — Concept (current) | `descriptor` (all five) |
+| *TTNN Readiness* — Secretly SPMD (WorkloadDescriptor only) | N/A — concept is `descriptor`, not `WorkloadDescriptor` |
+| *TTNN Readiness* — Custom hash | **Yes** (not a gate; port leaves it intact): `device/slice_device_operation.cpp:343` |
+| *TTNN Readiness* — `get_dynamic_runtime_args` | **No** ✓ — no such hook on the DeviceOperation; grep of the op returns zero hits |
+| *TTNN Readiness* — `override_runtime_arguments` | **Yes** (not a gate; selects `CustomProgramSpecFactoryConcept`) — all five factories: `…_rm.cpp:396`, `…_rm_sharded.cpp:415`, `…_rm_stride.cpp:178`, `…_tile.cpp:189`, `…_tile_tensor_args.cpp:195` |
+| *TTNN Readiness* — Pybind `create_descriptor` | **Yes** (not a gate; port deletes the binding): `slice_nanobind.cpp:168-179` (on `SliceTileProgramFactory` only). Sheet value is `PR` — handled in an in-flight PR |
+| *TTNN Readiness* — Op-owned tensors | **No** — sheet cell blank; no `create_workload_descriptor`, no `buffers` vector |
+| *TTNN Readiness* — Target concept | **`CustomProgramSpecFactoryConcept`** (no op-owned tensors) — matches the sheet's own `Porting Target` cell |
+| *Port work* — Offset base pointer | **none** ✓ — every `->address()` in the op is a bare base; the W-begin byte offset rides a **separate** RTA |
+| *Port work* — Tensor bindings (per binding) | 12 bindings: **10 × Case 1** (`TensorAccessor`), **2 × clean** (borrowed-memory DFB, RmSharded). No Case 2 |
+| *TTNN Readiness* — TensorParameter relaxation | **`none`** (clears) — verbatim, all five rows. The `Provisional relaxation finding (Edwin)` cell (`needs fix, then none`) is **confirmed stale by the op owner**; relaxations are fine and the value is `none` |
+| *Port work* — `TensorAccessor` 3rd arg | **2 sites, both Class 2** → mechanical drop. See the flagged sub-case in *Questions* |
+| *Port work* — CB endpoints | 7 CBs: **4 × plain 1:1 legal**, **3 × self-loop**. No multi-binding, no dead CB, no conditional DFB |
 
-**CB endpoints** are dispositions, not gates: every out-of-window CB here resolves with a **self-loop**
-(one toucher). No CB needs the multi-binding advanced option, and none is dead.
-
----
+**CB endpoints** are dispositions, not gates: every out-of-window CB here resolves to a **self-loop**
+(one toucher). Nothing in this subject blocks a Gen1 port.
 
 ## Result
 
-**RED at op level; no portable subset.** All five factory rows read `Is able to port? = no`, so there is no
-clean factory subset to carve out and **no porter brief is issued**.
+**GREEN → brief issued** (`METAL2_PORT_BRIEF.md`).
 
-Four distinct gates are open. Two are the items the requester already knows about; **two more sit
-downstream of them**, and one of those is new information:
+All five gate-bearing subjects clear:
 
-| # | Gate | Scope | Owner | Known? |
-|---|---|---|---|---|
-| 1 | `TensorParameter relaxation` = `(legality - pending analysis)` — the hash/relaxation legality analysis | all 5 factories | ops team | **known** |
-| 2 | **Offset base pointer, Type 2** — `input.buffer()->address() + begins_bytes - misalignment` fed to a `TensorAccessor` as its base | `SliceRmProgramFactory` | ops team **+ framework/Audrey, flag early** | on the sheet as `Known op issues`; characterised here |
-| 3 | **`TensorAccessor` 3rd argument, Class 3 / Special** — a load-bearing per-shard page-size override that the Metal 2.0 binding model cannot express, and that conflates page *payload* with page *stride* | `SliceRmProgramFactory` (reader + writer) | ops team | **NEW — not on the sheet, no triage-doc coverage available** |
-| 4 | TTNN factory-concept gate (`Is able to port? = no`) — the roll-up of #1 and #2 | all 5 factories | TTNN / readiness-sheet owner (verdict); ops team (causes) | **known** |
+1. **Device 2.0** ✓ — every kernel the op exercises, own and donor, is structurally Device 2.0.
+2. **Feature compatibility** ✓ — all three Appendix A entries `N/A`.
+3. **TTNN factory concept** ✓ — `Is able to port? == yes` on all five factory rows; cross-check clean.
+4. **Offset base pointers** ✓ — the catalogued Type-2 fold has been **split out**; the scan finds none.
+5. **`TensorAccessor` 3rd argument** ✓ — two sites, both Class 2 (mechanical drop).
 
-**Answer to "what else is downstream after the hashing/relaxation work?"** — three things, in descending
-order of risk:
-
-1. **Gate #3, the `TensorAccessor` 3rd-argument override** (below). This is the one item no existing
-   record covers. It is *not* the usual redundant page-size arg that drops mechanically: on
-   BLOCK/WIDTH-sharded row-major tensors the override is deliberately set to the per-shard payload width
-   so a shared helper can re-index shard-relative, and Metal 2.0 supplies `aligned_page_size` implicitly
-   with **no override API**. Resolving it also exposes what looks like a pre-existing payload-vs-stride
-   defect in `noc_async_{read,write}_sharded`.
-2. **`ccl/mesh_partition` is a host-side consumer of slice's factory API** — it calls all five
-   `create_descriptor`s and `patch_slice_program_addresses` directly and stores
-   `SliceDeviceOperation::program_factory_t` in its own `shared_variables_t`. The port changes the
-   factory entry point and deletes the patching shim, so mesh_partition breaks unless it is ported or
-   adapted in the same change. Not a gate under this recipe (which inventories *kernel* escapes only),
-   but it is a scheduling dependency, and mesh_partition is itself `legacy (MeshWorkload)` /
-   `Is able to port? = no` on the sheet.
-3. **The port is a `CustomProgramSpecFactoryConcept` translation of an unusually large patcher.**
-   `patch_slice_program_addresses` is a 60-line five-way `std::visit` shared across two ops, mixing
-   `GetRuntimeArgs` slot-poking, `apply_descriptor_runtime_args` on CB descriptors, and
-   `apply_dynamic_runtime_args`; it must become one `ProgramRunArgs`-returning method per factory.
-   Additionally, **every reader kernel reads variable-count RTA/CRTA blocks through
-   `get_arg_addr`/`get_common_arg_addr` pointers** (six vararg sites), and one of those blocks is
-   **mutated in place by the kernel** — which is also where a latent cache-hit bug lives (see
-   *Misc anomalies*).
-
-Everything else clears: **Device 2.0 is GREEN** for all nine kernels, **all three Appendix A features are
-absent**, **CB endpoint legality is clean** (three self-loops, nothing needing the multi-binding flag),
-and the kernel-side donor coupling is `✓ clean`.
-
-**Path forward.** None of the four gates is a missing Metal 2.0 feature. #1 and #2 are ops-team fixes on
-their own tracks; #3 needs an ops-team decision on the page-size override (and, if the alignment concern
-below is confirmed, a fix to the shared `noc_async_*_sharded` helpers); #4 lifts when #1–#3 do. The op is
-then re-audited.
-
-**Scoping-rule disclosure.** Both blocking causes are cleared on the **op-code side** (a relaxation/hash
-fix and an offset split both rewrite this code), so the recipe's *Red* scoping rule would have me **skip**
-the seven purely-informational subjects on a whole-op RED with no portable subset. I ran them **in full
-anyway**, because the requester explicitly asked what lies downstream of the known hash/relaxation work.
-Read the informational sections with that caveat: the RM reader/writer detail in particular will change
-when the offset split lands, so re-audit rather than porting from this document. Nothing was skipped.
-
----
+Port work is real but mechanical: **10 Case-1 tensor bindings**, **2 page-size arg drops**, **3 CB
+self-loops**, and **6 kernels carrying genuine RTA/CRTA vararg blocks**. Two items need the porter's
+attention beyond mechanics, both recorded in the brief: the **existing `_metal2` fork** of the eltwise
+donor (reuse it — rung 1), and **`ccl/mesh_partition`**, an out-of-directory host-side consumer that
+calls slice's `create_descriptor` and `patch_slice_program_addresses` directly and will not compile
+against a ported signature.
 
 ## Gate detail
 
-### TTNN factory concept (`Is able to port?`) — **RED**, all five factories
+- **TTNN factory concept (`Is able to port?`):** **GREEN.** All five `data_movement/slice` rows read
+  `Is able to port? = yes`. The sheet also carries `Op Classification = PD Op (custom)`,
+  `Execution Model = SPMD`, `Porting Target = CustomProgramSpecFactoryConcept`, and an empty
+  `Known op issues` on every row. Nothing blocks.
 
-Sheet cell `Is able to port?` = `no` on every slice row. Two blocking columns explain it:
+  Lightweight cross-check against the code — every cheaply-checkable factual column agrees:
 
-| Blocking column | Value (verbatim) | Rows | Route |
-|---|---|---|---|
-| `TensorParameter relaxation` | `(legality - pending analysis)` | all 5 | **ops team** |
-| `Known op issues` | `offset base ptr to TensorAccessor` | `SliceRmProgramFactory` | **ops team + framework** |
+  | Column | Sheet value | Code evidence | Agrees |
+  |---|---|---|---|
+  | `Concept` | `descriptor` (×5) | all five factories declare `static tt::tt_metal::ProgramDescriptor create_descriptor(...)` (e.g. `slice_program_factory_rm.hpp:26`) | ✓ |
+  | `Custom hash (compute_program_hash)` | `yes` (×5) | `slice_device_operation.hpp:51`, defined `slice_device_operation.cpp:343` | ✓ |
+  | `Backdoor custom hash (attribute_values / to_hash)` | `no` (×5) | grep for `attribute_values` / `to_hash` over the op: **zero hits** | ✓ |
+  | `Runtime-args update (get_dynamic_runtime_args)` | `no` (×5) | grep of the device-op and factories: **zero hits**; the two mechanisms are `static_assert`-exclusive and slice defines `override_runtime_arguments` | ✓ |
+  | `Override runtime args method? (PD only)` | `yes` (×5) | all five factories define it (sites in the status summary) | ✓ |
+  | `Pybind descriptor (nb::class_ of device op)` | `PR` | present in code at `slice_nanobind.cpp:168-179`; `PR` = handled in an in-flight PR, a status marker rather than a boolean claim → **not** a conflict | ✓ |
+  | `Smuggled pointer (raw buffer addr in RTA/CRTA)` | `no` (×5) | every buffer address enters `create_descriptor` as a **`Buffer*` binding**, never as `->address()`; the five `->address()` calls in the op all sit inside `override_runtime_arguments`' patch path (`slice_program_factory_rm_sharded.cpp:381,389,395,398,399`), which is the sanctioned refresh route | ✓ |
+  | `Op-owned tensors?` | *(blank)* | no `create_workload_descriptor`, no `buffers` vector | ✓ |
+  | `Secretly SPMD Workload?` | *(blank)* | N/A on a `descriptor` concept | ✓ |
+  | **Factory-set match** | 5 rows | 5 factories in `program_factory_t` (`slice_device_operation.hpp:36-41`); names and `Factory definition path` cells match one-to-one — no phantom row, no missing row | ✓ |
 
-The `Provisional relaxation finding (Edwin)` column reads `needs fix, then none` on the
-`SliceRmProgramFactory` and `SliceTileProgramFactory` rows and is blank on the other three — recorded
-verbatim, not interpreted. This is an *attributed* `no`, not an unattributed one; the readiness-sheet
-owner needs no question on the verdict itself.
+  Cross-column invariants hold: `get_dynamic_runtime_args == no` on a `descriptor` concept ✓;
+  `Op-owned tensors?` not `yes` on a `descriptor` concept ✓.
 
-**Lightweight cross-check — clean, with one observation.** Verified against the code:
+  *Recorded, non-gating:* the sheet's `Provisional relaxation finding (Edwin)` column reads
+  **`needs fix, then none`** on the `SliceRm` and `SliceTile` rows (blank on the other three). This is
+  **not** the gating `TensorParameter relaxation` column — that one reads `none` on all five rows and
+  clears. Flagged here because the two columns are easy to conflate; see *Questions*.
 
-| Column | Sheet | Code | ✓ |
-|---|---|---|---|
-| `Concept` | `descriptor` | `create_descriptor` → `ProgramDescriptor` on all five factory `.hpp`s | ✓ |
-| `Custom hash` | `yes` | `SliceDeviceOperation::compute_program_hash`, `slice_device_operation.cpp:302` | ✓ |
-| `Runtime-args update (get_dynamic_runtime_args)` | `no` | no such hook on the DeviceOperation (grep clean; the adapter `static_assert`s it cannot coexist with `override_runtime_arguments`, `mesh_device_operation_adapter.hpp:509`) | ✓ |
-| `Override runtime args method?` | `yes` | all five factories define it (sites in the status summary) | ✓ |
-| `Pybind descriptor` | `PR` | `slice_nanobind.cpp:167` binds `SliceTileProgramFactory::create_descriptor` | see note |
-| `Op-owned tensors?` | blank | no `WorkloadDescriptor`, no `buffers` vector | ✓ |
-| Factory-set match | 5 rows | 5 factories in `program_factory_t` (`slice_device_operation.hpp:36-41`), names match one-for-one | ✓ |
+- **Device 2.0 (every kernel used):** **GREEN.** Every kernel the op exercises is structurally Device
+  2.0 — `Noc` for all NOC traffic, `DataflowBuffer` for every CB, `CoreLocalMem` / `UnicastEndpoint`
+  where a raw L1 address or an explicit NOC target is needed. The sweep looked for
+  `InterleavedAddrGen` / `ShardedAddrGen` / `InterleavedAddrGenFast` / `InterleavedPow2AddrGen*`, bare
+  `noc_async_read(` / `noc_async_write(` / `noc_async_*_barrier(`, `cb_reserve_back` / `cb_push_back` /
+  `cb_wait_front` / `cb_pop_front`, raw semaphore addresses, `evil_set_*_ptr`, and a stale
+  `api/dataflow/circular_buffer.h` include: **zero hits** across all 9 kernel files, the eltwise donor,
+  and the in-family helper header.
 
-Cross-column invariants hold: `get_dynamic_runtime_args = no` on a `descriptor` concept ✓; no op-owned
-tensors on a `descriptor` row ✓; `Porting Target = CustomProgramSpecFactoryConcept` consistent with
-`Override runtime args method? = yes` ✓.
+  **No holdover table — there are no violations.** Two shapes were checked and deliberately *not*
+  flagged:
 
-Two observations that are **not** conflict claims — neither is in the recipe's cross-check set, and
-neither is offered as evidence the sheet is broken:
+  | File | Line | Call | Why not a violation |
+  |---|---|---|---|
+  | `eltwise/unary/…/writer_unary_interleaved_start_id.cpp` (donor) | `27` | `get_local_cb_interface(cb_id_out).fifo_page_size` | **Sanctioned** free function per the Device 2.0 Green bullet — the list is the whole test and does not turn on what object is in scope, so the adjacent `DataflowBuffer dfb(cb_id_out)` at `:30` does not unseat it. Moving this onto `dfb.get_entry_size()` is a **port-stage** change (kernel-side whitelist rule 7), not a Device 2.0 one — and here it is already done in the `_metal2` fork. |
+  | all slice kernels | various | `dfb_x.get_write_ptr()` / `dfb_x.get_read_ptr()` | These are **methods on a `DataflowBuffer` object**, not the CB-index-keyed free functions the holdover rule targets. 13 such sites; all method-form. |
 
-- `Pybind descriptor` carries the literal string **`PR`** (not `yes`/`no`) on all five rows. The code has
-  exactly one pybound `create_descriptor`, on the Tile factory (`slice_nanobind.cpp:164-176`); the
-  nanobind file additionally exposes `SliceParams`, `SliceInputs` and `SliceDeviceOperation`'s
-  `create_output_tensors` / `compute_output_specs` (`slice_nanobind.cpp:134-163`). Recorded so the porter
-  knows which sites the deletion touches. Question for the sheet owner below.
-- `Smuggled pointer (raw buffer addr in RTA/CRTA)` = `no`, while `SliceRmProgramFactory` does put a
-  `buffer()->address()`-derived value on reader RTA 0. This **reconciles**: the column tracks the
-  *stale-pointer* hazard, and because the factory defines `override_runtime_arguments` the value is
-  re-emitted on every cache hit (`slice_program_factory_rm.cpp:389-390` → `:423`), so it is never stale.
-  The offset that rides along is what gates, and it is captured under `Known op issues`.
+  The one *in-family* shared header the kernels include,
+  `ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp`, is itself Device 2.0: its
+  `noc_async_read_sharded` / `noc_async_write_sharded` / `tt_memmove` all take a leading `Noc`
+  parameter (`:325`, `:375`, `:143`), and the slice kernels call those overloads — **not** the
+  `[[deprecated]]` no-`Noc` forms at `:364`, `:413`, `:211`.
 
-### Device 2.0 (every kernel used) — **GREEN**
+- **Feature compatibility:** every Appendix A entry, in order. All `N/A`.
 
-Every kernel the op instantiates is structurally Device 2.0. No `InterleavedAddrGen` /
-`ShardedAddrGen` / `InterleavedAddrGenFast` / `InterleavedPow2AddrGen*`, no bare `noc_async_read` /
-`noc_async_write`, no `cb_reserve_back` / `cb_push_back` / `cb_wait_front` / `cb_pop_front`, no raw
-semaphore addresses, no `evil_set_*_ptr`. Every `get_write_ptr()` / `get_read_ptr()` in the op is a
-`DataflowBuffer` **method** on an in-scope wrapper (14 sites across 9 files), never the CB-index free
-function.
-
-Cross-op donor, also clear: `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`
-constructs a `DataflowBuffer` and a `Noc`, and reads its page size via
-`get_local_cb_interface(cb_id_out).fifo_page_size` (`:27`). `get_local_cb_interface(cb_id)` is on the
-audit's **sanctioned** free-function list, so this is **not** a holdover and does not knock the op out of
-Green — even though a wrapper is in scope and a wrapper method (`get_entry_size()`) exists. (Slice's own
-copy of that kernel already uses `dfb_out.get_entry_size()`,
-`device/kernels/dataflow/writer_unary_interleaved_start_id.cpp:26`.)
-
-No violations table — there are no violations.
-
-### Feature compatibility — **GREEN** (all entries `N/A`)
-
-| Feature | Status | Notes |
-|---|---|---|
-| GlobalCircularBuffer | N/A | No `GlobalCircularBuffer` type, `CreateGlobalCircularBuffer`, `global_circular_buffer.hpp` include, `CBDescriptor::global_circular_buffer` field, `remote_index(`, `remote_cb_*` identifier, `UpdateDynamicCircularBufferAddress`, or `num_global_cb_receivers` anywhere in the op. The two Buffer-backed CBs (`slice_program_factory_rm_sharded.cpp:290,302`) set only `.buffer` — the plain borrowed-memory pattern, which is a mechanical porting-recipe translation via `DataflowBufferSpec::borrowed_from`, not this entry. |
-| CBDescriptor `address_offset` (non-zero) | N/A | No `.address_offset`, `set_address_offset`, 4-arg `UpdateDynamicCircularBufferAddress`, or `cb_descriptor_from_sharded_tensor` in the op. The two `CBDescriptor`s that set `.buffer` leave `address_offset` defaulted to 0. (Note: the op's offset problem is a *host-folded pointer* — Type 2 below — **not** a CB `address_offset`; the two are different mechanisms and only the latter is this entry.) |
-| GlobalSemaphore | N/A | The op declares **no semaphores at all** — no `SemaphoreDescriptor`, no `CreateSemaphore`, no `GlobalSemaphore`, no `global_semaphore.hpp`. |
-
-Variadic CTA: no kernel calls `get_compile_time_arg_val` at a varying index — every CTA read is at a
-literal offset or a `TensorAccessorArgs<N>` constexpr chain.
-
-### Offset base pointers — **RED (Type 2 — accessor-fed offset arg)**, `SliceRmProgramFactory`
-
-**The fold** (`device/slice_program_factory_rm.cpp:43-50`):
-
-```cpp
-inline uint32_t slice_rm_reader_base_address(const Tensor& input, const ttnn::Shape& slice_start) {
-    const uint32_t begins_bytes = slice_start[-1] * input.element_size();
-    const auto src_buffer_alignment = input.buffer()->buffer_type() == BufferType::DRAM
-                                          ? ::hal::get_dram_alignment() : ::hal::get_l1_alignment();
-    const uint32_t misalignment = begins_bytes % src_buffer_alignment;
-    return input.buffer()->address() + begins_bytes - misalignment;   // :49  ← the fold
-}
-```
-
-Emitted as **reader RTA 0** at `slice_program_factory_rm.cpp:107`, and re-emitted on every cache hit at
-`:423` via `slice_rm_reader_dynamic_args` → `apply_dynamic_runtime_args` (`:389-390`).
-
-**The consumption — this is what makes it Type 2, not Type 1**
-(`device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:14,33,38`):
-
-```cpp
-const uint32_t src_addr = get_arg_val<uint32_t>(0);       // the base+offset value
-constexpr auto src_args = TensorAccessorArgs<0>();
-const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);   // ← offset IS the accessor base
-```
-
-The offset address is the `TensorAccessor`'s **base**, not a relocatable trailing `+` on a NoC address, so
-the mechanical Type-1 arg split does not apply. Metal 2.0's `TensorAccessor(tensor::name)` ctor takes the
-base implicitly from the binding's CRTA word and accepts **no** base override
-(`tt_metal/hw/inc/api/tensor/tensor_accessor.h:96-107` for the sharded specialisation, `:409-418` for the
-interleaved one — both delegate with the address only). There is no seam.
-
-- **Arg:** `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` — **reader RTA 0, role `src_addr`**.
-- **Offset expression:** `begins_bytes - misalignment`, where
-  `begins_bytes = slice_start[-1] * input.element_size()` and
-  `misalignment = begins_bytes % (DRAM ? dram_alignment : l1_alignment)`.
-  Deterministic from cache-miss inputs (`slice_start`, dtype, buffer type are all hashed), so this is a
-  real addressing pattern, not a one-off constant.
-- **Why the fold exists:** the kernel needs an *aligned* start below the requested byte offset, then
-  fixes up the residue on-device with a whole-stick `tt_memmove`
-  (`slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:97-101`), passing `misalignment` separately
-  as reader RTA 5. So the residue is *already* split out; only the aligned-multiple part is folded.
-- **Route:** **ops team** to refactor before the port, **and framework/Audrey — flag early.** The likely
-  shape (unsettled) is a plain `TensorAccessor` on the clean base plus kernel-side pointer manipulation,
-  weighed against a first-class tensor-view binding. The affected variant is row-major, matching the
-  recipe's characterisation of the wall as an RM phenomenon.
-
-**Other factories scanned — clean, and the reason each is clean matters:**
-
-| Factory | Address args | Verdict |
-|---|---|---|
-| `SliceRmShardedProgramFactory` | none — both tensors reach the kernel as borrowed-memory CBs (`.buffer = input.buffer()` / `output.buffer()`, `slice_program_factory_rm_sharded.cpp:290,302`). The width offset travels as a **separate CTA** (`begins_bytes`, `:310`) and is added kernel-side (`slice_reader_unary_unpad_dims_rm_sharded.cpp:69`). | ✓ clean — offset already split out |
-| `SliceRmStrideProgramFactory` | reader RTA 0 = `input_buffer`, writer RTA 0 = `output_buffer` — bare `Buffer*` bindings (`slice_program_factory_rm_stride.cpp:128,136,147,160`) | ✓ clean base |
-| `SliceTileProgramFactory` | reader CRTA 0 = `src0_buffer`, writer RTA 0 = `dst_buffer` (`slice_program_factory_tile.cpp:143,180`). The tile start offset rides a **clean tile-index scalar** (`start_offset` folded into `reader_args[0] = start_id`, `:97,119,125`) | ✓ clean base — the tiled variant the recipe predicts is unaffected |
-| `SliceTileTensorArgsProgramFactory` | reader CRTA 0/1/2 = `src_buffer` / `start_buffer` / `end_buffer`, writer RTA 0 = `dst_buffer` (`slice_program_factory_tile_tensor_args.cpp:182-184,151,168`). Start offset computed **on device** from the start tensor (`reader_..._tensor_args.cpp:85-112`) | ✓ clean base |
-
-No Type 1, no Type 3 (`address_offset`), no Type 4 (`ttnn::narrow` / interior-base `MeshBuffer::create`).
-Reconciliation against the checked-in triage doc was not possible (doc absent); this is a from-code scan
-of **every** address arg in all five factories, not a table lookup.
-
-### TensorAccessor 3rd argument — **RED (Class 3 / Special)** under B/W-sharding, Class 2 otherwise
-
-Only **two** accessors in the whole op pass a 3rd argument, and both belong to `SliceRmProgramFactory`.
-The other eleven `TensorAccessor` constructions in the op's kernels pass two arguments and are not this
-subject.
-
-| # | Site | Value | Host origin |
-|---|---|---|---|
-| A | `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:38` (`padded_stick_size`, reader RTA 1) | `per_shard_page_size_bytes(input, padded_row_size_bytes)` | `slice_program_factory_rm.cpp:102`, emitted `:108` |
-| B | `slice_writer_unary_stick_layout_interleaved_start_id.cpp:32` (`page_size_override`, writer RTA 7) | `per_shard_page_size_bytes(output, unpadded_row_size_bytes)` | `slice_program_factory_rm.cpp:171`, emitted `:181` |
-
-**Question 1 — sharded or interleaved?** Both. `SliceRmProgramFactory` is the catch-all row-major factory
-(`slice_device_operation.cpp:279-296`), so the same accessor is interleaved on some configs and sharded on
-others. The two specialisations read the argument differently, so the site must be classified per config.
-
-**Question 2 — magnitude.** `per_shard_page_size_bytes` (`data_movement/common/common.cpp:782-793`)
-returns three different things:
-
-| Input/output memory layout | Returned value | True `aligned_page_size` | Accessor specialisation | Class |
-|---|---|---|---|---|
-| Interleaved (DRAM or L1) | `row_bytes` = `padded_shape[-1] * E` = `buffer->page_size()` | `round_up(page_size, alignment)` | interleaved — realigns internally via `InterleavedAddrGen::aligned_page_size = align_power_of_2(page_size, allocator_alignment)` (`dataflow_api_addrgen.h:278-279`) | **2 — inert, drop** |
-| HEIGHT_SHARDED | `buffer()->aligned_page_size()` — *exactly* the default | same | sharded — verbatim | **2 — redundant, drop** |
-| **BLOCK_SHARDED / WIDTH_SHARDED** | `shard_spec.shape[1] * E` = `buffer->page_size()`, **unaligned** | `round_up(page_size, 16)` (L1) / DRAM alignment | **sharded — verbatim, no realignment net** | **3 / Special — GATE** |
-
-For row-major B/W-sharded tensors the buffer's page **is** the shard row
-(`page_config.cpp:111-118`: page width comes from the physical shard width; `tensor_layout.cpp:321-327`:
-the physical shard shape is the shard spec's shape unrounded), and the allocator strides pages at
-`align(page_size, alignment)` (`buffer.cpp:764`). The sharded `TensorAccessor` uses the passed value
-**verbatim** as that stride — `bank_start + bank_base_address + page_mapping.bank_page_offset *
-aligned_page_size + offset` (`tensor_accessor.h:307`). So whenever `shard_W * element_size` is not
-alignment-aligned, the accessor strides short and mis-addresses.
-
-**Why it is Special and not just a wrong value.** The override is *load-bearing by design*, and both
-kernels say so in comments (`..._rm_interleaved_start_id.cpp:36-37`,
-`..._stick_layout_...:20-21`): the value is consumed a second time inside the shared helpers
-`noc_async_read_sharded` / `noc_async_write_sharded`
-(`data_movement/common/kernels/common.hpp:375-409` / `:325-360`), which call
-`tensor.get_aligned_page_size()` (`:389` / `:340`) to split one logical row across shards:
-
-```cpp
-const uint32_t page_size = tensor.get_aligned_page_size();
-uint32_t sharded_src_id  = src_id * pages_per_row + offset / page_size;
-uint32_t sharded_offset  = offset % page_size;
-uint32_t read_size       = std::min(remaining, page_size - sharded_offset);   // ← wants the PAYLOAD size
-```
-
-The split arithmetic wants the page **payload** (`shard_W * E`); the accessor's addressing wants the page
-**stride** (`aligned_page_size`). One 3rd argument is being asked to be both. They coincide exactly when
-`shard_W * E % alignment == 0` — which is presumably why this has never been caught — and diverge
-otherwise. Metal 2.0 removes the override entirely (the binding-token ctors above supply
-`aligned_page_size` implicitly and offer no override), so the port cannot preserve today's behaviour on
-the B/W-sharded path even if that behaviour were correct.
-
-- **Class 2 (mechanical drop)** for interleaved and HEIGHT_SHARDED configs — both sites.
-- **Class 3 → GATE** for BLOCK_SHARDED / WIDTH_SHARDED configs, escalating to **Special** because the
-  intent (shard-relative payload paging) is not expressible through the binding model. Latent rather than
-  live: it is masked wherever the shard width happens to be alignment-aligned. I could not establish from
-  the code whether any shipped/tested config has `shard_W * element_size % 16 != 0`, so per the recipe's
-  "possibly-wrong-magnitude value gates" rule the site is **gated conservatively**.
-- **Route: ops team**, for both sites. The decision is theirs: confirm the override is redundant for
-  every reachable config (→ drops to Class 2 and the gate lifts), or fix the payload-vs-stride
-  conflation in the two shared `noc_async_*_sharded` helpers so the accessor can carry the true stride.
-  The helper fix is **outside the op** and would touch every data_movement caller of those helpers.
-
-No triage-doc cross-check was possible; this is a fresh classification. See *Questions*.
-
-### CB endpoints — **GATE-free**, all dispositions determined
-
-Device 2.0 is GREEN, so the census ran on intact Device-2.0 idioms — no deferral. Seven CB instances
-across the five factories; census per `(CB, config)`, per node:
-
-| Factory | CB | Touchers on a node | Verdict | Port-time resolution |
-|---|---|---|---|---|
-| `Rm` | `src0_cb_index = 0` (`slice_program_factory_rm.cpp:338-346`) | reader: `reserve_back`/`push_back` + own `get_write_ptr` peek → **1 locked producer**; writer: `wait_front`/`pop_front` + own `get_read_ptr` peek → **1 locked consumer** | **plain 1:1** | none — bind PRODUCER/CONSUMER as-is |
-| `RmSharded` | `c_0`, **borrowed from `input.buffer()`** (`:282-291`) | the single reader kernel, `get_write_ptr()` only (`slice_reader_..._rm_sharded.cpp:41`) — no FIFO ops → **1 role-free toucher** | **single-ended / sync-free** | **self-loop** — bind the reader PRODUCER **and** CONSUMER; plus `borrowed_from` the input |
-| `RmSharded` | `c_16`, **borrowed from `output.buffer()`** (`:294-303`) | the same single reader kernel: `reserve_back` / `get_write_ptr` / `push_back`, nothing drains (`:40-42,89`) → **1 locked producer** | **single-ended** | **self-loop**; plus `borrowed_from` the output |
-| `RmStride` | `in_cb = 0` (`slice_program_factory_rm_stride.cpp:69-77`) | reader (4d or nd) produces; writer (4d or nd) consumes | **plain 1:1** | none |
-| `Tile` | cb 0 (`slice_program_factory_tile.cpp:53-60`) | reader produces; writer consumes. Index reaches both kernels via `named_compile_time_args` `dfb_id_in` / `dfb_id_out` (`:139,161`) | **plain 1:1** | none |
-| `TileTensorArgs` | `src0_cb_index = 0` (`slice_program_factory_tile_tensor_args.cpp:56-64`) | reader produces; the **eltwise/unary donor** writer consumes | **plain 1:1** | none |
-| `TileTensorArgs` | `tensor_cb_index = 1` (`:65-73`) | the reader only, running a full `reserve_back`→`push_back`→`wait_front`→`pop_front` cycle twice as staging for the start/end tensors (`reader_..._tensor_args.cpp:52-83`) → **1 toucher, locked to both roles** | **single-ended (self-loop already in code)** | **self-loop** — bind the reader PRODUCER **and** CONSUMER |
-
-**Nothing here gates**, and the harder shapes are all absent:
-
-- **No dead CB.** Every allocated `buffer_index` is referenced by a bound kernel in every config;
-  each index was traced through its CTA / `named_compile_time_args` carrier to a real access.
-- **No hidden second writer.** Actively scanned every kernel that touches each CB for a
-  `get_write_ptr()` / `fifo_wr_ptr` write by a kernel that is not the CB's FIFO producer, gated by a
-  semaphore pair. There are **no semaphores anywhere in this op**, so the coordination mechanism that
-  face requires does not exist here.
-- **No multiple-readers face and no dual-instance work-split.** No factory pushes the same
-  `kernel_source` into two `KernelDescriptor`s; every kernel instance is unique per factory. No CB has
-  read sites in 2+ co-resident kernels beyond the ordinary producer/consumer pair.
-- **No config-dependent flip.** Each CB's census is the same across that factory's configs; no
-  conditional DFB is needed.
-
-One non-obvious `RmSharded` detail the porter should carry forward: `dfb_in.get_write_ptr()` (`:41`) is
-used as a **remote** L1 address — it is combined with *another core's* `noc_x`/`noc_y` (`:65,76`) to read
-that core's shard of the borrowed input buffer. That is legal precisely because the CB is
-`borrowed_from` the input buffer, so the local address is the same on every core the buffer occupies. It
-is a peek, not a second endpoint, and the census above already accounts for it.
-
----
-
-## Port-work summary  *(would mirror the brief — no brief is issued)*
-
-- **Tensor bindings** (per binding, per factory):
-  - `Rm` / `input` — **gated upstream** as the Type-2 offset base; *not* a Case 1/2 item. Do not classify
-    it as Case 1 or the offset silently vanishes.
-  - `Rm` / `output` — **Case 1** (writer RTA 0 `Buffer*` → `TensorAccessor(dst_args, dst_addr, ...)`).
-  - `RmSharded` / `input` — **clean** (borrowed-memory DFB read; `borrowed_from` the input buffer).
-  - `RmSharded` / `output` — **clean** (borrowed-memory DFB write; `borrowed_from` the output buffer).
-  - `RmStride` / `input`, `output` — **Case 1** each.
-  - `Tile` / `input`, `output` — **Case 1** each.
-  - `TileTensorArgs` / `input`, `start_tensor`, `end_tensor`, `output` — **Case 1** each (four bindings).
-  - **No Case 2 anywhere** — no kernel does hand-rolled arithmetic on a tensor base pointer, so no
-    `get_bank_base_address` bridge is needed.
-  - Delivery mechanism note: except for the `Rm` reader base, every address arrives as a `Buffer*`
-    binding pushed into an `RTArgList` / common-arg list. Because each factory defines
-    `override_runtime_arguments`, the adapter **bypasses** `resolve_bindings`
-    (`mesh_device_operation_adapter.hpp:449-455`), so those `Buffer*` entries only place the initial
-    value at cache-miss time — `patch_slice_program_addresses` is what actually re-points them on a hit.
-    Both mechanisms must be accounted for when the bindings become typed.
-- **TensorParameter relaxation:** `(legality - pending analysis)` on all five factories — blocked, ops team.
-- **TensorAccessor 3rd arg:** two sites (`Rm` reader `:38`, `Rm` writer `:32`) — Class 2 drop for
-  interleaved / HEIGHT_SHARDED, **blocked** (Class 3/Special) for BLOCK/WIDTH_SHARDED.
-- **CB endpoints:** self-loop `(RmSharded c_0, all configs)`, `(RmSharded c_16, all configs)`,
-  `(TileTensorArgs c_1, all configs)`; the remaining four CBs are plain 1:1. No dead-CB drop, no
-  multi-binding flag, no conditional DFB.
-- **`override_runtime_arguments` → `ProgramRunArgs` translation** (the `CustomProgramSpecFactoryConcept`
-  work), five methods funnelling into one shared 63-line patcher
-  (`slice_program_factory_rm_sharded.cpp:354-416`) that mixes three distinct patching mechanisms:
-  `apply_descriptor_runtime_args` on CB-address-only descriptors (`:363-367`), a raw
-  `GetRuntimeArgs` slot-0 poke with a "skip if the slot holds 0" heuristic (`:372-381`), and
-  `apply_dynamic_runtime_args` (`:390,404,412`). `slice_tile_dynamic_args`
-  (`slice_program_factory_tile.cpp:198-281`) and `slice_rm_reader_dynamic_args`
-  (`slice_program_factory_rm.cpp:405-433`) each **re-derive the work split** to stay in lockstep with
-  `create_descriptor` — duplication the `ProgramRunArgs` form should be able to collapse.
-  `<tt-metalium/experimental/program_descriptor_patching.hpp>` is included by all five factory `.cpp`s
-  and is self-described as the shim that Metal 2.0 deletes (`:8-19` of that header), so the port removes
-  every one of these calls.
-
----
-
-## Heads-ups  *(would mirror the brief — no brief is issued)*
-
-- **CB endpoints (multi-binding shapes to watch):** **none.** No CB in this op needs the multi-binding
-  advanced option; no hidden second writer exists (there are no semaphores to coordinate one). The three
-  out-of-window CBs are all one-toucher self-loops, listed in Port-work.
-- **Cross-op / shared kernels:**
-  - `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`
-    — instantiated by `SliceTileTensorArgsProgramFactory`
-    (`slice_program_factory_tile_tensor_args.cpp:133`). **A `_metal2` fork already exists beside it** at
-    `.../writer_unary_interleaved_start_id_metal2.cpp` — **bind that fork, do not create a second one.**
-    The legacy file's header comment names the sunset plan (issue **#52228**) and the consumer list.
-  - Broadly shared: ~25 other program factories instantiate the same legacy file (concat, tilize ×5,
-    transpose ×2, reshape_on_device, reduction ×4, matmul, embeddings, attn_matmul, nlp_concat_heads ×2,
-    gelu_bw, tanh_bw, examples ×2, plus tests and a programming example). That set is a
-    **sunset / coordination list, not authorization to convert the kernel in place.**
-  - Slice keeps its **own** copy of that kernel for the Tile factory
-    (`device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`) — same stem, different file,
-    slice-owned, no fork needed. Do not confuse the two; the Tile and TileTensorArgs factories point at
-    different files.
-  - **`ttnn/cpp/ttnn/operations/experimental/quasar/slice/` exists and is out of bounds.** It contains a
-    shortcut pre-port copy of this op (including a `slice_program_factory_rm_stride.cpp` that names the
-    same kernels). It is not a precedent, not a naming source, and not evidence that any construct here
-    is portable. Do not read it.
-- **RTA / CRTA varargs** — six genuine vararg sites; **prefer named args everywhere else**:
-  | Kernel | Site | Shape |
+  | Feature | Status | Notes |
   |---|---|---|
-  | `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | `:29-31` — three `num_dims`-length blocks via `get_arg_addr(13)`, `num_dims` from RTA 4 | RTA vararg |
-  | `slice_reader_unary_unpad_dims_rm_sharded.cpp` | `:26-30` — four blocks at **runtime-computed** offsets (`get_arg_addr(1 + num_cores_read * 2)`, `* 3`), variable count | RTA vararg (both recognition shapes) |
-  | `reader_unary_unpad_dims_interleaved_start_id.cpp` | `:17-18` — `2 * num_dims` CRTA block via `get_common_arg_addr(1)` | **CRTA** vararg (CTA-bounded still varies per instantiation) |
-  | `reader_unary_unpad_dims_interleaved_start_id.cpp` | `:23` — `num_dims`-length `id_per_dim` block via `get_arg_addr(2)` | RTA vararg |
-  | `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | `:25-26,31,91-92` — `3 * num_dims` CRTA span, one read at the runtime offset `get_common_arg_addr(3 + 2 * num_dims)`, plus the `id_per_dim` RTA block | CRTA + RTA vararg |
-  | `reader_multicore_slice_nd.cpp` / `writer_multicore_slice_nd.cpp` | reader `:73-88` (five `tensor_rank`-length blocks, running offset), writer `:73` (one block) — `tensor_rank` is an **RTA** | RTA vararg |
-  The two `*_4d.cpp` kernels are the counter-case: a fixed `rt_args_idx++` run over a constant field set
-  (`reader_multicore_slice_4d.cpp:52-77`, `writer_multicore_slice_4d.cpp:52-61`) → **name every one of
-  those**, they are not varargs.
-- **A vararg block is mutated in place by the kernel.** `id_per_dim` is written back into the runtime-arg
-  region as the reader walks dimensions — `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:76-78`,
-  `reader_unary_unpad_dims_interleaved_start_id.cpp:45-48`,
-  `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:124-127`, and the analogous `coords[]`
-  copy in `reader_multicore_slice_nd.cpp:103-105`. The arg region is being used as writable scratch that
-  must be re-initialised every dispatch. Confirm the vararg mechanism preserves that (and see the
-  related latent bug in *Misc anomalies* — do **not** carry today's behaviour forward as intended).
-- **`ccl/mesh_partition` is a second consumer of this op's factory API** — host-side, and the recipe's
-  coupling buckets do not cover it. `mesh_partition_program_factory.cpp:123-136` calls
-  `SliceOp::validate_on_program_cache_miss`, `SliceOp::select_program_factory` and then
-  `Factory::create_descriptor` for whichever slice factory is selected; `:149-156` calls
-  `ttnn::prim::patch_slice_program_addresses`; and `mesh_partition_device_operation.hpp:47-52` stores a
-  `prim::SliceDeviceOperation::program_factory_t` in its own `shared_variables_t`. Changing
-  `create_descriptor` → the spec entry point and deleting the patcher **breaks mesh_partition** unless it
-  is ported or adapted in the same change. mesh_partition is itself `legacy (MeshWorkload)` with
-  `Is able to port? = no` on the sheet, so the two cannot simply be ported together today.
-- **`const` vs `constexpr` at two CTA reads** — `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:15-16`
-  declares `tile_width` / `tile_height` as `const uint32_t` (not `constexpr`) from
-  `get_compile_time_arg_val`. That distinction decides token-form vs member-getter for the port; confirm
-  rather than swapping blind.
-- **`named_compile_time_args` is already in use** for CB indices on the Tile factory
-  (`slice_program_factory_tile.cpp:139,161` → `get_named_compile_time_arg_val("dfb_id_in"/"dfb_id_out")`),
-  with a stated fusion-remapping motive. Two of the op's kernels are therefore already part-modernised:
-  the port there is a binding-layer change, not an idiom rewrite. The other three factories still pass CB
-  indices positionally.
+  | GlobalCircularBuffer | **N/A** | Grepped the whole op for `GlobalCircularBuffer`, `CreateGlobalCircularBuffer`, the `global_circular_buffer` `CBDescriptor` field, `remote_index(`, `remote_cb_*`, `remote_circular_buffer.h`, `UpdateDynamicCircularBufferAddress`, `num_global_cb_receivers` — **zero hits**. The two Buffer-backed CBs (`slice_program_factory_rm_sharded.cpp:290,302`) set only `.buffer` — the plain borrowed-memory pattern, a mechanical porting-recipe translation via `DataflowBufferSpec::borrowed_from`, not this entry. |
+  | CBDescriptor `address_offset` (non-zero) | **N/A** | No `.address_offset`, no `set_address_offset`, no 4-arg `UpdateDynamicCircularBufferAddress`, no `cb_descriptor_from_sharded_tensor` anywhere in the op. All 7 `CBDescriptor`s leave `address_offset` defaulted to 0 — including the two that set `.buffer`. |
+  | GlobalSemaphore | **N/A** | The op declares **no semaphores at all** — no `SemaphoreDescriptor`, no `CreateSemaphore`, no `GlobalSemaphore`, no `global_semaphore.hpp`. A grep for `Semaphore` / `semaphore` across the op returns nothing. |
 
----
+- **CB endpoints (GATE-free):** every CB is either plain 1:1 or a one-toucher self-loop. Full
+  per-`(CB, config)` census, counting **every** access (FIFO ops *and* raw-pointer peeks), per node:
+
+  | Factory / config | CB | Touchers on a node | Verdict | Resolution |
+  |---|---|---|---|---|
+  | `SliceRm` (both the chunked and non-chunked paths) | `c_0` (`…_rm.cpp:322`) | reader `reserve_back`/`push_back` (+ own-binding `get_write_ptr` peek) = **locked producer**; writer `wait_front`/`pop_front` (+ `get_read_ptr` peek) = **locked consumer** | **plain 1:1** | bind 1 PRODUCER + 1 CONSUMER — no flag |
+  | `SliceRmSharded` | `c_0`, **borrowed** from `input.buffer()` (`…_rm_sharded.cpp:282,290`) | reader only, and only `dfb_in.get_write_ptr()` (`slice_reader_…_rm_sharded.cpp:41`) — a raw peek, **no FIFO ops** → **role-free**, 1 toucher | **single-ended / sync-free** | **self-loop** (bind the reader PRODUCER *and* CONSUMER) |
+  | `SliceRmSharded` | `c_16`, **borrowed** from `output.buffer()` (`…_rm_sharded.cpp:294,302`) | reader only: `reserve_back`(`:40`) / `get_write_ptr`(`:42`) / `push_back`(`:89`) → locked producer, 1 toucher, **nothing drains it** | **single-ended** | **self-loop** |
+  | `SliceRmStride` rank ≤ 4 | `c_0` (`…_rm_stride.cpp:69`) | `reader_multicore_slice_4d.cpp` produces (`:152,153,179`); `writer_multicore_slice_4d.cpp` consumes (`:81,82,93`) | **plain 1:1** | 1 PRODUCER + 1 CONSUMER |
+  | `SliceRmStride` rank > 4 | `c_0` (same descriptor) | `reader_multicore_slice_nd.cpp` produces (`:137,138,166`); `writer_multicore_slice_nd.cpp` consumes | **plain 1:1** | 1 PRODUCER + 1 CONSUMER |
+  | `SliceTile` | `c_0` (`…_tile.cpp:53-60`) | reader produces (`reader_unary_unpad_dims_interleaved_start_id.cpp:39,42`); slice's own writer consumes (`writer_unary_interleaved_start_id.cpp:48,50`) | **plain 1:1** | 1 PRODUCER + 1 CONSUMER |
+  | `SliceTileTensorArgs` | `c_0` (`…_tile_tensor_args.cpp:56`) | reader produces (`…_tensor_args.cpp:117,120`); **eltwise donor** writer consumes | **plain 1:1** | 1 PRODUCER + 1 CONSUMER |
+  | `SliceTileTensorArgs` | `c_1` — the start/end staging scratchpad (`…_tile_tensor_args.cpp:65`) | reader **only**, but it runs a full handshake on both sides: `reserve_back`/`get_write_ptr`/`push_back`/`wait_front`/`pop_front` twice (`…_tensor_args.cpp:52-59,66,69-76,83`) → 1 toucher holding both roles | **single-ended** | **self-loop** — the legacy code already behaves as one; the kernel body is untouched |
+
+  **Hidden-second-writer hunt (face a): none — and the mechanism is structurally absent.** The face
+  requires a raw co-fill coordinated by a dedicated semaphore pair; **this op has no semaphores at
+  all**, so there is nothing to coordinate one. Every `get_write_ptr()` / `get_read_ptr()` in the op was
+  individually attributed to the kernel that already holds that CB's FIFO role (a peek on its own
+  binding) or, in `SliceRmSharded`, to the *sole* toucher.
+
+  **Multiple-readers hunt (face b): none.** No CB is read by 2+ co-resident kernels. `SliceRmSharded`'s
+  borrowed input CB comes closest — it is a sync-free borrowed tensor view read by base pointer — but
+  that factory instantiates **exactly one kernel**, so the census is 1.
+
+  **Dual-instance work-split hunt (face c): none.** No factory pushes the same `kernel_source` into two
+  `KernelDescriptor`s; every factory's reader and writer are distinct sources, and `SliceRmSharded` has
+  a single kernel. So no CB has two co-resident same-source touchers.
+
+  **No dead CB.** All 7 `buffer_index` values are referenced by a bound kernel in every config — traced
+  through the indirection the recipe warns about: positional CTAs (`…_rm.cpp:332` → writer CTA 0),
+  **named** CTAs (`…_tile.cpp:139,161` → `get_named_compile_time_arg_val("dfb_id_in"/"dfb_id_out")`),
+  and `tt::CBIndex` constants baked kernel-side (`slice_reader_…_rm_sharded.cpp:32,33`). Nothing is
+  allocated-and-untouched, so there is no drop and no conditional DFB.
+
+- **Offset base pointers:** **GREEN — the triage doc is stale for `slice`.**
+
+  `analyses/2026-07-19_offset_base_pointers.md` lists `slice` under **Type 2 — accessor-fed offset arg**
+  (its table row: `slice_program_factory_rm.cpp`, *"reader RTA[0] — input base"*, offset expression
+  `input->address() + begins_bytes − misalignment`, caveat *"the canonical case"*). Type 2 is the
+  hardest gate in that subject — ops team **plus** framework, flag early. **It no longer applies.**
+
+  The recognition scan was run on **every** address RTA in the op, independently of the doc. Result:
+  **every `->address()` in the op is a bare base with no arithmetic** — the five sites are all inside
+  `patch_slice_program_addresses` (`slice_program_factory_rm_sharded.cpp:381,389,395,398,399`), the
+  `override_runtime_arguments` refresh path, not a host fold. And in `create_descriptor` the base does
+  not travel as an address at all: it is pushed as a **`Buffer*` binding**
+  (`…_rm.cpp:377,385`; `…_rm_stride.cpp:128,136,147,160`; `…_tile.cpp:143,180`;
+  `…_tile_tensor_args.cpp:151,168,182,183,184`).
+
+  The offset has been **split out into a separate scalar arg**, exactly the shape the recipe describes
+  as the Type-1 remedy — and here applied to what the doc had catalogued as Type 2:
+
+  - Host emits it as its own RTA: `begins_bytes - misalignment` at `slice_program_factory_rm.cpp:103`,
+    the last element of `common_reader_kernel_args`.
+  - Kernel reads it as its own argument: `src_offset_bytes = get_arg_val<uint32_t>(13)`
+    (`slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:30`).
+  - The accessor is built on the **unshifted** base: `TensorAccessor(src_args, src_addr, padded_stick_size)`
+    (`:43`) — `src_addr` is RTA 0, the bare `Buffer*`-bound base.
+  - The shift is applied **per read**, as the accessor's own `offset` parameter, never to the base:
+    `:67` (`offset = src_offset_bytes + cur * chunk_size`) and `:101`
+    (`/*offset=*/src_offset_bytes`), both reaching `noc.async_read(…, {.page_id, .offset_bytes})`.
+
+  The kernel says so in a comment at `:41-42` — *"The accessor base stays the unshifted buffer base:
+  Metal 2.0 supplies it from the tensor binding and offers no seam for a pre-offset base. The W-begin
+  shift rides each read as `src_offset_bytes`."*
+
+  This is the recipe's **third reconciliation outcome** — *fold absent, op in the tables → the doc is
+  stale → GREEN* — and the op drops to ordinary tensor-binding port work (Case 1 on the now-clean
+  base). No Type 1, no Type 2, no Type 3 (`address_offset` — Appendix A, absent), no Type 4
+  (`ttnn::narrow` / interior-base `MeshBuffer::create` — absent).
+
+  Beyond the RM path, the other factories never had a fold: `SliceTile` and `SliceTileTensorArgs` pass
+  the start offset as a clean **tile-index scalar** folded into `start_id`
+  (`…_tile.cpp:97,119,125`; `…_tile_tensor_args.cpp:112` computes it *on-device* from the start
+  tensor), and `SliceRmSharded` passes `begins_bytes` as a **CTA** (`…_rm_sharded.cpp:310`) that the
+  kernel adds to a local L1 offset (`slice_reader_…_rm_sharded.cpp:69`), never to a tensor base.
+
+  → **Routing:** nothing to route. Suggest the triage-doc owner retire `slice`'s Type-2 row.
+
+- **`TensorAccessor` 3rd argument:** **GREEN — two sites, both Class 2 (mechanical drop).**
+
+  Only two of the op's twelve accessor constructions pass a 3rd argument; the other ten omit it.
+
+  | Site | 3rd arg | Host value |
+  |---|---|---|
+  | `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:43` | `padded_stick_size` (RTA 1) | `per_shard_page_size_bytes(input_tensor, padded_row_size_bytes)` — `slice_program_factory_rm.cpp:86` |
+  | `slice_writer_unary_stick_layout_interleaved_start_id.cpp:32` | `page_size_override` (RTA 7) | `per_shard_page_size_bytes(output_tensor, unpadded_row_size_bytes)` — `slice_program_factory_rm.cpp:155` |
+
+  Both are in `SliceRmProgramFactory`, whose tensors may be interleaved **or** sharded, so the
+  load-bearing question — *which specialization?* — has three answers. `per_shard_page_size_bytes`
+  (`data_movement/common/common.cpp:782`) resolves them:
+
+  1. **Interleaved** → returns `row_bytes`, i.e. the tensor's true logical page
+     (`input_shape[-1]·E` for the reader, `output_shape[-1]·E` for the writer). Correct magnitude, on an
+     **interleaved** accessor, which realigns the value up to the allocator alignment → **inert. Class 2.**
+  2. **HEIGHT-sharded** → returns `t.buffer()->aligned_page_size()` — literally the value Metal 2.0
+     supplies implicitly (`TensorAccessorArgs::AlignedPageSize`, itself
+     `buffer.aligned_page_size()`: `tt_metal/impl/buffers/tensor_accessor_args.cpp:179-185`).
+     `== aligned_page_size` → **Class 2.**
+  3. **BLOCK/WIDTH-sharded** → returns `shard_spec.shape[1] · element_size`, which for a sharded RM
+     tensor *is* `buffer->page_size()` (page shape is `{1, physical_shard_width}`:
+     `tt_metal/impl/tensor/spec/layout/page_config.cpp:111-117`). `buffer->page_size()` is on the
+     recipe's **correct-magnitude** list → **Class 2.**
+
+  Neither site is Class 1: the page size cannot vary across a cache-reused shape, because
+  `compute_program_hash` folds in `input.padded_shape()`, `input.memory_config()`, and the output
+  spec's `padded_shape()` / `memory_config()` (`slice_device_operation.cpp:365-408`), so any change in
+  row width or shard width lands in a different cache entry. The 2026-07-06 triage doc classifies
+  `slice (interleaved RM path)` as *"1 — Dynamic page size (+ **S** base-offset)"*; **both halves are
+  now stale** — the `S` base-offset is the fold that has since been split out (above), and the
+  hash work removed the dynamism that made it Class 1. Per the subject's *"your own read is the source
+  of truth"* rule, the from-code read decides: **Class 2, drop the arg, no `dynamic_tensor_shape`.**
+
+  → **Port action:** drop both 3rd arguments; the accessor then takes `aligned_page_size` implicitly.
+  In every configuration where the op is correct today the passed value *equals* that implicit value,
+  so the drop is behaviour-preserving. **One sub-case is worth the porter confirming rather than
+  swapping blind, and is raised as a question below** — see *Questions* #1.
+
+## Port-work summary  *(mirrors the brief)*
+
+- **Tensor bindings** (per binding, 12 total — 10 Case 1, 2 clean, 0 Case 2):
+
+  | Factory | Binding | Delivery today | Kernel use | Case |
+  |---|---|---|---|---|
+  | `SliceRm` | `input` | `Buffer*` @ reader RTA 0 (`…_rm.cpp:377`) | `TensorAccessor(src_args, src_addr, …)` (`:43`) | **1** |
+  | `SliceRm` | `output` | `Buffer*` @ writer RTA 0 (`…_rm.cpp:385`) | `TensorAccessor(dst_args, dst_addr, …)` (`:32`) | **1** |
+  | `SliceRmSharded` | `input` | **no address arg** — CB `c_0` borrowed from `input.buffer()` | `dfb_in.get_write_ptr()` + remote NOC coords (`slice_reader_…_rm_sharded.cpp:41,65,76`) | **clean** (borrowed-memory DFB; causal-link gate) |
+  | `SliceRmSharded` | `output` | **no address arg** — CB `c_16` borrowed from `output.buffer()` | `dfb_out.get_write_ptr()` (`:42`) | **clean** |
+  | `SliceRmStride` | `input` | `Buffer*` @ reader RTA 0 (`:128`/`:147`) | `TensorAccessor(src_args, src_addr)` (4d `:89`, nd `:94`) | **1** |
+  | `SliceRmStride` | `output` | `Buffer*` @ writer RTA 0 (`:136`/`:160`) | `TensorAccessor(dst_args, dst_addr)` (4d `:72`, nd) | **1** |
+  | `SliceTile` | `input` | `Buffer*` @ reader **CRTA 0** (`…_tile.cpp:143`) | `TensorAccessor(src_args, src_addr)` (`:26`) | **1** |
+  | `SliceTile` | `output` | `Buffer*` @ writer RTA 0 (`…_tile.cpp:180`) | `TensorAccessor(dst_args, dst_addr)` (`:36`) | **1** |
+  | `SliceTileTensorArgs` | `input` | `Buffer*` @ reader CRTA 0 (`:182`) | `TensorAccessor(src_args, src_addr)` (`:33`) | **1** |
+  | `SliceTileTensorArgs` | `start_tensor` | `Buffer*` @ reader CRTA 1 (`:183`) | `TensorAccessor(start_args, start_addr)` (`:44`) | **1** |
+  | `SliceTileTensorArgs` | `end_tensor` | `Buffer*` @ reader CRTA 2 (`:184`) | `TensorAccessor(end_args, end_addr)` (`:45`) | **1** |
+  | `SliceTileTensorArgs` | `output` | `Buffer*` @ writer RTA 0 (`:151`/`:168`) | `TensorAccessor(dst_args, dst_addr)` (donor `:35`) | **1** |
+
+  **No Case 2 anywhere.** `SliceRmSharded`'s reader does raw address arithmetic, but on **L1 CB
+  pointers** obtained from a borrowed DFB — not on a tensor base — so it is the clean borrowed-memory
+  path, not a raw-pointer tensor consumption. And **none of the 12 is the silent-wrong hazard**: every
+  one arrives as a `Buffer*` binding, which the framework already patches on cache hits. This is
+  routine port work, not a correctness fix. The same `TensorParameter` is **clean in `SliceRmSharded`
+  and Case 1 elsewhere** — the per-factory split the recipe anticipates.
+
+- **TensorParameter relaxation:** **`none`** (verbatim, all five rows) — the port applies no
+  relaxation, and no `analyses/relaxations/data_movement_slice.md` is needed or expected.
+- **`TensorAccessor` 3rd arg:** drop the redundant page-size arg at
+  `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:43` and
+  `slice_writer_unary_stick_layout_interleaved_start_id.cpp:32`. Class 2 → no `dynamic_tensor_shape`.
+- **CB endpoints:** self-loop `c_0` and `c_16` in `SliceRmSharded`, and `c_1` in
+  `SliceTileTensorArgs`; the remaining four CBs are plain 1:1. No multi-binding flag, no dead-CB drop,
+  no conditional DFB.
+
+## Heads-ups  *(mirrors the brief)*
+
+- **CB endpoints (multi-binding shapes to watch):** **none.** No CB in this op reaches ≥3 touchers or
+  doubles a FIFO role, and the hidden-second-writer face is structurally absent (no semaphores).
+- **Cross-op / shared kernels:**
+  - `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` — cross-family
+    **borrowed** kernel, bound by `SliceTileTensorArgs` (`…_tile_tensor_args.cpp:133`). **A `_metal2`
+    fork already exists beside it** at
+    `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp` (a true
+    locational sibling, not under `experimental/quasar/`). → **Rung 1: reuse it.** Its interface, which
+    becomes slice's constraint: DFB `dfb::out`, tensor `tensor::dst`, named args `args::num_pages`,
+    `args::start_id`. That maps exactly onto what the factory supplies today
+    (`{dst_buffer, num_tiles_per_core, num_tiles_written}`). It gates `#ifdef OUT_SHARDED` and
+    `#ifdef BACKWARDS`; slice sets **no** `defines`, so neither fires — the same as today.
+  - Slice's **own** copy, `device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`, is bound by
+    `SliceTileProgramFactory` **and by nothing else** (verified: no file outside the slice directory
+    references the slice kernels path). It is neither borrowed nor lent → **no fork needed; convert in
+    place.** Do **not** be tempted to redirect `SliceTile` onto the shared `_metal2` fork: slice's copy
+    exists precisely because it takes its DFB index from a **named** CTA
+    (`get_named_compile_time_arg_val("dfb_id_out")`, `…_tile.cpp:161`) so the fusion infrastructure can
+    remap it — a capability the shared fork does not have.
+  - **Sunset list** for the eltwise legacy copy — *coordination and sunset tracking only, **not**
+    authorization to convert it in place*: at least 15 factories bind that path today, among them
+    `data_movement/concat`, `data_movement/reshape_on_device`, five `data_movement/tilize` factories,
+    `eltwise/unary_backward/tanh_bw`, `embedding`, `examples/example` (×2),
+    `experimental/matmul/attn_matmul`, `experimental/transformer/nlp_concat_heads`(+`_boltz`), plus
+    `SliceTileTensorArgs`. A filename-level census returns ~44 factories, but many of those bind their
+    own same-named private copy (slice itself is one), so the bound *path* is what counts. Tracked
+    upstream as **issue #52228**, which also records a **second, duplicate** `_metal2` fork at
+    `copy/typecast/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp` (names its
+    accessor `tensor::output`); the eltwise-sited fork is the one to bind.
+- **RTA varargs:** six kernels carry genuine variable-count blocks. Named args stay the default for
+  everything else — the fixed `arg_index++` runs below are explicitly **not** varargs.
+
+  | Kernel | Site | Shape | Verdict |
+  |---|---|---|---|
+  | `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | `:32-34` (`get_arg_addr(14)`) | three blocks of `num_dims` each (`num_unpadded_sticks`, `num_padded_sticks`, `id_per_dim`), where `num_dims` is **RTA 4** — a runtime value | **RTA vararg** |
+  | `slice_reader_unary_unpad_dims_rm_sharded.cpp` | `:26-30` (`get_arg_addr(1)`, `get_arg_addr(1 + num_cores_read*2)`, `get_arg_addr(1 + num_cores_read*3)`, `chunk_start_id + 1`) | interleaved noc-x/y pairs and per-core chunk descriptors, all indexed off the runtime `num_cores_read` (RTA 0) — count-driven **and** data-selected | **RTA vararg** — the most involved case in the op |
+  | `reader_multicore_slice_nd.cpp` | `:73-87` | **five** consecutive `tensor_rank`-length blocks (`input_dims`, `output_dims`, `slice_starts`, `slice_ends`, `slice_steps`), `rt_args_idx += tensor_rank` between each | **RTA vararg** |
+  | `writer_multicore_slice_nd.cpp` | `:73` | one `tensor_rank`-length block (`output_dims`) | **RTA vararg** |
+  | `reader_unary_unpad_dims_interleaved_start_id.cpp` | `:17-18` (`get_common_arg_addr(1)`), `:23` (`get_arg_addr(2)`) | `2·num_dims` **CRTA** block + `num_dims` **RTA** block. `num_dims` is a CTA (`:13`), which per the recipe **still** makes it a vararg — it varies across instantiations | **CRTA vararg + RTA vararg** |
+  | `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | `:25-26` (`get_common_arg_addr(3)`), `:92` (`get_common_arg_addr(3 + 2*num_dims)`), `:31` (`get_arg_addr(2)`) | `2·num_dims` + `num_dims` CRTA blocks (the second at a **computed** offset) + `num_dims` RTA block | **CRTA vararg + RTA vararg** |
+
+  **Not varargs — name these:** `reader_multicore_slice_4d.cpp:52-77` (a fixed run of **25** distinct
+  fields via `rt_args_idx++`) and `writer_multicore_slice_4d.cpp:52-61` (**9** fields), plus every
+  scalar ahead of a vararg block elsewhere (`src_addr`, `num_dims`, `start_id`, `num_tiles`,
+  `tensor_rank`, `element_size`, `num_rows_for_this_core`, `start_row_for_this_core`, and the
+  `SliceRm` writer's full 11-arg fixed set). A sequential counter over a fixed set is legacy positional
+  plumbing, not a loop.
+
+  **CTA varargs: none.** Every `get_compile_time_arg_val` in the op uses a literal constant index; no
+  count-driven compile-time-arg loop exists, so `KernelAdvancedOptions::compile_time_varargs` is not
+  needed.
+- **`ccl/mesh_partition` drives slice's factories from outside the op directory — the port will break
+  its build.** `ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp`
+  calls `SliceOp::validate_on_program_cache_miss` and `SliceOp::select_program_factory` (`:126-127`),
+  then `Factory::create_descriptor(...)` on whichever slice factory it selects (`:131`), wraps the
+  result in a `Program`, and refreshes it through `ttnn::prim::patch_slice_program_addresses` (`:155`).
+  `patch_slice_program_addresses` is *deliberately* shared for this — see its comment at
+  `slice_program_factory_rm_sharded.cpp:350-353` and
+  `mesh_partition_device_operation.hpp:47`. On the readiness sheet `ccl/mesh_partition` is
+  `Concept = legacy (MeshWorkload)` with `Is able to port? = no` and
+  `Porting Target = TBD (SPMD + coord args issue)`, so it **cannot co-migrate**. Details and options in
+  *Team-only*.
+- **The `id_per_dim` vararg block is written in place by the kernel**, not just read:
+  `slice_reader_…_rm_interleaved_start_id.cpp:80`, `reader_unary_unpad_dims_interleaved_start_id.cpp:45`,
+  `…_tensor_args.cpp:124`. Confirm the vararg mechanism gives a **writable** L1 view before assuming a
+  read-only one; the host relies on it (it seeds the block per core and the kernel advances it).
+- **`SliceRmSharded` reads a remote core's L1 at the address of its *own* borrowed CB.** The kernel
+  takes `l1_read_addr = dfb_in.get_write_ptr()` (`:41`) — a **local** pointer into its own borrowed
+  input CB — and then uses that same value as the `.addr` of reads targeting *other* cores
+  (`:65`, `:76`). That is correct only because a sharded CB lands at the same L1 offset on every core
+  in the range. Preserve the borrowed-from binding for `c_0` so the invariant survives; it is not
+  obvious from the call site.
+- **Two kernels are already part-modernized, so their port is a binding-layer change, not an idiom
+  rewrite.** `reader_unary_unpad_dims_interleaved_start_id.cpp` already uses
+  `get_named_compile_time_arg_val("dfb_id_in")` (`:12`), `dfb_in0.get_entry_size()` (`:33`) rather than
+  `get_tile_size(cb)`, and passes the DFB object straight into `noc.async_read(s0, dfb_in0, …)`
+  (`:40`); slice's own `writer_unary_interleaved_start_id.cpp` is the same shape. The host side already
+  emits `named_compile_time_args` for both (`…_tile.cpp:139,161`).
+- **A `constexpr`-vs-`const` detail that decides token-form vs member-getter:**
+  `…_tensor_args.cpp:15-16` declares `tile_width` / `tile_height` as **`const`** (not `constexpr`)
+  while reading them from `get_compile_time_arg_val(3)` / `(4)`; every other CTA in that file is
+  `constexpr`. Check which form the named-CTA replacement needs before swapping.
 
 ## Team-only
 
-### Out-of-directory coupling & donor shape
+- **Out-of-directory coupling & donor shape.**
 
-**Op-level roll-up (function-call escape): `✓ clean.`** Exactly one out-of-directory header is included by
-the op's kernels, it is in-family, and every function it exposes to slice takes Device 2.0-native
-handles.
+  **Op-level roll-up: ✓ clean.** No donor call shape needs work, and no donor blocks scheduling.
 
-| Op kernel | Donor file | Class | Status |
-|---|---|---|---|
-| `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp` | `ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp` | 5 — in-family shared | ✓ |
-| `slice_writer_unary_stick_layout_interleaved_start_id.cpp` | same | 5 | ✓ |
-| `reader_multicore_slice_4d.cpp` | same | 5 | ✓ |
-| `writer_multicore_slice_4d.cpp` | same | 5 | ✓ |
-| `reader_multicore_slice_nd.cpp` | same | 5 | ✓ |
-| `writer_multicore_slice_nd.cpp` | same | 5 | ✓ |
-| `slice_reader_unary_unpad_dims_rm_sharded.cpp` | *(none — `tt_metal/*` only)* | 1 | ✓ |
-| `reader_unary_unpad_dims_interleaved_start_id.cpp` | *(none)* | 1 | ✓ |
-| `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp` | *(none)* | 1 | ✓ |
-| `writer_unary_interleaved_start_id.cpp` (slice copy) | *(none)* | 1 | ✓ |
-| `eltwise/unary/.../writer_unary_interleaved_start_id.cpp` (donor) | *(none)* | 1 | ✓ |
+  *Function-call escape.* Every `#include` across the nine slice kernels resolves to one of two places:
 
-Every other include across all nine kernels resolves under `tt_metal/hw/inc/api/*`
-(`dataflow_api.h`, `noc.h`, `dataflow_buffer.h`, `core_local_mem.h`, `endpoints.h`,
-`tensor/noc_traits.h`) — bucket 1, no concern.
+  | Slice kernel(s) | Donor | Class | Status |
+  |---|---|---|---|
+  | all nine | `api/dataflow/dataflow_api.h`, `api/dataflow/noc.h`, `api/dataflow/dataflow_buffer.h`, `api/dataflow/endpoints.h`, `api/core_local_mem.h`, `api/tensor/noc_traits.h` | 1 — `tt_metal/*` LLK / HAL | ✓ no concern |
+  | `slice_reader_…_rm_interleaved_start_id.cpp`, `slice_writer_…_stick_layout_…`, `reader_multicore_slice_4d/nd`, `writer_multicore_slice_4d/nd` | `ttnn/operations/data_movement/common/kernels/common.hpp` | 5 — **in-family shared** (`data_movement`) | ✓ clean |
 
-**Per-call detail** (`data_movement/common/kernels/common.hpp`), three functions called:
+  Per-call shape analysis for the one non-framework donor (71 files across the tree include it, so it
+  is broadly shared in-family):
 
-| Function | Signature shape | Status |
-|---|---|---|
-| `noc_async_read_sharded(Noc, uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size)` (`:375`) | **Shape 1** — `TensorAccessor<DSpec>` by value, plus a `Noc` | ✓ excellent — porter constructs `TensorAccessor(tensor::name)` and passes it |
-| `noc_async_write_sharded(...)` (`:325`) | **Shape 1** — same | ✓ excellent |
-| `tt_memmove<...>(Noc, uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t bytes)` (`:143`) | plain L1 addresses + `Noc`; no CB / semaphore / accessor handle | ✓ no bridge needed |
+  | Function | Signature shape | Status |
+  |---|---|---|
+  | `noc_async_read_sharded(Noc, uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size)` (`:375`) | **Shape 1** — `TensorAccessor<DSpec>` by value (template) + `Noc` | ✓ excellent — porter constructs `TensorAccessor(tensor::name)` and passes it |
+  | `noc_async_write_sharded(...)` (`:325`) | **Shape 1** — same | ✓ excellent |
+  | `tt_memmove<…>(Noc, uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t bytes)` (`:143`) | plain L1 addresses + `Noc`; carries **no** CB, semaphore, or accessor handle | ✓ no bridge needed |
 
-No `uint32_t sem_id`, no `uint32_t`/`uint64_t` sem address, no `TensorAccessorArgs<N>` parameter, no CTA
-offset as NTTP, no old-style addr-gen, no `CircularBuffer&`, no `DataflowBuffer&` parameters. Nothing
-starred. The deprecated no-`Noc` overloads of both `noc_async_*_sharded` (`:363`, `:411`) exist in the
-donor but slice calls the `Noc`-first form everywhere.
+  No `uint32_t sem_id`, no `uint32_t sem_addr` / `uint64_t` NOC-encoded semaphore, no
+  `TensorAccessorArgs<N>`, no tensor-CTA-offset NTTP, no old-style addr-gen, and — the row that is easy
+  to read backwards — **no `CircularBuffer` / `CircularBuffer&` parameter anywhere**. Per-call detail is
+  therefore complete above; there is no ⚠ / ✗ / ⭐ entry to expand.
 
-Note for the framework/ops discussion in *TensorAccessor 3rd argument*: these two helpers are the reason
-the 3rd-arg override exists, and their internal use of `get_aligned_page_size()` for **both** the page
-stride and the per-page payload size is where that gate's root cause sits. Fixing it there is a
-data_movement-wide change, not a slice change.
+  *File-path kernel instantiation (borrowed kernel files).* One entry, covered in *Heads-ups*:
+  `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` (owner: `eltwise/unary`;
+  broadly shared — ≥15 binding factories; `_metal2` fork **already checked in** beside it → rung 1
+  reuse). Slice owns its other eight kernels and lends none of them.
 
-**Borrowed kernel files (file-path instantiation):**
+  *Host-side coupling — `ccl/mesh_partition` (the significant one).* This is not a kernel escape, so no
+  subject owns it, but it is the largest cross-op consequence of this port. `MeshPartition` reuses
+  slice's device-op statics and factories wholesale (`mesh_partition_program_factory.cpp:31,126-134,155`),
+  and shares `patch_slice_program_addresses` so the RTA slot layout has exactly one home. Porting
+  slice's five factories to `CustomProgramSpecFactoryConcept` replaces `create_descriptor` with a
+  spec-returning method and replaces `override_runtime_arguments` with a `ProgramRunArgs`-returning
+  one, so both of `MeshPartition`'s call sites stop compiling. `ccl/mesh_partition` is itself
+  `legacy (MeshWorkload)` / `Is able to port? = no`, so a bundled port is not available. Someone needs
+  to decide, **before the port lands**, between: (a) keeping the legacy `create_descriptor` +
+  `patch_slice_program_addresses` pair alive alongside the new spec path purely for `MeshPartition`;
+  (b) porting `MeshPartition`'s program construction in the same change (out of the port's scope, and
+  blocked by that op's own gate); or (c) sequencing slice's port behind `MeshPartition`'s. This routes
+  to the **ops team / TTNN**, not to the porter.
 
-| Kernel file | Owner | Also instantiated by | `_metal2` fork beside it? |
-|---|---|---|---|
-| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` | eltwise/unary (cross-family) | **broadly shared** — concat, tilize (×5), transpose (×2), reshape_on_device, reduction (×4, incl. welford), matmul multicore, embeddings fused, attn_matmul, nlp_concat_heads (×2), gelu_bw, tanh_bw, examples (×2), plus `tests/ttnn/.../test_generic_op.{cpp,py}`, `test_situ_glu_sfpu.py` and `tt_metal/programming_examples/matmul/matmul_multi_core` | **Yes** — `writer_unary_interleaved_start_id_metal2.cpp`, same directory. Bind it. |
+- **Relaxation candidates** (noticed in the custom hash while auditing): **FALLIBLE — candidates to
+  verify; default strict; the ops team owns the real analysis.** `compute_program_hash`
+  (`slice_device_operation.cpp:343-427`) keys on the **full** input spec (`logical_shape`, `rank`,
+  `padded_shape`, `layout`, `dtype`, `memory_config`) plus the full output spec, plus the start/end
+  tensors' and preallocated output's specs when present, plus `factory.index()`. The gating
+  `TensorParameter relaxation` column reads `none`, and this hash is consistent with that: nothing here
+  suggests slice depends on fewer tensor properties than the strict match provides. The one direction
+  worth an eventual look is the *opposite* of a relaxation candidate — the hash is deliberately
+  **over**-keyed relative to the default (see the comment at `:344-348`, and the `#53997` /
+  `#47602` / `#45144` history), so any future relaxation work on this op should start from why the
+  extra keys were needed, not from trimming them. The sheet's own
+  `Provisional relaxation finding (Edwin)` cell (`needs fix, then none`, on the `SliceRm` and
+  `SliceTile` rows) appears to predate that hash work; see *Questions* #2.
 
-The other eight kernels are slice-owned and instantiated only by slice. Two further `_metal2` files with
-the same stem exist elsewhere and are **not** forks to reuse: one is typecast's own copy
-(`copy/typecast/device/kernels/dataflow/`), and two live under `experimental/quasar/**` (out of bounds by
-the locational test).
+- **TTNN factory analysis** (sheet-derived facts, with `file:line` evidence):
+  - **Concept (current):** `descriptor` on all five factories — `create_descriptor` returning a
+    `ProgramDescriptor` (`slice_program_factory_rm.hpp:26` and the four peers).
+  - **Op-owned tensors:** none. No `create_workload_descriptor`, no `buffers` vector. Consistent with
+    the `descriptor` concept, which cannot carry them.
+  - **MeshWorkload need:** none for slice itself. (`ccl/mesh_partition`, which wraps slice's factories,
+    *is* a MeshWorkload and is `Secretly SPMD = yes / Why: Per-coord RTAs` — that is that op's finding,
+    not slice's.)
+  - **Pybind `create_descriptor`:** `slice_nanobind.cpp:168-179`, on `SliceTileProgramFactory` only.
+    Not a gate — the port **deletes** this binding, which is a user-visible API change and gets its own
+    entry in the port report. A replacement is expected later. The device-op is also pybound for
+    `create_output_tensors` / `compute_output_specs` (`:156-166`); those are not descriptor internals
+    and are not this signal. `SliceParams` / `SliceInputs` are pybound as plain structs (`:138-154`).
+  - **Other risky pybind:** none beyond the above.
+  - **Custom hash:** `slice_device_operation.cpp:343`. Not a gate; **the port leaves it exactly as it
+    is** — no rewrite, no trimming, no re-derivation. It is independent of the concept choice.
+  - **`get_dynamic_runtime_args`:** absent (zero grep hits). Gate conjunct confirmed clear.
+  - **`override_runtime_arguments`:** present on all five factories (sites in the status summary), each
+    a one-line delegation to `patch_slice_program_addresses`
+    (`slice_program_factory_rm_sharded.cpp:354-413`). This is the **target-concept selector**, not a
+    gate: slice ports to `CustomProgramSpecFactoryConcept`, and the porter **translates** that method
+    into one returning a `ProgramRunArgs` rather than deleting it. Note the translation is unusual in
+    shape: the five factories share one implementation that branches on the factory type
+    (`std::holds_alternative` at `:362`, then `std::visit` at `:383`), reaching three different
+    refresh mechanisms — `apply_descriptor_runtime_args` for the two borrowed CBs (RmSharded, `:366`),
+    a positional `GetRuntimeArgs` slot-0 patch (`patch_slot0`, `:372-380`), and
+    `apply_dynamic_runtime_args` over a `DynamicRuntimeArg` vector for the tile factories
+    (`:394-409`, plus `slice_tile_dynamic_args` at `slice_program_factory_tile.cpp:198`). Note also
+    that `tt::tt_metal::apply_dynamic_runtime_args` / `DynamicRuntimeArg` here is a **helper API**, not
+    the deprecated device-op `get_dynamic_runtime_args` hook — do not conflate them.
+  - **Target concept:** `CustomProgramSpecFactoryConcept`, no op-owned tensors. Independently derived
+    from `Override runtime args method? == yes` and confirmed by the sheet's own `Porting Target` cell.
 
-**Host-side coupling (no recipe bucket — see *Recipe notes*):** `ccl/mesh_partition` consumes slice's
-factory API directly, detailed under *Heads-ups*. Separately, four ops call slice's pure host-side offset
-helpers `get_rm_start_offset` / `get_tiled_start_offset` (`slice_device_operation.hpp:23-25`):
-`experimental/padded_slice` (2 factories), `experimental/slice_write` (3 factories),
-`experimental/transformer/nlp_kv_cache_load_slice`. Those are scalar arithmetic functions untouched by the
-port — recorded for completeness, not a coupling risk.
+## Misc anomalies  *(team-only, non-gating, not porter-actionable)*
 
-### Relaxation candidates (FALLIBLE — candidates to verify; the ops team owns the real analysis)
-
-Mined from `compute_program_hash` (`slice_device_operation.cpp:302-354`), which hashes the **full**
-input spec, the full output spec, the start-tensor spec when present, all slice params, `sub_core_grids`
-and `factory.index()`. Default strict is the safe reading; these are only observations:
-
-- The hash includes `input.memory_config()` and `output_spec.memory_config()` in full, and the factory's
-  correctness genuinely depends on the sharded-vs-interleaved distinction (the 3rd-arg finding above and
-  the `select_program_factory` height-sharded branch both key on it). So there is **no obvious
-  memory-config relaxation candidate** here.
-- Both `padded_shape` and `logical_shape` are hashed for input and output. The RM factory's CB sizing,
-  chunking and stride math derive from `padded_shape[-1]` and `slice_start[-1]` only
-  (`slice_program_factory_rm.cpp:205-303`), and the Tile factory's per-dim args derive from
-  `padded_shape` only — a `match_padded_shape`-style relaxation might be viable for the Tile factory, but
-  the RM factory also folds `element_size()` (i.e. dtype) into `begins_bytes`, and `sub_core_grids`
-  changes the work split. Fallible; the sheet's `(legality - pending analysis)` cell is the real analysis.
-- The comment at `:304-307` states the custom hash exists to *strengthen* distribution against
-  false cache hits ("weak distribution for small-integer shape sequences ... same pattern as concat fix
-  in PR #45144 (issue #47602)"), not to relax anything. If that reading holds, the relaxation column's
-  `needs fix, then none` provisional finding is consistent: this is a hash-correctness item, not a
-  genuine `TensorSpec` relaxation.
-
-### TTNN factory analysis (sheet-derived facts, with `file:line` evidence)
-
-- **Concept (current):** `descriptor`, all five factories. Each `.hpp` declares
-  `static ProgramDescriptor create_descriptor(const SliceParams&, const SliceInputs&, Tensor&)`.
-- **Op-owned tensors:** none — no `create_workload_descriptor`, no `WorkloadDescriptor`, no `buffers`
-  vector anywhere in the op.
-- **MeshWorkload need:** none. `select_program_factory` (`slice_device_operation.cpp:268-300`) picks one
-  single-program factory; `slice()` dispatches through `ttnn::device_operation::launch`
-  (`:381-384`). *(Note: `ccl/mesh_partition` wraps these same factories in a MeshWorkload of its own —
-  that need belongs to mesh_partition, not to slice.)*
-- **Custom hash:** `SliceDeviceOperation::compute_program_hash`, `slice_device_operation.cpp:302-354`.
-  **Not a gate**; the port leaves it exactly as it is. No backdoor `attribute_values` / `to_hash`
-  (sheet `no`, ✓ confirmed — `SliceParams` / `SliceInputs`, `slice_device_operation_types.hpp:13-28`,
-  declare neither).
-- **`get_dynamic_runtime_args`:** absent. The adapter's `static_assert`
-  (`mesh_device_operation_adapter.hpp:509-513`) makes it impossible to combine with the
-  `override_runtime_arguments` the op does define, so it cannot quietly return.
-- **`override_runtime_arguments`:** present on all five factories → target
-  **`CustomProgramSpecFactoryConcept`**. Sites: `slice_program_factory_rm.cpp:435`,
-  `slice_program_factory_rm_sharded.cpp:418`, `slice_program_factory_rm_stride.cpp:178`,
-  `slice_program_factory_tile.cpp:189`, `slice_program_factory_tile_tensor_args.cpp:195` — each a
-  one-line delegation to the shared `patch_slice_program_addresses`
-  (`slice_program_factory_rm_sharded.cpp:354-416`).
-- **Pybind `create_descriptor`:** `slice_nanobind.cpp:164-176` (`SliceTileProgramFactory`). Removing it
-  is a user-visible API change and gets its own entry in the eventual port report. Other risky pybinds in
-  the same function (`bind_slice_descriptor`, `:134-163`): `nb::class_` of `SliceParams` with
-  read-write access to every field, `nb::class_` of `SliceInputs`, and `nb::class_` of
-  `SliceDeviceOperation` exposing `create_output_tensors` / `compute_output_specs`.
-- **Target concept:** `CustomProgramSpecFactoryConcept`, no op-owned tensors — matches the sheet's
-  `Porting Target` on all five rows.
-- **Execution model:** `SPMD` on all five rows; consistent with the single-program `descriptor` shape.
-
----
-
-## Misc anomalies  *(team-only, non-gating; route to the ops team — the port does not act on these)*
-
-1. **Latent cache-hit bug: the RM reader's `id_per_dim` block is never re-initialised.** The reader
-   increments `id_per_dim[]` in place inside the runtime-arg region
-   (`slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:31,74-82,104-112`), so after a dispatch the
-   block holds the walked-to values, not the per-core start values `create_descriptor` wrote
-   (`slice_program_factory_rm.cpp:169`). Because `SliceRmProgramFactory` defines
-   `override_runtime_arguments`, the adapter uses **neither** `resolve_bindings` **nor**
-   `get_dynamic_runtime_args` and the factory owns the whole re-derivation
-   (`mesh_device_operation_adapter.hpp:449-455`) — but `slice_rm_reader_dynamic_args`
-   (`slice_program_factory_rm.cpp:405-433`) re-emits **only reader arg 0**, and
-   `patch_slice_program_addresses` re-emits only writer slot 0 for this factory. Nothing restores
-   `id_per_dim`. A second dispatch that hits the cached program should therefore start its dimension
-   walk from stale indices and read the wrong sticks. The sibling factories do **not** have this hole:
-   `slice_tile_dynamic_args` explicitly re-emits reader slots `2 .. 2+num_dims`
-   (`slice_program_factory_tile.cpp:268-271`), covering both Tile and TileTensorArgs, and
-   `slice_reader_unary_unpad_dims_rm_sharded.cpp` never mutates its args. Worth a targeted
-   repeat-dispatch test on the RM path (rank ≥ 2, ≥ 2 dims walked, two invocations with the same shapes).
-2. **Stale comments describe a hook that does not exist.** Five comments name
-   `SliceDeviceOperation::get_dynamic_runtime_args` as the mechanism that re-emits the RM reader base —
-   `slice_program_factory_rm.cpp:41,42,105,106` and `slice_program_factory_rm.hpp:40`. There is no such
-   hook; the mechanism is `override_runtime_arguments` → `slice_rm_reader_dynamic_args` →
-   `apply_dynamic_runtime_args`. Adding the hook the comments describe would now trip the adapter's
-   `static_assert`. Also at `slice_program_factory_rm_sharded.cpp:278-279` a comment says "the framework
-   copies runtime args and patches dynamic CB addresses" on a cache hit — which is the
-   `resolve_bindings` path this op opts out of by defining `override_runtime_arguments`. Both readings
-   are actively misleading for anyone reasoning about item 1.
-3. **Dead CTA in all four `*_multicore_slice_*` kernels.** `compile_time_element_size =
-   get_compile_time_arg_val(1)` is declared and never used —
-   `reader_multicore_slice_4d.cpp:81`, `writer_multicore_slice_4d.cpp:65`,
-   `reader_multicore_slice_nd.cpp:66`, `writer_multicore_slice_nd.cpp:65`. The host passes
-   `element_size` as CTA 1 (`slice_program_factory_rm_stride.cpp:79,82`) **and** again as an RTA
-   (`:132,142,149,161`); only the RTA is read.
-4. **Dead locals.** `output_bytes_per_row`, `output_h`, `output_d`, `output_n` are computed/read and never
-   used in `reader_multicore_slice_4d.cpp:56-62,86`. `old_src_tile_id` is assigned and never used in
-   `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:115`. `writer_multicore_slice_nd.cpp:73`
-   uses `get_arg_addr(rt_args_idx++)` where the post-increment is pointless (no further reads).
-5. **The `end_tensor` binding feeds nothing.** `SliceTileTensorArgsProgramFactory` requires an
-   `end_tensor` (`slice_program_factory_tile_tensor_args.cpp:27,46`), allocates a `TensorAccessor` for it
-   and reads a full tile from it on device
-   (`reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:45,69-83`), but `end_indices` is
-   declared `[[maybe_unused]]` (`:49`) and never read after the copy loop (`:80-82`). The output extent
-   comes from host-computed `num_unpadded_tiles_per_dim` instead. A whole tensor binding, accessor,
-   staging CB round-trip and NOC read exist to populate a dead array. If that is intended (e.g. reserved
-   for a future dynamic-extent path) it deserves a comment; if not, the binding and the second staging
-   read can go.
-6. **Dead `#ifdef` paths in slice's own copy of the unary writer.**
-   `device/kernels/dataflow/writer_unary_interleaved_start_id.cpp:29,38` branch on `OUT_SHARDED` and
-   `BACKWARDS`. No slice factory sets `defines` on that `KernelDescriptor`
-   (`slice_program_factory_tile.cpp:154-162`), so `OUT_SHARDED` is never taken and `BACKWARDS` never
-   compiled. Carried over from the eltwise original.
-7. **The `patch_slot0` "skip if zero" heuristic is undocumented as a contract.**
-   `slice_program_factory_rm_sharded.cpp:370-381` writes the new address into arg slot 0 of every core's
-   arg vector *except* where the slot currently holds 0, on the premise that a zero slot marks a core
-   `create_descriptor` left zero-filled. That premise holds today (the no-op-core paths write
-   `{0u, 0u, 0u}`, e.g. `slice_program_factory_tile.cpp:176`,
-   `slice_program_factory_tile_tensor_args.cpp:151`), but it is a value-based sentinel standing in for
-   structural information the descriptor already has, applied uniformly across four factories with
-   different slot layouts. It is the kind of shim that quietly mis-fires if a factory ever writes a
-   non-zero placeholder or a legitimately-zero address.
-8. **Two unreferenced kernel files** in `device/kernels/dataflow/`:
-   `strided_slice_reader_rm_interleaved_nd.cpp` and `strided_slice_writer_rm_interleaved.cpp`. No factory
-   names either (the strided path uses the `*_multicore_slice_{4d,nd}.cpp` pair instead). Likely
-   superseded; candidates for deletion.
-
----
+- **Dead CTA in four kernels.** `compile_time_element_size = get_compile_time_arg_val(1)` is declared
+  and never used at `reader_multicore_slice_4d.cpp:81`, `writer_multicore_slice_4d.cpp:65`,
+  `reader_multicore_slice_nd.cpp:67`, `writer_multicore_slice_nd.cpp:66`. All four kernels use the
+  *runtime* `element_size` throughout. The host still emits it (`slice_program_factory_rm_stride.cpp:79,82`).
+- **Dead RTAs in the 4D stride writer.** `output_h`, `output_d`, `output_n`
+  (`writer_multicore_slice_4d.cpp:56-58`) are read and never used — only `output_w` is. The host emits
+  all four (`slice_program_factory_rm_stride.cpp:139-142`). Same for `tensor_rank` (`:54`) in that file.
+- **`SliceTileTensorArgs` reads the end tensor and discards it.** The reader does a full DFB-staged
+  read of the end tensor and copies it into `end_indices`
+  (`reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp:69-83`), but `end_indices` is declared
+  `[[maybe_unused]]` (`:49`) and never read afterwards — only `start_indices` feeds the offset
+  computation. The op nonetheless binds the tensor, allocates its accessor args
+  (`slice_program_factory_tile_tensor_args.cpp:84`), hashes its spec
+  (`slice_device_operation.cpp:388-398`), and `TT_FATAL`s if it is absent (`…_tensor_args.cpp:46`).
+  Either the end tensor is genuinely unnecessary (a whole binding, a CB staging round-trip, and an
+  accessor could go) or a use was intended and lost. **The port must keep binding it** — the read still
+  happens — so this is an ops-team question, not port work.
+- **`constexpr uint32_t start_offset = 0;`** at `slice_program_factory_tile_tensor_args.cpp:129`, added
+  into `start_id` at `:158`. Always zero (the real offset is computed on-device from the start tensor),
+  so the addition is a no-op kept for symmetry with `SliceTileProgramFactory`. Harmless; noted because
+  it reads like a forgotten value.
+- **Dead preprocessor branches in slice's own writer copy.** `writer_unary_interleaved_start_id.cpp`
+  gates on `#ifdef OUT_SHARDED` (`:29`) and `#ifdef BACKWARDS` (`:38`), inherited from the eltwise
+  original. No slice factory sets any `defines`, so neither can ever fire.
+- **Belt-and-braces address refresh.** For `SliceRm` and `SliceRmStride`, arg slot 0 is *both* a
+  `Buffer*` binding (which the framework patches on a cache hit) *and* manually rewritten by
+  `patch_slot0` (`slice_program_factory_rm_sharded.cpp:381,389`). The manual patch is redundant for
+  the op's own dispatch path; it is presumably load-bearing for `MeshPartition`, which builds a bare
+  `Program` from the descriptor (`mesh_partition_program_factory.cpp:131-132`) and so may not get the
+  framework's binding injection. Worth confirming, since if it *is* redundant it is also the thing
+  making the tile factories' `patch_slot0`/`apply_dynamic_runtime_args` split necessary.
+- **`get_arg_addr(rt_args_idx++)`** at `writer_multicore_slice_nd.cpp:73` — the post-increment has no
+  effect (nothing reads `rt_args_idx` afterwards). Cosmetic.
+- **Interleaved-pair pointer trick.** `slice_reader_unary_unpad_dims_rm_sharded.cpp:26-27` takes
+  `read_noc_x = get_arg_addr(1)` and `read_noc_y = get_arg_addr(2)` — two pointers one word apart into
+  the same interleaved x/y stream — then strides both by 2 (`:85`). Correct, but it is the kind of
+  aliasing that a vararg-block port could easily get subtly wrong; called out here as well as in the
+  porter heads-ups.
 
 ## Per-DeviceOperation / per-factory attribution
 
-One DeviceOperation, so the bundling is per factory. Findings differ materially between them:
+Single DeviceOperation (`SliceDeviceOperation`), so the per-DOp roll-up equals the op roll-up: **GREEN**.
+Where findings differ, they differ by *factory*:
 
-| Factory | `Is able to port?` | Gates open | 3rd arg | Offset base ptr | CB dispositions | Bindings |
+| Factory | `Is able to port?` | Tensor bindings | 3rd arg | CB dispositions | Kernels | Notable |
 |---|---|---|---|---|---|---|
-| `SliceRmProgramFactory` | no | relaxation · **offset Type 2** · **3rd arg Class 3/S** | 2 sites | **Type 2 GATE** | 1× plain 1:1 | 1 Case 1, 1 gated |
-| `SliceRmShardedProgramFactory` | no | relaxation only | none | clean | 2× **self-loop** (both borrowed) | 2 clean |
-| `SliceRmStrideProgramFactory` | no | relaxation only | none | clean | 1× plain 1:1 | 2 Case 1 |
-| `SliceTileProgramFactory` | no | relaxation only | none | clean | 1× plain 1:1 | 2 Case 1 |
-| `SliceTileTensorArgsProgramFactory` | no | relaxation only | none | clean | 1× plain 1:1, 1× **self-loop** | 4 Case 1 |
+| `SliceRm` | yes | `input` C1, `output` C1 | **2 sites → drop** | `c_0` 1:1 | own ×2 | the ex-Type-2 offset fold, now split out |
+| `SliceRmSharded` | yes | both **clean** (borrowed DFB) | none | `c_0` self-loop, `c_16` self-loop | own ×1 | only factory with borrowed CBs; no `TensorAccessor` at all |
+| `SliceRmStride` | yes | `input` C1, `output` C1 | none | `c_0` 1:1 (both rank configs) | own ×4 | ND path is the heaviest RTA-vararg case |
+| `SliceTile` | yes | `input` C1, `output` C1 | none | `c_0` 1:1 | own ×2 | already uses named CTAs; carries the pybound `create_descriptor` |
+| `SliceTileTensorArgs` | yes | ×4, all C1 | none | `c_0` 1:1, `c_1` self-loop | own ×1 + **eltwise donor** | reuse the existing `_metal2` fork; end tensor read-and-discarded |
 
-Shared across all five: `descriptor` → `CustomProgramSpecFactoryConcept`, the custom hash, the
-`override_runtime_arguments` / `patch_slice_program_addresses` translation, and the `ccl/mesh_partition`
-host-side coupling. If the relaxation gate clears **without** the offset and 3rd-arg gates clearing, the
-four non-`Rm` factories become a viable clean subset — that is the most likely next re-audit outcome and
-worth planning for.
+## Questions for the user  *(all three resolved)*
 
----
+> **Update (2026-09-04), after reviewing PR #55433 (`akertesz/slice-test`, draft).** Questions 1 and 3
+> below are **answered and closed**; the branch already carries the code. **Question 2 was closed by
+> the op owner on 2026-09-04** — the spreadsheet cell is stale and the relaxation really is `none`.
+> Nothing in this audit remains open. See *Post-audit reconciliation* at the end of this document for
+> the branch delta and the recipe-version check.
 
-## Questions for the user
+1. ~~**`TensorAccessor` page size on a BLOCK/WIDTH-sharded RM tensor?**~~ — **CLOSED. Not a bug, and
+   the answer was already in the op directory; I should have found it rather than asking.**
+   `has_subaligned_shard_row` (`slice.cpp:47-57`) already exists at the audited HEAD and documents the
+   exact mechanism this question derived, in the same terms: *"TensorAccessor strides pages by the
+   buffer's **aligned** page size, but `noc_async_*_sharded` reads that same value back as the per-page
+   **payload**. For a B/W-sharded RM buffer the page is the shard row, so the two only agree when the
+   row is already a multiple of the buffer's alignment."* `needs_rm_composite_input` (`:60-77`) and
+   `needs_rm_composite_output` (`:79-86`) then route any such tensor down the **composite** path, so
+   `SliceRmProgramFactory` never receives one through `ttnn::slice`. So: an unaligned B/W shard width is
+   a supported *slice* configuration but an unreachable *factory* configuration — the tensor is
+   resharded first. **The 3rd-arg drop is safe, and it has already been done** (`87bd11a885e`), which
+   also removed the two now-dead host RTAs and reindexed both kernels, exactly as the brief prescribed.
+   PR #55433 additionally closes the one residual hole this audit identified — `MeshPartition` builds
+   these programs off `select_program_factory` and never sees `slice.cpp`'s guard — with a
+   `TT_FATAL` (`check_accessor_page_size`, `c65cafac4ee`) pinning the equivalence in
+   `SliceRmProgramFactory::create_descriptor`. **My audit gap:** I skimmed `slice.cpp` with a keyword
+   grep instead of reading it, and the pattern missed the guard. The mechanism analysis was right; the
+   reachability conclusion was available in scope and I raised it as a question instead of answering it.
 
-1. **Is the `TensorAccessor` 3rd-argument override on the RM path known to anyone?**
-   `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:38` and
-   `slice_writer_unary_stick_layout_interleaved_start_id.cpp:32` pass a per-shard page size that, on
-   BLOCK/WIDTH-sharded row-major tensors, is the page **payload** (`shard_W * element_size`) where the
-   sharded accessor uses the value verbatim as the page **stride** (`aligned_page_size`). It is not on
-   the readiness sheet (`Known op issues` names only the offset base pointer) and I could not consult
-   `2026-07-06_tensor_accessor_3rd_arg_triage.md`. Two things would settle the class: (a) does any
-   shipped or tested slice config have `shard_W * element_size % 16 != 0` on a B/W-sharded row-major
-   input **or** output? (b) is the payload-vs-stride conflation in
-   `data_movement/common/kernels/common.hpp:340,389` a known issue with an owner? If (a) is "no" for
-   every reachable config, both sites drop to Class 2 and this gate lifts.
-2. **`Pybind descriptor` = `PR` on all five slice rows.** The sheet uses the literal string `PR` where
-   other rows carry `yes`/`no`. The code has one pybound `create_descriptor`, on the Tile factory only
-   (`slice_nanobind.cpp:167`). Is `PR` "a PR is in flight to remove it", and does it apply to the whole
-   op or just the Tile row? Routed to the readiness-sheet owner as a question, not a defect claim —
-   `Pybind descriptor` is in the cross-check set, but a non-boolean value is a vocabulary question rather
-   than a code/sheet conflict.
-3. **Who owns adapting `ccl/mesh_partition`?** It calls all five slice `create_descriptor`s and
-   `patch_slice_program_addresses` directly and is itself `legacy (MeshWorkload)` /
-   `Is able to port? = no`. The slice port cannot land without either porting mesh_partition in the same
-   change or giving it an adapter, and mesh_partition is not portable today. This ordering constraint
-   should be settled before the slice port is scheduled, not discovered during it.
+2. ~~**`Provisional relaxation finding (Edwin)` = `needs fix, then none` — still current?**~~ —
+   **CLOSED by the op owner (2026-09-04): the spreadsheet cell is stale. The relaxations are fine and
+   the value is `none`.** That matches the gating `TensorParameter relaxation` column (`none` on all
+   five rows), this audit's own relaxation-candidate read (no candidate surfaced; the hash pins
+   essentially the full `TensorSpec`), and the two factories already ported with no relaxation applied.
+   **No relaxation work, no analysis doc, nothing to route.** The only residue is housekeeping: the
+   `Provisional relaxation finding (Edwin)` cell should be cleared on the `SliceRm` and `SliceTile`
+   rows so the next auditor doesn't weigh it against the gating column — and note the column is
+   undocumented in `ttnn_op_porting_readiness.md`, which is what made it ambiguous to two independent
+   auditors (see *Recipe notes*).
 
----
+3. ~~**`ccl/mesh_partition` sequencing.**~~ — **CLOSED. Option (b) was chosen and is implemented**, in
+   the same commit as the first factory port (`8c8b9eea947`). Rather than a name list, it adds a
+   concept keyed on the *entry point* —
+   `template <typename T> concept IsSliceSpecFactory = requires { &T::create_program_artifacts; };` —
+   and branches both call sites on it: `create_at` builds a spec factory via `MakeProgramFromSpec` +
+   `SetProgramRunArgs` and leaves the descriptor path untouched; `override_runtime_arguments` routes a
+   spec factory through `UpdateProgramRunArgs(program, Factory::override_runtime_arguments(...))` and
+   keeps `patch_slice_program_addresses` for the rest. Because it keys on the entry point, **each
+   further slice factory that migrates needs no additional edit there**, and the branch retires when
+   the last one converts. Two caveats to carry: the change was **explicitly authorized by the invoker**
+   as an out-of-op-directory edit, and it is **not run-verified** — MeshPartition's tests are
+   t3000/TG-only. It also invalidates my framing of this as a blocking sequencing decision: the port
+   turns out to be **incrementable per factory** (see *Post-audit reconciliation*).
 
 ## Recipe notes
 
-1. **No bucket for a host-side factory-API borrower.** *Out-of-directory coupling* is defined entirely in
-   terms of kernels: `#include` escapes (the six donor classes) and file-path kernel instantiation. It has
-   nowhere to record that **another op family calls this op's `create_descriptor` and its cache-hit
-   patcher from host code** (`ccl/mesh_partition/device/mesh_partition_program_factory.cpp:123-156`,
-   `mesh_partition_device_operation.hpp:47-52`). That is arguably the single highest-impact coupling
-   finding in this audit — the port changes the exact API mesh_partition consumes — yet the subject's
-   report format (roll-up / summary table / per-call detail / borrowed kernel files) has no row for it and
-   its gating carve-out (a donor kernel on pre-Device-2.0 idioms) does not apply. I surfaced it under
-   *Heads-ups* and *Team-only* by analogy. Suggestion: add a fourth escape type — *host-side factory-API
-   consumer* — with an explicit "does the consumer's own readiness allow a bundled port?" question, since
-   the answer here (`no`) is a real scheduling constraint.
-2. **The 3rd-argument magnitude rule is written for interleaved accessors and misclassifies sharded ones.**
-   *Question 2* lists "`buffer->page_size()`, `tt::tile_size` / `get_tile_size(cb)` and
-   `aligned_page_size()`" together as **correct magnitude**. But the *Class 2* row admits only
-   "`== aligned_page_size`, **or** a correct-magnitude value on an *interleaved* accessor", and the
-   load-bearing-subtlety paragraph says sharded uses the value verbatim with no safety net. On a sharded
-   accessor `buffer->page_size()` and `aligned_page_size()` differ by the alignment round-up, and that
-   difference **does** mis-address — so following Question 2 literally yields Class 2 while following the
-   table yields Class 3. I resolved it toward the table (and the conservative-gating rule), but the two
-   passages contradict each other. Suggestion: split Question 2's correct-magnitude list by
-   specialisation, or state explicitly that on a sharded accessor `page_size()` is *not* interchangeable
-   with `aligned_page_size()`.
-3. **The taxonomy has no clean slot for "load-bearing override that is also arguably wrong."** The site
-   here is simultaneously Special (the intent — shard-relative payload paging — is inexpressible in the
-   binding model) and Class 3 (the value looks wrong for the accessor's own addressing). Both route to
-   the ops team, so the verdict is unaffected, but the class label had to be reported as "3 / Special"
-   rather than picked. A note that the classes are not mutually exclusive, and that reporting both is
-   fine when they route identically, would save the next auditor the same hesitation.
-4. **The *Red* scoping rule's "which side does it clear on?" test is hard to apply to a relaxation
-   verdict.** `(legality - pending analysis)` means the ops team will *analyse* and *possibly* fix. If
-   the analysis concludes "no relaxation needed, the hash was merely strong", the cell flips with the op's
-   code untouched (→ run the seven subjects); if it concludes "needs fix", the code changes (→ skip). The
-   provisional column here says `needs fix, then none`, which I took as op-code side. The rule assumes
-   the clearing side is knowable at audit time; for a pending-analysis cell it is knowable only
-   probabilistically. Suggestion: name the pending-relaxation case explicitly and say which way to lean
-   (running the subjects and disclosing the staleness risk seems cheaper than a second full pass).
-5. **Provenance is unpinnable when the recipe is consumed out-of-tree.** The `git log` command targets
-   `docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/`, which does not exist in this checkout;
-   the recipe I followed lives at an absolute path outside the repo. The fallback instruction ("record
-   that instead") works, but a version stamp inside the recipe document itself would survive being copied
-   out of the doc branch — which appears to be the normal way these audits are actually run.
+1. **The `TensorAccessor` 3rd-arg magnitude test does not resolve `page_size` vs `aligned_page_size`
+   on a *sharded* accessor.** the `TensorAccessor 3rd argument` subject of `metal2_audit.md` question 2 says to compare the value to
+   "the true logical page (`buffer->page_size()`)" and lists `buffer->page_size()` among the
+   **correct-magnitude** values; Class 2's first clause is separately "`== aligned_page_size`". For an
+   interleaved accessor these agree, because realignment makes the difference inert — and the section
+   says so. For a **sharded** accessor they can disagree by up to `alignment - 1` per page, and the
+   same section says sharded "uses the passed value **verbatim** … *any* wrong value mis-addresses."
+   So a site passing exactly `buffer->page_size()` on a sharded accessor is simultaneously
+   correct-magnitude (not Class 3/4) and not `== aligned_page_size` (not Class 2's first clause) — the
+   taxonomy has no row for it. I resolved it toward Class 2 via Class 2's second clause plus the
+   port-relevance test. **The gap is real and is now independently evidenced:** the ops team needed a
+   bespoke predicate (`has_subaligned_shard_row`, `slice.cpp:47`) *and* a `TT_FATAL`
+   (`check_accessor_page_size`, PR #55433) to pin exactly this equivalence — which is more machinery
+   than a taxonomy with no row for the case would lead an auditor to expect. Suggest the section either
+   add `buffer->page_size()` on a sharded accessor as an explicit Class-2 sub-case with the
+   "coincides only when the shard row is alignment-aligned — check for an op-side guard" caveat, or
+   name it a Special. (Slice is a live example, and not the only one:
+   `per_shard_page_size_bytes` is shared with `data_movement/gather`, which passes the same value to
+   four accessors, so whatever is decided here applies there too.)
+
+   *Auditor's note, not a recipe defect:* the question this raised was answerable from the op directory
+   (`slice.cpp`'s guard), and I asked it instead of answering it. The recipe told me to audit the op;
+   I under-read its host-facing file. Recorded here only because the next auditor of a
+   page-size-override site should **grep the op root for a guard predicate before escalating** —
+   that specific habit would be a useful addition to the subject's two classifying questions.
+2. **"Fixed `arg_index++` run" vs "vararg" is clear; "computed CRTA offset" is a third shape worth
+   naming.** the `RTA varargs` subject of `metal2_audit.md` contrasts a counted loop (vararg) with a fixed `arg_index++` run
+   (nameable). Slice's tile readers do neither: they take a **base pointer** at a *host-computed*
+   offset — `get_common_arg_addr(3 + 2 * num_dims)`
+   (`…_tensor_args.cpp:92`) — and index the block by loop variable. It is unambiguously a vararg by the
+   spirit of shape (a), but no bullet quite describes "a `get_*_arg_addr` into a block whose *start*
+   is a function of another arg." Naming it would save the next auditor a derivation, and it is common
+   (six of nine slice kernels).
+3. **Recipe assumed slice would still be the offset-base exemplar; it isn't, and the doc already knew.**
+   the `Offset base pointers` subject of `metal2_audit.md` says "Reach that verdict from your scan, not from this paragraph. The
+   slice family is the catalogued example, which is exactly why it is the one most likely to have been
+   fixed since" — and the recipe's own newest commit is
+   `state the offset-base wall as a category, not as slice's current state`. Both were exactly right
+   and made the third-outcome call easy. Recording it as a positive: the two-source design (dated doc
+   as prior, code as truth) worked as intended here, and the pre-warning is what stopped a
+   doc-anchored lookup from RED'ing a GREEN op.
+4. **No subject owns a host-side out-of-directory *consumer*.**
+   the `Out-of-directory coupling` subject of `metal2_audit.md` covers two escape types, both kernel-facing: function-call escape and
+   file-path kernel instantiation. Slice's most consequential cross-op coupling is neither — it is
+   another op (`ccl/mesh_partition`) calling slice's **host** `create_descriptor` and a shared
+   address-patching helper, which the port's signature change breaks. I put it in the brief's open
+   "anything else" bullet and in Team-only, which works, but a one-line third escape type ("host-side:
+   another op calls this op's factory statics or device-op statics — grep the factory type names and
+   any exported helpers outside the op directory") would make it a found finding rather than an
+   incidental one. It is cheap to check and, when present, is a scheduling blocker.
+
+---
+
+## Post-audit reconciliation — PR #55433 (`akertesz/slice-test`)
+
+Reviewed after this audit was written, at the user's request. It does not change the **GREEN** verdict;
+it closes two of the three open questions (above) and adds context this audit did not have.
+
+**The port is already underway on that branch, and it is incremental per factory.** Two of the five
+factories are ported to `CustomProgramSpecFactoryConcept` — `SliceTileProgramFactory`
+(`8c8b9eea947`) and `SliceTileTensorArgsProgramFactory` (`aafc364bc0c`), both by Audrey Kertesz. The
+remaining three stay on `ProgramDescriptorFactoryConcept`, and *"the framework dispatches per-factory,
+so the op builds and runs with its factories on mixed concepts."* **This correction matters for
+planning:** this audit's brief was written as though the five factories port together, and framed the
+`ccl/mesh_partition` coupling as a blocking sequencing decision. Neither holds — the port can land one
+factory at a time, and the `MeshPartition` bridge is already in place for all of them.
+
+Reported verification for the first ported factory: Wormhole n150, Metal 2.0 legality checks forced on,
+`test_slice.py` **448 passed / 38 skipped, identical to the pre-port baseline**.
+
+**Ops-team work this audit called for is already done**, on the same branch and by the op's own author
+(Edwin Lee) rather than as a separate track:
+
+| Commit | What it does | This audit's corresponding item |
+|---|---|---|
+| `f91637843f4` | validate pre-allocated output on every input layout | — (new) |
+| `87bd11a885e` | **drops both `TensorAccessor` 3rd args**, removes the two now-dead host RTAs, reindexes both RM kernels | *Port-work summary* → `TensorAccessor 3rd arg` |
+| `c65cafac4ee` | adds `check_accessor_page_size` — a `TT_FATAL` pinning per-shard vs. aligned page size in `SliceRmProgramFactory::create_descriptor` | *Questions* #1 |
+| `30f896705ba` | restores a row-major logical-shape check on the preallocated output | — (new) |
+
+**Two artifacts on that branch differ from the ones in this directory.** The branch carries its own
+`METAL2_PREPORT_AUDIT.md` (242 lines) and `METAL2_PORT_BRIEF.md` (131 lines), plus a
+`METAL2_PORT_PLAN.md` and `METAL2_PORT_REPORT.md` from the port itself.
+
+### Recipe-version delta — checked 2026-09-04
+
+**This audit ran on the *newer* audit recipe, not the older one.** (An earlier revision of this section
+said the opposite; that was wrong, and the commit dates are why.) The branch's docs cite
+`1167faf7b42 2026-09-04 docs(metal_2.0): binary_ng relaxation analysis; invariant checks over commit
+stamps`; this document is pinned to `4bd4bf42bfe 2026-09-03`. The later *date* belongs to a
+**divergent branch** — `1167faf7b42` is reachable only from `origin/akertesz/slice-test`, and the merge
+base with the recipe branch is `1c2aff5064f` on `main`. On the audit recipe's own content,
+`4bd4bf42bfe` is the newer revision.
+
+**The whole delta across the `metal_2.0` doc tree between those two commits is one file, one hunk:**
+`ai/audit/metal2_audit.md`, *Offset base pointers → Code-path scope* (+1 / −3 lines).
+`ai/port/metal2_port.md` and every shared/analyses doc are **byte-identical**, so nothing in the delta
+touches the port recipe the porter will follow.
+
+That one hunk is `4bd4bf42bfe` itself — *"state the offset-base wall as a category, not as slice's
+current state"* — and it is precisely the paragraph that decides this op's offset-base verdict:
+
+- **`1167faf7b42` (what the branch's audit read)** states the wall in the indicative and pre-writes the
+  verdict: *"The wall is a row-major-layout phenomenon: the tiled variants of the same ops (`slice` /
+  `padded_slice` / `slice_write`) … So a slice-family RED applies Code-path scope — RED the RM factory
+  …"*
+- **`4bd4bf42bfe` (what this audit read)** makes it conditional and adds:
+  *"**Reach that verdict from your scan, not from this paragraph.** The slice family is the catalogued
+  example, which is exactly why it is the one most likely to have been fixed since. A listed op with no
+  fold is the third outcome above — the doc is stale, and the op is **GREEN**."*
+
+The fix commit's own message names the failure it repairs: *"a cold auditor reported slice RED after
+the blockers had been removed."* **The loop is closed in both directions:** the branch audit's
+*Recipe notes* #1 diagnosed exactly this and proposed making the paragraph conditional; `4bd4bf42bfe`
+implements that; and this audit, reading the fixed text, reached GREEN from its own scan. So the delta
+is real, it is confined to this one subject, and it worked — no re-audit is warranted on account of it.
+
+### Where the two audits differ, and why
+
+They agree on all five gates, the GREEN verdict, the target concept, the `none` relaxation, the CB
+census (4 legal + 3 self-loop), and *"no Case 2 anywhere"*. Three differences, all explainable:
+
+| Item | This audit | Branch audit | Cause |
+|---|---|---|---|
+| `TensorAccessor` 3rd arg | **2 sites, Class 2 → drop** | **none — all 12 sites two-arg** | **Code state, not judgement.** The branch includes `87bd11a885e`, which already dropped both args. Each audit is correct for the tree it read. |
+| Tensor-binding roll-up | 10 Case 1 + 2 clean | *"eight Case 1, two clean"* | **A miscount in the branch audit's summary line** — its own table lists 12 rows, 10 of them Case 1. Worth correcting there, since its brief and port report may inherit the figure. |
+| Offset-base reasoning | reached from scan, recipe conditional | reached from scan **against** a recipe paragraph that pre-committed to RED | the recipe delta above |
+
+**Whoever reconciles this directory should decide which pair survives** rather than merging blindly.
+This document is longer and carries the per-`(CB, config)` census, the full vararg table, the
+`MeshPartition` analysis and the resolved question trail; the branch's pair describes the
+**post-fix** tree (no 3rd-arg work outstanding) and sits next to the port plan and report it produced.
+The cleanest outcome is probably to keep the branch's pair as the live artifacts and fold this
+document's extra detail into it.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
@@ -46,51 +46,48 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Runtime arguments for 4D slice support with multi-core work distribution
-    uint32_t rt_args_idx = 0;
-    uint32_t src_addr = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t input_w = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t input_h = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t input_d = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t input_n = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_w = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_h = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_d = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_n = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_start_w = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_end_w = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_step_w = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_start_h = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_end_h = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_step_h = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_start_d = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_end_d = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_step_d = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_start_n = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_end_n = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t slice_step_n = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    const auto tensor_rank = get_arg(args::tensor_rank);
+    const auto input_w = get_arg(args::input_w);
+    const auto input_h = get_arg(args::input_h);
+    const auto input_d = get_arg(args::input_d);
+    const auto input_n = get_arg(args::input_n);
+    const auto output_w = get_arg(args::output_w);
+    const auto output_h = get_arg(args::output_h);
+    const auto output_d = get_arg(args::output_d);
+    const auto output_n = get_arg(args::output_n);
+    const auto slice_start_w = get_arg(args::slice_start_w);
+    const auto slice_end_w = get_arg(args::slice_end_w);
+    const auto slice_step_w = get_arg(args::slice_step_w);
+    const auto slice_start_h = get_arg(args::slice_start_h);
+    const auto slice_end_h = get_arg(args::slice_end_h);
+    const auto slice_step_h = get_arg(args::slice_step_h);
+    const auto slice_start_d = get_arg(args::slice_start_d);
+    const auto slice_end_d = get_arg(args::slice_end_d);
+    const auto slice_step_d = get_arg(args::slice_step_d);
+    const auto slice_start_n = get_arg(args::slice_start_n);
+    const auto slice_end_n = get_arg(args::slice_end_n);
+    const auto slice_step_n = get_arg(args::slice_step_n);
+    const auto element_size = get_arg(args::element_size);
+    const auto num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    const auto start_row_for_this_core = get_arg(args::start_row_for_this_core);
 
     // Compile-time arguments
-    constexpr uint32_t dfb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
-    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto compile_time_element_size = get_arg(args::compile_time_element_size);
 
     // Calculate sizes - working with rows, not tiles
     uint32_t input_bytes_per_row = input_w * element_size;  // Dynamic element size
     uint32_t output_bytes_per_row = output_w * element_size;
 
     // Set up TensorAccessor for input data - use row size as page size
-    const auto s0 = TensorAccessor(src_args, src_addr);
+    const auto s0 = TensorAccessor(tensor::src);
 
     Noc noc;
     // Create DataflowBuffer for Device 2.0 API
-    DataflowBuffer dfb_out(dfb_id_out);
+    DataflowBuffer dfb_out(dfb::out);
 
     // Multi-core work distribution: this core processes rows [start_row_for_this_core, start_row_for_this_core +
     // num_rows_for_this_core) We need to map these logical output row indices back to the corresponding (n,d,h)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
@@ -52,56 +52,42 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Runtime arguments - first get basic parameters
-    uint32_t rt_args_idx = 0;
-    uint32_t src_addr = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    const auto tensor_rank = get_arg(args::tensor_rank);
+    const auto element_size = get_arg(args::element_size);
+    const auto num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    const auto start_row_for_this_core = get_arg(args::start_row_for_this_core);
 
     // Compile-time arguments
-    constexpr uint32_t dfb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
-    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto compile_time_element_size = get_arg(args::compile_time_element_size);
 
-    // Get dimension arrays from runtime arguments
-    // Layout: input_dims[rank], output_dims[rank], slice_starts[rank], slice_ends[rank], slice_steps[rank]
-    // Read input dimensions
-    volatile tt_l1_ptr uint32_t* input_dims = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
-    rt_args_idx += tensor_rank;
-
-    // Read output dimensions
-    volatile tt_l1_ptr uint32_t* output_dims = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
-    rt_args_idx += tensor_rank;
-
-    // Read slice parameters
-    volatile tt_l1_ptr uint32_t* slice_starts = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
-    rt_args_idx += tensor_rank;
-
-    volatile tt_l1_ptr uint32_t* slice_ends = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
-    rt_args_idx += tensor_rank;
-
-    volatile tt_l1_ptr uint32_t* slice_steps = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx));
+    // Five tensor_rank-long runtime vararg blocks, in host push order:
+    //   input_dims, output_dims, slice_starts, slice_ends, slice_steps
+    const uint32_t input_dims_base = 0;
+    const uint32_t output_dims_base = tensor_rank;
+    const uint32_t slice_starts_base = tensor_rank * 2;
+    const uint32_t slice_ends_base = tensor_rank * 3;
+    const uint32_t slice_steps_base = tensor_rank * 4;
 
     // Calculate sizes - working with rows, not tiles
-    uint32_t input_bytes_per_row = input_dims[tensor_rank - 1] * element_size;
-    uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;
+    uint32_t input_bytes_per_row = get_vararg(input_dims_base + tensor_rank - 1) * element_size;
+    uint32_t output_bytes_per_row = get_vararg(output_dims_base + tensor_rank - 1) * element_size;
 
     // Set up TensorAccessor for input data - use row size as page size
-    const auto s0 = TensorAccessor(src_args, src_addr);
+    const auto s0 = TensorAccessor(tensor::src);
 
     Noc noc;
     // Create DataflowBuffer for Device 2.0 API
-    DataflowBuffer dfb_out(dfb_id_out);
+    DataflowBuffer dfb_out(dfb::out);
 
     // Multi-core work distribution using iterative approach with explicit coordinate tracking
     // Track current position in N-dimensional space
     uint32_t coords[16];  // Support up to 16 dimensions (reasonable limit)
     for (uint32_t i = 0; i < tensor_rank; ++i) {
-        coords[i] = slice_starts[i];
+        coords[i] = get_vararg(slice_starts_base + i);
     }
 
     uint32_t rows_processed = 0;
@@ -128,7 +114,7 @@ void kernel_main() {
                 for (int32_t dim = 0; dim < (int32_t)(tensor_rank - 1); ++dim) {
                     uint32_t stride = 1;
                     for (int32_t d = dim + 1; d < (int32_t)(tensor_rank - 1); ++d) {
-                        stride *= input_dims[d];
+                        stride *= get_vararg(input_dims_base + d);
                     }
                     input_row_idx += coords[dim] * stride;
                 }
@@ -145,16 +131,17 @@ void kernel_main() {
 
             // Now slice the row according to width slice parameters (last dimension)
             uint32_t last_dim = tensor_rank - 1;
-            if (slice_starts[last_dim] != 0 || slice_steps[last_dim] != 1 ||
-                slice_ends[last_dim] != input_dims[last_dim]) {
+            if (get_vararg(slice_starts_base + last_dim) != 0 || get_vararg(slice_steps_base + last_dim) != 1 ||
+                get_vararg(slice_ends_base + last_dim) != get_vararg(input_dims_base + last_dim)) {
                 // Need to reorganize the data in the buffer
                 volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
                 volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
 
                 uint32_t out_col = 0;
-                for (uint32_t input_col = slice_starts[last_dim];
-                     input_col < slice_ends[last_dim] && out_col < output_dims[last_dim];
-                     input_col += slice_steps[last_dim]) {
+                for (uint32_t input_col = get_vararg(slice_starts_base + last_dim);
+                     input_col < get_vararg(slice_ends_base + last_dim) &&
+                     out_col < get_vararg(output_dims_base + last_dim);
+                     input_col += get_vararg(slice_steps_base + last_dim)) {
                     // Copy element by element for the slice
                     for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
                         dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
@@ -172,11 +159,11 @@ void kernel_main() {
         // Advance to next coordinate combination (skip last dimension)
         bool carry = true;
         for (int32_t dim = (int32_t)(tensor_rank - 2); dim >= 0 && carry; --dim) {
-            coords[dim] += slice_steps[dim];
-            if (coords[dim] < slice_ends[dim]) {
+            coords[dim] += get_vararg(slice_steps_base + dim);
+            if (coords[dim] < get_vararg(slice_ends_base + dim)) {
                 carry = false;
             } else {
-                coords[dim] = slice_starts[dim];
+                coords[dim] = get_vararg(slice_starts_base + dim);
             }
         }
         if (carry) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
@@ -7,29 +7,35 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t dfb_id_in0 = get_named_compile_time_arg_val("dfb_id_in");
-    constexpr uint32_t num_dims = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
-    const uint32_t src_addr = get_common_arg_val<uint32_t>(0);
+    constexpr auto num_dims = get_arg(args::num_dims);
 
-    volatile tt_l1_ptr uint32_t* num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(1));
-    volatile tt_l1_ptr uint32_t* num_padded_tiles = num_unpadded_tiles + num_dims;
+    const auto start_id = get_arg(args::start_id);
+    const auto num_tiles = get_arg(args::num_tiles);
 
-    const uint32_t start_id = get_arg_val<uint32_t>(0);
-    const uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    // Two num_dims-long common vararg blocks, in host push order:
+    //   [0, num_dims)          num_unpadded_tiles per dim
+    //   [num_dims, 2*num_dims) num_padded_tiles per dim
+    constexpr uint32_t num_unpadded_tiles_base = 0;
+    constexpr uint32_t num_padded_tiles_base = num_dims;
 
-    tt_l1_ptr uint32_t* id_per_dim = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+    // The per-dim walk counters are seeded by the host and advanced as this kernel walks the input,
+    // so they are copied into a local: get_vararg() reads a vararg but cannot write one back.
+    uint32_t id_per_dim[num_dims];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        id_per_dim[j] = get_vararg(j);
+    }
 
     // In and out are assumed to be same dataformat
-    const auto s0 = TensorAccessor(src_args, src_addr);
+    const auto s0 = TensorAccessor(tensor::input);
 
     // Create objects for Device 2.0 API
-    DataflowBuffer dfb_in0(dfb_id_in0);
+    DataflowBuffer dfb_in0(dfb::in0);
     Noc noc;
 
-    // Get tile size from CB interface
+    // Get tile size from the DFB
     const uint32_t tile_size = dfb_in0.get_entry_size();
 
     uint32_t src_tile_id = start_id;
@@ -43,9 +49,9 @@ void kernel_main() {
         src_tile_id++;
         for (uint32_t j = 0; j < num_dims; ++j) {
             id_per_dim[j]++;
-            if (id_per_dim[j] == num_unpadded_tiles[j]) {
+            if (id_per_dim[j] == get_common_vararg(num_unpadded_tiles_base + j)) {
                 id_per_dim[j] = 0;
-                src_tile_id += num_padded_tiles[j];
+                src_tile_id += get_common_vararg(num_padded_tiles_base + j);
             } else {
                 break;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
@@ -7,53 +7,55 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t dfb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t dfb_id_tensor = get_compile_time_arg_val(1);
-    constexpr uint32_t num_dims = get_compile_time_arg_val(2);
-    const uint32_t tile_width = get_compile_time_arg_val(3);
-    const uint32_t tile_height = get_compile_time_arg_val(4);
-    constexpr auto src_args = TensorAccessorArgs<5>();
-    constexpr auto start_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
-    constexpr auto end_args = TensorAccessorArgs<start_args.next_compile_time_args_offset()>();
+    constexpr auto num_dims = get_arg(args::num_dims);
+    const auto tile_width = get_arg(args::tile_width);
+    const auto tile_height = get_arg(args::tile_height);
 
-    const uint32_t src_addr = get_common_arg_val<uint32_t>(0);
-    const uint32_t start_addr = get_common_arg_val<uint32_t>(1);
-    const uint32_t end_addr = get_common_arg_val<uint32_t>(2);
+    const auto start_id = get_arg(args::start_id);
+    const auto num_tiles = get_arg(args::num_tiles);
 
-    volatile tt_l1_ptr uint32_t* num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(3));
-    volatile tt_l1_ptr uint32_t* num_padded_tiles = num_unpadded_tiles + num_dims;
+    // Three num_dims-long common vararg blocks, in host push order:
+    //   [0, num_dims)            num_unpadded_tiles per dim
+    //   [num_dims, 2*num_dims)   num_padded_tiles per dim
+    //   [2*num_dims, 3*num_dims) the input shape
+    constexpr uint32_t num_unpadded_tiles_base = 0;
+    constexpr uint32_t num_padded_tiles_base = num_dims;
+    constexpr uint32_t input_shape_base = num_dims * 2;
 
-    const uint32_t start_id = get_arg_val<uint32_t>(0);
-    const uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    // The per-dim walk counters are seeded by the host and advanced as this kernel walks the input,
+    // so they are copied into a local: get_vararg() reads a vararg but cannot write one back.
+    uint32_t id_per_dim[num_dims];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        id_per_dim[j] = get_vararg(j);
+    }
 
-    tt_l1_ptr uint32_t* id_per_dim = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-
-    const auto s0 = TensorAccessor(src_args, src_addr);
+    const auto s0 = TensorAccessor(tensor::input);
 
     // Create objects for Device 2.0 API
-    DataflowBuffer dfb_in0(dfb_id_in0);
-    DataflowBuffer dfb_tensor(dfb_id_tensor);
+    DataflowBuffer dfb_in0(dfb::in0);
+    DataflowBuffer dfb_tensor(dfb::tensor_stage);
     Noc noc;
 
-    // Get tile size from CB interface
+    // Get tile size from the DFB
     const uint32_t tile_size = dfb_in0.get_entry_size();
 
     // Create TensorAccessors for start and end tensors
-    const auto start_tensor_accessor = TensorAccessor(start_args, start_addr);
-    const auto end_tensor_accessor = TensorAccessor(end_args, end_addr);
+    const auto start_tensor_accessor = TensorAccessor(tensor::start);
+    const auto end_tensor_accessor = TensorAccessor(tensor::end);
 
     // Read start and end indices from tensors using TensorAccessor
     uint32_t start_indices[num_dims];
     [[maybe_unused]] uint32_t end_indices[num_dims];
 
-    // Read start tensor data using separate circular buffer
+    // Read start tensor data using separate dataflow buffer
     dfb_tensor.reserve_back(1);
     uint32_t start_buffer_l1_addr = dfb_tensor.get_write_ptr();
     noc.async_read(start_tensor_accessor, dfb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
     noc.async_read_barrier();
-    // Complete the producer/consumer handshake (reserve -> push -> wait -> pop) so the scratch CB
+    // Complete the producer/consumer handshake (reserve -> push -> wait -> pop) so the scratch DFB
     // is left balanced after this single-tile staging read.
     dfb_tensor.push_back(1);
     dfb_tensor.wait_front(1);
@@ -65,12 +67,12 @@ void kernel_main() {
     }
     dfb_tensor.pop_front(1);
 
-    // Read end tensor data using separate circular buffer
+    // Read end tensor data using separate dataflow buffer
     dfb_tensor.reserve_back(1);
     uint32_t end_buffer_l1_addr = dfb_tensor.get_write_ptr();
     noc.async_read(end_tensor_accessor, dfb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
     noc.async_read_barrier();
-    // Complete the producer/consumer handshake (reserve -> push -> wait -> pop) so the scratch CB
+    // Complete the producer/consumer handshake (reserve -> push -> wait -> pop) so the scratch DFB
     // is left balanced after this single-tile staging read.
     dfb_tensor.push_back(1);
     dfb_tensor.wait_front(1);
@@ -88,10 +90,8 @@ void kernel_main() {
         uint32_t start_h_tiles = start_indices[num_dims - 2] / tile_height;
         uint32_t start_w_tiles = start_indices[num_dims - 1] / tile_width;
 
-        volatile tt_l1_ptr uint32_t* input_shape_args =
-            (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(3 + 2 * num_dims));
-        uint32_t input_width = input_shape_args[num_dims - 1];
-        uint32_t input_height = input_shape_args[num_dims - 2];
+        uint32_t input_width = get_common_vararg(input_shape_base + num_dims - 1);
+        uint32_t input_height = get_common_vararg(input_shape_base + num_dims - 2);
         uint32_t num_pages_width = input_width / tile_width;
 
         start_offset += start_h_tiles * num_pages_width + start_w_tiles;
@@ -102,7 +102,7 @@ void kernel_main() {
 
             // Row-major Horner; must match get_upper_start_offset() in slice_device_operation.cpp
             for (uint32_t i = 0; i + 2 < num_dims; ++i) {
-                upper_dims_offset = upper_dims_offset * input_shape_args[i] + start_indices[i];
+                upper_dims_offset = upper_dims_offset * get_common_vararg(input_shape_base + i) + start_indices[i];
             }
             start_offset += upper_dims_offset * multiplier;
         }
@@ -122,9 +122,9 @@ void kernel_main() {
         src_tile_id++;
         for (uint32_t j = 0; j < num_dims; ++j) {
             id_per_dim[j]++;
-            if (id_per_dim[j] == num_unpadded_tiles[j]) {
+            if (id_per_dim[j] == get_common_vararg(num_unpadded_tiles_base + j)) {
                 id_per_dim[j] = 0;
-                src_tile_id += num_padded_tiles[j];
+                src_tile_id += get_common_vararg(num_padded_tiles_base + j);
 
             } else {
                 break;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -9,50 +9,60 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "api/debug/assert.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t padded_stick_size = get_arg_val<uint32_t>(1);
-    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
-    const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
-    const uint32_t num_dims = get_arg_val<uint32_t>(4);
-    const uint32_t misalignment = get_arg_val<uint32_t>(5);
-    const uint32_t start_id = get_arg_val<uint32_t>(6);
-    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(7);
-    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(8);
-    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(9);
+    const auto unpadded_stick_size = get_arg(args::unpadded_stick_size);
+    const auto stick_size_offset = get_arg(args::stick_size_offset);
+    const auto num_dims = get_arg(args::num_dims);
+    const auto misalignment = get_arg(args::misalignment);
+    const auto start_id = get_arg(args::start_id);
+    const auto num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    const auto num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    const auto num_read_per_barrier = get_arg(args::num_read_per_barrier);
     // Sub-row chunking: `num_chunks_per_stick` NOC transfers of `chunk_size` per stick (last = `last_chunk_size`).
-    const uint32_t chunk_size = get_arg_val<uint32_t>(10);
-    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(11);
-    const uint32_t last_chunk_size = get_arg_val<uint32_t>(12);
+    const auto chunk_size = get_arg(args::chunk_size);
+    const auto num_chunks_per_stick = get_arg(args::num_chunks_per_stick);
+    const auto last_chunk_size = get_arg(args::last_chunk_size);
     // Byte offset of the slice's W-begin within a row, rounded down to the source buffer's alignment;
     // the leftover `misalignment` bytes are trimmed on-device by the tt_memmove below.
-    const uint32_t src_offset_bytes = get_arg_val<uint32_t>(13);
+    const auto src_offset_bytes = get_arg(args::src_offset_bytes);
 
-    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(14));
-    volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
-    volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
+    // Three num_dims-long runtime vararg blocks, in host push order:
+    //   [0, num_dims)            num_unpadded_sticks per dim
+    //   [num_dims, 2*num_dims)   num_padded_sticks per dim
+    //   [2*num_dims, 3*num_dims) the per-dim walk counters
+    const uint32_t num_unpadded_sticks_base = 0;
+    const uint32_t num_padded_sticks_base = num_dims;
+    const uint32_t id_per_dim_base = num_dims * 2;
 
-    constexpr auto src_args = TensorAccessorArgs<0>();
+    // The walk counters are seeded by the host and advanced as this kernel walks the input, so they
+    // are copied into a local: get_vararg() reads a vararg but cannot write one back. num_dims is a
+    // runtime value here, so the local is sized by the accessor's own rank ceiling.
+    ASSERT(num_dims <= tensor_accessor::MAX_RANK);
+    uint32_t id_per_dim[tensor_accessor::MAX_RANK];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        id_per_dim[j] = get_vararg(id_per_dim_base + j);
+    }
+
     uint32_t read_size = unpadded_stick_size + misalignment;
 
-    // padded_stick_size = per-shard page size (shard_W on B/W-sharded, full row otherwise);
-    // feeds `noc_async_read_sharded`'s multi-shard split via `get_aligned_page_size()`.
     // The accessor base stays the unshifted buffer base: Metal 2.0 supplies it from the tensor binding
     // and offers no seam for a pre-offset base. The W-begin shift rides each read as `src_offset_bytes`.
-    const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
-
-    constexpr uint32_t dfb_id_in0 = 0;
+    // The per-page stride is the buffer's aligned page size, which the binding supplies; the host
+    // pins that it equals the per-shard page size this kernel needs (check_accessor_page_size).
+    const auto s0 = TensorAccessor(tensor::src);
 
     Noc noc;
     // Create DataflowBuffer for Device 2.0 API
-    DataflowBuffer dfb_in0(dfb_id_in0);
+    DataflowBuffer dfb_in0(dfb::in0);
 
     uint32_t src_stick_id = start_id;
     uint32_t sticks_read = 0;
 
     if (num_chunks_per_stick > 1) {
-        // Chunked path: batch by `num_read_per_barrier` so the second CB pair pipelines behind the first.
+        // Chunked path: batch by `num_read_per_barrier` so the second DFB pair pipelines behind the first.
         for (uint32_t iter = 0; iter < num_sticks_per_core_read && sticks_read < num_sticks_per_core; ++iter) {
             uint32_t c = 0;
             while (c < num_chunks_per_stick) {
@@ -78,9 +88,9 @@ void kernel_main() {
             src_stick_id++;
             for (uint32_t j = 0; j < num_dims; j++) {
                 id_per_dim[j]++;
-                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                if (id_per_dim[j] == get_vararg(num_unpadded_sticks_base + j)) {
                     id_per_dim[j] = 0;
-                    src_stick_id += num_padded_sticks[j];
+                    src_stick_id += get_vararg(num_padded_sticks_base + j);
                 } else {
                     break;
                 }
@@ -108,9 +118,9 @@ void kernel_main() {
             src_stick_id++;
             for (uint32_t j = 0; j < num_dims; j++) {
                 id_per_dim[j]++;
-                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                if (id_per_dim[j] == get_vararg(num_unpadded_sticks_base + j)) {
                     id_per_dim[j] = 0;
-                    src_stick_id += num_padded_sticks[j];
+                    src_stick_id += get_vararg(num_padded_sticks_base + j);
                 } else {
                     break;
                 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp
@@ -9,33 +9,36 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t stick_size_unpadded = get_compile_time_arg_val(0);
-    constexpr uint32_t num_sticks_unpadded = get_compile_time_arg_val(1);
+    constexpr auto stick_size_unpadded = get_arg(args::stick_size_unpadded);
+    constexpr auto num_sticks_unpadded = get_arg(args::num_sticks_unpadded);
     // Buffer's aligned row stride (>= payload when W·E is not 16-aligned); begins_bytes = slice_start[-1] * E.
-    constexpr uint32_t src_stride_bytes = get_compile_time_arg_val(2);
-    constexpr uint32_t dst_stride_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t begins_bytes = get_compile_time_arg_val(4);
+    constexpr auto src_stride_bytes = get_arg(args::src_stride_bytes);
+    constexpr auto dst_stride_bytes = get_arg(args::dst_stride_bytes);
+    constexpr auto begins_bytes = get_arg(args::begins_bytes);
 
     // One coalesced read only when every row is contiguous on both sides and starts at column 0.
     constexpr bool can_coalesce =
         (begins_bytes == 0) && (src_stride_bytes == stick_size_unpadded) && (dst_stride_bytes == stick_size_unpadded);
 
-    const uint32_t num_cores_read = get_arg_val<uint32_t>(0);
-    tt_l1_ptr uint32_t* read_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(1));
-    tt_l1_ptr uint32_t* read_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-    tt_l1_ptr uint32_t* num_stick_chunks = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 2));
-    tt_l1_ptr uint32_t* chunk_start_id = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 3));
-    tt_l1_ptr uint32_t* chunk_num_sticks = (tt_l1_ptr uint32_t*)(chunk_start_id + 1);
+    const auto num_cores_read = get_arg(args::num_cores_read);
 
-    constexpr auto dfb_in0 = tt::CBIndex::c_0;
-    constexpr auto dfb_out0 = tt::CBIndex::c_16;
+    // The gather plan is data-directed, so it arrives as a runtime vararg block laid out as:
+    //   [0, 2*num_cores_read)                interleaved NoC (x, y) per source core
+    //   [2*num_cores_read, 3*num_cores_read) chunk count per source core
+    //   [3*num_cores_read, ...)              a (start_id, length) pair per chunk
+    // The x/y pairs share one interleaved run and are read one word apart, both strided by 2.
+    const uint32_t noc_xy_base = 0;
+    const uint32_t num_stick_chunks_base = num_cores_read * 2;
+    const uint32_t chunk_base = num_cores_read * 3;
 
     Noc noc;
-    // Create DataflowBuffers for Device 2.0 API
-    DataflowBuffer dfb_in(dfb_in0);
-    DataflowBuffer dfb_out(dfb_out0);
+    // Create DataflowBuffers for Device 2.0 API. Both borrow their backing memory from a tensor:
+    // dfb_in views the input shard, dfb_out the output shard.
+    DataflowBuffer dfb_in(dfb::in_shard);
+    DataflowBuffer dfb_out(dfb::out_shard);
 
     dfb_out.reserve_back(num_sticks_unpadded);
     uint32_t l1_read_addr = dfb_in.get_write_ptr();
@@ -45,19 +48,22 @@ void kernel_main() {
     uint32_t read_noc_xy_ptr_offset = 0;
 
     for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
-        const uint32_t src_noc_x = read_noc_x[read_noc_xy_ptr_offset];
-        const uint32_t src_noc_y = read_noc_y[read_noc_xy_ptr_offset];
+        const uint32_t src_noc_x = get_vararg(noc_xy_base + read_noc_xy_ptr_offset);
+        const uint32_t src_noc_y = get_vararg(noc_xy_base + read_noc_xy_ptr_offset + 1);
 
-        uint32_t curr_core_num_chunks = num_stick_chunks[curr_core];
+        uint32_t curr_core_num_chunks = get_vararg(num_stick_chunks_base + curr_core);
 
         for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
-            uint32_t curr_start_id = chunk_start_id[chunk_ptr_offset];
-            uint32_t curr_num_sticks = chunk_num_sticks[chunk_ptr_offset];
+            uint32_t curr_start_id = get_vararg(chunk_base + chunk_ptr_offset);
+            uint32_t curr_num_sticks = get_vararg(chunk_base + chunk_ptr_offset + 1);
 
             if constexpr (can_coalesce) {
                 uint32_t src_off = curr_start_id * src_stride_bytes;
                 uint32_t bytes = curr_num_sticks * stick_size_unpadded;
                 CoreLocalMem<uint32_t> dst(l1_write_addr);
+                // l1_read_addr is a pointer into this core's *own* borrowed input DFB, used as the
+                // address of a read aimed at another core. That is only correct because a sharded
+                // buffer sits at the same L1 offset on every core in the range.
                 noc.async_read(
                     UnicastEndpoint{},
                     dst,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -8,38 +8,34 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t stick_size = get_arg_val<uint32_t>(1);
-    uint32_t stick_size_offset = get_arg_val<uint32_t>(2);
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(3);
-    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(4);
-    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(5);
-    uint32_t start_id = get_arg_val<uint32_t>(6);
-    // Per-shard page size: shard_W on B/W-sharded outputs, full row otherwise.
-    // Feeds `noc_async_write_sharded`'s multi-shard split via `get_aligned_page_size()`.
-    uint32_t page_size_override = get_arg_val<uint32_t>(7);
-    // Sub-row chunking (mirrors reader): `num_chunks_per_stick` CB pages of `chunk_size` per stick (last =
+    const auto stick_size = get_arg(args::stick_size);
+    const auto stick_size_offset = get_arg(args::stick_size_offset);
+    const auto num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    const auto num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    const auto num_read_per_barrier = get_arg(args::num_read_per_barrier);
+    const auto start_id = get_arg(args::start_id);
+    // Sub-row chunking (mirrors reader): `num_chunks_per_stick` DFB entries of `chunk_size` per stick (last =
     // `last_chunk_size`).
-    const uint32_t chunk_size = get_arg_val<uint32_t>(8);
-    const uint32_t num_chunks_per_stick = get_arg_val<uint32_t>(9);
-    const uint32_t last_chunk_size = get_arg_val<uint32_t>(10);
+    const auto chunk_size = get_arg(args::chunk_size);
+    const auto num_chunks_per_stick = get_arg(args::num_chunks_per_stick);
+    const auto last_chunk_size = get_arg(args::last_chunk_size);
 
-    constexpr uint32_t dfb_id_out0 = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
-
-    const auto s0 = TensorAccessor(dst_args, dst_addr, page_size_override);
+    // The per-page stride is the buffer's aligned page size, which the binding supplies; the host
+    // pins that it equals the per-shard page size this kernel needs (check_accessor_page_size).
+    const auto s0 = TensorAccessor(tensor::dst);
 
     Noc noc;
     // Create DataflowBuffer for Device 2.0 API
-    DataflowBuffer dfb_out0(dfb_id_out0);
+    DataflowBuffer dfb_out0(dfb::out0);
 
     uint32_t i_stick = start_id;
     uint32_t sticks_read = 0;
 
     if (num_chunks_per_stick > 1) {
-        // Chunked path (mirrors reader): batch by `num_read_per_barrier` so the second CB pair pipelines.
+        // Chunked path (mirrors reader): batch by `num_read_per_barrier` so the second DFB pair pipelines.
         for (uint32_t iter = 0; iter < num_sticks_per_core_read && sticks_read < num_sticks_per_core; ++iter) {
             uint32_t c = 0;
             while (c < num_chunks_per_stick) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
@@ -46,34 +46,31 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Runtime arguments for 4D slice support with multi-core work distribution
-    uint32_t rt_args_idx = 0;
-    uint32_t dst_addr = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_w = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_h = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_d = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t output_n = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    const auto tensor_rank = get_arg(args::tensor_rank);
+    const auto output_w = get_arg(args::output_w);
+    const auto output_h = get_arg(args::output_h);
+    const auto output_d = get_arg(args::output_d);
+    const auto output_n = get_arg(args::output_n);
+    const auto element_size = get_arg(args::element_size);
+    const auto num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    const auto start_row_for_this_core = get_arg(args::start_row_for_this_core);
 
     // Compile-time arguments
-    constexpr uint32_t dfb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr auto compile_time_element_size = get_arg(args::compile_time_element_size);
 
     // Calculate sizes - working with rows, not tiles
     uint32_t output_bytes_per_row = output_w * element_size;  // Dynamic element size
 
     // Set up TensorAccessor for output data - use row size as page size
-    const auto s0 = TensorAccessor(dst_args, dst_addr);
+    const auto s0 = TensorAccessor(tensor::dst);
 
     Noc noc;
     // Create DataflowBuffer for Device 2.0 API
-    DataflowBuffer dfb_in(dfb_id_in);
+    DataflowBuffer dfb_in(dfb::in);
 
     // Multi-core work distribution: this core writes rows starting from start_row_for_this_core
     // Write each row from circular buffer to output tensor at the correct logical position

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
@@ -51,36 +51,30 @@
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Runtime arguments - first get basic parameters
-    uint32_t rt_args_idx = 0;
-    uint32_t dst_addr = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t tensor_rank = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t element_size = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(rt_args_idx++);
+    const auto tensor_rank = get_arg(args::tensor_rank);
+    const auto element_size = get_arg(args::element_size);
+    const auto num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    const auto start_row_for_this_core = get_arg(args::start_row_for_this_core);
 
     // Compile-time arguments
-    constexpr uint32_t dfb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr auto compile_time_element_size = get_arg(args::compile_time_element_size);
 
-    // Get dimension arrays from runtime arguments
-    // Layout: output_dims[rank]
-
-    // Read output dimensions
-    volatile tt_l1_ptr uint32_t* output_dims = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(rt_args_idx++));
+    // One tensor_rank-long runtime vararg block: output_dims
+    const uint32_t output_dims_base = 0;
 
     // Calculate sizes - working with rows, not tiles
-    uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;
+    uint32_t output_bytes_per_row = get_vararg(output_dims_base + tensor_rank - 1) * element_size;
 
     // Set up TensorAccessor for output data - use row size as page size
-    const auto s0 = TensorAccessor(dst_args, dst_addr);
+    const auto s0 = TensorAccessor(tensor::dst);
 
     Noc noc;
     // Create DataflowBuffer for Device 2.0 API
-    DataflowBuffer dfb_in(dfb_id_in);
+    DataflowBuffer dfb_in(dfb::in);
 
     // Multi-core work distribution: this core writes rows starting from start_row_for_this_core
     // Write each row from circular buffer to output tensor at the correct logical position

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -2,27 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Slice-specific writer using named compile-time args for DFB index.
-// Based on eltwise/unary writer but uses get_named_compile_time_arg_val("dfb_id_out")
-// so the DFB index can be remapped by the fusion infrastructure.
+// Slice-specific writer. Based on the eltwise/unary writer, but the DFB it drains is chosen per
+// KernelSpec rather than being fixed by the kernel, so the fusion infrastructure can remap it.
+// SliceTileProgramFactory is its only binder.
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_pages = get_arg_val<uint32_t>(1);
-    const uint32_t start_id = get_arg_val<uint32_t>(2);
-
-    constexpr uint32_t dfb_id_out = get_named_compile_time_arg_val("dfb_id_out");
-    constexpr auto dst_args = TensorAccessorArgs<0>();
+    const auto num_pages = get_arg(args::num_pages);
+    const auto start_id = get_arg(args::start_id);
 
     // Create objects for Device 2.0 API
-    DataflowBuffer dfb_out(dfb_id_out);
+    DataflowBuffer dfb_out(dfb::out);
 
-    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    // Get page size from the DFB (works for both TILE and ROW_MAJOR layouts)
     const uint32_t page_bytes = dfb_out.get_entry_size();
     Noc noc;
 
@@ -33,7 +30,7 @@ void kernel_main() {
     // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
     constexpr uint32_t onepage = 1;
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(tensor::dst);
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_pages;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -68,13 +68,4 @@ SliceDeviceOperation::tensor_return_value_t slice(
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
     const std::optional<Tensor>& preallocated_output = std::nullopt);
 
-// Re-point every per-dispatch address in a cached slice program, for the factory that built it.
-// MeshPartition drives these factories directly and shares this so the slot layout has one home.
-void patch_slice_program_addresses(
-    tt::tt_metal::Program& program,
-    const SliceDeviceOperation::program_factory_t& factory,
-    const SliceParams& operation_attributes,
-    const SliceInputs& tensor_args,
-    Tensor& output);
-
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -5,22 +5,26 @@
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp"
 
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
-
+#include <cstdint>
 #include <optional>
 #include <tuple>
-#include <tt-metalium/work_split.hpp>
+#include <utility>
+#include <vector>
+
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/work_split.hpp>
 
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::operations::data_movement {
 
@@ -33,11 +37,32 @@ struct ChunkingParams {
     uint32_t last_chunk_size;
 };
 
-inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
+// The reader / writer scalars that vary per node, plus the reader's runtime vararg block.
+struct RmPerNodeArgs {
+    uint32_t start_id = 0;
+    uint32_t num_sticks_per_core = 0;
+    uint32_t num_sticks_per_core_read = 0;
+    uint32_t num_read_per_barrier = 0;
+    // 3 * num_dims entries: num_unpadded_sticks_per_dim, num_padded_sticks_per_dim, id_per_dim.
+    std::vector<uint32_t> reader_varargs;
+    uint32_t num_sticks_written = 0;
+};
+
+// Program-wide scalars every node receives identically. Legacy emitted these per node as runtime
+// args and the port keeps them there: moving a per-node arg to a common one changes dispatch
+// semantics, which is a separate cleanup, not port work.
+struct RmSharedArgs {
+    uint32_t unpadded_row_size_bytes = 0;
+    uint32_t unpadded_row_size_bytes_offset = 0;
+    uint32_t num_dims = 0;
+    uint32_t misalignment = 0;
+    uint32_t src_offset_bytes = 0;
+};
+
+inline std::pair<RmSharedArgs, std::vector<RmPerNodeArgs>> get_slice_runtime_args_rm(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const ttnn::Shape& output_tensor_start,
-    uint32_t num_cores,
     const std::vector<CoreCoord>& all_cores_vec,
     const CoreRangeSet& core_group_1,
     const CoreRangeSet& core_group_2,
@@ -48,7 +73,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     auto input_shape = input_tensor.padded_shape();
     auto output_shape = output_tensor.padded_shape();
 
-    uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
@@ -83,31 +107,18 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t misalignment = begins_bytes % src_buffer_alignment;
     uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
 
-    const uint32_t reader_page_size = per_shard_page_size_bytes(input_tensor, padded_row_size_bytes);
+    RmSharedArgs shared{
+        .unpadded_row_size_bytes = unpadded_row_size_bytes,
+        .unpadded_row_size_bytes_offset = unpadded_row_size_bytes_offset,
+        .num_dims = num_dims,
+        .misalignment = misalignment,
+        // Byte offset of the slice's W-begin within a row, rounded down to the source buffer's
+        // alignment; the leftover `misalignment` bytes are trimmed on device.
+        .src_offset_bytes = begins_bytes - misalignment,
+    };
 
-    // Reader arg 0 is the plain input buffer base address; it is emitted as a Buffer* binding in
-    // create_descriptor (not here), so the args returned here start at arg 1.
-    std::vector<uint32_t> common_reader_kernel_args = {
-        reader_page_size,
-        unpadded_row_size_bytes,
-        unpadded_row_size_bytes_offset,
-        num_dims,
-        misalignment,
-        0,
-        0,
-        0,
-        0,
-        chunking.chunk_size,
-        chunking.num_chunks_per_stick,
-        chunking.last_chunk_size,
-        begins_bytes - misalignment};
-    common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
-    common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
-
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val;
-    ret_val.reserve(num_cores);
+    std::vector<RmPerNodeArgs> per_node;
+    per_node.reserve(all_cores_vec.size());
 
     uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
     uint32_t num_sticks_written = 0;
@@ -125,7 +136,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         if (num_sticks_per_core != 0) {
             if (chunking.num_chunks_per_stick > 1) {
                 num_sticks_per_core_read = num_sticks_per_core;
-                // Match `compute_cb_size`: nrpb=2 only when num_chunks is even, else 1 to avoid ring-wrap straddle.
+                // Match `compute_dfb_size`: nrpb=2 only when num_chunks is even, else 1 to avoid ring-wrap straddle.
                 num_read_per_barrier = (chunking.num_chunks_per_stick % 2 == 0) ? 2 : 1;
             } else {
                 auto num_sticks_per_core_pad32 = round_up_to_mul32(num_sticks_per_core);
@@ -144,41 +155,34 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
             start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
         }
-        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        uint32_t addr_offset = 5;
-        reader_kernel_args[addr_offset++] = start_id;
-        reader_kernel_args[addr_offset++] = num_sticks_per_core;
-        reader_kernel_args[addr_offset++] = num_sticks_per_core_read;
-        reader_kernel_args[addr_offset] = num_read_per_barrier;
-        reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
-        const uint32_t writer_page_size = per_shard_page_size_bytes(output_tensor, unpadded_row_size_bytes);
-        // Writer arg 0 is the plain output buffer base address; it is emitted as a Buffer* binding in
-        // create_descriptor (not here), so the args returned here start at arg 1.
-        std::vector<uint32_t> writer_kernel_args = {
-            unpadded_row_size_bytes,
-            unpadded_row_size_bytes_offset,
-            num_sticks_per_core,
-            num_sticks_per_core_read,
-            num_read_per_barrier,
-            num_sticks_written,
-            writer_page_size,
-            chunking.chunk_size,
-            chunking.num_chunks_per_stick,
-            chunking.last_chunk_size,
+        RmPerNodeArgs node_args{
+            .start_id = start_id,
+            .num_sticks_per_core = num_sticks_per_core,
+            .num_sticks_per_core_read = num_sticks_per_core_read,
+            .num_read_per_barrier = num_read_per_barrier,
+            .num_sticks_written = num_sticks_written,
         };
+        // Three num_dims-long blocks, in the order the kernel walks them.
+        node_args.reader_varargs.reserve(num_dims * 3);
+        node_args.reader_varargs.insert(
+            node_args.reader_varargs.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
+        node_args.reader_varargs.insert(
+            node_args.reader_varargs.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
+        node_args.reader_varargs.insert(node_args.reader_varargs.end(), id_per_dim.begin(), id_per_dim.end());
+
         num_sticks_written += num_sticks_per_core;
-        ret_val.emplace_back(reader_kernel_args, writer_kernel_args);
+        per_node.push_back(std::move(node_args));
     }
 
-    return ret_val;
+    return {shared, std::move(per_node)};
 }
 
 constexpr uint32_t MAX_READ_SIZE = 4096;
 constexpr uint32_t CHUNK_TARGET_BYTES = 8192;  // NOC-friendly chunk when splitting a wide row
 
-struct SliceCbSizing {
-    uint32_t cb_page_size;
+struct SliceDfbSizing {
+    uint32_t dfb_entry_size;
     uint32_t num_read_per_barrier;
     uint32_t misalignment;
     ChunkingParams chunking;
@@ -186,7 +190,7 @@ struct SliceCbSizing {
 
 // Chunks sub-row when double-buffered row page overflows L1; gated on misalignment==0
 // (misalign path uses a whole-stick memmove that doesn't compose with chunk boundaries).
-SliceCbSizing compute_cb_size(
+SliceDfbSizing compute_dfb_size(
     const Tensor& input,
     const Tensor& output,
     const Shape& output_tensor_start,
@@ -212,8 +216,8 @@ SliceCbSizing compute_cb_size(
 
     const uint32_t l1_budget = ttnn::operations::data_movement::get_max_l1_space(input);
 
-    SliceCbSizing s{
-        .cb_page_size = stick_size_aligned,
+    SliceDfbSizing s{
+        .dfb_entry_size = stick_size_aligned,
         .num_read_per_barrier = 0,
         .misalignment = misalignment,
         .chunking = {stick_size_aligned, 1, stick_size_aligned},
@@ -224,7 +228,7 @@ SliceCbSizing compute_cb_size(
     uint32_t stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
 
     if (needs_chunking) {
-        // l1_budget/8 leaves headroom for reader + writer CBs pair-batched (each 4*chunk_size).
+        // l1_budget/8 leaves headroom for reader + writer DFBs pair-batched (each 4*chunk_size).
         uint32_t max_chunk = std::min<uint32_t>(CHUNK_TARGET_BYTES, static_cast<uint32_t>(l1_budget / 8));
         max_chunk = (max_chunk / alignment) * alignment;
         TT_FATAL(
@@ -234,7 +238,7 @@ SliceCbSizing compute_cb_size(
             alignment);
 
         uint32_t num_chunks = (unpadded_row_size_bytes + max_chunk - 1) / max_chunk;
-        // Odd num_chunks with nrpb=2 straddles the 4-page CB ring on the next stick — try an aligned
+        // Odd num_chunks with nrpb=2 straddles the 4-page ring on the next stick — try an aligned
         // shrink to reach even; commit only if it lands, else let the nrpb=1 fallback do the work.
         constexpr uint32_t nrpb = 2;
         if ((num_chunks % nrpb) != 0) {
@@ -255,15 +259,15 @@ SliceCbSizing compute_cb_size(
             .num_chunks_per_stick = num_chunks,
             .last_chunk_size = (remainder == 0) ? max_chunk : remainder,
         };
-        s.cb_page_size = max_chunk;
+        s.dfb_entry_size = max_chunk;
         stride_for_merge = max_chunk;
     }
 
     TT_FATAL(
-        static_cast<uint64_t>(2u) * s.cb_page_size <= l1_budget,
-        "ttnn::slice: required CB size {} B exceeds per-core L1 budget {} B "
+        static_cast<uint64_t>(2u) * s.dfb_entry_size <= l1_budget,
+        "ttnn::slice: required DFB size {} B exceeds per-core L1 budget {} B "
         "(row_bytes={}, misalignment={}); consider slicing along a non-width dim",
-        2u * s.cb_page_size,
+        2u * s.dfb_entry_size,
         l1_budget,
         unpadded_row_size_bytes,
         misalignment);
@@ -286,19 +290,62 @@ SliceCbSizing compute_cb_size(
     return s;
 }
 
+// The port drops the TensorAccessor page-size override that this factory used to pass as a third
+// constructor argument; Metal 2.0 supplies the buffer's aligned page size instead and offers no
+// override.
+//
+// On an *interleaved* accessor the substitution is inert whatever the two values are: the accessor
+// realigns the passed page size up to the allocator alignment, so the old argument (the true logical
+// row) and the new implicit one (that row rounded up) address identically. Only a *sharded* accessor
+// uses the value verbatim, and there the two must actually agree — which they do for a
+// HEIGHT-sharded buffer by construction, and for a BLOCK/WIDTH-sharded one only while the shard row
+// is alignment-aligned. `ttnn::slice` guarantees that by resharding any tensor that would violate it
+// before this factory is reached, but MeshPartition builds these programs off select_program_factory
+// and never passes through that guard, so pin the invariant here rather than leaving it implicit.
+void check_accessor_page_size(const Tensor& tensor, uint32_t row_size_bytes, const char* role) {
+    if (!tensor.memory_config().is_sharded()) {
+        return;
+    }
+    const uint32_t passed = per_shard_page_size_bytes(tensor, row_size_bytes);
+    const uint32_t implicit = tensor.buffer()->aligned_page_size();
+    TT_FATAL(
+        passed == implicit,
+        "SliceRmProgramFactory: {} per-shard page size ({} B) must equal the buffer's aligned page size ({} B); "
+        "a sub-aligned shard row must be resharded before reaching this factory.",
+        role,
+        passed,
+        implicit);
+}
+
 }  // namespace
 
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
+namespace {
+
+// Function-local for the same unity-build reason as the other slice factories.
+struct RmSpecNames {
+    KernelSpecName reader{"reader"};
+    KernelSpecName writer{"writer"};
+    DFBSpecName src0{"src0"};
+    TensorParamName input{"input"};
+    TensorParamName output{"output"};
+};
+
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_artifacts(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const RmSpecNames names;
+
     const auto& input = tensor_args.input;
     tt::tt_metal::IDevice* device = input.device();
-    ProgramDescriptor desc;
 
-    uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
+
+    const uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
@@ -306,59 +353,33 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
             ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_sticks)
             : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
 
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const uint32_t padded_row_size_bytes = input.padded_shape()[-1] * input.element_size();
+    const uint32_t unpadded_row_size_bytes = output.padded_shape()[-1] * input.element_size();
+    ttnn::operations::data_movement::check_accessor_page_size(input, padded_row_size_bytes, "input");
+    ttnn::operations::data_movement::check_accessor_page_size(output, unpadded_row_size_bytes, "output");
 
-    constexpr uint8_t src0_cb_index = 0;
-
-    // CB sizing (incl. chunking) derives from padded_shape + slice_start + alignment, all of which
-    // fold into compute_program_hash(), so cache entries stay distinct per unique CB layout.
-    const auto sizing = ttnn::operations::data_movement::compute_cb_size(
+    // DFB sizing (incl. chunking) derives from padded_shape + slice_start + alignment, all of which
+    // fold into compute_program_hash(), so cache entries stay distinct per unique sizing.
+    const auto sizing = ttnn::operations::data_movement::compute_dfb_size(
         input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = sizing.num_read_per_barrier * 2 * sizing.cb_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = cb_data_format,
-            .page_size = sizing.cb_page_size,
-        }}},
-    });
+    const DataflowBufferSpec src0_dfb{
+        .unique_id = names.src0,
+        .entry_size = sizing.dfb_entry_size,
+        .num_entries = sizing.num_read_per_barrier * 2,
+        .data_format_metadata = dfb_data_format,
+    };
 
-    std::vector<uint32_t> writer_compile_time_args_vec = {static_cast<uint32_t>(src0_cb_index)};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args_vec);
+    const TensorParameter input_param{.unique_id = names.input, .spec = input.tensor_spec()};
+    const TensorParameter output_param{.unique_id = names.output, .spec = output.tensor_spec()};
 
-    std::vector<uint32_t> reader_compile_time_args_vec;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args_vec);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args_vec);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "slice_writer_unary_stick_layout_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args_vec);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    auto all_cores_vec = corerange_to_cores(all_cores);
-    auto all_runtime_args = ttnn::operations::data_movement::get_slice_runtime_args_rm(
+    const auto all_cores_vec = corerange_to_cores(all_cores);
+    auto [shared, per_node] = ttnn::operations::data_movement::get_slice_runtime_args_rm(
         input,
         output,
         args.slice_start,
-        num_cores,
         all_cores_vec,
         core_group_1,
         core_group_2,
@@ -367,39 +388,144 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
         ttnn::operations::data_movement::MAX_READ_SIZE,
         sizing.chunking);
 
-    reader_desc.runtime_args.reserve(all_cores_vec.size());
-    writer_desc.runtime_args.reserve(all_cores_vec.size());
-    for (size_t i = 0; i < all_cores_vec.size(); ++i) {
-        // Reader arg 0 = input buffer base address, declared as a Buffer* binding so the framework
-        // patches it on cache hits instead of rebuilding the descriptor; args 1.. follow unchanged.
-        KernelDescriptor::RTArgList reader_args;
-        reader_args.reserve(1 + all_runtime_args[i].first.size());
-        reader_args.push_back(src0_buffer);
-        reader_args.append(all_runtime_args[i].first);
-        reader_desc.emplace_runtime_args(all_cores_vec[i], reader_args);
+    const KernelSpec reader{
+        .unique_id = names.reader,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+            "slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.src0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.input, .accessor_name = "src"},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"unpadded_stick_size",
+                     "stick_size_offset",
+                     "num_dims",
+                     "misalignment",
+                     "start_id",
+                     "num_sticks_per_core",
+                     "num_sticks_per_core_read",
+                     "num_read_per_barrier",
+                     "chunk_size",
+                     "num_chunks_per_stick",
+                     "last_chunk_size",
+                     "src_offset_bytes"},
+            },
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .advanced_options = {.num_runtime_varargs = shared.num_dims * 3},
+    };
 
-        // Writer arg 0 = output buffer base address, declared as a Buffer* binding so the framework
-        // patches it on cache hits instead of rebuilding the descriptor; args 1.. follow unchanged.
-        KernelDescriptor::RTArgList writer_args;
-        writer_args.reserve(1 + all_runtime_args[i].second.size());
-        writer_args.push_back(dst_buffer);
-        writer_args.append(all_runtime_args[i].second);
-        writer_desc.emplace_runtime_args(all_cores_vec[i], writer_args);
+    const KernelSpec writer{
+        .unique_id = names.writer,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+            "slice_writer_unary_stick_layout_interleaved_start_id.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.src0,
+                    .accessor_name = "out0",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.output, .accessor_name = "dst"},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"stick_size",
+                     "stick_size_offset",
+                     "num_sticks_per_core",
+                     "num_sticks_per_core_read",
+                     "num_read_per_barrier",
+                     "start_id",
+                     "chunk_size",
+                     "num_chunks_per_stick",
+                     "last_chunk_size"},
+            },
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
+
+    KernelRunArgs reader_run_args{.kernel = names.reader};
+    KernelRunArgs writer_run_args{.kernel = names.writer};
+    for (size_t i = 0; i < all_cores_vec.size(); ++i) {
+        const auto& node = all_cores_vec[i];
+        const auto& node_args = per_node[i];
+
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            node,
+            {{"unpadded_stick_size", shared.unpadded_row_size_bytes},
+             {"stick_size_offset", shared.unpadded_row_size_bytes_offset},
+             {"num_dims", shared.num_dims},
+             {"misalignment", shared.misalignment},
+             {"start_id", node_args.start_id},
+             {"num_sticks_per_core", node_args.num_sticks_per_core},
+             {"num_sticks_per_core_read", node_args.num_sticks_per_core_read},
+             {"num_read_per_barrier", node_args.num_read_per_barrier},
+             {"chunk_size", sizing.chunking.chunk_size},
+             {"num_chunks_per_stick", sizing.chunking.num_chunks_per_stick},
+             {"last_chunk_size", sizing.chunking.last_chunk_size},
+             {"src_offset_bytes", shared.src_offset_bytes}});
+        reader_run_args.advanced_options.runtime_varargs[node] = node_args.reader_varargs;
+
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            node,
+            {{"stick_size", shared.unpadded_row_size_bytes},
+             {"stick_size_offset", shared.unpadded_row_size_bytes_offset},
+             {"num_sticks_per_core", node_args.num_sticks_per_core},
+             {"num_sticks_per_core_read", node_args.num_sticks_per_core_read},
+             {"num_read_per_barrier", node_args.num_read_per_barrier},
+             {"start_id", node_args.num_sticks_written},
+             {"chunk_size", sizing.chunking.chunk_size},
+             {"num_chunks_per_stick", sizing.chunking.num_chunks_per_stick},
+             {"last_chunk_size", sizing.chunking.last_chunk_size}});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    ProgramSpec spec{
+        .name = "slice_rm",
+        .kernels = {reader, writer},
+        .dataflow_buffers = {src0_dfb},
+        .tensor_parameters = {input_param, output_param},
+        .work_units = {WorkUnitSpec{
+            .name = "slice",
+            .kernels = {names.reader, names.writer},
+            .target_nodes = all_cores,
+        }},
+    };
 
-    return desc;
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {{names.input, input.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
-void SliceRmProgramFactory::override_runtime_arguments(
-    tt::tt_metal::Program& program,
-    const SliceParams& args,
+tt::tt_metal::experimental::ProgramRunArgs SliceRmProgramFactory::override_runtime_arguments(
+    const SliceParams& /*args*/,
     const SliceInputs& tensor_args,
     Tensor& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    patch_slice_program_addresses(program, SliceRmProgramFactory{}, args, tensor_args, output);
+    const RmSpecNames names;
+
+    // The legacy refresh for this factory re-pointed the two buffer addresses and nothing else; both
+    // now travel as tensor bindings, so re-supplying them is the whole job.
+    ProgramRunArgs run_args;
+    run_args.tensor_args = {{names.input, tensor_args.input.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
@@ -3,31 +3,28 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <vector>
-
-#include <tt-metalium/host_api.hpp>
 #include <optional>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include "ttnn/distributed/types.hpp"
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct SliceRmProgramFactory {
-    // Contract (1): per-coord ProgramDescriptor.  The src0 CB's total_size /
-    // page_size depend on slice_start (via misalignment / unpadded_row_size_bytes),
-    // so padded_shape is folded into compute_program_hash() — each unique CB
-    // sizing keeps its own cache entry.  On cache hit the framework copies
-    // runtime args and patches dynamic CB addresses; CB total_size/page_size
-    // are not re-applied (the cached descriptor already carries them).
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    // The src0 DFB's entry_size / num_entries depend on slice_start (via misalignment /
+    // unpadded_row_size_bytes), so padded_shape is folded into compute_program_hash() — each unique
+    // sizing keeps its own cache entry. DFB sizing is not re-applied on a cache hit; the cached
+    // program carries it.
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
+    // CustomProgramSpecFactoryConcept cache-hit hook. Every scalar is shape-derived and hashed, so
+    // only the tensor bindings move — but this concept applies nothing on its own, so they are
+    // re-supplied here.
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
         const SliceParams& args,
         const SliceInputs& tensor_args,
         Tensor& output,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -4,19 +4,25 @@
 
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp"
-#include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
 
+#include <algorithm>
+#include <cstdint>
 #include <map>
 #include <optional>
+#include <utility>
+#include <vector>
+
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::operations::data_movement {
 
@@ -57,14 +63,23 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<ui
     return chunks;
 }
 
-inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded(
+// One node's reader arguments.
+//
+// The gather plan is data-directed — num_cores_read source cores, then a NoC (x, y) pair per source
+// core, then a chunk count per source core, then a (start_id, length) pair per chunk — and the
+// counts come from the data itself, so nothing past num_cores_read has a per-element identity. That
+// block travels as runtime varargs; num_cores_read is a named argument.
+struct ShardedPerNodeArgs {
+    uint32_t num_cores_read = 0;
+    std::vector<uint32_t> reader_varargs;
+};
+
+inline std::vector<ShardedPerNodeArgs> get_slice_runtime_args_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const ttnn::Shape& output_tensor_start,
     uint32_t num_cores_unpadded,
     bool row_major,
-    uint32_t num_cores_x_unpadded,
-    uint32_t num_cores_y_unpadded,
     uint32_t shard_height_unpadded,
     uint32_t shard_height_padded,
     uint32_t num_cores_x_padded,
@@ -96,16 +111,10 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
 
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_unpadded);
+    std::vector<ShardedPerNodeArgs> ret_val(num_cores_unpadded);
 
     uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
     for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_unpadded; i++) {
-        CoreCoord core;
-        if (row_major) {
-            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
-        } else {
-            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
-        }
         uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
         uint32_t num_sticks_per_core_padded = shard_height_padded;
 
@@ -164,19 +173,20 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        // reader rt args
-        std::vector<uint32_t> reader_kernel_args;
-        reader_kernel_args.reserve(1 + 3 * core_stick_map.size() + 2 * num_sticks_per_core_unpadded);
-        reader_kernel_args.push_back(core_stick_map.size());  // num_cores
+        // reader args: num_cores_read is named, the gather plan below is the vararg block.
+        ShardedPerNodeArgs node_args;
+        node_args.num_cores_read = core_stick_map.size();
+        std::vector<uint32_t>& reader_varargs = node_args.reader_varargs;
+        reader_varargs.reserve(3 * core_stick_map.size() + 2 * num_sticks_per_core_unpadded);
 
         for (const auto& core_stick_pair : core_stick_map) {
             auto xy_pair = core_stick_pair.first;
             if (row_major) {
-                reader_kernel_args.push_back(xy_pair.second);  // noc x
-                reader_kernel_args.push_back(xy_pair.first);   // noc y
+                reader_varargs.push_back(xy_pair.second);  // noc x
+                reader_varargs.push_back(xy_pair.first);   // noc y
             } else {
-                reader_kernel_args.push_back(xy_pair.first);   // noc x
-                reader_kernel_args.push_back(xy_pair.second);  // noc y
+                reader_varargs.push_back(xy_pair.first);   // noc x
+                reader_varargs.push_back(xy_pair.second);  // noc y
             }
         }
 
@@ -185,19 +195,18 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         stick_chunks_per_core.reserve(core_stick_map.size());
         for (auto core_stick_pair : core_stick_map) {
             auto stick_chunks = group_contiguous_values(core_stick_pair.second);
-            reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+            reader_varargs.push_back(stick_chunks.size());  // num_chunks for current core
 
             stick_chunks_per_core.push_back(std::move(stick_chunks));
         }
         for (const auto& stick_chunks : stick_chunks_per_core) {
             for (auto chunk : stick_chunks) {
-                reader_kernel_args.push_back(chunk[0]);      // start id of a chunk
-                reader_kernel_args.push_back(chunk.size());  // length of a chunk
+                reader_varargs.push_back(chunk[0]);      // start id of a chunk
+                reader_varargs.push_back(chunk.size());  // length of a chunk
             }
         }
 
-        std::vector<uint32_t> writer_kernel_args;
-        ret_val[i] = {std::move(reader_kernel_args), std::move(writer_kernel_args)};
+        ret_val[i] = std::move(node_args);
     }
 
     return ret_val;
@@ -209,10 +218,25 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
+namespace {
+
+// Function-local for the same unity-build reason as the other slice factories.
+struct ShardedSpecNames {
+    KernelSpecName reader{"reader"};
+    DFBSpecName in_shard{"in_shard"};
+    DFBSpecName out_shard{"out_shard"};
+    TensorParamName input{"input"};
+    TensorParamName output{"output"};
+};
+
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts SliceRmShardedProgramFactory::create_program_artifacts(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const ShardedSpecNames names;
+
     const auto& input = tensor_args.input;
-    ProgramDescriptor desc;
+    tt::tt_metal::IDevice* device = input.device();
 
     [[maybe_unused]] uint32_t num_padded_sticks = input.physical_volume() / input.padded_shape()[-1];
     [[maybe_unused]] uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
@@ -257,11 +281,10 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
     log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat dst_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
     // Real per-row L1 stride is aligned_page_size(), not the compact payload (differs when W·E % 16 != 0).
     const uint32_t src_stride_bytes = input.buffer()->aligned_page_size();
@@ -272,42 +295,32 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
         "SliceRmShardedProgramFactory: width-begin ({} bytes) must be L1-aligned.",
         begins_bytes);
 
-    // Sharded CBs: total_size and page_size vary with shard shape / element size,
-    // so padded_shape is folded into compute_program_hash() to keep each unique
-    // sizing in its own cache entry.  On cache hit, the framework copies runtime
-    // args and patches dynamic CB addresses (.buffer is set below); CB sizing
-    // itself is not re-applied — it is carried by the cached descriptor.
-    // CB order here (src0, then c_16) is mirrored positionally by override_runtime_arguments; keep in sync.
-    constexpr uint8_t src0_cb_index = 0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = shard_height_padded * src_stride_bytes,
-        .core_ranges = all_cores_unpadded,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = cb_data_format,
-            .page_size = src_stride_bytes,
-        }}},
-        .buffer = input.buffer(),
-    });
+    // Both DFBs borrow their backing memory from a tensor, so the framework re-points them from the
+    // corresponding TensorArgument on every dispatch — no address ever travels as an argument.
+    //
+    // The reader is each one's only toucher, so it binds both endpoints of both (self-loop):
+    //  - in_shard is sync-free, touched only by a raw get_write_ptr() peek and no FIFO ops. Keeping
+    //    it borrowed from the input is load-bearing beyond addressing: the kernel uses that *local*
+    //    pointer as the address of reads aimed at *other* cores, which is only correct because a
+    //    sharded buffer lands at the same L1 offset on every core in the range.
+    //  - out_shard is a locked producer (reserve_back / push_back) that nothing drains.
+    const DataflowBufferSpec in_shard_dfb{
+        .unique_id = names.in_shard,
+        .entry_size = src_stride_bytes,
+        .num_entries = shard_height_padded,
+        .data_format_metadata = dfb_data_format,
+        .borrowed_from = names.input,
+    };
+    const DataflowBufferSpec out_shard_dfb{
+        .unique_id = names.out_shard,
+        .entry_size = dst_stride_bytes,
+        .num_entries = shard_height_unpadded,
+        .data_format_metadata = dst_dfb_data_format,
+        .borrowed_from = names.output,
+    };
 
-    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = shard_height_unpadded * dst_stride_bytes,
-        .core_ranges = all_cores_unpadded,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = dst_cb_data_format,
-            .page_size = dst_stride_bytes,
-        }}},
-        .buffer = output.buffer(),
-    });
-
-    std::vector<uint32_t> reader_ct_args = {
-        static_cast<uint32_t>(stick_size_unpadded),
-        static_cast<uint32_t>(shard_height_unpadded),
-        src_stride_bytes,
-        dst_stride_bytes,
-        begins_bytes};
+    const TensorParameter input_param{.unique_id = names.input, .spec = input.tensor_spec()};
+    const TensorParameter output_param{.unique_id = names.output, .spec = output.tensor_spec()};
 
     auto all_runtime_args = ttnn::operations::data_movement::get_slice_runtime_args_rm_sharded(
         input,
@@ -315,110 +328,108 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
         args.slice_start,
         num_cores_unpadded,
         row_major,
-        num_cores_x_unpadded,
-        num_cores_y_unpadded,
         shard_height_unpadded,
         shard_height_padded,
         num_cores_x_padded,
         num_cores_y_padded);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "slice_reader_unary_unpad_dims_rm_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores_unpadded;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    reader_desc.runtime_args.reserve(num_cores_unpadded);
-    for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
-        CoreCoord core;
-        if (row_major) {
-            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
-        } else {
-            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
-        }
-        reader_desc.runtime_args.emplace_back(core, std::move(all_runtime_args[i].first));
+    // The gather plan's length is data-dependent (it grows with the number of source cores and
+    // coalesced chunks a node reads from), but a KernelSpec declares one vararg count for every node
+    // it runs on. Declare the longest block and zero-fill the shorter ones: the kernel walks the
+    // block using the counts it reads out of it, so the tail is never read.
+    uint32_t num_reader_varargs = 0;
+    for (const auto& node_args : all_runtime_args) {
+        num_reader_varargs = std::max<uint32_t>(num_reader_varargs, node_args.reader_varargs.size());
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-
-    return desc;
-}
-
-// Re-point every per-dispatch address in a cached slice program, for the factory that built it.
-// Shared with MeshPartition, which drives these same factories directly, so the slot layout has one
-// home. Every shape-derived arg is keyed (both tensor specs, the slice params and factory.index() are
-// folded into compute_program_hash), so addresses are all that move on a hit.
-void patch_slice_program_addresses(
-    tt::tt_metal::Program& program,
-    const SliceDeviceOperation::program_factory_t& factory,
-    const SliceParams& operation_attributes,
-    const SliceInputs& tensor_args,
-    Tensor& output) {
-    // Height-sharded RM is CB-bound: the reader args are all keyed, so only the two sharded CB
-    // addresses move. CBs are matched positionally -- src0, then c_16.
-    if (std::holds_alternative<SliceRmShardedProgramFactory>(factory)) {
-        tt::tt_metal::ProgramDescriptor cb_addr_only;
-        cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = tensor_args.input.buffer()});
-        cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = output.buffer()});
-        tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);
-        return;
-    }
-
-    // A slot holding 0 belongs to a core create_descriptor left zero-filled; leave those alone.
-    constexpr uint32_t kReaderKernelIdx = 0, kWriterKernelIdx = 1;
-    const auto patch_slot0 = [&program](uint32_t kernel_idx, uint32_t addr) {
-        for (auto& col : tt::tt_metal::GetRuntimeArgs(program, kernel_idx)) {
-            for (auto& a : col) {
-                if (a.size() > 0 && a[0] != 0) {
-                    a[0] = addr;
-                }
-            }
-        }
+    const KernelSpec reader{
+        .unique_id = names.reader,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+            "slice_reader_unary_unpad_dims_rm_sharded.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.in_shard,
+                    .accessor_name = "in_shard",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = names.in_shard,
+                    .accessor_name = "in_shard",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = names.out_shard,
+                    .accessor_name = "out_shard",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = names.out_shard,
+                    .accessor_name = "out_shard",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"stick_size_unpadded", static_cast<uint32_t>(stick_size_unpadded)},
+                {"num_sticks_unpadded", shard_height_unpadded},
+                {"src_stride_bytes", src_stride_bytes},
+                {"dst_stride_bytes", dst_stride_bytes},
+                {"begins_bytes", begins_bytes},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_cores_read"}},
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .advanced_options = {.num_runtime_varargs = num_reader_varargs},
     };
-    patch_slot0(kWriterKernelIdx, output.buffer()->address());
 
-    std::visit(
-        [&](auto&& f) {
-            using Factory = std::decay_t<decltype(f)>;
-            if constexpr (
-                std::is_same_v<Factory, SliceRmProgramFactory> ||
-                std::is_same_v<Factory, SliceRmStrideProgramFactory>) {
-                patch_slot0(kReaderKernelIdx, tensor_args.input.buffer()->address());
-            } else if constexpr (
-                std::is_same_v<Factory, SliceTileProgramFactory> ||
-                std::is_same_v<Factory, SliceTileTensorArgsProgramFactory>) {
-                // Divergent-partition hit leaves writer num_pages=0 -> all-zero output (#52651).
-                std::vector<tt::tt_metal::DynamicRuntimeArg> dyn{
-                    {kReaderKernelIdx, {}, 0, tensor_args.input.buffer()->address(), true}};
-                if constexpr (std::is_same_v<Factory, SliceTileTensorArgsProgramFactory>) {
-                    dyn.push_back(
-                        {kReaderKernelIdx, {}, 1, tensor_args.start_tensor.value().buffer()->address(), true});
-                    dyn.push_back({kReaderKernelIdx, {}, 2, tensor_args.end_tensor.value().buffer()->address(), true});
-                }
-                tt::tt_metal::apply_dynamic_runtime_args(program, dyn);
+    KernelRunArgs reader_run_args{.kernel = names.reader};
+    for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
+        CoreCoord node;
+        if (row_major) {
+            node = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
+        } else {
+            node = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
+        }
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values, node, {{"num_cores_read", all_runtime_args[i].num_cores_read}});
+        AdvancedKernelRunArgs::Varargs reader_varargs = all_runtime_args[i].reader_varargs;
+        reader_varargs.resize(num_reader_varargs, 0u);
+        reader_run_args.advanced_options.runtime_varargs[node] = std::move(reader_varargs);
+    }
 
-                const uint32_t start_offset = std::is_same_v<Factory, SliceTileProgramFactory>
-                                                  ? ttnn::operations::data_movement::get_tiled_start_offset(
-                                                        tensor_args.input, operation_attributes.slice_start)
-                                                  : 0u;
-                const auto per_core = slice_tile_dynamic_args(
-                    operation_attributes, tensor_args, output, start_offset, kReaderKernelIdx, kWriterKernelIdx);
-                tt::tt_metal::apply_dynamic_runtime_args(program, per_core);
-            }
-        },
-        factory);
+    ProgramSpec spec{
+        .name = "slice_rm_sharded",
+        .kernels = {reader},
+        .dataflow_buffers = {in_shard_dfb, out_shard_dfb},
+        .tensor_parameters = {input_param, output_param},
+        .work_units = {WorkUnitSpec{
+            .name = "slice",
+            .kernels = {names.reader},
+            .target_nodes = all_cores_unpadded,
+        }},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args)};
+    run_args.tensor_args = {{names.input, input.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
-void SliceRmShardedProgramFactory::override_runtime_arguments(
-    tt::tt_metal::Program& program,
-    const SliceParams& args,
+tt::tt_metal::experimental::ProgramRunArgs SliceRmShardedProgramFactory::override_runtime_arguments(
+    const SliceParams& /*args*/,
     const SliceInputs& tensor_args,
     Tensor& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    patch_slice_program_addresses(program, SliceRmShardedProgramFactory{}, args, tensor_args, output);
+    const ShardedSpecNames names;
+
+    // The legacy refresh for this factory re-pointed the two borrowed backing addresses and nothing
+    // else, matching them positionally. Both now resolve by name from their backing tensor, so the
+    // positional order that had to be kept in sync stops mattering.
+    ProgramRunArgs run_args;
+    run_args.tensor_args = {{names.input, tensor_args.input.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
@@ -5,29 +5,27 @@
 
 #include <optional>
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct SliceRmShardedProgramFactory {
-    // Contract (1): per-coord ProgramDescriptor.  Both CBs are sharded
-    // (CBDescriptor::buffer bound to input/output buffers); the framework
-    // patches the dynamic CB addresses on cache hit via
-    // apply_descriptor_runtime_args.  CB total_size/page_size are NOT patched
-    // — padded_shape is folded into compute_program_hash() so each unique
-    // sizing gets its own cache entry.
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    // Both tensors reach the kernel as borrowed-memory DFBs rather than through accessors: the
+    // input and output shards already live in L1, and the reader gathers between them by NoC.
+    // The DFB entry sizes vary with shard shape / element size, so padded_shape is folded into
+    // compute_program_hash() to keep each unique sizing in its own cache entry. DFB sizing is not
+    // re-applied on a cache hit; the cached program carries it.
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 
-    // Cache-hit hook: the reader args depend only on shapes/slice_start/shard specs, all cache-keyed,
-    // so the only per-dispatch state is the two CB addresses. Patched in O(1); no descriptor rebuild.
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
+    // CustomProgramSpecFactoryConcept cache-hit hook. Every reader argument is shape-derived and
+    // hashed, so only the two borrowed backing addresses move — and those re-resolve from the
+    // tensor bindings supplied here.
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
         const SliceParams& args,
         const SliceInputs& tensor_args,
         Tensor& output,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -5,32 +5,53 @@
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp"
 
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
-
+#include <cstdint>
 #include <optional>
-#include <tt-metalium/work_split.hpp>
+#include <utility>
+#include <vector>
+
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SliceRmStrideProgramFactory::create_descriptor(
+namespace {
+
+// Function-local for the same unity-build reason as the other slice factories.
+struct StrideSpecNames {
+    KernelSpecName reader{"reader"};
+    KernelSpecName writer{"writer"};
+    // The accessor names are the kernels' own vocabulary: the reader fills what it calls its output
+    // buffer, and the writer drains what it calls its input buffer. Same DFB either way.
+    DFBSpecName in_dfb{"in_dfb"};
+    TensorParamName input{"input"};
+    TensorParamName output{"output"};
+};
+
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts SliceRmStrideProgramFactory::create_program_artifacts(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const StrideSpecNames names;
+
     const auto& input_tensor = tensor_args.input;
     tt::tt_metal::IDevice* device = input_tensor.device();
-    ProgramDescriptor desc;
 
     const auto& input_shape = input_tensor.padded_shape();
     const auto& output_shape = output.padded_shape();
-    uint32_t element_size = input_tensor.element_size();
+    const uint32_t element_size = input_tensor.element_size();
 
     // Calculate total output rows based on tensor rank
-    uint32_t total_output_rows = output_shape.volume() / output_shape[-1];
+    const uint32_t total_output_rows = output_shape.volume() / output_shape[-1];
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
@@ -39,84 +60,143 @@ tt::tt_metal::ProgramDescriptor SliceRmStrideProgramFactory::create_descriptor(
             : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_output_rows);
 
     // Select kernels based on tensor rank
-    std::string reader_kernel_path;
-    std::string writer_kernel_path;
-    if (input_shape.rank() <= 4) {
-        reader_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp";
-        writer_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp";
-    } else {
-        reader_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp";
-        writer_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp";
-    }
+    const bool using_4d_kernels = input_shape.rank() <= 4;
+    const std::string reader_kernel_path =
+        using_4d_kernels
+            ? "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp"
+            : "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp";
+    const std::string writer_kernel_path =
+        using_4d_kernels
+            ? "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp"
+            : "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp";
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t actual_input_w = input_shape[-1];
-    uint32_t input_bytes_per_row = actual_input_w * element_size;
-    uint32_t cb_page_size = input_bytes_per_row;
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    const uint32_t actual_input_w = input_shape[-1];
+    const uint32_t input_bytes_per_row = actual_input_w * element_size;
+    const uint32_t dfb_entry_size = input_bytes_per_row;
 
     auto src_buffer_alignment = input_tensor.buffer()->alignment();
     auto dst_buffer_alignment = output.buffer()->alignment();
     auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
 
-    uint32_t cb_page_size_aligned = tt::round_up(cb_page_size, alignment);
-    uint32_t cb_total_size = 2 * cb_page_size_aligned;
+    const uint32_t dfb_entry_size_aligned = tt::round_up(dfb_entry_size, alignment);
 
-    constexpr uint8_t in_cb = 0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_total_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = in_cb,
-            .data_format = cb_data_format,
-            .page_size = cb_page_size_aligned,
-        }}},
-    });
+    const DataflowBufferSpec in_dfb{
+        .unique_id = names.in_dfb,
+        .entry_size = dfb_entry_size_aligned,
+        .num_entries = 2,
+        .data_format_metadata = dfb_data_format,
+    };
 
-    std::vector<uint32_t> reader_compile_time_args = {in_cb, element_size};
-    TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
+    const TensorParameter input_param{.unique_id = names.input, .spec = input_tensor.tensor_spec()};
+    const TensorParameter output_param{.unique_id = names.output, .spec = output.tensor_spec()};
 
-    std::vector<uint32_t> writer_compile_time_args = {in_cb, element_size};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+    const uint32_t tensor_rank = input_shape.rank();
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source = reader_kernel_path;
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // Both kernel pairs still declare (and ignore) a compile-time element size; the runtime
+    // `element_size` is what they actually use. Kept so the port changes no behaviour.
+    KernelSpec::CompileTimeArgs shared_compile_time_args{{"compile_time_element_size", element_size}};
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source = writer_kernel_path;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    KernelSpec reader{
+        .unique_id = names.reader,
+        .source = reader_kernel_path,
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.in_dfb,
+                    .accessor_name = "out",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.input, .accessor_name = "src"},
+            },
+        .compile_time_args = shared_compile_time_args,
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+    };
 
-    // Calculate runtime arguments
-    uint32_t tensor_rank = input_shape.rank();
-    uint32_t base_rows_per_core = total_output_rows / num_cores;
-    uint32_t extra_rows = total_output_rows % num_cores;
+    KernelSpec writer{
+        .unique_id = names.writer,
+        .source = writer_kernel_path,
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.in_dfb,
+                    .accessor_name = "in",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.output, .accessor_name = "dst"},
+            },
+        .compile_time_args = shared_compile_time_args,
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
 
-    const bool using_4d_kernels = input_shape.rank() <= 4;
+    if (using_4d_kernels) {
+        // A fixed run of distinct fields on both sides: every one is a named argument.
+        reader.runtime_arg_schema.runtime_arg_names = {
+            "tensor_rank",
+            "input_w",
+            "input_h",
+            "input_d",
+            "input_n",
+            "output_w",
+            "output_h",
+            "output_d",
+            "output_n",
+            "slice_start_w",
+            "slice_end_w",
+            "slice_step_w",
+            "slice_start_h",
+            "slice_end_h",
+            "slice_step_h",
+            "slice_start_d",
+            "slice_end_d",
+            "slice_step_d",
+            "slice_start_n",
+            "slice_end_n",
+            "slice_step_n",
+            "element_size",
+            "num_rows_for_this_core",
+            "start_row_for_this_core"};
+        writer.runtime_arg_schema.runtime_arg_names = {
+            "tensor_rank",
+            "output_w",
+            "output_h",
+            "output_d",
+            "output_n",
+            "element_size",
+            "num_rows_for_this_core",
+            "start_row_for_this_core"};
+    } else {
+        // The dimension / slice-parameter blocks are tensor_rank long, so they travel as varargs.
+        reader.runtime_arg_schema.runtime_arg_names = {
+            "tensor_rank", "element_size", "num_rows_for_this_core", "start_row_for_this_core"};
+        reader.advanced_options.num_runtime_varargs = tensor_rank * 5;
+        writer.runtime_arg_schema.runtime_arg_names = {
+            "tensor_rank", "element_size", "num_rows_for_this_core", "start_row_for_this_core"};
+        writer.advanced_options.num_runtime_varargs = tensor_rank;
+    }
+
+    // Per-node work distribution. Note this is NOT the split_work_to_cores group split: the factory
+    // re-derives its own even spread with a one-row remainder, and the port preserves that.
+    const uint32_t base_rows_per_core = total_output_rows / num_cores;
+    const uint32_t extra_rows = total_output_rows % num_cores;
+
     const auto& slice_start = args.slice_start;
     const auto& slice_end = args.slice_end;
     const auto& slice_step = args.step;
 
-    auto all_cores_vec = corerange_to_cores(all_cores);
-    reader_desc.runtime_args.reserve(all_cores_vec.size());
-    writer_desc.runtime_args.reserve(all_cores_vec.size());
+    KernelRunArgs reader_run_args{.kernel = names.reader};
+    KernelRunArgs writer_run_args{.kernel = names.writer};
 
     uint32_t row_start_id = 0;
     uint32_t extra_rows_remaining = extra_rows;
 
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output.buffer();
-
-    for (const auto& core : all_cores_vec) {
+    for (const auto& node : corerange_to_cores(all_cores)) {
         uint32_t rows_for_this_core = base_rows_per_core;
         if (extra_rows_remaining > 0) {
             rows_for_this_core += 1;
@@ -124,64 +204,108 @@ tt::tt_metal::ProgramDescriptor SliceRmStrideProgramFactory::create_descriptor(
         }
 
         if (using_4d_kernels) {
-            reader_desc.emplace_runtime_args(
-                core, {input_buffer,    tensor_rank,      input_shape[-1],  input_shape[-2],    input_shape[-3],
-                       input_shape[-4], output_shape[-1], output_shape[-2], output_shape[-3],   output_shape[-4],
-                       slice_start[-1], slice_end[-1],    slice_step[-1],   slice_start[-2],    slice_end[-2],
-                       slice_step[-2],  slice_start[-3],  slice_end[-3],    slice_step[-3],     slice_start[-4],
-                       slice_end[-4],   slice_step[-4],   element_size,     rows_for_this_core, row_start_id});
+            AddRuntimeArgsForNode(
+                reader_run_args.runtime_arg_values,
+                node,
+                {{"tensor_rank", tensor_rank},
+                 {"input_w", input_shape[-1]},
+                 {"input_h", input_shape[-2]},
+                 {"input_d", input_shape[-3]},
+                 {"input_n", input_shape[-4]},
+                 {"output_w", output_shape[-1]},
+                 {"output_h", output_shape[-2]},
+                 {"output_d", output_shape[-3]},
+                 {"output_n", output_shape[-4]},
+                 {"slice_start_w", slice_start[-1]},
+                 {"slice_end_w", slice_end[-1]},
+                 {"slice_step_w", slice_step[-1]},
+                 {"slice_start_h", slice_start[-2]},
+                 {"slice_end_h", slice_end[-2]},
+                 {"slice_step_h", slice_step[-2]},
+                 {"slice_start_d", slice_start[-3]},
+                 {"slice_end_d", slice_end[-3]},
+                 {"slice_step_d", slice_step[-3]},
+                 {"slice_start_n", slice_start[-4]},
+                 {"slice_end_n", slice_end[-4]},
+                 {"slice_step_n", slice_step[-4]},
+                 {"element_size", element_size},
+                 {"num_rows_for_this_core", rows_for_this_core},
+                 {"start_row_for_this_core", row_start_id}});
 
-            writer_desc.emplace_runtime_args(
-                core,
-                {output_buffer,
-                 tensor_rank,
-                 output_shape[-1],
-                 output_shape[-2],
-                 output_shape[-3],
-                 output_shape[-4],
-                 element_size,
-                 rows_for_this_core,
-                 row_start_id});
+            AddRuntimeArgsForNode(
+                writer_run_args.runtime_arg_values,
+                node,
+                {{"tensor_rank", tensor_rank},
+                 {"output_w", output_shape[-1]},
+                 {"output_h", output_shape[-2]},
+                 {"output_d", output_shape[-3]},
+                 {"output_n", output_shape[-4]},
+                 {"element_size", element_size},
+                 {"num_rows_for_this_core", rows_for_this_core},
+                 {"start_row_for_this_core", row_start_id}});
         } else {
-            KernelDescriptor::RTArgList reader_args;
-            reader_args.push_back(input_buffer);
-            reader_args.push_back(tensor_rank);
-            reader_args.push_back(element_size);
-            reader_args.push_back(rows_for_this_core);
-            reader_args.push_back(row_start_id);
-            reader_args.append(std::vector<uint32_t>(input_shape.cbegin(), input_shape.cend()));
-            reader_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
-            reader_args.append(std::vector<uint32_t>(slice_start.cbegin(), slice_start.cend()));
-            reader_args.append(std::vector<uint32_t>(slice_end.cbegin(), slice_end.cend()));
-            reader_args.append(std::vector<uint32_t>(slice_step.cbegin(), slice_step.cend()));
-            reader_desc.emplace_runtime_args(core, reader_args);
+            AddRuntimeArgsForNode(
+                reader_run_args.runtime_arg_values,
+                node,
+                {{"tensor_rank", tensor_rank},
+                 {"element_size", element_size},
+                 {"num_rows_for_this_core", rows_for_this_core},
+                 {"start_row_for_this_core", row_start_id}});
+            // Five tensor_rank-long blocks, in the order the kernel walks them.
+            AdvancedKernelRunArgs::Varargs reader_varargs;
+            reader_varargs.reserve(tensor_rank * 5);
+            reader_varargs.insert(reader_varargs.end(), input_shape.cbegin(), input_shape.cend());
+            reader_varargs.insert(reader_varargs.end(), output_shape.cbegin(), output_shape.cend());
+            reader_varargs.insert(reader_varargs.end(), slice_start.cbegin(), slice_start.cend());
+            reader_varargs.insert(reader_varargs.end(), slice_end.cbegin(), slice_end.cend());
+            reader_varargs.insert(reader_varargs.end(), slice_step.cbegin(), slice_step.cend());
+            reader_run_args.advanced_options.runtime_varargs[node] = std::move(reader_varargs);
 
-            KernelDescriptor::RTArgList writer_args;
-            writer_args.push_back(output_buffer);
-            writer_args.push_back(tensor_rank);
-            writer_args.push_back(element_size);
-            writer_args.push_back(rows_for_this_core);
-            writer_args.push_back(row_start_id);
-            writer_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
-            writer_desc.emplace_runtime_args(core, writer_args);
+            AddRuntimeArgsForNode(
+                writer_run_args.runtime_arg_values,
+                node,
+                {{"tensor_rank", tensor_rank},
+                 {"element_size", element_size},
+                 {"num_rows_for_this_core", rows_for_this_core},
+                 {"start_row_for_this_core", row_start_id}});
+            writer_run_args.advanced_options.runtime_varargs[node] =
+                AdvancedKernelRunArgs::Varargs(output_shape.cbegin(), output_shape.cend());
         }
 
         row_start_id += rows_for_this_core;
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    ProgramSpec spec{
+        .name = "slice_rm_stride",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = {in_dfb},
+        .tensor_parameters = {input_param, output_param},
+        .work_units = {WorkUnitSpec{
+            .name = "slice",
+            .kernels = {names.reader, names.writer},
+            .target_nodes = all_cores,
+        }},
+    };
 
-    return desc;
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {{names.input, input_tensor.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
-void SliceRmStrideProgramFactory::override_runtime_arguments(
-    tt::tt_metal::Program& program,
-    const SliceParams& args,
+tt::tt_metal::experimental::ProgramRunArgs SliceRmStrideProgramFactory::override_runtime_arguments(
+    const SliceParams& /*args*/,
     const SliceInputs& tensor_args,
     Tensor& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    patch_slice_program_addresses(program, SliceRmStrideProgramFactory{}, args, tensor_args, output);
+    const StrideSpecNames names;
+
+    // The legacy refresh for this factory re-pointed the two buffer addresses and nothing else; both
+    // now travel as tensor bindings, so re-supplying them is the whole job.
+    ProgramRunArgs run_args;
+    run_args.tensor_args = {{names.input, tensor_args.input.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
@@ -3,22 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
 #include <optional>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include "ttnn/distributed/types.hpp"
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct SliceRmStrideProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    // Binds one of two reader/writer kernel pairs, chosen by tensor rank (<= 4 vs > 4). The two
+    // pairs take different argument schemas, so the KernelSpecs are built per rank path.
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
+    // CustomProgramSpecFactoryConcept cache-hit hook. Every scalar this factory emits is
+    // shape-derived and therefore folded into compute_program_hash, so only the tensor bindings
+    // move on a hit — but they must still be supplied here, since this concept's adapter applies
+    // nothing on its own.
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
         const SliceParams& args,
         const SliceInputs& tensor_args,
         Tensor& output,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -5,206 +5,45 @@
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
 
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
-
+#include <cstdint>
 #include <optional>
-#include <span>
-#include <tt-metalium/work_split.hpp>
+#include <utility>
+#include <vector>
+
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+namespace {
+
+// Spec resource names are declared function-locally rather than at file scope: all five slice
+// factories land in one unity-build translation unit, where two files declaring `READER` would
+// collide.
+struct TileSpecNames {
+    KernelSpecName reader{"reader"};
+    KernelSpecName writer{"writer"};
+    DFBSpecName src0{"src0"};
+    TensorParamName input{"input"};
+    TensorParamName output{"output"};
+};
+
+}  // namespace
+
+SliceTileWorkSplit slice_tile_work_split(
+    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output, uint32_t start_offset) {
     const auto& input = tensor_args.input;
     tt::tt_metal::IDevice* device = input.device();
 
-    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        args.sub_core_grids.has_value()
-            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
-            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
-
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
-
-    const auto& input_shape = input.padded_shape();
-    const auto& output_shape = output.padded_shape();
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-
-    // --- CB Descriptor ---
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = 2;
-
-    tt::tt_metal::ProgramDescriptor program_descriptor;
-
-    tt::tt_metal::CBDescriptor cb_desc;
-    cb_desc.total_size = num_input_tiles * single_tile_size;
-    cb_desc.core_ranges = all_cores;
-    cb_desc.format_descriptors.push_back(tt::tt_metal::CBFormatDescriptor{
-        .buffer_index = static_cast<uint8_t>(src0_cb_index),
-        .data_format = cb_data_format,
-        .page_size = single_tile_size});
-    program_descriptor.cbs.push_back(std::move(cb_desc));
-
-    // --- Reader Kernel Descriptor ---
-    // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> reader_compile_time_args = {num_dims};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
-    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
-    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
-    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
-    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
-    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
-    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
-
-    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
-    accumulated_total_per_dim[0] = num_total_Xt;
-    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
-
-    // src0 buffer binding is registered separately below; this vector holds only the per-dim values.
-    std::vector<uint32_t> reader_common_dims(num_dims * 2);
-    std::span<uint32_t> reader_common_dims_view{reader_common_dims};
-    auto num_unpadded_tiles_per_dim = reader_common_dims_view.subspan(0, num_dims);
-    auto num_padded_tiles_per_dim = reader_common_dims_view.subspan(num_dims, num_dims);
-    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
-    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
-    num_padded_tiles_per_dim[0] = num_padded_Xt;
-    num_padded_tiles_per_dim[1] = num_padded_Yt;
-    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
-        uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
-        num_padded_tiles_per_dim[i] = num_padded_dim;
-        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
-    }
-
-    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
-
-    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
-    tt::tt_metal::KernelDescriptor::RuntimeArgs reader_runtime_args;
-    uint32_t num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            std::vector<uint32_t> reader_args(2 + num_dims, 0);
-            reader_runtime_args.emplace_back(core, std::move(reader_args));
-            continue;
-        }
-
-        std::vector<uint32_t> reader_args(2 + num_dims);
-        // Compute per-dim indices for this core's starting position
-        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
-        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
-        uint32_t start_id = reader_args[2] + start_offset;
-        for (uint32_t j = 1; j < num_dims; ++j) {
-            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
-            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
-        }
-        reader_args[0] = start_id;
-        reader_args[1] = num_tiles_per_core;
-
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        num_tiles_written += num_tiles_per_core;
-    }
-
-    tt::tt_metal::KernelDescriptor reader_kernel_desc;
-    reader_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "reader_unary_unpad_dims_interleaved_start_id.cpp";
-    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-    reader_kernel_desc.core_ranges = all_cores;
-    reader_kernel_desc.compile_time_args = reader_compile_time_args;
-    reader_kernel_desc.named_compile_time_args = {{"dfb_id_in", src0_cb_index}};
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
-    tt::tt_metal::KernelDescriptor::RTArgList reader_common;
-    reader_common.reserve(1 + (num_dims * 2));
-    reader_common.push_back(src0_buffer);
-    reader_common.append(reader_common_dims);
-    reader_kernel_desc.emplace_common_runtime_args(reader_common);
-    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
-    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
-
-    // --- Writer Kernel Descriptor ---
-    // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> writer_compile_time_args = {};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    tt::tt_metal::KernelDescriptor writer_kernel_desc;
-    writer_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "writer_unary_interleaved_start_id.cpp";
-    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-    writer_kernel_desc.core_ranges = all_cores;
-    writer_kernel_desc.compile_time_args = writer_compile_time_args;
-    writer_kernel_desc.named_compile_time_args = {{"dfb_id_out", src0_cb_index}};
-    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
-
-    // Writer per-core runtime args: [dst_addr, num_tiles, start_id].
-    // dst_buffer is declared as a buffer binding at arg 0, so the framework patches its
-    // base address on program-cache hits instead of rebuilding the descriptor.
-    num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            writer_kernel_desc.emplace_runtime_args(core, {0u, 0u, 0u});
-            continue;
-        }
-
-        writer_kernel_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
-        num_tiles_written += num_tiles_per_core;
-    }
-
-    program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
-
-    return program_descriptor;
-}
-
-void SliceTileProgramFactory::override_runtime_arguments(
-    tt::tt_metal::Program& program,
-    const SliceParams& args,
-    const SliceInputs& tensor_args,
-    Tensor& output,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    patch_slice_program_addresses(program, SliceTileProgramFactory{}, args, tensor_args, output);
-}
-
-std::vector<tt::tt_metal::DynamicRuntimeArg> slice_tile_dynamic_args(
-    const SliceParams& args,
-    const SliceInputs& tensor_args,
-    const Tensor& output,
-    uint32_t start_offset,
-    uint32_t reader_kernel_idx,
-    uint32_t writer_kernel_idx) {
-    // Must reproduce create_descriptor's work split exactly; divergence leaves stale scalars in these slots.
-    const auto& input = tensor_args.input;
-    tt::tt_metal::IDevice* device = input.device();
     const uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
@@ -234,50 +73,227 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> slice_tile_dynamic_args(
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
 
-    const auto cores = corerange_to_cores(all_cores);
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size() * (2 + num_dims + 2));
+    SliceTileWorkSplit split;
+    split.all_nodes = all_cores;
+    const auto nodes = corerange_to_cores(all_cores);
+    split.per_node.reserve(nodes.size());
 
     uint32_t num_tiles_written = 0;
-    for (const auto& core : cores) {
-        uint32_t num_tiles_per_core = 0;
-        bool active = true;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            active = false;
+    for (const auto& node : nodes) {
+        SliceTilePerNodeArgs per_node;
+        per_node.node = node;
+        per_node.id_per_dim.assign(num_dims, 0);
+        per_node.num_tiles_written = num_tiles_written;
+
+        if (core_group_1.contains(node)) {
+            per_node.active = true;
+            per_node.num_tiles = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(node)) {
+            per_node.active = true;
+            per_node.num_tiles = num_tiles_per_core_group_2;
         }
 
-        uint32_t id0 = 0, start_id = 0;
-        std::vector<uint32_t> id_per_dim(num_dims, 0);
-        if (active) {
-            id0 = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        if (per_node.active) {
+            // Per-dim indices for this node's starting position.
+            per_node.id_per_dim[0] = num_tiles_written % num_unpadded_tiles_per_dim[0];
             uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
-            start_id = id0 + start_offset;
+            per_node.start_id = per_node.id_per_dim[0] + start_offset;
             for (uint32_t j = 1; j < num_dims; ++j) {
-                id_per_dim[j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+                per_node.id_per_dim[j] = unpadded_written % num_unpadded_tiles_per_dim[j];
                 unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
-                start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+                per_node.start_id += per_node.id_per_dim[j] * accumulated_total_per_dim[j - 1];
             }
+            num_tiles_written += per_node.num_tiles;
         }
 
-        dynamic_args.push_back({reader_kernel_idx, core, 0, start_id, false});
-        dynamic_args.push_back({reader_kernel_idx, core, 1, num_tiles_per_core, false});
-        dynamic_args.push_back({reader_kernel_idx, core, 2, id0, false});
-        for (uint32_t j = 1; j < num_dims; ++j) {
-            dynamic_args.push_back({reader_kernel_idx, core, 2 + j, id_per_dim[j], false});
-        }
-        // Writer slot 0 (dst buffer) is patched by patch_slot0; re-emit only slots 1 and 2.
-        dynamic_args.push_back({writer_kernel_idx, core, 1, num_tiles_per_core, false});
-        dynamic_args.push_back({writer_kernel_idx, core, 2, num_tiles_written, false});
-
-        if (active) {
-            num_tiles_written += num_tiles_per_core;
-        }
+        split.per_node.push_back(std::move(per_node));
     }
-    return dynamic_args;
+    return split;
+}
+
+ttnn::device_operation::ProgramArtifacts SliceTileProgramFactory::create_program_artifacts(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const TileSpecNames names;
+
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const uint32_t single_tile_size = tt::tile_size(dfb_data_format);
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    const std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+
+    const uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
+    const auto split = slice_tile_work_split(args, tensor_args, output, start_offset);
+
+    // --- DFB ---
+    constexpr uint32_t num_input_tiles = 2;
+    const DataflowBufferSpec src0_dfb{
+        .unique_id = names.src0,
+        .entry_size = single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = dfb_data_format,
+    };
+
+    // --- Tensor parameters ---
+    const TensorParameter input_param{.unique_id = names.input, .spec = input.tensor_spec()};
+    const TensorParameter output_param{.unique_id = names.output, .spec = output.tensor_spec()};
+
+    // --- Reader common varargs: [num_unpadded_tiles_per_dim..., num_padded_tiles_per_dim...] ---
+    const uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    const uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    const uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    const uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    const uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    const uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    AdvancedKernelRunArgs::Varargs reader_common_varargs(num_dims * 2);
+    reader_common_varargs[0] = num_unpadded_Xt;
+    reader_common_varargs[1] = num_unpadded_Yt;
+    reader_common_varargs[num_dims] = num_padded_Xt;
+    reader_common_varargs[num_dims + 1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        const uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        const uint32_t num_total_dim = input_shape[-(i + 1)];
+        reader_common_varargs[i] = num_unpadded_dim;
+        reader_common_varargs[num_dims + i] = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    // --- Kernels ---
+    const KernelSpec reader{
+        .unique_id = names.reader,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+            "reader_unary_unpad_dims_interleaved_start_id.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.src0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.input, .accessor_name = "input"},
+            },
+        .compile_time_args = {{"num_dims", num_dims}},
+        .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .advanced_options =
+            {
+                .num_runtime_varargs = num_dims,
+                .num_common_runtime_varargs = num_dims * 2,
+            },
+    };
+
+    // Slice keeps its own copy of the unary writer rather than binding the shared eltwise one: the
+    // DFB it drains is selected per instantiation so the fusion infrastructure can remap it, which
+    // the shared copy cannot express.
+    const KernelSpec writer{
+        .unique_id = names.writer,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+            "writer_unary_interleaved_start_id.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.src0,
+                    .accessor_name = "out",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.output, .accessor_name = "dst"},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
+
+    // --- Per-node run args ---
+    KernelRunArgs reader_run_args{.kernel = names.reader};
+    KernelRunArgs writer_run_args{.kernel = names.writer};
+    reader_run_args.advanced_options.common_runtime_varargs = std::move(reader_common_varargs);
+
+    for (const auto& per_node : split.per_node) {
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            per_node.node,
+            {{"start_id", per_node.start_id}, {"num_tiles", per_node.num_tiles}});
+        reader_run_args.advanced_options.runtime_varargs[per_node.node] = per_node.id_per_dim;
+
+        // An inactive node writes nothing, so its start_id is never read; the value emitted here is
+        // 0, which is what the legacy descriptor emitted. (The cache-hit path below re-emits the
+        // running tile count instead — a legacy divergence, preserved.)
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            per_node.node,
+            {{"num_pages", per_node.num_tiles}, {"start_id", per_node.active ? per_node.num_tiles_written : 0u}});
+    }
+
+    ProgramSpec spec{
+        .name = "slice_tile",
+        .kernels = {reader, writer},
+        .dataflow_buffers = {src0_dfb},
+        .tensor_parameters = {input_param, output_param},
+        .work_units = {WorkUnitSpec{
+            .name = "slice",
+            .kernels = {names.reader, names.writer},
+            .target_nodes = split.all_nodes,
+        }},
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {{names.input, input.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+}
+
+tt::tt_metal::experimental::ProgramRunArgs SliceTileProgramFactory::override_runtime_arguments(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    const TileSpecNames names;
+
+    const uint32_t start_offset =
+        ttnn::operations::data_movement::get_tiled_start_offset(tensor_args.input, args.slice_start);
+    const auto split = slice_tile_work_split(args, tensor_args, output, start_offset);
+
+    KernelRunArgs reader_run_args{.kernel = names.reader};
+    KernelRunArgs writer_run_args{.kernel = names.writer};
+    for (const auto& per_node : split.per_node) {
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            per_node.node,
+            {{"start_id", per_node.start_id}, {"num_tiles", per_node.num_tiles}});
+        reader_run_args.advanced_options.runtime_varargs[per_node.node] = per_node.id_per_dim;
+        // Unconditionally the running tile count, including on an inactive node — where it differs
+        // from the value the cache-miss path emitted (0). Inert either way: num_pages is 0 there, so
+        // the writer's loop never runs and start_id is never read.
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            per_node.node,
+            {{"num_pages", per_node.num_tiles}, {"start_id", per_node.num_tiles_written}});
+    }
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    // On this concept the framework refreshes nothing on its own, so every tensor binding is
+    // re-supplied here; that is what re-points the input and output base addresses on a cache hit.
+    run_args.tensor_args = {{names.input, tensor_args.input.mesh_tensor()}, {names.output, output.mesh_tensor()}};
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
@@ -3,36 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
-#include <tt-metalium/host_api.hpp>
+#include <cstdint>
 #include <optional>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <vector>
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct SliceTileProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
+    // CustomProgramSpecFactoryConcept cache-hit hook. The per-core scalars below are excluded from
+    // compute_program_hash, so a divergent-partition cache hit would otherwise leave them stale and
+    // produce an all-zero output (#52651); they are re-applied on every hit, together with the tensor
+    // bindings the framework re-points addresses through.
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
         const SliceParams& args,
         const SliceInputs& tensor_args,
         Tensor& output,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
-// Per-core scalars are hash-excluded; a divergent-partition cache hit leaves them stale -> all-zero output (#52651).
-std::vector<tt::tt_metal::DynamicRuntimeArg> slice_tile_dynamic_args(
-    const SliceParams& args,
-    const SliceInputs& tensor_args,
-    const Tensor& output,
-    uint32_t start_offset,
-    uint32_t reader_kernel_idx,
-    uint32_t writer_kernel_idx);
+// One node's reader/writer scalar arguments for the two TILE factories.
+struct SliceTilePerNodeArgs {
+    tt::tt_metal::CoreCoord node;
+    // False for a node the work split left with nothing to do. Such a node is still given a full
+    // argument row so every node's layout is identical.
+    bool active = false;
+    uint32_t start_id = 0;
+    uint32_t num_tiles = 0;
+    // num_dims entries; the reader's runtime vararg block, seeded here and advanced on device.
+    std::vector<uint32_t> id_per_dim;
+    // Tiles emitted by all preceding nodes — the writer's start_id on an active node.
+    uint32_t num_tiles_written = 0;
+};
+
+struct SliceTileWorkSplit {
+    tt::tt_metal::CoreRangeSet all_nodes;
+    std::vector<SliceTilePerNodeArgs> per_node;
+};
+
+// Single source of truth for the TILE factories' work split and per-node scalars, shared by
+// create_program_artifacts (cache miss) and override_runtime_arguments (cache hit) so the node order
+// and the values cannot drift between the two. `start_offset` is the tile-index base the reader adds
+// to every node's start_id: SliceTile passes get_tiled_start_offset(...), SliceTileTensorArgs passes
+// 0 because it computes the real offset on device from the start tensor.
+SliceTileWorkSplit slice_tile_work_split(
+    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output, uint32_t start_offset);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -4,201 +4,269 @@
 
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
 
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
-
+#include <cstdint>
 #include <optional>
-#include <span>
-#include <tt-metalium/work_split.hpp>
+#include <utility>
+#include <vector>
+
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descriptor(
+namespace {
+
+// Function-local for the same unity-build reason as the other slice factories.
+struct TensorArgsSpecNames {
+    KernelSpecName reader{"reader"};
+    KernelSpecName writer{"writer"};
+    DFBSpecName src0{"src0"};
+    // Single-entry staging buffer the reader fills and drains itself, once for the start tensor and
+    // once for the end tensor.
+    DFBSpecName tensor_stage{"tensor_stage"};
+    TensorParamName input{"input"};
+    TensorParamName start{"start"};
+    TensorParamName end{"end"};
+    // The writer is the eltwise/unary Metal 2.0 fork; `output` is bound to its own `tensor::dst`.
+    TensorParamName output{"output"};
+};
+
+// The start offset is computed on device from the start tensor, so the host contributes none.
+constexpr uint32_t kHostStartOffset = 0;
+
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts SliceTileTensorArgsProgramFactory::create_program_artifacts(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const TensorArgsSpecNames names;
+
     const auto& input_tensor = tensor_args.input;
     const auto& start_tensor = tensor_args.start_tensor.value();
     const auto& end_tensor = tensor_args.end_tensor.value();
     tt::tt_metal::IDevice* device = input_tensor.device();
-    ProgramDescriptor desc;
 
-    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input buffer should be allocated on device!");
+    TT_FATAL(start_tensor.buffer() != nullptr, "Start buffer should be allocated on device!");
+    TT_FATAL(end_tensor.buffer() != nullptr, "End buffer should be allocated on device!");
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        args.sub_core_grids.has_value()
-            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
-            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    const uint32_t single_tile_size = tt::tile_size(dfb_data_format);
 
-    tt::tt_metal::Buffer* src_buffer = input_tensor.buffer();
-    tt::tt_metal::Buffer* start_buffer = start_tensor.buffer();
-    tt::tt_metal::Buffer* end_buffer = end_tensor.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-
-    TT_FATAL(src_buffer != nullptr, "Input buffer should be allocated on device!");
-    TT_FATAL(start_buffer != nullptr, "Start buffer should be allocated on device!");
-    TT_FATAL(end_buffer != nullptr, "End buffer should be allocated on device!");
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
-
-    constexpr uint8_t src0_cb_index = 0;
-    constexpr uint8_t tensor_cb_index = 1;
-    constexpr uint32_t num_input_tiles = 2;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = tensor_cb_index,
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    uint32_t tile_width = tile_shape[1];
-    uint32_t tile_height = tile_shape[0];
-
-    std::vector<uint32_t> reader_compile_time_args = {
-        src0_cb_index, tensor_cb_index, num_dims, tile_width, tile_height};
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*start_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*end_buffer).append_to(reader_compile_time_args);
-
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Reader common runtime args layout (matches kernel):
-    //   [src_addr, start_buf_addr, end_buf_addr,
-    //    num_unpadded_per_dim..., num_padded_per_dim..., input_shape...]
     const auto& input_shape = input_tensor.padded_shape();
     const auto& output_shape = output.padded_shape();
-    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
-    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
-    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
-    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
-    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
-    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+    const std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    const auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    const uint32_t tile_width = tile_shape[1];
+    const uint32_t tile_height = tile_shape[0];
+
+    const auto split = slice_tile_work_split(args, tensor_args, output, kHostStartOffset);
+
+    // --- DFBs ---
+    constexpr uint32_t num_input_tiles = 2;
+    const DataflowBufferSpec src0_dfb{
+        .unique_id = names.src0,
+        .entry_size = single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = dfb_data_format,
+    };
+    // One toucher that already runs both halves of the handshake (reserve/push/wait/pop, twice), so
+    // the reader binds both endpoints.
+    const DataflowBufferSpec tensor_stage_dfb{
+        .unique_id = names.tensor_stage,
+        .entry_size = single_tile_size,
+        .num_entries = 1,
+        .data_format_metadata = dfb_data_format,
+    };
+
+    // --- Tensor parameters ---
+    const TensorParameter input_param{.unique_id = names.input, .spec = input_tensor.tensor_spec()};
+    const TensorParameter start_param{.unique_id = names.start, .spec = start_tensor.tensor_spec()};
+    const TensorParameter end_param{.unique_id = names.end, .spec = end_tensor.tensor_spec()};
+    const TensorParameter output_param{.unique_id = names.output, .spec = output.tensor_spec()};
+
+    // --- Reader common varargs ---
+    //   [num_unpadded_tiles_per_dim..., num_padded_tiles_per_dim..., input_shape...]
+    const uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    const uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    const uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    const uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    const uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    const uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
 
     std::vector<uint32_t> accumulated_total_per_dim(num_dims);
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    // src/start/end buffer bindings are registered separately below; this vector holds only the per-dim values.
-    std::vector<uint32_t> reader_common_dims(num_dims * 3);
-    std::span<uint32_t> reader_common_dims_view{reader_common_dims};
-    auto num_unpadded_tiles_per_dim = reader_common_dims_view.subspan(0, num_dims);
-    auto num_padded_tiles_per_dim = reader_common_dims_view.subspan(num_dims, num_dims);
-    auto input_shape_args = reader_common_dims_view.subspan(num_dims * 2, num_dims);
-    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
-    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
-    num_padded_tiles_per_dim[0] = num_padded_Xt;
-    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    AdvancedKernelRunArgs::Varargs reader_common_varargs(num_dims * 3);
+    reader_common_varargs[0] = num_unpadded_Xt;
+    reader_common_varargs[1] = num_unpadded_Yt;
+    reader_common_varargs[num_dims] = num_padded_Xt;
+    reader_common_varargs[num_dims + 1] = num_padded_Yt;
     for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
-        uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
-        num_padded_tiles_per_dim[i] = num_padded_dim;
+        const uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        const uint32_t num_total_dim = input_shape[-(i + 1)];
+        reader_common_varargs[i] = num_unpadded_dim;
+        reader_common_varargs[num_dims + i] = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
     for (int32_t i = 0; i < static_cast<int32_t>(num_dims); ++i) {
-        input_shape_args[i] = input_shape[i];
+        reader_common_varargs[num_dims * 2 + i] = input_shape[i];
     }
 
-    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
-    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
-    constexpr uint32_t start_offset = 0;
+    // --- Kernels ---
+    const KernelSpec reader{
+        .unique_id = names.reader,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+            "reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.src0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = names.tensor_stage,
+                    .accessor_name = "tensor_stage",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = names.tensor_stage,
+                    .accessor_name = "tensor_stage",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.input, .accessor_name = "input"},
+                TensorBinding{.tensor_parameter_name = names.start, .accessor_name = "start"},
+                TensorBinding{.tensor_parameter_name = names.end, .accessor_name = "end"},
+            },
+        .compile_time_args =
+            {
+                {"num_dims", num_dims},
+                {"tile_width", tile_width},
+                {"tile_height", tile_height},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .advanced_options =
+            {
+                .num_runtime_varargs = num_dims,
+                .num_common_runtime_varargs = num_dims * 3,
+            },
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // Reuse the Metal 2.0 fork that lives beside the eltwise/unary original. Its interface is fixed
+    // by the ops already bound to it: DFB `out`, tensor `dst`, named args `num_pages` / `start_id`.
+    // It gates on OUT_SHARDED / BACKWARDS, and slice sets no defines, so neither fires.
+    const KernelSpec writer{
+        .unique_id = names.writer,
+        .source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+            "writer_unary_interleaved_start_id_metal2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = names.src0,
+                    .accessor_name = "out",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = names.output, .accessor_name = "dst"},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
 
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    uint32_t num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core (num_tiles == 0 → address unused, but bound for a uniform arg layout)
-            std::vector<uint32_t> reader_args(2 + num_dims, 0);
-            reader_runtime_args.emplace_back(core, std::move(reader_args));
-            writer_desc.emplace_runtime_args(core, {dst_buffer, 0u, 0u});
-            continue;
-        }
+    // --- Per-node run args ---
+    KernelRunArgs reader_run_args{.kernel = names.reader};
+    KernelRunArgs writer_run_args{.kernel = names.writer};
+    reader_run_args.advanced_options.common_runtime_varargs = std::move(reader_common_varargs);
 
-        std::vector<uint32_t> reader_args(2 + num_dims);
-        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
-        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
-        uint32_t start_id = reader_args[2] + start_offset;
-        for (uint32_t j = 1; j < num_dims; ++j) {
-            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
-            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
-        }
-        reader_args[0] = start_id;
-        reader_args[1] = num_tiles_per_core;
-
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        writer_desc.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
-        num_tiles_written += num_tiles_per_core;
+    for (const auto& per_node : split.per_node) {
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            per_node.node,
+            {{"start_id", per_node.start_id}, {"num_tiles", per_node.num_tiles}});
+        reader_run_args.advanced_options.runtime_varargs[per_node.node] = per_node.id_per_dim;
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            per_node.node,
+            {{"num_pages", per_node.num_tiles}, {"start_id", per_node.active ? per_node.num_tiles_written : 0u}});
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.runtime_args = std::move(reader_runtime_args);
-    KernelDescriptor::RTArgList reader_common;
-    reader_common.reserve(3 + (num_dims * 3));
-    reader_common.push_back(src_buffer);
-    reader_common.push_back(start_buffer);
-    reader_common.push_back(end_buffer);
-    reader_common.append(reader_common_dims);
-    reader_desc.emplace_common_runtime_args(reader_common);
-    reader_desc.config = ReaderConfigDescriptor{};
-    desc.kernels.push_back(std::move(reader_desc));
+    ProgramSpec spec{
+        .name = "slice_tile_tensor_args",
+        .kernels = {reader, writer},
+        .dataflow_buffers = {src0_dfb, tensor_stage_dfb},
+        .tensor_parameters = {input_param, start_param, end_param, output_param},
+        .work_units = {WorkUnitSpec{
+            .name = "slice",
+            .kernels = {names.reader, names.writer},
+            .target_nodes = split.all_nodes,
+        }},
+    };
 
-    desc.kernels.push_back(std::move(writer_desc));
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {
+        {names.input, input_tensor.mesh_tensor()},
+        {names.start, start_tensor.mesh_tensor()},
+        {names.end, end_tensor.mesh_tensor()},
+        {names.output, output.mesh_tensor()}};
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
-void SliceTileTensorArgsProgramFactory::override_runtime_arguments(
-    tt::tt_metal::Program& program,
+tt::tt_metal::experimental::ProgramRunArgs SliceTileTensorArgsProgramFactory::override_runtime_arguments(
     const SliceParams& args,
     const SliceInputs& tensor_args,
     Tensor& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    patch_slice_program_addresses(program, SliceTileTensorArgsProgramFactory{}, args, tensor_args, output);
+    const TensorArgsSpecNames names;
+
+    const auto split = slice_tile_work_split(args, tensor_args, output, kHostStartOffset);
+
+    KernelRunArgs reader_run_args{.kernel = names.reader};
+    KernelRunArgs writer_run_args{.kernel = names.writer};
+    for (const auto& per_node : split.per_node) {
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            per_node.node,
+            {{"start_id", per_node.start_id}, {"num_tiles", per_node.num_tiles}});
+        reader_run_args.advanced_options.runtime_varargs[per_node.node] = per_node.id_per_dim;
+        // See SliceTileProgramFactory::override_runtime_arguments: the running tile count goes out
+        // even on an inactive node, matching the legacy refresh path rather than the legacy build.
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            per_node.node,
+            {{"num_pages", per_node.num_tiles}, {"start_id", per_node.num_tiles_written}});
+    }
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {
+        {names.input, tensor_args.input.mesh_tensor()},
+        {names.start, tensor_args.start_tensor.value().mesh_tensor()},
+        {names.end, tensor_args.end_tensor.value().mesh_tensor()},
+        {names.output, output.mesh_tensor()}};
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
@@ -3,22 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
-#include "ttnn/device_operation.hpp"
-#include <tt-metalium/host_api.hpp>
 #include <optional>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct SliceTileTensorArgsProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
+    // CustomProgramSpecFactoryConcept cache-hit hook; see SliceTileProgramFactory for why the
+    // per-node scalars have to be re-applied on every hit (#52651).
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
         const SliceParams& args,
         const SliceInputs& tensor_args,
         Tensor& output,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -165,18 +165,11 @@ void bind_slice_descriptor(nb::module_& mod) {
             nb::arg("operation_attributes"),
             nb::arg("tensor_args"));
 
-    nb::class_<ttnn::prim::SliceTileProgramFactory>(mod, "SliceTileProgramFactory")
-        .def_static(
-            "create_descriptor",
-            [](const ttnn::prim::SliceParams& operation_attributes,
-               const ttnn::prim::SliceInputs& tensor_args,
-               Tensor& tensor_return_value) {
-                return ttnn::prim::SliceTileProgramFactory::create_descriptor(
-                    operation_attributes, tensor_args, tensor_return_value);
-            },
-            nb::arg("operation_attributes"),
-            nb::arg("tensor_args"),
-            nb::arg("tensor_return_value"));
+    // Bound with no methods. Its `create_descriptor` went away when the factory moved to Metal 2.0,
+    // and a ProgramSpec is not something a descriptor-fusion branch can consume; the type stays
+    // bound so callers get a clear missing-method error rather than a missing-symbol one, and so
+    // the fusion suite's skip guard has something to detect. Same shape as the layernorm factories.
+    nb::class_<ttnn::prim::SliceTileProgramFactory>(mod, "SliceTileProgramFactory");
 }
 
 }  // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Summary
This is an AI driven port of Slice to Metal 2.0. Here is a summary of the five factories ported:

| Factory | Config it serves |
|---|---|
| `SliceRm` | RM, interleaved or BLOCK/WIDTH-sharded |
| `SliceRmSharded` | RM, HEIGHT-sharded in and out, no step, W-begin L1-aligned |
| `SliceRmStride` | RM, any `step != 1` (rank ≤ 4 and rank > 4 bind different kernels) |
| `SliceTile` | TILE |
| `SliceTileTensorArgs` | TILE with `use_tensor_args` |

It's important to mention, this test skips some fusion tests. This is necessary because Slice's `create_descriptor` goes away with the port. The fusion branch requires the returned `ProgramDescriptor`, whereas the ported factory produces a
`ProgramSpec`.


It's worth mentioning, the previous `layernorm` port already had this issue. The fusion suite already pytest skips when there's a missing `create_descriptor`. This is tracked in  **issue #54365**.

This PR adds the slice factory to that fixture's tuple (it just renames `_LAYERNORM_FACTORIES` → `_BRANCH_FACTORIES` and makes the skip message not layernorm-specific).

Like Layernorm, `slice_nanobind.cpp` keeps an **empty** `nb::class_<SliceTileProgramFactory>`
and both Python re-exports — matching `layernorm_nanobind.cpp:339` exactly. Only the `def_static` is
removed. That keeps the symbol resolvable (a clear missing-*method* error rather than a
missing-*symbol* one) and gives the skip guard something to detect.

