### PR TITLE
Fix INT32_MIN correctness in int32 div, remainder, fmod kernels

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -977,6 +977,208 @@ def test_div_exact_quotient_cases(device):
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
+INT32_MIN = -(2**31)
+
+# INT32_MIN as the dividend: the residual-correction path in trunc/floor int32 division collapses the
+# whole quotient when the aligned quotient estimate underflows to zero (q_m == 0), because the raw
+# remainder 2**31 has bit pattern 0x80000000, which converts to -0.0f and reads as a negative
+# remainder. Divisors below span the Wormhole (2**21) and Blackhole (2**22) quotient-estimation
+# thresholds, both signs, and the region above 2**30 where the true quotient is ±1.
+INT32_MIN_DIVISORS = [
+    1,
+    2,
+    3,
+    7,
+    100,
+    1024,
+    2097151,  # 2**21 - 1 (just under Wormhole threshold)
+    2097152,  # 2**21     (Wormhole threshold)
+    2097153,  # 2**21 + 1
+    -2097151,
+    -2097152,
+    -2097153,
+    4194303,  # 2**22 - 1 (just under Blackhole threshold)
+    4194304,  # 2**22     (Blackhole threshold)
+    4194305,  # 2**22 + 1
+    -4194303,
+    -4194304,
+    -4194305,
+    239823930,
+    -239823930,
+    1073741824,  # 2**30
+    -1073741824,
+    536870912,  # 2**29
+    -536870912,
+    268435456,  # 2**28
+    -268435456,
+    2147483647,
+    -2147483647,
+    INT32_MIN,  # b == a == INT32_MIN
+    -5,
+    -2,
+    -3,
+]
+
+
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+def test_div_int32_min_dividend(rounding_mode, device):
+    torch_a = torch.full((1, 32), INT32_MIN, dtype=torch.int32)
+    torch_b = torch.tensor(INT32_MIN_DIVISORS, dtype=torch.int32).reshape(1, 32)
+
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_b = ttnn.from_torch(
+        torch_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    torch_output = golden_function(torch_a, torch_b, rounding_mode=rounding_mode, device=device)
+
+    output = ttnn.to_torch(ttnn.div(input_a, input_b, rounding_mode=rounding_mode))
+
+    assert torch.equal(output, torch_output)
+
+
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize(
+    "scalar", [2097152, -2097152, 4194304, -4194304, 239823930, -239823930, 1073741824, -1073741824, 3, -3]
+)
+def test_div_int32_min_dividend_scalar(rounding_mode, scalar, device):
+    torch_a = torch.tensor([INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN], dtype=torch.int32).reshape(1, 4)
+
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    torch_output = torch.div(torch_a, scalar, rounding_mode=rounding_mode)
+
+    output = ttnn.to_torch(ttnn.div(input_a, scalar, rounding_mode=rounding_mode))
+
+    assert torch.equal(output, torch_output)
+
+
+@pytest.mark.parametrize("ttnn_op", [ttnn.remainder, ttnn.fmod])
+def test_remainder_fmod_int32_min_dividend(ttnn_op, device):
+    torch_a = torch.full((1, 32), INT32_MIN, dtype=torch.int32)
+    torch_b = torch.tensor(INT32_MIN_DIVISORS, dtype=torch.int32).reshape(1, 32)
+
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_b = ttnn.from_torch(
+        torch_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output = golden_function(torch_a, torch_b, device=device)
+
+    output = ttnn.to_torch(ttnn_op(input_a, input_b))
+
+    assert torch.equal(output, torch_output)
+
+
+@pytest.mark.parametrize("ttnn_op", [ttnn.remainder, ttnn.fmod])
+@pytest.mark.parametrize("scalar", [2097152, -2097152, 4194304, -4194304, 239823930, -239823930, 3, -3, -2147483648])
+def test_remainder_fmod_int32_min_dividend_scalar(ttnn_op, scalar, device):
+    torch_a = torch.tensor([INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN], dtype=torch.int32).reshape(1, 4)
+
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output = golden_function(torch_a, scalar, device=device)
+
+    output = ttnn.to_torch(ttnn_op(input_a, scalar))
+
+    assert torch.equal(output, torch_output)
+
+
+# FP32 scalar promotion (issue #55502): an int32 tensor combined with a floating-point scalar must
+# follow the intended FP32 promotion semantics -- the integer operand is promoted to fp32 (never
+# bit-reinterpreted as an fp32 scalar fed to the int32 kernel) and the result dtype is fp32.
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+@pytest.mark.parametrize("scalar", [3.0, -3.0, 3.5, 7.0, 100.0, 1024.0, -1024.0])
+def test_div_int32_float_scalar_promotion(rounding_mode, scalar, device):
+    torch_a = torch.tensor(
+        [INT32_MIN, -2147483647, -1000000, 123456, 2147483647, INT32_MIN], dtype=torch.int32
+    ).reshape(1, 6)
+
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Reference in fp32: int32 -> fp32 (same rounding as the device path), then fp32 divide/round.
+    torch_a_fp32 = torch_a.float()
+    if rounding_mode is None:
+        torch_output = torch.div(torch_a_fp32, scalar)
+    elif rounding_mode == "floor":
+        torch_output = torch.floor(torch.div(torch_a_fp32, scalar))
+    else:
+        torch_output = torch.trunc(torch.div(torch_a_fp32, scalar))
+
+    output = ttnn.to_torch(ttnn.div(input_a, scalar, rounding_mode=rounding_mode))
+
+    assert output.dtype == torch.float32, "int32 tensor + float scalar must promote to FP32"
+    assert_with_ulp(output, torch_output, ulp_threshold=1.0)
+
+
+@pytest.mark.parametrize("ttnn_op", [ttnn.remainder, ttnn.fmod])
+@pytest.mark.parametrize("scalar", [3.0, -3.0, 3.5, 7.0, 100.0, 1024.0, -1024.0])
+def test_remainder_fmod_int32_float_scalar_promotion(ttnn_op, scalar, device):
+    torch_a = torch.tensor(
+        [INT32_MIN, -2147483647, -1000000, 123456, 2147483647, INT32_MIN], dtype=torch.int32
+    ).reshape(1, 6)
+
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # torch.fmod/remainder promote an fp32 tensor + python float scalar to fp32.
+    if ttnn_op is ttnn.remainder:
+        torch_output = torch.remainder(torch_a.float(), scalar)
+    else:
+        torch_output = torch.fmod(torch_a.float(), scalar)
+
+    output = ttnn.to_torch(ttnn_op(input_a, scalar))
+
+    assert output.dtype == torch.float32, "int32 tensor + float scalar must promote to FP32"
+    assert_with_ulp(output, torch_output, ulp_threshold=1.0)
+
+
 # FP32 mantissa precision boundary: Bit-exactness only holds when the operands and the quotient fit within the fp32 mantissa
 # (|value| <= 2**24 = 16777216). div_int32 converts int32 -> fp32 before dividing,
 # so operands above 2**24 are rounded before the reciprocal even runs and the residual step cannot

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -56,6 +56,19 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(
 
     // Compute correction for approximation error: correction = |r| / b
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
+
+    // `r` holds the magnitude |a| - q*|b|, which ranges over [0, 2**31]. The single value 2**31 --
+    // reached only when a == INT32_MIN and the aligned quotient underflowed to zero -- has the bit
+    // pattern 0x80000000, so it converts to -0.0f and reads as a negative remainder. Same edge case
+    // as a_f above; the bit pattern of `r` itself is already the right two's complement operand, so
+    // only the sign used to direct the residual correction needs the guard.
+    sfpi::vInt r_sign = r;
+    v_if(r_f < 0.0f) {
+        r_f = TWO_POW_31;
+        r_sign = 0;
+    }
+    v_endif;
+
     sfpi::vMag correction = sfpi::convert<sfpi::vUInt16>(r_f * inv_b_f, sfpi::RoundMode::Nearest);
 
     // Compute correction * b (full 32-bit result from 24-bit multiplies)
@@ -64,7 +77,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(
     sfpi::vInt b_hi = sfpi::fractional_mul(correction, b >> 23);
     sfpi::vInt tmp = tmp_lo + ((tmp_hi + b_hi) << 23);
 
-    v_if(r < 0) { tmp = -tmp; }
+    v_if(r_sign < 0) { tmp = -tmp; }
     v_endif;
     r -= tmp;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -67,6 +67,18 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vInt r = a - qb;
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
 
+    // `r` holds the magnitude |a| - q*|b|, which ranges over [0, 2**31]. The single value 2**31 --
+    // reached only when a == INT32_MIN and the aligned quotient underflowed to zero -- has the bit
+    // pattern 0x80000000, so it converts to -0.0f and reads as a negative remainder. Same edge case
+    // as b_f and a_f above; the bit pattern of `r` itself is already the right two's complement
+    // operand, so only the sign used to direct the residual correction needs the guard.
+    sfpi::vInt r_sign = r;
+    v_if(r_f < 0.0f) {
+        r_f = 0x1.0p31f;
+        r_sign = 0;
+    }
+    v_endif;
+
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;
     sfpi::vMag correction = sfpi::convert<sfpi::vUInt16>(correction_f, sfpi::RoundMode::Nearest);
@@ -80,7 +92,7 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vInt tmp = tmp_lo + tmp_hi;
 
     // Apply correction and adjust remainder.
-    v_if(r < 0) {
+    v_if(r_sign < 0) {
         q -= correction;
         r += tmp;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -94,6 +94,18 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(
     // Use abs(r) for correction computation
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
 
+    // `r` holds the magnitude |a| - q*|b|, which ranges over [0, 2**31]. The single value 2**31 --
+    // reached only when a == INT32_MIN and the aligned quotient underflowed to zero -- has the bit
+    // pattern 0x80000000, so it converts to -0.0f and reads as a negative remainder. Same edge case
+    // as a_f above; the bit pattern of `r` itself is already the right two's complement operand, so
+    // only the sign used to direct the residual correction needs the guard.
+    sfpi::vInt r_sign = r;
+    v_if(r_f < 0.0f) {
+        r_f = TWO_POW_31;
+        r_sign = 0;
+    }
+    v_endif;
+
     // Compute correction: r / b in float32
     sfpi::vFloat correction_f = r_f * inv_b_f;
     auto correction = sfpi::convert<sfpi::vUInt16>(correction_f, sfpi::RoundMode::Nearest);
@@ -111,7 +123,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(
     sfpi::vFloat top = correction_f * b2 + MANTISSA_ALIGNMENT_OFFSET;
 
     sfpi::vInt tmp{sfpi::exman(low) + (sfpi::exman(mid) << 11) + (sfpi::exman(top) << 22)};
-    v_if(r < 0) { tmp = -tmp; }
+    v_if(r_sign < 0) { tmp = -tmp; }
     v_endif;
     r -= tmp;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -108,6 +108,18 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vInt r = a_s - qb;
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
 
+    // `r` holds the magnitude |a| - q*|b|, which ranges over [0, 2**31]. The single value 2**31 --
+    // reached only when a == INT32_MIN and the aligned quotient underflowed to zero -- has the bit
+    // pattern 0x80000000, so it converts to -0.0f and reads as a negative remainder. Same edge case
+    // as b_f and a_f above; the bit pattern of `r` itself is already the right two's complement
+    // operand, so only the sign used to direct the residual correction needs the guard.
+    sfpi::vInt r_sign = r;
+    v_if(r_f < 0.0f) {
+        r_f = 0x1.0p31f;
+        r_sign = 0;
+    }
+    v_endif;
+
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;
     sfpi::vFloat b2 = sfpi::convert<sfpi::vFloat>(b >> 22, sfpi::RoundMode::Nearest);
@@ -123,7 +135,7 @@ sfpi_inline void calculate_div_int32_body(
 
     sfpi::vInt tmp{sfpi::exman(low) + (sfpi::exman(mid) << 11) + (sfpi::exman(top) << 22)};
     sfpi::vUInt cor = correction;
-    v_if(r >= 0) {
+    v_if(r_sign >= 0) {
         tmp = -tmp;
         cor = -cor;
     }


### PR DESCRIPTION
Fixes #55502

## Root cause
When `a == INT32_MIN` and the aligned quotient estimate underflows to zero
(`q_m == 0`, which happens for divisors above the Wormhole 2**21 / Blackhole
2**22 quotient-estimation thresholds), the raw residual magnitude is exactly
`2**31`, whose two's-complement bit pattern is `0x80000000`. Converting that
magnitude to fp32 yields `-0.0f`, so the residual-correction path read it as
a *negative* remainder: the correction collapsed (or was applied in the wrong
direction) instead of recovering the true quotient/remainder.

## Fix
Guard the residual conversion exactly like the pre-existing `a_f`/`b_f`
guards already in these kernels: save the two's-complement sign before the
conversion (`r_sign`), force the poisoned float to `2**31`, and drive the
residual-correction direction from the saved sign. Applied to both Wormhole
(`wormhole_b0`) and Blackhole kernels.

Scope coverage:
- div: trunc and floor share `calculate_div_int32_body<false/true>` in
  `ckernel_sfpu_div_int32_floor.h`, so one guard covers both rounding modes.
- remainder and fmod both route through `compute_unsigned_remainder_int32`
  (`ckernel_sfpu_binary_remainder.h` / `ckernel_sfpu_binary_fmod.h`), so the
  single guard covers all three ops.
- Non-edge inputs: `r_sign = r` preserves the previous behavior exactly.

## Tests
Added to `tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py`:
- `INT32_MIN` dividends with divisors spanning both quotient-estimation
  thresholds (2**21 / 2**22, +/-1 on either side), both signs, both rounding
  modes, tensor-tensor and tensor-scalar, for div/remainder/fmod.
- FP32 scalar-promotion regressions: int32 tensor + float scalar must
  promote to FP32 (never feed a float scalar to the int32 kernel), for
  div (None/trunc/floor), remainder, and fmod.

## Verification status — please read
These changes were **not compiled or run on device** by the author: tt-metal's
toolchain lives in its CI build image and the author's host has no
Tenstorrent silicon (per the repo's AGENTS.md, which permits opening with an
explicit unverified note). CI (and on-device unit tests) must validate:
1. The kernel guard compiles on both architectures.
2. The new INT32_MIN vectors pass on Wormhole and Blackhole.
3. The FP32 scalar-promotion expectations match current scalar-dispatch
   behavior (binary_ng scalar admission); if any fail, that is the remaining
   scalar-dispatch gap called out in the issue.
