### PR TITLE
[Bug fix] Fix INT32_MIN residual overflow in int32 div SFPU kernels

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -66,7 +66,10 @@ sfpi_inline void calculate_div_int32_body(
     // Compute remainder.
     sfpi::vInt r = a - qb;
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
-
+   v_if(r_f < 0.0f) {
+        r_f = 0x1.0p31f;
+    }
+    v_endif;
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;
     sfpi::vMag correction = sfpi::convert<sfpi::vUInt16>(correction_f, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -107,7 +107,10 @@ sfpi_inline void calculate_div_int32_body(
     a_s = sfpi::abs(a_s);
     sfpi::vInt r = a_s - qb;
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
-
+    v_if(r_f < 0.0f) {
+        r_f = 0x1.0p31f;
+    }
+    v_endif;
     // Compute correction value in float32.
     sfpi::vFloat correction_f = r_f * inv_b_f;
     sfpi::vFloat b2 = sfpi::convert<sfpi::vFloat>(b >> 22, sfpi::RoundMode::Nearest);


### PR DESCRIPTION
Fixes #55502
### Summary
Guards the unsigned magnitude conversion to `vFloat` at the residual site for INT32_MIN dividends in both Wormhole B0 and Blackhole SFPU kernels.