### PR TITLE
[Test Only] Fix non-blocking LaunchProgram

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -158,7 +158,7 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Run sender program
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
 
     // Validate status of sender
     std::vector<uint32_t> sender_status;
@@ -247,7 +247,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
     auto recv_program = create_receiver_program(compile_time_args, receiver_runtime_args, receiver_logical_core);
 
     // Run receiver program
-    tt_metal::LaunchProgram(*receiver_device, std::move(*recv_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*receiver_device, std::move(*recv_program));
 
     // Validate status of the receiver
     std::vector<uint32_t> receiver_status;
@@ -364,7 +364,7 @@ void run_mcast_sender_step(
     tt_metal::SetRuntimeArgs(mcast_send_program, mcast_send_kernel, sender_logical_core, sender_runtime_args);
 
     log_debug(tt::LogTest, "Run Sender on: {}", sender_device->id());
-    tt_metal::LaunchProgram(*sender_device, std::move(mcast_send_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(mcast_send_program));
 
     // Validate status of sender
     std::vector<uint32_t> sender_status;

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -23,6 +23,8 @@
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "test_host_kernel_common.hpp"
 
+#include <unordered_map>
+
 namespace tt::tt_fabric::fabric_router_tests {
 
 class ControlPlaneFixture : public ::testing::Test {
@@ -63,6 +65,9 @@ public:
     inline static std::map<ChipId, std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devices_map_;
     inline static std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devices_;
     inline static bool slow_dispatch_;
+
+    std::unordered_map<tt::tt_metal::distributed::MeshDevice*, std::vector<tt::tt_metal::distributed::MeshWorkload>>
+        pending_async_workloads_;
 
     const std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>>& get_devices() const { return devices_; }
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& get_device(ChipId id) const {
@@ -135,12 +140,13 @@ public:
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void RunProgramNonblocking(
         const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device, tt::tt_metal::Program&& program) {
-        tt_metal::LaunchProgram(*device, std::move(program), /*wait_until_cores_done=*/false);
+        pending_async_workloads_[device.get()].push_back(tt_metal::LaunchProgramAsync(*device, std::move(program)));
     }
 
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void WaitForSingleProgramDone(const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device) {
         tt::tt_metal::distributed::Finish(device->mesh_command_queue());
+        pending_async_workloads_.erase(device.get());
     }
 
     // Utility function reused across tests to get address params

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -505,7 +505,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
 
     // Launch sender and receiver programs and wait for them to finish
     fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate the status and packets processed by sender and receiver
@@ -667,7 +667,7 @@ void run_unicast_test_bw_chips(
 
     // Launch sender and receiver programs and wait for them to finish
     fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate the status and packets processed by sender and receiver
@@ -1056,7 +1056,7 @@ void RunTestMCastConnAPI(
     }
 
     // Launch sender program and wait for sender to finish
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
 
     // Wait for receivers to finish
     for (const auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
@@ -1595,7 +1595,7 @@ void RunTest2DMCastConnAPI(
         log_debug(tt::LogTest, "Rx Launched on physical device {}", physical_end_device_id);
     }
     // Launch sender program and wait for sender to finish
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
 
     // Wait for receivers to finish
     for (auto rx_physical_device_id : rx_physical_device_ids) {
@@ -1807,7 +1807,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
     }
 
     // Launch sender program and wait for sender to finish
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     log_info(tt::LogTest, "Sender Launched on physical device {}", src_phys_chip_id);
     log_info(tt::LogTest, "Sender Finished");
 
@@ -2057,7 +2057,7 @@ void RunEDMConnectionStressTest(
             // Launch program and wait for completion
             auto start_time = std::chrono::high_resolution_clock::now();
             log_debug(tt::LogTest, "Launching program");
-            tt_metal::LaunchProgram(*sender_device, std::move(program), /*wait_until_cores_done=*/true);
+            tt_metal::LaunchProgram(*sender_device, std::move(program));
             auto end_time = std::chrono::high_resolution_clock::now();
             auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
 
@@ -2239,7 +2239,7 @@ void FabricUnicastCommon(
     for (auto& [recv_dev, receiver_program] : receiver_programs) {
         fixture->RunProgramNonblocking(recv_dev, std::move(receiver_program));
     }
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     for (auto& [recv_dev, receiver_program] : receiver_programs) {
         fixture->WaitForSingleProgramDone(recv_dev);
     }
@@ -2571,7 +2571,7 @@ void UDMFabricUnicastCommon(
 
     // Run programs
     fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     fixture->WaitForSingleProgramDone(receiver_device);
 
     // Helper lambda to check test results for a given RISC
@@ -3329,7 +3329,7 @@ void Fabric2DMulticastCommon(
         receiver_devices.emplace_back(receiver_device);
     }
 
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
 
     for (auto& dev : receiver_devices) {
         fixture->WaitForSingleProgramDone(dev);
@@ -3510,7 +3510,7 @@ void FabricMulticastCommon(
         }
     }
 
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
 
     for (auto& dev : receiver_devices) {
         fixture->WaitForSingleProgramDone(dev);
@@ -3796,7 +3796,7 @@ void FabricSparseMulticastCommon(
         }
     }
 
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
 
     for (auto& dev : receiver_devices) {
         fixture->WaitForSingleProgramDone(dev);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
@@ -788,10 +788,7 @@ void run_test_case(BaseFabricFixture& fixture, const TestCaseConfig& test_case) 
             receiver_device_context.receiver_mux_deployment.device,
             std::move(*receiver_device_context.receiver_mux_deployment.program));
     }
-    tt_metal::LaunchProgram(
-        *sender_mux_deployment->device,
-        std::move(*sender_mux_deployment->program),
-        /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_mux_deployment->device, std::move(*sender_mux_deployment->program));
     for (const auto& receiver_device_context_entry : receiver_device_contexts.value()) {
         const auto& receiver_device_context = receiver_device_context_entry.second;
         fixture.WaitForSingleProgramDone(receiver_device_context.receiver_mux_deployment.device);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -137,7 +137,7 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
 
     // Run programs
     fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate results

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
@@ -142,7 +142,7 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
         receiver_devices.push_back(receiver_device);
     }
 
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     for (const auto& dev : receiver_devices) {
         fixture->WaitForSingleProgramDone(dev);
     }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -345,7 +345,7 @@ UnicastTrafficResult run_unicast_traffic_bw_nodes(
 
     // Launch and wait
     fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
-    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program));
     fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate sender/receiver status

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -270,7 +270,7 @@ void LaunchAndLogDfbInitTiming(
     DfbInitTimingBenchContext& ctx, Program&& program, const CoreCoord& core, const char* benchmark_name) {
     ClearDfbInitTimingL1(ctx.device, core);
     const uint16_t used_slots_mask = DfbInitTimingUsedSlotsMask(program, core);
-    LaunchProgram(*ctx.mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*ctx.mesh_device, std::move(program));
     LogDfbInitTimingFromL1(ctx.device, core, benchmark_name, used_slots_mask);
 }
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -467,7 +467,7 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
         slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, slice);
     }
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     // Verify (DM consumer only — Tensix consumer doesn't write DRAM).
     if (p.consumer_type == M2PorCType::DM) {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -280,7 +280,7 @@ void run_alias_dfb_program(
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
@@ -614,7 +614,7 @@ TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> out_la, out_lb, out_ra, out_rb;
     slow_dispatch::ReadFromBuffer(left.out_a.mesh_buffer(), out_la);
@@ -874,7 +874,7 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -182,7 +182,7 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     std::vector<DataT> result_init(expected_scalar_reads.size(), 0u);
     slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), result_l1_addr, result_init);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     tt_driver_atomics::mfence();
     std::vector<DataT> scalar_results;
@@ -472,7 +472,7 @@ void run_extent_probe(distributed::MeshDevice& mesh_device, const ExtentProbePar
     };
     m2::SetProgramRunArgs(program, run_args);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
     tt_driver_atomics::mfence();
 
     const CoreCoord core{0, 0};

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -303,7 +303,7 @@ TEST_F(UnitMeshAnyDispatchFixture, HalfGrid3Plus3DFBsOnDevice) {
     }
     m2::SetProgramRunArgs(program, params);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         std::vector<uint32_t> got;
@@ -452,7 +452,7 @@ TEST_F(UnitMeshAnyDispatchFixture, HalfGridOnDeviceDataflow1DFBEach) {
     m2_writeshard_barrier_uint32(this->device(), in_a, input_a);
     m2_writeshard_barrier_uint32(this->device(), in_b, input_b);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -127,7 +127,7 @@ static void run_a1_pipeline(distributed::MeshDevice& mesh_device, A1Transform tr
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -365,7 +365,7 @@ TEST_F(UnitMeshFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -596,7 +596,7 @@ TEST_F(UnitMeshFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -108,7 +108,7 @@ static void run_intra_tensix_dfb_program(
 
     slow_dispatch::WriteToL1(mesh_device, logical_core, dfb_l1_addr, input);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     // Packer increments each word by 1, then unpacker increments it by 1 → +2 per word.
     // This holds for every Neo's ring independently, so the entire L1 region is input + 2.
@@ -258,7 +258,7 @@ TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     EXPECT_NE(self_rc.config.intra_shadow_tc_id, self_tc);
     EXPECT_GE(self_rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -346,7 +346,7 @@ static void run_intra_tensix_dfb_program_2_0(
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_bytes / sizeof(uint32_t));
     slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, input);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> expected(input.size());
     std::transform(input.begin(), input.end(), expected.begin(), [](uint32_t v) { return v + 2; });
@@ -535,7 +535,7 @@ TEST_F(UnitMeshFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     // the program into the workload, which invalidates program (and remapper_dfb) once the launch returns.
     const uint32_t remapper_l1_addr = remapper_dfb->uniform_alloc_addr();
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     // Verify remapper ring L1: DM wrote input_remapper; Tensix consumed credits
     // (ALL pattern) but did not overwrite the ring's data.
@@ -693,7 +693,7 @@ TEST_F(UnitMeshFixture, TensixIntraIsolatesOverlayTCs) {
     const auto before = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GE(before.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> scratch;
     slow_dispatch::ReadFromL1(

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -112,7 +112,7 @@ static void run_single_dfb_multicore_2_0(
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -218,7 +218,7 @@ static void run_concurrent_dfbs_program_2_0(
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -362,7 +362,7 @@ static void run_sequential_4_dfbs_2_0(
         m2_writeshard_barrier_uint32(mesh_device, in_tensors[i], inputs[i]);
     }
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     for (uint32_t i = 0; i < 4; ++i) {
         std::vector<uint32_t> output;
@@ -555,7 +555,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
         slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), dfb_l1_addr, inputs[i]);
     }
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         std::vector<uint32_t> output;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
@@ -187,7 +187,7 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(distributed::MeshDevice& me
         slow_dispatch::WriteToL1(mesh_device, core, ring_base, prefill);
     }
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     // Kernels write their in-kernel verification read-back (via the non-cacheable alias so the result lands
     // in TL1) to the scratch region; the host reads it directly. Layout: handshake -> num_rounds words (one

--- a/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
@@ -60,7 +60,7 @@ TEST_F(UnitMeshFixture, NocRead_L1_Misaligned_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -93,7 +93,7 @@ TEST_F(UnitMeshFixture, NocWrite_L1_Misaligned_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -128,7 +128,7 @@ TEST_F(UnitMeshFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -163,7 +163,7 @@ TEST_F(UnitMeshFixture, NocWrite_L1_Misaligned_Dest_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -219,7 +219,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_dst});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*NOC Transfer Alignment.*DRAM source.*must be 32-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -276,7 +276,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_dst});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*NOC Transfer Alignment.*DRAM source.*must be 64-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -320,7 +320,7 @@ TEST_F(UnitMeshFixture, NocWrite_DRAM_Misaligned_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_src});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*NOC Transfer Alignment.*DRAM destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -395,7 +395,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
 
     // Must NOT abort. If the alignment mask regresses to something stricter than
     // 0x1F, this LaunchProgram SIGABRTs and the harness marks the test failed.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -467,7 +467,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
 
     // Must NOT abort. If the alignment mask regresses to something stricter than
     // 0x3F, this LaunchProgram SIGABRTs and the harness marks the test failed.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -517,7 +517,7 @@ TEST_F(UnitMeshFixture, NocRead_L1_Aligned_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {base});
 
     // Must NOT abort on the alignment check.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
@@ -62,7 +62,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_ReserveWithoutPush) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
 }
 
@@ -103,7 +103,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_WaitWithoutPop) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
 }
 
@@ -150,7 +150,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_LookaheadReserve_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — lookahead over-reservation is correct on silicon.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -193,7 +193,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_Balanced_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -233,7 +233,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_SkipEnv_Suppresses) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — the Dirty CB check is suppressed by the opt-out env var.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
@@ -45,9 +45,7 @@ TEST_F(UnitMeshFixture, CB_Reservation_Overflow_SanityCheck) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
-        ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
+    EXPECT_DEATH(LaunchProgram(this->device(), std::move(program)), ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
 }
 
 // CB Reservation Overflow is the one check that is ALWAYS ON (not gated by
@@ -80,9 +78,7 @@ TEST_F(UnitMeshFixture, CB_Reservation_Overflow_AlwaysOn) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
-        ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
+    EXPECT_DEATH(LaunchProgram(this->device(), std::move(program)), ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
 }
 
 // Boundary positive control: reserving EXACTLY the CB's capacity (n ==
@@ -127,7 +123,7 @@ TEST_F(UnitMeshFixture, CB_Reservation_ExactCapacity_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
@@ -67,9 +67,7 @@ TEST_F(UnitMeshFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
-        ".*\\[ASAN ERROR\\] Metadata Overflow.*");
+    EXPECT_DEATH(LaunchProgram(this->device(), std::move(program)), ".*\\[ASAN ERROR\\] Metadata Overflow.*");
 }
 
 // Directly exercises the emule-only static KERNEL_CONFIG-window check
@@ -153,9 +151,7 @@ TEST_F(UnitMeshFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
     std::vector<uint32_t> args(n_args, 0u);
     SetRuntimeArgs(program, kernel, logical_core, args);
 
-    EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
-        ".*\\[ASAN ERROR\\] Metadata Overflow.*");
+    EXPECT_DEATH(LaunchProgram(this->device(), std::move(program)), ".*\\[ASAN ERROR\\] Metadata Overflow.*");
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -193,7 +189,7 @@ TEST_F(UnitMeshFixture, Metadata_CB_Tensor_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
@@ -63,7 +63,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_Missing_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Race Condition: cb_pop_front.*called while a NoC read is still pending.*");
 }
 
@@ -121,7 +121,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {src_buf->address(), dst_buf->address()});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Race Condition: cb_pop_front.*called while a NoC read is still pending.*");
 }
 
@@ -171,7 +171,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_Present_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     // Must NOT abort.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -224,7 +224,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     // Must NOT abort — the single barrier cleared both in-flight reads.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
@@ -74,7 +74,7 @@ TEST_F(UnitMeshFixture, Tensor_Padding_Violation_SanityCheck) {
 
     // 3. The emulator should intercept the illegal write inside l1_ptr
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Tensor Padding Violation: Attempted to write to a padded memory region at address 0x.*");
 }
 

--- a/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
@@ -44,8 +44,7 @@ TEST_F(UnitMeshFixture, Local_L1_Alignment_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
-        ".*Local L1 Alignment: Offset 0x5 must be 4-byte aligned.*");
+        LaunchProgram(this->device(), std::move(program)), ".*Local L1 Alignment: Offset 0x5 must be 4-byte aligned.*");
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -45,7 +45,7 @@ TEST_F(UnitMeshFixture, Semaphore_Direct_Write_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Illegal Semaphore Access: Offset 0x.*is inside the reserved Semaphore region.*");
 }
 
@@ -83,7 +83,7 @@ TEST_F(UnitMeshFixture, Semaphore_OutsideRegion_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr});
 
     // Must NOT abort.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -127,7 +127,7 @@ TEST_F(UnitMeshFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
 
     // Must NOT abort.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -187,7 +187,7 @@ TEST_F(UnitMeshFixture, Semaphore_RelayUnicast_NoViolation) {
     SetRuntimeArgs(program, sender_kernel, sender_core, {rx_virtual.x, rx_virtual.y});
 
     // Must NOT abort (and must not hang: the relay's value wakes the waiter).
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -226,8 +226,7 @@ TEST_F(UnitMeshFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
 
-    EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true), ".*Out-of-Bounds Write.*");
+    EXPECT_DEATH(LaunchProgram(this->device(), std::move(program)), ".*Out-of-Bounds Write.*");
     ::unsetenv("TT_METAL_EMULE_ASAN");
 }
 

--- a/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
@@ -95,7 +95,7 @@ TEST_F(UnitMeshFixture, Object_Intent_Provenance_Violation_SanityCheck) {
 
     // 3. The sanitizer should catch that the execution sequence breached pointer provenance bounds
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Object Intent Violation: Attempted to modify memory belonging to an adjacent object context.*");
 }
 
@@ -162,7 +162,7 @@ TEST_F(UnitMeshFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr_a, addr_c - addr_a});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Object Intent Violation: Attempted to modify memory belonging to an adjacent object context.*");
 }
 
@@ -209,7 +209,7 @@ TEST_F(UnitMeshFixture, Object_Intent_Provenance_NoViolation_Control) {
 
     // Must NOT abort. If the sanitizer is over-eager, LaunchProgram will SIGABRT
     // and the test harness will mark this as failed.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 }
 
@@ -259,7 +259,7 @@ TEST_F(UnitMeshFixture, Object_Intent_IOArg_Exempt_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr_a, addr_b});
 
     // Must NOT abort — B was handed to the kernel as a runtime arg.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -324,7 +324,7 @@ TEST_F(UnitMeshFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — writing a globally-allocated CB the kernel owns is legitimate.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -384,7 +384,7 @@ TEST_F(UnitMeshFixture, Object_Intent_MultiKernel_Core_NoViolation) {
     SetRuntimeArgs(program, kernel_1, logical_core, {buffer_2->address()});
 
     // Must NOT abort — Object Intent no-ops on multi-kernel cores.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
@@ -64,7 +64,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Violation_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*CB Boundary Violation: Attempted to access CB 0.*reserved.*");
 }
 
@@ -110,7 +110,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Violation_Read_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*CB Boundary Violation: Attempted to access CB 0.*Read window.*");
 }
 
@@ -166,8 +166,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
-        ".*CB Boundary Violation: Attempted to access CB 0.*");
+        LaunchProgram(this->device(), std::move(program)), ".*CB Boundary Violation: Attempted to access CB 0.*");
 }
 
 // Wraparound positive control. On a 3-page CB we cycle the write/read pointers
@@ -225,7 +224,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Wraparound_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Wrapped access is legal and the kernel exits flushed → no sanitizer fires.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -270,7 +269,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_NoActiveWindow_NoViolation) {
 
     // Must NOT abort. If the window check regresses to firing without an active
     // reservation/wait, LaunchProgram SIGABRTs and this test fails.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -318,7 +317,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Reuse of produced data is legal and the kernel exits flushed → no abort.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -375,7 +374,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — globally-allocated CBs are exempt from the boundary window check.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -64,7 +64,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_Gap_L1_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {oob_addr});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Out-of-Bounds Write: Attempted to access address.*not part of any allocated tensor.*");
 }
 
@@ -112,7 +112,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {oob_addr});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Out-of-Bounds Write: Attempted to access DRAM address.*not part of any allocated tensor.*");
 }
 
@@ -157,7 +157,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {past_addr});
 
     EXPECT_DEATH(
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program)),
         ".*Out-of-Bounds Write: Attempted to access address.*not part of any allocated tensor.*");
 }
 
@@ -195,7 +195,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_L1_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the address is inside an allocated tensor.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -233,7 +233,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the offset is inside an allocated DRAM tensor.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -289,7 +289,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_SameAddressTempBuffer_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the owner's full range is still live.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -338,7 +338,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {poke_addr});
 
     // Must NOT abort — the address is inside a host-designated raw-L1 region.
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -177,7 +177,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // -------------------------------------------------------
     // Dispatch
     // -------------------------------------------------------
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     // -------------------------------------------------------
     // Verify
@@ -319,7 +319,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     }
     distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/true);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> output_data;
     distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
@@ -399,7 +399,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     std::vector<uint32_t> zero_report(1, 0u);
     detail::WriteToDeviceL1(device, node, report_addr, zero_report);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, report_addr, sizeof(uint32_t), reported);
@@ -489,7 +489,7 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
     }
     distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/true);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> output_data;
     distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
@@ -553,7 +553,7 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopbackCompute) {
     std::vector<uint32_t> zero_report(1, 0u);
     detail::WriteToDeviceL1(device, node, report_addr, zero_report);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, report_addr, sizeof(uint32_t), reported);
@@ -632,7 +632,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     };
 
     Program program = MakeProgramFromSpec(*mesh_device, spec);
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
     // If we got here, both kernels resolved their sem accessors to the same ID.
 }
 
@@ -758,7 +758,7 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     // -------------------------------------------------------
     // Dispatch
     // -------------------------------------------------------
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     // -------------------------------------------------------
     // Verify
@@ -832,7 +832,7 @@ TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
     std::vector<uint32_t> zero_report(kNumReportWords, 0u);
     detail::WriteToDeviceL1(device, node, kReportAddr, zero_report);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, kReportAddr, kNumReportWords * sizeof(uint32_t), reported);
@@ -952,7 +952,7 @@ TEST_F(ProgramSpecHWTest, ScratchpadWriteReadback) {
     detail::WriteToDeviceL1(device, node, kReportAddr, zero_report);
 
     // Dispatch via the slow-dispatch path (blocking — wait_until_cores_done defaults to true).
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, kReportAddr, sizeof(uint32_t), reported);

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -310,7 +310,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<uint32_t> dest_buffer_data;
     slow_dispatch::ReadFromBuffer(*output_dram_buffer, dest_buffer_data);

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -133,7 +133,7 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
             make_run_params(KernelSpecName{cfg.name}, node, cfg.layout, kRounds, kSkewIters));
     }
     SetProgramRunArgs(program, params);
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     for (const auto& cfg : kernel_configs) {
         std::vector<uint32_t> observed;

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -1164,7 +1164,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
     experimental::ProgramRunArgs merged = experimental::MergeProgramRunArgs(std::move(part1), rest);
     experimental::SetProgramRunArgs(program, merged);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> out(2, 0);
     slow_dispatch::ReadFromL1(this->device(), node, address_1, 2 * sizeof(uint32_t), out);

--- a/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
@@ -26,7 +26,7 @@ TEST_F(UnitMeshFixture, StreamScratchRegisterTensixCores) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Execute the program
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 }
 
 // Test stream scratch register APIs on Erisc cores
@@ -54,7 +54,7 @@ TEST_F(UnitMeshFixture, StreamScratchRegisterEriscCores) {
         EthernetConfig{.noc = NOC::NOC_0});
 
     // Execute the program
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -130,7 +130,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
     };
     Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     // Step 5: Host verifies dst hugepage region matches src.
     std::vector<uint32_t> host_dst_readback(expected.size());

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -104,7 +104,7 @@ TEST_F(UnitMeshAnyDispatchFixture, DataflowCb) {
     SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_cb});
     SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_cb});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
@@ -194,7 +194,7 @@ TEST_F(UnitMeshAnyDispatchFixture, DataflowDfb) {
     SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_dfb});
     SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_dfb});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -577,7 +577,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarDispatchSInstantiatedAndRunning)
     slow_dispatch::WriteToL1(this->device(), worker_node, l1_address, cleared_l1);
 
     auto program = create_quasar_l1_write_program(this->device(), worker_node, l1_address, test_value);
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result(1, 0);
     slow_dispatch::ReadFromL1(this->device(), worker_node, l1_address, sizeof(uint32_t), result);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -181,7 +181,7 @@ static vector<uint32_t> run_mxfp4_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -186,7 +186,7 @@ static vector<uint32_t> run_mxfp6_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -185,7 +185,7 @@ static vector<uint32_t> run_mxfp8_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -168,7 +168,7 @@ static vector<uint32_t> run_mxint_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
@@ -224,7 +224,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<std::uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -620,7 +620,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<std::uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, out_dram, zero_coord, false);
@@ -977,7 +977,7 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     std::vector<std::uint32_t> out0_data;
     std::vector<std::uint32_t> out1_data;

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -979,7 +979,7 @@ std::vector<uint32_t> sfpu_quasar_run(
     for (const auto& [buf, data] : inputs) {
         slow_dispatch::WriteToBuffer(*buf, *data);
     }
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
     std::vector<uint32_t> dest;
     slow_dispatch::ReadFromBuffer(*out_buf, dest);
     return dest;

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -425,7 +425,7 @@ void run_single_core_unary_broadcast_quasar(
         in_t, out_t, num_tiles, test_config.broadcast_dim, packed_tilized_input, golden_packed_tilized_output);
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), packed_tilized_input);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> dest_buffer_data;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), dest_buffer_data);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1240,7 +1240,7 @@ public:
         tt_metal::SetRuntimeArgs(program, dispatch_kernel, disp_logical, {0u, 0u, 0u});
 
         device_data.overflow_check(this->device_);
-        tt_metal::LaunchProgram(*this->mesh_device_, std::move(program), /*wait_until_cores_done=*/true);
+        tt_metal::LaunchProgram(*this->mesh_device_, std::move(program));
         const bool pass = device_data.validate(this->device_);
         EXPECT_TRUE(pass) << "SD Dispatcher test failed validation";
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -3020,7 +3020,7 @@ public:
         }
 
         device_data.overflow_check(this->device_);
-        tt_metal::LaunchProgram(*this->mesh_device_, std::move(program), /*wait_until_cores_done=*/true);
+        tt_metal::LaunchProgram(*this->mesh_device_, std::move(program));
         // Ensure host CPU sees any PCIe-written completion queue data before validating.
         tt_driver_atomics::mfence();
         // DRAM-backed Quasar CQs need a staging-buffer readback before validation; host-backed queues are

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -61,7 +61,7 @@ void measure_latency(const std::string& kernel_name) {
 
     tt::tt_metal::detail::SetDeviceProfilerDir(kernel_name + "_microbenchmark");
     tt::tt_metal::detail::FreshProfilerDeviceLog();
-    tt_metal::LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    tt_metal::LaunchProgram(*mesh_device, std::move(program));
 }
 
 int main() {

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -256,7 +256,7 @@ void run_bcast_test(distributed::MeshDevice& mesh_device, BcastDim::Enum bcast_d
     vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 10.0f, 0x1234);
     slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_vec);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -334,7 +334,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, BmmMultinode) {
     slow_dispatch::WriteToBuffer(tensors.src0.mesh_buffer(), src0_vec);
     slow_dispatch::WriteToBuffer(tensors.src1.mesh_buffer(), src1_vec);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(tensors.dst.mesh_buffer(), result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -81,7 +81,7 @@ TEST_F(UnitMeshFixture, Datacopy) {
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -83,7 +83,7 @@ TEST_F(UnitMeshFixture, DatacopyBfp8b) {
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -89,7 +89,7 @@ TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
          (std::uint32_t)l1_dst_noc_xy.y,
          num_tiles});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -148,7 +148,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
     }
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> outputs{0};
     slow_dispatch::ReadFromDRAMChannel(this->device(), 0, dram_address, sizeof(uint32_t), outputs);

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -117,7 +117,7 @@ TEST_F(UnitMeshFixture, DramCopySticksMultiCore) {
             }
         }
 
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+        LaunchProgram(this->device(), std::move(program));
         // std::vector<uint32_t> result_vec;
         // slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -58,7 +58,7 @@ TEST_F(UnitMeshFixture, DramLoopbackSingleCore) {
         core,
         {l1_buffer_addr, input_dram_buffer_addr, 0, output_dram_buffer_addr, 0, dram_buffer_size});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*output_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -297,7 +297,7 @@ TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
 
         tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_rt_args);
 
-        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+        LaunchProgram(this->device(), std::move(program));
 
         std::vector<uint32_t> result_vec;
         slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -120,7 +120,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     params.kernel_run_args = {kra1, kra2, kra3};
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> dram_data;
     slow_dispatch::ReadFromDRAMChannel(this->device(), dram_channel, dram_address, TOTAL_RESULT_BYTES, dram_data);
@@ -333,7 +333,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     }};
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> l1_data;
     slow_dispatch::ReadFromL1(this->device(), core, l1_result_addr, total_result_bytes, l1_data, CoreType::WORKER);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -111,7 +111,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
 
     SetRuntimeArgs(program, unary_writer_kernel, core, {(uint32_t)dst_dram_buffer->address(), 0, num_tiles});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -117,7 +117,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -113,7 +113,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelSameRuntimeArgs) {
     set_rt_args(program, reader_kernel_id, all_cores, unary_reader_args);
     set_rt_args(program, writer_kernel_id, all_cores, unary_writer_args);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
@@ -168,7 +168,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelUniqueRuntimeArgs) {
         set_rt_args(program, writer_kernel_id, core_range, rt_args.at(core_range_idx++));
     }
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec_1;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer_1, result_vec_1);

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -219,7 +219,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
         *src1_dram_buffer,
         *dst_dram_buffer);
 
-    LaunchProgram(this->device(), std::move(program1), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program1));
 
     std::vector<uint32_t> intermediate_result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, intermediate_result_vec);
@@ -243,7 +243,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
         *src1_dram_buffer,
         *dst_dram_buffer);
 
-    LaunchProgram(this->device(), std::move(program2), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program2));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -174,7 +174,7 @@ void run_pack_relu_test(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program));
 
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/test_quasar_fds.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_fds.cpp
@@ -210,7 +210,7 @@ FdsProgramResult run_fds_program(IDevice* dev, FdsProgram spec) {
                 .num_threads_per_cluster = 1, .named_compile_args = group.args});
     }
 
-    detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+    detail::LaunchProgram(dev, program);
     MetalContext::instance().get_cluster().l1_barrier(dev->id());
 
     FdsProgramResult result;

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -146,5 +146,5 @@ TEST_F(UnitMeshFixture, DISABLED_StressNocMcast) {
     }
     log_info(LogTest, "Running for {} seconds", time_secs);
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 }

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -125,7 +125,7 @@ TEST_F(UnitMeshFixture, TransposeHC) {
     SetRuntimeArgs(program, reader_kernel, core, {dram_buffer_src0_addr, 0U, W, H, C, HW, N, CHW});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0U, num_tensor_tiles});
 
-    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -202,7 +202,7 @@ void run_strided_dfb_copy_test(
     // -----------------------------------------------------------------------
     // Dispatch and verify
     // -----------------------------------------------------------------------
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program));
 
     const auto output_cpu = output_tensor.cpu(true);
     const auto output_shard = ttnn::distributed::get_device_tensors(output_cpu).front();

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -3279,10 +3279,18 @@ bool detail::ProgramCompileGroup::contains(tt::tt_metal::IDevice* device) {
     return program_device_map_.contains(device);
 }
 
-void LaunchProgram(distributed::MeshDevice& mesh_device, Program&& program, bool wait_until_cores_done) {
+[[nodiscard]] distributed::MeshWorkload LaunchProgramAsync(distributed::MeshDevice& mesh_device, Program&& program) {
     distributed::MeshWorkload workload;
     workload.add_program(distributed::MeshCoordinateRange(mesh_device.shape()), std::move(program));
-    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, wait_until_cores_done);
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, /*blocking=*/false);
+    return workload;
+}
+
+distributed::MeshWorkload LaunchProgram(distributed::MeshDevice& mesh_device, Program&& program) {
+    distributed::MeshWorkload workload;
+    workload.add_program(distributed::MeshCoordinateRange(mesh_device.shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, /*blocking=*/true);
+    return workload;
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -14,6 +14,7 @@
 #include "tt-metalium/hal_types.hpp"       // HalProgrammableCoreType
 #include "tt-metalium/kernel_types.hpp"    // KernelHandle
 #include "tt-metalium/program.hpp"         // KernelGroup
+#include "tt-metalium/mesh_workload.hpp"
 #include "hostdev/remote_dfb_constants.h"  // REMOTE_DFB_OFFSET_NONE
 #include "program_device_map.hpp"          // ProgramTransferInfo
 #include "impl/buffers/semaphore.hpp"
@@ -705,8 +706,20 @@ private:
 
 }  // namespace detail
 
-// Launch `program` on every device in `mesh_device` via EnqueueMeshWorkload.
-// Takes ownership of `program`. When `wait_until_cores_done` is true, enqueue is blocking.
-void LaunchProgram(distributed::MeshDevice& mesh_device, Program&& program, bool wait_until_cores_done);
+// Launch `program` on every device in `mesh_device` via EnqueueMeshWorkload, blocking until completion.
+//
+// Exception: a service workload (a program targeting claimed service cores) is routed by
+// EnqueueMeshWorkload to slow dispatch, which rings GO and returns without waiting - `blocking` is not
+// consulted on that path. Callers that launch onto claimed service cores must synchronize themselves.
+//
+// @return MeshWorkload that takes ownership of the program.
+distributed::MeshWorkload LaunchProgram(distributed::MeshDevice& mesh_device, Program&& program);
+
+// Launch `program` on every device in `mesh_device` via EnqueueMeshWorkload, without blocking.
+//
+// @return MeshWorkload that takes ownership of the program, and must be kept alive until Finish (or a blocking enqueue)
+// on the same command queue. The reason is that MeshWorkload owns kernel-binary DRAM that fast dispatch may
+// still prefetch after this function returns.
+[[nodiscard]] distributed::MeshWorkload LaunchProgramAsync(distributed::MeshDevice& mesh_device, Program&& program);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -199,10 +199,7 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
 
         double wait_for_kernel_time = execute_work_synced_start(
             1,
-            [device, &pgm](int /*thread_idx*/) {
-                // Program
-                LaunchProgram(*device, std::move(pgm), true);
-            },
+            [device, &pgm](int /*thread_idx*/) { LaunchProgram(*device, std::move(pgm)); },
             [&]() {
                 if (ctx.enable_host_copy_with_kernels) {
                     // Host copy while waiting for program
@@ -263,10 +260,7 @@ TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) 
 
         double wait_for_kernel_time = execute_work_synced_start(
             1,
-            [device, &pgm](int /*thread_idx*/) {
-                // Program
-                LaunchProgram(*device, std::move(pgm), true);
-            },
+            [device, &pgm](int /*thread_idx*/) { LaunchProgram(*device, std::move(pgm)); },
             [&]() {
                 // Host copy while waiting for program
                 host_copy_time =
@@ -308,12 +302,12 @@ TestResult mem_bench_multi_mmio_devices(
                      .value()});
         }
 
+        std::vector<distributed::MeshWorkload> workloads;
         execute_work_synced_start(
             1,
-            [devices, &programs](int /*thread_idx*/) {
-                // Program
+            [devices, &programs, &workloads](int /*thread_idx*/) {
                 for (auto& [device_id, pgm] : programs) {
-                    LaunchProgram(*devices.at(device_id), std::move(pgm), false);
+                    workloads.push_back(LaunchProgramAsync(*devices.at(device_id), std::move(pgm)));
                 }
             },
             []() {});
@@ -420,10 +414,7 @@ TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
 
         double wait_for_kernel_time = execute_work_synced_start(
             1,
-            [device, &pgm](int /*thread_idx*/) {
-                // Program
-                LaunchProgram(*device, std::move(pgm), true);
-            },
+            [device, &pgm](int /*thread_idx*/) { LaunchProgram(*device, std::move(pgm)); },
             [&]() {
                 // Host copy while waiting for program
                 host_copy_time =


### PR DESCRIPTION
### PR Category
Bug fix, Test Only

### Summary

Calling `LaunchProgram` with `wait_until_cores_done` false has potential issues because `MeshWorkload` is created on stack and destroyed before the function returns.

**Fast dispatch**: the host object is not needed after enqueue, but the DRAM it owns is. `MeshWorkloadImpl::load_binaries` allocates `kernel_bin_buf_` and writes kernel images there. Dispatch commands are copied into the issue queue, and those copies are `CQ_PREFETCH_RELAY_PAGED` (or the prefetcher-cache setup) with `base_address = kernels_buffer->address()`. The prefetcher later reads that DRAM.

Destroying the temporary workload drops `kernel_bin_buf_` / `ProgramImpl::kernels_buffer_`, which frees that DRAM while the CQ can still be waiting to fetch from it. A later allocation can reuse the same address. Blocking mode is safe because `enqueue_mesh_workload` calls finish before the stack workload dies, so the prefetch and run have finished.

**Slow dispatch**: `detail::LaunchProgram(..., wait=false)` compiles, writes binaries/runtime args to L1, then rings GO before enqueue returns. `Finish` waits using a copied core-idle list, not the Program object. CB teardown on destroy is `GraphTracker` unregister, not recycling the L1 the kernel is using. A temporary workload after a non-blocking SD launch is not the same DRAM UAF.

### Fix

`LaunchProgram` now returns the `MeshWorkload` so that it can be persisted after the call.
Separate version `LaunchProgramAsync` is added with `[[nodiscard]]` return as an extra protection against the bug.

`LaunchProgram` is used only in tests so far, and only fabric tests used the async version.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-launch-program-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-launch-program-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-launch-program-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-launch-program-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-launch-program-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-launch-program-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-launch-program-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-launch-program-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-launch-program-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-launch-program-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-launch-program-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-launch-program-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-launch-program-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-launch-program-fix)