### PR TITLE
Fix pow_bw returning +inf for negative and zero bases

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -273,10 +273,8 @@ std::vector<std::optional<Tensor>> pow_bw(
 
     Tensor result = ttnn::multiply(power_input, exponent, std::nullopt, output_mem_config);
     power_input.deallocate();
-    Tensor final_result = ttnn::multiply(result, grad, std::nullopt, output_mem_config);
+    input_grad = ttnn::multiply(result, grad, std::nullopt, output_mem_config, input_grad);
     result.deallocate();
-    // Handle negative inputs by returning infinity
-    where(ttnn::lez(input), std::numeric_limits<float>::infinity(), final_result, output_mem_config, input_grad);
     grad_tensor.emplace_back(input_grad);
     return grad_tensor;
 }


### PR DESCRIPTION
Fixes #54439.

## Problem
`ttnn.pow_bw` incorrectly forced all non-positive inputs (both negative bases and zero) to return `+inf` through a `where(ttnn::lez(input), infinity, ...)` hack.
This broke the gradient calculation mathematically, since `ttnn::pow` combined with `power_iterative` already properly handles integer powers of negative bases and returns the mathematically correct finite values (or NaNs where mathematically undefined), matching PyTorch's behavior. Additionally, this naive `lez` check forced the derivative at `0.0` to be `+inf` for all exponents, which is incorrect (e.g. `d/dx(x^2)` at `x=0` is `0`, not `inf`).

## Solution
Removed the artificial `lez` infinity branch and directly propagate the result to `input_grad`.
By allowing `ttnn::pow` (and `power_iterative` for integers) to naturally evaluate the derivatives, `pow_bw` now mirrors PyTorch:
- Negative bases with integer exponents return the correct finite gradients (e.g. `x^2` at `-2` -> `-4`).
- Negative bases with fractional exponents naturally evaluate to `NaN`.
- `0.0` bases evaluate correctly to `0` for exponent > 1, and `+inf` (via reciprocal) for exponent < 1.

The fix preserves all memory config invariants and correctly populates caller-supplied `input_grad`.
