### PR TITLE
Gives worker coords closest to given eth core

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/device.hpp
@@ -39,4 +39,10 @@ uint32_t get_worker_noc_hop_distance(
     const CoreCoord& logical_src,
     const CoreCoord& logical_dst,
     NOC noc);
+
+// Returns the logical worker coordinate with the fewest hops to logical_eth_core
+// on a given NOC, and that hop count. The distance is measured worker -> eth core.
+// This API is experimental and may evolve into a stable Device API in the future
+CoreCoord get_closest_worker_to_eth_core(
+    IDevice* device, const CoreCoord& logical_eth_core, NOC noc, uint32_t& noc_hops);
 }  // namespace tt::tt_metal::experimental::Device

--- a/tt_metal/api/tt-metalium/experimental/device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/device.hpp
@@ -40,9 +40,16 @@ uint32_t get_worker_noc_hop_distance(
     const CoreCoord& logical_dst,
     NOC noc);
 
+// Represents a logical coord of a core at the specified distance from a reference point.
+// Reference point is context-defined. E.g. the closest worker to a given core returned
+// by a function which takes the reference point as an argument.
+struct CoreAtNocHops {
+    CoreCoord logical_coord;
+    uint32_t distance_in_noc_hops;
+};
+
 // Returns the logical worker coordinate with the fewest hops to logical_eth_core
 // on a given NOC, and that hop count. The distance is measured worker -> eth core.
 // This API is experimental and may evolve into a stable Device API in the future
-CoreCoord get_closest_worker_to_eth_core(
-    IDevice* device, const CoreCoord& logical_eth_core, NOC noc, uint32_t& noc_hops);
+CoreAtNocHops get_closest_worker_to_eth_core(IDevice* device, const CoreCoord& logical_eth_core, NOC noc);
 }  // namespace tt::tt_metal::experimental::Device

--- a/tt_metal/api/tt-metalium/experimental/device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/device.hpp
@@ -51,5 +51,5 @@ struct CoreAtNocHops {
 // Returns the logical worker coordinate with the fewest hops to logical_eth_core
 // on a given NOC, and that hop count. The distance is measured worker -> eth core.
 // This API is experimental and may evolve into a stable Device API in the future
-CoreAtNocHops get_closest_worker_to_eth_core(IDevice* device, const CoreCoord& logical_eth_core, NOC noc);
+CoreAtNocHops get_closest_worker_to_eth_core(const IDevice& device, const CoreCoord& logical_eth_core, NOC noc);
 }  // namespace tt::tt_metal::experimental::Device

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -772,6 +772,11 @@ CoreCoord Device::physical_worker_core_from_logical_core(const CoreCoord& logica
     return soc_desc.get_physical_tensix_core_from_logical(logical_core);
 }
 
+CoreCoord Device::physical_eth_core_from_logical_core(const CoreCoord& logical_core) const {
+    const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
+    return soc_desc.get_physical_ethernet_core_from_logical(logical_core);
+}
+
 std::vector<CoreCoord> Device::worker_cores_from_logical_cores(const std::vector<CoreCoord>& logical_cores) const {
     std::vector<CoreCoord> worker_cores(logical_cores.size());
     for (std::size_t idx = 0; idx < logical_cores.size(); idx++) {

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -223,6 +223,7 @@ private:
     void invalidate_smc_dispatch_telemetry_control();
 
     CoreCoord physical_worker_core_from_logical_core(const CoreCoord& logical_core) const;
+    CoreCoord physical_eth_core_from_logical_core(const CoreCoord& logical_core) const;
     CoreCoord dram_core_from_dram_channel(uint32_t dram_channel, NOC noc = NOC::NOC_0) const;
     CoreCoord virtual_core_from_physical_core(const CoreCoord& physical_coord) const;
 
@@ -280,6 +281,9 @@ private:
     // Friend declaration for experimental API
     friend uint32_t experimental::Device::get_worker_noc_hop_distance(
         IDevice* device, const CoreCoord& logical_src, const CoreCoord& logical_dst, NOC noc);
+
+    friend CoreCoord experimental::Device::get_closest_worker_to_eth_core(
+        IDevice* device, const CoreCoord& logical_eth_core, NOC noc, uint32_t& noc_hops);
 
     friend class experimental::DispatchContext;
 };

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -282,8 +282,8 @@ private:
     friend uint32_t experimental::Device::get_worker_noc_hop_distance(
         IDevice* device, const CoreCoord& logical_src, const CoreCoord& logical_dst, NOC noc);
 
-    friend CoreCoord experimental::Device::get_closest_worker_to_eth_core(
-        IDevice* device, const CoreCoord& logical_eth_core, NOC noc, uint32_t& noc_hops);
+    friend experimental::Device::CoreAtNocHops experimental::Device::get_closest_worker_to_eth_core(
+        IDevice* device, const CoreCoord& logical_eth_core, NOC noc);
 
     friend class experimental::DispatchContext;
 };

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -283,7 +283,7 @@ private:
         IDevice* device, const CoreCoord& logical_src, const CoreCoord& logical_dst, NOC noc);
 
     friend experimental::Device::CoreAtNocHops experimental::Device::get_closest_worker_to_eth_core(
-        IDevice* device, const CoreCoord& logical_eth_core, NOC noc);
+        const IDevice& device, const CoreCoord& logical_eth_core, NOC noc);
 
     friend class experimental::DispatchContext;
 };

--- a/tt_metal/impl/device/experimental/device.cpp
+++ b/tt_metal/impl/device/experimental/device.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <limits>
+
 #include <tt-metalium/experimental/device.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -11,26 +13,22 @@
 
 namespace tt::tt_metal::experimental::Device {
 
-uint32_t get_worker_noc_hop_distance(
-    IDevice* device, const CoreCoord& logical_src, const CoreCoord& logical_dst, NOC noc) {
+namespace {
+
+tt::tt_metal::Device* concrete_device(IDevice* device) {
     TT_FATAL(device != nullptr, "Device pointer cannot be null");
 
-    // Check if it's a MeshDevice and handle appropriately
     if (auto* mesh = dynamic_cast<distributed::MeshDevice*>(device)) {
-        TT_FATAL(mesh->num_devices() == 1, "get_worker_noc_hop_distance() is only supported on unit MeshDevice.");
-        // Delegate to the underlying device
-        return get_worker_noc_hop_distance(mesh->get_devices().front(), logical_src, logical_dst, noc);
+        TT_FATAL(mesh->num_devices() == 1, "Experimental NOC geometry APIs are only supported on unit MeshDevice.");
+        return concrete_device(mesh->get_devices().front());
     }
 
-    // Handle regular Device - cast to access internal physical_worker_core_from_logical_core
     auto* dev = dynamic_cast<tt::tt_metal::Device*>(device);
     TT_FATAL(dev != nullptr, "Device pointer must be a valid Device or MeshDevice");
+    return dev;
+}
 
-    // Convert logical to physical worker coordinates
-    auto src = dev->physical_worker_core_from_logical_core(logical_src);
-    auto dst = dev->physical_worker_core_from_logical_core(logical_dst);
-    auto grid_size = device->grid_size();
-
+uint32_t noc_hop_distance(const CoreCoord& src, const CoreCoord& dst, const CoreCoord& grid_size, NOC noc) {
     if (noc == NOC::NOC_0) {
         // NOC0: Preferred +x -> +y
         uint32_t dist_right = src.x <= dst.x ? dst.x - src.x : grid_size.x - src.x + dst.x;
@@ -40,6 +38,18 @@ uint32_t get_worker_noc_hop_distance(
     uint32_t dist_left = src.x >= dst.x ? src.x - dst.x : grid_size.x - dst.x + src.x;
     uint32_t dist_top = src.y >= dst.y ? src.y - dst.y : grid_size.y - dst.y + src.y;
     return dist_left + dist_top;
+}
+
+}  // namespace
+
+uint32_t get_worker_noc_hop_distance(
+    IDevice* device, const CoreCoord& logical_src, const CoreCoord& logical_dst, NOC noc) {
+    auto* dev = concrete_device(device);
+    return noc_hop_distance(
+        dev->physical_worker_core_from_logical_core(logical_src),
+        dev->physical_worker_core_from_logical_core(logical_dst),
+        dev->grid_size(),
+        noc);
 }
 
 uint32_t get_worker_noc_hop_distance(
@@ -71,6 +81,30 @@ uint32_t get_worker_noc_hop_distance(
         device = local_devices.front();
     }
     return get_worker_noc_hop_distance(device, logical_src, logical_dst, noc);
+}
+
+CoreCoord get_closest_worker_to_eth_core(
+    IDevice* device, const CoreCoord& logical_eth_core, NOC noc, uint32_t& noc_hops) {
+    auto* dev = concrete_device(device);
+    const auto eth_core = dev->physical_eth_core_from_logical_core(logical_eth_core);
+    const auto grid_size = dev->grid_size();
+    const auto worker_grid_size = dev->compute_with_storage_grid_size();
+
+    CoreCoord closest = CoreCoord{0, 0};
+    uint32_t min_hops_so_far = std::numeric_limits<uint32_t>::max();
+    for (uint32_t y = 0; y < worker_grid_size.y; y++) {
+        for (uint32_t x = 0; x < worker_grid_size.x; x++) {
+            uint32_t hops = noc_hop_distance(
+                dev->physical_worker_core_from_logical_core(CoreCoord{x, y}), eth_core, grid_size, noc);
+            if (hops < min_hops_so_far) {
+                min_hops_so_far = hops;
+                closest = CoreCoord{x, y};
+            }
+        }
+    }
+
+    noc_hops = min_hops_so_far;
+    return closest;
 }
 
 }  // namespace tt::tt_metal::experimental::Device

--- a/tt_metal/impl/device/experimental/device.cpp
+++ b/tt_metal/impl/device/experimental/device.cpp
@@ -48,7 +48,7 @@ uint32_t get_worker_noc_hop_distance(
     return noc_hop_distance(
         dev->physical_worker_core_from_logical_core(logical_src),
         dev->physical_worker_core_from_logical_core(logical_dst),
-        dev->grid_size(),
+        device->grid_size(),
         noc);
 }
 
@@ -87,8 +87,8 @@ CoreCoord get_closest_worker_to_eth_core(
     IDevice* device, const CoreCoord& logical_eth_core, NOC noc, uint32_t& noc_hops) {
     auto* dev = concrete_device(device);
     const auto eth_core = dev->physical_eth_core_from_logical_core(logical_eth_core);
-    const auto grid_size = dev->grid_size();
-    const auto worker_grid_size = dev->compute_with_storage_grid_size();
+    const auto grid_size = device->grid_size();
+    const auto worker_grid_size = device->compute_with_storage_grid_size();
 
     CoreCoord closest = CoreCoord{0, 0};
     uint32_t min_hops_so_far = std::numeric_limits<uint32_t>::max();

--- a/tt_metal/impl/device/experimental/device.cpp
+++ b/tt_metal/impl/device/experimental/device.cpp
@@ -83,27 +83,23 @@ uint32_t get_worker_noc_hop_distance(
     return get_worker_noc_hop_distance(device, logical_src, logical_dst, noc);
 }
 
-CoreCoord get_closest_worker_to_eth_core(
-    IDevice* device, const CoreCoord& logical_eth_core, NOC noc, uint32_t& noc_hops) {
+CoreAtNocHops get_closest_worker_to_eth_core(IDevice* device, const CoreCoord& logical_eth_core, NOC noc) {
     auto* dev = concrete_device(device);
     const auto eth_core = dev->physical_eth_core_from_logical_core(logical_eth_core);
     const auto grid_size = device->grid_size();
     const auto worker_grid_size = device->compute_with_storage_grid_size();
 
-    CoreCoord closest = CoreCoord{0, 0};
-    uint32_t min_hops_so_far = std::numeric_limits<uint32_t>::max();
+    CoreAtNocHops closest{CoreCoord{0, 0}, std::numeric_limits<uint32_t>::max()};
     for (uint32_t y = 0; y < worker_grid_size.y; y++) {
         for (uint32_t x = 0; x < worker_grid_size.x; x++) {
             uint32_t hops = noc_hop_distance(
                 dev->physical_worker_core_from_logical_core(CoreCoord{x, y}), eth_core, grid_size, noc);
-            if (hops < min_hops_so_far) {
-                min_hops_so_far = hops;
-                closest = CoreCoord{x, y};
+            if (hops < closest.distance_in_noc_hops) {
+                closest = CoreAtNocHops{CoreCoord{x, y}, hops};
             }
         }
     }
 
-    noc_hops = min_hops_so_far;
     return closest;
 }
 

--- a/tt_metal/impl/device/experimental/device.cpp
+++ b/tt_metal/impl/device/experimental/device.cpp
@@ -15,17 +15,19 @@ namespace tt::tt_metal::experimental::Device {
 
 namespace {
 
-tt::tt_metal::Device* concrete_device(IDevice* device) {
-    TT_FATAL(device != nullptr, "Device pointer cannot be null");
-
-    if (auto* mesh = dynamic_cast<distributed::MeshDevice*>(device)) {
+const tt::tt_metal::Device& concrete_device(const IDevice& device) {
+    if (const auto* mesh = dynamic_cast<const distributed::MeshDevice*>(&device)) {
         TT_FATAL(mesh->num_devices() == 1, "Experimental NOC geometry APIs are only supported on unit MeshDevice.");
-        return concrete_device(mesh->get_devices().front());
+        const auto* only_device = mesh->get_devices().front();
+        TT_FATAL(only_device != nullptr, "Device pointer cannot be null");
+        return concrete_device(*only_device);
     }
 
-    auto* dev = dynamic_cast<tt::tt_metal::Device*>(device);
-    TT_FATAL(dev != nullptr, "Device pointer must be a valid Device or MeshDevice");
-    return dev;
+    const auto* dev = dynamic_cast<const tt::tt_metal::Device*>(&device);
+    TT_FATAL(
+        dev != nullptr,
+        "Experimental NOC geometry APIs are only supported on tt::tt_metal::Device or unit MeshDevice.");
+    return *dev;
 }
 
 uint32_t noc_hop_distance(const CoreCoord& src, const CoreCoord& dst, const CoreCoord& grid_size, NOC noc) {
@@ -44,10 +46,11 @@ uint32_t noc_hop_distance(const CoreCoord& src, const CoreCoord& dst, const Core
 
 uint32_t get_worker_noc_hop_distance(
     IDevice* device, const CoreCoord& logical_src, const CoreCoord& logical_dst, NOC noc) {
-    auto* dev = concrete_device(device);
+    TT_FATAL(device != nullptr, "Device pointer cannot be null");
+    const auto& dev = concrete_device(*device);
     return noc_hop_distance(
-        dev->physical_worker_core_from_logical_core(logical_src),
-        dev->physical_worker_core_from_logical_core(logical_dst),
+        dev.physical_worker_core_from_logical_core(logical_src),
+        dev.physical_worker_core_from_logical_core(logical_dst),
         device->grid_size(),
         noc);
 }
@@ -83,17 +86,17 @@ uint32_t get_worker_noc_hop_distance(
     return get_worker_noc_hop_distance(device, logical_src, logical_dst, noc);
 }
 
-CoreAtNocHops get_closest_worker_to_eth_core(IDevice* device, const CoreCoord& logical_eth_core, NOC noc) {
-    auto* dev = concrete_device(device);
-    const auto eth_core = dev->physical_eth_core_from_logical_core(logical_eth_core);
-    const auto grid_size = device->grid_size();
-    const auto worker_grid_size = device->compute_with_storage_grid_size();
+CoreAtNocHops get_closest_worker_to_eth_core(const IDevice& device, const CoreCoord& logical_eth_core, NOC noc) {
+    const auto& dev = concrete_device(device);
+    const auto eth_core = dev.physical_eth_core_from_logical_core(logical_eth_core);
+    const auto grid_size = device.grid_size();
+    const auto worker_grid_size = device.compute_with_storage_grid_size();
 
     CoreAtNocHops closest{CoreCoord{0, 0}, std::numeric_limits<uint32_t>::max()};
     for (uint32_t y = 0; y < worker_grid_size.y; y++) {
         for (uint32_t x = 0; x < worker_grid_size.x; x++) {
             uint32_t hops = noc_hop_distance(
-                dev->physical_worker_core_from_logical_core(CoreCoord{x, y}), eth_core, grid_size, noc);
+                dev.physical_worker_core_from_logical_core(CoreCoord{x, y}), eth_core, grid_size, noc);
             if (hops < closest.distance_in_noc_hops) {
                 closest = CoreAtNocHops{CoreCoord{x, y}, hops};
             }


### PR DESCRIPTION
### PR Category - Performance

### Summary

This is 3rd PR (out of 3) which enable ops to place worker cores near the eth cores they use. Placing worker cores arbitrarily can result in traffic coming to multiple eth cables through the same NoC line, and on fast links making fabric underutilized.

In MoE/Combine op for example this reduces op speed by 0 - 25%, depending on how lucky the eth-unaware worker positioning was. The op is as fast as the slowest chip so on large machines, such as GLX, chance of not hitting that 25% drop is vanishingly small.

PRs covering this work are
1. New device API - [Gives worker coords closest to given eth core](https://github.com/tenstorrent/tt-metal/pull/55535)
2. New fabric API - [Expose coords of the ethernet core for given link and direction](https://github.com/tenstorrent/tt-metal/pull/55536)
3. Example of the op usage in MoE/Combine - [Example of usage of the proposed new APIs](https://github.com/tenstorrent/tt-metal/pull/55537)

The effect of the overall improvement (all 3 PRs together) is depicted [here](https://claude.ai/code/artifact/e4090d08-2073-4ea5-a371-f98282ce5592)

### The new API

The new Device API enables callers (ops) to get worker logical coords closest to given eth logical coord. The API also gives achieved manhattan distance in NoC hops. Strictly speaking, identifying given eth core does not need to be done via its logical coord, but fabric and device need to agree on the identity, so logical coord was chosen as the least coupling one.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dlukic/device-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dlukic/device-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dlukic/device-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dlukic/device-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dlukic/device-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dlukic/device-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dlukic/device-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dlukic/device-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dlukic/device-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dlukic/device-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dlukic/device-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dlukic/device-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dlukic/device-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dlukic/device-API-expansion-proposal)