### PR TITLE
Expose coords of the ethernet core for given link and direction

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -115,6 +115,11 @@ uint32_t append_routing_plane_connection_manager_rt_args(
 std::vector<uint32_t> get_forwarding_link_indices(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
 
+// returns the logical ethernet core on src that link_idx forwards through toward dst, for a link index
+// from get_forwarding_link_indices
+tt::tt_metal::CoreCoord get_forwarding_eth_core(
+    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, uint32_t link_idx);
+
 FabricNodeId get_fabric_node_id_from_physical_chip_id(ChipId physical_chip_id);
 
 std::vector<chan_id_t> get_active_fabric_eth_routing_planes_in_direction(

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -517,6 +517,32 @@ std::vector<uint32_t> get_forwarding_link_indices(
         control_plane, src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
 }
 
+tt::tt_metal::CoreCoord get_forwarding_eth_core(
+    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, uint32_t link_idx) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+    TT_FATAL(
+        forwarding_direction.has_value(),
+        "Could not determine forwarding direction from src {} to dst {}",
+        src_fabric_node_id,
+        dst_fabric_node_id);
+
+    const auto eth_chans =
+        control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
+    TT_FATAL(
+        link_idx < eth_chans.size(),
+        "Requested link index {} is out of bounds. {} ethernet channels available to forward b/w src {} and dst {}",
+        link_idx,
+        eth_chans.size(),
+        src_fabric_node_id,
+        dst_fabric_node_id);
+
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
+    return cluster.get_logical_ethernet_core_from_virtual(
+        physical_chip_id, cluster.get_virtual_eth_core_from_channel(physical_chip_id, eth_chans[link_idx]));
+}
+
 tt::tt_fabric::Topology get_fabric_topology() {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     return control_plane.get_fabric_context().get_fabric_topology();


### PR DESCRIPTION
### PR Category - Performance

### Summary

This is 3rd PR (out of 3) which enable ops to place worker cores near the eth cores they use. Placing worker cores arbitrarily can result in traffic coming to multiple eth cables through the same NoC line, and on fast links making fabric underutilized.

In MoE/Combine op for example this reduces op speed by 0 - 25%, depending on how lucky the eth-unaware worker positioning was. The op is as fast as the slowest chip so on large machines, such as GLX, chance of not hitting that 25% drop is vanishingly small.

PRs covering this work are
1. New device API - [Gives worker coords closest to given eth core](https://github.com/tenstorrent/tt-metal/pull/55535)
2. New fabric API - [Expose coords of the ethernet core for given link and direction](https://github.com/tenstorrent/tt-metal/pull/55536)
3. Example of the op usage in MoE/Combine - [Example of usage of the proposed new APIs](https://github.com/tenstorrent/tt-metal/pull/55537)

The effect of the overall improvement (all 3 PRs together) is depicted [here](https://claude.ai/code/artifact/e4090d08-2073-4ea5-a371-f98282ce5592)

### The new API

This API gives enables ops to identify logical position of a particular eth core which will is cabled so that it transmits data in the given direction and over the given fabric plane. Strictly speaking logical coords of the eth core are not needed, but some kind of individual eth core identity, linkable to its role, is. And this identity is required to be recognized by the Device component as it will be used in its new API, so logical coord is used here for that eth-core-identity purpose as the least coupling option.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dlukic/fabric-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dlukic/fabric-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dlukic/fabric-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dlukic/fabric-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dlukic/fabric-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dlukic/fabric-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dlukic/fabric-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dlukic/fabric-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dlukic/fabric-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dlukic/fabric-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dlukic/fabric-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dlukic/fabric-API-expansion-proposal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dlukic/fabric-API-expansion-proposal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dlukic/fabric-API-expansion-proposal)