### PR TITLE
Example of usage of the proposed new APIs

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_placement.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_placement.cpp
@@ -4,7 +4,10 @@
 
 #include "combine_fabric2d_placement.hpp"
 
+#include <set>
+
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/experimental/device.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt_stl/assert.hpp>
@@ -13,17 +16,26 @@ namespace ttnn::operations::experimental::deepseek_prefill::combine_fabric2d {
 
 namespace {
 
-// One packed column per stream, row 0. Of the fixed layouts swept on a Blackhole galaxy these were the
-// steadiest run to run and within 2% of the fastest; every layout spread further across the grid was at
-// least 9% slower.
-constexpr uint32_t worker_column(StreamId stream) { return stream; }
+// The sender reaches its eth core over NOC_1, so that is the NOC distances are minimised on.
+constexpr tt::tt_metal::NOC SENDER_NOC = tt::tt_metal::NOC::NOC_1;
+
+// Eth cores own a row no worker sits in, so the NOC_1 -y leg always costs one hop and a shared column
+// is exactly what removes the -x leg. One hop therefore means "same column as the eth core".
+constexpr uint32_t SENDER_NOC_MIN_ETH_HOPS = 1;
+
+struct WorkerCandidate {
+    tt::tt_metal::CoreCoord worker;
+    uint32_t noc_hops = 0;
+    ttnn::MeshCoordinate downstream_coord{0, 0};
+    tt::tt_fabric::FabricNodeId downstream_node{tt::tt_fabric::MeshId{0}, 0};
+};
 
 StreamPlacements decide_device_placement(
     ttnn::MeshDevice* mesh, const ttnn::MeshCoordinate& coord, uint32_t axis, uint32_t num_links) {
     auto* dev = mesh->get_device(coord);
     const auto self_node = mesh->get_fabric_node_id(coord);
 
-    StreamPlacements placements;
+    std::map<StreamId, WorkerCandidate> candidates;
     for (int delta : {1, -1}) {
         const auto nbr = coord.get_neighbor(
             mesh->shape(), delta, static_cast<int32_t>(axis), ttnn::MeshCoordinate::BoundaryMode::WRAP);
@@ -43,13 +55,52 @@ StreamPlacements decide_device_placement(
             nbr_node,
             num_links);
         for (uint32_t k = 0; k < num_links; k++) {
-            const auto stream = make_stream_id(k, delta == 1);
-            const tt::tt_metal::CoreCoord worker{worker_column(stream), 0};
-            placements.emplace(
-                stream,
-                StreamPlacement{
-                    worker, dev->virtual_core_from_logical_core(worker, tt::CoreType::WORKER), *nbr, nbr_node});
+            uint32_t noc_hops = 0;
+            const tt::tt_metal::CoreCoord worker = tt::tt_metal::experimental::Device::get_closest_worker_to_eth_core(
+                dev, tt::tt_fabric::get_forwarding_eth_core(self_node, nbr_node, k), SENDER_NOC, noc_hops);
+            candidates.emplace(make_stream_id(k, delta == 1), WorkerCandidate{worker, noc_hops, *nbr, nbr_node});
         }
+    }
+
+    StreamPlacements placements;
+    std::set<tt::tt_metal::CoreCoord> taken;
+    auto assign = [&](StreamId stream, const WorkerCandidate& candidate, const tt::tt_metal::CoreCoord& worker) {
+        TT_FATAL(
+            taken.insert(worker).second,
+            "combine_fabric2d {}: stream {} was placed on {}, which another stream already owns",
+            self_node,
+            stream,
+            worker);
+        placements.emplace(
+            stream,
+            StreamPlacement{
+                worker,
+                dev->virtual_core_from_logical_core(worker, tt::CoreType::WORKER),
+                candidate.downstream_coord,
+                candidate.downstream_node});
+    };
+
+    for (const auto& [stream, candidate] : candidates) {
+        if (candidate.noc_hops == SENDER_NOC_MIN_ETH_HOPS) {
+            assign(stream, candidate, candidate.worker);
+        }
+    }
+    const uint32_t grid_width = mesh->compute_with_storage_grid_size().x;
+    for (const auto& [stream, candidate] : candidates) {
+        if (candidate.noc_hops == SENDER_NOC_MIN_ETH_HOPS) {
+            continue;
+        }
+        tt::tt_metal::CoreCoord worker = candidate.worker;
+        for (uint32_t tried = 0; taken.contains(worker); tried++) {
+            TT_FATAL(
+                tried < grid_width,
+                "combine_fabric2d {}: no free worker on row {} for stream {}",
+                self_node,
+                worker.y,
+                stream);
+            worker.x = (worker.x + 1) % grid_width;
+        }
+        assign(stream, candidate, worker);
     }
     return placements;
 }
@@ -58,12 +109,6 @@ StreamPlacements decide_device_placement(
 
 MeshPlacement decide_placement(ttnn::MeshDevice* mesh, uint32_t axis, uint32_t num_links) {
     TT_FATAL(mesh != nullptr, "combine_fabric2d: mesh device is null");
-    TT_FATAL(
-        worker_column(stream_count(num_links) - 1) < mesh->compute_with_storage_grid_size().x,
-        "combine_fabric2d: {} streams need worker columns up to {}, but the compute grid is only {} wide",
-        stream_count(num_links),
-        worker_column(stream_count(num_links) - 1),
-        mesh->compute_with_storage_grid_size().x);
 
     MeshPlacement placement;
     for (const auto& coord : ttnn::MeshCoordinateRange(mesh->shape())) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_placement.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine_fabric2d/device/combine_fabric2d_placement.cpp
@@ -55,9 +55,8 @@ StreamPlacements decide_device_placement(
             nbr_node,
             num_links);
         for (uint32_t k = 0; k < num_links; k++) {
-            uint32_t noc_hops = 0;
-            const tt::tt_metal::CoreCoord worker = tt::tt_metal::experimental::Device::get_closest_worker_to_eth_core(
-                dev, tt::tt_fabric::get_forwarding_eth_core(self_node, nbr_node, k), SENDER_NOC, noc_hops);
+            const auto [worker, noc_hops] = tt::tt_metal::experimental::Device::get_closest_worker_to_eth_core(
+                *dev, tt::tt_fabric::get_forwarding_eth_core(self_node, nbr_node, k), SENDER_NOC);
             candidates.emplace(make_stream_id(k, delta == 1), WorkerCandidate{worker, noc_hops, *nbr, nbr_node});
         }
     }


### PR DESCRIPTION
### PR Category - Performance

### Summary

This is 3rd PR (out of 3) which enable ops to place worker cores near the eth cores they use. Placing worker cores arbitrarily can result in traffic coming to multiple eth cables through the same NoC line, and on fast links making fabric underutilized.

In MoE/Combine op for example this reduces op speed by 0 - 25%, depending on how lucky the eth-unaware worker positioning was. The op is as fast as the slowest chip so on large machines, such as GLX, chance of not hitting that 25% drop is vanishingly small.

PRs covering this work are
1. New device API - [Gives worker coords closest to given eth core](https://github.com/tenstorrent/tt-metal/pull/55535)
2. New fabric API - [Expose coords of the ethernet core for given link and direction](https://github.com/tenstorrent/tt-metal/pull/55536)
3. Example of the op usage in MoE/Combine - [Example of usage of the proposed new APIs](https://github.com/tenstorrent/tt-metal/pull/55537)

The effect of the overall improvement (all 3 PRs together) is depicted [here](https://claude.ai/code/artifact/e4090d08-2073-4ea5-a371-f98282ce5592)

### How are the new APIs used

MoE/Combine moves data along a single dimension (SP axis) and uses 2 fabric links. This needs 4 eth cores actively used. 4 worker cores, called "Senders" by the op are placed to aggregate data from multiple other worker cores into 4 distinct data streams and send them to the eth cores.

At the same time ETH cores are receiving data and writing to DRAM, at roughly the same speed as they send data, and some of that traffic goes over the same NoC lines as Sender->Eth traffic.

Position of a particular ETH core which moves data on a particular fabric plane and in the particular direction, relative to some fixed logical worker coords depends on worker core harvesting, but also on eth cabling.

Senders are capable of preparing data quickly enough for fabric links to be utilized if the Sender->Eth movement is unobstructed. But with 4 outbound and 4 inbound data streams, chances are some fixed worker placement will result in enough data streams using the same NoC line, on at leat one chip. For example, with eth BW of 25GB/s/direction/link, 4 data streams are faster than a single NoC line, making it, rather than the eth, the bottleneck.

To make positioning eth-aware, the op finds ideal position for each Sender by first using the new fabric API to identify logical eth coords of the eth core which transmits data in a given direction and over a given plane (those that sender needs), and then uses the new device API to find closest tensix logical coord to that eth core. The op also gets the manhattan distance between the two and if that is greater than 1 it knows the cores cannot be in the same physical column (which might be important for further op positioning logic).

From that point on, it's op-specific logic, but the MoE/Combine places those sender cores which have option to sit in the same column as their eth cores, they will be using, then proceeds to place other senders if their closest spot is not already taken or move to higher x coord and wrap around if those spots are taken. That way the number of overlapping streams is minimized and low enough to keep the fabric utilized.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dlukic/new-api-usage-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dlukic/new-api-usage-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dlukic/new-api-usage-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dlukic/new-api-usage-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dlukic/new-api-usage-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dlukic/new-api-usage-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dlukic/new-api-usage-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dlukic/new-api-usage-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dlukic/new-api-usage-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dlukic/new-api-usage-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dlukic/new-api-usage-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dlukic/new-api-usage-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dlukic/new-api-usage-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dlukic/new-api-usage-example)