### PR TITLE
[MOCKUP] Scratch mock-up of Metal 2.0 host APIs for new resource types

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -139,31 +139,31 @@ struct DataflowBufferSpec {
 // CrossNodeDataflowBufferSpec
 //------------------------------------------------
 
-// NOTE: Cross-Node DataflowBuffer is not yet supported!
-//       A sketch is included in the experimental Metal 2.0 APIs for visibility.
-//       See also Global DataflowBuffer (which has a user-managed lifetime).
-//
 // CrossNodeDataflowBufferSpec is the descriptor for a "cross-node" DFB:
 // A DFB whose producer and consumer kernels run on different nodes, with data
-// flowing over the NoC. Its semantics should be as close as possible to that of
-// a local DFB.
+// flowing over the NoC.
 //
-// A CrossNodeDataflowBufferSpec has all of the properties of a DataflowBufferSpec,
-// but must specify additional cross-node DFB specific properties, such as the
-// producer-consumer node mapping.
-//
-// TBD: Much about cross-node DFBs is still TBD! Everything below this line is expected
-//   to change with the implementation.
-//
-// Invariant: Every cross-node DFB instance has exactly one producer kernel instance and
-//   one consumer kernel instance. The instances must not be on the same node.
+// A cross-node DFB differs from a local DFB in that:
+//   - Its producer and consumer kernel instances run on different nodes.
+//   - You must specify the producer-consumer kernel instance node mapping.
+//     (For local DFB, this is inferred, as the producer and consumer kernel
+//     instances must be on the same node.)
+//   - A cross-node DFB instance may have MULTIPLE consumer kernel instances.
+//     Producer data is multicast to all consumers.
 //
 // Instancing: At runtime, one cross-node DFB instance is allocated per entry in the
 //   producer_consumer_map. The runtime infrastructure allocates SRAM ("L1") at both
 //   endpoints.
 //
-// Placement: Specified directly via producer_consumer_map (rather than derived as
+// Placement: Specified directly via producer_consumer_map (rather than derived, as
 //   for local DFBs).
+//
+// Legality:
+//   - For any kernel bound to a cross-node DFB, that cross-node DFB must have a
+//     a corresponding endpoint instance on every node where that kernel runs.
+//   - If a compute kernel is bound to a cross-node DFB, you must provide a DFB "relay"
+//     binding on one of the DM kernels within the same WorkUnitSpec. (A compute kernel
+//     cannot directly access the NoC; the "relay" provides the necessary mediation.)
 //
 struct CrossNodeDataflowBufferSpec {
     // A cross-node DFB has all of the same properties as a local DFB
@@ -172,12 +172,12 @@ struct CrossNodeDataflowBufferSpec {
     // Plus, some cross-node DFB-specific properties.
     // (These are TBD...)
 
-    // Producer-consumer node mapping: each entry pairs a producer node with the
-    // consumer node it feeds.
-    // (What about multi-casting? TBD.)
+    // Producer-consumer node mapping:
+    // Each entry pairs a producer node with one or more consumer nodes that it
+    // feeds via multicast.
     using ProducerNode = NodeCoord;
     using ConsumerNode = NodeCoord;
-    using ProducerConsumerMap = Table<ProducerNode, ConsumerNode>;
+    using ProducerConsumerMap = Table<ProducerNode, Group<ConsumerNode>>;
     ProducerConsumerMap producer_consumer_map;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/global_semaphore_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/global_semaphore_parameter.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include <tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp>
+#include <tt-metalium/tensor/spec/tensor_spec.hpp>
+#include <tt_stl/strong_type.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// ============================================================================
+//  GlobalSemaphoreParameter API
+// ============================================================================
+//
+// TODO...
+
+// A name identifying a GlobalSemaphoreParameter within a ProgramSpec.
+using GlobalSemaphoreParamName = ttsl::StrongType<std::string, struct GlobalSemaphoreParamNameTag>;
+
+struct GlobalSemaphoreParameter {
+    // GlobalSemaphore identifier: used to reference this GlobalSemaphore within the ProgramSpec
+    GlobalSemaphoreParamName unique_id;
+
+    // TODO...
+    // Are there any properties a GlobalSemaphore has, that we need to legality check
+    // against the supplied GlobalSemaphore object at runtime?
+};
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -123,8 +123,14 @@ struct KernelSpec {
     ///////////////////////////////////////////////////////////////////
 
     // DFB bindings
-    // Declares that this kernel requires a DFB resource (declared at the ProgramSpec level)
-    // The kernel constructs a DataflowBuffer from the binding token:
+    // Declares that this kernel accesses a DFB resource.
+    // The underlying resource can be:
+    //  - A local DataflowBuffer (declared at the ProgramSpec level)
+    //  - A cross-node DataflowBuffer (declared at the ProgramSpec level)
+    //  - A PrefetcherPipe (a user-managed resource - the ProgramSpec declares
+    //      the parameter, and the PrefetcherPipe argument is passed at runtime)
+    //
+    // The kernel constructs a DataflowBuffer object from the binding token:
     //   DataflowBuffer(dfb::<accessor_name>)
     struct DFBBinding {
         // Endpoint role this binding plays for the DFB.
@@ -137,19 +143,44 @@ struct KernelSpec {
         //            (NOT YET SUPPORTED — currently rejected at runtime)
         enum class AccessPattern { STRIDED, ALL, BLOCKED };
 
-        DFBSpecName dfb_spec_name;   // identify the DFB within the ProgramSpec
-        std::string accessor_name;   // DFB accessor name (used in the kernel source code)
-        EndpointType endpoint_type;  // producer or consumer
+        // A DFB binding can refer to a local DFB, a cross-node DFB, or a prefetcher pipe.
+        typedef std::variant<DFBSpecName, CrossNodeDFBSpecName, PrefetcherPipeParamName> DFBResourceName;
+
+        DFBResourceName dfb_resource_name;  // The resource this binding refers to
+        std::string accessor_name;          // DFB binding token name (used in the kernel source code)
+        EndpointType endpoint_type;         // producer or consumer
         AccessPattern access_pattern = AccessPattern::STRIDED;
     };
     Group<DFBBinding> dfb_bindings;
 
+    // DFB relay bindings
+    // If a compute kernel is bound to a cross-node DFB or a prefetcher pipe, a DM kernel from the
+    // same WorkUnitSpec must provide a relay binding in order to mediate its NoC access.
+    // Only DM cores can serve as relays, so only DM kernels can have DFB relay bindings.
+    // Prefer a DM kernel with a light workload to serve as a relay.
+    //
+    // The kernel constructs a ??? object from the binding token:
+    //   RelayDataflowBuffer(dfb::<accessor_name>) // <-- AK: is it a special object?
+    // The DM kernel code does not interact directly with the relay object. <-- AK: true??
+    struct DFBRelayBinding {
+        typedef std::variant<CrossNodeDFBSpecName, PrefetcherPipeParamName> DFBResourceName;
+
+        DFBResourceName dfb_resource_name;  // The resource this binding refers to
+        std::string accessor_name;          // Binding token name (used in the kernel source code)
+    };
+    Group<DFBRelayBinding> dfb_relay_bindings;
+
     // Semaphore bindings
     // Declares that this kernel accesses a semaphore resource (declared at the ProgramSpec level)
-    // The kernel constructs a Semaphore from the emitted id: Semaphore(sem::<accessor_name>)
+    // or a user-managed GlobalSemaphore resource (declared as a ProgramSpec parameter).
+    //
+    // The kernel constructs a Semaphore from the resulting binding token:
+    //   Semaphore(sem::<accessor_name>)
     struct SemaphoreBinding {
-        SemaphoreSpecName semaphore_spec_name;  // identify the semaphore within the ProgramSpec
-        std::string accessor_name;              // semaphore accessor name (used in the kernel source code)
+        typedef std::variant<SemaphoreSpecName, GlobalSemaphoreParamName> SemaphoreResourceName;
+
+        SemaphoreResourceName semaphore_spec_name;  // identify the semaphore within the ProgramSpec
+        std::string accessor_name;                  // binding token name (used in the kernel source code)
     };
     Group<SemaphoreBinding> semaphore_bindings;
 
@@ -159,7 +190,7 @@ struct KernelSpec {
     //   Scratchpad<uint32_t>(scratch::<accessor_name>)
     struct ScratchpadBinding {
         ScratchpadSpecName scratchpad_spec_name;  // identify the scratchpad within the ProgramSpec
-        std::string accessor_name;                // scratchpad accessor name (used in the kernel source code)
+        std::string accessor_name;                // binding token name (used in the kernel source code)
     };
     Group<ScratchpadBinding> scratchpad_bindings;
 
@@ -173,7 +204,7 @@ struct KernelSpec {
     //   TensorAccessor(tensor::<accessor_name>)
     struct TensorBinding {
         TensorParamName tensor_parameter_name;  // identify the TensorParameter within the ProgramSpec
-        std::string accessor_name;              // tensor accessor name (used in the kernel source code)
+        std::string accessor_name;              // binding token name (used in the kernel source code)
     };
     Group<TensorBinding> tensor_bindings;
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/prefetcher_pipe_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/prefetcher_pipe_parameter.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include <tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp>
+#include <tt-metalium/tensor/spec/tensor_spec.hpp>
+#include <tt_stl/strong_type.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// ============================================================================
+//  PrefetcherPipeParameter API
+// ============================================================================
+//
+// TODO...
+
+// A name identifying a PrefetcherPipeParameter within a ProgramSpec.
+using PrefetcherPipeParamName = ttsl::StrongType<std::string, struct PrefetcherPipeParamNameTag>;
+
+struct PrefetcherPipeParameter {
+    // PrefetcherPipe identifier: used to reference this PrefetcherPipe within the ProgramSpec
+    PrefetcherPipeParamName unique_id;
+
+    // TODO...
+    // What properties does a PrefetcherPipe have, that we need to legality check
+    // against the supplied PrefetcherPipe object at runtime?
+    //
+    // I want to reuse a struct that is used to construct the actual PrefetcherPipe object.
+    // (In much the way we do with TensorParameter and TensorSpec.)
+    //
+};
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
@@ -105,12 +105,36 @@ struct ProgramRunArgs {
     //
     // CAUTION: MeshTensor is an RAII object. The user is responsible for ensuring that the MeshTensor
     //          object remains alive until the last Program execution that uses it has completed on the
-    //          device. Use extreme caution if you use UpdateProgramRunArgs with an incomplete set of
-    //          TensorArguments. A stale binding to a destroyed MeshTensor will produce undefined behavior.
+    //          device. A stale binding to a destroyed MeshTensor will produce undefined behavior.
+    //          Use extreme caution if you use UpdateProgramRunArgs with an incomplete set of TensorArguments.
     //
     // The argument's TensorSpec MUST match the TensorParameter's TensorSpec (shape, layout, data type).
     // (Any declared TensorParameter relaxations will modify the matching rules; see advanced_options.hpp.)
     Table<TensorParamName, TensorArgument> tensor_args;
+
+    ////////////////////////////////////////////////////////////////////////
+    // GlobalSemaphore arguments
+    ////////////////////////////////////////////////////////////////////////
+
+    // A GlobalSemaphoreArgument must be specified:
+    //  For EVERY GlobalSemaphoreParameter in the ProgramSpec, when calling SetProgramRunArgs.
+    //  For any SUBSET of GlobalSemaphoreParameters, when calling UpdateProgramRunArgs. (For advanced users only.)
+    //
+    // CAUTION: GlobalSemaphore is an RAII object. The user is responsible for ensuring that the GlobalSemaphore
+    //          object remains alive until the last Program execution that uses it has completed on the
+    //          device. A stale binding to a destroyed GlobalSemaphore will produce undefined behavior.
+    //
+    using GlobalSemaphoreArgument = std::reference_wrapper<const GlobalSemaphore>;
+    Table<GlobalSemaphoreParamName, GlobalSemaphoreArgument> global_semaphore_args;
+
+    ////////////////////////////////////////////////////////////////////////
+    // PrefetcherPipe arguments
+    ////////////////////////////////////////////////////////////////////////
+
+    // PrefetcherPipeArguments work in a similar way to GlobalSemaphoreArguments.
+    // The properties of the supplied PrefetcherPipe object must match the declared PrefetcherPipeParameter.
+    using PrefetcherPipeArgument = std::reference_wrapper<const PrefetcherPipe>;
+    Table<PrefetcherPipeParamName, PrefetcherPipeArgument> prefetcher_pipe_args;
 
     ////////////////////////////////////////////////////////////////////////
     // DFB parameters (optional, advanced use cases)

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -80,19 +80,42 @@ struct ProgramSpec {
     // Kernels that make up the Program
     Group<KernelSpec> kernels;
 
-    // Program-scope resources (allocated for the Program's execution lifetime)
-    // DFBs (local + cross-node), and semaphores
+    ////////////////////////////////////
+    // Program-scope resources
+    ////////////////////////////////////
+
+    // Program-scope resources are runtime-managed memory resouces.
+    // Their allocation is handled automatically, and they exist only during the
+    // Program's execution lifetime.
+
     Group<DataflowBufferSpec> dataflow_buffers;
     Group<CrossNodeDataflowBufferSpec> cross_node_dataflow_buffers;
     Group<SemaphoreSpec> semaphores;
     Group<ScratchpadSpec> scratchpads;
 
-    // Tensor parameter declarations
-    // Provides ids and layout specs for tensors the Program's kernels will operate on
-    // (The actual MeshTensors are supplied via ProgramRunArgs.)
+    ////////////////////////////////////
+    // Program parameters
+    ////////////////////////////////////
+
+    // Program parameters are user-managed memory resources. (User-controlled lifetime.)
+    // The ProgramSpec declares these resources as parameters.
+    // The actual resource objects are to supplied by the user as Program arguments at
+    // runtime (via ProgramRunArgs), prior to enqueueing the Program for execution.
+
+    // Tensor parameters
+    // Defines the IDs and layout specs for MeshTensors the Program's kernels will operate on
     Group<TensorParameter> tensor_parameters;
 
-    // WorkUnit specifications:
+    // GlobalSemaphore parameters
+    Group<GlobalSemaphoreParameter> global_semaphore_parameters;
+
+    // PrefetcherPipe parameters
+    Group<PrefetcherPipeParameter> prefetcher_pipe_parameters;
+
+    ////////////////////////////////////
+    // Work Units
+    ////////////////////////////////////
+
     // A valid ProgramSpec has at least one WorkUnitSpec.
     // Each kernel must be referenced by at least one WorkUnitSpec.
     Group<WorkUnitSpec> work_units;


### PR DESCRIPTION
## PR Category
For illustrative purposes only!
Non-compiling mockup, not for merging.

## Summary
This is a very quick-and-dirty mockup of the Metal 2.0 semantics I envision for the new resource types:
 - `CrossNodeDFB` (ephemeral)
 - `PrefetcherPipe` (user-managed)
 -  `GlobalSemaphore` (user-managed)

**Disclaimer**: This was done in something of a mad rush. I created this based on my from-conversations understanding of the intended use cases of these new resource types. I did not (with apologies!) study the PRs for the DFB objects in detail. Apologies in advance for any misunderstandings/ half-bakedness therein!

**Design decisions**
 - A relay DFB binding is a different binding type altogether. (Previously, we had "Relay" alongside Producer and Consumer as endpoints types... I find this confusing, as the binding is an inert object and the rest of the binding's properties don't really apply... or at least, I think so.)
 - The kernel code can create a `Semaphore` Device 2.0 object from _either_ a Program-scope ephemeral semaphore resource or a `GlobalSemaphore` resource, and the device API looks symmetric to the kernel user. I'm not 100% sure if this is valid. If I'm out to lunch, and the device side behaves differently, could also make a separate GlobalSemaphore resource. This way seems nicer though, assuming it works.
 - Similarly, the kernel code can create a `DataflowBuffer` endpoint object out of any of a local DFB, cross-node DFB, or prefetcher pipe. The device-side semantics are basically the same regardless. (Err... this is definitely not true for a prefetcher pipe Producer, but I swept that under the rug because I figured it would be in a runtime-authored DRISC kernel. I did not adequately think through what would happen for a user-defined prefetcher pipe producer sitting on a normal DM core in a SubDevice. Perhaps it could just be able to make a special object out of the same binding token?)


## Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/new-resource-types-mockup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/new-resource-types-mockup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/new-resource-types-mockup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/new-resource-types-mockup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/new-resource-types-mockup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/new-resource-types-mockup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/new-resource-types-mockup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/new-resource-types-mockup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/new-resource-types-mockup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/new-resource-types-mockup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/new-resource-types-mockup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/new-resource-types-mockup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/new-resource-types-mockup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/new-resource-types-mockup)