### PR TITLE
[Bug fix] Matmul with fused activations: Fix Selu param order and missing Softplus param

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -4,44 +4,223 @@
 
 """Numeric tolerances for matmul tests, predicted from the device number formats.
 
-Nothing imports this module. The tests hold their limits as literals so that the
-limit being applied is visible at the point it is applied, and so that editing the
-model here cannot quietly move what every test accepts. This module is the record
-of where those literals came from: run its functions by hand to re-derive a table
-when a test's shapes, seeds, data types or activations change, and paste the
-result back. A literal is set to the most permissive value the model gives over
-the cases it covers, rounded outward, so that no case is held to a tighter limit
-than the model asks for.
+A test compares a matrix multiply run on Tenstorrent hardware against the same
+matrix multiply run in PyTorch on the host. The two never agree bit for bit, so
+the test has to accept some difference. assert_numeric_metrics, the helper the
+tests call to make the comparison, takes four limits:
 
-A matmul on device and the same matmul in PyTorch never agree bit for bit, so a
-test has to accept some difference. Choosing that limit by raising it until the
-test passes produces limits that no longer detect a wrong answer: a limit of
-``rtol = 10 * K`` grants every element an allowance thousands of times its own
-value, and a relative Frobenius limit above 1.0 is passed by a tensor of zeros.
+    atol, rtol (absolute and relative tolerance)
+                         every element must satisfy
+                         abs(device - reference) <= atol + rtol * abs(reference),
+                         so atol is the fixed part of the per element allowance
+                         and rtol the part that grows with the element's value
+    frobenius_threshold  root-mean-square difference over the whole tensor, as a
+                         fraction of the root-mean-square of the reference
+    pcc_threshold        smallest Pearson correlation coefficient allowed between
+                         the two tensors
 
-The functions here predict the error instead, from the width of each number
-format on the path and the number of times a value is rounded into one. The
-prediction is then the limit. Nothing here measures the device.
+matmul_numeric_tolerances returns all four. Tests never call it at run time. You
+run it yourself while writing a test and paste the numbers in, so the limits stay
+plain constants where they are used, and so editing this module cannot quietly
+move what every test accepts.
 
-The error is summarised as a single **relative error** ``r``, meaning the
-predicted error on a result has standard deviation ``r`` times the standard
-deviation of that result. Independent sources combine as ``sqrt(sum of
-squares)``.
+The matmul can also apply an activation function to its result on device. The
+test still compares against the reference with the activation applied (below, the
+activated reference), but what you hand this module is the product before the
+activation, because working out how the activation transforms an error needs the
+values going into it. You pass the activation itself twice: as the device side op
+(from ttnn, the Python interface to the device ops), which the module uses to
+look up how accurately the hardware evaluates that activation, and as the
+equivalent PyTorch function, which the module evaluates to find how much the
+activation stretches or compresses an error. Accuracy varies by activation: the
+device evaluates some as a fitted polynomial and others from a piecewise linear
+lookup table, which is much coarser.
 
-Two facts shape everything below.
+The calculation runs in two stages.
 
-*The relative error of a matmul does not grow with K.* Each product carries a
-fractional slip from the narrowed mantissas. Those slips multiply values of
-random sign, so the total error grows as ``sqrt(K)``, and so does the result
-itself. They cancel. The one term that does grow is accumulator rounding, and it
-grows as ``sqrt(K)``, never as ``K``.
+Stage one: a single relative error. matmul_relative_error predicts one relative
+error r from the configuration only, never from the data. r is defined so that
+across the whole output tensor the predicted error has a standard deviation of r
+times the standard deviation of the reference. It reads these inputs:
 
-*A one-sided slip behaves like a random one.* Mantissa bits are dropped rather
-than rounded, so every slip has the same sign. It still does not build up,
-because it multiplies a mean-zero quantity. The figure that matters is therefore
-the root-mean-square of the slip including its mean, rather than its standard
-deviation about that mean. For a slip spread over ``[0, 2**-m)`` on a significand
-in ``[1, 2)`` that is ``2**-m / sqrt(6)``.
+  - how many mantissa bits each number format keeps, from the inputs through to
+    the partial sums. The final rounding into the output format is not part of r;
+    stage two adds it, because it scales with the element's own value
+  - K, the reduction length, which is the shared dimension of the two operands
+  - math_fidelity, which selects how many passes the multiply hardware makes and
+    so how much of each input's mantissa it uses
+  - k_tiles_per_block, how many 32 element slices of K are summed before the
+    partial sum is written out and rounded. The hardware works in 32 by 32 tiles,
+    and fewer slices per write means more roundings along K
+  - fp32_dest_acc_en, whether partial sums are held in 32 bit rather than 16 bit,
+    and packer_l1_acc, whether a new partial sum is added straight into the
+    output buffer as it is written, instead of the value there being read back,
+    so that one rounding to the output format is skipped
+
+Every rounding step in that chain contributes one relative error term. K and
+k_tiles_per_block set how many times each step happens; math_fidelity and the two
+accumulation settings set how large each term is. The terms are combined as the
+square root of the sum of their squares, the usual rule for independent errors.
+
+Stage two: the four limits. Turning r into them needs the reference tensor as
+well, because r is only a ratio: atol is an absolute number, and the activation
+corrections depend on the reference values.
+
+- atol. Each output element is a sum of K products. The model takes the error of
+  that sum to be about the same size for every element, because it comes from
+  rounding partial sums, whose typical magnitude is the same across the output,
+  not from the size of the element it lands in. Stage one already fixed that
+  size, r times the standard deviation of the reference, and taking it to be the
+  same everywhere is what lets one number serve as atol for the whole tensor.
+  That error is itself a sum of many independent roundings, so it is close to
+  Gaussian. Write n for the number of output elements. An error can fall either
+  way, so the largest absolute error among n elements is about as extreme as the
+  largest of 2n one sided samples, which for a Gaussian sits about
+  sqrt(2 * ln(2n)) standard deviations from zero. The module then shifts each
+  reference value by that distance, up and down, applies the activation to all
+  three values, and keeps the largest change in the activation's output over
+  every element and both directions. It does not multiply the distance by the
+  activation's slope: at worst case distance the activation is nowhere near
+  straight. This is why an activation that flattens out at both ends, such as
+  sigmoid, is never assigned more error than its whole output range. The device's
+  own absolute error in evaluating the activation is then added.
+
+- rtol takes the two contributions that do scale with an element's own value: the
+  activation's relative error and the rounding into the output format. r does not
+  enter it. The two are added rather than combined in quadrature, so that rtol
+  stays a bound for every element rather than a typical value. For an activation
+  the device evaluates as a polynomial the activation's own error dominates, 87
+  percent of the total in the example below.
+
+- frobenius_threshold combines three terms as the square root of the sum of their
+  squares: r times the standard deviation of the reference, since that is how r
+  is defined, multiplied by the root-mean-square of the activation's slope taken
+  over the reference values; the sum of the output format rounding and the
+  activation's relative error, multiplied by the root-mean-square of the
+  activated reference; and the device's absolute error on the activation. The
+  result is divided by the root-mean-square of the activated reference. A slope
+  is enough here, where atol needed an evaluation, because this term describes a
+  typical error, far smaller than the worst case atol has to cover, and the
+  activation is nearly linear over an interval that small.
+
+- pcc_threshold reuses that combined error, before it is divided. Write q for the
+  combined error divided by the standard deviation of the activated reference,
+  the standard deviation and not the root-mean-square because a correlation
+  removes the mean of each tensor first. An error independent of the reference
+  values adds to the device tensor's variance without adding to the covariance,
+  which scales the correlation by 1 / sqrt(1 + q * q). matmul_numeric_tolerances
+  returns the small q approximation of that, 1 - q * q / 2.
+
+atol, rtol and frobenius_threshold are multiplied by the safety argument, 2.0 by
+default. pcc_threshold does not use it: q is always multiplied by sqrt(1.5), a
+fixed module constant. Because a correlation's distance from 1 goes as the square
+of the error, that is a margin of 1.5 on the distance from 1.
+
+To get limits for a new entry in a test's pytest.mark.parametrize list, build the
+reference tensor the test will compare against and call matmul_numeric_tolerances
+with it. Run this from a Python session whose working directory is the repository
+root, so that the import resolves:
+
+    import torch
+    import ttnn
+    import torch.nn.functional as F
+    from tests.ttnn.nightly.unit_tests.operations.matmul.numeric_tolerances import (
+        matmul_numeric_tolerances,
+    )
+
+    M, K, N = 128, 512, 512
+    torch.manual_seed(0)
+    # bfloat16 is a 16 bit float that stores 7 mantissa bits. Rounding the
+    # inputs to it here is what the device does when it receives them.
+    in0 = torch.randn(1, 1, M, K).bfloat16().float()
+    in1 = torch.randn(1, 1, K, N).bfloat16().float()
+
+    print(
+        matmul_numeric_tolerances(
+            in0 @ in1,                                    # reference, pre activation
+            ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),   # as the device applies it
+            F.gelu,                                       # the PyTorch equivalent
+            K=K,
+            in0_dtype=ttnn.bfloat16,
+            in1_dtype=ttnn.bfloat16,
+            out_dtype=ttnn.bfloat16,
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+            k_tiles_per_block=2,
+        )
+    )
+
+which prints
+
+    {'atol': 6.565339088439941, 'rtol': 0.035760548978043954,
+     'frobenius_threshold': 0.06724930087282528,
+     'pcc_threshold': 0.9987590077261392}
+
+The two per element limits can be followed by hand. For atol, r is 0.0284 for
+this configuration and the reference has a standard deviation of 22.6, so one
+element's error has a standard deviation of 0.64. The output has M * N =
+128 * 512 = 65536 elements, so 2n is 131072 and sqrt(2 * ln(131072)) is 4.855,
+giving a worst element error of 4.855 * 0.64 = 3.11. Shifting the reference by
+that distance and reapplying GELU raises it to 3.28: the largest change is at a
+reference value of 0.75, where GELU gives 0.58, while at 3.86, which is 3.11
+higher, GELU is close enough to the identity to give 3.87, a change of 3.28. The
+module records no absolute error for GELU, because the device fits it with a
+polynomial and that inaccuracy is carried as the relative error in rtol instead.
+The safety argument of 2.0 gives the printed 6.57.
+
+For rtol, a unit in the last place is the gap between neighbouring representable
+values, which for a 7 bit mantissa is 2**-7 of the value. The module's table
+gives GELU a relative error of two of those in whatever format the accumulator
+holds, which is bfloat16 here because fp32_dest_acc_en is False, so 2 * 2**-7 =
+0.0156. Rounding into a bfloat16 output moves a value by at most half a unit in
+the last place, 2**-8; taking that error as uniform over the rounding interval
+gives a root-mean-square relative error of 2**-8 / sqrt(3) = 0.0023. Twice their
+sum is the printed 0.0358. The two tensor wide limits use the same pieces through
+the formulas above and are not traced here.
+
+One parametrize entry usually covers several shapes, data types and settings. Run
+the calculation for each and keep the largest atol, rtol and
+frobenius_threshold and the smallest pcc_threshold. Round the first three up and
+pcc_threshold down.
+
+Notes:
+
+- The relative error of a matmul does not grow with K. Each product carries a
+relative rounding error from the narrowed mantissas. Because inputs to the tests
+include both positive and negative random values (from torch.randn), those errors
+multiply values of random sign, so the total error grows as sqrt(K), and so
+does the result itself. As far as relative error is concerned, they cancel out.
+The terms that do grow are the two that round a running total: the accumulator
+itself, once per 16 elements of K per fidelity pass, and the partial sum spilled
+between K blocks. Both grow as sqrt(K). Both scale with the accumulator
+format, so with fp32_dest_acc_en they fall below every other term and
+K stops mattering at all; they are only significant with a 16 bit accumulator.
+
+- Truncation is biased: it always errs in the same direction. The matrix engine
+drops the low mantissa bits of each operand instead of rounding to nearest, which
+moves that operand toward zero, so no product comes out larger in magnitude than
+the true result. Consider the product of a and b as a*b*(1-d), where d is the
+fraction of the true product lost from the two truncated operands together.
+d is always positive because the result is always truncated toward zero.
+One might expect a loss that never changes sign to add up over the K products,
+making the total grow linearly with K.
+It does not, because only d has a fixed sign. The products a*b can be either
+positive or negative, so the errors -d*a*b can be either positive or negative
+and cancel in the sum just as the products themselves do. Therefore, relative
+error does not grow with K.
+
+The bias does change how the truncation term enters r. A source whose error
+averages to zero contributes the standard deviation of its error divided by the
+standard deviation of the result. Truncation does not average to zero. Split
+the error one product contributes into a bias part, -mu*a*b where mu is the
+average of d, and a noise part, -(d-mu)*a*b: the bias part sums to exactly the
+true result shrunk by mu, and only the noise part averages to zero. The
+root-mean-square of d is the square root of the sum of mu squared and the
+variance, so using it in place of a standard deviation carries the bias into
+the same sum of squares as every other source. That is not exact for a fixed
+offset, it is a simple upper bound, and _truncation_relative_error, which
+computes this root-mean-square for one operand, measures the margin it leaves.
 """
 
 import math
@@ -54,7 +233,7 @@ _SQRT6 = math.sqrt(6.0)
 
 # Margin on the correlation limit, as a multiplier on the relative error. Squared
 # by the conversion to a correlation, so it allows 1.5x on the distance from 1.
-# The whole-tensor and elementwise limits take the larger ``safety`` factor
+# The whole-tensor and elementwise limits take the larger safety factor
 # instead; a correlation needs less because the quantity it is built from is a
 # root-mean-square over tens of thousands of elements, which barely varies from
 # run to run. Some margin is still needed: with the truncation term corrected the
@@ -78,7 +257,7 @@ _BLOCK_FLOAT_BITS = {
     ttnn.bfloat4_b: 2,
 }
 
-# Mantissa bits the matrix unit keeps from each operand, as (SrcA, SrcB), taken
+# Mantissa bits the matrix engine keeps from each operand, as (SrcA, SrcB), taken
 # from the union of the per-pass bit masks. The multiplier is 5 bits by 7 bits
 # and each fidelity level makes another pass to consume more of the inputs
 # (tech_reports/matrix_engine/matrix_engine.md). A matmul loads the right hand
@@ -116,14 +295,14 @@ _K_PER_ACCUMULATION = 16
 
 
 def _format_relative_error(dtype):
-    """Contribution to ``r`` from one rounding of a value into ``dtype``.
+    """Contribution to r from one rounding of a value into dtype.
 
     For a normalised format this is the rounding error relative to the value.
     For a block float format the step is fixed across a block of 16 by the
     largest magnitude in it, which for normally distributed data is about two
     standard deviations, so the error is absolute rather than relative. An
-    absolute error of ``k`` standard deviations on an operand contributes ``k``
-    to ``r`` in exactly the same way a relative one does, which is why both
+    absolute error of k standard deviations on an operand contributes k
+    to r in exactly the same way a relative one does, which is why both
     return a single comparable number.
     """
     bits = _BLOCK_FLOAT_BITS.get(dtype)
@@ -140,15 +319,57 @@ def _source_mantissa_bits(dtype):
 
 
 def _truncation_relative_error(bits_kept, bits_available):
-    """Contribution to ``r`` from dropping mantissa bits below ``bits_kept``.
+    """Contribution to r from dropping mantissa bits, for one operand.
 
-    Keeping ``m`` bits leaves a dropped remainder spread over ``[0, 2**-m)``,
-    whose root-mean-square is ``2**-m / sqrt(3)``. That is an error on the
-    significand, which lies in ``[1, 2)``, so the *relative* error is smaller by
-    a further factor: ``E[1/v**2]`` over that interval is 1/2, giving
-    ``2**-m / sqrt(6)``. Simulating the truncation on normally distributed data
-    gives 0.0237, 0.0107 and 0.0041 for 4, 5 and 6 kept bits, against this
-    formula's 0.0255, 0.0128 and 0.0064, so it stays an upper bound.
+    The operand arrives with bits_available mantissa bits and the matrix engine
+    keeps only bits_kept of them. If it keeps at least as many as arrive, nothing
+    is dropped and the contribution is zero.
+
+    The mantissa bits encode a significand, a value at least 1 and below 2.
+    Dropping the bits below bits_kept removes less than the value of the lowest
+    kept bit, one unit in the last kept place, u = 2**-bits_kept. Taking the
+    amount removed as equally likely anywhere from zero to u, its average is u/2
+    and its standard deviation is u/sqrt(12), the standard deviation of a uniform
+    range of width u. Its root-mean-square is the square root of the sum of the
+    average squared and the standard deviation squared, u*sqrt(1/4 + 1/12), which
+    is u/sqrt(3). Truncation is biased, so the root-mean-square is the figure to
+    use, as the module docstring explains; the standard deviation alone would be
+    a factor of two lower.
+
+    What r needs is the loss relative to the operand's own value. The amount
+    removed and the value share the same power of two, so that factor cancels and
+    the relative loss is the amount removed divided by the significand alone.
+    Taking the amount removed as independent of the significand, the mean square
+    of the ratio is the mean square of the amount removed times the average of
+    one over the square of the significand. Taking the significand as equally
+    likely anywhere in its range, that average is exactly a half: the area under
+    1/s**2 from s = 1 to s = 2 is 1 - 1/2, and the range has width 1, so that
+    area is the average. The relative root-mean-square is therefore u/sqrt(3)
+    times sqrt(1/2), which is u/sqrt(6). The same division by the significand
+    turns the average u/2 into the mu of the module docstring.
+
+    Both uniform assumptions are approximations, so the formula is checked
+    against measurement. Truncating bfloat16 values drawn from torch.randn, the
+    distribution the tests use, which carry 7 mantissa bits, and measuring the
+    root-mean-square relative loss on one operand gives 0.0236, 0.0107 and 0.0041
+    for 4, 5 and 6 kept bits, that is 3, 2 and 1 dropped bits, against this
+    formula's 0.0255, 0.0128 and 0.0064. The formula is the larger number every
+    time, by 8, 20 and 57 percent. The overstatement grows as fewer bits are
+    dropped, because the amount removed then takes only a few discrete values
+    rather than a continuous spread: its root-mean-square is 0.523u with three
+    dropped bits and 0.354u with one, where the continuous figure of
+    u/sqrt(3) = 0.577u is 1.10 and 1.63 times those.
+
+    An understatement in how the caller combines the operands nearly cancels that
+    overstatement. A product loses from both operands, and matmul_relative_error
+    adds the two contributions as the square root of the sum of squares. Squaring
+    the sum of the two relative losses produces a term in the two biases together
+    that a sum of squares leaves out, so the correct figure for the pair is 1.16
+    times what the caller computes. For bfloat16 operands at LoFi, the engine's
+    lowest precision setting, which keeps 4 mantissa bits of one operand and 6 of
+    the other, the two effects very nearly cancel and the caller's figure lands
+    0.5 percent above the measured pair. This term therefore carries almost no
+    margin of its own and relies on the safety factor applied to the limits.
     """
     if bits_kept >= bits_available:
         return 0.0
@@ -156,13 +377,13 @@ def _truncation_relative_error(bits_kept, bits_available):
 
 
 def _accumulated_rounding_relative_error(step_error, steps):
-    """Contribution to ``r`` from rounding a running total ``steps`` times.
+    """Contribution to r from rounding a running total steps times.
 
     These roundings act on the partial sum rather than on individual products,
-    so they do not cancel against the ``sqrt(K)`` growth of the result. After
-    ``j`` of ``n`` steps the partial sum is ``sqrt(j / n)`` of the final size, and
+    so they do not cancel against the sqrt(K) growth of the result. After
+    j of n steps the partial sum is sqrt(j / n) of the final size, and
     the error introduced there survives to the end, so the variances sum to
-    ``step_error**2 * (n + 1) / 2`` times the square of the final size.
+    step_error**2 * (n + 1) / 2 times the square of the final size.
     """
     if steps < 1:
         return 0.0
@@ -186,7 +407,7 @@ def matmul_relative_error(
         K: the reduction length.
         in0_dtype, in1_dtype: device formats of the left and right operands.
         out_dtype: device format of the result. It reaches the accumulation, not
-            only the final value, because without ``packer_l1_acc`` the partial
+            only the final value, because without packer_l1_acc the partial
             sums are spilled to memory in this format.
         math_fidelity: how many passes the matrix unit makes over the inputs.
         fp32_dest_acc_en: whether the accumulator is 32 bit rather than 16 bit.
@@ -200,6 +421,15 @@ def matmul_relative_error(
 
     Returns:
         The relative error as a float.
+
+    The truncation sources carry a bias and not only noise, and that reaches the
+    limits built from this number unevenly. The elementwise absolute limit and
+    the whole-tensor relative error limit both need it counted, since it moves
+    every element toward zero. The minimum correlation does not: scaling every
+    element by close to the same factor barely changes the correlation with the
+    reference, so counting the bias asks for less correlation than would be
+    justified, which cannot cause a false failure but does let more real error
+    through.
     """
     srca_bits, srcb_bits = _FIDELITY_MANTISSA_BITS_KEPT[math_fidelity]
     terms = [
@@ -298,9 +528,9 @@ _ALWAYS_16_BIT_ACTIVATIONS = frozenset(
 
 
 def activation_evaluation_error(activation, dest_dtype):
-    """Error of evaluating ``activation`` on device, as (relative, absolute).
+    """Error of evaluating activation on device, as (relative, absolute).
 
-    ``dest_dtype`` is the format the activation runs in, which is the
+    dest_dtype is the format the activation runs in, which is the
     accumulator format rather than the output format: the activation is applied
     to the value still held in the accumulator, before it is packed out.
     """
@@ -336,9 +566,9 @@ def matmul_numeric_tolerances(
     reference_dtype=None,
     safety=2.0,
 ):
-    """Tolerances for ``assert_numeric_metrics`` on a matmul with a fused activation.
+    """Tolerances for assert_numeric_metrics on a matmul with a fused activation.
 
-    Splat the result into the assertion::
+    Splat the result into the assertion:
 
         assert_numeric_metrics(golden, actual, check_ulp=False, **tolerances)
 
@@ -347,30 +577,29 @@ def matmul_numeric_tolerances(
             there is one, before the activation. Its spread sets the scale of the
             predicted error, so it is needed even when the reference the test
             finally compares against is the activated one.
-        activation: the ``ttnn.UnaryWithParam`` (or ``None``) the device applied,
+        activation: the ttnn.UnaryWithParam (or None) the device applied,
             used to work out how accurately the device evaluates it.
         activation_fn: the same activation as a callable on a torch tensor, used
-            to carry the predicted error through it. ``None`` means no activation.
-        safety: multiplier on the predicted error, applied to ``atol``, ``rtol``
-            and ``frobenius_threshold``. Those scale linearly with the error, so
+            to carry the predicted error through it. None means no activation.
+        safety: multiplier on the predicted error, applied to atol, rtol
+            and frobenius_threshold. Those scale linearly with the error, so
             a factor of 2 stays a factor of 2. Since independent errors combine
             in quadrature it covers a missed term up to sqrt(3) times the
             largest one already counted, and for the elementwise limit it also
             covers the run-to-run spread of an extreme value.
 
-            It is **not** applied to ``pcc_threshold``, which takes the smaller
-            ``_PCC_MARGIN`` instead. The distance of a correlation from 1 goes
+            It is not applied to pcc_threshold, which takes the smaller
+            _PCC_MARGIN instead. The distance of a correlation from 1 goes
             as the square of the relative error, so this factor of 2 would
             become a factor of 4 there. For an activation that saturates, where
             the reference's variance collapses and the distance from 1 is large
             enough to see, that produces a limit several times looser than the
             hardware needs.
 
-    Other arguments are as for :func:`matmul_relative_error`.
+    Other arguments are as for matmul_relative_error.
 
     Returns:
-        A dict with ``atol``, ``rtol``, ``frobenius_threshold`` and
-        ``pcc_threshold``.
+        A dict with atol, rtol, frobenius_threshold and pcc_threshold.
     """
     pre_activation = pre_activation.float()
 
@@ -388,9 +617,9 @@ def matmul_numeric_tolerances(
 
     # The error on an output element is proportional to the spread of the whole
     # dot product, not to that element's own value, because it is the accumulated
-    # slip of K products. A bias is added after the matmul and carries none of
-    # that error; it is left in here because the tests that use one make it far
-    # smaller than the matmul result.
+    # rounding error of K products. A bias is added after the matmul and carries
+    # none of that error; it is left in here because the tests that use one make
+    # it far smaller than the matmul result.
     error_before_activation = relative_error * pre_activation.std().item()
 
     # Largest error a single element can plausibly receive before the activation.
@@ -458,7 +687,7 @@ def matmul_numeric_tolerances(
     # removed, so the divisor is the reference's standard deviation and not its
     # root-mean-square; for a saturating activation such as sigmoid those differ
     # by a lot, because most of the reference's size is in its mean.
-    # _PCC_MARGIN rather than ``safety``: see the note on ``safety`` above.
+    # _PCC_MARGIN rather than safety: see the note on safety above.
     if golden_std > 0.0:
         noise_ratio = _PCC_MARGIN * rms_error / golden_std
         tolerances["pcc_threshold"] = max(0.0, min(0.999999, 1.0 - noise_ratio * noise_ratio / 2.0))

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -39,8 +39,9 @@ grows as ``sqrt(K)``, never as ``K``.
 *A one-sided slip behaves like a random one.* Mantissa bits are dropped rather
 than rounded, so every slip has the same sign. It still does not build up,
 because it multiplies a mean-zero quantity. The figure that matters is therefore
-the root-mean-square of the slip including its mean, ``2**-m / sqrt(3)`` for a
-slip spread over ``[0, 2**-m)``, rather than its standard deviation.
+the root-mean-square of the slip including its mean, rather than its standard
+deviation about that mean. For a slip spread over ``[0, 2**-m)`` on a significand
+in ``[1, 2)`` that is ``2**-m / sqrt(6)``.
 """
 
 import math
@@ -49,6 +50,16 @@ import torch
 import ttnn
 
 _SQRT3 = math.sqrt(3.0)
+_SQRT6 = math.sqrt(6.0)
+
+# Margin on the correlation limit, as a multiplier on the relative error. Squared
+# by the conversion to a correlation, so it allows 1.5x on the distance from 1.
+# The whole-tensor and elementwise limits take the larger ``safety`` factor
+# instead; a correlation needs less because the quantity it is built from is a
+# root-mean-square over tens of thousands of elements, which barely varies from
+# run to run. Some margin is still needed: with the truncation term corrected the
+# budget tracks the measured error closely rather than sitting well above it.
+_PCC_MARGIN = math.sqrt(1.5)
 
 # Stored mantissa bits, excluding the leading one bit that normalised floating
 # point formats imply rather than store. The gap between neighbouring values is
@@ -67,17 +78,26 @@ _BLOCK_FLOAT_BITS = {
     ttnn.bfloat4_b: 2,
 }
 
-# Mantissa bits the matrix unit keeps from each operand, as (SrcA, SrcB).
-# The multiplier is 5 bits by 7 bits and each fidelity level makes another pass
-# over the inputs to consume more of them
+# Mantissa bits the matrix unit keeps from each operand, as (SrcA, SrcB), taken
+# from the union of the per-pass bit masks. The multiplier is 5 bits by 7 bits
+# and each fidelity level makes another pass to consume more of the inputs
 # (tech_reports/matrix_engine/matrix_engine.md). A matmul loads the right hand
 # operand into SrcA and the left hand operand into SrcB, the opposite of other
 # operations, so the right hand operand takes the narrower path.
+#
+# Over an 11 bit significand field with the hidden bit at position 10, the masks
+# cover SrcA 10..6 then 5..1, and SrcB 10..4 then 3..0. Accumulating those:
+#   LoFi   pass 0        SrcA 4 bits,  SrcB 6 bits
+#   HiFi2  passes 0,1    SrcA 9 bits,  SrcB 6 bits
+#   HiFi3  passes 0,1,2  SrcA 9 bits,  SrcB 10 bits
+#   HiFi4  all passes    same coverage as HiFi3, plus the low-by-low cross term
+# Nine and ten bits exceed what any input format here carries, so those operands
+# are consumed whole and contribute nothing.
 _FIDELITY_MANTISSA_BITS_KEPT = {
     ttnn.MathFidelity.LoFi: (4, 6),
-    ttnn.MathFidelity.HiFi2: (7, 6),
-    ttnn.MathFidelity.HiFi3: (4, 7),
-    ttnn.MathFidelity.HiFi4: (7, 7),
+    ttnn.MathFidelity.HiFi2: (9, 6),
+    ttnn.MathFidelity.HiFi3: (9, 10),
+    ttnn.MathFidelity.HiFi4: (9, 10),
 }
 
 # Passes over the inputs, which is also how many times each fidelity level
@@ -120,10 +140,19 @@ def _source_mantissa_bits(dtype):
 
 
 def _truncation_relative_error(bits_kept, bits_available):
-    """Contribution to ``r`` from dropping mantissa bits below ``bits_kept``."""
+    """Contribution to ``r`` from dropping mantissa bits below ``bits_kept``.
+
+    Keeping ``m`` bits leaves a dropped remainder spread over ``[0, 2**-m)``,
+    whose root-mean-square is ``2**-m / sqrt(3)``. That is an error on the
+    significand, which lies in ``[1, 2)``, so the *relative* error is smaller by
+    a further factor: ``E[1/v**2]`` over that interval is 1/2, giving
+    ``2**-m / sqrt(6)``. Simulating the truncation on normally distributed data
+    gives 0.0237, 0.0107 and 0.0041 for 4, 5 and 6 kept bits, against this
+    formula's 0.0255, 0.0128 and 0.0064, so it stays an upper bound.
+    """
     if bits_kept >= bits_available:
         return 0.0
-    return 2.0**-bits_kept / _SQRT3
+    return 2.0**-bits_kept / _SQRT6
 
 
 def _accumulated_rounding_relative_error(step_error, steps):
@@ -322,14 +351,20 @@ def matmul_numeric_tolerances(
             used to work out how accurately the device evaluates it.
         activation_fn: the same activation as a callable on a torch tensor, used
             to carry the predicted error through it. ``None`` means no activation.
-        safety: multiplier on the predicted error. For the whole-tensor checks
-            the prediction is a root-mean-square over tens of thousands of
-            elements, so it barely varies from run to run and the margin covers
-            the model missing a term. Since independent errors combine in
-            quadrature, a factor of 2 covers a missed term up to sqrt(3) times
-            the largest one already counted. The elementwise limit is different:
-            it rests on an extreme value, which does vary noticeably from run to
-            run, so there the margin covers both.
+        safety: multiplier on the predicted error, applied to ``atol``, ``rtol``
+            and ``frobenius_threshold``. Those scale linearly with the error, so
+            a factor of 2 stays a factor of 2. Since independent errors combine
+            in quadrature it covers a missed term up to sqrt(3) times the
+            largest one already counted, and for the elementwise limit it also
+            covers the run-to-run spread of an extreme value.
+
+            It is **not** applied to ``pcc_threshold``, which takes the smaller
+            ``_PCC_MARGIN`` instead. The distance of a correlation from 1 goes
+            as the square of the relative error, so this factor of 2 would
+            become a factor of 4 there. For an activation that saturates, where
+            the reference's variance collapses and the distance from 1 is large
+            enough to see, that produces a limit several times looser than the
+            hardware needs.
 
     Other arguments are as for :func:`matmul_relative_error`.
 
@@ -423,8 +458,9 @@ def matmul_numeric_tolerances(
     # removed, so the divisor is the reference's standard deviation and not its
     # root-mean-square; for a saturating activation such as sigmoid those differ
     # by a lot, because most of the reference's size is in its mean.
+    # _PCC_MARGIN rather than ``safety``: see the note on ``safety`` above.
     if golden_std > 0.0:
-        noise_ratio = safety * rms_error / golden_std
+        noise_ratio = _PCC_MARGIN * rms_error / golden_std
         tolerances["pcc_threshold"] = max(0.0, min(0.999999, 1.0 - noise_ratio * noise_ratio / 2.0))
     else:
         tolerances["pcc_threshold"] = 0.0

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -2,11 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""Numeric tolerances for matmul tests, predicted from the device number formats.
+"""Matmul test tolerances, derived from the mantissa bits lost at each step.
 
-A test compares a matrix multiply run on Tenstorrent hardware against the same
-matrix multiply run in PyTorch on the host. The two never agree bit for bit, so
-the test has to accept some difference. assert_numeric_metrics, the helper the
+Matmul tests compare a matrix multiply run on Tenstorrent hardware against the
+same matrix multiply run in PyTorch on the host. The two never agree bit for bit,
+so the test has to accept some difference. assert_numeric_metrics, the helper the
 tests call to make the comparison, takes four limits:
 
     atol, rtol (absolute and relative tolerance)
@@ -19,107 +19,109 @@ tests call to make the comparison, takes four limits:
     pcc_threshold        smallest Pearson correlation coefficient allowed between
                          the two tensors
 
-matmul_numeric_tolerances returns all four. Tests never call it at run time. You
-run it yourself while writing a test and paste the numbers in, so the limits stay
-plain constants where they are used, and so editing this module cannot quietly
-move what every test accepts.
+matmul_numeric_tolerances returns all four. You run it yourself while writing a
+test and paste the numbers into the test, so the limits stay plain constants where
+they are used, and so editing this module cannot quietly move what every test
+accepts. The predictions assume test inputs drawn from a normal distribution, so
+a mix of positive and negative numbers, which is what the tests generate.
 
-The matmul can also apply an activation function to its result on device. The
-test still compares against the reference with the activation applied (below, the
-activated reference), but what you hand this module is the product before the
-activation, because working out how the activation transforms an error needs the
-values going into it. You pass the activation itself twice: as the device side op
-(from ttnn, the Python interface to the device ops), which the module uses to
-look up how accurately the hardware evaluates that activation, and as the
-equivalent PyTorch function, which the module evaluates to find how much the
-activation stretches or compresses an error. Accuracy varies by activation: the
-device evaluates some as a fitted polynomial and others from a piecewise linear
-lookup table, which is much coarser.
+The matmul can also apply an activation function to its result on device (a fused
+activation). The test compares against the activated reference, the product with
+the activation applied, but what you hand this module is the pre-activation
+reference, the product before it. Working out how the activation transforms an
+error needs the values going into it, and the activated reference cannot supply
+them: an activation that saturates (i.e. it flattens out at both ends), is not
+invertible.
 
-The calculation runs in two stages.
+You pass the activation twice: as the device side op (from ttnn, the Python
+interface to the device ops), which fixes how accurately the hardware evaluates
+it, and as the equivalent PyTorch function, which the module evaluates to find
+how much the activation stretches or compresses an error. Nothing checks that the
+two agree, so pass the function that matches the op.
+
+How accurately the hardware evaluates an activation varies. relu, relu6 and
+hardtanh are exact, being comparison and selection only. The rest are fitted
+polynomials, held to two units in the last place. gelu, tanh and sigmoid also
+accept a flag that swaps the fit for a handful of straight line segments, which
+is far coarser; see _PIECEWISE_LINEAR_ABSOLUTE_ERROR for how loose those cases
+end up, and why gelu's figure is the one number in this module that is measured
+rather than derived.
 
 Stage one: a single relative error. matmul_relative_error predicts one relative
-error r from the configuration only, never from the data. r is defined so that
-across the whole output tensor the predicted error has a standard deviation of r
-times the standard deviation of the reference. It reads these inputs:
+error "r" from the configuration only, never from the data. "r" is defined so that
+across the whole output tensor the predicted error has a standard deviation of "r"
+times the standard deviation of the pre-activation reference. It reads these
+inputs:
 
   - how many mantissa bits each number format keeps, from the inputs through to
-    the partial sums. The final rounding into the output format is not part of r;
+    the partial sums. The final rounding into the output format is not part of "r";
     stage two adds it, because it scales with the element's own value
   - K, the reduction length, which is the shared dimension of the two operands
-  - math_fidelity, which selects how many passes the multiply hardware makes and
-    so how much of each input's mantissa it uses
+  - math_fidelity, which selects how many passes the matrix engine makes and so
+    how much of each input's mantissa it uses
   - k_tiles_per_block, how many 32 element slices of K are summed before the
     partial sum is written out and rounded. The hardware works in 32 by 32 tiles,
     and fewer slices per write means more roundings along K
   - fp32_dest_acc_en, whether partial sums are held in 32 bit rather than 16 bit,
-    and packer_l1_acc, whether a new partial sum is added straight into the
-    output buffer as it is written, instead of the value there being read back,
-    so that one rounding to the output format is skipped
+    and packer_l1_acc, whether the packer adds each new partial sum into the buffer
+    as it writes. The alternative reads the stored value back and adds it in the
+    accumulator, which costs one extra rounding to the output format
 
-Every rounding step in that chain contributes one relative error term. K and
-k_tiles_per_block set how many times each step happens; math_fidelity and the two
-accumulation settings set how large each term is. The terms are combined as the
-square root of the sum of their squares, the usual rule for independent errors.
+Every rounding step in that chain contributes one relative error term. K,
+k_tiles_per_block, and math_fidelity set how many times each step happens;
+math_fidelity and the two accumulation settings set how large each term is. The
+terms are combined as the square root of the sum of their squares, the usual rule
+for independent errors.
 
-Stage two: the four limits. Turning r into them needs the reference tensor as
-well, because r is only a ratio: atol is an absolute number, and the activation
-corrections depend on the reference values.
+Stage two: the four limits, each built from "r" and the reference tensor, which is
+needed whether or not an activation applies.
 
-- atol. Each output element is a sum of K products. The model takes the error of
-  that sum to be about the same size for every element, because it comes from
-  rounding partial sums, whose typical magnitude is the same across the output,
-  not from the size of the element it lands in. Stage one already fixed that
-  size, r times the standard deviation of the reference, and taking it to be the
-  same everywhere is what lets one number serve as atol for the whole tensor.
-  That error is itself a sum of many independent roundings, so it is close to
-  Gaussian. Write n for the number of output elements. An error can fall either
-  way, so the largest absolute error among n elements is about as extreme as the
-  largest of 2n one sided samples, which for a Gaussian sits about
-  sqrt(2 * ln(2n)) standard deviations from zero. The module then shifts each
-  reference value by that distance, up and down, applies the activation to all
-  three values, and keeps the largest change in the activation's output over
-  every element and both directions. It does not multiply the distance by the
-  activation's slope: at worst case distance the activation is nowhere near
-  straight. This is why an activation that flattens out at both ends, such as
-  sigmoid, is never assigned more error than its whole output range. The device's
-  own absolute error in evaluating the activation is then added.
+- atol. An element's error comes from rounding partial sums, whose size does not
+  depend on the dot product they land in, so it is about the same for every
+  element: "r" times the standard deviation of the pre-activation reference. One
+  number therefore serves the whole tensor. It is a sum of many roundings, so it
+  is close to Gaussian. An error can come out too high or too low, and the
+  largest of n such errors, in either direction, sits about sqrt(2 * ln(2n))
+  standard deviations from zero, for n the number of output elements. The module
+  then shifts every reference value by that distance, up and down, applies the
+  activation to all three values, and keeps the largest change in the
+  activation's output. It does not scale the distance by the activation's
+  slope, because at worst case distance the activation is nowhere near straight;
+  this is why a saturating activation is never assigned more error than its whole
+  output range. The device's own absolute error on the activation is then added.
 
 - rtol takes the two contributions that do scale with an element's own value: the
-  activation's relative error and the rounding into the output format. r does not
+  activation's relative error and the rounding into the output format. "r" does not
   enter it. The two are added rather than combined in quadrature, so that rtol
-  stays a bound for every element rather than a typical value. For an activation
-  the device evaluates as a polynomial the activation's own error dominates, 87
-  percent of the total in the example below.
+  stays a bound for every element rather than a typical value.
 
 - frobenius_threshold combines three terms as the square root of the sum of their
-  squares: r times the standard deviation of the reference, since that is how r
-  is defined, multiplied by the root-mean-square of the activation's slope taken
-  over the reference values; the sum of the output format rounding and the
-  activation's relative error, multiplied by the root-mean-square of the
+  squares: "r" times the standard deviation of the pre-activation reference, scaled
+  by the root-mean-square of the activation's slope; the output format rounding
+  plus the activation's relative error, times the root-mean-square of the
   activated reference; and the device's absolute error on the activation. The
-  result is divided by the root-mean-square of the activated reference. A slope
-  is enough here, where atol needed an evaluation, because this term describes a
-  typical error, far smaller than the worst case atol has to cover, and the
-  activation is nearly linear over an interval that small.
+  result is divided by that same root-mean-square. A slope serves here, where
+  atol needed an evaluation, because this term describes a typical error, and a
+  slope averaged over an interval that size is the right thing for it.
 
-- pcc_threshold reuses that combined error, before it is divided. Write q for the
-  combined error divided by the standard deviation of the activated reference,
-  the standard deviation and not the root-mean-square because a correlation
-  removes the mean of each tensor first. An error independent of the reference
-  values adds to the device tensor's variance without adding to the covariance,
-  which scales the correlation by 1 / sqrt(1 + q * q). matmul_numeric_tolerances
-  returns the small q approximation of that, 1 - q * q / 2.
+- pcc_threshold reuses that combined error, before it is divided. Write q, the
+  code's noise_ratio, for that error divided by the standard deviation of the
+  activated reference, not its root-mean-square, because a correlation removes
+  the mean of each tensor first. An error independent of the reference values adds
+  to the device tensor's variance without adding to the covariance, which scales
+  the correlation by 1 / sqrt(1 + q * q). matmul_numeric_tolerances returns the
+  small q approximation of that, 1 - q * q / 2. One caveat: a uniform scaling
+  leaves a correlation unchanged, so counting the truncation bias here asks for
+  less correlation than is justified. That is safe against a false failure, but it
+  lets more real error through.
 
 atol, rtol and frobenius_threshold are multiplied by the safety argument, 2.0 by
-default. pcc_threshold does not use it: q is always multiplied by sqrt(1.5), a
-fixed module constant. Because a correlation's distance from 1 goes as the square
-of the error, that is a margin of 1.5 on the distance from 1.
+default. pcc_threshold uses _PCC_MARGIN instead; see that constant for why.
 
 To get limits for a new entry in a test's pytest.mark.parametrize list, build the
-reference tensor the test will compare against and call matmul_numeric_tolerances
-with it. Run this from a Python session whose working directory is the repository
-root, so that the import resolves:
+pre-activation product the test's reference is built from and call
+matmul_numeric_tolerances with it. Run this from a Python session whose working
+directory is the repository root, so that the import resolves:
 
     import torch
     import ttnn
@@ -157,27 +159,17 @@ which prints
      'frobenius_threshold': 0.06724930087282528,
      'pcc_threshold': 0.9987590077261392}
 
-The two per element limits can be followed by hand. For atol, r is 0.0284 for
-this configuration and the reference has a standard deviation of 22.6, so one
-element's error has a standard deviation of 0.64. The output has M * N =
-128 * 512 = 65536 elements, so 2n is 131072 and sqrt(2 * ln(131072)) is 4.855,
-giving a worst element error of 4.855 * 0.64 = 3.11. Shifting the reference by
-that distance and reapplying GELU raises it to 3.28: the largest change is at a
-reference value of 0.75, where GELU gives 0.58, while at 3.86, which is 3.11
-higher, GELU is close enough to the identity to give 3.87, a change of 3.28. The
-module records no absolute error for GELU, because the device fits it with a
-polynomial and that inaccuracy is carried as the relative error in rtol instead.
-The safety argument of 2.0 gives the printed 6.57.
-
-For rtol, a unit in the last place is the gap between neighbouring representable
-values, which for a 7 bit mantissa is 2**-7 of the value. The module's table
-gives GELU a relative error of two of those in whatever format the accumulator
-holds, which is bfloat16 here because fp32_dest_acc_en is False, so 2 * 2**-7 =
-0.0156. Rounding into a bfloat16 output moves a value by at most half a unit in
-the last place, 2**-8; taking that error as uniform over the rounding interval
-gives a root-mean-square relative error of 2**-8 / sqrt(3) = 0.0023. Twice their
-sum is the printed 0.0358. The two tensor wide limits use the same pieces through
-the formulas above and are not traced here.
+Both per element limits can be checked by hand. For atol, "r" is 0.0284 here and
+the pre-activation reference has a standard deviation of 22.6, so one element's
+error has a standard deviation of 0.64. There are M * N = 65536 elements, and
+sqrt(2 * ln(131072)) is 4.855, so the worst element error is 3.11. Reapplying
+GELU either side of that shift raises it to 3.28, and the safety argument of 2.0
+gives the printed 6.57. GELU contributes no absolute error, because the device
+fits it with a polynomial and that inaccuracy counts as a relative error in rtol
+instead. For rtol, the table gives GELU a relative error of 2 * 2**-7 = 0.0156 in
+the accumulator format, bfloat16 here because fp32_dest_acc_en is False, and the
+output rounding adds 2**-8 / sqrt(3) = 0.0023 (see _format_relative_error). Twice
+their sum is the printed 0.0358.
 
 One parametrize entry usually covers several shapes, data types and settings. Run
 the calculation for each and keep the largest atol, rtol and
@@ -186,41 +178,32 @@ pcc_threshold down.
 
 Notes:
 
-- The relative error of a matmul does not grow with K. Each product carries a
-relative rounding error from the narrowed mantissas. Because inputs to the tests
-include both positive and negative random values (from torch.randn), those errors
-multiply values of random sign, so the total error grows as sqrt(K), and so
-does the result itself. As far as relative error is concerned, they cancel out.
-The terms that do grow are the two that round a running total: the accumulator
-itself, once per 16 elements of K per fidelity pass, and the partial sum spilled
-between K blocks. Both grow as sqrt(K). Both scale with the accumulator
-format, so with fp32_dest_acc_en they fall below every other term and
-K stops mattering at all; they are only significant with a 16 bit accumulator.
+- The relative error does not grow with K. Each product carries a relative
+rounding error from the narrowed mantissas, and the test inputs are a mix of
+positive and negative numbers, so those errors multiply values that are as often
+negative as positive and partly cancel. The total error grows as sqrt(K), the
+result grows as sqrt(K), and the ratio is flat. The two terms that do grow
+are the ones that round a running total: the accumulator (see
+_K_PER_ACCUMULATION) and the partial sum spilled between K blocks. Both grow as
+sqrt(K), never as K. With fp32_dest_acc_en both are held in 32 bit, so they fall
+below every other term and K stops mattering; they matter only with a 16 bit
+accumulator.
 
-- Truncation is biased: it always errs in the same direction. The matrix engine
+- Truncation is biased, and it still does not grow with K. The matrix engine
 drops the low mantissa bits of each operand instead of rounding to nearest, which
 moves that operand toward zero, so no product comes out larger in magnitude than
-the true result. Consider the product of a and b as a*b*(1-d), where d is the
-fraction of the true product lost from the two truncated operands together.
-d is always positive because the result is always truncated toward zero.
-One might expect a loss that never changes sign to add up over the K products,
-making the total grow linearly with K.
-It does not, because only d has a fixed sign. The products a*b can be either
-positive or negative, so the errors -d*a*b can be either positive or negative
-and cancel in the sum just as the products themselves do. Therefore, relative
-error does not grow with K.
+the true one. Write the product of a and b as a*b*(1-d), where d is the fraction
+lost from the two truncated operands together; d is never negative. Only d has a
+fixed sign, though. Each product a*b is positive or negative depending on its
+operands, so the errors -d*a*b are too, and they partly cancel in the sum just as
+the products themselves do.
 
-The bias does change how the truncation term enters r. A source whose error
-averages to zero contributes the standard deviation of its error divided by the
-standard deviation of the result. Truncation does not average to zero. Split
-the error one product contributes into a bias part, -mu*a*b where mu is the
-average of d, and a noise part, -(d-mu)*a*b: the bias part sums to exactly the
-true result shrunk by mu, and only the noise part averages to zero. The
-root-mean-square of d is the square root of the sum of mu squared and the
-variance, so using it in place of a standard deviation carries the bias into
-the same sum of squares as every other source. That is not exact for a fixed
-offset, it is a simple upper bound, and _truncation_relative_error, which
-computes this root-mean-square for one operand, measures the margin it leaves.
+The bias does decide how truncation enters r. An error that averages to zero
+contributes its standard deviation divided by the result's. Truncation does not
+average to zero, so _truncation_relative_error uses a root-mean-square instead,
+which covers the average of d and the spread around it together. That is an upper
+bound rather than an exact treatment of a fixed offset, and that function records
+how much margin it leaves.
 """
 
 import math
@@ -231,18 +214,17 @@ import ttnn
 _SQRT3 = math.sqrt(3.0)
 _SQRT6 = math.sqrt(6.0)
 
-# Margin on the correlation limit, as a multiplier on the relative error. Squared
-# by the conversion to a correlation, so it allows 1.5x on the distance from 1.
-# The whole-tensor and elementwise limits take the larger safety factor
-# instead; a correlation needs less because the quantity it is built from is a
-# root-mean-square over tens of thousands of elements, which barely varies from
-# run to run. Some margin is still needed: with the truncation term corrected the
-# budget tracks the measured error closely rather than sitting well above it.
+# Margin on the correlation limit, as a multiplier on the relative error, which
+# the conversion to a correlation squares into 1.5x on the distance from 1. It is
+# less than the safety factor the other three limits take, because the
+# root-mean-square it is built from averages tens of thousands of elements and so
+# barely moves from run to run. Some margin is still needed: the prediction
+# tracks the measured error closely rather than sitting well above it.
 _PCC_MARGIN = math.sqrt(1.5)
 
 # Stored mantissa bits, excluding the leading one bit that normalised floating
-# point formats imply rather than store. The gap between neighbouring values is
-# 2**-bits relative to that leading bit.
+# point formats imply rather than store. The gap between neighbouring values, one
+# unit in the last place, is 2**-bits times the place value of that leading bit.
 _MANTISSA_BITS = {
     ttnn.float32: 23,
     ttnn.bfloat16: 7,
@@ -257,9 +239,10 @@ _BLOCK_FLOAT_BITS = {
     ttnn.bfloat4_b: 2,
 }
 
-# Mantissa bits the matrix engine keeps from each operand, as (SrcA, SrcB), taken
-# from the union of the per-pass bit masks. The multiplier is 5 bits by 7 bits
-# and each fidelity level makes another pass to consume more of the inputs
+# Mantissa bits the matrix engine keeps from each operand, as (SrcA, SrcB), its
+# two operand registers, taken from the union of the per-pass bit masks. The
+# multiplier is 5 bits by 7 bits, and each fidelity level makes another pass to
+# consume more of the inputs
 # (tech_reports/matrix_engine/matrix_engine.md). A matmul loads the right hand
 # operand into SrcA and the left hand operand into SrcB, the opposite of other
 # operations, so the right hand operand takes the narrower path.
@@ -269,9 +252,9 @@ _BLOCK_FLOAT_BITS = {
 #   LoFi   pass 0        SrcA 4 bits,  SrcB 6 bits
 #   HiFi2  passes 0,1    SrcA 9 bits,  SrcB 6 bits
 #   HiFi3  passes 0,1,2  SrcA 9 bits,  SrcB 10 bits
-#   HiFi4  all passes    same coverage as HiFi3, plus the low-by-low cross term
-# Nine and ten bits exceed what any input format here carries, so those operands
-# are consumed whole and contribute nothing.
+#   HiFi4  all passes    same coverage as HiFi3
+# Nine and ten bits exceed what bfloat16 and the block float formats carry, so
+# those operands are consumed whole and contribute nothing.
 _FIDELITY_MANTISSA_BITS_KEPT = {
     ttnn.MathFidelity.LoFi: (4, 6),
     ttnn.MathFidelity.HiFi2: (9, 6),
@@ -295,15 +278,15 @@ _K_PER_ACCUMULATION = 16
 
 
 def _format_relative_error(dtype):
-    """Contribution to r from one rounding of a value into dtype.
+    """Contribution to "r" from one rounding of a value into dtype.
 
     For a normalised format this is the rounding error relative to the value.
     For a block float format the step is fixed across a block of 16 by the
     largest magnitude in it, which for normally distributed data is about two
-    standard deviations, so the error is absolute rather than relative. An
-    absolute error of k standard deviations on an operand contributes k
-    to r in exactly the same way a relative one does, which is why both
-    return a single comparable number.
+    standard deviations, so the error is absolute rather than relative. An error
+    of k standard deviations on an operand enters the sum of squares as the same
+    size of term a relative error of k would, which is why both cases return one
+    comparable number.
     """
     bits = _BLOCK_FLOAT_BITS.get(dtype)
     if bits is not None:
@@ -319,7 +302,7 @@ def _source_mantissa_bits(dtype):
 
 
 def _truncation_relative_error(bits_kept, bits_available):
-    """Contribution to r from dropping mantissa bits, for one operand.
+    """Contribution to "r" from dropping mantissa bits, for one operand.
 
     The operand arrives with bits_available mantissa bits and the matrix engine
     keeps only bits_kept of them. If it keeps at least as many as arrive, nothing
@@ -329,47 +312,37 @@ def _truncation_relative_error(bits_kept, bits_available):
     Dropping the bits below bits_kept removes less than the value of the lowest
     kept bit, one unit in the last kept place, u = 2**-bits_kept. Taking the
     amount removed as equally likely anywhere from zero to u, its average is u/2
-    and its standard deviation is u/sqrt(12), the standard deviation of a uniform
-    range of width u. Its root-mean-square is the square root of the sum of the
-    average squared and the standard deviation squared, u*sqrt(1/4 + 1/12), which
-    is u/sqrt(3). Truncation is biased, so the root-mean-square is the figure to
-    use, as the module docstring explains; the standard deviation alone would be
-    a factor of two lower.
+    and its standard deviation is u/sqrt(12), so its root-mean-square is
+    u*sqrt(1/4 + 1/12) = u/sqrt(3). The root-mean-square is the figure to use
+    rather than the standard deviation, which would be half as large, because
+    truncation is biased; see the module docstring.
 
-    What r needs is the loss relative to the operand's own value. The amount
+    What "r" needs is the loss relative to the operand's own value. The amount
     removed and the value share the same power of two, so that factor cancels and
     the relative loss is the amount removed divided by the significand alone.
-    Taking the amount removed as independent of the significand, the mean square
-    of the ratio is the mean square of the amount removed times the average of
-    one over the square of the significand. Taking the significand as equally
-    likely anywhere in its range, that average is exactly a half: the area under
-    1/s**2 from s = 1 to s = 2 is 1 - 1/2, and the range has width 1, so that
-    area is the average. The relative root-mean-square is therefore u/sqrt(3)
-    times sqrt(1/2), which is u/sqrt(6). The same division by the significand
-    turns the average u/2 into the mu of the module docstring.
+    Taking the two as independent, the mean square of the ratio is the mean square
+    of the amount removed times the average of one over the square of the
+    significand, and taking the significand as equally likely anywhere in its
+    range that average is exactly a half: the area under 1/s**2 from 1 to 2 is
+    1 - 1/2, over a range of width 1. So the answer is u/sqrt(3) times sqrt(1/2),
+    which is u/sqrt(6). That same division turns the average u/2 into mu.
 
-    Both uniform assumptions are approximations, so the formula is checked
-    against measurement. Truncating bfloat16 values drawn from torch.randn, the
-    distribution the tests use, which carry 7 mantissa bits, and measuring the
-    root-mean-square relative loss on one operand gives 0.0236, 0.0107 and 0.0041
-    for 4, 5 and 6 kept bits, that is 3, 2 and 1 dropped bits, against this
-    formula's 0.0255, 0.0128 and 0.0064. The formula is the larger number every
+    Both uniform assumptions are approximations, so the formula is checked against
+    measurement. Truncating bfloat16 values from torch.randn, which carry 7
+    mantissa bits, and measuring the root-mean-square relative loss on one operand
+    gives 0.0236, 0.0107 and 0.0041 for 4, 5 and 6 kept bits, that is 3, 2 and 1
+    dropped bits, against this formula's 0.0255, 0.0128 and 0.0064: larger every
     time, by 8, 20 and 57 percent. The overstatement grows as fewer bits are
     dropped, because the amount removed then takes only a few discrete values
-    rather than a continuous spread: its root-mean-square is 0.523u with three
-    dropped bits and 0.354u with one, where the continuous figure of
-    u/sqrt(3) = 0.577u is 1.10 and 1.63 times those.
+    instead of the continuous spread assumed above.
 
-    An understatement in how the caller combines the operands nearly cancels that
-    overstatement. A product loses from both operands, and matmul_relative_error
-    adds the two contributions as the square root of the sum of squares. Squaring
-    the sum of the two relative losses produces a term in the two biases together
-    that a sum of squares leaves out, so the correct figure for the pair is 1.16
-    times what the caller computes. For bfloat16 operands at LoFi, the engine's
-    lowest precision setting, which keeps 4 mantissa bits of one operand and 6 of
-    the other, the two effects very nearly cancel and the caller's figure lands
-    0.5 percent above the measured pair. This term therefore carries almost no
-    margin of its own and relies on the safety factor applied to the limits.
+    An understatement in how the caller combines the operands nearly cancels that.
+    A product loses from both operands, and matmul_relative_error adds the two
+    contributions as the square root of the sum of squares, which drops the cross
+    term between the two biases; for bfloat16 operands at LoFi that cross term is
+    worth 16 percent. The two effects very nearly cancel there, leaving the caller
+    0.5 percent above the measured pair, so this term carries almost no margin of
+    its own and relies on the safety factor.
     """
     if bits_kept >= bits_available:
         return 0.0
@@ -377,7 +350,7 @@ def _truncation_relative_error(bits_kept, bits_available):
 
 
 def _accumulated_rounding_relative_error(step_error, steps):
-    """Contribution to r from rounding a running total steps times.
+    """Contribution to "r" from rounding a running total steps times.
 
     These roundings act on the partial sum rather than on individual products,
     so they do not cancel against the sqrt(K) growth of the result. After
@@ -409,27 +382,18 @@ def matmul_relative_error(
         out_dtype: device format of the result. It reaches the accumulation, not
             only the final value, because without packer_l1_acc the partial
             sums are spilled to memory in this format.
-        math_fidelity: how many passes the matrix unit makes over the inputs.
+        math_fidelity: how many passes the matrix engine makes over the inputs.
         fp32_dest_acc_en: whether the accumulator is 32 bit rather than 16 bit.
         packer_l1_acc: whether partial sums are accumulated in place in memory
             instead of being written out and read back once per K block.
-        k_tiles_per_block: K tiles per block, which sets how many blocks the
-            reduction is split into. The default of 1 gives the most blocks and
-            so the most partial sum roundings.
+        k_tiles_per_block: how many 32 element slices of K are summed before the
+            partial sum is written out. The default of 1 gives the most blocks
+            and so the most partial sum roundings.
         reference_dtype: format the host reference was rounded to, if it was not
             computed in float32.
 
     Returns:
         The relative error as a float.
-
-    The truncation sources carry a bias and not only noise, and that reaches the
-    limits built from this number unevenly. The elementwise absolute limit and
-    the whole-tensor relative error limit both need it counted, since it moves
-    every element toward zero. The minimum correlation does not: scaling every
-    element by close to the same factor barely changes the correlation with the
-    reference, so counting the bias asks for less correlation than would be
-    justified, which cannot cause a false failure but does let more real error
-    through.
     """
     srca_bits, srcb_bits = _FIDELITY_MANTISSA_BITS_KEPT[math_fidelity]
     terms = [
@@ -466,8 +430,8 @@ def _op_type(activation):
 
 
 # Activations the fused matmul path evaluates with comparison and selection only,
-# so they carry no error beyond the rounding of the value they produce. relu is
-# not even a vector unit operation there: it is a packer setting.
+# so they carry no error beyond the rounding of the value they produce. relu
+# needs no evaluation at all: the packer applies it while writing the value out.
 _EXACT_ACTIVATIONS = frozenset(
     {
         ttnn.UnaryOpType.RELU,
@@ -478,47 +442,55 @@ _EXACT_ACTIVATIONS = frozenset(
 
 # Every other activation the matmul can fuse is a fitted polynomial or an
 # exponential. The implementations record maximum errors between 0.28 and 1 unit
-# in the last place of the format they run in; two units is the group bound.
+# in the last place of the format they run in, so 2 is used for all of them,
+# double the worst recorded.
 _FITTED_ACTIVATION_ULPS = 2.0
 
-# gelu, tanh and sigmoid each accept a flag that replaces the fit with a handful
-# of straight line segments. The bound is the peak distance from those segments
-# to the true function, so it is absolute and does not shrink with the output.
+# gelu, tanh and sigmoid each accept a flag that replaces the fitted polynomial
+# with a handful of straight line segments. The error is then the peak distance
+# from those segments to the true function, which is absolute: unlike a rounding
+# error it does not shrink as the output does.
 #
-# tanh's three segments are written out in the kernel that loads them: 0.90625*x,
-# then 0.09375*x + 0.8125, then 1. They join at x = 1 and x = 2, and their
-# greatest distance from tanh is at x = 1, where 0.90625 - tanh(1) = 0.145.
+# tanh's segments are written out in the kernel that loads them, 0.90625*x, then
+# 0.09375*x + 0.8125, then 1, joining at x = 1 and x = 2. Their greatest distance
+# from tanh is at the first join, where 0.90625 - tanh(1) = 0.145.
 #
-# The gelu and sigmoid tables are loaded as packed constants with no arithmetic
-# form recorded beside them, so their bounds are not derived here. 0.13 is the
-# figure the vector unit's own sweep tests record for both
-# (tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py), noting that
-# the absolute error of a coarse table peaks near the segment joins. This is the
-# one quantity in this module taken from an observation rather than from a
-# format width or a written algorithm.
+# gelu's and sigmoid's tables are packed constants with no arithmetic form beside
+# them, so 0.13 is not obtained that way. It is what the vector unit's own sweep
+# tests record for both, in
+# tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py. That makes it the
+# only figure in this module measured from the implementation instead of worked
+# out from a format width or a written algorithm, so a device error the sweep
+# tests also miss would pass here too.
+#
+# These three numbers are large enough to matter. The safety factor doubles 0.13
+# to 0.26, and sigmoid's output range is only 1.0, so a case with the flag set
+# accepts a result wrong by a quarter of everything sigmoid can produce. Such a
+# case checks that the op runs and is roughly right, not that it computes the
+# function accurately.
 _PIECEWISE_LINEAR_ABSOLUTE_ERROR = {
     ttnn.UnaryOpType.GELU: 0.13,
     ttnn.UnaryOpType.TANH: 0.15,
     ttnn.UnaryOpType.SIGMOID: 0.13,
 }
 
-# Index of the parameter that selects the piecewise linear table. For sigmoid the
-# first parameter is the vector mode and the flag is the second one.
+# Index of the parameter that selects the piecewise linear table. For sigmoid it
+# is the second parameter rather than the first.
 _PIECEWISE_LINEAR_FLAG_INDEX = {
     ttnn.UnaryOpType.GELU: 0,
     ttnn.UnaryOpType.TANH: 0,
     ttnn.UnaryOpType.SIGMOID: 1,
 }
 
-# The root-mean-square error of a piecewise linear fit is well below its peak,
-# because the segments meet the curve at their ends. Half the peak is used for
-# the whole-tensor checks, while the peak itself is used elementwise.
+# The root-mean-square error of a piecewise linear fit is below its peak, because
+# the segments meet the curve at their ends. Half the peak is a rough stand-in
+# for the whole-tensor checks; the peak itself is used elementwise.
 _PIECEWISE_LINEAR_RMS_FRACTION = 0.5
 
 # Most activations pick a higher accuracy inner algorithm when the accumulator is
-# 32 bit. These two do not: they select it from a compile time macro that only the
-# eltwise unary path defines, so fused into a matmul they always take their 16 bit
-# polynomial branch however the accumulator is configured.
+# 32 bit. These two do not: they select it from a compile time setting that only
+# the standalone activation op defines, so fused into a matmul they always take
+# their 16 bit polynomial branch however the accumulator is configured.
 _ALWAYS_16_BIT_ACTIVATIONS = frozenset(
     {
         ttnn.UnaryOpType.SELU,
@@ -568,7 +540,8 @@ def matmul_numeric_tolerances(
 ):
     """Tolerances for assert_numeric_metrics on a matmul with a fused activation.
 
-    Splat the result into the assertion:
+    Pass the result straight into the assertion, with the unit in the last place
+    check off because this module predicts no bound for it:
 
         assert_numeric_metrics(golden, actual, check_ulp=False, **tolerances)
 
@@ -581,20 +554,10 @@ def matmul_numeric_tolerances(
             used to work out how accurately the device evaluates it.
         activation_fn: the same activation as a callable on a torch tensor, used
             to carry the predicted error through it. None means no activation.
-        safety: multiplier on the predicted error, applied to atol, rtol
-            and frobenius_threshold. Those scale linearly with the error, so
-            a factor of 2 stays a factor of 2. Since independent errors combine
-            in quadrature it covers a missed term up to sqrt(3) times the
-            largest one already counted, and for the elementwise limit it also
-            covers the run-to-run spread of an extreme value.
-
-            It is not applied to pcc_threshold, which takes the smaller
-            _PCC_MARGIN instead. The distance of a correlation from 1 goes
-            as the square of the relative error, so this factor of 2 would
-            become a factor of 4 there. For an activation that saturates, where
-            the reference's variance collapses and the distance from 1 is large
-            enough to see, that produces a limit several times looser than the
-            hardware needs.
+        safety: multiplier on the predicted error, applied to atol, rtol and
+            frobenius_threshold, which all scale linearly with it. It is not
+            applied to pcc_threshold, which takes _PCC_MARGIN instead; see that
+            constant.
 
     Other arguments are as for matmul_relative_error.
 
@@ -615,19 +578,12 @@ def matmul_numeric_tolerances(
         reference_dtype=reference_dtype,
     )
 
-    # The error on an output element is proportional to the spread of the whole
-    # dot product, not to that element's own value, because it is the accumulated
-    # rounding error of K products. A bias is added after the matmul and carries
-    # none of that error; it is left in here because the tests that use one make
-    # it far smaller than the matmul result.
+    # An element's error is set by the spread of the whole dot product, not by
+    # the element's own value. A bias carries none of that error; it is left in
+    # because the tests that use one keep it far smaller than the matmul result.
     error_before_activation = relative_error * pre_activation.std().item()
 
-    # Largest error a single element can plausibly receive before the activation.
-    # The errors are a sum of many independent contributions and so are close to
-    # normally distributed. The elementwise check bounds the magnitude of the
-    # error, so the statistic wanted is the largest of n absolute values, which
-    # sits at about sqrt(2 * ln(2n)) standard deviations rather than
-    # sqrt(2 * ln(n)).
+    # Largest error one element can plausibly receive, before the activation.
     extreme_value_factor = math.sqrt(2.0 * math.log(2 * max(pre_activation.numel(), 2)))
     extreme_error_before_activation = extreme_value_factor * error_before_activation
 
@@ -637,16 +593,15 @@ def matmul_numeric_tolerances(
         max_propagated_error = extreme_error_before_activation
     else:
         golden = activation_fn(pre_activation).float()
-        # A symmetric difference taken at the scale of the error, rather than at
-        # a vanishing scale, gives the average slope over the interval the error
-        # can move the value. A corner such as relu's kink or hardtanh's clamp
-        # then contributes a partial slope instead of an undefined one.
+        # A symmetric difference at the scale of the error, rather than at a
+        # vanishing scale, averages the slope over the interval the error can
+        # move the value, so relu's kink gives a partial slope not an undefined
+        # one.
         step = error_before_activation if error_before_activation > 0.0 else 1e-6
         slope = ((activation_fn(pre_activation + step) - activation_fn(pre_activation - step)) / (2.0 * step)).float()
         slope_rms = slope.pow(2).mean().sqrt().item()
-        # For the elementwise bound the activation is evaluated at the extreme of
-        # the error rather than multiplied by a slope, so that a bounded
-        # activation cannot be credited with more error than its range allows.
+        # Evaluated at the extreme rather than scaled by a slope, so a
+        # saturating activation cannot be assigned more error than its range.
         shift = extreme_error_before_activation if extreme_error_before_activation > 0.0 else 1e-6
         moved_up = (activation_fn(pre_activation + shift).float() - golden).abs()
         moved_down = (activation_fn(pre_activation - shift).float() - golden).abs()
@@ -666,28 +621,25 @@ def matmul_numeric_tolerances(
         + (_PIECEWISE_LINEAR_RMS_FRACTION * activation_absolute) ** 2
     )
 
-    # Largest error over all elements. Every element is credited with the extreme
-    # error rather than only the unluckiest one, so this is an upper bound rather
-    # than an estimate. The activation's own error is already a bound, so it is
-    # added rather than scaled.
+    # Every element is credited with the extreme error rather than only the
+    # unluckiest one, so this is an upper bound. The activation's own error is
+    # already a bound, so it is added rather than combined in quadrature.
     max_error = max_propagated_error + activation_absolute
 
-    # rtol carries only what genuinely scales with an element's own value: the
-    # rounding into the output format and the activation's relative error. atol
-    # carries the accumulated error, which does not.
+    # rtol carries only what scales with an element's own value; atol carries the
+    # accumulated error, which does not.
     tolerances = {
         "atol": safety * max_error,
         "rtol": safety * (output_relative + activation_relative),
         "frobenius_threshold": safety * rms_error / golden_rms if golden_rms > 0.0 else safety * rms_error,
     }
 
-    # Writing the device result as the reference plus independent noise of
-    # relative size r gives a correlation of 1 / sqrt(1 + r**2), or about
-    # 1 - r**2 / 2. The correlation is taken after each tensor has its mean
-    # removed, so the divisor is the reference's standard deviation and not its
-    # root-mean-square; for a saturating activation such as sigmoid those differ
-    # by a lot, because most of the reference's size is in its mean.
-    # _PCC_MARGIN rather than safety: see the note on safety above.
+    # 1 - q**2 / 2 for q the error over the activated reference's standard
+    # deviation, not its root-mean-square: a correlation removes the mean first,
+    # and for a saturating activation most of that size is in the mean. Capped at
+    # 0.999999, since no test should demand more agreement than that. An all-zero
+    # reference has no scale to divide by, so the frobenius limit above is left
+    # absolute and the correlation limit drops to zero.
     if golden_std > 0.0:
         noise_ratio = _PCC_MARGIN * rms_error / golden_std
         tolerances["pcc_threshold"] = max(0.0, min(0.999999, 1.0 - noise_ratio * noise_ratio / 2.0))

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -1,0 +1,441 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Numeric tolerances for matmul tests, predicted from the device number formats.
+
+A matmul on device and the same matmul in PyTorch never agree bit for bit, so a
+test has to accept some difference. Choosing that limit by raising it until the
+test passes produces limits that no longer detect a wrong answer: a limit of
+``rtol = 10 * K`` grants every element an allowance thousands of times its own
+value, and a relative Frobenius limit above 1.0 is passed by a tensor of zeros.
+
+The functions here predict the error instead, from the width of each number
+format on the path and the number of times a value is rounded into one. The
+prediction is then the limit. Nothing here measures the device.
+
+The error is summarised as a single **relative error** ``r``, meaning the
+predicted error on a result has standard deviation ``r`` times the standard
+deviation of that result. Independent sources combine as ``sqrt(sum of
+squares)``.
+
+Two facts shape everything below.
+
+*The relative error of a matmul does not grow with K.* Each product carries a
+fractional slip from the narrowed mantissas. Those slips multiply values of
+random sign, so the total error grows as ``sqrt(K)``, and so does the result
+itself. They cancel. The one term that does grow is accumulator rounding, and it
+grows as ``sqrt(K)``, never as ``K``.
+
+*A one-sided slip behaves like a random one.* Mantissa bits are dropped rather
+than rounded, so every slip has the same sign. It still does not build up,
+because it multiplies a mean-zero quantity. The figure that matters is therefore
+the root-mean-square of the slip including its mean, ``2**-m / sqrt(3)`` for a
+slip spread over ``[0, 2**-m)``, rather than its standard deviation.
+"""
+
+import math
+import re
+
+import torch
+import ttnn
+
+_SQRT3 = math.sqrt(3.0)
+
+# Stored mantissa bits, excluding the leading one bit that normalised floating
+# point formats imply rather than store. The gap between neighbouring values is
+# 2**-bits relative to that leading bit.
+_MANTISSA_BITS = {
+    ttnn.float32: 23,
+    ttnn.bfloat16: 7,
+}
+
+# Block float formats share one exponent between 16 consecutive values and store
+# the leading one bit explicitly, so the usable magnitude bits are one fewer than
+# the field width suggests: bfloat8_b spends 8 bits as 1 sign + 7 magnitude and
+# has 6 bits of real precision (tech_reports/data_formats/data_formats.md).
+_BLOCK_FLOAT_BITS = {
+    ttnn.bfloat8_b: 6,
+    ttnn.bfloat4_b: 2,
+}
+
+# Mantissa bits the matrix unit keeps from each operand, as (SrcA, SrcB).
+# The multiplier is 5 bits by 7 bits and each fidelity level makes another pass
+# over the inputs to consume more of them
+# (tech_reports/matrix_engine/matrix_engine.md). A matmul loads the right hand
+# operand into SrcA and the left hand operand into SrcB, the opposite of other
+# operations, so the right hand operand takes the narrower path.
+_FIDELITY_MANTISSA_BITS_KEPT = {
+    ttnn.MathFidelity.LoFi: (4, 6),
+    ttnn.MathFidelity.HiFi2: (7, 6),
+    ttnn.MathFidelity.HiFi3: (4, 7),
+    ttnn.MathFidelity.HiFi4: (7, 7),
+}
+
+# Passes over the inputs, which is also how many times each fidelity level
+# re-runs the multiply sequence and accumulates on top of the same result.
+_FIDELITY_PASSES = {
+    ttnn.MathFidelity.LoFi: 1,
+    ttnn.MathFidelity.HiFi2: 2,
+    ttnn.MathFidelity.HiFi3: 3,
+    ttnn.MathFidelity.HiFi4: 4,
+}
+
+# One matmul instruction reduces 16 elements of K, and two of them contribute to
+# each output element per 32 element K tile, so the running total is rounded into
+# the accumulator once per 16 elements of K per fidelity pass.
+_K_PER_ACCUMULATION = 16
+
+
+def _format_relative_error(dtype):
+    """Contribution to ``r`` from one rounding of a value into ``dtype``.
+
+    For a normalised format this is the rounding error relative to the value.
+    For a block float format the step is fixed across a block of 16 by the
+    largest magnitude in it, which for normally distributed data is about two
+    standard deviations, so the error is absolute rather than relative. An
+    absolute error of ``k`` standard deviations on an operand contributes ``k``
+    to ``r`` in exactly the same way a relative one does, which is why both
+    return a single comparable number.
+    """
+    bits = _BLOCK_FLOAT_BITS.get(dtype)
+    if bits is not None:
+        # Step at most 2 * 2**-bits standard deviations, rounded to nearest.
+        return 2.0**-bits / _SQRT3
+    return 2.0 ** -(_MANTISSA_BITS[dtype] + 1) / _SQRT3
+
+
+def _source_mantissa_bits(dtype):
+    """Mantissa bits the data actually carries when it reaches the multiplier."""
+    bits = _BLOCK_FLOAT_BITS.get(dtype)
+    return bits if bits is not None else _MANTISSA_BITS[dtype]
+
+
+def _truncation_relative_error(bits_kept, bits_available):
+    """Contribution to ``r`` from dropping mantissa bits below ``bits_kept``."""
+    if bits_kept >= bits_available:
+        return 0.0
+    return 2.0**-bits_kept / _SQRT3
+
+
+def _accumulated_rounding_relative_error(step_error, steps):
+    """Contribution to ``r`` from rounding a running total ``steps`` times.
+
+    These roundings act on the partial sum rather than on individual products,
+    so they do not cancel against the ``sqrt(K)`` growth of the result. After
+    ``j`` of ``n`` steps the partial sum is ``sqrt(j / n)`` of the final size, and
+    the error introduced there survives to the end, so the variances sum to
+    ``step_error**2 * (n + 1) / 2`` times the square of the final size.
+    """
+    if steps < 1:
+        return 0.0
+    return step_error * math.sqrt((steps + 1) / 2.0)
+
+
+def matmul_relative_error(
+    K,
+    in0_dtype,
+    in1_dtype,
+    out_dtype,
+    math_fidelity,
+    fp32_dest_acc_en,
+    packer_l1_acc,
+    k_tiles_per_block=1,
+    reference_dtype=None,
+):
+    """Predicted relative error of a matmul result, before any fused activation.
+
+    Args:
+        K: the reduction length.
+        in0_dtype, in1_dtype: device formats of the left and right operands.
+        out_dtype: device format of the result. It reaches the accumulation, not
+            only the final value, because without ``packer_l1_acc`` the partial
+            sums are spilled to memory in this format.
+        math_fidelity: how many passes the matrix unit makes over the inputs.
+        fp32_dest_acc_en: whether the accumulator is 32 bit rather than 16 bit.
+        packer_l1_acc: whether partial sums are accumulated in place in memory
+            instead of being written out and read back once per K block.
+        k_tiles_per_block: K tiles per block, which sets how many blocks the
+            reduction is split into. The default of 1 gives the most blocks and
+            so the most partial sum roundings.
+        reference_dtype: format the host reference was rounded to, if it was not
+            computed in float32.
+
+    Returns:
+        The relative error as a float.
+    """
+    srca_bits, srcb_bits = _FIDELITY_MANTISSA_BITS_KEPT[math_fidelity]
+    terms = [
+        # Converting each operand to its device format.
+        _format_relative_error(in0_dtype),
+        _format_relative_error(in1_dtype),
+        # The multiplier discarding the low mantissa bits of each operand.
+        _truncation_relative_error(srcb_bits, _source_mantissa_bits(in0_dtype)),
+        _truncation_relative_error(srca_bits, _source_mantissa_bits(in1_dtype)),
+    ]
+
+    accumulator_dtype = ttnn.float32 if fp32_dest_acc_en else ttnn.bfloat16
+    accumulations = (K // _K_PER_ACCUMULATION) * _FIDELITY_PASSES[math_fidelity]
+    terms.append(_accumulated_rounding_relative_error(_format_relative_error(accumulator_dtype), accumulations))
+
+    blocks = max(1, (K // ttnn.TILE_SIZE) // max(1, k_tiles_per_block))
+    if blocks > 1:
+        if fp32_dest_acc_en:
+            partial_dtype = ttnn.float32
+        elif packer_l1_acc:
+            partial_dtype = ttnn.bfloat16
+        else:
+            partial_dtype = out_dtype
+        terms.append(_accumulated_rounding_relative_error(_format_relative_error(partial_dtype), blocks - 1))
+
+    if reference_dtype is not None:
+        terms.append(_format_relative_error(reference_dtype))
+
+    return math.sqrt(sum(term * term for term in terms))
+
+
+_PARAMS_PATTERN = re.compile(r"params=\[([^\]]*)\]")
+
+
+def activation_params(activation):
+    """Parameters of a ``ttnn.UnaryWithParam``, read from its text form.
+
+    The binding exposes ``op_type`` but no accessor for the parameters, so the
+    only way to recover them is the object's own text form.
+    """
+    if activation is None:
+        return []
+    match = _PARAMS_PATTERN.search(repr(activation))
+    if match is None or not match.group(1).strip():
+        return []
+    return [float(value) for value in match.group(1).split(",")]
+
+
+def _op_type(activation):
+    return getattr(activation, "op_type", None)
+
+
+# Activations the fused matmul path evaluates with comparison and selection only,
+# so they carry no error beyond the rounding of the value they produce. relu is
+# not even a vector unit operation there: it is a packer setting.
+_EXACT_ACTIVATIONS = frozenset(
+    {
+        ttnn.UnaryOpType.RELU,
+        ttnn.UnaryOpType.RELU6,
+        ttnn.UnaryOpType.HARDTANH,
+    }
+)
+
+# Every other activation the matmul can fuse is a fitted polynomial or an
+# exponential. The implementations record maximum errors between 0.28 and 1 unit
+# in the last place of the format they run in; two units is the group bound.
+_FITTED_ACTIVATION_ULPS = 2.0
+
+# gelu, tanh and sigmoid each accept a flag that replaces the fit with a handful
+# of straight line segments. The bound is the peak distance from those segments
+# to the true function, so it is absolute and does not shrink with the output.
+#
+# tanh's three segments are written out in the kernel that loads them: 0.90625*x,
+# then 0.09375*x + 0.8125, then 1. They join at x = 1 and x = 2, and their
+# greatest distance from tanh is at x = 1, where 0.90625 - tanh(1) = 0.145.
+#
+# The gelu and sigmoid tables are loaded as packed constants with no arithmetic
+# form recorded beside them, so their bounds are not derived here. 0.13 is the
+# figure the vector unit's own sweep tests record for both
+# (tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py), noting that
+# the absolute error of a coarse table peaks near the segment joins. This is the
+# one quantity in this module taken from an observation rather than from a
+# format width or a written algorithm.
+_PIECEWISE_LINEAR_ABSOLUTE_ERROR = {
+    ttnn.UnaryOpType.GELU: 0.13,
+    ttnn.UnaryOpType.TANH: 0.15,
+    ttnn.UnaryOpType.SIGMOID: 0.13,
+}
+
+# Index of the parameter that selects the piecewise linear table. For sigmoid the
+# first parameter is the vector mode and the flag is the second one.
+_PIECEWISE_LINEAR_FLAG_INDEX = {
+    ttnn.UnaryOpType.GELU: 0,
+    ttnn.UnaryOpType.TANH: 0,
+    ttnn.UnaryOpType.SIGMOID: 1,
+}
+
+# The root-mean-square error of a piecewise linear fit is well below its peak,
+# because the segments meet the curve at their ends. Half the peak is used for
+# the whole-tensor checks, while the peak itself is used elementwise.
+_PIECEWISE_LINEAR_RMS_FRACTION = 0.5
+
+# Most activations pick a higher accuracy inner algorithm when the accumulator is
+# 32 bit. These two do not: they select it from a compile time macro that only the
+# eltwise unary path defines, so fused into a matmul they always take their 16 bit
+# polynomial branch however the accumulator is configured.
+_ALWAYS_16_BIT_ACTIVATIONS = frozenset(
+    {
+        ttnn.UnaryOpType.SELU,
+        ttnn.UnaryOpType.SOFTPLUS,
+    }
+)
+
+
+def activation_evaluation_error(activation, dest_dtype):
+    """Error of evaluating ``activation`` on device, as (relative, absolute).
+
+    ``dest_dtype`` is the format the activation runs in, which is the
+    accumulator format rather than the output format: the activation is applied
+    to the value still held in the accumulator, before it is packed out.
+    """
+    op_type = _op_type(activation)
+    if op_type is None or op_type in _EXACT_ACTIVATIONS:
+        return 0.0, 0.0
+
+    flag_index = _PIECEWISE_LINEAR_FLAG_INDEX.get(op_type)
+    if flag_index is not None:
+        params = activation_params(activation)
+        if len(params) > flag_index and params[flag_index] != 0.0:
+            return 0.0, _PIECEWISE_LINEAR_ABSOLUTE_ERROR[op_type]
+
+    if op_type in _ALWAYS_16_BIT_ACTIVATIONS:
+        dest_dtype = ttnn.bfloat16
+
+    return _FITTED_ACTIVATION_ULPS * 2.0 ** -_MANTISSA_BITS[dest_dtype], 0.0
+
+
+def matmul_numeric_tolerances(
+    pre_activation,
+    activation=None,
+    activation_fn=None,
+    *,
+    K,
+    in0_dtype,
+    in1_dtype,
+    out_dtype,
+    math_fidelity,
+    fp32_dest_acc_en,
+    packer_l1_acc,
+    k_tiles_per_block=1,
+    reference_dtype=None,
+    safety=2.0,
+):
+    """Tolerances for ``assert_numeric_metrics`` on a matmul with a fused activation.
+
+    Splat the result into the assertion::
+
+        assert_numeric_metrics(golden, actual, check_ulp=False, **tolerances)
+
+    Args:
+        pre_activation: the exact host reference for the matmul, and the bias if
+            there is one, before the activation. Its spread sets the scale of the
+            predicted error, so it is needed even when the reference the test
+            finally compares against is the activated one.
+        activation: the ``ttnn.UnaryWithParam`` (or ``None``) the device applied,
+            used to work out how accurately the device evaluates it.
+        activation_fn: the same activation as a callable on a torch tensor, used
+            to carry the predicted error through it. ``None`` means no activation.
+        safety: multiplier on the predicted error. For the whole-tensor checks
+            the prediction is a root-mean-square over tens of thousands of
+            elements, so it barely varies from run to run and the margin covers
+            the model missing a term. Since independent errors combine in
+            quadrature, a factor of 2 covers a missed term up to sqrt(3) times
+            the largest one already counted. The elementwise limit is different:
+            it rests on an extreme value, which does vary noticeably from run to
+            run, so there the margin covers both.
+
+    Other arguments are as for :func:`matmul_relative_error`.
+
+    Returns:
+        A dict with ``atol``, ``rtol``, ``frobenius_threshold`` and
+        ``pcc_threshold``.
+    """
+    pre_activation = pre_activation.float()
+
+    relative_error = matmul_relative_error(
+        K=K,
+        in0_dtype=in0_dtype,
+        in1_dtype=in1_dtype,
+        out_dtype=out_dtype,
+        math_fidelity=math_fidelity,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        packer_l1_acc=packer_l1_acc,
+        k_tiles_per_block=k_tiles_per_block,
+        reference_dtype=reference_dtype,
+    )
+
+    # The error on an output element is proportional to the spread of the whole
+    # dot product, not to that element's own value, because it is the accumulated
+    # slip of K products. A bias is added after the matmul and carries none of
+    # that error; it is left in here because the tests that use one make it far
+    # smaller than the matmul result.
+    error_before_activation = relative_error * pre_activation.std().item()
+
+    # Largest error a single element can plausibly receive before the activation.
+    # The errors are a sum of many independent contributions and so are close to
+    # normally distributed. The elementwise check bounds the magnitude of the
+    # error, so the statistic wanted is the largest of n absolute values, which
+    # sits at about sqrt(2 * ln(2n)) standard deviations rather than
+    # sqrt(2 * ln(n)).
+    extreme_value_factor = math.sqrt(2.0 * math.log(2 * max(pre_activation.numel(), 2)))
+    extreme_error_before_activation = extreme_value_factor * error_before_activation
+
+    if activation_fn is None:
+        golden = pre_activation
+        slope_rms = 1.0
+        max_propagated_error = extreme_error_before_activation
+    else:
+        golden = activation_fn(pre_activation).float()
+        # A symmetric difference taken at the scale of the error, rather than at
+        # a vanishing scale, gives the average slope over the interval the error
+        # can move the value. A corner such as relu's kink or hardtanh's clamp
+        # then contributes a partial slope instead of an undefined one.
+        step = error_before_activation if error_before_activation > 0.0 else 1e-6
+        slope = ((activation_fn(pre_activation + step) - activation_fn(pre_activation - step)) / (2.0 * step)).float()
+        slope_rms = slope.pow(2).mean().sqrt().item()
+        # For the elementwise bound the activation is evaluated at the extreme of
+        # the error rather than multiplied by a slope, so that a bounded
+        # activation cannot be credited with more error than its range allows.
+        shift = extreme_error_before_activation if extreme_error_before_activation > 0.0 else 1e-6
+        moved_up = (activation_fn(pre_activation + shift).float() - golden).abs()
+        moved_down = (activation_fn(pre_activation - shift).float() - golden).abs()
+        max_propagated_error = torch.maximum(moved_up, moved_down).max().item()
+
+    accumulator_dtype = ttnn.float32 if fp32_dest_acc_en else ttnn.bfloat16
+    activation_relative, activation_absolute = activation_evaluation_error(activation, accumulator_dtype)
+    output_relative = _format_relative_error(out_dtype)
+
+    golden_rms = golden.pow(2).mean().sqrt().item()
+    golden_std = golden.std().item()
+
+    # Whole-tensor error, as a root-mean-square over elements.
+    rms_error = math.sqrt(
+        (slope_rms * error_before_activation) ** 2
+        + ((activation_relative + output_relative) * golden_rms) ** 2
+        + (_PIECEWISE_LINEAR_RMS_FRACTION * activation_absolute) ** 2
+    )
+
+    # Largest error over all elements. Every element is credited with the extreme
+    # error rather than only the unluckiest one, so this is an upper bound rather
+    # than an estimate. The activation's own error is already a bound, so it is
+    # added rather than scaled.
+    max_error = max_propagated_error + activation_absolute
+
+    # rtol carries only what genuinely scales with an element's own value: the
+    # rounding into the output format and the activation's relative error. atol
+    # carries the accumulated error, which does not.
+    tolerances = {
+        "atol": safety * max_error,
+        "rtol": safety * (output_relative + activation_relative),
+        "frobenius_threshold": safety * rms_error / golden_rms if golden_rms > 0.0 else safety * rms_error,
+    }
+
+    # Writing the device result as the reference plus independent noise of
+    # relative size r gives a correlation of 1 / sqrt(1 + r**2), or about
+    # 1 - r**2 / 2. The correlation is taken after each tensor has its mean
+    # removed, so the divisor is the reference's standard deviation and not its
+    # root-mean-square; for a saturating activation such as sigmoid those differ
+    # by a lot, because most of the reference's size is in its mean.
+    if golden_std > 0.0:
+        noise_ratio = safety * rms_error / golden_std
+        tolerances["pcc_threshold"] = max(0.0, min(0.999999, 1.0 - noise_ratio * noise_ratio / 2.0))
+    else:
+        tolerances["pcc_threshold"] = 0.0
+
+    return tolerances

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -4,6 +4,15 @@
 
 """Numeric tolerances for matmul tests, predicted from the device number formats.
 
+Nothing imports this module. The tests hold their limits as literals so that the
+limit being applied is visible at the point it is applied, and so that editing the
+model here cannot quietly move what every test accepts. This module is the record
+of where those literals came from: run its functions by hand to re-derive a table
+when a test's shapes, seeds, data types or activations change, and paste the
+result back. A literal is set to the most permissive value the model gives over
+the cases it covers, rounded outward, so that no case is held to a tighter limit
+than the model asks for.
+
 A matmul on device and the same matmul in PyTorch never agree bit for bit, so a
 test has to accept some difference. Choosing that limit by raising it until the
 test passes produces limits that no longer detect a wrong answer: a limit of

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -42,10 +42,10 @@ two agree, so pass the function that matches the op.
 How accurately the hardware evaluates an activation varies. relu, relu6 and
 hardtanh are exact, being comparison and selection only. The rest are fitted
 polynomials, held to two units in the last place. gelu, tanh and sigmoid also
-accept a flag that swaps the fit for a handful of straight line segments, which
-is far coarser; see _PIECEWISE_LINEAR_ABSOLUTE_ERROR for how loose those cases
-end up, and why gelu's figure is the one number in this module that is measured
-rather than derived.
+accept a flag that swaps that polynomial for a handful of straight line segments,
+which is far coarser; see _PIECEWISE_LINEAR_ABSOLUTE_ERROR for how loose those
+cases end up, and why gelu's figure is the one number in this module that is
+measured rather than derived.
 
 Stage one: a single relative error. matmul_relative_error predicts one relative
 error "r" from the configuration only, never from the data. "r" is defined so that
@@ -115,7 +115,7 @@ needed whether or not an activation applies.
   less correlation than is justified. That is safe against a false failure, but it
   lets more real error through.
 
-atol, rtol and frobenius_threshold are multiplied by the safety argument, 2.0 by
+atol, rtol and frobenius_threshold are multiplied by the safety factor, 2.0 by
 default. pcc_threshold uses _PCC_MARGIN instead; see that constant for why.
 
 To get limits for a new entry in a test's pytest.mark.parametrize list, build the
@@ -153,26 +153,8 @@ directory is the repository root, so that the import resolves:
         )
     )
 
-which prints
-
-    {'atol': 6.565339088439941, 'rtol': 0.035760548978043954,
-     'frobenius_threshold': 0.06724930087282528,
-     'pcc_threshold': 0.9987590077261392}
-
-Both per element limits can be checked by hand. For atol, "r" is 0.0284 here and
-the pre-activation reference has a standard deviation of 22.6, so one element's
-error has a standard deviation of 0.64. There are M * N = 65536 elements, and
-sqrt(2 * ln(131072)) is 4.855, so the worst element error is 3.11. Reapplying
-GELU either side of that shift raises it to 3.28, and the safety argument of 2.0
-gives the printed 6.57. GELU contributes no absolute error, because the device
-fits it with a polynomial and that inaccuracy counts as a relative error in rtol
-instead. For rtol, the table gives GELU a relative error of 2 * 2**-7 = 0.0156 in
-the accumulator format, bfloat16 here because fp32_dest_acc_en is False, and the
-output rounding adds 2**-8 / sqrt(3) = 0.0023 (see _format_relative_error). Twice
-their sum is the printed 0.0358.
-
-One parametrize entry usually covers several shapes, data types and settings. Run
-the calculation for each and keep the largest atol, rtol and
+One parametrize entry in the test file usually covers several shapes, data types
+and settings. Run the calculation for each and keep the largest atol, rtol and
 frobenius_threshold and the smallest pcc_threshold. Round the first three up and
 pcc_threshold down.
 
@@ -181,29 +163,28 @@ Notes:
 - The relative error does not grow with K. Each product carries a relative
 rounding error from the narrowed mantissas, and the test inputs are a mix of
 positive and negative numbers, so those errors multiply values that are as often
-negative as positive and partly cancel. The total error grows as sqrt(K), the
-result grows as sqrt(K), and the ratio is flat. The two terms that do grow
-are the ones that round a running total: the accumulator (see
-_K_PER_ACCUMULATION) and the partial sum spilled between K blocks. Both grow as
-sqrt(K), never as K. With fp32_dest_acc_en both are held in 32 bit, so they fall
+negative as positive and partly cancel. Both the total error and the result grow
+with sqrt(K), so their ratio is flat. There are two terms that do grow with sqrt(K),
+not linearly with K. Both come from rounding a partial sum, the running total as it
+is built. One is the accumulator (see _K_PER_ACCUMULATION); the other is the write
+out between K blocks. With fp32_dest_acc_en they are held in 32 bit, so they fall
 below every other term and K stops mattering; they matter only with a 16 bit
 accumulator.
 
 - Truncation is biased, and it still does not grow with K. The matrix engine
 drops the low mantissa bits of each operand instead of rounding to nearest, which
 moves that operand toward zero, so no product comes out larger in magnitude than
-the true one. Write the product of a and b as a*b*(1-d), where d is the fraction
-lost from the two truncated operands together; d is never negative. Only d has a
-fixed sign, though. Each product a*b is positive or negative depending on its
+the true one. Write the product of a and b as a*b*(1-d), where "d" is the fraction
+lost from the two truncated operands together, so "d" is never negative. Only "d"
+has a fixed sign. Each product a*b can be positive or negative depending on its
 operands, so the errors -d*a*b are too, and they partly cancel in the sum just as
 the products themselves do.
 
-The bias does decide how truncation enters r. An error that averages to zero
+The bias does decide how truncation enters "r". An error that averages to zero
 contributes its standard deviation divided by the result's. Truncation does not
 average to zero, so _truncation_relative_error uses a root-mean-square instead,
-which covers the average of d and the spread around it together. That is an upper
-bound rather than an exact treatment of a fixed offset, and that function records
-how much margin it leaves.
+which covers the average of "d" and the spread around it together. That is an
+upper bound, and that function records how much margin it leaves.
 """
 
 import math
@@ -241,8 +222,8 @@ _BLOCK_FLOAT_BITS = {
 
 # Mantissa bits the matrix engine keeps from each operand, as (SrcA, SrcB), its
 # two operand registers, taken from the union of the per-pass bit masks. The
-# multiplier is 5 bits by 7 bits, and each fidelity level makes another pass to
-# consume more of the inputs
+# engine's multiplier array is 5 bits by 7 bits, and each fidelity level makes
+# another pass to consume more of the inputs
 # (tech_reports/matrix_engine/matrix_engine.md). A matmul loads the right hand
 # operand into SrcA and the left hand operand into SrcB, the opposite of other
 # operations, so the right hand operand takes the narrower path.
@@ -296,7 +277,7 @@ def _format_relative_error(dtype):
 
 
 def _source_mantissa_bits(dtype):
-    """Mantissa bits the data actually carries when it reaches the multiplier."""
+    """Mantissa bits the data actually carries when it reaches the matrix engine."""
     bits = _BLOCK_FLOAT_BITS.get(dtype)
     return bits if bits is not None else _MANTISSA_BITS[dtype]
 
@@ -325,7 +306,8 @@ def _truncation_relative_error(bits_kept, bits_available):
     significand, and taking the significand as equally likely anywhere in its
     range that average is exactly a half: the area under 1/s**2 from 1 to 2 is
     1 - 1/2, over a range of width 1. So the answer is u/sqrt(3) times sqrt(1/2),
-    which is u/sqrt(6). That same division turns the average u/2 into mu.
+    which is u/sqrt(6). The same division turns the average u/2 into the average
+    relative loss, which the module docstring calls mu.
 
     Both uniform assumptions are approximations, so the formula is checked against
     measurement. Truncating bfloat16 values from torch.randn, which carry 7
@@ -336,13 +318,19 @@ def _truncation_relative_error(bits_kept, bits_available):
     dropped, because the amount removed then takes only a few discrete values
     instead of the continuous spread assumed above.
 
-    An understatement in how the caller combines the operands nearly cancels that.
-    A product loses from both operands, and matmul_relative_error adds the two
-    contributions as the square root of the sum of squares, which drops the cross
-    term between the two biases; for bfloat16 operands at LoFi that cross term is
-    worth 16 percent. The two effects very nearly cancel there, leaving the caller
-    0.5 percent above the measured pair, so this term carries almost no margin of
-    its own and relies on the safety factor.
+    A second error, in the opposite direction, comes one step later. Both operands
+    of a product are truncated, so the product's total loss is one such loss from
+    each operand, and matmul_relative_error combines them as the square root of
+    the sum of squares. That is right for the noise part of each loss but wrong
+    for the bias part, because biases add directly, so the total comes out too
+    small: for bfloat16 operands at LoFi the true total is 16 percent above what
+    the caller computes.
+
+    The two errors nearly cancel. This function overstates each operand's loss and
+    the combination understates the total, so for that same LoFi case the caller
+    finishes only 0.5 percent above the measured total. Close agreement, but it
+    leaves this term with no margin of its own, so it depends on the safety factor
+    the limits apply.
     """
     if bits_kept >= bits_available:
         return 0.0
@@ -400,7 +388,7 @@ def matmul_relative_error(
         # Converting each operand to its device format.
         _format_relative_error(in0_dtype),
         _format_relative_error(in1_dtype),
-        # The multiplier discarding the low mantissa bits of each operand.
+        # The matrix engine discarding the low mantissa bits of each operand.
         _truncation_relative_error(srcb_bits, _source_mantissa_bits(in0_dtype)),
         _truncation_relative_error(srca_bits, _source_mantissa_bits(in1_dtype)),
     ]
@@ -593,10 +581,9 @@ def matmul_numeric_tolerances(
         max_propagated_error = extreme_error_before_activation
     else:
         golden = activation_fn(pre_activation).float()
-        # A symmetric difference at the scale of the error, rather than at a
-        # vanishing scale, averages the slope over the interval the error can
-        # move the value, so relu's kink gives a partial slope not an undefined
-        # one.
+        # The slope is averaged over the interval the error can actually move
+        # the value, not taken as a true derivative at a point, so relu's kink
+        # gives a partial slope instead of an undefined one.
         step = error_before_activation if error_before_activation > 0.0 else 1e-6
         slope = ((activation_fn(pre_activation + step) - activation_fn(pre_activation - step)) / (2.0 * step)).float()
         slope_rms = slope.pow(2).mean().sqrt().item()
@@ -621,9 +608,13 @@ def matmul_numeric_tolerances(
         + (_PIECEWISE_LINEAR_RMS_FRACTION * activation_absolute) ** 2
     )
 
-    # Every element is credited with the extreme error rather than only the
-    # unluckiest one, so this is an upper bound. The activation's own error is
-    # already a bound, so it is added rather than combined in quadrature.
+    # The shift above is the largest error any one of the n elements is likely to
+    # see, yet it is applied to all of them and the largest resulting change kept.
+    # Only one element would really see an error that big, and it might sit where
+    # the activation is flat while another sits on a steep part, so taking the
+    # worst of both makes this an upper bound rather than an estimate. The
+    # activation's own error is already a bound, so it is added rather than
+    # combined in quadrature.
     max_error = max_propagated_error + activation_absolute
 
     # rtol carries only what scales with an element's own value; atol carries the
@@ -634,12 +625,15 @@ def matmul_numeric_tolerances(
         "frobenius_threshold": safety * rms_error / golden_rms if golden_rms > 0.0 else safety * rms_error,
     }
 
-    # 1 - q**2 / 2 for q the error over the activated reference's standard
-    # deviation, not its root-mean-square: a correlation removes the mean first,
-    # and for a saturating activation most of that size is in the mean. Capped at
-    # 0.999999, since no test should demand more agreement than that. An all-zero
-    # reference has no scale to divide by, so the frobenius limit above is left
-    # absolute and the correlation limit drops to zero.
+    # noise_ratio divides the same rms_error the frobenius limit above uses, but by
+    # the standard deviation of the activated reference where that one divides by
+    # the root-mean-square. A correlation removes the mean of each tensor before
+    # comparing them, so the standard deviation is the matching divisor here, and
+    # for a saturating activation the two are far apart because most of the
+    # reference's size sits in its mean. The correlation that follows is
+    # 1 - noise_ratio**2 / 2, capped at 0.999999 since no test should demand closer
+    # agreement than that. An all-zero reference has no scale to divide by, so the
+    # frobenius limit is left absolute and this one drops to zero.
     if golden_std > 0.0:
         noise_ratio = _PCC_MARGIN * rms_error / golden_std
         tolerances["pcc_threshold"] = max(0.0, min(0.999999, 1.0 - noise_ratio * noise_ratio / 2.0))

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -44,7 +44,6 @@ slip spread over ``[0, 2**-m)``, rather than its standard deviation.
 """
 
 import math
-import re
 
 import torch
 import ttnn
@@ -203,23 +202,6 @@ def matmul_relative_error(
     return math.sqrt(sum(term * term for term in terms))
 
 
-_PARAMS_PATTERN = re.compile(r"params=\[([^\]]*)\]")
-
-
-def activation_params(activation):
-    """Parameters of a ``ttnn.UnaryWithParam``, read from its text form.
-
-    The binding exposes ``op_type`` but no accessor for the parameters, so the
-    only way to recover them is the object's own text form.
-    """
-    if activation is None:
-        return []
-    match = _PARAMS_PATTERN.search(repr(activation))
-    if match is None or not match.group(1).strip():
-        return []
-    return [float(value) for value in match.group(1).split(",")]
-
-
 def _op_type(activation):
     return getattr(activation, "op_type", None)
 
@@ -299,7 +281,7 @@ def activation_evaluation_error(activation, dest_dtype):
 
     flag_index = _PIECEWISE_LINEAR_FLAG_INDEX.get(op_type)
     if flag_index is not None:
-        params = activation_params(activation)
+        params = activation.params
         if len(params) > flag_index and params[flag_index] != 0.0:
             return 0.0, _PIECEWISE_LINEAR_ABSOLUTE_ERROR[op_type]
 

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -78,19 +78,32 @@ needed whether or not an activation applies.
 
 - atol. An element's error comes from rounding partial sums, whose size does not
   depend on the dot product they land in, so it is about the same for every
-  element: "r" times the standard deviation of the pre-activation reference, which
-  for independent operands is sqrt(K) times the product of the operands' own
-  standard deviations, so atol grows as sqrt(K). One number therefore serves the
-  whole tensor. It is a sum of many roundings, so it is close to Gaussian. An
-  error can come out too high or too low, and the largest of n such errors, in
-  either direction, sits about sqrt(2 * ln(2n)) standard deviations from zero, for
-  n the number of output elements, so M and N enter only inside that logarithm.
-  The module then shifts every reference value by that distance, up and down,
-  applies the activation to all three values, and keeps the largest change in the
-  activation's output. It does not scale the distance by the activation's
-  slope, because at worst case distance the activation is nowhere near straight;
-  this is why a saturating activation is never assigned more error than its whole
-  output range. The device's own absolute error on the activation is then added.
+  element and one number serves the whole tensor: "r" times the standard deviation
+  of the pre-activation reference, which for independent operands is sqrt(K) times
+  the product of the operands' own standard deviations. Whether atol grows faster
+  than that with K depends on whether "r" grows too. Only two of the terms in "r"
+  depend on K at all, both from rounding a partial sum: the accumulator, and the
+  write out between K blocks. Both grow as sqrt(K) whatever the accumulator holds,
+  and the notes below cover them. The terms they compete with, converting an
+  operand to its device format and the matrix engine truncating its mantissa, are
+  flat in K. A 32 bit accumulator holds the two partial sum terms so far below the
+  flat ones that they never come to matter, leaving "r" flat and atol growing as
+  sqrt(K). A 16 bit accumulator lets them overtake the flat terms at a K in the
+  low thousands, after which atol approaches growing as K. The error is a sum of
+  many roundings, so it is close to Gaussian. It can come out too high or too low,
+  and the largest of n such errors, in either direction, sits about
+  sqrt(2 * ln(2n)) standard deviations from zero, for n the number of output
+  elements, so M and N enter only inside that logarithm. The module then shifts
+  every reference value by that distance, up and down, applies the activation to
+  all three values, and keeps the largest change in the activation's output. It
+  does not scale the distance by the activation's slope, because at worst case
+  distance the activation is nowhere near straight, so the
+  change it finds for a saturating activation cannot exceed that activation's
+  whole output range. atol is larger than the change, though: the device's own
+  absolute error on the activation is added to it, and the safety factor
+  multiplies the total. So for a saturating activation atol is the safety
+  factor times the output range (e.g. atol=2 for sigmoid, which only ever
+  produces values between 0 and 1).
 
 - rtol takes the two contributions that do scale with an element's reference
   value, the abs(reference) the allowance above multiplies: the activation's

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/numeric_tolerances.py
@@ -55,7 +55,7 @@ inputs:
 
   - how many mantissa bits each number format keeps, from the inputs through to
     the partial sums. The final rounding into the output format is not part of "r";
-    stage two adds it, because it scales with the element's own value
+    stage two adds it, because it scales with each element's reference value
   - K, the reduction length, which is the shared dimension of the two operands
   - math_fidelity, which selects how many passes the matrix engine makes and so
     how much of each input's mantissa it uses
@@ -78,20 +78,23 @@ needed whether or not an activation applies.
 
 - atol. An element's error comes from rounding partial sums, whose size does not
   depend on the dot product they land in, so it is about the same for every
-  element: "r" times the standard deviation of the pre-activation reference. One
-  number therefore serves the whole tensor. It is a sum of many roundings, so it
-  is close to Gaussian. An error can come out too high or too low, and the
-  largest of n such errors, in either direction, sits about sqrt(2 * ln(2n))
-  standard deviations from zero, for n the number of output elements. The module
-  then shifts every reference value by that distance, up and down, applies the
-  activation to all three values, and keeps the largest change in the
+  element: "r" times the standard deviation of the pre-activation reference, which
+  for independent operands is sqrt(K) times the product of the operands' own
+  standard deviations, so atol grows as sqrt(K). One number therefore serves the
+  whole tensor. It is a sum of many roundings, so it is close to Gaussian. An
+  error can come out too high or too low, and the largest of n such errors, in
+  either direction, sits about sqrt(2 * ln(2n)) standard deviations from zero, for
+  n the number of output elements, so M and N enter only inside that logarithm.
+  The module then shifts every reference value by that distance, up and down,
+  applies the activation to all three values, and keeps the largest change in the
   activation's output. It does not scale the distance by the activation's
   slope, because at worst case distance the activation is nowhere near straight;
   this is why a saturating activation is never assigned more error than its whole
   output range. The device's own absolute error on the activation is then added.
 
-- rtol takes the two contributions that do scale with an element's own value: the
-  activation's relative error and the rounding into the output format. "r" does not
+- rtol takes the two contributions that do scale with an element's reference
+  value, the abs(reference) the allowance above multiplies: the activation's
+  relative error and the rounding into the output format. "r" does not
   enter it. The two are added rather than combined in quadrature, so that rtol
   stays a bound for every element rather than a typical value.
 
@@ -475,13 +478,26 @@ _PIECEWISE_LINEAR_FLAG_INDEX = {
 # for the whole-tensor checks; the peak itself is used elementwise.
 _PIECEWISE_LINEAR_RMS_FRACTION = 0.5
 
-# Most activations pick a higher accuracy inner algorithm when the accumulator is
-# 32 bit. These two do not: they select it from a compile time setting that only
-# the standalone activation op defines, so fused into a matmul they always take
-# their 16 bit polynomial branch however the accumulator is configured.
+# An activation is allowed two units in the last place of the format it is
+# evaluated in, which is the accumulator's, so a 32 bit accumulator normally
+# makes that allowance negligible. Softplus is the exception. Its kernel picks
+# its polynomial on the INP_FLOAT32 macro, which only the eltwise unary program
+# factory defines, so a fused softplus always takes the degree-6 branch whatever
+# fp32_dest_acc_en says. That branch records itself as bf16-accurate at
+# "<0.28 ULP", the low end of the range quoted above, so its allowance is two
+# units of bfloat16. The flag still reaches the kernel, but there it decides only
+# whether the result is rounded to bfloat16 on the way out.
+#
+# Softplus is the only entry. Every other activation the matmul can fuse chooses
+# its polynomial from is_fp32_dest_acc_en, the same setting that decides the
+# accumulator format, so the rule above already covers them.
+# Softplus therefore carries the loosest rtol here: its allowance dominates,
+# where every other activation's vanishes once the accumulator is 32 bit, so its
+# fused tests are correspondingly less sensitive. The absence of a selectable
+# accurate softplus is tracked by #54673; this exception may be removed once that
+# issue is resolved.
 _ALWAYS_16_BIT_ACTIVATIONS = frozenset(
     {
-        ttnn.UnaryOpType.SELU,
         ttnn.UnaryOpType.SOFTPLUS,
     }
 )
@@ -567,7 +583,7 @@ def matmul_numeric_tolerances(
     )
 
     # An element's error is set by the spread of the whole dot product, not by
-    # the element's own value. A bias carries none of that error; it is left in
+    # that element's own reference value. A bias carries none of that error; it is left in
     # because the tests that use one keep it far smaller than the matmul result.
     error_before_activation = relative_error * pre_activation.std().item()
 
@@ -617,8 +633,8 @@ def matmul_numeric_tolerances(
     # combined in quadrature.
     max_error = max_propagated_error + activation_absolute
 
-    # rtol carries only what scales with an element's own value; atol carries the
-    # accumulated error, which does not.
+    # rtol carries only what scales with an element's reference value; atol
+    # carries the accumulated error, which does not.
     tolerances = {
         "atol": safety * max_error,
         "rtol": safety * (output_relative + activation_relative),

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -25,7 +25,7 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 # not grow with K. Each product carries a fractional slip from the mantissa bits
 # the multiplier discards, those slips multiply values of random sign, so the
 # error grows as sqrt(K) and so does the result. They cancel. At LoFi the
-# multiplier keeps only 4 of the 7 mantissa bits of the right hand operand, a 3.6
+# multiplier keeps only 4 of the 7 mantissa bits of the right hand operand, a 2.6
 # percent relative error that dominates every other term, which is why the limits
 # below barely move with K or with the data type.
 
@@ -102,7 +102,7 @@ def find_max_subblock(out_block_h, out_block_w):
 # Limits for each activation, folded over the two shapes, both data types and both
 # packer_l1_acc settings. Each is the most permissive value the budget gives over
 # those cases, so no case is held tighter than predicted; the trailing comment
-# gives the full range, widest spread 1.69x. The last field says whether the
+# gives the full range, widest spread 1.88x. The last field says whether the
 # device evaluates the activation exactly, with comparison and selection only,
 # rather than with a fitted polynomial, which is what picks rtol out of
 # _RTOL_BY_OUTPUT_FORMAT.
@@ -114,30 +114,30 @@ def find_max_subblock(out_block_h, out_block_w):
     "activation, atol, frobenius_threshold, pcc_threshold, evaluated_exactly",
     [
         # activation                atol      frob       pcc    exact      derived atol      frobenius            pcc
-        (None, 9.857, 0.0886, 0.99607, True),  # 5.83..9.86   0.0766..0.0886  0.99608..0.99707
+        (None, 7.9688, 0.0724, 0.99901, True),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
         # String-based activations
-        ("relu", 9.857, 0.0879, 0.99433, True),  # 5.83..9.86   0.0765..0.0878  0.99433..0.99572
-        ("relu6", 9.857, 0.1528, 0.97807, True),  # 5.83..9.86   0.1204..0.1528  0.97808..0.98686
-        ("silu", 10.3894, 0.0997, 0.99272, False),  # 6.27..10.39   0.0850..0.0996  0.99273..0.99476
-        ("gelu", 10.1969, 0.0995, 0.99274, False),  # 6.17..10.20   0.0848..0.0994  0.99275..0.99476
-        ("tanh", 3.9426, 0.2803, 0.96072, False),  # 3.59..3.94   0.2264..0.2803  0.96072..0.97437
-        ("sigmoid", 1.6864, 0.1563, 0.97458, False),  # 1.24..1.69   0.1206..0.1562  0.97459..0.98475
-        ("hardsigmoid", 1.6429, 0.1525, 0.9758, False),  # 0.97..1.64   0.1173..0.1524  0.97581..0.98557
-        ("hardtanh", 4.0, 0.3064, 0.95307, True),  # 4.00..4.00   0.2542..0.3064  0.95307..0.96770
-        ("selu", 10.6898, 0.1013, 0.99308, False),  # 6.46..10.69   0.0865..0.1012  0.99309..0.99507
-        ("softplus", 9.857, 0.0982, 0.9929, False),  # 5.83..9.86   0.0829..0.0981  0.99290..0.99495
+        ("relu", 7.9688, 0.0719, 0.99857, True),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
+        ("relu6", 7.9688, 0.1254, 0.99446, True),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
+        ("silu", 8.4736, 0.0857, 0.99798, False),  # 4.59..8.47   0.0664..0.0857  0.99798..0.99880
+        ("gelu", 8.3088, 0.0856, 0.99798, False),  # 4.56..8.31   0.0663..0.0855  0.99799..0.99880
+        ("tanh", 3.8539, 0.2356, 0.98959, False),  # 3.14..3.85   0.1696..0.2356  0.98959..0.99461
+        ("sigmoid", 1.52, 0.1308, 0.99332, False),  # 0.97..1.52   0.0914..0.1307  0.99333..0.99672
+        ("hardsigmoid", 1.3282, 0.1279, 0.99361, False),  # 0.71..1.33   0.0893..0.1279  0.99362..0.99686
+        ("hardtanh", 4.0, 0.2594, 0.98739, True),  # 4.00..4.00   0.1912..0.2593  0.98739..0.99315
+        ("selu", 8.7059, 0.0867, 0.99808, False),  # 4.78..8.71   0.0676..0.0866  0.99809..0.99888
+        ("softplus", 7.9688, 0.0846, 0.99802, False),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
         # UnaryWithParam versions with default parameters, same limits as the
         # string spelling of the same activation
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), 9.857, 0.0879, 0.99433, True),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6), 9.857, 0.1528, 0.97807, True),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU), 10.3894, 0.0997, 0.99272, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU), 10.1969, 0.0995, 0.99274, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH), 3.9426, 0.2803, 0.96072, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID), 1.6864, 0.1563, 0.97458, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID), 1.6429, 0.1525, 0.9758, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH), 4.0, 0.3064, 0.95307, True),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU), 10.6898, 0.1013, 0.99308, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS), 9.857, 0.0982, 0.9929, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), 7.9688, 0.0719, 0.99857, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6), 7.9688, 0.1254, 0.99446, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU), 8.4736, 0.0857, 0.99798, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU), 8.3088, 0.0856, 0.99798, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH), 3.8539, 0.2356, 0.98959, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID), 1.52, 0.1308, 0.99332, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID), 1.3282, 0.1279, 0.99361, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH), 4.0, 0.2594, 0.98739, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU), 8.7059, 0.0867, 0.99808, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS), 7.9688, 0.0846, 0.99802, False),
     ],
     ids=[
         "no_activation",
@@ -291,15 +291,15 @@ def test_matmul_with_fused_activations(
     "activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [
         # activation with its custom parameters             atol     rtol     frob      pcc
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 3.0), 3.7732, 0.0046, 0.1338, 0.98297),  # Custom max=3.0
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 3.7732, 0.0046, 0.1608, 0.98708),  # Custom min/max
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1), 5.6739, 0.0358, 0.0854, 0.99512),  # Custom scale/alpha
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 3.0), 2.7127, 0.0046, 0.0976, 0.9966),  # Custom max=3.0
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 2.7127, 0.0046, 0.1171, 0.99743),  # Custom min/max
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1), 4.0831, 0.0358, 0.0662, 0.9989),  # Custom scale/alpha
         (
             ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0),
-            3.7732,
+            2.7127,
             0.0358,
-            0.0831,
-            0.99489,
+            0.0647,
+            0.99883,
         ),  # Custom beta/threshold
     ],
     ids=["relu6_custom", "hardtanh_custom", "selu_custom", "softplus_custom"],
@@ -400,11 +400,11 @@ def test_matmul_with_custom_activation_params(
     "activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [
         # activation      atol     rtol     frob      pcc
-        ("relu", 5.9798, 0.0046, 0.076, 0.99576),
-        ("gelu", 6.3191, 0.0358, 0.0843, 0.99479),
-        ("sigmoid", 1.2673, 0.0358, 0.1185, 0.9851),
-        ("hardtanh", 4.0, 0.0046, 0.2471, 0.96947),
-        ("softplus", 5.9798, 0.0358, 0.0825, 0.99498),
+        ("relu", 4.3409, 0.0046, 0.0553, 0.99915),
+        ("gelu", 4.6711, 0.0358, 0.066, 0.9988),
+        ("sigmoid", 0.99, 0.0358, 0.0899, 0.99678),
+        ("hardtanh", 4.0, 0.0046, 0.1854, 0.99355),
+        ("softplus", 4.3409, 0.0358, 0.0647, 0.99884),
     ],
     ids=["relu", "gelu", "sigmoid", "hardtanh", "softplus"],
 )
@@ -696,15 +696,18 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
     bias_t = None
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, 32 - bias_padded.size(2)), "constant", 0)
+        # Shape [1, 1, 1, N]. The op broadcasts a single bias row across every
+        # output row, so the bias must stay one row tall. Padding it out to a
+        # full tile height makes it logically that many rows, all but the first
+        # of them zero, and then only the first output row receives the bias.
+        bias_row = bias.unsqueeze(2)
         bias_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
         bias_shard_spec = ttnn.ShardSpec(bias_shard_grid, bias_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
         bias_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, bias_shard_spec
         )
-        bias_t = torch2tt_tensor(bias_padded, device, tt_memory_config=bias_mem_config, tt_dtype=ttnn.bfloat16)
+        bias_t = torch2tt_tensor(bias_row, device, tt_memory_config=bias_mem_config, tt_dtype=ttnn.bfloat16)
 
     # Shard in0
     in0_t = ttnn.interleaved_to_sharded(
@@ -789,23 +792,23 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
         #
         #                       atol     rtol     frob      pcc
         # Test bias alone
-        (True, None, 33.6096, 0.0046, 0.0769, 0.99704),
-        (False, None, 33.607, 0.0046, 0.0769, 0.99704),
+        (True, None, 24.4546, 0.0046, 0.056, 0.99941),
+        (False, None, 24.4527, 0.0046, 0.056, 0.99941),
         # Test activation alone
-        (False, "relu", 33.607, 0.0046, 0.0768, 0.99566),
-        (False, "gelu", 33.9469, 0.0046, 0.0769, 0.99565),
-        (False, "sigmoid", 1.9992, 0.0046, 0.2126, 0.95478),
-        (False, "softplus", 33.607, 0.0358, 0.0844, 0.99476),
+        (False, "relu", 24.4527, 0.0046, 0.0561, 0.99913),
+        (False, "gelu", 24.7926, 0.0046, 0.0561, 0.99913),
+        (False, "sigmoid", 1.9912, 0.0046, 0.1693, 0.98925),
+        (False, "softplus", 24.4527, 0.0358, 0.0662, 0.99879),
         # Test bias + activation combinations (main focus)
-        (True, "relu", 33.6096, 0.0046, 0.0769, 0.99566),
-        (True, "gelu", 33.9495, 0.0046, 0.077, 0.99565),
-        (True, "sigmoid", 1.9992, 0.0046, 0.2132, 0.95453),
-        (True, "hardtanh", 4.0, 0.0046, 0.3372, 0.94316),
-        (True, "selu", 35.6466, 0.0358, 0.0853, 0.99481),
-        (True, "softplus", 33.6096, 0.0358, 0.0845, 0.99476),
+        (True, "relu", 24.4546, 0.0046, 0.0561, 0.99913),
+        (True, "gelu", 24.7945, 0.0046, 0.0562, 0.99913),
+        (True, "sigmoid", 1.9912, 0.0046, 0.1696, 0.98921),
+        (True, "hardtanh", 4.0, 0.0046, 0.2834, 0.98494),
+        (True, "selu", 26.0275, 0.0358, 0.0668, 0.9988),
+        (True, "softplus", 24.4546, 0.0358, 0.0662, 0.99879),
         # Test with UnaryWithParam
-        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 6.0), 12.0, 0.0046, 0.211, 0.95665),
-        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0), 4.0, 0.0046, 0.3372, 0.94316),
+        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 6.0), 12.0, 0.0046, 0.1658, 0.98996),
+        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0), 4.0, 0.0046, 0.2834, 0.98494),
     ],
     ids=[
         "bias_only",
@@ -889,9 +892,9 @@ def test_matmul_dram_sharded_with_bias_and_activation(
         # 7 bits, which is why tanh reaches 0.992 here.
         #
         # Special combinations to test edge cases
-        ("tanh", ttnn.MathFidelity.HiFi2, True, 3.5315, 0.0046, 0.1249, 0.99221),  # High precision with tanh
-        ("gelu", ttnn.MathFidelity.LoFi, False, 16.777, 0.0046, 0.0767, 0.9957),  # Fast approximation with GELU
-        ("sigmoid", ttnn.MathFidelity.LoFi, True, 1.9354, 0.0046, 0.1738, 0.96931),  # Sigmoid with L1 accumulation
+        ("tanh", ttnn.MathFidelity.HiFi2, True, 3.3451, 0.0046, 0.1098, 0.99774),  # High precision with tanh
+        ("gelu", ttnn.MathFidelity.LoFi, False, 12.2997, 0.0046, 0.056, 0.99914),  # Fast approximation with GELU
+        ("sigmoid", ttnn.MathFidelity.LoFi, True, 1.8085, 0.0046, 0.1314, 0.99341),  # Sigmoid with L1 accumulation
     ],
     ids=["tanh_hifi", "gelu_lofi", "sigmoid_l1acc"],
 )
@@ -944,8 +947,8 @@ def test_special_activation_combinations(
 # line segments, whose error is absolute and so does not shrink with the output.
 # At this input scale that error is the whole budget, which is why their limits
 # are an order of magnitude looser than accurate gelu's and tanh's. gelu_fast is
-# the one entry in this file whose fold exceeds 2x (its pcc runs 0.856 at K = 2048
-# to 0.931 at K = 4096, a 2.08x spread in the distance from 1); it is left folded
+# the one entry in this file whose fold exceeds 2x (its pcc runs 0.947 at K = 2048
+# to 0.975 at K = 4096, a 2.11x spread in the distance from 1); it is left folded
 # because the spread comes entirely from the segment error bound, the single
 # quantity in the budget that is estimated rather than derived, so splitting it
 # would give false precision.
@@ -953,22 +956,22 @@ def test_special_activation_combinations(
     "activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [
         #                                              atol     rtol     frob      pcc
-        (None, 0.2897, 0.0046, 0.0958, 0.99541),
-        ("relu", 0.2897, 0.0046, 0.0948, 0.99341),
-        ("relu6", 0.2897, 0.0046, 0.0948, 0.99341),
-        ("silu", 0.3186, 0.0358, 0.1042, 0.99416),
-        ("gelu", 0.3269, 0.0358, 0.1051, 0.99367),
-        ("tanh", 0.2892, 0.0358, 0.1050, 0.99449),
-        ("sigmoid", 0.0724, 0.0358, 0.0449, 0.98184),
-        ("hardsigmoid", 0.0483, 0.0358, 0.0410, 0.96747),
-        ("hardtanh", 0.2897, 0.0046, 0.1002, 0.99498),
-        ("selu", 0.4741, 0.0358, 0.1039, 0.99458),
-        ("softplus", 0.2736, 0.0358, 0.0533, 0.98921),
+        (None, 0.2419, 0.0046, 0.08, 0.9988),
+        ("relu", 0.2419, 0.0046, 0.0793, 0.99827),
+        ("relu6", 0.2419, 0.0046, 0.0793, 0.99827),
+        ("silu", 0.2661, 0.0358, 0.0892, 0.99839),
+        ("gelu", 0.273, 0.0358, 0.0899, 0.99826),
+        ("tanh", 0.2416, 0.0358, 0.0899, 0.99848),
+        ("sigmoid", 0.0605, 0.0358, 0.0424, 0.99371),
+        ("hardsigmoid", 0.0404, 0.0358, 0.0395, 0.98832),
+        ("hardtanh", 0.2419, 0.0046, 0.0838, 0.99868),
+        ("selu", 0.4006, 0.0358, 0.089, 0.9985),
+        ("softplus", 0.2283, 0.0358, 0.0487, 0.99648),
         # Test with UnaryWithParam objects with parameters
         # fast_and_approximate mode
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, 1.0), 0.5869, 0.0046, 0.5131, 0.85621),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, 1.0), 0.533, 0.0046, 0.5103, 0.94668),
         # fast_and_approximate mode
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH, 1.0), 0.5892, 0.0046, 0.3976, 0.92096),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH, 1.0), 0.5416, 0.0046, 0.394, 0.97089),
         # There is no fast sigmoid case here. sigmoid numbers its parameters
         # differently from gelu and tanh: the first is the vector mode and the
         # second is the fast_and_approximate flag, so reaching the table takes
@@ -979,11 +982,11 @@ def test_special_activation_combinations(
         # bound is an absolute 0.13. The limit would have to admit an error
         # larger than the signal, which no longer tests anything.
         # Custom min/max
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 0.2897, 0.0046, 0.0959, 0.99541),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 0.2419, 0.0046, 0.0801, 0.99879),
         # Custom scale/alpha
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2), 0.4854, 0.0358, 0.1033, 0.99463),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2), 0.4101, 0.0358, 0.0885, 0.99852),
         # Custom beta/threshold
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0), 0.2887, 0.0358, 0.0716, 0.99326),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0), 0.2411, 0.0358, 0.063, 0.99804),
     ],
     ids=[
         "no_activation",

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -5,7 +5,6 @@
 """Extended matmul tests with all supported fused activations."""
 
 import functools
-import re
 
 import pytest
 from loguru import logger
@@ -41,22 +40,6 @@ _RTOL_BY_OUTPUT_FORMAT = {
     (ttnn.bfloat8_b, True): 0.0181,
     (ttnn.bfloat8_b, False): 0.0493,
 }
-
-_ACTIVATION_PARAMS_PATTERN = re.compile(r"params=\[([^\]]*)\]")
-
-
-def activation_params(activation):
-    """Parameters of a ``ttnn.UnaryWithParam``, read from its text form.
-
-    The binding exposes ``op_type`` but no accessor for the parameters, so the
-    only way to recover them is the object's own text form.
-    """
-    if activation is None:
-        return []
-    match = _ACTIVATION_PARAMS_PATTERN.search(repr(activation))
-    if match is None or not match.group(1).strip():
-        return []
-    return [float(value) for value in match.group(1).split(",")]
 
 
 def get_activation_golden_function(activation):
@@ -603,7 +586,7 @@ def apply_activation_to_reference(tensor, activation):
             return tensor
 
     op_type = getattr(activation, "op_type", activation)
-    params = activation_params(activation)
+    params = getattr(activation, "params", [])
 
     if op_type == ttnn.UnaryOpType.RELU:
         return torch.nn.functional.relu(tensor)

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -5,19 +5,58 @@
 """Extended matmul tests with all supported fused activations."""
 
 import functools
+import re
 
 import pytest
 from loguru import logger
 import ttnn
 from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul, ttnn_linear
-from tests.ttnn.nightly.unit_tests.operations.matmul.numeric_tolerances import (
-    activation_params,
-    matmul_numeric_tolerances,
-)
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
 import torch
 import torch.nn.functional as F
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+
+# Every tolerance in this file is a literal, predicted from the number formats on
+# the device path rather than observed. numeric_tolerances.py in this directory
+# records the error budget the literals come from and how each one is arrived at;
+# nothing imports it, so re-derive the tables from it by hand if a test's shapes,
+# seeds or activations change.
+#
+# The shape of the answer, from that budget: the relative error of a matmul does
+# not grow with K. Each product carries a fractional slip from the mantissa bits
+# the multiplier discards, those slips multiply values of random sign, so the
+# error grows as sqrt(K) and so does the result. They cancel. At LoFi the
+# multiplier keeps only 4 of the 7 mantissa bits of the right hand operand, a 3.6
+# percent relative error that dominates every other term, which is why the limits
+# below barely move with K or with the data type.
+
+# rtol carries only what scales with an element's own value: the rounding into the
+# output format, doubled for the safety factor, plus two units in the last place
+# when the activation is a fitted polynomial rather than a clamp the device
+# evaluates exactly. Everything else in a matmul's error is proportional to the
+# size of the whole dot product, not to the element, so atol carries it.
+_RTOL_BY_OUTPUT_FORMAT = {
+    (ttnn.bfloat16, True): 0.0046,
+    (ttnn.bfloat16, False): 0.0358,
+    (ttnn.bfloat8_b, True): 0.0181,
+    (ttnn.bfloat8_b, False): 0.0493,
+}
+
+_ACTIVATION_PARAMS_PATTERN = re.compile(r"params=\[([^\]]*)\]")
+
+
+def activation_params(activation):
+    """Parameters of a ``ttnn.UnaryWithParam``, read from its text form.
+
+    The binding exposes ``op_type`` but no accessor for the parameters, so the
+    only way to recover them is the object's own text form.
+    """
+    if activation is None:
+        return []
+    match = _ACTIVATION_PARAMS_PATTERN.search(repr(activation))
+    if match is None or not match.group(1).strip():
+        return []
+    return [float(value) for value in match.group(1).split(",")]
 
 
 def get_activation_golden_function(activation):
@@ -77,32 +116,45 @@ def find_max_subblock(out_block_h, out_block_w):
     return best_h, best_w, max_product
 
 
+# Limits for each activation, folded over the two shapes, both data types and both
+# packer_l1_acc settings. Each is the most permissive value the budget gives over
+# those cases, so no case is held tighter than predicted; the trailing comment
+# gives the full range, widest spread 1.69x. The last field says whether the
+# device evaluates the activation exactly, with comparison and selection only,
+# rather than with a fitted polynomial, which is what picks rtol out of
+# _RTOL_BY_OUTPUT_FORMAT.
+#
+# atol for an activation that saturates is set by that activation's own output
+# range rather than by K, which is why hardtanh sits at 4.0 and the unbounded
+# activations near 10.
 @pytest.mark.parametrize(
-    "activation",
+    "activation, atol, frobenius_threshold, pcc_threshold, evaluated_exactly",
     [
-        None,  # No activation
+        # activation                atol      frob       pcc    exact      derived atol      frobenius            pcc
+        (None, 9.857, 0.0886, 0.99607, True),  # 5.83..9.86   0.0766..0.0886  0.99608..0.99707
         # String-based activations
-        "relu",
-        "relu6",
-        "silu",
-        "gelu",
-        "tanh",
-        "sigmoid",
-        "hardsigmoid",
-        "hardtanh",
-        "selu",
-        "softplus",
-        # UnaryWithParam versions with default parameters
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS),
+        ("relu", 9.857, 0.0879, 0.99433, True),  # 5.83..9.86   0.0765..0.0878  0.99433..0.99572
+        ("relu6", 9.857, 0.1528, 0.97807, True),  # 5.83..9.86   0.1204..0.1528  0.97808..0.98686
+        ("silu", 10.3894, 0.0997, 0.99272, False),  # 6.27..10.39   0.0850..0.0996  0.99273..0.99476
+        ("gelu", 10.1969, 0.0995, 0.99274, False),  # 6.17..10.20   0.0848..0.0994  0.99275..0.99476
+        ("tanh", 3.9426, 0.2803, 0.96072, False),  # 3.59..3.94   0.2264..0.2803  0.96072..0.97437
+        ("sigmoid", 1.6864, 0.1563, 0.97458, False),  # 1.24..1.69   0.1206..0.1562  0.97459..0.98475
+        ("hardsigmoid", 1.6429, 0.1525, 0.9758, False),  # 0.97..1.64   0.1173..0.1524  0.97581..0.98557
+        ("hardtanh", 4.0, 0.3064, 0.95307, True),  # 4.00..4.00   0.2542..0.3064  0.95307..0.96770
+        ("selu", 10.6898, 0.1013, 0.99308, False),  # 6.46..10.69   0.0865..0.1012  0.99309..0.99507
+        ("softplus", 9.857, 0.0982, 0.9929, False),  # 5.83..9.86   0.0829..0.0981  0.99290..0.99495
+        # UnaryWithParam versions with default parameters, same limits as the
+        # string spelling of the same activation
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), 9.857, 0.0879, 0.99433, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6), 9.857, 0.1528, 0.97807, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU), 10.3894, 0.0997, 0.99272, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU), 10.1969, 0.0995, 0.99274, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH), 3.9426, 0.2803, 0.96072, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID), 1.6864, 0.1563, 0.97458, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID), 1.6429, 0.1525, 0.9758, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH), 4.0, 0.3064, 0.95307, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU), 10.6898, 0.1013, 0.99308, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS), 9.857, 0.0982, 0.9929, False),
     ],
     ids=[
         "no_activation",
@@ -143,6 +195,10 @@ def find_max_subblock(out_block_h, out_block_w):
 def test_matmul_with_fused_activations(
     device,
     activation,
+    atol,
+    frobenius_threshold,
+    pcc_threshold,
+    evaluated_exactly,
     M,
     K,
     N,
@@ -233,45 +289,45 @@ def test_matmul_with_fused_activations(
     activation_fn = get_activation_golden_function(activation)
     pt_out = activation_fn(pt_matmul)
 
-    tolerances = matmul_numeric_tolerances(
-        pt_matmul,
-        fused_activation,
-        activation_fn,
-        K=K,
-        in0_dtype=dtype,
-        in1_dtype=dtype,
-        out_dtype=dtype,
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=packer_l1_acc,
-        k_tiles_per_block=in0_block_w,
-        # Both operands are bfloat16, so the reference product is rounded to
-        # bfloat16 as well.
-        reference_dtype=ttnn.bfloat16,
-    )
-
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
+        atol=atol,
+        rtol=_RTOL_BY_OUTPUT_FORMAT[(dtype, evaluated_exactly)],
+        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=pcc_threshold,
         check_ulp=False,
-        **tolerances,
     )
 
 
+# One shape, one data type and one packer_l1_acc setting here, so each row holds
+# the limits for exactly its own case with nothing folded in. rtol is 0.0045 for
+# the two clamps and 0.0358 for the two fitted polynomials, matching
+# _RTOL_BY_OUTPUT_FORMAT for a bfloat16 output.
 @pytest.mark.parametrize(
-    "activation",
+    "activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [
-        # Test activations with custom parameters
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 3.0),  # Custom max=3.0
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0),  # Custom min/max
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1),  # Custom alpha/lambda
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0),  # Custom beta/threshold
+        # activation with its custom parameters             atol     rtol     frob      pcc
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 3.0), 3.7732, 0.0046, 0.1338, 0.98297),  # Custom max=3.0
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 3.7732, 0.0046, 0.1608, 0.98708),  # Custom min/max
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1), 4.3585, 0.0358, 0.0862, 0.99518),  # Custom alpha/lambda
+        (
+            ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0),
+            3.7732,
+            0.0358,
+            0.0831,
+            0.99489,
+        ),  # Custom beta/threshold
     ],
     ids=["relu6_custom", "hardtanh_custom", "selu_custom", "softplus_custom"],
 )
 def test_matmul_with_custom_activation_params(
     device,
     activation,
+    atol,
+    rtol,
+    frobenius_threshold,
+    pcc_threshold,
     function_level_defaults,
 ):
     """Test matmul with activations using custom parameters."""
@@ -336,26 +392,14 @@ def test_matmul_with_custom_activation_params(
     activation_fn = functools.partial(apply_activation_to_reference, activation=activation)
     pt_out = activation_fn(pt_matmul)
 
-    tolerances = matmul_numeric_tolerances(
-        pt_matmul,
-        activation,
-        activation_fn,
-        K=K,
-        in0_dtype=ttnn.bfloat16,
-        in1_dtype=ttnn.bfloat16,
-        out_dtype=ttnn.bfloat16,
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-        k_tiles_per_block=in0_block_w,
-        reference_dtype=ttnn.bfloat16,
-    )
-
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
+        atol=atol,
+        rtol=rtol,
+        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=pcc_threshold,
         check_ulp=False,
-        **tolerances,
     )
 
 
@@ -367,15 +411,28 @@ def test_matmul_with_custom_activation_params(
     ],
     ids=["1d_multicast", "2d_multicast"],
 )
+# Folded over the 1D and 2D grid configs, which differ only in how many K tiles a
+# block covers (1 against 2) and so move the limits by at most 1.01x.
 @pytest.mark.parametrize(
-    "activation",
-    ["relu", "gelu", "sigmoid", "hardtanh", "softplus"],
+    "activation, atol, rtol, frobenius_threshold, pcc_threshold",
+    [
+        # activation      atol     rtol     frob      pcc
+        ("relu", 5.9798, 0.0046, 0.076, 0.99576),
+        ("gelu", 6.3191, 0.0358, 0.0843, 0.99479),
+        ("sigmoid", 1.2673, 0.0358, 0.1185, 0.9851),
+        ("hardtanh", 4.0, 0.0046, 0.2471, 0.96947),
+        ("softplus", 5.9798, 0.0358, 0.0825, 0.99498),
+    ],
     ids=["relu", "gelu", "sigmoid", "hardtanh", "softplus"],
 )
 def test_activation_with_different_program_configs(
     device,
     grid_config,
     activation,
+    atol,
+    rtol,
+    frobenius_threshold,
+    pcc_threshold,
     function_level_defaults,
 ):
     """Test activations work with different program configurations."""
@@ -465,26 +522,14 @@ def test_activation_with_different_program_configs(
     activation_fn = get_activation_golden_function(activation)
     pt_out = activation_fn(pt_matmul)
 
-    tolerances = matmul_numeric_tolerances(
-        pt_matmul,
-        fused_activation,
-        activation_fn,
-        K=K,
-        in0_dtype=ttnn.bfloat16,
-        in1_dtype=ttnn.bfloat16,
-        out_dtype=ttnn.bfloat16,
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-        k_tiles_per_block=in0_block_w,
-        reference_dtype=ttnn.bfloat16,
-    )
-
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
+        atol=atol,
+        rtol=rtol,
+        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=pcc_threshold,
         check_ulp=False,
-        **tolerances,
     )
 
 
@@ -615,6 +660,10 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
     in0_dtype,
     in1_dtype,
     out_dtype,
+    atol,
+    rtol,
+    frobenius_threshold,
+    pcc_threshold,
     function_level_defaults,
 ):
     torch.manual_seed(0)
@@ -734,51 +783,45 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
 
     tt_out = tt2torch_tensor(output_t)
 
-    tolerances = matmul_numeric_tolerances(
-        pt_pre_activation,
-        activation_param,
-        activation_fn,
-        K=K,
-        in0_dtype=in0_dtype,
-        in1_dtype=in1_dtype,
-        out_dtype=out_dtype,
-        math_fidelity=fidelity,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=packer_l1_acc,
-        # The program config is given a quarter of the per-core K width.
-        k_tiles_per_block=max(1, in0_block_w // 4),
-    )
-
     assert_numeric_metrics(
         pt_out,
         tt_out,
+        atol=atol,
+        rtol=rtol,
+        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=pcc_threshold,
         check_ulp=False,
-        **tolerances,
     )
 
 
 @pytest.mark.parametrize("fidelity", [ttnn.MathFidelity.LoFi], ids=["LoFi"])
 @pytest.mark.parametrize("packer_l1_acc", [False, True], ids=["no_l1_acc", "l1_acc"])
 @pytest.mark.parametrize(
-    "has_bias, activation",
+    "has_bias, activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [
+        # Limits folded over the two shapes and both packer_l1_acc settings,
+        # widest spread 1.46x, on atol between K = 4096 and K = 8192. The 32 bit
+        # accumulator puts rtol at its floor everywhere except selu and softplus,
+        # which take their 16 bit polynomial branch whatever the accumulator is.
+        #
+        #                       atol     rtol     frob      pcc
         # Test bias alone
-        (True, None),
-        (False, None),
+        (True, None, 33.6096, 0.0046, 0.0769, 0.99704),
+        (False, None, 33.607, 0.0046, 0.0769, 0.99704),
         # Test activation alone
-        (False, "relu"),
-        (False, "gelu"),
-        (False, "sigmoid"),
+        (False, "relu", 33.607, 0.0046, 0.0768, 0.99566),
+        (False, "gelu", 33.9469, 0.0046, 0.0769, 0.99565),
+        (False, "sigmoid", 1.9992, 0.0046, 0.2126, 0.95478),
         # Test bias + activation combinations (main focus)
-        (True, "relu"),
-        (True, "gelu"),
-        (True, "sigmoid"),
-        (True, "hardtanh"),
-        (True, "selu"),
-        (True, "softplus"),
+        (True, "relu", 33.6096, 0.0046, 0.0769, 0.99566),
+        (True, "gelu", 33.9495, 0.0046, 0.077, 0.99565),
+        (True, "sigmoid", 1.9992, 0.0046, 0.2132, 0.95453),
+        (True, "hardtanh", 4.0, 0.0046, 0.3372, 0.94316),
+        (True, "selu", 35.6466, 0.0358, 0.0853, 0.99481),
+        (True, "softplus", 33.6096, 0.0358, 0.0845, 0.99476),
         # Test with UnaryWithParam
-        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 6.0)),
-        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0)),
+        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 6.0), 12.0, 0.0046, 0.211, 0.95665),
+        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0), 4.0, 0.0046, 0.3372, 0.94316),
     ],
     ids=[
         "bias_only",
@@ -817,6 +860,10 @@ def test_matmul_dram_sharded_with_bias_and_activation(
     packer_l1_acc,
     has_bias,
     activation,
+    atol,
+    rtol,
+    frobenius_threshold,
+    pcc_threshold,
     grid_size,
     in0_dtype,
     in1_dtype,
@@ -840,28 +887,41 @@ def test_matmul_dram_sharded_with_bias_and_activation(
         in0_dtype=in0_dtype,
         in1_dtype=in1_dtype,
         out_dtype=out_dtype,
+        atol=atol,
+        rtol=rtol,
+        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=pcc_threshold,
         function_level_defaults=function_level_defaults,
     )
 
 
 @pytest.mark.parametrize(
-    "activation_combo",
+    "activation, fidelity, packer_l1_acc, atol, rtol, frobenius_threshold, pcc_threshold",
     [
+        # One shape and one setting each, so nothing is folded into these limits.
+        # HiFi2 makes the whole budget about three times smaller than LoFi, since
+        # it consumes the right hand operand's full mantissa instead of 4 of its
+        # 7 bits, which is why tanh reaches 0.992 here.
+        #
         # Special combinations to test edge cases
-        ("tanh", ttnn.MathFidelity.HiFi2, True),  # High precision with tanh
-        ("gelu", ttnn.MathFidelity.LoFi, False),  # Fast approximation with GELU
-        ("sigmoid", ttnn.MathFidelity.LoFi, True),  # Sigmoid with L1 accumulation
+        ("tanh", ttnn.MathFidelity.HiFi2, True, 3.5315, 0.0046, 0.1249, 0.99221),  # High precision with tanh
+        ("gelu", ttnn.MathFidelity.LoFi, False, 16.777, 0.0046, 0.0767, 0.9957),  # Fast approximation with GELU
+        ("sigmoid", ttnn.MathFidelity.LoFi, True, 1.9354, 0.0046, 0.1738, 0.96931),  # Sigmoid with L1 accumulation
     ],
     ids=["tanh_hifi", "gelu_lofi", "sigmoid_l1acc"],
 )
 def test_special_activation_combinations(
     device,
-    activation_combo,
+    activation,
+    fidelity,
+    packer_l1_acc,
+    atol,
+    rtol,
+    frobenius_threshold,
+    pcc_threshold,
     function_level_defaults,
 ):
     """Test specific activation combinations with different settings."""
-    activation, fidelity, packer_l1_acc = activation_combo
-
     # Fixed test parameters
     M, K, N = 32, 2048, 1024
     grid_size = (8, 1)
@@ -883,31 +943,57 @@ def test_special_activation_combinations(
         in0_dtype=ttnn.bfloat16,
         in1_dtype=ttnn.bfloat8_b,
         out_dtype=ttnn.bfloat16,
+        atol=atol,
+        rtol=rtol,
+        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=pcc_threshold,
         function_level_defaults=function_level_defaults,
     )
 
 
+# Limits folded over the three shapes. The inputs here are scaled by 0.1, so the
+# products are a hundredth the size of the other tests' and every absolute limit
+# scales with them.
+#
+# gelu_fast and tanh_fast replace the fitted polynomial with a handful of straight
+# line segments, whose error is absolute and so does not shrink with the output.
+# At this input scale that error is the whole budget, which is why their limits
+# are an order of magnitude looser than accurate gelu's and tanh's. gelu_fast is
+# the one entry in this file whose fold exceeds 2x (its pcc runs 0.856 at K = 2048
+# to 0.931 at K = 4096, a 2.08x spread in the distance from 1); it is left folded
+# because the spread comes entirely from the segment error bound, the single
+# quantity in the budget that is estimated rather than derived, so splitting it
+# would give false precision.
 @pytest.mark.parametrize(
-    "activation",
+    "activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [
-        None,
-        "relu",
-        "relu6",
-        "silu",
-        "gelu",
-        "tanh",
-        "sigmoid",
-        "hardsigmoid",
-        "hardtanh",
-        "selu",
-        "softplus",
+        #                                              atol     rtol     frob      pcc
+        (None, 0.2897, 0.0046, 0.0958, 0.99541),
+        ("relu", 0.2897, 0.0046, 0.0948, 0.99341),
+        ("relu6", 0.2897, 0.0046, 0.0948, 0.99341),
+        ("silu", 0.3186, 0.0358, 0.1042, 0.99416),
+        ("gelu", 0.3269, 0.0358, 0.1051, 0.99367),
+        ("tanh", 0.2892, 0.0358, 0.1050, 0.99449),
+        ("sigmoid", 0.0724, 0.0358, 0.0449, 0.98184),
+        ("hardsigmoid", 0.0483, 0.0358, 0.0410, 0.96747),
+        ("hardtanh", 0.2897, 0.0046, 0.1002, 0.99498),
+        ("selu", 0.4741, 0.0358, 0.1039, 0.99458),
+        ("softplus", 0.2736, 0.0358, 0.0533, 0.98921),
         # Test with UnaryWithParam objects with parameters
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, 1.0),  # fast_and_approximate mode
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH, 1.0),  # fast_and_approximate mode
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID, 1.0),  # fast_and_approximate mode
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0),  # Custom min/max
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2),  # Custom alpha/lambda
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0),  # Custom beta/threshold
+        # fast_and_approximate mode
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, 1.0), 0.5869, 0.0046, 0.5131, 0.85621),
+        # fast_and_approximate mode
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH, 1.0), 0.5892, 0.0046, 0.3976, 0.92096),
+        # The first parameter of sigmoid is the vector mode, not the
+        # fast_and_approximate flag, which is the second one, so this case runs
+        # the accurate sigmoid and carries the same limits as it.
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID, 1.0), 0.0724, 0.0358, 0.0449, 0.98184),
+        # Custom min/max
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 0.2897, 0.0046, 0.0959, 0.99541),
+        # Custom alpha/lambda
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2), 0.4854, 0.0358, 0.1037, 0.99462),
+        # Custom beta/threshold
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0), 0.2887, 0.0358, 0.0716, 0.99326),
     ],
     ids=[
         "no_activation",
@@ -946,6 +1032,10 @@ def test_special_activation_combinations(
 def test_matmul_1d_gather_with_activations(
     device,
     activation,
+    atol,
+    rtol,
+    frobenius_threshold,
+    pcc_threshold,
     M,
     K,
     N,
@@ -1026,27 +1116,16 @@ def test_matmul_1d_gather_with_activations(
     activation_fn = functools.partial(apply_activation_to_reference, activation=activation_param)
     reference = activation_fn(pt_pre_activation)
 
-    tolerances = matmul_numeric_tolerances(
-        pt_pre_activation,
-        activation_param,
-        activation_fn,
-        K=K,
-        in0_dtype=in0_dtype,
-        in1_dtype=in1_dtype,
-        out_dtype=out_dtype,
-        # No compute kernel config is passed, so the op's own defaults apply:
-        # LoFi because a program config was supplied, a 16 bit accumulator
-        # because the output is not float32, and accumulation in memory for the
-        # same reason.
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=out_dtype != ttnn.float32,
-        k_tiles_per_block=2,
-    )
-
+    # No compute kernel config is passed, so the limits above were derived from
+    # the op's own defaults: LoFi because a program config was supplied, a 16 bit
+    # accumulator because the output is not float32, and accumulation in memory
+    # for the same reason.
     assert_numeric_metrics(
         reference,
         output,
+        atol=atol,
+        rtol=rtol,
+        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=pcc_threshold,
         check_ulp=False,
-        **tolerances,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -15,19 +15,10 @@ import torch
 import torch.nn.functional as F
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
-# Every tolerance in this file is a literal, predicted from the number formats on
-# the device path rather than observed. numeric_tolerances.py in this directory
-# records the error budget the literals come from and how each one is arrived at;
-# nothing imports it, so re-derive the tables from it by hand if a test's shapes,
-# seeds or activations change.
-#
-# The shape of the answer, from that budget: the relative error of a matmul does
-# not grow with K. Each product carries a fractional slip from the mantissa bits
-# the multiplier discards, those slips multiply values of random sign, so the
-# error grows as sqrt(K) and so does the result. They cancel. At LoFi the
-# multiplier keeps only 4 of the 7 mantissa bits of the right hand operand, a 2.6
-# percent relative error that dominates every other term, which is why the limits
-# below barely move with K or with the data type.
+# Tolerances in this file are hard coded, derived based on the number formats used.
+# numeric_tolerances.py records the error budget the hard coded values came from
+# and how each one was derived.
+
 
 # rtol carries only what scales with an element's own value: the rounding into the
 # output format, doubled for the safety factor, plus two units in the last place

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -4,10 +4,16 @@
 
 """Extended matmul tests with all supported fused activations."""
 
+import functools
+
 import pytest
 from loguru import logger
 import ttnn
 from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul, ttnn_linear
+from tests.ttnn.nightly.unit_tests.operations.matmul.numeric_tolerances import (
+    activation_params,
+    matmul_numeric_tolerances,
+)
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
 import torch
 import torch.nn.functional as F
@@ -30,7 +36,6 @@ def get_activation_golden_function(activation):
         "hardtanh": F.hardtanh,
         "selu": F.selu,
         "softplus": F.softplus,
-        "mish": F.mish,
     }
 
     if isinstance(activation, str):
@@ -186,7 +191,6 @@ def test_matmul_with_fused_activations(
             "hardtanh": ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH),
             "selu": ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU),
             "softplus": ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS),
-            "mish": ttnn.UnaryWithParam(ttnn.UnaryOpType.MISH),
         }
         fused_activation = activation_map.get(activation, None)
     else:
@@ -225,29 +229,32 @@ def test_matmul_with_fused_activations(
     tt_out = tt2torch_tensor(output_t)
 
     # Compute golden reference
-    pt_out = in0 @ in1
+    pt_matmul = in0 @ in1
     activation_fn = get_activation_golden_function(activation)
-    pt_out = activation_fn(pt_out)
+    pt_out = activation_fn(pt_matmul)
 
-    if dtype == ttnn.bfloat8_b:
-        atol = 0.05 * K
-        rtol = 15.0 * K
-    else:
-        atol = 0.02 * K
-        rtol = 10.0 * K
-
-    if activation in ["selu", "softplus", "mish", "gelu"]:
-        atol *= 2
-        rtol *= 2
+    tolerances = matmul_numeric_tolerances(
+        pt_matmul,
+        fused_activation,
+        activation_fn,
+        K=K,
+        in0_dtype=dtype,
+        in1_dtype=dtype,
+        out_dtype=dtype,
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=packer_l1_acc,
+        k_tiles_per_block=in0_block_w,
+        # Both operands are bfloat16, so the reference product is rounded to
+        # bfloat16 as well.
+        reference_dtype=ttnn.bfloat16,
+    )
 
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
-        atol=atol,
-        rtol=rtol,
-        frobenius_threshold=0.01 * K,
-        pcc_threshold=0.98,
         check_ulp=False,
+        **tolerances,
     )
 
 
@@ -288,10 +295,12 @@ def test_matmul_with_custom_activation_params(
     grid_size = (max_cores, 1)
     num_cores = grid_size[0]
 
+    in0_block_w = K // num_cores // 32
+
     # activation is already UnaryWithParam in this test, no conversion needed
     program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=ttnn.CoreCoord(grid_size[0], grid_size[1]),
-        in0_block_w=K // num_cores // 32,  # K/num_cores/32
+        in0_block_w=in0_block_w,
         out_subblock_h=1,
         out_subblock_w=1,
         per_core_M=M // 32,  # M/32
@@ -321,35 +330,32 @@ def test_matmul_with_custom_activation_params(
     # Get TT output
     tt_out = tt2torch_tensor(output_t)
 
-    # Compute golden reference with custom parameters
-    pt_out = in0 @ in1
+    # Compute golden reference, taking the activation parameters from the same
+    # object the device was given so the two cannot drift apart.
+    pt_matmul = in0 @ in1
+    activation_fn = functools.partial(apply_activation_to_reference, activation=activation)
+    pt_out = activation_fn(pt_matmul)
 
-    # Apply custom activation based on type
-    # Map the test parameters to the golden functions
-    # Note: We hardcode the params here since we know what we're testing
-    if activation.op_type == ttnn.UnaryOpType.RELU6:
-        # Test uses 3.0 as max value
-        pt_out = torch.clamp(pt_out, min=0, max=3.0)
-    elif activation.op_type == ttnn.UnaryOpType.HARDTANH:
-        # Test uses -2.0, 2.0 as min/max
-        pt_out = F.hardtanh(pt_out, -2.0, 2.0)
-    elif activation.op_type == ttnn.UnaryOpType.SELU:
-        # Test uses alpha=1.5, lambda=1.1
-        # SELU formula: lambda * (max(0,x) + min(0, alpha * (exp(x) - 1)))
-        alpha, lambd = 1.5, 1.1
-        pt_out = lambd * torch.where(pt_out > 0, pt_out, alpha * (torch.exp(pt_out) - 1))
-    elif activation.op_type == ttnn.UnaryOpType.SOFTPLUS:
-        # Test uses beta=2.0, threshold=10.0
-        pt_out = F.softplus(pt_out, beta=2.0, threshold=10.0)
+    tolerances = matmul_numeric_tolerances(
+        pt_matmul,
+        activation,
+        activation_fn,
+        K=K,
+        in0_dtype=ttnn.bfloat16,
+        in1_dtype=ttnn.bfloat16,
+        out_dtype=ttnn.bfloat16,
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+        k_tiles_per_block=in0_block_w,
+        reference_dtype=ttnn.bfloat16,
+    )
 
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
-        atol=0.05 * K,
-        rtol=15.0 * K,
-        frobenius_threshold=0.02 * K,
-        pcc_threshold=0.95,
         check_ulp=False,
+        **tolerances,
     )
 
 
@@ -405,10 +411,11 @@ def test_activation_with_different_program_configs(
         num_cores = grid_size[0]
         per_core_N = N // num_cores // 32
         out_subblock_w = min(2, per_core_N) if per_core_N > 0 else 1
+        in0_block_w = K // num_cores // 32
 
         program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(grid_size[0], grid_size[1]),
-            in0_block_w=K // num_cores // 32,
+            in0_block_w=in0_block_w,
             out_subblock_h=1,
             out_subblock_w=out_subblock_w,
             per_core_M=M // 32,
@@ -421,10 +428,11 @@ def test_activation_with_different_program_configs(
         # 2D multicast configuration
         per_core_N = N // grid_size[0] // 32
         out_subblock_w = min(2, per_core_N) if per_core_N > 0 else 1
+        in0_block_w = K // grid_size[0] // 32
 
         program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(grid_size[0], grid_size[1]),
-            in0_block_w=K // grid_size[0] // 32,
+            in0_block_w=in0_block_w,
             out_subblock_h=1,
             out_subblock_w=out_subblock_w,
             per_core_M=M // grid_size[1] // 32,
@@ -453,18 +461,30 @@ def test_activation_with_different_program_configs(
     tt_out = tt2torch_tensor(output_t)
 
     # Golden reference
-    pt_out = in0 @ in1
+    pt_matmul = in0 @ in1
     activation_fn = get_activation_golden_function(activation)
-    pt_out = activation_fn(pt_out)
+    pt_out = activation_fn(pt_matmul)
+
+    tolerances = matmul_numeric_tolerances(
+        pt_matmul,
+        fused_activation,
+        activation_fn,
+        K=K,
+        in0_dtype=ttnn.bfloat16,
+        in1_dtype=ttnn.bfloat16,
+        out_dtype=ttnn.bfloat16,
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+        k_tiles_per_block=in0_block_w,
+        reference_dtype=ttnn.bfloat16,
+    )
 
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
-        atol=0.03 * K,
-        rtol=12.0 * K,
-        frobenius_threshold=0.01 * K,
-        pcc_threshold=0.97,
         check_ulp=False,
+        **tolerances,
     )
 
 
@@ -521,26 +541,25 @@ def convert_activation_to_unary_param(activation):
 
 
 def apply_activation_to_reference(tensor, activation):
-    """Apply activation function to reference tensor for comparison."""
+    """Apply an activation to a reference tensor, honouring its parameters.
+
+    The reference is always the true mathematical function. Some activations
+    accept a flag that makes the device evaluate them with a coarse piecewise
+    linear table instead of a fitted polynomial, but that changes only how
+    accurately the function is computed, not which function is intended, so it
+    belongs in the tolerance rather than in the reference.
+    """
     if activation is None:
         return tensor
 
-    # Handle UnaryWithParam or UnaryOpType
-    if isinstance(activation, ttnn.UnaryWithParam):
-        op_type = activation.op_type
-        params = activation.get_params() if hasattr(activation, "get_params") else []
-    elif isinstance(activation, str):
-        # Convert string to UnaryWithParam first
+    if isinstance(activation, str):
         activation = convert_activation_to_unary_param(activation)
         if activation is None:
             return tensor
-        op_type = activation.op_type
-        params = activation.get_params() if hasattr(activation, "get_params") else []
-    else:
-        op_type = activation
-        params = []
 
-    # Apply activation based on type
+    op_type = getattr(activation, "op_type", activation)
+    params = activation_params(activation)
+
     if op_type == ttnn.UnaryOpType.RELU:
         return torch.nn.functional.relu(tensor)
     elif op_type == ttnn.UnaryOpType.RELU6:
@@ -549,23 +568,13 @@ def apply_activation_to_reference(tensor, activation):
     elif op_type == ttnn.UnaryOpType.SILU:
         return torch.nn.functional.silu(tensor)
     elif op_type == ttnn.UnaryOpType.GELU:
-        fast_mode = bool(params[0]) if params else False
-        return torch.nn.functional.gelu(tensor, approximate="tanh" if fast_mode else "none")
+        return torch.nn.functional.gelu(tensor)
+    elif op_type == ttnn.UnaryOpType.GELU_TANH:
+        return torch.nn.functional.gelu(tensor, approximate="tanh")
     elif op_type == ttnn.UnaryOpType.TANH:
-        fast_mode = bool(params[0]) if params else False
-        if fast_mode:
-            # Fast tanh approximation using clipped linear region
-            x = torch.clamp(tensor, min=-3.0, max=3.0)
-            return x * (27.0 + x * x) / (27.0 + 9.0 * x * x)
-        else:
-            return torch.tanh(tensor)
+        return torch.tanh(tensor)
     elif op_type == ttnn.UnaryOpType.SIGMOID:
-        fast_mode = bool(params[0]) if params else False
-        if fast_mode:
-            # Fast sigmoid approximation: tanh(x/2)/2 + 0.5
-            return torch.tanh(tensor * 0.5) * 0.5 + 0.5
-        else:
-            return torch.sigmoid(tensor)
+        return torch.sigmoid(tensor)
     elif op_type == ttnn.UnaryOpType.HARDSIGMOID:
         return torch.nn.functional.hardsigmoid(tensor)
     elif op_type == ttnn.UnaryOpType.HARDTANH:
@@ -573,7 +582,15 @@ def apply_activation_to_reference(tensor, activation):
         max_val = params[1] if len(params) > 1 else 1.0
         return torch.nn.functional.hardtanh(tensor, min_val=min_val, max_val=max_val)
     elif op_type == ttnn.UnaryOpType.SELU:
-        return torch.nn.functional.selu(tensor)
+        # The fused activation interface documents the first parameter as alpha
+        # and the second as the scale, so the reference reads them in that
+        # order. With no parameters the standard SELU constants apply. SELU is
+        # scale * (max(0, x) + min(0, alpha * (exp(x) - 1))).
+        if not params:
+            return torch.nn.functional.selu(tensor)
+        alpha = params[0]
+        scale = params[1] if len(params) > 1 else 1.0507009873554805
+        return scale * torch.where(tensor > 0, tensor, alpha * (torch.exp(tensor) - 1.0))
     elif op_type == ttnn.UnaryOpType.SOFTPLUS:
         beta = params[0] if params else 1.0
         threshold = params[1] if len(params) > 1 else 20.0
@@ -709,83 +726,34 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
     output_t = ttnn.sharded_to_interleaved(output_t, interleaved_mem_config)
 
     # Compute golden reference
-    pt_out = in0 @ in1
-    if has_bias:
-        pt_out += bias
+    pt_matmul = in0 @ in1
+    pt_pre_activation = (pt_matmul + bias) if has_bias else pt_matmul
 
-    # Apply activation
-    activation_fn = get_activation_golden_function(activation)
-    pt_out = activation_fn(pt_out)
+    activation_fn = functools.partial(apply_activation_to_reference, activation=activation_param)
+    pt_out = activation_fn(pt_pre_activation)
 
     tt_out = tt2torch_tensor(output_t)
 
-    # Determine tolerances and PCC threshold based on activation type and math fidelity
-    # Get activation name for comparison
-    activation_name = activation
-    if isinstance(activation, ttnn.UnaryWithParam):
-        # Map UnaryWithParam to string name for tolerance selection
-        op_type_to_name = {
-            ttnn.UnaryOpType.SIGMOID: "sigmoid",
-            ttnn.UnaryOpType.HARDSIGMOID: "hardsigmoid",
-            ttnn.UnaryOpType.HARDTANH: "hardtanh",
-            ttnn.UnaryOpType.SELU: "selu",
-            ttnn.UnaryOpType.SOFTPLUS: "softplus",
-            ttnn.UnaryOpType.RELU6: "relu6",
-            ttnn.UnaryOpType.TANH: "tanh",
-        }
-        activation_name = op_type_to_name.get(activation.op_type, "other")
+    tolerances = matmul_numeric_tolerances(
+        pt_pre_activation,
+        activation_param,
+        activation_fn,
+        K=K,
+        in0_dtype=in0_dtype,
+        in1_dtype=in1_dtype,
+        out_dtype=out_dtype,
+        math_fidelity=fidelity,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=packer_l1_acc,
+        # The program config is given a quarter of the per-core K width.
+        k_tiles_per_block=max(1, in0_block_w // 4),
+    )
 
-    # Set tolerances and PCC threshold based on activation type and math fidelity
-    if fidelity == ttnn.MathFidelity.LoFi:
-        if activation_name in ["sigmoid", "hardsigmoid", "hardtanh"]:
-            # These activations have lower accuracy with LoFi math
-            atol = 0.01 * K
-            rtol = 3.0 * K
-            pcc_threshold = 0.99
-        elif activation_name in ["relu6", "tanh", "selu", "softplus"]:
-            # Relaxed tolerances
-            atol = 0.008 * K
-            rtol = 2.5 * K
-            pcc_threshold = 0.994
-        elif activation is not None:
-            # Standard tolerances for other activations
-            atol = 0.005 * K
-            rtol = 2.0 * K
-            pcc_threshold = 0.998
-        else:
-            # No activation - tighter tolerances
-            atol = 0.002 * K
-            rtol = 1.062 * K
-            pcc_threshold = 0.999
-    else:
-        # HiFi math - use appropriate thresholds
-        if activation_name in ["tanh"]:
-            # Tanh with HiFi2 still has slightly lower accuracy
-            atol = 0.008 * K
-            rtol = 2.5 * K
-            pcc_threshold = 0.993
-        elif activation_name in ["sigmoid", "hardsigmoid", "hardtanh"]:
-            atol = 0.007 * K
-            rtol = 2.0 * K
-            pcc_threshold = 0.995
-        elif activation is not None:
-            atol = 0.005 * K
-            rtol = 1.5 * K
-            pcc_threshold = 0.998
-        else:
-            atol = 0.002 * K
-            rtol = 1.062 * K
-            pcc_threshold = 0.9999
-
-    # Use assert_numeric_metrics with appropriate PCC threshold
     assert_numeric_metrics(
         pt_out,
         tt_out,
-        atol=atol,
-        rtol=rtol,
-        frobenius_threshold=0.001 * K,
-        pcc_threshold=pcc_threshold,
         check_ulp=False,
+        **tolerances,
     )
 
 
@@ -1054,47 +1022,31 @@ def test_matmul_1d_gather_with_activations(
     output = ttnn.to_torch(output_ttnn)
 
     # Compute reference in PyTorch
-    reference = torch.matmul(in0, in1)
+    pt_pre_activation = torch.matmul(in0, in1)
+    activation_fn = functools.partial(apply_activation_to_reference, activation=activation_param)
+    reference = activation_fn(pt_pre_activation)
 
-    # Apply activation to reference
-    if activation_param is not None:
-        reference = apply_activation_to_reference(reference, activation_param)
+    tolerances = matmul_numeric_tolerances(
+        pt_pre_activation,
+        activation_param,
+        activation_fn,
+        K=K,
+        in0_dtype=in0_dtype,
+        in1_dtype=in1_dtype,
+        out_dtype=out_dtype,
+        # No compute kernel config is passed, so the op's own defaults apply:
+        # LoFi because a program config was supplied, a 16 bit accumulator
+        # because the output is not float32, and accumulation in memory for the
+        # same reason.
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=out_dtype != ttnn.float32,
+        k_tiles_per_block=2,
+    )
 
-    # Check if this is a fast approximation that has low accuracy
-    skip_low_accuracy_fast = False
-    if isinstance(activation_param, ttnn.UnaryWithParam):
-        # Check if using fast approximation based on activation type
-        if activation_param.op_type in [ttnn.UnaryOpType.SIGMOID, ttnn.UnaryOpType.TANH, ttnn.UnaryOpType.GELU]:
-            # Check for fast mode - the parameter might be passed as 1 or 1.0
-            try:
-                params = activation_param.get_params() if hasattr(activation_param, "get_params") else []
-                if not params:  # Try alternative method to get params
-                    # Activation was created with params, check the string representation
-                    if "params=[1" in str(activation_param):
-                        # Sigmoid fast approximation has very low accuracy
-                        if activation_param.op_type == ttnn.UnaryOpType.SIGMOID:
-                            skip_low_accuracy_fast = True
-                elif len(params) > 0 and (params[0] == 1.0 or params[0] == 1):
-                    # Sigmoid fast approximation has very low accuracy
-                    if activation_param.op_type == ttnn.UnaryOpType.SIGMOID:
-                        skip_low_accuracy_fast = True
-            except Exception:
-                # If params can't be accessed, check string representation
-                if "params=[1" in str(activation_param) and activation_param.op_type == ttnn.UnaryOpType.SIGMOID:
-                    skip_low_accuracy_fast = True
-
-    if skip_low_accuracy_fast:
-        pytest.skip(f"Skipping {activation} - fast approximation has accuracy below 0.9 PCC threshold")
-
-    # Compare results
-    pcc = ttnn.pearson_correlation_coefficient(output, reference)
-    pcc_threshold = 0.96
-
-    # lower threshold for other fast approximations
-    if isinstance(activation_param, ttnn.UnaryWithParam):
-        if activation_param.op_type in [ttnn.UnaryOpType.TANH, ttnn.UnaryOpType.GELU]:
-            if "params=[1" in str(activation_param):
-                pcc_threshold = 0.90  # lower threshold for fast approximations
-                logger.info(f"Using lower PCC threshold {pcc_threshold} for fast approximation")
-
-    assert pcc >= pcc_threshold, f"PCC {pcc:.4f} below threshold {pcc_threshold} for activation {activation}"
+    assert_numeric_metrics(
+        reference,
+        output,
+        check_ulp=False,
+        **tolerances,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -310,7 +310,7 @@ def test_matmul_with_fused_activations(
         # activation with its custom parameters             atol     rtol     frob      pcc
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 3.0), 3.7732, 0.0046, 0.1338, 0.98297),  # Custom max=3.0
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 3.7732, 0.0046, 0.1608, 0.98708),  # Custom min/max
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1), 4.3585, 0.0358, 0.0862, 0.99518),  # Custom alpha/lambda
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1), 5.6739, 0.0358, 0.0854, 0.99512),  # Custom scale/alpha
         (
             ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0),
             3.7732,
@@ -627,14 +627,14 @@ def apply_activation_to_reference(tensor, activation):
         max_val = params[1] if len(params) > 1 else 1.0
         return torch.nn.functional.hardtanh(tensor, min_val=min_val, max_val=max_val)
     elif op_type == ttnn.UnaryOpType.SELU:
-        # The fused activation interface documents the first parameter as alpha
-        # and the second as the scale, so the reference reads them in that
-        # order. With no parameters the standard SELU constants apply. SELU is
-        # scale * (max(0, x) + min(0, alpha * (exp(x) - 1))).
+        # The first parameter is the scale and the second is alpha, the order the
+        # kernel takes them in. With no parameters the standard SELU constants
+        # apply. SELU is scale * x for x >= 0, and scale * alpha * (exp(x) - 1)
+        # for x < 0.
         if not params:
             return torch.nn.functional.selu(tensor)
-        alpha = params[0]
-        scale = params[1] if len(params) > 1 else 1.0507009873554805
+        scale = params[0]
+        alpha = params[1] if len(params) > 1 else 1.6732632423543772
         return scale * torch.where(tensor > 0, tensor, alpha * (torch.exp(tensor) - 1.0))
     elif op_type == ttnn.UnaryOpType.SOFTPLUS:
         beta = params[0] if params else 1.0
@@ -990,8 +990,8 @@ def test_special_activation_combinations(
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID, 1.0), 0.0724, 0.0358, 0.0449, 0.98184),
         # Custom min/max
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 0.2897, 0.0046, 0.0959, 0.99541),
-        # Custom alpha/lambda
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2), 0.4854, 0.0358, 0.1037, 0.99462),
+        # Custom scale/alpha
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2), 0.4854, 0.0358, 0.1033, 0.99463),
         # Custom beta/threshold
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0), 0.2887, 0.0358, 0.0716, 0.99326),
     ],

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -90,8 +90,8 @@ def find_max_subblock(out_block_h, out_block_w):
     return best_h, best_w, max_product
 
 
-# Limits for each activation, folded over the two shapes, both data types and both
-# packer_l1_acc settings. Each is the most permissive value the budget gives over
+# One set of limits per activation, shared by the two shapes, both data types and
+# both packer_l1_acc settings. Each is the most permissive value the budget gives over
 # those cases, so no case is held tighter than predicted; the trailing comment
 # gives the full range, widest spread 1.88x. The last field says whether the
 # device evaluates the activation exactly, with comparison and selection only,
@@ -105,10 +105,10 @@ def find_max_subblock(out_block_h, out_block_w):
     "activation, atol, frobenius_threshold, pcc_threshold, evaluated_exactly",
     [
         # activation                atol      frob       pcc    exact      derived atol      frobenius            pcc
-        (None, 7.9688, 0.0724, 0.99901, True),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
+        (None, 7.9688, 0.0724, 0.99901, True),  # 4.23..7.97   0.0557..0.0724  0.99902..0.99942
         # String-based activations
-        ("relu", 7.9688, 0.0719, 0.99857, True),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
-        ("relu6", 7.9688, 0.1254, 0.99446, True),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
+        ("relu", 7.9688, 0.0719, 0.99857, True),  # 4.23..7.97   0.0557..0.0719  0.99858..0.99915
+        ("relu6", 7.9688, 0.1254, 0.99446, True),  # 4.23..7.97   0.0884..0.1254  0.99446..0.99734
         ("silu", 8.4736, 0.0857, 0.99798, False),  # 4.59..8.47   0.0664..0.0857  0.99798..0.99880
         ("gelu", 8.3088, 0.0856, 0.99798, False),  # 4.56..8.31   0.0663..0.0855  0.99799..0.99880
         ("tanh", 3.8539, 0.2356, 0.98959, False),  # 3.14..3.85   0.1696..0.2356  0.98959..0.99461
@@ -275,7 +275,7 @@ def test_matmul_with_fused_activations(
 
 
 # One shape, one data type and one packer_l1_acc setting here, so each row holds
-# the limits for exactly its own case with nothing folded in. rtol is 0.0045 for
+# the limits for exactly its own case, shared with nothing else. rtol is 0.0045 for
 # the two clamps and 0.0358 for the two fitted polynomials, matching
 # _RTOL_BY_OUTPUT_FORMAT for a bfloat16 output.
 @pytest.mark.parametrize(
@@ -776,7 +776,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
 @pytest.mark.parametrize(
     "has_bias, activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [
-        # Limits folded over the two shapes and both packer_l1_acc settings,
+        # Limits shared by the two shapes and both packer_l1_acc settings,
         # widest spread 1.46x, on atol between K = 4096 and K = 8192. The 32 bit
         # accumulator puts rtol at its floor everywhere except selu and softplus,
         # which take their 16 bit polynomial branch whatever the accumulator is.
@@ -877,7 +877,7 @@ def test_matmul_dram_sharded_with_bias_and_activation(
 @pytest.mark.parametrize(
     "activation, fidelity, packer_l1_acc, atol, rtol, frobenius_threshold, pcc_threshold",
     [
-        # One shape and one setting each, so nothing is folded into these limits.
+        # One shape and one setting each, so no row's limits are shared with another case.
         # HiFi2 makes the whole budget about three times smaller than LoFi, since
         # it consumes the right hand operand's full mantissa instead of 4 of its
         # 7 bits, which is why tanh reaches 0.992 here.
@@ -930,19 +930,26 @@ def test_special_activation_combinations(
     )
 
 
-# Limits folded over the three shapes. The inputs here are scaled by 0.1, so the
+# Limits shared by the three shapes. The inputs here are scaled by 0.1, so the
 # products are a hundredth the size of the other tests' and every absolute limit
 # scales with them.
 #
 # gelu_fast and tanh_fast replace the fitted polynomial with a handful of straight
-# line segments, whose error is absolute and so does not shrink with the output.
-# At this input scale that error is the whole budget, which is why their limits
-# are an order of magnitude looser than accurate gelu's and tanh's. gelu_fast is
-# the one entry in this file whose fold exceeds 2x (its pcc runs 0.947 at K = 2048
-# to 0.975 at K = 4096, a 2.11x spread in the distance from 1); it is left folded
-# because the spread comes entirely from the segment error bound, the single
-# quantity in the budget that is estimated rather than derived, so splitting it
-# would give false precision.
+# line segments, which miss the true function by a fixed absolute amount. Unlike
+# every other term in the budget, that segment error does not shrink when the
+# output does. At this input scale the output is small, so the segment error is
+# several times the matmul's own typical error, and it sets both tensor wide
+# limits: an order of magnitude looser here than for accurate gelu and tanh. atol
+# only doubles, because it is set by the worst single element rather than a
+# typical one, and there the matmul's own error is comparable.
+#
+# gelu_fast is the one entry in this file whose predictions spread more than 2x
+# across the shapes sharing a limit: its pcc runs 0.947 at K = 2048 to 0.975 at
+# K = 4096, a 2.11x spread in 1 - pcc. The three shapes still share
+# one limit, because that spread comes entirely from the segment error bound, the
+# single quantity in the budget measured from the implementation instead of worked
+# out from a format width or a written algorithm, so a PCC per shape would give
+# a false impression of precision.
 @pytest.mark.parametrize(
     "activation, atol, rtol, frobenius_threshold, pcc_threshold",
     [

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -795,6 +795,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
         (False, "relu", 33.607, 0.0046, 0.0768, 0.99566),
         (False, "gelu", 33.9469, 0.0046, 0.0769, 0.99565),
         (False, "sigmoid", 1.9992, 0.0046, 0.2126, 0.95478),
+        (False, "softplus", 33.607, 0.0358, 0.0844, 0.99476),
         # Test bias + activation combinations (main focus)
         (True, "relu", 33.6096, 0.0046, 0.0769, 0.99566),
         (True, "gelu", 33.9495, 0.0046, 0.077, 0.99565),
@@ -812,6 +813,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
         "relu_only",
         "gelu_only",
         "sigmoid_only",
+        "softplus_only",
         "bias_relu",
         "bias_gelu",
         "bias_sigmoid",

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -967,10 +967,15 @@ def test_special_activation_combinations(
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, 1.0), 0.5869, 0.0046, 0.5131, 0.85621),
         # fast_and_approximate mode
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH, 1.0), 0.5892, 0.0046, 0.3976, 0.92096),
-        # The first parameter of sigmoid is the vector mode, not the
-        # fast_and_approximate flag, which is the second one, so this case runs
-        # the accurate sigmoid and carries the same limits as it.
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID, 1.0), 0.0724, 0.0358, 0.0449, 0.98184),
+        # There is no fast sigmoid case here. sigmoid numbers its parameters
+        # differently from gelu and tanh: the first is the vector mode and the
+        # second is the fast_and_approximate flag, so reaching the table takes
+        # (4.0, 1.0). It is left out because it cannot be checked meaningfully at
+        # this input scale. The inputs are scaled by 0.1, which keeps 97 percent
+        # of them inside |x| < 1 where sigmoid is nearly linear, so its output
+        # spans only about 0.11 in standard deviation while the table's error
+        # bound is an absolute 0.13. The limit would have to admit an error
+        # larger than the signal, which no longer tests anything.
         # Custom min/max
         (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 0.2897, 0.0046, 0.0959, 0.99541),
         # Custom scale/alpha
@@ -992,7 +997,6 @@ def test_special_activation_combinations(
         "softplus_str",
         "gelu_fast",
         "tanh_fast",
-        "sigmoid_fast",
         "hardtanh_custom",
         "selu_custom",
         "softplus_custom",

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -4,8 +4,6 @@
 
 """Extended matmul tests with all supported fused activations."""
 
-import functools
-
 import pytest
 from loguru import logger
 import ttnn
@@ -19,17 +17,24 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 # numeric_tolerances.py records the error budget the hard coded values came from
 # and how each one was derived.
 
-
-# rtol carries only what scales with an element's own value: the rounding into the
-# output format, doubled for the safety factor, plus two units in the last place
-# when the activation is a fitted polynomial rather than a clamp the device
-# evaluates exactly. Everything else in a matmul's error is proportional to the
-# size of the whole dot product, not to the element, so atol carries it.
-_RTOL_BY_OUTPUT_FORMAT = {
-    (ttnn.bfloat16, True): 0.0046,
-    (ttnn.bfloat16, False): 0.0358,
-    (ttnn.bfloat8_b, True): 0.0181,
-    (ttnn.bfloat8_b, False): 0.0493,
+# rtol is multiplied by each element's reference value, so it carries only what
+# scales with that value: the rounding into the output format, doubled for the
+# safety factor, plus two units in the last place of the accumulator when the
+# activation is evaluated in the accumulator as a fitted polynomial.
+# Each key pair consists of the output format with activation_adds_ulps; the
+# flag that is True when the activation is a fitted polynomial evaluated in
+# a 16 bit accumulator, so fp32_dest_acc_en makes it False for most activations.
+# Softplus is the exception, because its kernel picks its polynomial on a
+# compile time macro that only the standalone eltwise op defines, so a fused
+# softplus takes the 16 bit branch whatever the accumulator is. The flag is also
+# False for relu, relu6 and hardtanh, which need only comparison and selection,
+# and for gelu, tanh or sigmoid with the piecewise linear flag set, whose error
+# is absolute and so lands in atol.
+_RTOL_BY_FORMAT_AND_ACTIVATION = {
+    (ttnn.bfloat16, False): 0.0046,
+    (ttnn.bfloat16, True): 0.0358,
+    (ttnn.bfloat8_b, False): 0.0181,
+    (ttnn.bfloat8_b, True): 0.0493,
 }
 
 
@@ -90,45 +95,43 @@ def find_max_subblock(out_block_h, out_block_w):
     return best_h, best_w, max_product
 
 
-# One set of limits per activation, shared by the two shapes, both data types and
-# both packer_l1_acc settings. Each is the most permissive value the budget gives over
-# those cases, so no case is held tighter than predicted; the trailing comment
-# gives the full range, widest spread 1.88x. The last field says whether the
-# device evaluates the activation exactly, with comparison and selection only,
-# rather than with a fitted polynomial, which is what picks rtol out of
-# _RTOL_BY_OUTPUT_FORMAT.
+# One set of limits per activation, shared by both shapes in the M, K, N table
+# below, both data types and both packer_l1_acc settings. Each is the most
+# permissive value the budget gives over those cases (the trailing comment gives
+# the full range). The last field is activation_adds_ulps, which picks rtol out
+# of _RTOL_BY_FORMAT_AND_ACTIVATION; see that dictionary for details.
 #
-# atol for an activation that saturates is set by that activation's own output
-# range rather than by K, which is why hardtanh sits at 4.0 and the unbounded
-# activations near 10.
+# atol is an absolute limit, so it tracks the spread of the dot product, which
+# grows as sqrt(K); the data type affects it as well. Dependence on M and N is
+# logarithmic, so they barely move it.
 @pytest.mark.parametrize(
-    "activation, atol, frobenius_threshold, pcc_threshold, evaluated_exactly",
+    "activation, atol, frobenius_threshold, pcc_threshold, activation_adds_ulps",
     [
-        # activation                atol      frob       pcc    exact      derived atol      frobenius            pcc
-        (None, 7.9688, 0.0724, 0.99901, True),  # 4.23..7.97   0.0557..0.0724  0.99902..0.99942
+        # activation                atol      frob       pcc    adds       derived atol      frobenius            pcc
+        (None, 7.9688, 0.0724, 0.99901, False),  # 4.23..7.97   0.0557..0.0724  0.99902..0.99942
         # String-based activations
-        ("relu", 7.9688, 0.0719, 0.99857, True),  # 4.23..7.97   0.0557..0.0719  0.99858..0.99915
-        ("relu6", 7.9688, 0.1254, 0.99446, True),  # 4.23..7.97   0.0884..0.1254  0.99446..0.99734
-        ("silu", 8.4736, 0.0857, 0.99798, False),  # 4.59..8.47   0.0664..0.0857  0.99798..0.99880
-        ("gelu", 8.3088, 0.0856, 0.99798, False),  # 4.56..8.31   0.0663..0.0855  0.99799..0.99880
-        ("tanh", 3.8539, 0.2356, 0.98959, False),  # 3.14..3.85   0.1696..0.2356  0.98959..0.99461
-        ("sigmoid", 1.52, 0.1308, 0.99332, False),  # 0.97..1.52   0.0914..0.1307  0.99333..0.99672
-        ("hardsigmoid", 1.3282, 0.1279, 0.99361, False),  # 0.71..1.33   0.0893..0.1279  0.99362..0.99686
-        ("hardtanh", 4.0, 0.2594, 0.98739, True),  # 4.00..4.00   0.1912..0.2593  0.98739..0.99315
-        ("selu", 8.7059, 0.0867, 0.99808, False),  # 4.78..8.71   0.0676..0.0866  0.99809..0.99888
-        ("softplus", 7.9688, 0.0846, 0.99802, False),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
+        ("relu", 7.9688, 0.0719, 0.99857, False),  # 4.23..7.97   0.0557..0.0719  0.99858..0.99915
+        ("relu6", 7.9688, 0.1254, 0.99446, False),  # 4.23..7.97   0.0884..0.1254  0.99446..0.99734
+        ("silu", 8.4736, 0.0857, 0.99798, True),  # 4.59..8.47   0.0664..0.0857  0.99798..0.99880
+        ("gelu", 8.3088, 0.0856, 0.99798, True),  # 4.56..8.31   0.0663..0.0855  0.99799..0.99880
+        ("tanh", 3.8539, 0.2356, 0.98959, True),  # 3.14..3.85   0.1696..0.2356  0.98959..0.99461
+        ("sigmoid", 1.52, 0.1308, 0.99332, True),  # 0.97..1.52   0.0914..0.1307  0.99333..0.99672
+        ("hardsigmoid", 1.3282, 0.1279, 0.99361, True),  # 0.71..1.33   0.0893..0.1279  0.99362..0.99686
+        ("hardtanh", 4.0, 0.2594, 0.98739, False),  # 4.00..4.00   0.1912..0.2593  0.98739..0.99315
+        ("selu", 8.7059, 0.0867, 0.99808, True),  # 4.78..8.71   0.0676..0.0866  0.99809..0.99888
+        ("softplus", 7.9688, 0.0846, 0.99802, True),  # 4.23..7.97   0.0650..0.0845  0.99803..0.99884
         # UnaryWithParam versions with default parameters, same limits as the
         # string spelling of the same activation
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), 7.9688, 0.0719, 0.99857, True),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6), 7.9688, 0.1254, 0.99446, True),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU), 8.4736, 0.0857, 0.99798, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU), 8.3088, 0.0856, 0.99798, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH), 3.8539, 0.2356, 0.98959, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID), 1.52, 0.1308, 0.99332, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID), 1.3282, 0.1279, 0.99361, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH), 4.0, 0.2594, 0.98739, True),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU), 8.7059, 0.0867, 0.99808, False),
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS), 7.9688, 0.0846, 0.99802, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), 7.9688, 0.0719, 0.99857, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6), 7.9688, 0.1254, 0.99446, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU), 8.4736, 0.0857, 0.99798, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU), 8.3088, 0.0856, 0.99798, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH), 3.8539, 0.2356, 0.98959, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID), 1.52, 0.1308, 0.99332, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID), 1.3282, 0.1279, 0.99361, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH), 4.0, 0.2594, 0.98739, False),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU), 8.7059, 0.0867, 0.99808, True),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS), 7.9688, 0.0846, 0.99802, True),
     ],
     ids=[
         "no_activation",
@@ -172,7 +175,7 @@ def test_matmul_with_fused_activations(
     atol,
     frobenius_threshold,
     pcc_threshold,
-    evaluated_exactly,
+    activation_adds_ulps,
     M,
     K,
     N,
@@ -259,15 +262,15 @@ def test_matmul_with_fused_activations(
     tt_out = tt2torch_tensor(output_t)
 
     # Compute golden reference
-    pt_matmul = in0 @ in1
+    pt_out = in0 @ in1
     activation_fn = get_activation_golden_function(activation)
-    pt_out = activation_fn(pt_matmul)
+    pt_out = activation_fn(pt_out)
 
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
         atol=atol,
-        rtol=_RTOL_BY_OUTPUT_FORMAT[(dtype, evaluated_exactly)],
+        rtol=_RTOL_BY_FORMAT_AND_ACTIVATION[(dtype, activation_adds_ulps)],
         frobenius_threshold=frobenius_threshold,
         pcc_threshold=pcc_threshold,
         check_ulp=False,
@@ -275,20 +278,23 @@ def test_matmul_with_fused_activations(
 
 
 # One shape, one data type and one packer_l1_acc setting here, so each row holds
-# the limits for exactly its own case, shared with nothing else. rtol is 0.0045 for
-# the two clamps and 0.0358 for the two fitted polynomials, matching
-# _RTOL_BY_OUTPUT_FORMAT for a bfloat16 output.
+# the limits for exactly its own case, with no spread to summarize. rtol is not
+# in the row; the "adds" column picks it out of _RTOL_BY_FORMAT_AND_ACTIVATION:
+# - False for relu6 and hardtanh, which involve only comparison and selection, so
+#   they contribute no error beyond the rounding of the final result.
+# - True for selu and softplus, which are fitted curves, and this test leaves
+#   fp32_dest_acc_en off, so they are evaluated in a 16 bit accumulator.
 @pytest.mark.parametrize(
-    "activation, atol, rtol, frobenius_threshold, pcc_threshold",
+    "activation, atol, activation_adds_ulps, frobenius_threshold, pcc_threshold",
     [
-        # activation with its custom parameters             atol     rtol     frob      pcc
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 3.0), 2.7127, 0.0046, 0.0976, 0.9966),  # Custom max=3.0
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 2.7127, 0.0046, 0.1171, 0.99743),  # Custom min/max
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1), 4.0831, 0.0358, 0.0662, 0.9989),  # Custom scale/alpha
+        # activation with its custom parameters             atol     adds     frob      pcc
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 3.0), 2.7127, False, 0.0976, 0.9966),  # Custom max=3.0
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 2.7127, False, 0.1171, 0.99743),  # Custom min/max
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.1), 4.0831, True, 0.0662, 0.9989),  # Custom scale/alpha
         (
             ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0),
             2.7127,
-            0.0358,
+            True,
             0.0647,
             0.99883,
         ),  # Custom beta/threshold
@@ -299,7 +305,7 @@ def test_matmul_with_custom_activation_params(
     device,
     activation,
     atol,
-    rtol,
+    activation_adds_ulps,
     frobenius_threshold,
     pcc_threshold,
     function_level_defaults,
@@ -325,12 +331,10 @@ def test_matmul_with_custom_activation_params(
     grid_size = (max_cores, 1)
     num_cores = grid_size[0]
 
-    in0_block_w = K // num_cores // 32
-
     # activation is already UnaryWithParam in this test, no conversion needed
     program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=ttnn.CoreCoord(grid_size[0], grid_size[1]),
-        in0_block_w=in0_block_w,
+        in0_block_w=K // num_cores // 32,  # K/num_cores/32
         out_subblock_h=1,
         out_subblock_w=1,
         per_core_M=M // 32,  # M/32
@@ -362,15 +366,14 @@ def test_matmul_with_custom_activation_params(
 
     # Compute golden reference, taking the activation parameters from the same
     # object the device was given so the two cannot drift apart.
-    pt_matmul = in0 @ in1
-    activation_fn = functools.partial(apply_activation_to_reference, activation=activation)
-    pt_out = activation_fn(pt_matmul)
+    pt_out = in0 @ in1
+    pt_out = apply_activation_to_reference(pt_out, activation=activation)
 
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
         atol=atol,
-        rtol=rtol,
+        rtol=_RTOL_BY_FORMAT_AND_ACTIVATION[(ttnn.bfloat16, activation_adds_ulps)],
         frobenius_threshold=frobenius_threshold,
         pcc_threshold=pcc_threshold,
         check_ulp=False,
@@ -388,14 +391,14 @@ def test_matmul_with_custom_activation_params(
 # Folded over the 1D and 2D grid configs, which differ only in how many K tiles a
 # block covers (1 against 2) and so move the limits by at most 1.01x.
 @pytest.mark.parametrize(
-    "activation, atol, rtol, frobenius_threshold, pcc_threshold",
+    "activation, atol, activation_adds_ulps, frobenius_threshold, pcc_threshold",
     [
-        # activation      atol     rtol     frob      pcc
-        ("relu", 4.3409, 0.0046, 0.0553, 0.99915),
-        ("gelu", 4.6711, 0.0358, 0.066, 0.9988),
-        ("sigmoid", 0.99, 0.0358, 0.0899, 0.99678),
-        ("hardtanh", 4.0, 0.0046, 0.1854, 0.99355),
-        ("softplus", 4.3409, 0.0358, 0.0647, 0.99884),
+        # activation      atol     adds     frob      pcc
+        ("relu", 4.3409, False, 0.0553, 0.99915),
+        ("gelu", 4.6711, True, 0.066, 0.9988),
+        ("sigmoid", 0.99, True, 0.0899, 0.99678),
+        ("hardtanh", 4.0, False, 0.1854, 0.99355),
+        ("softplus", 4.3409, True, 0.0647, 0.99884),
     ],
     ids=["relu", "gelu", "sigmoid", "hardtanh", "softplus"],
 )
@@ -404,7 +407,7 @@ def test_activation_with_different_program_configs(
     grid_config,
     activation,
     atol,
-    rtol,
+    activation_adds_ulps,
     frobenius_threshold,
     pcc_threshold,
     function_level_defaults,
@@ -442,11 +445,10 @@ def test_activation_with_different_program_configs(
         num_cores = grid_size[0]
         per_core_N = N // num_cores // 32
         out_subblock_w = min(2, per_core_N) if per_core_N > 0 else 1
-        in0_block_w = K // num_cores // 32
 
         program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(grid_size[0], grid_size[1]),
-            in0_block_w=in0_block_w,
+            in0_block_w=K // num_cores // 32,
             out_subblock_h=1,
             out_subblock_w=out_subblock_w,
             per_core_M=M // 32,
@@ -459,11 +461,10 @@ def test_activation_with_different_program_configs(
         # 2D multicast configuration
         per_core_N = N // grid_size[0] // 32
         out_subblock_w = min(2, per_core_N) if per_core_N > 0 else 1
-        in0_block_w = K // grid_size[0] // 32
 
         program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(grid_size[0], grid_size[1]),
-            in0_block_w=in0_block_w,
+            in0_block_w=K // grid_size[0] // 32,
             out_subblock_h=1,
             out_subblock_w=out_subblock_w,
             per_core_M=M // grid_size[1] // 32,
@@ -492,15 +493,15 @@ def test_activation_with_different_program_configs(
     tt_out = tt2torch_tensor(output_t)
 
     # Golden reference
-    pt_matmul = in0 @ in1
+    pt_out = in0 @ in1
     activation_fn = get_activation_golden_function(activation)
-    pt_out = activation_fn(pt_matmul)
+    pt_out = activation_fn(pt_out)
 
     assert_numeric_metrics(
         pt_out.float(),
         tt_out,
         atol=atol,
-        rtol=rtol,
+        rtol=_RTOL_BY_FORMAT_AND_ACTIVATION[(ttnn.bfloat16, activation_adds_ulps)],
         frobenius_threshold=frobenius_threshold,
         pcc_threshold=pcc_threshold,
         check_ulp=False,
@@ -601,9 +602,9 @@ def apply_activation_to_reference(tensor, activation):
         max_val = params[1] if len(params) > 1 else 1.0
         return torch.nn.functional.hardtanh(tensor, min_val=min_val, max_val=max_val)
     elif op_type == ttnn.UnaryOpType.SELU:
-        # The first parameter is the scale and the second is alpha, the order the
-        # kernel takes them in. With no parameters the standard SELU constants
-        # apply. SELU is scale * x for x >= 0, and scale * alpha * (exp(x) - 1)
+        # The first parameter is the scale and the second is alpha.
+        # With no parameters the standard SELU constants apply.
+        # SELU is scale * x for x >= 0, and scale * alpha * (exp(x) - 1)
         # for x < 0.
         if not params:
             return torch.nn.functional.selu(tensor)
@@ -635,7 +636,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
     in1_dtype,
     out_dtype,
     atol,
-    rtol,
+    activation_adds_ulps,
     frobenius_threshold,
     pcc_threshold,
     function_level_defaults,
@@ -688,9 +689,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
         # Shape [1, 1, 1, N]. The op broadcasts a single bias row across every
-        # output row, so the bias must stay one row tall. Padding it out to a
-        # full tile height makes it logically that many rows, all but the first
-        # of them zero, and then only the first output row receives the bias.
+        # output row, so the bias must stay one row tall.
         bias_row = bias.unsqueeze(2)
         bias_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
@@ -752,11 +751,11 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
     output_t = ttnn.sharded_to_interleaved(output_t, interleaved_mem_config)
 
     # Compute golden reference
-    pt_matmul = in0 @ in1
-    pt_pre_activation = (pt_matmul + bias) if has_bias else pt_matmul
+    pt_out = in0 @ in1
+    if has_bias:
+        pt_out += bias
 
-    activation_fn = functools.partial(apply_activation_to_reference, activation=activation_param)
-    pt_out = activation_fn(pt_pre_activation)
+    pt_out = apply_activation_to_reference(pt_out, activation=activation_param)
 
     tt_out = tt2torch_tensor(output_t)
 
@@ -764,7 +763,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
         pt_out,
         tt_out,
         atol=atol,
-        rtol=rtol,
+        rtol=_RTOL_BY_FORMAT_AND_ACTIVATION[(ttnn.bfloat16, activation_adds_ulps)],
         frobenius_threshold=frobenius_threshold,
         pcc_threshold=pcc_threshold,
         check_ulp=False,
@@ -774,32 +773,35 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
 @pytest.mark.parametrize("fidelity", [ttnn.MathFidelity.LoFi], ids=["LoFi"])
 @pytest.mark.parametrize("packer_l1_acc", [False, True], ids=["no_l1_acc", "l1_acc"])
 @pytest.mark.parametrize(
-    "has_bias, activation, atol, rtol, frobenius_threshold, pcc_threshold",
+    "has_bias, activation, atol, activation_adds_ulps, frobenius_threshold, pcc_threshold",
     [
-        # Limits shared by the two shapes and both packer_l1_acc settings,
-        # widest spread 1.46x, on atol between K = 4096 and K = 8192. The 32 bit
-        # accumulator puts rtol at its floor everywhere except selu and softplus,
-        # which take their 16 bit polynomial branch whatever the accumulator is.
+        # Limits shared by the two shapes and both packer_l1_acc settings. rtol is
+        # not in the row; the shared helper picks it out of
+        # _RTOL_BY_FORMAT_AND_ACTIVATION from the "adds" column. That column is
+        # False almost everywhere here, because the helper sets fp32_dest_acc_en,
+        # and two ULPS for a 32 bit accumulator is negligible compared to the rounding into
+        # a bfloat16 output. Softplus is the only True: a fused matmul evaluates it
+        # in 16 bit whatever the accumulator is.
         #
-        #                       atol     rtol     frob      pcc
+        #                       atol     adds     frob      pcc
         # Test bias alone
-        (True, None, 24.4546, 0.0046, 0.056, 0.99941),
-        (False, None, 24.4527, 0.0046, 0.056, 0.99941),
+        (True, None, 24.4546, False, 0.056, 0.99941),
+        (False, None, 24.4527, False, 0.056, 0.99941),
         # Test activation alone
-        (False, "relu", 24.4527, 0.0046, 0.0561, 0.99913),
-        (False, "gelu", 24.7926, 0.0046, 0.0561, 0.99913),
-        (False, "sigmoid", 1.9912, 0.0046, 0.1693, 0.98925),
-        (False, "softplus", 24.4527, 0.0358, 0.0662, 0.99879),
+        (False, "relu", 24.4527, False, 0.0561, 0.99913),
+        (False, "gelu", 24.7926, False, 0.0561, 0.99913),
+        (False, "sigmoid", 1.9912, False, 0.1693, 0.98925),
+        (False, "softplus", 24.4527, True, 0.0662, 0.99879),
         # Test bias + activation combinations (main focus)
-        (True, "relu", 24.4546, 0.0046, 0.0561, 0.99913),
-        (True, "gelu", 24.7945, 0.0046, 0.0562, 0.99913),
-        (True, "sigmoid", 1.9912, 0.0046, 0.1696, 0.98921),
-        (True, "hardtanh", 4.0, 0.0046, 0.2834, 0.98494),
-        (True, "selu", 26.0275, 0.0358, 0.0668, 0.9988),
-        (True, "softplus", 24.4546, 0.0358, 0.0662, 0.99879),
+        (True, "relu", 24.4546, False, 0.0561, 0.99913),
+        (True, "gelu", 24.7945, False, 0.0562, 0.99913),
+        (True, "sigmoid", 1.9912, False, 0.1696, 0.98921),
+        (True, "hardtanh", 4.0, False, 0.2834, 0.98494),
+        (True, "selu", 26.0275, False, 0.0566, 0.99914),
+        (True, "softplus", 24.4546, True, 0.0662, 0.99879),
         # Test with UnaryWithParam
-        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 6.0), 12.0, 0.0046, 0.1658, 0.98996),
-        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0), 4.0, 0.0046, 0.2834, 0.98494),
+        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU6, 6.0), 12.0, False, 0.1658, 0.98996),
+        (True, ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0), 4.0, False, 0.2834, 0.98494),
     ],
     ids=[
         "bias_only",
@@ -840,7 +842,7 @@ def test_matmul_dram_sharded_with_bias_and_activation(
     has_bias,
     activation,
     atol,
-    rtol,
+    activation_adds_ulps,
     frobenius_threshold,
     pcc_threshold,
     grid_size,
@@ -867,7 +869,7 @@ def test_matmul_dram_sharded_with_bias_and_activation(
         in1_dtype=in1_dtype,
         out_dtype=out_dtype,
         atol=atol,
-        rtol=rtol,
+        activation_adds_ulps=activation_adds_ulps,
         frobenius_threshold=frobenius_threshold,
         pcc_threshold=pcc_threshold,
         function_level_defaults=function_level_defaults,
@@ -875,17 +877,18 @@ def test_matmul_dram_sharded_with_bias_and_activation(
 
 
 @pytest.mark.parametrize(
-    "activation, fidelity, packer_l1_acc, atol, rtol, frobenius_threshold, pcc_threshold",
+    "activation, fidelity, packer_l1_acc, atol, activation_adds_ulps, frobenius_threshold, pcc_threshold",
     [
         # One shape and one setting each, so no row's limits are shared with another case.
-        # HiFi2 makes the whole budget about three times smaller than LoFi, since
-        # it consumes the right hand operand's full mantissa instead of 4 of its
-        # 7 bits, which is why tanh reaches 0.992 here.
+        # HiFi2 consumes the right hand operand's full mantissa instead of 4 of
+        # its 7 bits, which removes the largest single term from the relative
+        # error. The tanh row's limits are about four times tighter than the same
+        # case would need at LoFi.
         #
         # Special combinations to test edge cases
-        ("tanh", ttnn.MathFidelity.HiFi2, True, 3.3451, 0.0046, 0.1098, 0.99774),  # High precision with tanh
-        ("gelu", ttnn.MathFidelity.LoFi, False, 12.2997, 0.0046, 0.056, 0.99914),  # Fast approximation with GELU
-        ("sigmoid", ttnn.MathFidelity.LoFi, True, 1.8085, 0.0046, 0.1314, 0.99341),  # Sigmoid with L1 accumulation
+        ("tanh", ttnn.MathFidelity.HiFi2, True, 3.3451, False, 0.1098, 0.99774),  # High precision with tanh
+        ("gelu", ttnn.MathFidelity.LoFi, False, 12.2997, False, 0.056, 0.99914),  # Fast approximation with GELU
+        ("sigmoid", ttnn.MathFidelity.LoFi, True, 1.8085, False, 0.1314, 0.99341),  # Sigmoid with L1 accumulation
     ],
     ids=["tanh_hifi", "gelu_lofi", "sigmoid_l1acc"],
 )
@@ -895,7 +898,7 @@ def test_special_activation_combinations(
     fidelity,
     packer_l1_acc,
     atol,
-    rtol,
+    activation_adds_ulps,
     frobenius_threshold,
     pcc_threshold,
     function_level_defaults,
@@ -923,7 +926,7 @@ def test_special_activation_combinations(
         in1_dtype=ttnn.bfloat8_b,
         out_dtype=ttnn.bfloat16,
         atol=atol,
-        rtol=rtol,
+        activation_adds_ulps=activation_adds_ulps,
         frobenius_threshold=frobenius_threshold,
         pcc_threshold=pcc_threshold,
         function_level_defaults=function_level_defaults,
@@ -942,34 +945,26 @@ def test_special_activation_combinations(
 # limits: an order of magnitude looser here than for accurate gelu and tanh. atol
 # only doubles, because it is set by the worst single element rather than a
 # typical one, and there the matmul's own error is comparable.
-#
-# gelu_fast is the one entry in this file whose predictions spread more than 2x
-# across the shapes sharing a limit: its pcc runs 0.947 at K = 2048 to 0.975 at
-# K = 4096, a 2.11x spread in 1 - pcc. The three shapes still share
-# one limit, because that spread comes entirely from the segment error bound, the
-# single quantity in the budget measured from the implementation instead of worked
-# out from a format width or a written algorithm, so a PCC per shape would give
-# a false impression of precision.
 @pytest.mark.parametrize(
-    "activation, atol, rtol, frobenius_threshold, pcc_threshold",
+    "activation, atol, activation_adds_ulps, frobenius_threshold, pcc_threshold",
     [
-        #                                              atol     rtol     frob      pcc
-        (None, 0.2419, 0.0046, 0.08, 0.9988),
-        ("relu", 0.2419, 0.0046, 0.0793, 0.99827),
-        ("relu6", 0.2419, 0.0046, 0.0793, 0.99827),
-        ("silu", 0.2661, 0.0358, 0.0892, 0.99839),
-        ("gelu", 0.273, 0.0358, 0.0899, 0.99826),
-        ("tanh", 0.2416, 0.0358, 0.0899, 0.99848),
-        ("sigmoid", 0.0605, 0.0358, 0.0424, 0.99371),
-        ("hardsigmoid", 0.0404, 0.0358, 0.0395, 0.98832),
-        ("hardtanh", 0.2419, 0.0046, 0.0838, 0.99868),
-        ("selu", 0.4006, 0.0358, 0.089, 0.9985),
-        ("softplus", 0.2283, 0.0358, 0.0487, 0.99648),
+        #                                              atol     adds     frob      pcc
+        (None, 0.2419, False, 0.08, 0.9988),
+        ("relu", 0.2419, False, 0.0793, 0.99827),
+        ("relu6", 0.2419, False, 0.0793, 0.99827),
+        ("silu", 0.2661, True, 0.0892, 0.99839),
+        ("gelu", 0.273, True, 0.0899, 0.99826),
+        ("tanh", 0.2416, True, 0.0899, 0.99848),
+        ("sigmoid", 0.0605, True, 0.0424, 0.99371),
+        ("hardsigmoid", 0.0404, True, 0.0395, 0.98832),
+        ("hardtanh", 0.2419, False, 0.0838, 0.99868),
+        ("selu", 0.4006, True, 0.089, 0.9985),
+        ("softplus", 0.2283, True, 0.0487, 0.99648),
         # Test with UnaryWithParam objects with parameters
         # fast_and_approximate mode
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, 1.0), 0.533, 0.0046, 0.5103, 0.94668),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU, 1.0), 0.533, False, 0.5103, 0.94668),
         # fast_and_approximate mode
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH, 1.0), 0.5416, 0.0046, 0.394, 0.97089),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH, 1.0), 0.5416, False, 0.394, 0.97089),
         # There is no fast sigmoid case here. sigmoid numbers its parameters
         # differently from gelu and tanh: the first is the vector mode and the
         # second is the fast_and_approximate flag, so reaching the table takes
@@ -980,11 +975,11 @@ def test_special_activation_combinations(
         # bound is an absolute 0.13. The limit would have to admit an error
         # larger than the signal, which no longer tests anything.
         # Custom min/max
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 0.2419, 0.0046, 0.0801, 0.99879),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -2.0, 2.0), 0.2419, False, 0.0801, 0.99879),
         # Custom scale/alpha
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2), 0.4101, 0.0358, 0.0885, 0.99852),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.5, 1.2), 0.4101, True, 0.0885, 0.99852),
         # Custom beta/threshold
-        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0), 0.2411, 0.0358, 0.063, 0.99804),
+        (ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 2.0, 10.0), 0.2411, True, 0.063, 0.99804),
     ],
     ids=[
         "no_activation",
@@ -1023,7 +1018,7 @@ def test_matmul_1d_gather_with_activations(
     device,
     activation,
     atol,
-    rtol,
+    activation_adds_ulps,
     frobenius_threshold,
     pcc_threshold,
     M,
@@ -1103,8 +1098,7 @@ def test_matmul_1d_gather_with_activations(
 
     # Compute reference in PyTorch
     pt_pre_activation = torch.matmul(in0, in1)
-    activation_fn = functools.partial(apply_activation_to_reference, activation=activation_param)
-    reference = activation_fn(pt_pre_activation)
+    reference = apply_activation_to_reference(pt_pre_activation, activation=activation_param)
 
     # No compute kernel config is passed, so the limits above were derived from
     # the op's own defaults: LoFi because a program config was supplied, a 16 bit
@@ -1114,7 +1108,7 @@ def test_matmul_1d_gather_with_activations(
         reference,
         output,
         atol=atol,
-        rtol=rtol,
+        rtol=_RTOL_BY_FORMAT_AND_ACTIVATION[(ttnn.bfloat16, activation_adds_ulps)],
         frobenius_threshold=frobenius_threshold,
         pcc_threshold=pcc_threshold,
         check_ulp=False,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
@@ -130,15 +130,18 @@ def run_test_matmul_in1_dram_sharded(
 
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, 32 - bias_padded.size(2)), "constant", 0)
+        # Shape [1, 1, 1, N]. The op broadcasts a single bias row across every
+        # output row, so the bias must stay one row tall. Padding it out to a
+        # full tile height makes it logically that many rows, all but the first
+        # of them zero, and then only the first output row receives the bias.
+        bias_row = bias.unsqueeze(2)
         bias_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
         bias_shard_spec = ttnn.ShardSpec(bias_shard_grid, bias_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
         bias_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, bias_shard_spec
         )
-        bias_t = torch2tt_tensor(bias_padded, device, tt_memory_config=bias_mem_config, tt_dtype=ttnn.bfloat16)
+        bias_t = torch2tt_tensor(bias_row, device, tt_memory_config=bias_mem_config, tt_dtype=ttnn.bfloat16)
 
     in0_t = ttnn.interleaved_to_sharded(
         in0_t,
@@ -729,14 +732,16 @@ def test_matmul_2d_in1_dram_sharded(
 
     if has_bias:
         bias = torch.ones(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
+        # Shape [1, 1, 1, N]; the op broadcasts this single row across every
+        # output row.
+        bias_row = bias.unsqueeze(2)
         bias_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
         bias_shard_spec = ttnn.ShardSpec(bias_shard_grid, bias_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
         bias_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, bias_shard_spec
         )
-        bias_t = torch2tt_tensor(bias_padded, device, tt_memory_config=bias_mem_config, tt_dtype=ttnn.bfloat16)
+        bias_t = torch2tt_tensor(bias_row, device, tt_memory_config=bias_mem_config, tt_dtype=ttnn.bfloat16)
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -255,7 +255,7 @@ def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_s
         ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID),
         ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDSIGMOID),
         ttnn.UnaryWithParam(ttnn.UnaryOpType.HARDTANH, -1.0, 1.0),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.6732632, 1.0507009),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SELU, 1.0507009, 1.6732632),
         ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0),
     ],
 )

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -535,8 +535,11 @@ def test_matmul_in1_dram_sharded_tiny_tile(
 
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, tile_h - bias_padded.size(2)), "constant", 0)
+        # Shape [1, 1, 1, N]. The op broadcasts a single bias row across every
+        # output row, so the bias must stay one row tall. Padding it out to a
+        # full tile height makes it logically that many rows, all but the first
+        # of them zero, and then only the first output row receives the bias.
+        bias_row = bias.unsqueeze(2)
         bias_shard_grid = ttnn.CoreCoord(mesh_device.dram_grid_size().x - 1, mesh_device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
         bias_shard_spec = ttnn.ShardSpec(bias_shard_grid, bias_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
@@ -544,7 +547,7 @@ def test_matmul_in1_dram_sharded_tiny_tile(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, bias_shard_spec
         )
         bias_t = ttnn.from_torch(
-            bias_padded,
+            bias_row,
             tile=ttnn.Tile((tile_h, tile_w)),
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
@@ -1423,10 +1426,13 @@ def run_matmul_1d_multiple_output_blocks_per_core(
 
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
-        bias_padded = bias.unsqueeze(2)
-        bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, 32 - bias_padded.size(2)), "constant", 0)
+        # Shape [1, 1, 1, N]. The op broadcasts a single bias row across every
+        # output row, so the bias must stay one row tall. Padding it out to a
+        # full tile height makes it logically that many rows, all but the first
+        # of them zero, and then only the first output row receives the bias.
+        bias_row = bias.unsqueeze(2)
         bias_t = ttnn.from_torch(
-            bias_padded,
+            bias_row,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=device,

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -536,9 +536,7 @@ def test_matmul_in1_dram_sharded_tiny_tile(
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
         # Shape [1, 1, 1, N]. The op broadcasts a single bias row across every
-        # output row, so the bias must stay one row tall. Padding it out to a
-        # full tile height makes it logically that many rows, all but the first
-        # of them zero, and then only the first output row receives the bias.
+        # output row, so the bias must stay one row tall.
         bias_row = bias.unsqueeze(2)
         bias_shard_grid = ttnn.CoreCoord(mesh_device.dram_grid_size().x - 1, mesh_device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
@@ -1427,9 +1425,7 @@ def run_matmul_1d_multiple_output_blocks_per_core(
     if has_bias:
         bias = torch.randn(bias_shape).bfloat16().float()
         # Shape [1, 1, 1, N]. The op broadcasts a single bias row across every
-        # output row, so the bias must stay one row tall. Padding it out to a
-        # full tile height makes it logically that many rows, all but the first
-        # of them zero, and then only the first output row receives the bias.
+        # output row, so the bias must stay one row tall.
         bias_row = bias.unsqueeze(2)
         bias_t = ttnn.from_torch(
             bias_row,

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/selu.h
@@ -14,22 +14,22 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Performs element-wise computation of:  selu = scale *(max(0,x) + min(0,alpha * (exp(x)-1))) by broadcast , where x is each element of a tile
- * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
- * acquired state via *acquire_dst* call. This call is blocking and is only
- * available on the compute engine.
+ * Performs element-wise computation of selu = scale * (max(0,x) + min(0, alpha * (exp(x)-1))), where x is each
+ * element of a tile in DST register at index tile_index. scale and alpha are each passed as the raw bits of a
+ * float. The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is
+ * only available on the compute engine.
  *
  * Return value: None
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | param0          | scale value                                                                | uint32_t |                                                       | True     |
- * | param1          | alpha value                                                                | uint32_t |                                                       | True     |
+ * | scale           | Scale used in selu calculation, as the raw bits of a float                 | uint32_t |                                                       | True     |
+ * | alpha           | Alpha used in selu calculation, as the raw bits of a float                 | uint32_t |                                                       | True     |
  */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void selu_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
+ALWI void selu_tile(uint32_t idst, uint32_t scale, uint32_t alpha) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
@@ -37,12 +37,12 @@ ALWI void selu_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
         (APPROX, is_fp32_dest_acc_en, 8 /* ITERATIONS */),
         idst,
         VectorMode::RC,
-        param0,
-        param1));
+        scale,
+        alpha));
 }
 
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-ALWI void selu_tile_pack(uint32_t idst, uint32_t param0, uint32_t param1) {
+ALWI void selu_tile_pack(uint32_t idst, uint32_t scale, uint32_t alpha) {
     PACK(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
@@ -50,8 +50,8 @@ ALWI void selu_tile_pack(uint32_t idst, uint32_t param0, uint32_t param1) {
         (APPROX, is_fp32_dest_acc_en, 8 /* ITERATIONS */),
         idst,
         VectorMode::RC,
-        param0,
-        param1));
+        scale,
+        alpha));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -1069,9 +1069,12 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::XIELU, {0.8f, 0.8f});  // alpha_p=0.8, alpha_n=0.8
     }
     if (name == "selu") {
+        // selu_tile takes the scale first and alpha second, the same order ttnn::selu exposes
+        // them in. Values below are the exact values of the nearest floats to the published SELU
+        // constants: 1.0507009873554804934193349852946 and 1.6732632423543772848170429916717.
+        float scale = 1.05070102214813232421875f;
         float alpha = 1.67326319217681884765625f;
-        float lambda = 1.05070102214813232421875f;
-        return UnaryWithParam(UnaryOpType::SELU, {alpha, lambda});
+        return UnaryWithParam(UnaryOpType::SELU, {scale, alpha});
     }
     if (name == "alt_complex_rotate90") {
         return UnaryWithParam(UnaryOpType::ALT_COMPLEX_ROTATE90);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_fused_activation.hpp
@@ -92,7 +92,7 @@ struct ActivationApplyHelper {
         } else if constexpr (ACT == KernelActivation::HARDTANH) {
             hardtanh_tile_pack(tile_index, PARAM0, PARAM1);
         } else if constexpr (ACT == KernelActivation::SELU) {
-            // PARAM0 is alpha, PARAM1 is lambda
+            // PARAM0 is the scale, PARAM1 is alpha
             selu_tile_pack(tile_index, PARAM0, PARAM1);
         } else if constexpr (ACT == KernelActivation::SOFTPLUS) {
             // PARAM0 is beta, PARAM2 beta reciprocal, PARAM1 is threshold

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp
@@ -298,10 +298,18 @@ inline ActivationParams get_activation_params(const ttnn::operations::unary::Una
 
         case UnaryOpType::SELU:
             result.type = KernelActivation::SELU;
-            // param0 is alpha (default 1.67326)
-            result.param0 = has_first ? std::bit_cast<uint32_t>(params[0]) : 0x3fd637bdu;
-            // param1 is lambda (default 1.05070)
-            result.param1 = has_second ? std::bit_cast<uint32_t>(params[1]) : 0x3f8674f5u;
+            // selu(x) is scale * x for x >= 0, and scale * alpha * (exp(x) - 1) for x < 0.
+            // selu_tile_pack takes the scale first and alpha second.
+            //
+            // Each default is the nearest float to the published SELU constant. Shown below as
+            // the published value and the exact value of the float it rounds to, which is what
+            // the bit patterns hold:
+            //   scale  1.0507009873554804934193349852946 -> 1.05070102214813232421875
+            //   alpha  1.6732632423543772848170429916717 -> 1.67326319217681884765625
+            // param0 is scale
+            result.param0 = has_first ? std::bit_cast<uint32_t>(params[0]) : 0x3f867d5fu;
+            // param1 is alpha
+            result.param1 = has_second ? std::bit_cast<uint32_t>(params[1]) : 0x3fd62d7du;
             break;
 
         case UnaryOpType::SOFTPLUS:

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp
@@ -96,7 +96,7 @@ struct ActivationApplyHelper {
         } else if constexpr (ACT == KernelActivation::HARDTANH) {
             hardtanh_tile_pack(tile_index, PARAM0, PARAM1);
         } else if constexpr (ACT == KernelActivation::SELU) {
-            // PARAM0 is alpha, PARAM1 is lambda
+            // PARAM0 is the scale, PARAM1 is alpha
             selu_tile_pack(tile_index, PARAM0, PARAM1);
         } else if constexpr (ACT == KernelActivation::SOFTPLUS) {
             // PARAM0 is beta, PARAM2 beta reciprocal, PARAM1 is threshold

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -304,10 +304,18 @@ inline ActivationParams get_activation_params(const ttnn::operations::unary::Una
 
         case UnaryOpType::SELU:
             result.type = KernelActivation::SELU;
-            // param0 is alpha (default 1.67326)
-            result.param0 = has_first ? std::bit_cast<uint32_t>(params[0]) : 0x3fd637bdu;
-            // param1 is lambda (default 1.05070)
-            result.param1 = has_second ? std::bit_cast<uint32_t>(params[1]) : 0x3f8674f5u;
+            // selu(x) is scale * x for x >= 0, and scale * alpha * (exp(x) - 1) for x < 0.
+            // selu_tile_pack takes the scale first and alpha second.
+            //
+            // Each default is the nearest float to the published SELU constant. Shown below as
+            // the published value and the exact value of the float it rounds to, which is what
+            // the bit patterns hold:
+            //   scale  1.0507009873554804934193349852946 -> 1.05070102214813232421875
+            //   alpha  1.6732632423543772848170429916717 -> 1.67326319217681884765625
+            // param0 is scale
+            result.param0 = has_first ? std::bit_cast<uint32_t>(params[0]) : 0x3f867d5fu;
+            // param1 is alpha
+            result.param1 = has_second ? std::bit_cast<uint32_t>(params[1]) : 0x3fd62d7du;
             break;
 
         case UnaryOpType::SOFTPLUS:


### PR DESCRIPTION
### Summary

Fixes #55252. Fixes #55266.

`ttnn.matmul(a, b, activation="selu")` reversed order of `alpha` and `scale` on paths where activation is fused into matmul kernel. CI did not catch it because the tolerances in the matmul activation tests accepted almost anything. `rtol`, the relative tolerance, was `15.0 * K` (`K` = shared inner dimension of matmul), so for `K = 512` that is 7,680 (i.e.  768,000%). `atol` and Frobenius threshold also grew with `K` past the largest reasonable error. Tightening tolerances also exposed a wrong softplus parameter and a wrongly shaped bias in the tests.

Fixed on the device side:

- **SELU parameter order.** In `unary_op_utils.cpp` and in both copies of `matmul_utilities.hpp` (BH/WH and Quasar).
- **SELU defaults.** When the caller passes no parameters, hardcoded constants used differed from the intended values stated in the comments.
- **Softplus.** `bmm_large_block_zm_fused_bias_activation.cpp` didn't pass the third parameter (the reciprocal of the softplus sharpness `beta`) to `ActivationApplyHelper`, so that param defaulted to 0, causing fused Softplus to be wrong for every `beta`.

Fixed in the tests:
- **Bias shape.** The tests built the bias as a full 32 row tile, the real values in row 0 and zeros in the rest. The op picks its bias path from that shape: one row means broadcast to every output row, more than one means an elementwise add. The DRAM-sharded and 2D multicast program configs read that shape, so there the bias reached output row 0 only while the Pytorch reference broadcast it to all rows. The tests now build the single row they intended and let broadcast propagate it.
- **Tolerances** in `test_matmul_activations.py` are now constants in the parametrize list next to the case they apply to. The new `numeric_tolerances.py` exposes `matmul_numeric_tolerances` to compute those limits (computation done offline and tolerances are placed into the tests for easier diff, and to avoid changes to the helper module accidentally loosening existing tolerances).
- Removed `mish` from the two activation lookup maps in `test_matmul_activations.py` (matmul has no fused mish), and dropped the `sigmoid_fast` case from `test_matmul_1d_gather_with_activations` (the case was previously skipped anyways). Proper test should use a different input, which is outside the scope of this PR.

### Notes for reviewers

- The new tolerances were derived by AI, with all the usual caveats of AI use (the may not be perfectly accurate in all cases and even reasoning around derivation may have inaccuracies; I did many rounds of back-and forth with Claude, but I only performed cursory manual review). However almost all tolerances are tighter than before (in many cases orders of magnitude tighter) and in a handful of cases only marginally looser.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec/55252_mm_activation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec/55252_mm_activation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fplavec/55252_mm_activation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fplavec/55252_mm_activation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec/55252_mm_activation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec/55252_mm_activation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec/55252_mm_activation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec/55252_mm_activation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec/55252_mm_activation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec/55252_mm_activation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec/55252_mm_activation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec/55252_mm_activation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec/55252_mm_activation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec/55252_mm_activation)