### PR TITLE
[deepseek_prefill] Wait for the act sender's own INCL_SRC loopback copy to land before publishing the CB

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_swigluoai_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_swigluoai_routed_expert.py
@@ -229,16 +229,19 @@ def test_swigluoai_routed_expert_deterministic(mesh_device, device_params):
     own copy comes back over the NoC. Receivers are ordered by the valid-sem riding the
     linked path; the sender has only its own wait, and noc_async_writes_flushed() reports
     the request as SENT, not landed. Consuming that slot early corrupts one core's block
-    nondeterministically, so this runs the largest supported shape repeatedly and requires
-    bit-identical output. NOT a fail-without-fix reproducer: the window is ~1 L1 poll wide
-    and downstream work masks it, so this guards against it widening (grid, payload or
-    scheduling changes), it does not demonstrate the bug.
+    nondeterministically, so this repeats the highest-exposure shape and requires
+    bit-identical output. Uses the M3 dims (emb 6144 / hidden 3072) at 4096 tokens: the
+    multicast payload, and with it the measured landing window, scales with the block
+    size -- instrumented on p100a the loopback was unlanded at the flush point ~4x more
+    often at these dims than at M2.7's. NOT a fail-without-fix reproducer: the residual
+    window is ~1 L1 poll wide and downstream work masks it, so this guards against the
+    window widening (grid, payload or scheduling changes), it does not demonstrate the bug.
     """
     run_swigluoai_routed_expert(
         mesh_device,
         num_tokens=4096,
-        emb_dim=MiniMaxM27Config.EMB_SIZE,
-        hidden_dim=MiniMaxM27Config.MOE_INTERMEDIATE_SIZE,
+        emb_dim=6144,
+        hidden_dim=3072,
         activation=ttnn.RoutedExpertActivation.SwiGluOai,
         repeat=10,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_swigluoai_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_swigluoai_routed_expert.py
@@ -64,7 +64,7 @@ def _torch_swigluoai_expert(x, w, alpha=SWIGLU_ALPHA, limit=SWIGLU_LIMIT):
     return F.linear(activated, w["down_proj"])
 
 
-def run_swigluoai_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim, activation):
+def run_swigluoai_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim, activation, repeat=1):
     """1 chip, 1 expert. Compares the fused op (selected RoutedExpertActivation) vs torch reference."""
     torch.manual_seed(42)
     is_swigluoai = activation == ttnn.RoutedExpertActivation.SwiGluOai
@@ -84,14 +84,6 @@ def run_swigluoai_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim, ac
             torch_output = _torch_swigluoai_expert(torch_input, weights)
         else:
             torch_output = _torch_silu_expert(torch_input, weights)
-
-    tt_input = ttnn.from_torch(
-        torch_input,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-        layout=ttnn.TILE_LAYOUT,
-        device=mesh_device,
-        dtype=ttnn.bfloat8_b,
-    )
 
     def _make_idx_tensor(values):
         return ttnn.from_torch(
@@ -118,11 +110,34 @@ def run_swigluoai_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim, ac
         activation=activation,
     )
 
-    tt_output = tt_expert(tt_input, expert_token_counts_tt, expert_region_offsets_tt)
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
-    )[:num_tokens]
+    def _run_once():
+        # Re-upload the activation each time: the op's input buffer is not guaranteed to
+        # survive a previous invocation, so a reused handle would compare garbage.
+        inp = ttnn.from_torch(
+            torch_input,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.bfloat8_b,
+        )
+        out = tt_expert(inp, expert_token_counts_tt, expert_region_offsets_tt)
+        return ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:num_tokens]
+
+    tt_output_torch = _run_once()
+
+    # Same inputs, same program: every later invocation must be BIT-identical. The op
+    # publishes its down-matmul input through a multicast whose sender also receives its
+    # own copy via the INCL_SRC loopback; if that copy is consumed before it lands, the
+    # affected core's output block changes run to run. A drifting result here means an
+    # ordering guarantee was lost, which PCC alone is too coarse to catch.
+    for i in range(1, repeat):
+        again = _run_once()
+        mismatches = int((again != tt_output_torch).sum())
+        assert mismatches == 0, (
+            f"run {i} differs from run 0 in {mismatches} element(s) "
+            f"(max |delta| {float((again - tt_output_torch).abs().max())}) - "
+            "output is not deterministic"
+        )
 
     passing, pcc = comp_pcc(torch_output, tt_output_torch, 0.97)
     logger.info(f"activation={activation} num_tokens={num_tokens}: PCC={pcc}")
@@ -201,3 +216,29 @@ def test_routed_expert_activation_enum_exposed():
     assert hasattr(activation, "Silu") and hasattr(activation, "SwiGluOai"), "enum is missing Silu/SwiGluOai variants"
     # Distinct variants so SiLU and SwiGLU-OAI cache as separate device programs.
     assert activation.Silu != activation.SwiGluOai
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert op is Blackhole-only")
+@pytest.mark.parametrize(
+    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
+)
+def test_swigluoai_routed_expert_deterministic(mesh_device, device_params):
+    """Ordering guard for the activated multicast (issue #50154 finding 17).
+
+    The act sender multicasts cb_activated -> cb_in0_down_full with MCAST_INCL_SRC, so its
+    own copy comes back over the NoC. Receivers are ordered by the valid-sem riding the
+    linked path; the sender has only its own wait, and noc_async_writes_flushed() reports
+    the request as SENT, not landed. Consuming that slot early corrupts one core's block
+    nondeterministically, so this runs the largest supported shape repeatedly and requires
+    bit-identical output. NOT a fail-without-fix reproducer: the window is ~1 L1 poll wide
+    and downstream work masks it, so this guards against it widening (grid, payload or
+    scheduling changes), it does not demonstrate the bug.
+    """
+    run_swigluoai_routed_expert(
+        mesh_device,
+        num_tokens=4096,
+        emb_dim=MiniMaxM27Config.EMB_SIZE,
+        hidden_dim=MiniMaxM27Config.MOE_INTERMEDIATE_SIZE,
+        activation=ttnn.RoutedExpertActivation.SwiGluOai,
+        repeat=10,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_swigluoai_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_swigluoai_routed_expert.py
@@ -227,15 +227,17 @@ def test_swigluoai_routed_expert_deterministic(mesh_device, device_params):
 
     The act sender multicasts cb_activated -> cb_in0_down_full with MCAST_INCL_SRC, so its
     own copy comes back over the NoC. Receivers are ordered by the valid-sem riding the
-    linked path; the sender has only its own wait, and noc_async_writes_flushed() reports
-    the request as SENT, not landed. Consuming that slot early corrupts one core's block
-    nondeterministically, so this repeats the highest-exposure shape and requires
-    bit-identical output. Uses the M3 dims (emb 6144 / hidden 3072) at 4096 tokens: the
-    multicast payload, and with it the measured landing window, scales with the block
-    size -- instrumented on p100a the loopback was unlanded at the flush point ~4x more
-    often at these dims than at M2.7's. NOT a fail-without-fix reproducer: the residual
-    window is ~1 L1 poll wide and downstream work masks it, so this guards against the
-    window widening (grid, payload or scheduling changes), it does not demonstrate the bug.
+    linked path; the sender's own copy is ordered by the async_write_barrier() at step 5 of
+    the reader. Consuming that slot before the loopback copy lands would make one core's
+    down-matmul output block change run to run, so this requires bit-identical output
+    across repeats -- PCC alone is too coarse to catch it.
+
+    Uses the M3 dims (emb 6144 / hidden 3072) at 4096 tokens because the multicast payload,
+    and with it the landing window, scales with the block size: instrumented on p100a the
+    loopback was unlanded at the flush point ~4x more often at these dims than at M2.7's.
+
+    The exposure is only ~1 L1 poll wide and downstream work masks it, so this is a guard
+    against that window widening (grid, payload or scheduling changes), not a reproducer.
     """
     run_swigluoai_routed_expert(
         mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -882,10 +882,12 @@ void kernel_main() {
                 // overtake the bulk data multicast at a receiver -> the receiver
                 // observes act_valid, pushes cb_in0_down_full, and compute reads
                 // stale L1 -> that core's whole down-matmul output block is wrong
-                // (run-to-run nondeterministic). A write barrier does NOT fix this
-                // on Blackhole (multicast writes are posted; no completion ack to
-                // wait on) — only path-linking orders the sem behind the data.
-                // Mirrors the canonical matmul in0 sender
+                // (run-to-run nondeterministic). Path-linking orders the sem behind
+                // the data for free; the alternative, an ack-wait before sending the
+                // sem, would stall this core on every receiver's ack. (The mcast is
+                // non-posted and ack-counted, so an ack-wait also orders it — step 5
+                // needs exactly that for the sender's own loopback copy.) Mirrors the
+                // canonical matmul in0 sender
                 // (reader_bmm_tile_layout_in0_sender_padding.cpp).
                 if (mcast_bytes > 0) {
                     noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
@@ -913,6 +915,13 @@ void kernel_main() {
             // Step 5: receivers wait for both valid sems and push.
             if (!is_act_sender) {
                 act_valid_sem.wait(ACT_VALID);
+            } else {
+                // The sender's own copy arrives via the INCL_SRC loopback, so it needs a wait
+                // too. async_writes_flushed() is not one: it polls NIU_MST_NONPOSTED_WR_REQ_SENT
+                // (request left this NIU), not the ack. The mcast is non-posted, so only the
+                // ack-wait proves the data LANDED before this core's compute reads the slot.
+                // Placed after the valid-sem mcast so receivers are not held up.
+                noc.async_write_barrier();
             }
             cb_in0_down_full_obj.push_back(d_in0_block_num_tiles);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -920,7 +920,9 @@ void kernel_main() {
                 // too. async_writes_flushed() is not one: it polls NIU_MST_NONPOSTED_WR_REQ_SENT
                 // (request left this NIU), not the ack. The mcast is non-posted, so only the
                 // ack-wait proves the data LANDED before this core's compute reads the slot.
-                // Placed after the valid-sem mcast so receivers are not held up.
+                // Placed after the valid-sem mcast so receivers are not held up; note the
+                // wait is whole-queue, so it also covers that sem mcast's acks, not just
+                // the loopback copy.
                 noc.async_write_barrier();
             }
             cb_in0_down_full_obj.push_back(d_in0_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -878,7 +878,7 @@ void kernel_main() {
                 // linked=true keeps the multicast path RESERVED so the
                 // valid-semaphore multicast below travels the SAME path and is
                 // delivered AFTER the data at every receiver. With linked=false
-                // the path is released and the (posted) valid-sem multicast can
+                // the path is released and the valid-sem multicast can
                 // overtake the bulk data multicast at a receiver -> the receiver
                 // observes act_valid, pushes cb_in0_down_full, and compute reads
                 // stale L1 -> that core's whole down-matmul output block is wrong


### PR DESCRIPTION
### PR Category
Bug fix — kernel NoC ordering (Blackhole)

Closes #55551. Sub-issue of #50154 (finding 17).

### Summary

The `unified_routed_expert_ffn` act sender multicasts `cb_activated -> cb_in0_down_full` with `MCAST_INCL_SRC`, so its **own** copy of the block travels back over the NoC. Receivers are ordered correctly — the valid-sem multicast rides the same `linked=true` path. The sender has no wait at all:

```cpp
noc.async_writes_flushed();                       // request SENT, not landed
act_valid_sem.set(ACT_VALID);                     // local store
act_valid_sem.set_multicast<MCAST_INCL_SRC>(...);
...
if (!is_act_sender) { act_valid_sem.wait(ACT_VALID); }   // sender skips
cb_in0_down_full_obj.push_back(...);                     // its own compute may now read the slot
```

`noc_async_writes_flushed()` polls `NIU_MST_NONPOSTED_WR_REQ_SENT`. A sender-side `wait(ACT_VALID)` would not help either — the local `set(ACT_VALID)` two lines up makes it return instantly.

### Why it was left this way

The comment above the multicast asserted that a write barrier could not fix it, *"multicast writes are posted on Blackhole; no completion ack to wait on"*. The code disagrees — `ncrisc_noc_fast_write_loopback_src` issues with `NOC_CMD_RESP_MARKED` and books the acks:

```c
noc_nonposted_writes_num_issued[noc] += 1;
noc_nonposted_writes_acked[noc]      += num_dests;
```

So the multicast is non-posted and ack-counted, and `noc_async_write_barrier()` (→ `NIU_MST_WR_ACK_RECEIVED`) does cover it. The comment is corrected in this PR.

### Measured on p100a

Instrumented the kernel: stamp a sentinel into the last word of the sender's own destination slot, read it back so the store is processed, issue the multicast, then re-check the sentinel.

| Checkpoint | Loopback not landed |
|---|---|
| after `async_writes_flushed()`, `test_swigluoai_routed_expert` | 15 / 1408 (1.1%) |
| after `async_writes_flushed()`, `..._m3_shapes` | 44 / 1056 (4.2%) |
| **same point + `noc.async_write_barrier()`** | **0 / 1056** |

The rate scales with payload, as a landing-latency race should, and the barrier removes it at the identical program point.

### Honest scope: this is a contract fix, not a live failure

At the real `push_back` the sentinel was gone in 1408/1408 samples — the valid-sem multicast and `pop_front` mask a residual of 0-1 poll iterations. PCC is bit-identical to baseline (0.9802969368556544 / 0.9801282203471553). I could not force an observable corruption on a single card.

What it buys: today the guarantee is incidental. Any change that shortens publish-to-first-read (grid, payload, scheduling) crosses it, and the failure is silent — one core's entire down-matmul block, nondeterministic run to run.

### Cost

Measured at the insertion point: **~15-20 polls per sender publish** (max 26 observed). The barrier waits on all `GRID_X_NOC`=11 destination acks — and, since `noc_semaphore_set_multicast_loopback_src` also passes `/*posted=*/false`, on the valid-sem multicast's acks too. That is stronger than the sender needs, but multicasts have no per-transaction ack-wait (`NocOptions::TXN_ID` is `static_assert`ed unsupported); the measured number already includes both. It is placed **after** the valid-sem multicast, so receivers are released before the sender waits. A coarse wall-clock A/B could not resolve a difference; worth a perf-suite run before merge.

### Test

`test_swigluoai_routed_expert_deterministic` — **highest-exposure** shape (M3 dims, emb 6144 / hidden 3072, 4096 tokens), 10 invocations, requires **bit-identical** output. This class of race surfaces as run-to-run drift, which PCC is too coarse to catch. The M3 dims matter: instrumented, the loopback was unlanded at the flush point 4.2% of the time there versus 1.1% at M2.7 dims, because the window scales with the multicast payload.

It is a **guard, not a fail-without-fix reproducer**, and its docstring says so: it passes with and without the fix on this hardware. Same posture as `test_linear_granular_write_ordering` (#50364) in this issue family.

It re-uploads the activation each iteration — the op does not preserve its input buffer, and a reused handle compares garbage (the first draft of this test "failed" for exactly that reason, 12.5M elements differing).

### Verification

- `tests/.../test_swigluoai_routed_expert.py`: **8 passed** on p100a with the fix.
- PCC unchanged on every shared case.
- Blackhole-only op; not exercised on WH/QSR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/ds-prefill-act-loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/ds-prefill-act-loopback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/ds-prefill-act-loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/ds-prefill-act-loopback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/ds-prefill-act-loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/ds-prefill-act-loopback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/ds-prefill-act-loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/ds-prefill-act-loopback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/ds-prefill-act-loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/ds-prefill-act-loopback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/ds-prefill-act-loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/ds-prefill-act-loopback)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/ds-prefill-act-loopback)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/ds-prefill-act-loopback)
### Review follow-up (Copilot)

Both comments checked against the code; both had a correct factual core and are addressed in `984b0b4`:

* **"the preceding sentence still calls the valid-sem multicast posted"** — correct. `noc_semaphore_set_multicast_loopback_src` passes `/*posted=*/false` into `ncrisc_noc_fast_write_any_len_loopback_src`, the same non-posted ack-counted path as the data multicast. Qualifier removed; the cost section above now reflects that the barrier covers those acks too.
* **"the repeated guard uses the lower-incidence payload"** — correct, and my docstring wrongly said "largest supported shape". Switched to the M3 dims, where the measured exposure is ~4x higher.

**Not** taken without owner input: the suggestion to *"add a deterministic test-only discriminator that observes the sender loopback destination at publication time"*. That is exactly how I measured this (sentinel stamped in the sender's own slot, re-checked after the flush), but it only works from **inside the kernel** — it needs a poison store plus a read-back in the multicast hot path, and a host-side define to gate it. Shipping test-only instrumentation in a production kernel is the op owners' call, not mine to make in a bug-fix PR. The limitation is stated plainly in the test docstring and above; happy to add the gated probe if @tenstorrent/metalium-developers-ds-prefill wants it.