### PR TITLE
[test][noc] Guard write->atomic credit commit ordering (ISA gives no such guarantee)

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -63,6 +63,7 @@ set(UNIT_TESTS_API_SOURCES
     test_offline_kernel_compile.cpp
     test_memory_pin.cpp
     test_noc.cpp
+    test_write_then_atomic_credit_ordering.cpp
     test_pinned_memory.cpp
     test_blaze_named_args_hashing.cpp
     test_blaze_named_runtime_args.cpp

--- a/tests/tt_metal/tt_metal/api/test_write_then_atomic_credit_ordering.cpp
+++ b/tests/tt_metal/tt_metal/api/test_write_then_atomic_credit_ordering.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Data-before-credit ordering when the credit is a remote ATOMIC.
+//
+// A sender writes a payload into a peer core's L1, drains with
+// noc_async_writes_flushed() (which polls NIU_MST_NONPOSTED_WR_REQ_SENT -- the
+// request has LEFT this NIU) and then credits the peer with noc_semaphore_inc.
+//
+// WormholeB0/NoC/Ordering.md enumerates the recipient-NIU ordering guarantees for
+// two packets arriving on the same virtual channel: write->read, linked-read->any,
+// atomic->atomic, write->write, and two MMIO cases. write->atomic is NOT among
+// them, so the credit may be applied before the payload commits. The payload write
+// and the atomic also use different command buffers (write_cmd_buf vs
+// write_at_cmd_buf). The barrier form (noc_async_write_barrier, which polls
+// NIU_MST_WR_ACK_RECEIVED) has no such gap.
+//
+// The kernels tag every payload word with the iteration number and the receiver
+// checks the packet tail -- the last thing to commit -- immediately after the
+// credit lands. A stale tag is a credit observed ahead of its data.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "device_fixture.hpp"
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+
+namespace tt::tt_metal {
+
+namespace {
+
+constexpr uint32_t kPayloadBytes = 262144;
+constexpr uint32_t kIters = 500;
+// Mirrors of the device-side VC ids (dataflow_api_common.h is a kernel header).
+constexpr uint32_t kUnicastWriteVc = 1;
+constexpr uint32_t kOtherVc = 4;
+
+struct ProbeResult {
+    uint32_t stale_publishes;
+    uint32_t stale_words;
+    uint32_t first_bad_iter;
+    uint32_t iters;
+};
+
+// Runs the sender/receiver pair once. `use_barrier` selects the ack-wait
+// (noc_async_write_barrier) instead of the send-wait (noc_async_writes_flushed).
+ProbeResult run_probe(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    bool use_barrier,
+    uint32_t credit_vc = kUnicastWriteVc,
+    bool credit_first = false) {
+    const CoreCoord sender_core{0, 0};
+    const CoreCoord receiver_core{0, 1};
+
+    auto& cq = mesh_device->mesh_command_queue();
+    const auto zero_coord = distributed::MeshCoordinate(0, 0);
+    const auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    const uint32_t l1_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const auto align_up = [alignment](uint32_t v) { return ((v + alignment - 1) / alignment) * alignment; };
+
+    // Receiver L1 layout: payload | result. Sender L1 layout: payload source.
+    const uint32_t payload_addr = align_up(l1_base);
+    const uint32_t result_addr = align_up(payload_addr + kPayloadBytes);
+    const uint32_t src_addr = payload_addr;
+
+    // Zero the receiver's payload tail and result so a missing write is never
+    // mistaken for a correct tag (tags start at 1).
+    std::vector<uint32_t> zeros(kPayloadBytes / sizeof(uint32_t), 0);
+    slow_dispatch::WriteToL1(*mesh_device, receiver_core, payload_addr, zeros);
+    std::vector<uint32_t> zero_result(alignment / sizeof(uint32_t), 0);
+    slow_dispatch::WriteToL1(*mesh_device, receiver_core, result_addr, zero_result);
+
+    Program program = CreateProgram();
+    // data_sem lives on the receiver, ack_sem on the sender; CreateSemaphore over
+    // both cores keeps a single id valid on each.
+    const CoreRangeSet both_cores(std::vector<CoreRange>{CoreRange(sender_core), CoreRange(receiver_core)});
+    const uint32_t data_sem_id = CreateSemaphore(program, both_cores, 0);
+    const uint32_t ack_sem_id = CreateSemaphore(program, both_cores, 0);
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+
+    const CoreCoord virtual_sender = mesh_device->worker_core_from_logical_core(sender_core);
+    const CoreCoord virtual_receiver = mesh_device->worker_core_from_logical_core(receiver_core);
+
+    const KernelHandle sender = CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/write_then_atomic_credit_sender.cpp",
+        sender_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+    SetRuntimeArgs(
+        program_,
+        sender,
+        sender_core,
+        {virtual_receiver.x,
+         virtual_receiver.y,
+         payload_addr,
+         kPayloadBytes,
+         data_sem_id,
+         ack_sem_id,
+         kIters,
+         src_addr,
+         static_cast<uint32_t>(use_barrier),
+         credit_vc,
+         static_cast<uint32_t>(credit_first)});
+
+    const KernelHandle receiver = CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/write_then_atomic_credit_receiver.cpp",
+        receiver_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
+    SetRuntimeArgs(
+        program_,
+        receiver,
+        receiver_core,
+        {virtual_sender.x,
+         virtual_sender.y,
+         payload_addr,
+         kPayloadBytes,
+         data_sem_id,
+         ack_sem_id,
+         kIters,
+         result_addr});
+
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> readback;
+    slow_dispatch::ReadFromL1(*mesh_device, receiver_core, result_addr, alignment, readback);
+    return ProbeResult{readback[0], readback[1], readback[2], readback[3]};
+}
+
+}  // namespace
+
+// The ack-wait form must never publish a credit ahead of its payload. This is the
+// half that has to stay green: it is the contract the fix relies on.
+TEST_F(MeshDeviceFixture, TensixWriteThenAtomicCreditBarrierIsOrdered) {
+    for (const std::shared_ptr<distributed::MeshDevice>& mesh_device : this->devices_) {
+        const ProbeResult r = run_probe(mesh_device, /*use_barrier=*/true);
+        EXPECT_EQ(r.iters, kIters);
+        EXPECT_EQ(r.stale_publishes, 0u) << "noc_async_write_barrier() must commit the payload before the atomic "
+                                            "credit, but "
+                                         << r.stale_publishes << " of " << r.iters
+                                         << " publishes exposed a stale tail (first at iteration " << r.first_bad_iter
+                                         << ", " << r.stale_words << " stale words)";
+    }
+}
+
+// Companion measurement for the flush-only form. It is reported, not asserted:
+// the ISA gives no write->atomic ordering guarantee, so a zero here means the race
+// was not won on this part, never that the ordering is safe.
+TEST_F(MeshDeviceFixture, TensixWriteThenAtomicCreditFlushOnlyIsUnordered) {
+    for (const std::shared_ptr<distributed::MeshDevice>& mesh_device : this->devices_) {
+        const ProbeResult r = run_probe(mesh_device, /*use_barrier=*/false);
+        EXPECT_EQ(r.iters, kIters);
+        log_info(
+            tt::LogTest,
+            "flush-only write->atomic credit: {} / {} publishes had a stale tail ({} stale words, first at iter {})",
+            r.stale_publishes,
+            r.iters,
+            r.stale_words,
+            r.first_bad_iter);
+    }
+}
+
+// Mechanism probe: the ISA says two requests arriving on DIFFERENT virtual channels
+// can be reordered arbitrarily at the recipient NIU, so this is the configuration
+// most likely to expose the write->atomic gap if it is exposable at all.
+TEST_F(MeshDeviceFixture, TensixWriteThenAtomicCreditFlushOnlyCrossVc) {
+    for (const std::shared_ptr<distributed::MeshDevice>& mesh_device : this->devices_) {
+        const ProbeResult r = run_probe(mesh_device, /*use_barrier=*/false, /*credit_vc=*/kOtherVc);
+        log_info(
+            tt::LogTest,
+            "flush-only cross-VC credit: {} / {} publishes had a stale tail ({} stale words, first at iter {})",
+            r.stale_publishes,
+            r.iters,
+            r.stale_words,
+            r.first_bad_iter);
+    }
+}
+
+// Detector self-test. Sends the credit before the payload is even issued, so the
+// receiver MUST observe a stale tail. Without this, a zero from the probes above
+// would be indistinguishable from a probe that cannot detect anything.
+TEST_F(MeshDeviceFixture, TensixWriteThenAtomicCreditDetectorFires) {
+    for (const std::shared_ptr<distributed::MeshDevice>& mesh_device : this->devices_) {
+        const ProbeResult r =
+            run_probe(mesh_device, /*use_barrier=*/false, /*credit_vc=*/kUnicastWriteVc, /*credit_first=*/true);
+        EXPECT_GT(r.stale_publishes, 0u) << "detector never fired even with the credit sent before the payload -- "
+                                            "the probe is not measuring ordering";
+        log_info(
+            tt::LogTest, "detector self-test: {} / {} publishes stale (expected ~all)", r.stale_publishes, r.iters);
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/write_then_atomic_credit_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/write_then_atomic_credit_receiver.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Receiver half of the write->atomic-credit ordering probe.
+//
+// The sender writes a payload into this core's L1, drains only with
+// noc_async_writes_flushed() (request SENT, not committed), then credits us with a
+// remote atomic increment. Per WormholeB0/NoC/Ordering.md the recipient NIU's
+// same-VC guarantees enumerate write->read, atomic->atomic and write->write, but
+// NOT write->atomic -- so the credit may be applied before the payload commits.
+//
+// Every word of the payload carries the iteration tag. We check the LAST words,
+// which commit last: a stale tag there means we observed the credit before the data.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t sender_x = get_arg_val<uint32_t>(0);
+    const uint32_t sender_y = get_arg_val<uint32_t>(1);
+    const uint32_t payload_addr = get_arg_val<uint32_t>(2);
+    const uint32_t payload_bytes = get_arg_val<uint32_t>(3);
+    const uint32_t data_sem_addr = get_semaphore(get_arg_val<uint32_t>(4));
+    const uint32_t ack_sem_addr = get_semaphore(get_arg_val<uint32_t>(5));
+    const uint32_t iters = get_arg_val<uint32_t>(6);
+    const uint32_t result_addr = get_arg_val<uint32_t>(7);
+
+    volatile tt_l1_ptr uint32_t* data_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(data_sem_addr);
+    volatile tt_l1_ptr uint32_t* payload = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(payload_addr);
+    volatile tt_l1_ptr uint32_t* result = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(result_addr);
+
+    const uint32_t words = payload_bytes / sizeof(uint32_t);
+    const uint64_t ack_sem_noc_addr = get_noc_addr(sender_x, sender_y, ack_sem_addr);
+
+    uint32_t stale_publishes = 0;  // iterations whose tail was stale at credit time
+    uint32_t stale_words = 0;      // total stale words seen across those iterations
+    uint32_t first_bad_iter = 0;
+
+    // Check the final 8 words (two 16-byte L1 write streams x 4 words) -- the tail of
+    // the packet, which is the last thing to commit.
+    const uint32_t check_from = (words > 8) ? (words - 8) : 0;
+
+    for (uint32_t i = 1; i <= iters; ++i) {
+        noc_semaphore_wait_min(data_sem, i);
+
+        invalidate_l1_cache();
+        uint32_t bad = 0;
+        for (uint32_t w = check_from; w < words; ++w) {
+            if (payload[w] != i) {
+                bad++;
+            }
+        }
+        if (bad) {
+            stale_publishes++;
+            stale_words += bad;
+            if (first_bad_iter == 0) {
+                first_bad_iter = i;
+            }
+        }
+
+        // Release the sender for the next iteration.
+        noc_semaphore_inc(ack_sem_noc_addr, 1);
+    }
+
+    result[0] = stale_publishes;
+    result[1] = stale_words;
+    result[2] = first_bad_iter;
+    result[3] = iters;
+
+    noc_async_atomic_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/write_then_atomic_credit_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/write_then_atomic_credit_sender.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Sender half of the write->atomic-credit ordering probe (see the receiver for the
+// hazard description). Publishes a payload with noc_async_writes_flushed() only --
+// i.e. "request has left this NIU", NOT "committed at the destination" -- and then
+// sends the credit as a remote atomic increment.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t recv_x = get_arg_val<uint32_t>(0);
+    const uint32_t recv_y = get_arg_val<uint32_t>(1);
+    const uint32_t payload_addr = get_arg_val<uint32_t>(2);
+    const uint32_t payload_bytes = get_arg_val<uint32_t>(3);
+    const uint32_t data_sem_addr = get_semaphore(get_arg_val<uint32_t>(4));
+    const uint32_t ack_sem_addr = get_semaphore(get_arg_val<uint32_t>(5));
+    const uint32_t iters = get_arg_val<uint32_t>(6);
+    const uint32_t src_addr = get_arg_val<uint32_t>(7);
+    const uint32_t use_barrier = get_arg_val<uint32_t>(8);
+    const uint32_t credit_vc = get_arg_val<uint32_t>(9);
+    const uint32_t credit_first = get_arg_val<uint32_t>(10);  // detector self-test
+
+    volatile tt_l1_ptr uint32_t* ack_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ack_sem_addr);
+    volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);
+    const uint32_t words = payload_bytes / sizeof(uint32_t);
+
+    const uint64_t dst_noc_addr = get_noc_addr(recv_x, recv_y, payload_addr);
+    const uint64_t data_sem_noc_addr = get_noc_addr(recv_x, recv_y, data_sem_addr);
+
+    for (uint32_t i = 1; i <= iters; ++i) {
+        // Stamp the whole payload with this iteration's tag so a not-yet-committed
+        // tail still holds iteration i-1 and is therefore detectable.
+        for (uint32_t w = 0; w < words; ++w) {
+            src[w] = i;
+        }
+
+        if (credit_first) {
+            // Detector self-test: credit BEFORE the payload is even issued. The
+            // receiver must see a stale tail essentially every iteration; if it does
+            // not, the probe is not measuring anything.
+            noc_semaphore_inc(data_sem_noc_addr, 1, noc_index, credit_vc);
+            noc_async_write(src_addr, dst_noc_addr, payload_bytes);
+            noc_async_write_barrier();
+        } else {
+            noc_async_write(src_addr, dst_noc_addr, payload_bytes);
+            if (use_barrier) {
+                noc_async_write_barrier();  // waits for ACKs: payload committed
+            } else {
+                noc_async_writes_flushed();  // waits only for requests SENT
+            }
+            noc_semaphore_inc(data_sem_noc_addr, 1, noc_index, credit_vc);
+        }
+
+        // Serialize with the receiver so the next iteration cannot overwrite the
+        // payload while it is still being checked.
+        noc_semaphore_wait(ack_sem, i);
+    }
+
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+}


### PR DESCRIPTION
### PR Category
Test only — NoC ordering contract guard

Closes #55555. Sub-issue of #50974 (finding F26).

### What this establishes

`WormholeB0/NoC/Ordering.md` lists the recipient-NIU guarantees for two requests arriving on the **same** virtual channel:

1. write → read · 2. linked read → any · 3. atomic → atomic · 4. write → write (overlapping) · 5. MMIO write → MMIO write · 6. read → read (MMIO)

**write → atomic is absent.** Cross-type orderings *are* enumerated where they exist (item 1), so this is a real omission rather than an oversight. Across different VCs the page is explicit: *"arbitrary reordering and interleaving can happen."* `BlackholeA0/NoC/Ordering.md` returns 404.

So publishing a payload with `noc_async_writes_flushed()` — which polls `NIU_MST_NONPOSTED_WR_REQ_SENT`, i.e. the request has *left this NIU* — and then crediting with a remote `noc_semaphore_inc` has no documented commit ordering. `noc_async_write_barrier()` (`NIU_MST_WR_ACK_RECEIVED`) does. They also travel on different command buffers: `write_cmd_buf` vs `write_at_cmd_buf`.

### Measured on p100a — the hazard did NOT reproduce

The sender writes a tagged payload into a peer core's L1 and publishes it; the receiver wakes on the credit and immediately checks the packet **tail**, which commits last. 256 KB payload, 500 iterations, identical across three consecutive runs:

| configuration | stale tail at credit time |
|---|---|
| `noc_async_write_barrier()` (ack-wait) | 0 / 500 |
| flush-only, same VC | **0 / 500** |
| flush-only, cross-VC (ISA says may reorder arbitrarily) | **0 / 500** |
| **detector self-test** — credit sent *before* the payload | **500 / 500** |

The self-test is the load-bearing case. Without it, a zero is indistinguishable from a probe that cannot detect anything — the vacuous-zero trap. It fires 500/500, so the zeros above are genuine negatives.

Reading: on this part the receiving NIU appears to commit the write before processing a later atomic, even cross-VC and with a large payload. That is silicon behaviour I could not defeat by payload size or VC choice — **not** a guarantee, and not something code should rely on.

### Test design

Two cases **assert**:
- `...BarrierIsOrdered` — the ack-wait must never publish a credit ahead of its payload. This is the contract any fix would rest on.
- `...DetectorFires` — the probe must be able to see a mis-ordered publish.

Two cases **report without asserting** (`...FlushOnlyIsUnordered`, `...FlushOnlyCrossVc`): a zero means the race was not won, never that the ordering is safe. Asserting zero would bake in an unguaranteed behaviour; asserting non-zero would be flaky. They exist so the counts show up in CI logs if silicon or routing changes.

Runs under `TT_METAL_SLOW_DISPATCH_MODE=1` (the `MeshDeviceFixture` requirement); ~0.6 s total.

### No behavioural change

`remote_cb_push_back_and_write_pages` (#50974 F10) relies on exactly this ordering — payload writes followed by `noc_semaphore_inc` with nothing between. I have deliberately **not** changed it: with no reproduction and a remote-CB hot path at stake, switching flush→barrier is the NoC owner's call, and the open question is in #55555.

The question that would settle both: **does the recipient NIU commit an L1 write before processing a subsequent atomic on the same VC, and is that architectural or incidental?** If architectural, the Blackhole Ordering page should say so and both F26 and F10 clear.

### Verification
- 4/4 pass on p100a, three consecutive runs, stable counts.
- clang-format clean.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/noc-write-atomic-credit-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/noc-write-atomic-credit-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/noc-write-atomic-credit-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/noc-write-atomic-credit-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/noc-write-atomic-credit-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/noc-write-atomic-credit-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/noc-write-atomic-credit-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/noc-write-atomic-credit-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/noc-write-atomic-credit-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/noc-write-atomic-credit-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/noc-write-atomic-credit-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/noc-write-atomic-credit-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/noc-write-atomic-credit-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/noc-write-atomic-credit-ordering)