### PR TITLE
[d2d] Drain the worker-release atomics before the D2D sender returns

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -20,6 +20,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_checkpoint.cpp
     device_print/test_cb_hash.cpp
     watcher/test_assert.cpp
+    watcher/test_atomic_at_exit.cpp
     watcher/test_link_training.cpp
     watcher/test_mcast_wrap_around.cpp
     watcher/test_mcast_wrap_around_device.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_atomic_at_exit.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_atomic_at_exit.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// The kernel-exit epilogue requires an idle NoC: a non-posted atomic still in flight
+// when kernel_main returns races the next kernel's counter re-init. These tests pin
+// that contract for the multicast-atomic credit shape used by persistent service and
+// mcast-receiver kernels -- issue the credit, then return.
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <cstdint>
+#include "debug_tools_fixture.hpp"
+#include "impl/context/metal_context.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+constexpr const char* kKernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_atomic_at_exit.cpp";
+constexpr const char* kExpected = "missing NOC non-posted atomics flushed barrier";
+
+class NonPostedAtomicAtExitFixture : public MeshWatcherFixture {
+protected:
+    std::shared_ptr<distributed::MeshDevice> mesh_device;
+    IDevice* device{nullptr};
+    std::uint32_t l1_unreserved_base{0};
+
+    void SetUp() override {
+        if (MetalContext::instance().rtoptions().watcher_assert_disabled()) {
+            GTEST_SKIP() << "This test requires watcher asserts to be enabled";
+        }
+        MeshWatcherFixture::SetUp();
+        if (arch_ == tt::ARCH::QUASAR) {
+            // The Quasar kernel epilogue does not yet run the NoC-idle asserts.
+            GTEST_SKIP() << "Kernel-exit NoC-idle asserts are not enabled on Quasar";
+        }
+        mesh_device = devices_[0];
+        device = mesh_device->get_devices()[0];
+        l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    }
+
+    // Multicasts a non-posted atomic increment from (0,0) to every other storage-grid
+    // core, then returns. `drain` selects the trailing atomic barrier.
+    void Run(std::uint32_t drain) {
+        const CoreCoord grid = device->compute_with_storage_grid_size();
+        ASSERT_GE(grid.x, 2u);
+        const CoreCoord sender{0, 0};
+        const CoreRange dests(CoreCoord(1, 0), CoreCoord(grid.x - 1, grid.y - 1));
+        const std::uint32_t num_dests = (grid.x - 1) * grid.y;
+
+        std::vector<std::uint32_t> zero{0};
+        for (const auto& c : dests) {
+            tt::tt_metal::detail::WriteToDeviceL1(device, c, l1_unreserved_base, zero);
+        }
+
+        const CoreCoord start = device->worker_core_from_logical_core(dests.start_coord);
+        const CoreCoord end = device->worker_core_from_logical_core(dests.end_coord);
+
+        Program program;
+        auto kernel = CreateKernel(
+            program,
+            kKernel,
+            sender,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        SetRuntimeArgs(program, kernel, sender, {l1_unreserved_base, start.x, start.y, end.x, end.y, num_dests, drain});
+
+        distributed::MeshWorkload workload;
+        const distributed::MeshCoordinate zero_coord{0, 0};
+        const distributed::MeshCoordinateRange device_range{zero_coord, zero_coord};
+        workload.add_program(device_range, std::move(program));
+        try {
+            RunProgram(mesh_device, workload);
+        } catch (const std::runtime_error& e) {
+            log_info(tt::LogTest, "Caught exception: {}", e.what());
+        }
+    }
+
+    std::string WaitForException(std::chrono::milliseconds timeout) {
+        const auto start = std::chrono::steady_clock::now();
+        std::string exception;
+        while (std::chrono::steady_clock::now() - start < timeout) {
+            exception = MetalContext::instance().watcher_server()->exception_message();
+            if (!exception.empty()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        return exception;
+    }
+};
+
+// Control: draining with noc_async_atomic_barrier keeps the NoC idle at exit.
+TEST_F(NonPostedAtomicAtExitFixture, DrainedMulticastCredit) {
+    Run(/*drain=*/1);
+    EXPECT_EQ(WaitForException(std::chrono::milliseconds(1500)), "");
+}
+
+// Returning with the multicast atomic still in flight trips the epilogue assert.
+// The assert halts the core; the fixture reopens the device for the next test.
+TEST_F(NonPostedAtomicAtExitFixture, UndrainedMulticastCredit) {
+    Run(/*drain=*/0);
+    const std::string exception = WaitForException(std::chrono::milliseconds(5000));
+    EXPECT_NE(exception.find(kExpected), std::string::npos) << "actual: " << exception;
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_atomic_at_exit.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_atomic_at_exit.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Mirrors the terminal shape of a persistent service kernel: issue a non-posted
+// multicast atomic credit, then return. `drain` selects whether the kernel drains
+// the atomic (noc_async_atomic_barrier) before returning.
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    const std::uint32_t sem_addr = get_arg_val<std::uint32_t>(0);
+    const std::uint32_t x_start = get_arg_val<std::uint32_t>(1);
+    const std::uint32_t y_start = get_arg_val<std::uint32_t>(2);
+    const std::uint32_t x_end = get_arg_val<std::uint32_t>(3);
+    const std::uint32_t y_end = get_arg_val<std::uint32_t>(4);
+    const std::uint32_t num_dests = get_arg_val<std::uint32_t>(5);
+    const std::uint32_t drain = get_arg_val<std::uint32_t>(6);
+
+    const std::uint64_t mcast_addr = get_noc_multicast_addr(x_start, y_start, x_end, y_end, sem_addr);
+    noc_semaphore_inc_multicast(mcast_addr, 1, num_dests);
+    if (drain) {
+        noc_async_atomic_barrier();
+    }
+}

--- a/ttnn/core/tensor/kernels/persistent_d2d_sender.cpp
+++ b/ttnn/core/tensor/kernels/persistent_d2d_sender.cpp
@@ -401,6 +401,9 @@ void kernel_main() {
             }
         }
 
+        // Drain the non-posted consumed_sem multicasts before the exit epilogue's
+        // NoC-idle check, as the receiver does before its own update_socket_config.
+        noc.async_atomic_barrier();
         update_socket_config(sender_socket);
         if (fabric_open) {
             fabric_connection.close();


### PR DESCRIPTION
### Summary

`persistent_d2d_sender.cpp`'s master lane releases the sender worker grid with a
**non-posted** multicast atomic and, on termination, returns without draining it:

```cpp
// 7. Release the sender worker grid so it can overwrite the SENDER backing.
if constexpr (worker_sync_enabled) {
    noc_semaphore_inc_multicast(consumed_mcast_addr, /*incr=*/1, /*num_dests=*/num_workers);
}
...
update_socket_config(sender_socket);   // two plain L1 stores, then return
```

`noc_semaphore_inc_multicast` defaults to `posted = false`, so it needs `num_dests` acks.
The sibling `persistent_d2d_receiver.cpp` drains the identical credit immediately before
the same call:

```cpp
noc.async_write_barrier();
noc.async_atomic_barrier();
update_socket_config(receiver_socket);
```

Both kernels landed together in #47245; the receiver got the drain, the sender did not.
This PR adds the matching `noc.async_atomic_barrier()`. Only the atomic counter needs it:
the master's DRAM reads are all barriered by the trid ring in `stream_half`, and its
payload writes go over fabric.

### Why this code is unlikely to fail today

The atomic is drained incidentally, not by contract. In OWN mode
(`share_fabric_links == 0`) `fabric_connection.close()` runs after
`update_socket_config()`; in LEASE mode it runs at step 8, right after the multicast.
Either way `close_finish()` spins on the EDM teardown ack — a full round trip — which
covers the atomic's ack latency. Reorder or remove that close and the guarantee is gone.

`worker_sync_enabled` is `constexpr true` on both sender build paths in
`ttnn/core/tensor/d2d_stream_service.cpp`, so the multicast is always live.

### Why add the synchronization anyway

The kernel-exit epilogue (`tt_metal/hw/firmware/src/tt-1xx/brisck.cc`) asserts
`ncrisc_noc_nonposted_atomics_flushed`. With Watcher on that halts the core; with Watcher
off the late ack races the next kernel's `noc_local_state_init` counter re-sync. The
sender is safe today only because an unrelated fabric teardown happens to sit in the exit
path.

### Test

`tests/tt_metal/tt_metal/debug_tools/watcher/test_atomic_at_exit.cpp` pins the contract
the fix satisfies, in exactly the sender's terminal shape (issue a non-posted multicast
atomic credit, then return):

* `UndrainedMulticastCredit` — no barrier → `BRISC detected an inter-kernel data race due
  to kernel completing with pending NOC transactions (missing NOC non-posted atomics
  flushed barrier).`
* `DrainedMulticastCredit` — with `noc_async_atomic_barrier()` → clean.

Measured on Blackhole p100a, 3/3 runs each, both in one process. Skipped on Quasar (its
epilogue does not yet run the NoC-idle asserts) and when watcher asserts are disabled.

### Validation

* Watcher test pair: 3/3 green on Blackhole p100a (single card).
* The modified `persistent_d2d_sender.cpp` JIT-compiles for Blackhole with the master
  lane's real CT-arg layout (`is_master = 1`, `worker_sync_enabled = 1`); the harness was
  itself validated by confirming it fails on a deliberately injected error.
* **Not** run end-to-end: the D2D service path needs a >= 2-device Blackhole mesh
  (`ServiceCoreManager::claim()` requires Blackhole or UBB Galaxy, and a sender/receiver
  pair needs two submeshes), which this single-card p100a does not have. CI's multi-card
  Blackhole runners cover `test_d2d_stream_service` / `test_stream_pipeline`.

Closes #55557. Part of #50973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/d2d-sender-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/d2d-sender-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/d2d-sender-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/d2d-sender-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/d2d-sender-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/d2d-sender-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/d2d-sender-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/d2d-sender-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/d2d-sender-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/d2d-sender-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/d2d-sender-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/d2d-sender-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/d2d-sender-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/d2d-sender-atomic-barrier)