### PR TITLE
docs: add kernel API page for init_sfpu

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
@@ -26,6 +26,7 @@ Initialization
 .. toctree::
 
   init_functions
+  init_sfpu
   binary_op_init_funcs
 
 Compute (FPU/matrix engine)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/init_sfpu.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/init_sfpu.rst
@@ -1,0 +1,7 @@
+init_sfpu
+=========
+
+.. deprecated:: 2026-09-20
+   Use :doc:`compute_kernel_hw_startup` once at kernel start, then ``copy_init(icb)`` before the op, as documented in the doxygen comment below.
+
+.. doxygenfunction:: init_sfpu


### PR DESCRIPTION
### Ticket

Closes #50533

### What

`init_sfpu` is referenced throughout kernel examples but had no page under Kernel APIs > Compute. This adds one and links it in the Initialization toctree.

The page is a `doxygenfunction` directive, so it renders the existing doxygen comment in `tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h` (argument table, "Legacy SFPU init" note). Since the function is `[[deprecated]]` with removal after 20-09-2026, the page leads with a `.. deprecated::` note pointing readers to the replacement path: `compute_kernel_hw_startup(icb, ocb)` once at kernel start, then `copy_init(icb)` before the op.

### Testing

Docs-only change. Verified locally: rst parses, toctree entry matches the new filename, the referenced function exists at the path above, and `compute_kernel_hw_startup` already has a doc page for the deprecation link to land on.