### PR TITLE
fix(ttnn): handle zero inputs in prod_bw gradient calculation (#54551)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1672,12 +1672,34 @@ std::vector<Tensor> prod_bw(
     }
 
     if (all_dimensions) {
-        Tensor temp = ttnn::multiply(
-            prod_result, grad, std::nullopt, output_memory_config);  // result is stored in the first position
+        // Zero-aware gradient handling to prevent non-finite (inf * 0) results (#54551)
+        Tensor is_zero = ttnn::eq(input, 0.0f, std::nullopt, output_memory_config);
+        Tensor zero_count = ttnn::sum(is_zero, std::nullopt, false, output_memory_config);
+        Tensor non_zero_input = ttnn::where(is_zero, 1.0f, input, output_memory_config);
+        Tensor non_zero_prod = ttnn::prod(non_zero_input, dim, keepdim, output_memory_config);
+
+        Tensor temp = ttnn::multiply(prod_result, grad, std::nullopt, output_memory_config);
         Tensor fill_tensor = ttnn::fill_first_val_into_tensor<::bfloat16>(
             temp, temp.dtype(), temp.layout(), temp.device(), output_memory_config);
-        Tensor all_dimension_result = ttnn::multiply(
-            ttnn::reciprocal(input, output_memory_config), fill_tensor, std::nullopt, output_memory_config);
+        Tensor normal_grad = ttnn::multiply(
+            ttnn::reciprocal(non_zero_input, output_memory_config), fill_tensor, std::nullopt, output_memory_config);
+
+        Tensor single_zero_grad = ttnn::where(
+            is_zero,
+            ttnn::multiply(non_zero_prod, grad, std::nullopt, output_memory_config),
+            0.0f,
+            output_memory_config);
+
+        Tensor all_dimension_result = ttnn::where(
+            ttnn::eq(zero_count, 0.0f, std::nullopt, output_memory_config),
+            normal_grad,
+            ttnn::where(
+                ttnn::eq(zero_count, 1.0f, std::nullopt, output_memory_config),
+                single_zero_grad,
+                0.0f,
+                output_memory_config),
+            output_memory_config);
+
         grad_tensor.emplace_back(all_dimension_result);
         return grad_tensor;
     }


### PR DESCRIPTION
### Summary

Resolves #54551.

### Root Cause
`ttnn.prod_bw` previously computed the gradient via `reciprocal(input) * (prod * grad)`. When an input element contains an exact zero, `reciprocal(0.0)` evaluates to `+inf`, and multiplying by `prod(input) == 0.0` produced non-finite (`inf * 0.0 -> NaN`) values on device instead of the mathematically correct finite gradient.

### Fix Details
1. **Zero-Aware Masking**:
   - Computes `is_zero = ttnn::eq(input, 0.0f)` and counts total zeros across reduction dimensions.
   - Replaces zero inputs with `1.0f` for safe reciprocal and non-zero product computations.
2. **Branching Gradient Logic**:
   - **Case 0 (No zeros)**: Standard fast-path `(prod * grad) / input`.
   - **Case 1 (Single zero)**: Position of the zero element evaluates to `prod(non_zero_elements) * grad`, and zero everywhere else.
   - **Case 2 (Two or more zeros)**: Gradient is finite `0.0f` everywhere.
3. Preserves layout and memory configurations across device tensors.
