### PR TITLE
fix(ttnn): use canonical fp32 SELU constants in python bindings and selu_bw (#55393)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
@@ -143,3 +143,20 @@ def test_selu_atol(low, high, expected_Atol, device):
     tt_result = ttnn.selu(tt_in)
     result = ttnn.to_torch(tt_result)
     torch.allclose(golden, result, atol=expected_Atol)
+
+
+def test_selu_canonical_constants_precision(device):
+    # Verify that default ttnn.selu aligns with canonical PyTorch float32 constants (#55393)
+    torch_input = torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=torch.bfloat16).reshape(1, 1, 1, 5)
+    golden = torch.nn.functional.selu(torch_input)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.selu(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
@@ -159,4 +159,4 @@ def test_selu_canonical_constants_precision(device):
     )
     tt_result = ttnn.selu(tt_in)
     result = ttnn.to_torch(tt_result)
-    assert_with_pcc(golden, result, 0.999)
+    assert_with_ulp(golden, result)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -1935,8 +1935,8 @@ void py_module(nb::module_& mod) {
             input_tensor (ttnn.Tensor): the input tensor.
 
         Keyword args:
-            scale (float, optional): Scale value. Defaults to `1.0507`.
-            alpha (float, optional): Alpha value. Defaults to `1.67326`.
+            scale (float, optional): Scale value. Defaults to `1.050700987f`.
+            alpha (float, optional): Alpha value. Defaults to `1.673263242f`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             sub_core_grids (ttnn.CoreRangeSet, optional): Sub-core grids. Defaults to `None`.
@@ -1950,8 +1950,8 @@ void py_module(nb::module_& mod) {
             &ttnn::selu,
             nb::arg("input_tensor"),
             nb::kw_only(),
-            nb::arg("scale") = 1.0507f,
-            nb::arg("alpha") = 1.67326f,
+            nb::arg("scale") = 1.050700987f,
+            nb::arg("alpha") = 1.673263242f,
             nb::arg("memory_config") = nb::none(),
             nb::arg("output_tensor") = nb::none(),
             nb::arg("sub_core_grids") = nb::none());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -904,12 +904,12 @@ std::vector<std::optional<Tensor>> silu_bw(
 std::vector<Tensor> selu_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor grad_lambd = ttnn::multiply(grad, 1.0507f, std::nullopt, output_mem_config);
+    Tensor grad_lambd = ttnn::multiply(grad, 1.050700987f, std::nullopt, output_mem_config);
     Tensor grad_result = where(
         ttnn::gtz(input, output_mem_config),
         grad_lambd,
         ttnn::multiply(
-            ttnn::multiply(grad_lambd, 1.673260f, std::nullopt, output_mem_config),
+            ttnn::multiply(grad_lambd, 1.673263242f, std::nullopt, output_mem_config),
             ttnn::exp(input, false, output_mem_config),
             std::nullopt,
             output_mem_config),


### PR DESCRIPTION
### Summary
Resolves #55393.

Aligns SELU scale and alpha constants across the Python bindings (`unary_nanobind.cpp`) and autograd backward pass (`unary_backward.cpp`) to the canonical float32 representations (`scale = 1.050700987f`, `alpha = 1.673263242f`), matching the C++ defaults in `unary.hpp`, `unary_op_utils.cpp`, and PyTorch `torch.nn.functional.selu`.

### Changes
1. **Python Bindings (`unary_nanobind.cpp`)**:
   - Replaced truncated float literals `1.0507f` and `1.67326f` with canonical float32 constants `1.050700987f` and `1.673263242f`.
   - Updated docstring default value descriptions to reflect exact values.
2. **Backward Implementation (`unary_backward.cpp`)**:
   - Updated `selu_bw` constants from truncated `1.0507f` and `1.673260f` to `1.050700987f` and `1.673263242f`.
   - Eliminates the 9 ULP / 27 ULP discrepancy between forward and backward passes.
3. **Tests (`test_eltwise_selu.py`)**:
   - Added regression test `test_selu_canonical_constants_precision` ensuring default Python calls match PyTorch golden references.

### Verification
- Measured ULP delta against PyTorch canonical values dropped from 9/27 ULP to 0 ULP.
- Validated parameter agreement between C++ `ttnn::selu`, Python `ttnn.selu`, and autograd backward.
