### PR TITLE
fix(ttnn): eliminate 16 dead dispatches and discarded where() guards in div_bw (fixes #55392)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -718,24 +718,14 @@ std::vector<std::optional<Tensor>> div_bw(
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
 
     if (rounding_mode == std::nullopt) {
-        float t_nan = std::nanf("");
-        float t_inf = std::numeric_limits<float>::infinity();
-        float neg_inf = -std::numeric_limits<float>::infinity();
         if (are_required_outputs.at(0)) {
+            // reciprocal(+-0) already produces exact IEEE signed infinity / NaN; eliminating 6 dead dispatches
             ttnn::multiply(
                 grad_tensor, ttnn::reciprocal(other, output_mem_config), std::nullopt, output_mem_config, input_grad);
-            ttnn::where(
-                ttnn::eqz(other, output_mem_config),
-                ttnn::where(
-                    ttnn::eqz(grad_tensor, output_mem_config),
-                    t_nan,
-                    ttnn::multiply(ttnn::sign(grad_tensor, output_mem_config), t_inf, std::nullopt, output_mem_config),
-                    output_mem_config),
-                input_grad.value(),
-                output_mem_config);
             result[0] = input_grad;
         }
         if (are_required_outputs.at(1)) {
+            // square(+-0) -> +0; reciprocal(+0) -> +inf; eliminating 10 dead dispatches while preserving IEEE sign semantics
             ttnn::multiply(
                 ttnn::neg(grad_tensor, output_mem_config),
                 (ttnn::multiply(
@@ -746,24 +736,6 @@ std::vector<std::optional<Tensor>> div_bw(
                 std::nullopt,
                 output_mem_config,
                 other_grad);
-            ttnn::where(
-                ttnn::eqz(other, output_mem_config),
-                ttnn::where(
-                    ttnn::eqz(grad_tensor, output_mem_config),
-                    t_nan,
-                    ttnn::where(
-                        ttnn::eqz(input_a, output_mem_config),
-                        t_nan,
-                        ttnn::multiply(
-                            ttnn::multiply(
-                                ttnn::sign(input_a, output_mem_config), neg_inf, std::nullopt, output_mem_config),
-                            ttnn::sign(grad_tensor, output_mem_config),
-                            std::nullopt,
-                            output_mem_config),
-                        output_mem_config),
-                    output_mem_config),
-                other_grad.value(),
-                output_mem_config);
             result[1] = other_grad;
         }
     } else {


### PR DESCRIPTION
### Summary
Resolves #55392.

In `ttnn.div_bw(grad_tensor, input_a, other, ...)` (tensor-tensor overload), two `ttnn::where(...)` zero-divisor guard blocks were evaluated and immediately discarded because the calls omitted the 5th `output` destination argument and their return values were never captured. As a result, 16 out of 23 device op launches (~70%) were allocating temporary tensors whose contents were never used.

Furthermore, IEEE fp32 `reciprocal(+-0.0)` already yields signed infinities and NaNs consistent with PyTorch autograd semantics. Retaining the dead guards with a destination argument would have introduced an erroneous positive-infinity sign overwrite on negative zero (`-0.0`) divisors.

### Changes
- Removed the 16 dead device op dispatches (`ttnn::eqz`, `ttnn::sign`, `ttnn::where`) and unused constants (`t_nan`, `t_inf`, `neg_inf`) in `ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp`.
- Reduced device op launches from 23 down to 7 (70% reduction) when both input gradients are requested, cutting memory overhead and execution latency while preserving exact bit-for-bit IEEE fp32 gradient semantics.

Fixes #55392.
