### PR TITLE
[Bug fix] Fix Blackhole bitwise_right_shift out-of-range shift guard

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -396,6 +396,35 @@ def test_bitwise_right_shift(device, ttnn_function, ttnn_dtype):
 @pytest.mark.parametrize(
     "ttnn_function",
     [
+        ttnn.bitwise_right_shift,
+        ttnn.bitwise_left_shift,
+    ],
+)
+@pytest.mark.parametrize(
+    "ttnn_dtype",
+    [
+        ttnn.int32,
+        ttnn.uint32,
+    ],
+)
+def test_bitwise_shift_out_of_range_amount(device, ttnn_function, ttnn_dtype):
+    """A shift amount outside [0, 31] produces 0, for both shift directions."""
+    values = [1, 8, 47, 1024, 99999, 123456789, 2**31 - 1]
+    shifts = [-33, -8, -1, 32, 33, 63]
+
+    x_torch = torch.tensor([[v for v in values for _ in shifts]], dtype=torch.int32)
+    y_torch = torch.tensor([[s for _ in values for s in shifts]], dtype=torch.int32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = ttnn.to_torch(ttnn_function(x_tt, y_tt))
+
+    assert torch.equal(tt_out, torch.zeros_like(x_torch))
+
+
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
         ttnn.logical_right_shift,
     ],
 )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
@@ -51,32 +51,40 @@ inline void calculate_binary_right_shift(
 
     constexpr InstrModLoadStore sfpload_instr_mod =
         SIGN_MAGNITUDE_FORMAT ? InstrModLoadStore::INT32_2S_COMP : INSTRUCTION_MODE;
-    // SFPU microcode
+    // Pick the DataLayout whose load/store format byte matches the InstrModLoadStore
+    // (LO16->U16, INT32/2S_COMP->I32; on Blackhole INT32_2S_COMP is raw int32).
+    constexpr sfpi::DataLayout layout =
+        (sfpload_instr_mod == InstrModLoadStore::LO16) ? sfpi::DataLayout::U16 : sfpi::DataLayout::I32;
+    using vType = std::conditional_t<layout == sfpi::DataLayout::U16, sfpi::vUInt, sfpi::vInt>;
+
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64 rows
-        constexpr std::uint32_t dst_tile_size = 64;
-        // load
-        TT_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);  // save shift_value for later
-        // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
-        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0);  // 0xFE0 = -32
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 6);  // take negative of shift_amount to shift right
-        // shift right
-        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        // if shift_value was negative, need to shift in 1's manually
-        TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);     // only run if shift_value is negative
-        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);     // only needed if shift_amount>0
-        TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5);  // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);    // put all 1's into LREG3
-        TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);      // shift all 1's by 32-shift_amount
-        TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);        // OR in the 1's
-        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        // store result
-        TT_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        vType a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<layout>();
+        vType s = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<layout>();
+        sfpi::vUInt value = sfpi::as<sfpi::vUInt>(a);
+        sfpi::vInt shift = sfpi::as<sfpi::vInt>(s);
+
+        // Right shift by `shift` (a negative shift amount shifts left). Out-of-range lanes are
+        // fixed up to 0 by the final guard below, so their intermediate result here is don't-care.
+        sfpi::vUInt result = sfpi::shft(value, 0 - shift, sfpi::ShiftMode::Logical);
+
+        // Arithmetic shift: when the original value is negative (and the shift is non-zero) the
+        // vacated high bits must be filled with 1's rather than 0's.
+        v_if(sfpi::as<sfpi::vInt>(value) < 0 && shift != 0) {
+            sfpi::vUInt high_ones = sfpi::shft(~sfpi::vUInt(0), 32 - shift, sfpi::ShiftMode::Logical);
+            result = result | high_ones;
+        }
+        v_endif;
+
+        // Out-of-range shift amounts (shift < 0 or shift >= 32) produce 0, matching the sibling
+        // kernels and the "shift_amount < 0 OR >= 32 -> 0" contract.
+        v_if(shift < 0 || shift >= 32) { result = 0; }
+        v_endif;
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<layout>() = sfpi::as<vType>(result);
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #55332.

On Blackhole a shift amount outside `[0, 31]` returned a wrong value from `bitwise_right_shift` instead of 0: a negative shift shifted left, so `8 >> -1` gave 16 and `1024 >> -8` gave 262144.

In `ckernel_sfpu_shift.h` the range guard passed a register selector (`p_sfpu::LCONST_0`) where the instruction modifier belongs and was missing the `TTI_SFPCOMPC` its left-shift sibling has, and the sign-extension block then ran on lanes the guard should have zeroed. This replaces that sequence with the SFPI implementation Wormhole already uses, which applies the guard last. `bitwise_left_shift` and `logical_right_shift` are untouched.

Verified on ttsim (Blackhole, `v0.79.0-dev20260903`): the 80 value/shift combinations from the issue go from 25 wrong to 0, the new test goes from 21 of 42 lanes non-zero to 0 on both `int32` and `uint32`, and the existing `test_bitwise_right_shift` passes before and after.

### Notes for reviewers
For negative values with an out-of-range shift the kernel contract, Wormhole and the left-shift sibling all give 0, while the registered golden (`torch.bitwise_right_shift`) saturates to -1. This change matches Wormhole rather than the golden, and the new test only asserts the positive-value cases where the two agree. Say the word if you would rather both architectures follow the golden.
