### PR TITLE
[skip ci] Return the dtype-converted tensor from torch_random_with_zeros

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -87,10 +87,9 @@ def torch_random_with_zeros(shape, low, high, dtype, zero_fraction=0.1):
     # Shuffle the tensor
     shuffled = combined[torch.randperm(combined.size(0))]
 
-    # Reshape to the desired shape
+    # Reshape to the desired shape. Tensor.to is not in-place, so return the converted tensor.
     result_tensor = shuffled.view(shape)
-    result_tensor.to(dtype)
-    return result_tensor
+    return result_tensor.to(dtype)
 
 
 ### Profiling ###


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`torch_random_with_zeros()` in `models/common/utility_functions.py` takes a `dtype`
argument and then discards the conversion:

```python
result_tensor = shuffled.view(shape)
result_tensor.to(dtype)      # return value dropped; Tensor.to is not in-place
return result_tensor
```

`shuffled` comes from `torch.empty(...).uniform_()` and `torch.zeros(...)`, so the function
always returns float32 no matter what the caller asked for.

```
requested torch.bfloat16 -> got torch.float32   (before)
requested torch.bfloat16 -> got torch.bfloat16  (after)
```

The corrected form already exists in the tree, in the Quasar port of Llama 3.2 1B added by
#51337:

https://github.com/tenstorrent/tt-metal/blob/main/models/experimental/llama32_1b_quasar/utility_functions.py#L93

That copy returns `result_tensor.to(dtype)` and carries a comment noting that `Tensor.to`
is not in-place. The fix was never brought back to the shared `models/common` version, so
every caller of the common helper still gets the wrong dtype. This PR applies the same
one-line fix to the canonical copy.

### Why it has not been noticed

Both current callers pass `dtype=torch.float32`:

- `tests/sweep_framework/sweeps/eltwise/unary/eqz/eqz.py:49`
- `tests/sweep_framework/sweeps/eltwise/unary/eqz/eqz_sharded.py:95`

float32 is exactly what the un-converted tensor already is, so the defect is invisible
today. It becomes visible the moment a caller asks for bfloat16 or float16, which is the
whole reason the parameter exists.

### Testing

The change is behaviour-preserving for both existing callers, since float32 in and float32
out is unchanged.

Verified the function directly for the three dtypes a caller would plausibly request, and
confirmed shape and zero-fraction behaviour are untouched:

```
requested torch.bfloat16  -> got torch.bfloat16   shape (4, 4)  zero_frac 0.06
requested torch.float16   -> got torch.float16    shape (4, 4)  zero_frac 0.06
requested torch.float32   -> got torch.float32    shape (4, 4)  zero_frac 0.06
```
