### PR TITLE
[Bug fix] Restrict tt-smi to x86_64 so tt-llk test deps install on aarch64

### DIFF
--- a/tt_metal/tt-llk/tests/TTSIM.md
+++ b/tt_metal/tt-llk/tests/TTSIM.md
@@ -2,7 +2,7 @@
 
 [ttsim](https://github.com/tenstorrent/ttsim) is Tenstorrent's functional
 simulator. It models a Wormhole or Blackhole chip end-to-end on a plain
-x86_64 Linux host — no silicon required. The LLK test suite can target
+x86_64 or aarch64 Linux host — no silicon required. The LLK test suite can target
 ttsim with the same pytest invocations used for silicon, modulo a couple
 of environment variables.
 

--- a/tt_metal/tt-llk/tests/requirements.txt
+++ b/tt_metal/tt-llk/tests/requirements.txt
@@ -5,8 +5,10 @@
 # tt packages from test.pypi.org
 tt-exalens==0.3.31
 
-# tt-smi from pypi
-tt-smi==3.1.1
+# tt-smi from pypi. Hardware-management CLI, used by setup_clangd.sh for architecture
+# detection and for device resets; no test imports it. Its pyluwen dependency ships no
+# aarch64 wheel, so it is restricted to x86_64 to keep the rest installable on arm64.
+tt-smi==3.1.1; platform_machine == "x86_64"
 
 coverage[toml]==7.10.5
 exceptiongroup==1.3.0


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #54854.

`pip install -r tt_metal/tt-llk/tests/requirements.txt` fails on aarch64, so the LLK test suite cannot be set up there even though ttsim and SFPI both ship aarch64 builds.

The blocker is `tt-smi`, which depends on `pyluwen~=0.8.0`, and pyluwen publishes only x86_64 wheels: pip falls back to building the Rust extension from source and takes the whole install down with it. `tt-smi` is a hardware-management CLI, called by `setup_clangd.sh` for architecture detection and used for device resets, and no test imports it, so this restricts it to x86_64 with an environment marker.

Verified: on x86_64 the resolution is byte-identical, 92 packages before and after with both `tt-smi` and `pyluwen` present, so nothing changes for existing hosts. The marker evaluates False on aarch64, and pyluwen's latest release ships two x86_64 wheels and no aarch64 wheel. #54854 reports the suite running 426 passed / 120 skipped on an arm64 container once `tt-smi` is out of the way.

### Notes for reviewers
An aarch64 host that does have silicon would also skip `tt-smi` under this marker. Splitting the file into a base set plus a hardware extra is the fuller fix if you prefer that shape; the marker is the smallest change that unblocks simulator-only arm64 runs.
