### PR TITLE
Fix is_real and is_imag goldens and make their sweeps exercise the predicate

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary_complex/is_imag.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_complex/is_imag.py
@@ -69,9 +69,14 @@ def run(
         partial(torch_random, low=0.01, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
-    torch_output_tensor = torch.isreal(
-        torch.complex(torch_input_tensor_ar.to(torch.float32), torch_input_tensor_ac.to(torch.float32))
+    # is_imag is true only where the real part is zero, so the real part has to actually
+    # reach zero for this sweep to exercise the op rather than compare all-false to all-false.
+    torch_input_tensor_ar[..., ::2] = 0
+
+    torch_complex_input = torch.complex(
+        torch_input_tensor_ar.to(torch.float32), torch_input_tensor_ac.to(torch.float32)
     )
+    torch_output_tensor = torch.real(torch_complex_input) == 0
 
     input_tensor_ar = ttnn.from_torch(
         torch_input_tensor_ar,

--- a/tests/sweep_framework/sweeps/eltwise/unary_complex/is_real.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_complex/is_real.py
@@ -57,8 +57,12 @@ def run(
     )(input_shape)
 
     torch_input_tensor_ac = gen_func_with_cast_tt(
-        partial(torch_random, low=100, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
+
+    # is_real is true only where the imaginary part is zero, so the imaginary part has to
+    # actually reach zero for this sweep to exercise the op.
+    torch_input_tensor_ac[..., ::2] = 0
 
     torch_output_tensor = torch.isreal(
         torch.complex(torch_input_tensor_ar.to(torch.float32), torch_input_tensor_ac.to(torch.float32))

--- a/ttnn/ttnn/operations/unary_complex.py
+++ b/ttnn/ttnn/operations/unary_complex.py
@@ -37,7 +37,8 @@ ttnn.attach_golden_function(ttnn.angle, golden_function=_golden_function)
 def _golden_function(input_tensor_a, *args, **kwargs):
     import torch
 
-    return torch.is_imag(input_tensor_a)
+    # ttnn.is_imag is eqz(real part): true where the value is purely imaginary.
+    return torch.real(input_tensor_a) == 0
 
 
 ttnn.attach_golden_function(ttnn.is_imag, golden_function=_golden_function)
@@ -46,7 +47,8 @@ ttnn.attach_golden_function(ttnn.is_imag, golden_function=_golden_function)
 def _golden_function(input_tensor_a, *args, **kwargs):
     import torch
 
-    return torch.is_real(input_tensor_a)
+    # ttnn.is_real is eqz(imag part): true where the value is purely real.
+    return torch.isreal(input_tensor_a)
 
 
 ttnn.attach_golden_function(ttnn.is_real, golden_function=_golden_function)


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`ttnn.is_real` and `ttnn.is_imag` have never been validated. Their golden functions raise,
and their sweeps compare all-false against all-false.

**1. Both goldens call torch functions that do not exist.**

`ttnn/ttnn/operations/unary_complex.py` had:

```python
return torch.is_imag(input_tensor_a)   # AttributeError
return torch.is_real(input_tensor_a)   # AttributeError
```

There is no `torch.is_imag` or `torch.is_real`. The real spelling is `torch.isreal`, and
there is no elementwise `isimag`. Any call through `ttnn.get_golden_function(...)` for
either op fails before a comparison happens, so neither has ever been checked against a
reference.

The device semantics come from `complex_unary_op.cpp`:

```cpp
Tensor _is_imag(...) { return ttnn::eqz(input[0]); }   // real part zero
Tensor _is_real(...) { return ttnn::eqz(input[1]); }   // imag part zero
```

so the goldens become `torch.real(x) == 0` and `torch.isreal(x)` respectively.

**2. The `is_imag` sweep used the wrong predicate.**

`tests/sweep_framework/sweeps/eltwise/unary_complex/is_imag.py` computed its reference with
`torch.isreal(...)`, which tests the imaginary part. `ttnn.is_imag` tests the real part.
Those are different predicates: on a mixed input they disagree on half the elements.

**3. Neither sweep could ever fail.**

`is_imag` drew both the real and imaginary parts from `torch_random(low=0.01, high=100)`,
so the real part was never zero and the op could never return true. `is_real` drew its
imaginary part from `torch_random(low=100, high=100)`, a constant 100, so the imaginary
part was never zero either. Both sweeps compared an all-false reference against an
all-false result and passed without exercising anything.

This PR fixes the two goldens, corrects the `is_imag` reference, and zeroes every other
column of the relevant part in both sweeps so the predicate is actually true for half the
elements.

### Testing

Both ops are correct; only the validation around them was broken. On Blackhole p150b, with
a mixed input where the predicate holds for half the elements:

```
is_imag  golden vs device: wrong 0/1024  true_count=512  MATCH
is_real  golden vs device: wrong 0/1024  true_count=512  MATCH
old is_imag reference (torch.isreal) vs correct predicate: differs on 512/1024 elements
```

So the fixed goldens agree with the device exactly on inputs that exercise them, and the
previous reference is measurably the wrong function.

Ran the repo pre-commit hooks over all three files; black, trailing whitespace, end of
files and the rest pass.
