### PR TITLE
[Bug fix] Guard the pow Veltkamp split against exponent overflow

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -227,6 +227,16 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vFloat pc = pow * VELTKAMP_SPLIT;
     sfpi::vFloat pow_hi = pc - (pc - pow);
     sfpi::vFloat pow_lo = pow - pow_hi;
+    // pc overflows to inf once |pow| > FLT_MAX/VELTKAMP_SPLIT, and pc - (pc - pow) is then
+    // inf - inf = NaN, which propagates through z_hi and z_lo into the result. FLT_MAX/4097
+    // lies inside [2**115, 2**116), so 115 is the first exponent that can overflow. A |pow|
+    // that large drives pow*log2(base) far outside the 2**z range for every base except 1,
+    // where exp_f32 and ln_m are both zero, so the split has nothing left to preserve.
+    v_if(sfpi::exexp(pow) >= 115) {
+        pow_hi = pow;
+        pow_lo = 0.0f;
+    }
+    v_endif;
 
     sfpi::vFloat z_hi = pow_hi * exp_f32;
     sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -289,6 +289,16 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vFloat pc = pow * VELTKAMP_SPLIT;
     sfpi::vFloat pow_hi = pc - (pc - pow);
     sfpi::vFloat pow_lo = pow - pow_hi;
+    // pc overflows to inf once |pow| > FLT_MAX/VELTKAMP_SPLIT, and pc - (pc - pow) is then
+    // inf - inf = NaN, which propagates through z_hi and z_lo into the result. FLT_MAX/4097
+    // lies inside [2**115, 2**116), so 115 is the first exponent that can overflow. A |pow|
+    // that large drives pow*log2(base) far outside the 2**z range for every base except 1,
+    // where exp_f32 and ln_m are both zero, so the split has nothing left to preserve.
+    v_if(sfpi::exexp(pow) >= 115) {
+        pow_hi = pow;
+        pow_lo = 0.0f;
+    }
+    v_endif;
 
     sfpi::vFloat z_hi = pow_hi * exp_f32;
     sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -228,6 +228,16 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     sfpi::vFloat pc = pow * VELTKAMP_SPLIT;
     sfpi::vFloat pow_hi = pc - (pc - pow);
     sfpi::vFloat pow_lo = pow - pow_hi;
+    // pc overflows to inf once |pow| > FLT_MAX/VELTKAMP_SPLIT, and pc - (pc - pow) is then
+    // inf - inf = NaN, which propagates through z_hi and z_lo into the result. FLT_MAX/4097
+    // lies inside [2**115, 2**116), so 115 is the first exponent that can overflow. A |pow|
+    // that large drives pow*log2(base) far outside the 2**z range for every base except 1,
+    // where exp_f32 and ln_m are both zero, so the split has nothing left to preserve.
+    v_if(sfpi::exexp(pow) >= 115) {
+        pow_hi = pow;
+        pow_lo = 0.0f;
+    }
+    v_endif;
 
     sfpi::vFloat z_hi = pow_hi * exp_f32;
     sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -297,6 +297,16 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vFloat pc = pow * VELTKAMP_SPLIT;
     sfpi::vFloat pow_hi = pc - (pc - pow);
     sfpi::vFloat pow_lo = pow - pow_hi;
+    // pc overflows to inf once |pow| > FLT_MAX/VELTKAMP_SPLIT, and pc - (pc - pow) is then
+    // inf - inf = NaN, which propagates through z_hi and z_lo into the result. FLT_MAX/4097
+    // lies inside [2**115, 2**116), so 115 is the first exponent that can overflow. A |pow|
+    // that large drives pow*log2(base) far outside the 2**z range for every base except 1,
+    // where exp_f32 and ln_m are both zero, so the split has nothing left to preserve.
+    v_if(sfpi::exexp(pow) >= 115) {
+        pow_hi = pow;
+        pow_lo = 0.0f;
+    }
+    v_endif;
 
     sfpi::vFloat z_hi = pow_hi * exp_f32;
     sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #55129.

On the fp32 path `ttnn.pow` returned `+inf` for every base once `|exponent| > FLT_MAX/4097`, including cases IEEE fixes exactly: `pow(1.0, 1e35)` gave `inf` instead of `1.0`, and `pow(0.5, 1e35)` gave `inf` instead of `0.0`.

The Veltkamp split multiplies the exponent by 4097 before decomposing it, so `pc` overflows to `inf`, `pc - (pc - pow)` becomes `inf - inf = NaN`, and the NaN reaches the final overflow guard as a biased exponent of 255, which turns every lane into `+inf`. This skips the decomposition where it cannot be represented: such an exponent drives `pow*log2(base)` far outside the `2**z` range for every base except 1, where `exp_f32` and `ln_m` are both zero, so the split has nothing to preserve. The threshold is exponent 115 rather than 116 because `FLT_MAX/4097 = 8.305647e34` falls inside `[2**115, 2**116)`, so a 116 guard would leave `[8.305647e34, 8.307675e34)` still overflowing. Applied to the binary and unary kernels on both architectures, which carry the same three lines.

Verified on ttsim (Blackhole, `v0.79.0-dev20260903`): of 17 cases spanning the band, 10 were wrong before and 1 after. On 1024 random ordinary inputs the results are bit-identical before and after, `max_rel 2.643e-07` on the tensor-tensor path and `2.220e-07` on `x**2.5`, so nothing outside the band moves.

### Notes for reviewers
The one case still wrong is `pow(-1.0, 1e35)`, which returns NaN where IEEE gives 1.0. That is a different mechanism: the negative-base path decides integer parity with `convert<vSMag16>`, and a 16-bit conversion cannot represent an exponent that large. It returned `inf` before this change and NaN after, both wrong, and I have left it alone rather than widen the scope.
