### PR TITLE
[Bug fix] moreh_clip_grad_norm: support norm_type inf, -inf and 0

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
@@ -98,6 +98,56 @@ def test_moreh_clip_grad_norm(
             assert pass_input_i
 
 
+@pytest.mark.parametrize("norm_type", [float("inf"), float("-inf"), 0.0])
+@pytest.mark.parametrize("max_norm", [1.0, 0.5])
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [(1, 1, TILE_HEIGHT, TILE_WIDTH)],
+        [(2, 3, 2 * TILE_HEIGHT - 7, 3 * TILE_WIDTH - 5), (1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1)],
+        [(1, 2, TILE_HEIGHT + 3, TILE_WIDTH), (1, 1, TILE_HEIGHT, 2 * TILE_WIDTH - 9), (1, 1, 5, 7)],
+    ],
+)
+def test_moreh_clip_grad_norm_special_norm_type(input_shapes, max_norm, norm_type, device):
+    """norm_type in {inf, -inf, 0} does not go through Sum[|e|^p]^(1/p); the per-tensor norms
+    (max, min, nonzero count) are combined with the same order, exactly as torch does."""
+    torch.manual_seed(2023)
+
+    cpu_dtype = torch.float32
+    npu_dtype = ttnn.bfloat16
+
+    cpu_inputs = []
+    npu_inputs = []
+    for input_shape in input_shapes:
+        param = torch.nn.Parameter(torch.empty(input_shape, dtype=cpu_dtype))
+        # Round-trip through bfloat16 so torch and ttnn see identical gradients: max / min are
+        # order statistics, so a single rounding difference would change the result.
+        grad = torch.empty(input_shape, dtype=cpu_dtype).uniform_(-2.5, 2.5).bfloat16().float()
+        # Plant a few exact zeros so the -inf and 0 orders exercise their edge values.
+        grad.flatten()[::97] = 0.0
+        param.grad = grad
+        cpu_inputs.append(param)
+        npu_inputs.append(ttnn.from_torch(grad.bfloat16(), dtype=npu_dtype, layout=ttnn.TILE_LAYOUT, device=device))
+
+    cpu_total_norm = torch.nn.utils.clip_grad_norm_(cpu_inputs, max_norm, norm_type)
+    npu_total_norm = ttnn.operations.moreh.clip_grad_norm(npu_inputs, max_norm, norm_type)
+    actual_total_norm = ttnn.to_torch(npu_total_norm).reshape(1)
+
+    rtol = atol = 0.02
+    pass_total_norm, out_total_norm = comp_allclose_and_pcc(
+        actual_total_norm, cpu_total_norm.reshape(1), rtol=rtol, atol=atol
+    )
+    logger.debug(f"total_norm's {out_total_norm}")
+    assert pass_total_norm
+
+    for i, cpu_input in enumerate(cpu_inputs):
+        expected_input_i = cpu_input.grad
+        actual_input_i = ttnn.to_torch(npu_inputs[i])
+        pass_input_i, out_input_i = comp_allclose_and_pcc(expected_input_i, actual_input_i, rtol=rtol, atol=atol)
+        logger.debug(f"inputs[{i}]-shape[{input_shapes[i]}]'s {out_input_i}")
+        assert pass_input_i
+
+
 @pytest.mark.parametrize("error_if_nonfinite", [True, False])
 def test_moreh_clip_grad_norm_with_error_if_nonfinite(error_if_nonfinite, device, expect_error):
     torch.manual_seed(2023)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
@@ -4,6 +4,7 @@
 
 #include "moreh_clip_grad_norm.hpp"
 
+#include <cmath>
 #include <optional>
 
 #include <tt-metalium/base_types.hpp>
@@ -12,6 +13,10 @@
 #include "moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/operations/moreh/moreh_norm/moreh_norm.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -43,6 +48,60 @@ inline uint32_t get_num_device_cores(IDevice* device) {
     return num_cores_x * num_cores_y;
 }
 
+// Orders for which the total norm is not Sum[|e|^p]^(1/p). The step1/step2 kernels decompose
+// norm_type into an integer part, a fractional part and a sign; that decomposition is only
+// meaningful for finite non-zero p (floor(inf) is inf and inf - inf is NaN, and 1/0 is inf).
+// moreh_norm already special-cases exactly these orders, so the total norm is assembled from
+// per-tensor moreh_norm calls, combined with the same order the way torch.nn.utils.clip_grad_norm_
+// does (torch.linalg.vector_norm(torch.stack(per_tensor_norms), norm_type)):
+//   +inf : max over tensors of max|e|
+//   -inf : min over tensors of min|e|
+//    0   : number of tensors whose count of nonzero elements is nonzero
+inline bool is_special_norm_type(float norm_type) { return norm_type == 0.0f || std::isinf(norm_type); }
+
+inline Tensor per_tensor_norm(
+    const Tensor& input,
+    float norm_type,
+    const std::optional<MemoryConfig>& memory_config,
+    const DeviceComputeKernelConfig& compute_kernel_config) {
+    // Full reduction with keepdim so the result stays a [1, ..., 1] TILE tensor that can be reshaped
+    // to the [1, 1] total_norm layout produced by step2.
+    Tensor norm = ttnn::moreh_norm(
+        input, norm_type, std::nullopt, /*keepdim=*/true, std::nullopt, memory_config, compute_kernel_config);
+    return ttnn::reshape(norm, ttnn::Shape({1, 1}));
+}
+
+inline Tensor special_total_norm(
+    const std::vector<Tensor>& inputs,
+    float norm_type,
+    const std::optional<const Tensor>& total_norm,
+    const std::optional<MemoryConfig>& memory_config,
+    const DeviceComputeKernelConfig& compute_kernel_config) {
+    const bool is_zero_order = norm_type == 0.0f;
+    const bool is_plus_inf = norm_type > 0.0f;
+
+    Tensor total = per_tensor_norm(inputs.front(), norm_type, memory_config, compute_kernel_config);
+    if (is_zero_order) {
+        total = ttnn::nez(total, memory_config);
+    }
+    for (size_t i = 1; i < inputs.size(); ++i) {
+        Tensor norm_i = per_tensor_norm(inputs.at(i), norm_type, memory_config, compute_kernel_config);
+        if (is_zero_order) {
+            total = ttnn::add(total, ttnn::nez(norm_i, memory_config), std::nullopt, memory_config);
+        } else if (is_plus_inf) {
+            total = ttnn::maximum(total, norm_i, std::nullopt, memory_config);
+        } else {
+            total = ttnn::minimum(total, norm_i, std::nullopt, memory_config);
+        }
+    }
+
+    if (total_norm.has_value()) {
+        ttnn::assign(total, *total_norm);
+        return *total_norm;
+    }
+    return total;
+}
+
 }  // namespace ttnn::operations::moreh::moreh_clip_grad_norm
 
 namespace ttnn {
@@ -64,7 +123,8 @@ Tensor moreh_clip_grad_norm(
             "`error_if_nonfinite=False`",
             norm_type);
     }
-    auto* device = inputs.at(0).device();
+    TT_FATAL(!inputs.empty(), "moreh_clip_grad_norm expects at least one input tensor");
+    auto* device = inputs.front().device();
     const auto compute_kernel_config_val =
         init_device_compute_kernel_config(device->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4);
 
@@ -72,45 +132,50 @@ Tensor moreh_clip_grad_norm(
     const auto max_num_inputs = operations::moreh::moreh_clip_grad_norm::get_num_device_cores(device);
     const auto total_num_inputs = static_cast<uint32_t>(inputs.size());
     const auto num_iter = (total_num_inputs + max_num_inputs - 1) / max_num_inputs;
-    // Store intermediate reduction of Sum[|e|^p]
-    auto tmp_pow_sum = create_device_tensor(
-        tt::tt_metal::TensorSpec(
-            Shape{static_cast<uint32_t>(inputs.size()), 1, 1},
-            tt::tt_metal::TensorLayout(
-                inputs.at(0).dtype(),
-                tt::tt_metal::PageConfig(Layout::TILE),
-                memory_config.value_or(inputs.at(0).memory_config()))),
-        device);
 
-    // Run Step 1
-    // Sum[|e|^p]
-    uint32_t tile_offset{0};
-    auto num_inputs = total_num_inputs;
-    for (uint32_t i = 0; i < num_iter; i++) {
-        const auto num_inputs_at_this_iter = std::min(num_inputs, max_num_inputs);
-
-        ttnn::prim::moreh_clip_grad_norm_step1(
-            std::vector<Tensor>(inputs.begin() + tile_offset, inputs.begin() + tile_offset + num_inputs_at_this_iter),
-            norm_type,
-            tile_offset,
-            tmp_pow_sum,
-            memory_config,
-            compute_kernel_config_val);
-
-        if (i < (num_iter - 1)) {
-            tile_offset += num_inputs_at_this_iter;
-            num_inputs -= num_inputs_at_this_iter;
+    const Tensor output_total_norm = [&]() -> Tensor {
+        if (operations::moreh::moreh_clip_grad_norm::is_special_norm_type(norm_type)) {
+            // +inf, -inf and 0 cannot go through the Sum[|e|^p]^(1/p) kernels; see special_total_norm.
+            return operations::moreh::moreh_clip_grad_norm::special_total_norm(
+                inputs, norm_type, total_norm, memory_config, compute_kernel_config_val);
         }
-    }
+        // Store intermediate reduction of Sum[|e|^p]
+        auto tmp_pow_sum = create_device_tensor(
+            tt::tt_metal::TensorSpec(
+                Shape{static_cast<uint32_t>(inputs.size()), 1, 1},
+                tt::tt_metal::TensorLayout(
+                    inputs.at(0).dtype(),
+                    tt::tt_metal::PageConfig(Layout::TILE),
+                    memory_config.value_or(inputs.front().memory_config()))),
+            device);
 
-    // Run Step 2
-    // Sum[Sum[|e|^p]]^(1/p)
-    auto output_total_norm = ttnn::prim::moreh_clip_grad_norm_step2(
-        tmp_pow_sum,
-        norm_type,
-        total_norm,
-        memory_config,
-        init_device_compute_kernel_config(inputs.at(0).device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4));
+        // Run Step 1
+        // Sum[|e|^p]
+        uint32_t tile_offset{0};
+        auto num_inputs = total_num_inputs;
+        for (uint32_t i = 0; i < num_iter; i++) {
+            const auto num_inputs_at_this_iter = std::min(num_inputs, max_num_inputs);
+
+            ttnn::prim::moreh_clip_grad_norm_step1(
+                std::vector<Tensor>(
+                    inputs.begin() + tile_offset, inputs.begin() + tile_offset + num_inputs_at_this_iter),
+                norm_type,
+                tile_offset,
+                tmp_pow_sum,
+                memory_config,
+                compute_kernel_config_val);
+
+            if (i < (num_iter - 1)) {
+                tile_offset += num_inputs_at_this_iter;
+                num_inputs -= num_inputs_at_this_iter;
+            }
+        }
+
+        // Run Step 2
+        // Sum[Sum[|e|^p]]^(1/p)
+        return ttnn::prim::moreh_clip_grad_norm_step2(
+            tmp_pow_sum, norm_type, total_norm, memory_config, compute_kernel_config_val);
+    }();
 
     if (error_if_nonfinite) {
         const auto fp32_total_norm =
@@ -136,7 +201,7 @@ Tensor moreh_clip_grad_norm(
     // Run Step 3
     // Inplace update inputs(inputs *= clip_coef_clamped)
     uint32_t start_input_idx{0};
-    num_inputs = total_num_inputs;
+    auto num_inputs = total_num_inputs;
     for (uint32_t i = 0; i < num_iter; ++i) {
         const auto num_inputs_at_this_iter = std::min(num_inputs, max_num_inputs);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.hpp
@@ -19,6 +19,11 @@ namespace ttnn {
  * The total norm is computed as:
  *   total_norm = (sum(|grad_i|^norm_type for all grads))^(1/norm_type)
  *
+ * norm_type = +inf, -inf and 0 follow torch.nn.utils.clip_grad_norm_: the per-tensor norms
+ * (max|grad_i|, min|grad_i| and the count of nonzero elements respectively) are combined with
+ * the same order, i.e. max over tensors, min over tensors, and the count of tensors with a
+ * nonzero per-tensor norm.
+ *
  * If total_norm > max_norm, each gradient is scaled by:
  *   clip_coef = max_norm / (total_norm + 1e-6)
  *

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_nanobind.cpp
@@ -38,6 +38,8 @@ void bind_moreh_clip_grad_norm_operation(nb::module_& mod) {
                 inputs (List[ttnn.Tensor]): Input tensors containing gradients to be clipped. All tensors must be on the same device.
                 max_norm (float): Maximum norm value to clip gradients.
                 norm_type (float, optional): Type of the norm (e.g., 2.0 for L2 norm). Defaults to 2.0.
+                    ``inf``, ``-inf`` and ``0`` follow ``torch.nn.utils.clip_grad_norm_``: the per-tensor
+                    norms (max, min and nonzero count) are combined with the same order.
                 error_if_nonfinite (bool, optional): If True, throws error when total norm is non-finite (NaN or Inf). Defaults to False.
 
             Keyword Args:


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55587

`ttnn.operations.moreh.clip_grad_norm` accepted `norm_type = +inf`, `-inf` and `0` but fed them into the `Sum[|e|^p]^(1/p)` kernels, whose host-side decomposition (`floor`, `ord - floor(ord)`, `static_cast<uint32_t>`) is undefined for non-finite orders and whose step2 uses `1/norm_type`. The result was a total norm unrelated to the gradients (exactly `1.0`, or non-finite) and gradients silently rescaled by it.

This routes those three orders around step1/step2 and assembles the total norm from per-tensor `ttnn::moreh_norm` calls (which already implement them), combined with the same order the way `torch.nn.utils.clip_grad_norm_` does (`torch.linalg.vector_norm(torch.stack(norms), norm_type)`):

- `+inf`: `ttnn::maximum` across tensors of `max|g|`
- `-inf`: `ttnn::minimum` across tensors of `min|g|`
- `0`: count of tensors with a nonzero per-tensor norm (`ttnn::nez` + `ttnn::add`)

The optional `total_norm` output tensor is honoured on that path via `ttnn::assign`; the existing `clip_coef` and step3 code is reused unchanged, and finite non-zero orders take exactly the same path as before.

Adds `test_moreh_clip_grad_norm_special_norm_type` (nightly) covering the three orders, both `max_norm` values, tile-aligned and padded shapes, with planted exact zeros so `-inf` and `0` exercise their edge values; gradients are round-tripped through bfloat16 so torch and ttnn see identical inputs (max/min are order statistics).

### Notes for reviewers
- Combining across tensors is a loop of tiny binary ops (one per input tensor) rather than a new multi-input kernel, mirroring the loops `moreh_norm` itself uses for multi-dim reductions. It is correct first; if the per-call cost matters for hundreds of parameters, a concat + single `moreh_norm` would be the follow-up.
- `ttnn::maximum` / `ttnn::minimum` drop NaN (#51470), so a NaN gradient under `norm_type=inf` may not propagate to `total_norm` the way torch's `max` does. Finite inputs are unaffected.
- I do not have device access; the host-side replay in #55587 is verified, the new test has not been run on silicon. Please let CI pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aoAi82eAKEGM8bxHKxh5v
