### PR TITLE
Rotate the ring MLA chunked Q remainder across grid rows per ring iteration

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -285,6 +285,57 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
         )
     )
 
+    # Local-only: the one DENSE (non-chunked) ring-MLA shape small enough to test. mla_100k is the
+    # only other dense MLA config and it is is_balanced=True, which both trips the rotation's
+    # !is_balanced term AND makes its active mask full -- so nothing in the tree exercised dense
+    # causal's PARTIAL mask, the case the rotation's ordinal indexing exists for. is_balanced=False
+    # keeps the causal drop (ring_iter_does_work skips device_index < ring_id), giving a genuinely
+    # partial mask that the HOST knows (unlike kv-pad, where it is device-derived).
+    # Sized for the CPU reference, which is what makes mla_100k time out: 8 heads and 1280 local seq
+    # instead of 29 and 3200.
+    if os.environ.get("RING_MLA_K_SWEEP"):
+        configs.append(
+            ModelConfig(
+                name="mla_dense_small",
+                nhq=8,
+                nhk=1,
+                nhv=8,
+                d_q=576,
+                d_k=576,
+                d_v=128,
+                is_causal=True,
+                is_balanced=False,
+                q_dtype=ttnn.bfloat16,
+                kv_dtype=ttnn.bfloat8_b,
+                q_chunk_sizes=[160],
+                k_chunk_sizes=[320],
+                seq_len=1280,
+            )
+        )
+
+    # Local-only companion to mla_dense_small: same shape, zigzag balancing ON. Exists to TEST the
+    # rotation's !is_balanced term rather than take it on reasoning -- mla_100k is balanced too but
+    # times out, so the term had no counterexample.
+    if os.environ.get("RING_MLA_K_SWEEP"):
+        configs.append(
+            ModelConfig(
+                name="mla_dense_small_balanced",
+                nhq=8,
+                nhk=1,
+                nhv=8,
+                d_q=576,
+                d_k=576,
+                d_v=128,
+                is_causal=True,
+                is_balanced=True,
+                q_dtype=ttnn.bfloat16,
+                kv_dtype=ttnn.bfloat8_b,
+                q_chunk_sizes=[160],
+                k_chunk_sizes=[320],
+                seq_len=1280,
+            )
+        )
+
     configs.append(
         ModelConfig(
             name="mla_128k",
@@ -402,6 +453,7 @@ from tests.nightly.sdpa_perf_utils import compute_math_utilization as compute_ri
 from tests.nightly.sdpa_perf_utils import (
     compute_sdpa_flops,
     create_balanced_chunk_order,
+    parse_grid_spec,
     post_process_ops_log,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
@@ -582,6 +634,28 @@ class RingJointSDPARuntime:
     compute_kernel_config: object
 
 
+def _sdpa_compute_grid_for(mesh_config):
+    """SDPA compute grid, honoring the RING_MLA_SDPA_GRID_OVERRIDE debug escape hatch.
+
+    Shrinking the grid changes num_cores, which is what sets the rotated-Q-split work division
+    (rotated_base_chunks = total_q_chunks // num_cores, rotated_float_chunks = the remainder, and the number
+    of grid rows that host floats). It is therefore the only knob that sweeps this feature's actual
+    schedule without new hardware, so accuracy runs honor it too, not just the perf check.
+    """
+    grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
+    override = os.environ.get("RING_MLA_SDPA_GRID_OVERRIDE")
+    if not override:
+        return grid
+    cols, rows = parse_grid_spec(override, "RING_MLA_SDPA_GRID_OVERRIDE")
+    # Only shrinking is meaningful: a grid wider than the chip has builds a program on cores that do
+    # not exist, which hangs rather than raising.
+    assert cols <= mesh_config.sdpa_cols and rows <= mesh_config.grid_rows, (
+        f"RING_MLA_SDPA_GRID_OVERRIDE={override} must fit within " f"{mesh_config.sdpa_cols}x{mesh_config.grid_rows}"
+    )
+    logger.info(f"RING_MLA_SDPA_GRID_OVERRIDE={override}: SDPA grid {grid} -> {(cols, rows)}")
+    return (cols, rows)
+
+
 def open_ring_joint_sdpa_runtime(
     mesh_config,
     *,
@@ -627,6 +701,17 @@ def open_ring_joint_sdpa_runtime(
         mesh_device = ttnn.open_mesh_device(**mesh_device_kwargs)
 
         full_compute_grid = mesh_device.compute_with_storage_grid_size()
+        # MeshConfig derives the SDPA/CCL split from the grid it detected before any device was
+        # opened; the device is the authority. A mismatch means the split (and every expected_util
+        # normalized to mesh_config.sdpa_cores) is wrong for this host, so say so loudly.
+        if (full_compute_grid.x, full_compute_grid.y) != (mesh_config.grid_cols, mesh_config.grid_rows):
+            logger.warning(
+                f"MeshConfig grid {mesh_config.grid_cols}x{mesh_config.grid_rows} disagrees with the device's "
+                f"{full_compute_grid.x}x{full_compute_grid.y} compute grid: SDPA runs on "
+                f"{mesh_config.sdpa_cols}x{mesh_config.grid_rows} and utilization is normalized to "
+                f"{mesh_config.sdpa_cores} cores. Set SDPA_PERF_PROGRAM_GRID="
+                f"{full_compute_grid.x}x{full_compute_grid.y} to correct it."
+            )
         ccl_sub_device_crs = ttnn.CoreRangeSet(
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
         )
@@ -642,7 +727,7 @@ def open_ring_joint_sdpa_runtime(
             sp_axis=sp_axis,
             tp_axis=tp_axis,
             num_links=2,
-            sdpa_compute_grid=(mesh_config.sdpa_cols, mesh_config.grid_rows),
+            sdpa_compute_grid=_sdpa_compute_grid_for(mesh_config),
             ccl_column=mesh_config.ccl_column,
             worker_sub_device_id=worker_sub_device_id,
             ccl_semaphore_handles=create_global_semaphores(
@@ -1634,8 +1719,10 @@ CHUNKED_PREFILL_PCC_THRESHOLD_FP32 = 0.994
 # head shard => heads-per-ring == heads-per-device. nhq/nhv below are PER RING; the
 # run multiplies by tp_size for the total head count (e.g. 16 per ring => 64 total on
 # galaxy 4x8), matching the per-ring convention used by the sweep configs.
-# Hardware-dependent to keep per-core work balanced: galaxy has 110 SDPA cores, the
-# non-galaxy single ring has 100 (10x10), so it carries fewer heads per ring.
+# Hardware-dependent to keep per-core work balanced: galaxy has 110 SDPA cores, a stock non-galaxy
+# single ring has 100 (10x10), so it carries fewer heads per ring. Deliberately NOT re-derived from
+# MESH_CONFIG.sdpa_cores: on a re-flashed 110-core box that would change the tested shape and
+# invalidate the committed ring-4 baselines.
 CHUNKED_PREFILL_HEADS_PER_RING = 16 if MESH_CONFIG.is_galaxy else 14
 CHUNKED_PREFILL_SEED = 1234
 # Set to a chunk index to run/profile only that chunk in isolation instead of the
@@ -2993,6 +3080,7 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
     pcc_threshold=CHUNKED_PREFILL_PCC_THRESHOLD,
     rmse_threshold=DEFAULT_RMSE_THRESHOLD,
     full_mesh=False,
+    runtime=None,
 ):
     sp_size = mesh_config.num_devices if full_mesh else mesh_config.sp_size
     if sp_size < 2:
@@ -3036,7 +3124,11 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
     q_full = fa_rand(b, nhq, total_seq, d_q)
     kv_full = fa_rand(b, nhk, total_seq, d_k)
 
-    runtime = open_ring_joint_sdpa_runtime(mesh_config, full_mesh=full_mesh)
+    # A caller that already holds a runtime (the perf probe, which must profile inside the
+    # device's lifetime) passes it in and keeps ownership; otherwise open and close our own.
+    owns_runtime = runtime is None
+    if owns_runtime:
+        runtime = open_ring_joint_sdpa_runtime(mesh_config, full_mesh=full_mesh)
     mesh_device = runtime.mesh_device
     topology = runtime.topology
     sp_axis = runtime.sp_axis
@@ -3263,7 +3355,8 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
         )
 
     finally:
-        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
+        if owns_runtime:
+            close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
 
 
 def run_ring_mla_sdpa_chunked_indexed_kv_cache(
@@ -3601,6 +3694,67 @@ def test_ring_mla_chunked_kv_actual_isl_indexed_reuse_max_accuracy_and_determini
     mesh_config = MESH_CONFIG
     run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
         mesh_config,
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("RING_MLA_K_SWEEP"), reason="Local coverage for the rotated Q split on the kv-pad path"
+)
+def test_ring_mla_chunked_kv_actual_isl_rotated_q_split_accuracy():
+    """Same kv-pad (kv_actual_isl) path, sized so the rotated Q split can actually engage.
+
+    The default case is chunk_size_local=32 with q_chunk_size=32, i.e. ONE Q chunk per head and
+    total_q_chunks = 4 -- far below any real core count, so rotated_base_chunks is 0 and the rotation
+    always declines. Widening the local chunk to 256 gives 8 chunks per head (total 32), which
+    reaches rotated_base_chunks >= 1 under a shrunken grid (RING_MLA_SDPA_GRID_OVERRIDE=3x2 -> 6 cores
+    -> base 5, floats 2). Without this the kv-pad path has no configuration in which the rotation
+    is exercised at all, so its predicate term could not be validated either way.
+    """
+    run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
+        MESH_CONFIG,
+        chunk_size_local=256,
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("RING_MLA_K_SWEEP"), reason="Report-only kv-pad perf probe for the rotated-Q-split A/B"
+)
+def test_ring_mla_chunked_kv_actual_isl_rotated_q_split_perf_report_only():
+    """Report device time on the kv-pad (kv_actual_isl) path so the rotated Q split can be A/B'd there.
+
+    The rotation only engages on kv-pad from this commit onward, and every other kv-pad test is
+    accuracy-only, so there was no way to tell whether enabling it there costs anything. Report-only
+    by design: the shape is the small accuracy config (4 heads, d_q=64, chunk_size_local=256), far too
+    small to carry a committed utilization baseline. Its value is the ON-vs-OFF DELTA on one fixed
+    shape, not the absolute number.
+
+    Needs RING_MLA_SDPA_GRID_OVERRIDE, since total_q_chunks is 32 here and the default 110-core grid
+    gives rotated_base_chunks == 0 (rotation declines, and most rows have no work so the K mcast injector
+    cannot be picked either). 3x8 -> 24 cores -> base 1, floats 8, which exercises a real float
+    handoff. Pair with RING_MLA_DISABLE_ROTATED_Q_SPLIT=1 for the OFF arm.
+    """
+    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
+    try:
+        duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
+            runtime.mesh_device,
+            lambda: run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
+                MESH_CONFIG,
+                chunk_size_local=256,
+                runtime=runtime,
+            ),
+        )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
+
+    rotation = "OFF" if os.environ.get("RING_MLA_DISABLE_ROTATED_Q_SPLIT") else "ON"
+    grid = os.environ.get("RING_MLA_SDPA_GRID_OVERRIDE", "default")
+    # Report the SDPA span per chip, not the raw records: each record carries its kernel_sources
+    # tuple, so logging the list itself buries the numbers in several KB of paths.
+    sdpa_us = sorted(r["duration_ns"] / 1e3 for r in perf_records)
+    logger.info(
+        f"ring_mla kv_actual_isl rotated-Q-split perf probe: rotation={rotation} grid={grid} "
+        f"duration={duration_ns / 1e6:.3f} ms, chips={len(perf_records)}, "
+        f"per-chip us min={sdpa_us[0]:.1f} max={sdpa_us[-1]:.1f}"
     )
 
 
@@ -4774,24 +4928,32 @@ PERF_TEST_CONFIG_MODELS = list(RING_JOINT_PERF_MODEL_CONFIGS.keys())
 def generate_ring_mla_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, ModelConfig]):
     if mesh_config.sp_size < 2 or "mla_100k" not in model_configs:
         return [], []
-    model = model_configs["mla_100k"]
-    q_chunk_size = 160
-    k_chunk_size = 320
-    config = (
-        BATCH_SIZE,
-        model.seq_len * mesh_config.sp_size,
-        model.nhq * mesh_config.tp_size,
-        model.nhk,
-        model.d_q,
-        model.d_k,
-        model.d_v,
-        q_chunk_size,
-        k_chunk_size,
-        model.is_balanced,
-        model.q_dtype,
-        model.kv_dtype,
-    )
-    return [config], [f"ring_mla-{model.name}-q{q_chunk_size}-k{k_chunk_size}"]
+    configs, ids = [], []
+    # mla_dense_small (RING_MLA_K_SWEEP only) is the non-balanced dense shape; see its ModelConfig.
+    for name in ("mla_100k", "mla_dense_small", "mla_dense_small_balanced"):
+        if name not in model_configs:
+            continue
+        model = model_configs[name]
+        q_chunk_size = model.q_chunk_sizes[0]
+        k_chunk_size = model.k_chunk_sizes[-1]
+        configs.append(
+            (
+                BATCH_SIZE,
+                model.seq_len * mesh_config.sp_size,
+                model.nhq * mesh_config.tp_size,
+                model.nhk,
+                model.d_q,
+                model.d_k,
+                model.d_v,
+                q_chunk_size,
+                k_chunk_size,
+                model.is_balanced,
+                model.q_dtype,
+                model.kv_dtype,
+            )
+        )
+        ids.append(f"ring_mla-{model.name}-q{q_chunk_size}-k{k_chunk_size}")
+    return configs, ids
 
 
 RING_MLA_TEST_CONFIGS, RING_MLA_TEST_CONFIG_IDS = generate_ring_mla_test_configs(MESH_CONFIG, MODEL_CONFIGS)
@@ -5514,6 +5676,24 @@ def _generate_chunked_configs(model_configs):
 
 CHUNKED_CONFIGS, CHUNKED_CONFIG_IDS = _generate_chunked_configs(CHUNKED_PREFILL_MODEL_CONFIGS)
 RING_MLA_CHUNKED_CONFIGS, RING_MLA_CHUNKED_CONFIG_IDS = _generate_chunked_configs(RING_MLA_CHUNKED_MODEL_CONFIGS)
+if os.environ.get("RING_MLA_K_SWEEP"):
+    # Local only. Extends the base list (not the derived *_TEST_CONFIGS, whose ids list is the same
+    # object) so accuracy/determinism/perf_impl all pick these up with matching lengths.
+    # Accuracy/determinism coverage for the shapes only q32 used to have. These are the shapes that
+    # exercise the small-rotated_base_chunks paths: q64 -> 240 units/110 cores = base 2, q128 -> 120
+    # units = base 1 (both were unsupported or broken before; see the predicate in
+    # ring_joint_sdpa_program_factory.cpp). q128's k is capped by L1.
+    # q64 (Sq_chunk_t == 2) used to fail at k320 and k448 with PCC ~0.12 / RMSE ~100, independently
+    # of the rotated split -- a missing PACK->UNPACK barrier in compute_streaming.hpp Phase 2, fixed
+    # there. The k values are kept spread across Skt % 4 == 0 (k128/k256/k384, which always worked)
+    # and Skt % 4 == 2 (k320/k448, which did not) so a regression in that gate is caught.
+    RING_MLA_CHUNKED_CONFIGS.append(("kimi_k3", 64, 448))
+    RING_MLA_CHUNKED_CONFIG_IDS.append("kimi_k3-q64-k448")
+    RING_MLA_CHUNKED_CONFIGS.append(("kimi_k3", 128, 256))
+    RING_MLA_CHUNKED_CONFIG_IDS.append("kimi_k3-q128-k256")
+    for _k in (128, 256, 320, 384):
+        RING_MLA_CHUNKED_CONFIGS.append(("kimi_k3", 64, _k))
+        RING_MLA_CHUNKED_CONFIG_IDS.append(f"kimi_k3-q64-k{_k}")
 MINIMAX3_GQA_CHUNKED_CONFIGS, MINIMAX3_GQA_CHUNKED_CONFIG_IDS = _generate_chunked_configs(
     MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS
 )
@@ -6390,11 +6570,15 @@ def test_ring_mla_create_chunked_perf_table(model_name, q_chunk_size, k_chunk_si
 if MESH_CONFIG.is_galaxy:
     RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
         # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
-        # 8-device ring (Galaxy, sp=8 tp=4, 100 SDPA cores)
+        # 8-device ring (Galaxy, sp=8 tp=4, 110 SDPA cores)
         ("kimi50k", 32, 640, 8, 68.5),
-        # Kimi-K3: same chunk and tuned q32/k640, H_loc 24 vs 16. Measured 2026-08-05 on
-        # bh_sc1_high_power -- 9.680 ms vs kimi50k's 5.722, i.e. 1.69x time for 1.5x ideal work.
-        ("kimi_k3", 32, 640, 8, 61.03),
+        # Kimi-K3: same chunk and tuned q32/k640, H_loc 24 vs 16. Was 61.03 (measured 2026-08-05,
+        # bh_sc1_high_power, 9.680 ms) before the rotated Q split. PROJECTED 2026-08-18: the
+        # rotated per-ring-iteration split lifts the 480-unit/110-core occupancy ceiling from
+        # 8*ceil(480/110)=40 to 36 K-stream slots (61.03 * 40/36 * 0.989 stall factor measured on
+        # the QuietBox 9x10-grid emulation, which went 5.708 -> 5.290 ms). Replace with the first
+        # bh_sc1_high_power measurement.
+        ("kimi_k3", 32, 640, 8, 67.0),
     ]
 else:
     RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
@@ -6405,6 +6589,64 @@ else:
         # #52190 ungates this test here; kimi50k read 65.89 vs its committed 66.05 in the same run.
         ("kimi_k3", 32, 640, 4, 67.07),
     ]
+
+# An 8-chip non-galaxy Blackhole box runs a single 8-device ring with TP=1, so kimi_k3 keeps its
+# production 24 Q heads per device while the ring length matches galaxy's sp=8. Neither branch
+# above covers sp_size=8 off galaxy, so the ring-4 ids skip and the ring-8 ids do not exist there.
+#
+# Measured 2026-08-20 on bh-lb-33 (8x p150b re-flashed to tensix_col_disable_count=1: 12x10 program
+# grid -> 11x10 = 110 SDPA cores, the same split galaxy gets), kimi_k3 50k+5k final chunk, fresh KV.
+# Gated on that core count, not merely on sp_size=8: utilization is per-core but the work-split
+# quantization is not, so a stock 100-core p150 box lands close to yet outside the band (q32/k640
+# read 9.445 ms / 68.81% there against +/-1% around 68.05). The gate also keeps these ids off
+# wormhole 8-device hosts, where detection falls back to 100 cores. Re-measure to widen it.
+RING_MLA_RING8_BASELINE_SDPA_CORES = 110
+RING_MLA_RING8_BASELINES_APPLY = (
+    not MESH_CONFIG.is_galaxy
+    and MESH_CONFIG.sp_size == 8
+    and MESH_CONFIG.sdpa_cores == RING_MLA_RING8_BASELINE_SDPA_CORES
+)
+if RING_MLA_RING8_BASELINES_APPLY:
+    RING_MLA_CHUNKED_PERF_CHECK_CONFIGS += [
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # Shipped q32/k640 shape: 8.67 ms. Unaffected by the Sq_chunk_t == 2 barrier fix below
+        # (Sq_chunk_t is 1 here), and the fastest shape that is also numerically correct.
+        ("kimi_k3", 32, 640, 8, 68.05),
+        # q64/k448: 8.68 ms, measured over 3 runs (68.05-68.09%) with the PACK->UNPACK barrier in
+        # compute_streaming.hpp Phase 2 present and its two halves split around the unpack-side
+        # setup. The previous 71.28 / 8.288 ms was recorded while that barrier was absent, i.e. it
+        # timed a kernel that skipped a required synchronization and produced garbage (PCC ~0.12) --
+        # so it was never a real 4% win over q32/k640; the two shapes are within noise of each other.
+        # Every q64 figure in the sweep note below predates the fix and is optimistic for the same
+        # reason.
+        ("kimi_k3", 64, 448, 8, 68.07),
+    ]
+
+# Local k-chunk exploration, off by default so it costs no collected ids: RING_MLA_K_SWEEP=1.
+# expected_util is None for these, meaning "measure and report, gate nothing" -- the committed
+# baselines do not apply to shapes they were not measured on.
+#
+# Why these k values: q32 prefers the largest k that fits L1, because at Sq_chunk_t=1 the
+# kt_inplace_v path is data-movement bound and chunk count dominates. The sweep stops at 480 because
+# k512 and up overflow L1 at q64.
+# CAUTION: the q64 ranking this sweep originally produced (k448 > k320, attributed to Sk_chunk_t
+# factorization) was measured before the Sq_chunk_t == 2 barrier fix, and the shapes it favoured are
+# exactly the ones the missing barrier made fast and wrong -- Skt not divisible by 4 forces the QK
+# subblock to height 1, which is the case that skipped the barrier. Re-run before trusting any q64
+# ordering. No q128 entries: rotated_base_chunks would be 1, which the rotated split must
+# refuse (it hangs -- see the diagnosis in the program factory), and L1 caps k there anyway.
+# The per-device K prefix at the final chunk is 7040 rows, so k in (128, 160, 320, 352, 640)
+# divides it exactly and the rest straddle.
+if os.environ.get("RING_MLA_K_SWEEP") and RING_MLA_RING8_BASELINES_APPLY:
+    # k448 (q64) and k640 (q32) are omitted: they are the committed entries above.
+    for _k in (128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 480):
+        RING_MLA_CHUNKED_PERF_CHECK_CONFIGS.append(("kimi_k3", 64, _k, 8, None))
+    for _k in (320, 448, 576, 608):
+        RING_MLA_CHUNKED_PERF_CHECK_CONFIGS.append(("kimi_k3", 32, _k, 8, None))
+    # q128 -> 24 heads x (640/128) = 120 work units over 110 cores, i.e. rotated_base_chunks == 1: the
+    # worst static imbalance (2:1) and so the largest rotation win. k is capped by L1 here.
+    for _k in (224, 256):
+        RING_MLA_CHUNKED_PERF_CHECK_CONFIGS.append(("kimi_k3", 128, _k, 8, None))
 
 
 if MESH_CONFIG.is_galaxy:
@@ -6419,6 +6661,62 @@ else:
         # 4-device ring (QuietBox): same per-device Q rows and 16Q/1KV local GQA shape.
         ("minimax3_55k", 128, 512, 4, 47.0),
     ]
+
+
+@pytest.mark.timeout(900)
+@pytest.mark.skipif(not os.environ.get("RING_MLA_K_SWEEP"), reason="Report-only separate-V chunked perf probe")
+@pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
+@pytest.mark.parametrize("q_chunk_size,k_chunk_size", [(32, 640)], ids=["q32-k640"])
+# kimi50k is the separate-V chunked shape: CHUNKED_PREFILL_MODEL_CONFIGS holds just kimi50k and
+# minimax3_55k, and minimax3 is GQA (gqa_grouped_kv -> no batch chain -> no K mcast).
+@pytest.mark.parametrize("model_name", ["kimi50k"], ids=["kimi50k"])
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_ring_joint_attention_chunked_perf_check_report_only(model_name, q_chunk_size, k_chunk_size, chunk_size):
+    """SEPARATE-V chunked-prefill math utilization, measured and reported, gating nothing.
+
+    The separate-V chunked path had no perf harness at all: its only perf tests are the tracy
+    perf_table generators, which need a Tracy-enabled build and cannot run here. This uses the same
+    in-process profiler as the ring_mla perf check, so the path is at least measurable in a ~1 minute
+    run. No expected_util: this is a probe, not a committed baseline.
+
+    Note the rotated Q split does NOT engage here -- its predicate requires v_shares_k_buffer
+    (latent-V), and this is separate-V -- so RING_MLA_DISABLE_ROTATED_Q_SPLIT has no effect on this
+    number. Separate-V rotation was implemented and removed; see the predicate in
+    ring_joint_sdpa_program_factory.cpp for why.
+    """
+    model = CHUNKED_PREFILL_MODEL_CONFIGS[model_name]
+    n_chunks = CHUNKED_PREFILL_TOTAL_SEQ // chunk_size
+    perf_chunk = n_chunks - 1
+
+    config_id = f"{get_test_case_id(model, q_chunk_size, k_chunk_size)}-chunk{chunk_size}-fresh_kv"
+    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
+    try:
+        with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(perf_chunk)}):
+            duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
+                runtime.mesh_device,
+                lambda: run_ring_joint_sdpa_chunked(
+                    MESH_CONFIG,
+                    model,
+                    chunk_size=chunk_size,
+                    qk_configs=[(q_chunk_size, k_chunk_size)],
+                    persistent_buffer_mode="reuse_max",
+                    use_ring_mla=False,
+                    do_check=False,
+                    reuse_kv_buffer=False,
+                    runtime=runtime,
+                ),
+            )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
+
+    utilization, _ = compute_chunked_prefill_perf_check_utilization(
+        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, MESH_CONFIG.sdpa_cores
+    )
+    logger.info(
+        f"separate-V chunked perf probe {config_id}: duration={duration_ns/1e6:.3f} ms, "
+        f"math_util={utilization:.2f}%, profiler_records={len(perf_records)}"
+    )
 
 
 @pytest.mark.timeout(600)
@@ -6453,6 +6751,23 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
 
     config_id = f"{get_test_case_id(model, q_chunk_size, k_chunk_size)}-chunk{chunk_size}-fresh_kv"
     runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
+    # Debug aid: RING_MLA_SDPA_GRID_OVERRIDE="9x10" shrinks the SDPA compute grid to emulate a
+    # different core count's work-split quantization (e.g. Galaxy's 480 units / 110 cores ratio on a
+    # QuietBox). Utilization is then normalized to the overridden core count, and the band assert is
+    # skipped (the committed expectation only applies to the standard grid).
+    grid_override = os.environ.get("RING_MLA_SDPA_GRID_OVERRIDE")
+    sdpa_cores_for_util = MESH_CONFIG.sdpa_cores
+    if grid_override:
+        cols, rows = parse_grid_spec(grid_override, "RING_MLA_SDPA_GRID_OVERRIDE")
+        # Only shrinking is meaningful: a grid wider than the chip has builds a program on cores
+        # that do not exist, which hangs rather than raising. Rows must match exactly, because
+        # compute_chunked_prefill_perf_check_utilization still rounds by MESH_CONFIG.grid_rows.
+        assert cols <= MESH_CONFIG.sdpa_cols and rows == MESH_CONFIG.grid_rows, (
+            f"RING_MLA_SDPA_GRID_OVERRIDE={grid_override} must be at most {MESH_CONFIG.sdpa_cols} "
+            f"cols and exactly {MESH_CONFIG.grid_rows} rows"
+        )
+        runtime.sdpa_compute_grid = (cols, rows)
+        sdpa_cores_for_util = cols * rows
     try:
         with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(perf_chunk)}):
             duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
@@ -6473,18 +6788,33 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
         close_ring_joint_sdpa_runtime(runtime)
 
     utilization, _ = compute_chunked_prefill_perf_check_utilization(
-        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, MESH_CONFIG.sdpa_cores
+        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, sdpa_cores_for_util
     )
 
-    lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
-    upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
+    # expected_util is None for the RING_MLA_K_SWEEP exploration shapes, which have no baseline.
+    if expected_util is None:
+        band = "no committed baseline, reporting only"
+    else:
+        lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
+        upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
+        band = f"expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}]"
 
     logger.info(
         f"ring_mla chunked 50k+5k perf check {config_id}: "
         f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
-        f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}]), "
-        f"profiler_records={len(perf_records)}"
+        f"({band}), profiler_records={len(perf_records)}"
     )
+
+    if expected_util is None:
+        pytest.skip(f"{config_id}: measured {utilization:.2f}% ({band})")
+    # A shrunken grid changes the work-split quantization the baseline was measured under. Skip
+    # rather than return: a silent pass here would mean every id reports green if this variable
+    # ever leaked into a runner environment.
+    if grid_override:
+        pytest.skip(
+            f"RING_MLA_SDPA_GRID_OVERRIDE={grid_override}: measured {utilization:.2f}%, "
+            f"band assert does not apply to an overridden grid"
+        )
 
     assert lower <= utilization <= upper, (
         f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -5908,6 +5908,21 @@ def test_ring_joint_attention_minimax3_gqa_chunked_accuracy():
     )
 
 
+def test_ring_joint_attention_minimax3_gqa_rotated_q_accuracy():
+    """Validate rotated Q scheduling for GQA against the CPU reference."""
+    # q32 gives 16 heads * (640 / 32) = 320 work units, leaving remainder chunks
+    # on both 100 and 110 cores. This exercises GQA rotated-Q handoffs; the
+    # existing q128 case has only 80 units and cannot activate rotation there.
+    run_ring_joint_sdpa_chunked(
+        MESH_CONFIG,
+        MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS["minimax3_55k"],
+        chunk_size=MINIMAX3_GQA_CHUNKED_ACCURACY_CHUNK_SIZE,
+        total_seq=MINIMAX3_GQA_CHUNKED_ACCURACY_TOTAL_SEQ,
+        qk_configs=[(32, 512)],
+        persistent_buffer_mode="reuse_max",
+    )
+
+
 def test_ring_joint_attention_minimax3_gqa_full_causal_attention_sink_accuracy_and_determinism():
     """Balanced M3 full-causal GQA consumes sinks without the sliding-window specialization."""
     model = replace(MODEL_CONFIGS["minimax3_gqa_smoke"], name="minimax3_gqa_full_causal_sink", seq_len=512)
@@ -6546,6 +6561,61 @@ def test_ring_joint_attention_minimax3_gqa_chunked_perf_check(
     logger.info(
         f"Minimax3 GQA chunked final-chunk perf check {config_id}: "
         f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
+        f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}]), "
+        f"profiler_records={len(perf_records)}"
+    )
+
+    assert lower <= utilization <= upper, (
+        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {RING_JOINT_PERF_MARGIN*100:.1f}%)"
+    )
+
+
+@pytest.mark.timeout(600)
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_ring_joint_attention_minimax3_gqa_rotated_q_perf():
+    """Guard the GQA rotated-Q speedup for Minimax3 q32/k512 on QuietBox.
+
+    The matching accuracy test checks the same Q/K chunk sizes. Here the final
+    chunk uses the existing Minimax3 perf check's oversized reusable KV cache.
+    """
+    if MESH_CONFIG.is_galaxy or MESH_CONFIG.sp_size != 4 or MESH_CONFIG.sdpa_cores != 100:
+        pytest.skip("GQA rotated-Q performance threshold is calibrated for QuietBox ring-4 with 100 SDPA cores")
+
+    expected_util = 32.43
+    model = MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS["minimax3_55k"]
+    chunk_size = CHUNKED_PREFILL_CHUNK_SIZE
+    perf_chunk = CHUNKED_PREFILL_N_CHUNKS - 1
+    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
+    try:
+        with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(perf_chunk)}):
+            duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
+                runtime.mesh_device,
+                lambda: run_ring_joint_sdpa_chunked(
+                    MESH_CONFIG,
+                    model,
+                    chunk_size=chunk_size,
+                    qk_configs=[(32, 512)],
+                    persistent_buffer_mode="reuse_max",
+                    do_check=False,
+                    reuse_kv_buffer=True,
+                    runtime=runtime,
+                ),
+            )
+        assert len(perf_records) == runtime.mesh_device.get_num_devices(), "Incomplete per-device profiler records"
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
+
+    utilization, _ = compute_chunked_prefill_perf_check_utilization(
+        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, MESH_CONFIG.sdpa_cores
+    )
+    lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
+    upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
+    logger.info(
+        f"Minimax3 GQA rotated-Q perf q32-k512: "
+        f"ring={MESH_CONFIG.sp_size}, sdpa_cores={MESH_CONFIG.sdpa_cores}, "
+        f"duration={duration_ns / 1e6:.3f} ms, math_util={utilization:.2f}% "
         f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}]), "
         f"profiler_records={len(perf_records)}"
     )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -6405,10 +6405,8 @@ def test_ring_mla_create_chunked_perf_table(model_name, q_chunk_size, k_chunk_si
 if MESH_CONFIG.is_galaxy:
     RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
         # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
-        # 8-device ring (Galaxy, sp=8 tp=4, 100 SDPA cores)
+        # 8-device ring (Galaxy, sp=8 tp=4)
         ("kimi50k", 32, 640, 8, 68.5),
-        # Kimi-K3: same chunk and tuned q32/k640, H_loc 24 vs 16. Measured 2026-08-05 on
-        # bh_sc1_high_power -- 9.680 ms vs kimi50k's 5.722, i.e. 1.69x time for 1.5x ideal work.
         ("kimi_k3", 32, 640, 8, 68.04),
     ]
 else:
@@ -6416,8 +6414,6 @@ else:
         # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
         # 4-device ring (QuietBox, 100 SDPA cores)
         ("kimi50k", 32, 640, 4, 66.05),
-        # Kimi-K3, measured 2026-08-05 on bh_quietbox_2 (run 31003064713): 4.845 ms. Inert until
-        # #52190 ungates this test here; kimi50k read 65.89 vs its committed 66.05 in the same run.
         ("kimi_k3", 32, 640, 4, 67.07),
     ]
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -6409,7 +6409,7 @@ if MESH_CONFIG.is_galaxy:
         ("kimi50k", 32, 640, 8, 68.5),
         # Kimi-K3: same chunk and tuned q32/k640, H_loc 24 vs 16. Measured 2026-08-05 on
         # bh_sc1_high_power -- 9.680 ms vs kimi50k's 5.722, i.e. 1.69x time for 1.5x ideal work.
-        ("kimi_k3", 32, 640, 8, 61.03),
+        ("kimi_k3", 32, 640, 8, 68.04),
     ]
 else:
     RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -285,57 +285,6 @@ def generate_model_configs(mesh_config: MeshConfig) -> Dict[str, ModelConfig]:
         )
     )
 
-    # Local-only: the one DENSE (non-chunked) ring-MLA shape small enough to test. mla_100k is the
-    # only other dense MLA config and it is is_balanced=True, which both trips the rotation's
-    # !is_balanced term AND makes its active mask full -- so nothing in the tree exercised dense
-    # causal's PARTIAL mask, the case the rotation's ordinal indexing exists for. is_balanced=False
-    # keeps the causal drop (ring_iter_does_work skips device_index < ring_id), giving a genuinely
-    # partial mask that the HOST knows (unlike kv-pad, where it is device-derived).
-    # Sized for the CPU reference, which is what makes mla_100k time out: 8 heads and 1280 local seq
-    # instead of 29 and 3200.
-    if os.environ.get("RING_MLA_K_SWEEP"):
-        configs.append(
-            ModelConfig(
-                name="mla_dense_small",
-                nhq=8,
-                nhk=1,
-                nhv=8,
-                d_q=576,
-                d_k=576,
-                d_v=128,
-                is_causal=True,
-                is_balanced=False,
-                q_dtype=ttnn.bfloat16,
-                kv_dtype=ttnn.bfloat8_b,
-                q_chunk_sizes=[160],
-                k_chunk_sizes=[320],
-                seq_len=1280,
-            )
-        )
-
-    # Local-only companion to mla_dense_small: same shape, zigzag balancing ON. Exists to TEST the
-    # rotation's !is_balanced term rather than take it on reasoning -- mla_100k is balanced too but
-    # times out, so the term had no counterexample.
-    if os.environ.get("RING_MLA_K_SWEEP"):
-        configs.append(
-            ModelConfig(
-                name="mla_dense_small_balanced",
-                nhq=8,
-                nhk=1,
-                nhv=8,
-                d_q=576,
-                d_k=576,
-                d_v=128,
-                is_causal=True,
-                is_balanced=True,
-                q_dtype=ttnn.bfloat16,
-                kv_dtype=ttnn.bfloat8_b,
-                q_chunk_sizes=[160],
-                k_chunk_sizes=[320],
-                seq_len=1280,
-            )
-        )
-
     configs.append(
         ModelConfig(
             name="mla_128k",
@@ -453,7 +402,6 @@ from tests.nightly.sdpa_perf_utils import compute_math_utilization as compute_ri
 from tests.nightly.sdpa_perf_utils import (
     compute_sdpa_flops,
     create_balanced_chunk_order,
-    parse_grid_spec,
     post_process_ops_log,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
@@ -634,28 +582,6 @@ class RingJointSDPARuntime:
     compute_kernel_config: object
 
 
-def _sdpa_compute_grid_for(mesh_config):
-    """SDPA compute grid, honoring the RING_MLA_SDPA_GRID_OVERRIDE debug escape hatch.
-
-    Shrinking the grid changes num_cores, which is what sets the rotated-Q-split work division
-    (rotated_base_chunks = total_q_chunks // num_cores, rotated_float_chunks = the remainder, and the number
-    of grid rows that host floats). It is therefore the only knob that sweeps this feature's actual
-    schedule without new hardware, so accuracy runs honor it too, not just the perf check.
-    """
-    grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
-    override = os.environ.get("RING_MLA_SDPA_GRID_OVERRIDE")
-    if not override:
-        return grid
-    cols, rows = parse_grid_spec(override, "RING_MLA_SDPA_GRID_OVERRIDE")
-    # Only shrinking is meaningful: a grid wider than the chip has builds a program on cores that do
-    # not exist, which hangs rather than raising.
-    assert cols <= mesh_config.sdpa_cols and rows <= mesh_config.grid_rows, (
-        f"RING_MLA_SDPA_GRID_OVERRIDE={override} must fit within " f"{mesh_config.sdpa_cols}x{mesh_config.grid_rows}"
-    )
-    logger.info(f"RING_MLA_SDPA_GRID_OVERRIDE={override}: SDPA grid {grid} -> {(cols, rows)}")
-    return (cols, rows)
-
-
 def open_ring_joint_sdpa_runtime(
     mesh_config,
     *,
@@ -701,17 +627,6 @@ def open_ring_joint_sdpa_runtime(
         mesh_device = ttnn.open_mesh_device(**mesh_device_kwargs)
 
         full_compute_grid = mesh_device.compute_with_storage_grid_size()
-        # MeshConfig derives the SDPA/CCL split from the grid it detected before any device was
-        # opened; the device is the authority. A mismatch means the split (and every expected_util
-        # normalized to mesh_config.sdpa_cores) is wrong for this host, so say so loudly.
-        if (full_compute_grid.x, full_compute_grid.y) != (mesh_config.grid_cols, mesh_config.grid_rows):
-            logger.warning(
-                f"MeshConfig grid {mesh_config.grid_cols}x{mesh_config.grid_rows} disagrees with the device's "
-                f"{full_compute_grid.x}x{full_compute_grid.y} compute grid: SDPA runs on "
-                f"{mesh_config.sdpa_cols}x{mesh_config.grid_rows} and utilization is normalized to "
-                f"{mesh_config.sdpa_cores} cores. Set SDPA_PERF_PROGRAM_GRID="
-                f"{full_compute_grid.x}x{full_compute_grid.y} to correct it."
-            )
         ccl_sub_device_crs = ttnn.CoreRangeSet(
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
         )
@@ -727,7 +642,7 @@ def open_ring_joint_sdpa_runtime(
             sp_axis=sp_axis,
             tp_axis=tp_axis,
             num_links=2,
-            sdpa_compute_grid=_sdpa_compute_grid_for(mesh_config),
+            sdpa_compute_grid=(mesh_config.sdpa_cols, mesh_config.grid_rows),
             ccl_column=mesh_config.ccl_column,
             worker_sub_device_id=worker_sub_device_id,
             ccl_semaphore_handles=create_global_semaphores(
@@ -1719,10 +1634,8 @@ CHUNKED_PREFILL_PCC_THRESHOLD_FP32 = 0.994
 # head shard => heads-per-ring == heads-per-device. nhq/nhv below are PER RING; the
 # run multiplies by tp_size for the total head count (e.g. 16 per ring => 64 total on
 # galaxy 4x8), matching the per-ring convention used by the sweep configs.
-# Hardware-dependent to keep per-core work balanced: galaxy has 110 SDPA cores, a stock non-galaxy
-# single ring has 100 (10x10), so it carries fewer heads per ring. Deliberately NOT re-derived from
-# MESH_CONFIG.sdpa_cores: on a re-flashed 110-core box that would change the tested shape and
-# invalidate the committed ring-4 baselines.
+# Hardware-dependent to keep per-core work balanced: galaxy has 110 SDPA cores, the
+# non-galaxy single ring has 100 (10x10), so it carries fewer heads per ring.
 CHUNKED_PREFILL_HEADS_PER_RING = 16 if MESH_CONFIG.is_galaxy else 14
 CHUNKED_PREFILL_SEED = 1234
 # Set to a chunk index to run/profile only that chunk in isolation instead of the
@@ -3080,7 +2993,6 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
     pcc_threshold=CHUNKED_PREFILL_PCC_THRESHOLD,
     rmse_threshold=DEFAULT_RMSE_THRESHOLD,
     full_mesh=False,
-    runtime=None,
 ):
     sp_size = mesh_config.num_devices if full_mesh else mesh_config.sp_size
     if sp_size < 2:
@@ -3124,11 +3036,7 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
     q_full = fa_rand(b, nhq, total_seq, d_q)
     kv_full = fa_rand(b, nhk, total_seq, d_k)
 
-    # A caller that already holds a runtime (the perf probe, which must profile inside the
-    # device's lifetime) passes it in and keeps ownership; otherwise open and close our own.
-    owns_runtime = runtime is None
-    if owns_runtime:
-        runtime = open_ring_joint_sdpa_runtime(mesh_config, full_mesh=full_mesh)
+    runtime = open_ring_joint_sdpa_runtime(mesh_config, full_mesh=full_mesh)
     mesh_device = runtime.mesh_device
     topology = runtime.topology
     sp_axis = runtime.sp_axis
@@ -3355,8 +3263,7 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
         )
 
     finally:
-        if owns_runtime:
-            close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
+        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
 
 
 def run_ring_mla_sdpa_chunked_indexed_kv_cache(
@@ -3694,67 +3601,6 @@ def test_ring_mla_chunked_kv_actual_isl_indexed_reuse_max_accuracy_and_determini
     mesh_config = MESH_CONFIG
     run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
         mesh_config,
-    )
-
-
-@pytest.mark.skipif(
-    not os.environ.get("RING_MLA_K_SWEEP"), reason="Local coverage for the rotated Q split on the kv-pad path"
-)
-def test_ring_mla_chunked_kv_actual_isl_rotated_q_split_accuracy():
-    """Same kv-pad (kv_actual_isl) path, sized so the rotated Q split can actually engage.
-
-    The default case is chunk_size_local=32 with q_chunk_size=32, i.e. ONE Q chunk per head and
-    total_q_chunks = 4 -- far below any real core count, so rotated_base_chunks is 0 and the rotation
-    always declines. Widening the local chunk to 256 gives 8 chunks per head (total 32), which
-    reaches rotated_base_chunks >= 1 under a shrunken grid (RING_MLA_SDPA_GRID_OVERRIDE=3x2 -> 6 cores
-    -> base 5, floats 2). Without this the kv-pad path has no configuration in which the rotation
-    is exercised at all, so its predicate term could not be validated either way.
-    """
-    run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
-        MESH_CONFIG,
-        chunk_size_local=256,
-    )
-
-
-@pytest.mark.skipif(
-    not os.environ.get("RING_MLA_K_SWEEP"), reason="Report-only kv-pad perf probe for the rotated-Q-split A/B"
-)
-def test_ring_mla_chunked_kv_actual_isl_rotated_q_split_perf_report_only():
-    """Report device time on the kv-pad (kv_actual_isl) path so the rotated Q split can be A/B'd there.
-
-    The rotation only engages on kv-pad from this commit onward, and every other kv-pad test is
-    accuracy-only, so there was no way to tell whether enabling it there costs anything. Report-only
-    by design: the shape is the small accuracy config (4 heads, d_q=64, chunk_size_local=256), far too
-    small to carry a committed utilization baseline. Its value is the ON-vs-OFF DELTA on one fixed
-    shape, not the absolute number.
-
-    Needs RING_MLA_SDPA_GRID_OVERRIDE, since total_q_chunks is 32 here and the default 110-core grid
-    gives rotated_base_chunks == 0 (rotation declines, and most rows have no work so the K mcast injector
-    cannot be picked either). 3x8 -> 24 cores -> base 1, floats 8, which exercises a real float
-    handoff. Pair with RING_MLA_DISABLE_ROTATED_Q_SPLIT=1 for the OFF arm.
-    """
-    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
-    try:
-        duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
-            runtime.mesh_device,
-            lambda: run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
-                MESH_CONFIG,
-                chunk_size_local=256,
-                runtime=runtime,
-            ),
-        )
-    finally:
-        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
-
-    rotation = "OFF" if os.environ.get("RING_MLA_DISABLE_ROTATED_Q_SPLIT") else "ON"
-    grid = os.environ.get("RING_MLA_SDPA_GRID_OVERRIDE", "default")
-    # Report the SDPA span per chip, not the raw records: each record carries its kernel_sources
-    # tuple, so logging the list itself buries the numbers in several KB of paths.
-    sdpa_us = sorted(r["duration_ns"] / 1e3 for r in perf_records)
-    logger.info(
-        f"ring_mla kv_actual_isl rotated-Q-split perf probe: rotation={rotation} grid={grid} "
-        f"duration={duration_ns / 1e6:.3f} ms, chips={len(perf_records)}, "
-        f"per-chip us min={sdpa_us[0]:.1f} max={sdpa_us[-1]:.1f}"
     )
 
 
@@ -4928,32 +4774,24 @@ PERF_TEST_CONFIG_MODELS = list(RING_JOINT_PERF_MODEL_CONFIGS.keys())
 def generate_ring_mla_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, ModelConfig]):
     if mesh_config.sp_size < 2 or "mla_100k" not in model_configs:
         return [], []
-    configs, ids = [], []
-    # mla_dense_small (RING_MLA_K_SWEEP only) is the non-balanced dense shape; see its ModelConfig.
-    for name in ("mla_100k", "mla_dense_small", "mla_dense_small_balanced"):
-        if name not in model_configs:
-            continue
-        model = model_configs[name]
-        q_chunk_size = model.q_chunk_sizes[0]
-        k_chunk_size = model.k_chunk_sizes[-1]
-        configs.append(
-            (
-                BATCH_SIZE,
-                model.seq_len * mesh_config.sp_size,
-                model.nhq * mesh_config.tp_size,
-                model.nhk,
-                model.d_q,
-                model.d_k,
-                model.d_v,
-                q_chunk_size,
-                k_chunk_size,
-                model.is_balanced,
-                model.q_dtype,
-                model.kv_dtype,
-            )
-        )
-        ids.append(f"ring_mla-{model.name}-q{q_chunk_size}-k{k_chunk_size}")
-    return configs, ids
+    model = model_configs["mla_100k"]
+    q_chunk_size = 160
+    k_chunk_size = 320
+    config = (
+        BATCH_SIZE,
+        model.seq_len * mesh_config.sp_size,
+        model.nhq * mesh_config.tp_size,
+        model.nhk,
+        model.d_q,
+        model.d_k,
+        model.d_v,
+        q_chunk_size,
+        k_chunk_size,
+        model.is_balanced,
+        model.q_dtype,
+        model.kv_dtype,
+    )
+    return [config], [f"ring_mla-{model.name}-q{q_chunk_size}-k{k_chunk_size}"]
 
 
 RING_MLA_TEST_CONFIGS, RING_MLA_TEST_CONFIG_IDS = generate_ring_mla_test_configs(MESH_CONFIG, MODEL_CONFIGS)
@@ -5676,24 +5514,6 @@ def _generate_chunked_configs(model_configs):
 
 CHUNKED_CONFIGS, CHUNKED_CONFIG_IDS = _generate_chunked_configs(CHUNKED_PREFILL_MODEL_CONFIGS)
 RING_MLA_CHUNKED_CONFIGS, RING_MLA_CHUNKED_CONFIG_IDS = _generate_chunked_configs(RING_MLA_CHUNKED_MODEL_CONFIGS)
-if os.environ.get("RING_MLA_K_SWEEP"):
-    # Local only. Extends the base list (not the derived *_TEST_CONFIGS, whose ids list is the same
-    # object) so accuracy/determinism/perf_impl all pick these up with matching lengths.
-    # Accuracy/determinism coverage for the shapes only q32 used to have. These are the shapes that
-    # exercise the small-rotated_base_chunks paths: q64 -> 240 units/110 cores = base 2, q128 -> 120
-    # units = base 1 (both were unsupported or broken before; see the predicate in
-    # ring_joint_sdpa_program_factory.cpp). q128's k is capped by L1.
-    # q64 (Sq_chunk_t == 2) used to fail at k320 and k448 with PCC ~0.12 / RMSE ~100, independently
-    # of the rotated split -- a missing PACK->UNPACK barrier in compute_streaming.hpp Phase 2, fixed
-    # there. The k values are kept spread across Skt % 4 == 0 (k128/k256/k384, which always worked)
-    # and Skt % 4 == 2 (k320/k448, which did not) so a regression in that gate is caught.
-    RING_MLA_CHUNKED_CONFIGS.append(("kimi_k3", 64, 448))
-    RING_MLA_CHUNKED_CONFIG_IDS.append("kimi_k3-q64-k448")
-    RING_MLA_CHUNKED_CONFIGS.append(("kimi_k3", 128, 256))
-    RING_MLA_CHUNKED_CONFIG_IDS.append("kimi_k3-q128-k256")
-    for _k in (128, 256, 320, 384):
-        RING_MLA_CHUNKED_CONFIGS.append(("kimi_k3", 64, _k))
-        RING_MLA_CHUNKED_CONFIG_IDS.append(f"kimi_k3-q64-k{_k}")
 MINIMAX3_GQA_CHUNKED_CONFIGS, MINIMAX3_GQA_CHUNKED_CONFIG_IDS = _generate_chunked_configs(
     MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS
 )
@@ -6570,15 +6390,11 @@ def test_ring_mla_create_chunked_perf_table(model_name, q_chunk_size, k_chunk_si
 if MESH_CONFIG.is_galaxy:
     RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
         # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
-        # 8-device ring (Galaxy, sp=8 tp=4, 110 SDPA cores)
+        # 8-device ring (Galaxy, sp=8 tp=4, 100 SDPA cores)
         ("kimi50k", 32, 640, 8, 68.5),
-        # Kimi-K3: same chunk and tuned q32/k640, H_loc 24 vs 16. Was 61.03 (measured 2026-08-05,
-        # bh_sc1_high_power, 9.680 ms) before the rotated Q split. PROJECTED 2026-08-18: the
-        # rotated per-ring-iteration split lifts the 480-unit/110-core occupancy ceiling from
-        # 8*ceil(480/110)=40 to 36 K-stream slots (61.03 * 40/36 * 0.989 stall factor measured on
-        # the QuietBox 9x10-grid emulation, which went 5.708 -> 5.290 ms). Replace with the first
-        # bh_sc1_high_power measurement.
-        ("kimi_k3", 32, 640, 8, 67.0),
+        # Kimi-K3: same chunk and tuned q32/k640, H_loc 24 vs 16. Measured 2026-08-05 on
+        # bh_sc1_high_power -- 9.680 ms vs kimi50k's 5.722, i.e. 1.69x time for 1.5x ideal work.
+        ("kimi_k3", 32, 640, 8, 61.03),
     ]
 else:
     RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
@@ -6589,64 +6405,6 @@ else:
         # #52190 ungates this test here; kimi50k read 65.89 vs its committed 66.05 in the same run.
         ("kimi_k3", 32, 640, 4, 67.07),
     ]
-
-# An 8-chip non-galaxy Blackhole box runs a single 8-device ring with TP=1, so kimi_k3 keeps its
-# production 24 Q heads per device while the ring length matches galaxy's sp=8. Neither branch
-# above covers sp_size=8 off galaxy, so the ring-4 ids skip and the ring-8 ids do not exist there.
-#
-# Measured 2026-08-20 on bh-lb-33 (8x p150b re-flashed to tensix_col_disable_count=1: 12x10 program
-# grid -> 11x10 = 110 SDPA cores, the same split galaxy gets), kimi_k3 50k+5k final chunk, fresh KV.
-# Gated on that core count, not merely on sp_size=8: utilization is per-core but the work-split
-# quantization is not, so a stock 100-core p150 box lands close to yet outside the band (q32/k640
-# read 9.445 ms / 68.81% there against +/-1% around 68.05). The gate also keeps these ids off
-# wormhole 8-device hosts, where detection falls back to 100 cores. Re-measure to widen it.
-RING_MLA_RING8_BASELINE_SDPA_CORES = 110
-RING_MLA_RING8_BASELINES_APPLY = (
-    not MESH_CONFIG.is_galaxy
-    and MESH_CONFIG.sp_size == 8
-    and MESH_CONFIG.sdpa_cores == RING_MLA_RING8_BASELINE_SDPA_CORES
-)
-if RING_MLA_RING8_BASELINES_APPLY:
-    RING_MLA_CHUNKED_PERF_CHECK_CONFIGS += [
-        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
-        # Shipped q32/k640 shape: 8.67 ms. Unaffected by the Sq_chunk_t == 2 barrier fix below
-        # (Sq_chunk_t is 1 here), and the fastest shape that is also numerically correct.
-        ("kimi_k3", 32, 640, 8, 68.05),
-        # q64/k448: 8.68 ms, measured over 3 runs (68.05-68.09%) with the PACK->UNPACK barrier in
-        # compute_streaming.hpp Phase 2 present and its two halves split around the unpack-side
-        # setup. The previous 71.28 / 8.288 ms was recorded while that barrier was absent, i.e. it
-        # timed a kernel that skipped a required synchronization and produced garbage (PCC ~0.12) --
-        # so it was never a real 4% win over q32/k640; the two shapes are within noise of each other.
-        # Every q64 figure in the sweep note below predates the fix and is optimistic for the same
-        # reason.
-        ("kimi_k3", 64, 448, 8, 68.07),
-    ]
-
-# Local k-chunk exploration, off by default so it costs no collected ids: RING_MLA_K_SWEEP=1.
-# expected_util is None for these, meaning "measure and report, gate nothing" -- the committed
-# baselines do not apply to shapes they were not measured on.
-#
-# Why these k values: q32 prefers the largest k that fits L1, because at Sq_chunk_t=1 the
-# kt_inplace_v path is data-movement bound and chunk count dominates. The sweep stops at 480 because
-# k512 and up overflow L1 at q64.
-# CAUTION: the q64 ranking this sweep originally produced (k448 > k320, attributed to Sk_chunk_t
-# factorization) was measured before the Sq_chunk_t == 2 barrier fix, and the shapes it favoured are
-# exactly the ones the missing barrier made fast and wrong -- Skt not divisible by 4 forces the QK
-# subblock to height 1, which is the case that skipped the barrier. Re-run before trusting any q64
-# ordering. No q128 entries: rotated_base_chunks would be 1, which the rotated split must
-# refuse (it hangs -- see the diagnosis in the program factory), and L1 caps k there anyway.
-# The per-device K prefix at the final chunk is 7040 rows, so k in (128, 160, 320, 352, 640)
-# divides it exactly and the rest straddle.
-if os.environ.get("RING_MLA_K_SWEEP") and RING_MLA_RING8_BASELINES_APPLY:
-    # k448 (q64) and k640 (q32) are omitted: they are the committed entries above.
-    for _k in (128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 480):
-        RING_MLA_CHUNKED_PERF_CHECK_CONFIGS.append(("kimi_k3", 64, _k, 8, None))
-    for _k in (320, 448, 576, 608):
-        RING_MLA_CHUNKED_PERF_CHECK_CONFIGS.append(("kimi_k3", 32, _k, 8, None))
-    # q128 -> 24 heads x (640/128) = 120 work units over 110 cores, i.e. rotated_base_chunks == 1: the
-    # worst static imbalance (2:1) and so the largest rotation win. k is capped by L1 here.
-    for _k in (224, 256):
-        RING_MLA_CHUNKED_PERF_CHECK_CONFIGS.append(("kimi_k3", 128, _k, 8, None))
 
 
 if MESH_CONFIG.is_galaxy:
@@ -6661,62 +6419,6 @@ else:
         # 4-device ring (QuietBox): same per-device Q rows and 16Q/1KV local GQA shape.
         ("minimax3_55k", 128, 512, 4, 47.0),
     ]
-
-
-@pytest.mark.timeout(900)
-@pytest.mark.skipif(not os.environ.get("RING_MLA_K_SWEEP"), reason="Report-only separate-V chunked perf probe")
-@pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
-@pytest.mark.parametrize("q_chunk_size,k_chunk_size", [(32, 640)], ids=["q32-k640"])
-# kimi50k is the separate-V chunked shape: CHUNKED_PREFILL_MODEL_CONFIGS holds just kimi50k and
-# minimax3_55k, and minimax3 is GQA (gqa_grouped_kv -> no batch chain -> no K mcast).
-@pytest.mark.parametrize("model_name", ["kimi50k"], ids=["kimi50k"])
-@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
-@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
-def test_ring_joint_attention_chunked_perf_check_report_only(model_name, q_chunk_size, k_chunk_size, chunk_size):
-    """SEPARATE-V chunked-prefill math utilization, measured and reported, gating nothing.
-
-    The separate-V chunked path had no perf harness at all: its only perf tests are the tracy
-    perf_table generators, which need a Tracy-enabled build and cannot run here. This uses the same
-    in-process profiler as the ring_mla perf check, so the path is at least measurable in a ~1 minute
-    run. No expected_util: this is a probe, not a committed baseline.
-
-    Note the rotated Q split does NOT engage here -- its predicate requires v_shares_k_buffer
-    (latent-V), and this is separate-V -- so RING_MLA_DISABLE_ROTATED_Q_SPLIT has no effect on this
-    number. Separate-V rotation was implemented and removed; see the predicate in
-    ring_joint_sdpa_program_factory.cpp for why.
-    """
-    model = CHUNKED_PREFILL_MODEL_CONFIGS[model_name]
-    n_chunks = CHUNKED_PREFILL_TOTAL_SEQ // chunk_size
-    perf_chunk = n_chunks - 1
-
-    config_id = f"{get_test_case_id(model, q_chunk_size, k_chunk_size)}-chunk{chunk_size}-fresh_kv"
-    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
-    try:
-        with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(perf_chunk)}):
-            duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
-                runtime.mesh_device,
-                lambda: run_ring_joint_sdpa_chunked(
-                    MESH_CONFIG,
-                    model,
-                    chunk_size=chunk_size,
-                    qk_configs=[(q_chunk_size, k_chunk_size)],
-                    persistent_buffer_mode="reuse_max",
-                    use_ring_mla=False,
-                    do_check=False,
-                    reuse_kv_buffer=False,
-                    runtime=runtime,
-                ),
-            )
-    finally:
-        close_ring_joint_sdpa_runtime(runtime)
-
-    utilization, _ = compute_chunked_prefill_perf_check_utilization(
-        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, MESH_CONFIG.sdpa_cores
-    )
-    logger.info(
-        f"separate-V chunked perf probe {config_id}: duration={duration_ns/1e6:.3f} ms, "
-        f"math_util={utilization:.2f}%, profiler_records={len(perf_records)}"
-    )
 
 
 @pytest.mark.timeout(600)
@@ -6751,23 +6453,6 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
 
     config_id = f"{get_test_case_id(model, q_chunk_size, k_chunk_size)}-chunk{chunk_size}-fresh_kv"
     runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
-    # Debug aid: RING_MLA_SDPA_GRID_OVERRIDE="9x10" shrinks the SDPA compute grid to emulate a
-    # different core count's work-split quantization (e.g. Galaxy's 480 units / 110 cores ratio on a
-    # QuietBox). Utilization is then normalized to the overridden core count, and the band assert is
-    # skipped (the committed expectation only applies to the standard grid).
-    grid_override = os.environ.get("RING_MLA_SDPA_GRID_OVERRIDE")
-    sdpa_cores_for_util = MESH_CONFIG.sdpa_cores
-    if grid_override:
-        cols, rows = parse_grid_spec(grid_override, "RING_MLA_SDPA_GRID_OVERRIDE")
-        # Only shrinking is meaningful: a grid wider than the chip has builds a program on cores
-        # that do not exist, which hangs rather than raising. Rows must match exactly, because
-        # compute_chunked_prefill_perf_check_utilization still rounds by MESH_CONFIG.grid_rows.
-        assert cols <= MESH_CONFIG.sdpa_cols and rows == MESH_CONFIG.grid_rows, (
-            f"RING_MLA_SDPA_GRID_OVERRIDE={grid_override} must be at most {MESH_CONFIG.sdpa_cols} "
-            f"cols and exactly {MESH_CONFIG.grid_rows} rows"
-        )
-        runtime.sdpa_compute_grid = (cols, rows)
-        sdpa_cores_for_util = cols * rows
     try:
         with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(perf_chunk)}):
             duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
@@ -6788,33 +6473,18 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
         close_ring_joint_sdpa_runtime(runtime)
 
     utilization, _ = compute_chunked_prefill_perf_check_utilization(
-        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, sdpa_cores_for_util
+        MESH_CONFIG, model, chunk_size, perf_chunk, duration_ns, MESH_CONFIG.sdpa_cores
     )
 
-    # expected_util is None for the RING_MLA_K_SWEEP exploration shapes, which have no baseline.
-    if expected_util is None:
-        band = "no committed baseline, reporting only"
-    else:
-        lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
-        upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
-        band = f"expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}]"
+    lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
+    upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
 
     logger.info(
         f"ring_mla chunked 50k+5k perf check {config_id}: "
         f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
-        f"({band}), profiler_records={len(perf_records)}"
+        f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}]), "
+        f"profiler_records={len(perf_records)}"
     )
-
-    if expected_util is None:
-        pytest.skip(f"{config_id}: measured {utilization:.2f}% ({band})")
-    # A shrunken grid changes the work-split quantization the baseline was measured under. Skip
-    # rather than return: a silent pass here would mean every id reports green if this variable
-    # ever leaked into a runner environment.
-    if grid_override:
-        pytest.skip(
-            f"RING_MLA_SDPA_GRID_OVERRIDE={grid_override}: measured {utilization:.2f}%, "
-            f"band assert does not apply to an overridden grid"
-        )
 
     assert lower <= utilization <= upper, (
         f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "

--- a/tests/nightly/sdpa_perf_utils.py
+++ b/tests/nightly/sdpa_perf_utils.py
@@ -11,7 +11,9 @@ Used by:
 - tests/nightly/t3000/ccl/test_ring_joint_attention.py
 """
 
+import glob
 import math
+import os
 from dataclasses import dataclass, field
 from typing import ClassVar, Tuple, List
 
@@ -39,19 +41,106 @@ ARCH_CONSTANTS = {
 # ============================================================================
 
 
-def _detect_devices_without_opening():
+def _pci_interface_ids():
     """
-    Detect the number of available TT devices WITHOUT opening them.
-    Uses /dev/tenstorrent/* device files to avoid holding device locks.
-    This is required for performance tests that use run_device_profiler().
+    PCI interface ids of the local TT devices, read from /dev/tenstorrent/* WITHOUT opening
+    them. Avoids holding device locks, which is required for performance tests that use
+    run_device_profiler().
     """
-    import glob
     import os
 
     # Device nodes are named numerically (/dev/tenstorrent/0, .../1, ...). Filter to those
     # so sibling entries like the `by-id/` directory are not miscounted as devices.
-    device_files = [p for p in glob.glob("/dev/tenstorrent/*") if os.path.basename(p).isdigit()]
-    return len(device_files)
+    return sorted(int(os.path.basename(p)) for p in glob.glob("/dev/tenstorrent/*") if os.path.basename(p).isdigit())
+
+
+def _detect_devices_without_opening():
+    """Number of available TT devices, detected without opening them."""
+    return len(_pci_interface_ids())
+
+
+# Blackhole harvests whole tensix columns, so the row count is fixed and only the column
+# count varies with the flashed harvesting mask.
+BLACKHOLE_TENSIX_ROWS = 10
+BLACKHOLE_TENSIX_COLUMNS = 14
+# metal reserves one enabled tensix column for dispatch, so the program grid is one column
+# narrower than the enabled-column count.
+BLACKHOLE_DISPATCH_COLUMNS = 1
+
+
+def parse_grid_spec(spec, var_name):
+    """(cols, rows) from a "<cols>x<rows>" spec, or ValueError naming var_name.
+
+    Shared by the SDPA_PERF_PROGRAM_GRID and RING_MLA_SDPA_GRID_OVERRIDE env vars. Both feed a
+    program grid straight to the device, where a nonsensical value hangs rather than errors, so
+    reject malformed input loudly instead of letting int() raise something that does not say which
+    variable was wrong.
+    """
+    parts = spec.lower().split("x")
+    if len(parts) != 2 or not all(p.strip().isdigit() for p in parts):
+        raise ValueError(f'{var_name}="{spec}" is not of the form "<cols>x<rows>" (e.g. "12x10")')
+    cols, rows = (int(p) for p in parts)
+    if not (1 <= cols <= BLACKHOLE_TENSIX_COLUMNS and 1 <= rows <= BLACKHOLE_TENSIX_ROWS):
+        raise ValueError(
+            f'{var_name}="{spec}" is outside the {BLACKHOLE_TENSIX_COLUMNS}x{BLACKHOLE_TENSIX_ROWS} '
+            "physical tensix grid"
+        )
+    return (cols, rows)
+
+
+def _detect_program_grid():
+    """
+    (cols, rows) metal program grid of the local chips, or None when it cannot be determined
+    (non-Blackhole, no pyluwen, no devices, telemetry read failure).
+
+    Detection reads the tensix column-harvesting mask out of chip telemetry: it opens the
+    /dev/tenstorrent char device only to read the telemetry mailbox (~1 ms per chip), taking no
+    metal device lock and allocating no TLBs -- the same access tt-smi makes while other processes
+    run. That keeps it safe to call at import time next to _detect_devices_without_opening().
+    Column harvesting is Blackhole-specific, hence the arch check below.
+
+    Stock p150 ships with product_spec_harvesting.tensix_col_disable_count=2 -> 12 enabled
+    columns -> an 11x10 program grid. Boards re-flashed to disable_count=1 have 13 enabled
+    columns -> 12x10 (verified against mesh_device.compute_with_storage_grid_size() on bh-lb-33,
+    whose 8 p150b boards report tensix_enabled_col=0x1fff and a 12x10 grid).
+
+    SDPA_PERF_PROGRAM_GRID="<cols>x<rows>" forces the answer, both as an escape hatch for hosts
+    where telemetry is unavailable and as a kill switch for the detection itself.
+    """
+    forced = os.environ.get("SDPA_PERF_PROGRAM_GRID")
+    if forced:
+        return parse_grid_spec(forced, "SDPA_PERF_PROGRAM_GRID")
+
+    try:
+        import pyluwen
+    except Exception:
+        # pyluwen is a compiled extension: absent, or ABI-skewed against this python, it can raise
+        # OSError as readily as ImportError. This runs at import time, so anything escaping here
+        # would fail collection of every module that imports this file.
+        return None
+
+    enabled_cols = []
+    for interface_id in _pci_interface_ids():
+        try:
+            chip = pyluwen.PciChip(pci_interface=interface_id)
+            if chip.as_bh() is None:  # column harvesting is Blackhole-specific
+                return None
+            mask = chip.get_telemetry().tensix_enabled_col
+        except Exception:
+            return None
+        if not mask:
+            return None
+        enabled_cols.append(bin(mask).count("1"))
+
+    if not enabled_cols:
+        return None
+    # Mixed harvesting across boards: metal's mesh grid is the one common to every chip.
+    cols = min(enabled_cols) - BLACKHOLE_DISPATCH_COLUMNS
+    # Out of range on either end means tensix_enabled_col is not the field we think it is; fall
+    # back rather than size a program for a grid the chip does not have.
+    if not (1 <= cols < BLACKHOLE_TENSIX_COLUMNS):
+        return None
+    return (cols, BLACKHOLE_TENSIX_ROWS)
 
 
 @dataclass
@@ -68,7 +157,10 @@ class MeshConfig:
     GALAXY_SP_SIZE: ClassVar[int] = 8
 
     # Non-Galaxy hardware constants
-    # 11x10 full grid -> 10x10 (100 cores) for SDPA after reserving the last column for CCL.
+    # Fallback program grid when the harvesting mask cannot be read (see _detect_program_grid):
+    # stock p150, tensix_col_disable_count=2 -> 12 enabled columns -> an 11x10 program grid ->
+    # 10x10 (100 cores) for SDPA once the last column is reserved for CCL. Boards re-flashed to
+    # disable_count=1 detect as 12x10 -> 11x10 (110 SDPA cores), matching galaxy's split.
     NON_GALAXY_GRID: ClassVar[Tuple[int, int]] = (11, 10)  # (cols, rows)
 
     # Instance fields (set by detect())
@@ -95,10 +187,27 @@ class MeshConfig:
 
     @classmethod
     def detect(cls) -> "MeshConfig":
-        """Detect hardware and create config with all values resolved."""
+        """Detect hardware and create config with all values resolved.
+
+        RING_MLA_RING_SIZE_OVERRIDE=<n> opens an n-device sub-mesh instead of the whole box, so a
+        ring length other than the local device count can be exercised (e.g. ring-4 on an 8-chip
+        host). Ring length is otherwise fixed by the hardware, and it is a dimension the ring-MLA
+        work-split schedule depends on, so it needs to be reachable in a test.
+        """
         num_devices = _detect_devices_without_opening()
+        ring_override = os.environ.get("RING_MLA_RING_SIZE_OVERRIDE")
+        if ring_override:
+            if not ring_override.isdigit() or not (2 <= int(ring_override) <= num_devices):
+                raise ValueError(
+                    f'RING_MLA_RING_SIZE_OVERRIDE="{ring_override}" must be an integer in '
+                    f"[2, {num_devices}] (the detected device count)"
+                )
+            num_devices = int(ring_override)
         is_galaxy = num_devices == cls.GALAXY_DEVICE_COUNT
-        grid = cls.GALAXY_GRID if is_galaxy else cls.NON_GALAXY_GRID
+        # Galaxy keeps its constant: every committed galaxy baseline was measured against a 12x10
+        # grid, and detection there would have to reason about its 32-chip topology rather than the
+        # local PCI devices.
+        grid = cls.GALAXY_GRID if is_galaxy else (_detect_program_grid() or cls.NON_GALAXY_GRID)
         return cls(
             is_galaxy=is_galaxy,
             num_devices=num_devices,

--- a/tests/nightly/sdpa_perf_utils.py
+++ b/tests/nightly/sdpa_perf_utils.py
@@ -11,9 +11,7 @@ Used by:
 - tests/nightly/t3000/ccl/test_ring_joint_attention.py
 """
 
-import glob
 import math
-import os
 from dataclasses import dataclass, field
 from typing import ClassVar, Tuple, List
 
@@ -41,106 +39,19 @@ ARCH_CONSTANTS = {
 # ============================================================================
 
 
-def _pci_interface_ids():
+def _detect_devices_without_opening():
     """
-    PCI interface ids of the local TT devices, read from /dev/tenstorrent/* WITHOUT opening
-    them. Avoids holding device locks, which is required for performance tests that use
-    run_device_profiler().
+    Detect the number of available TT devices WITHOUT opening them.
+    Uses /dev/tenstorrent/* device files to avoid holding device locks.
+    This is required for performance tests that use run_device_profiler().
     """
+    import glob
     import os
 
     # Device nodes are named numerically (/dev/tenstorrent/0, .../1, ...). Filter to those
     # so sibling entries like the `by-id/` directory are not miscounted as devices.
-    return sorted(int(os.path.basename(p)) for p in glob.glob("/dev/tenstorrent/*") if os.path.basename(p).isdigit())
-
-
-def _detect_devices_without_opening():
-    """Number of available TT devices, detected without opening them."""
-    return len(_pci_interface_ids())
-
-
-# Blackhole harvests whole tensix columns, so the row count is fixed and only the column
-# count varies with the flashed harvesting mask.
-BLACKHOLE_TENSIX_ROWS = 10
-BLACKHOLE_TENSIX_COLUMNS = 14
-# metal reserves one enabled tensix column for dispatch, so the program grid is one column
-# narrower than the enabled-column count.
-BLACKHOLE_DISPATCH_COLUMNS = 1
-
-
-def parse_grid_spec(spec, var_name):
-    """(cols, rows) from a "<cols>x<rows>" spec, or ValueError naming var_name.
-
-    Shared by the SDPA_PERF_PROGRAM_GRID and RING_MLA_SDPA_GRID_OVERRIDE env vars. Both feed a
-    program grid straight to the device, where a nonsensical value hangs rather than errors, so
-    reject malformed input loudly instead of letting int() raise something that does not say which
-    variable was wrong.
-    """
-    parts = spec.lower().split("x")
-    if len(parts) != 2 or not all(p.strip().isdigit() for p in parts):
-        raise ValueError(f'{var_name}="{spec}" is not of the form "<cols>x<rows>" (e.g. "12x10")')
-    cols, rows = (int(p) for p in parts)
-    if not (1 <= cols <= BLACKHOLE_TENSIX_COLUMNS and 1 <= rows <= BLACKHOLE_TENSIX_ROWS):
-        raise ValueError(
-            f'{var_name}="{spec}" is outside the {BLACKHOLE_TENSIX_COLUMNS}x{BLACKHOLE_TENSIX_ROWS} '
-            "physical tensix grid"
-        )
-    return (cols, rows)
-
-
-def _detect_program_grid():
-    """
-    (cols, rows) metal program grid of the local chips, or None when it cannot be determined
-    (non-Blackhole, no pyluwen, no devices, telemetry read failure).
-
-    Detection reads the tensix column-harvesting mask out of chip telemetry: it opens the
-    /dev/tenstorrent char device only to read the telemetry mailbox (~1 ms per chip), taking no
-    metal device lock and allocating no TLBs -- the same access tt-smi makes while other processes
-    run. That keeps it safe to call at import time next to _detect_devices_without_opening().
-    Column harvesting is Blackhole-specific, hence the arch check below.
-
-    Stock p150 ships with product_spec_harvesting.tensix_col_disable_count=2 -> 12 enabled
-    columns -> an 11x10 program grid. Boards re-flashed to disable_count=1 have 13 enabled
-    columns -> 12x10 (verified against mesh_device.compute_with_storage_grid_size() on bh-lb-33,
-    whose 8 p150b boards report tensix_enabled_col=0x1fff and a 12x10 grid).
-
-    SDPA_PERF_PROGRAM_GRID="<cols>x<rows>" forces the answer, both as an escape hatch for hosts
-    where telemetry is unavailable and as a kill switch for the detection itself.
-    """
-    forced = os.environ.get("SDPA_PERF_PROGRAM_GRID")
-    if forced:
-        return parse_grid_spec(forced, "SDPA_PERF_PROGRAM_GRID")
-
-    try:
-        import pyluwen
-    except Exception:
-        # pyluwen is a compiled extension: absent, or ABI-skewed against this python, it can raise
-        # OSError as readily as ImportError. This runs at import time, so anything escaping here
-        # would fail collection of every module that imports this file.
-        return None
-
-    enabled_cols = []
-    for interface_id in _pci_interface_ids():
-        try:
-            chip = pyluwen.PciChip(pci_interface=interface_id)
-            if chip.as_bh() is None:  # column harvesting is Blackhole-specific
-                return None
-            mask = chip.get_telemetry().tensix_enabled_col
-        except Exception:
-            return None
-        if not mask:
-            return None
-        enabled_cols.append(bin(mask).count("1"))
-
-    if not enabled_cols:
-        return None
-    # Mixed harvesting across boards: metal's mesh grid is the one common to every chip.
-    cols = min(enabled_cols) - BLACKHOLE_DISPATCH_COLUMNS
-    # Out of range on either end means tensix_enabled_col is not the field we think it is; fall
-    # back rather than size a program for a grid the chip does not have.
-    if not (1 <= cols < BLACKHOLE_TENSIX_COLUMNS):
-        return None
-    return (cols, BLACKHOLE_TENSIX_ROWS)
+    device_files = [p for p in glob.glob("/dev/tenstorrent/*") if os.path.basename(p).isdigit()]
+    return len(device_files)
 
 
 @dataclass
@@ -157,10 +68,7 @@ class MeshConfig:
     GALAXY_SP_SIZE: ClassVar[int] = 8
 
     # Non-Galaxy hardware constants
-    # Fallback program grid when the harvesting mask cannot be read (see _detect_program_grid):
-    # stock p150, tensix_col_disable_count=2 -> 12 enabled columns -> an 11x10 program grid ->
-    # 10x10 (100 cores) for SDPA once the last column is reserved for CCL. Boards re-flashed to
-    # disable_count=1 detect as 12x10 -> 11x10 (110 SDPA cores), matching galaxy's split.
+    # 11x10 full grid -> 10x10 (100 cores) for SDPA after reserving the last column for CCL.
     NON_GALAXY_GRID: ClassVar[Tuple[int, int]] = (11, 10)  # (cols, rows)
 
     # Instance fields (set by detect())
@@ -187,27 +95,10 @@ class MeshConfig:
 
     @classmethod
     def detect(cls) -> "MeshConfig":
-        """Detect hardware and create config with all values resolved.
-
-        RING_MLA_RING_SIZE_OVERRIDE=<n> opens an n-device sub-mesh instead of the whole box, so a
-        ring length other than the local device count can be exercised (e.g. ring-4 on an 8-chip
-        host). Ring length is otherwise fixed by the hardware, and it is a dimension the ring-MLA
-        work-split schedule depends on, so it needs to be reachable in a test.
-        """
+        """Detect hardware and create config with all values resolved."""
         num_devices = _detect_devices_without_opening()
-        ring_override = os.environ.get("RING_MLA_RING_SIZE_OVERRIDE")
-        if ring_override:
-            if not ring_override.isdigit() or not (2 <= int(ring_override) <= num_devices):
-                raise ValueError(
-                    f'RING_MLA_RING_SIZE_OVERRIDE="{ring_override}" must be an integer in '
-                    f"[2, {num_devices}] (the detected device count)"
-                )
-            num_devices = int(ring_override)
         is_galaxy = num_devices == cls.GALAXY_DEVICE_COUNT
-        # Galaxy keeps its constant: every committed galaxy baseline was measured against a 12x10
-        # grid, and detection there would have to reason about its 32-chip topology rather than the
-        # local PCI devices.
-        grid = cls.GALAXY_GRID if is_galaxy else (_detect_program_grid() or cls.NON_GALAXY_GRID)
+        grid = cls.GALAXY_GRID if is_galaxy else cls.NON_GALAXY_GRID
         return cls(
             is_galaxy=is_galaxy,
             num_devices=num_devices,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1533,6 +1533,12 @@ static void sdpa_inner_loop_step(
         static_assert(vDHt % qktv_subblock_w == 0, "vDHt must be evenly divisible by qktv_subblock_w");
         static_assert(qktv_h * qktv_subblock_w <= dst_size, "qktv subblock must fit in dest register file");
         constexpr uint32_t qktv_q_num_subblocks = Sq_chunk_t / qktv_h;  // full subblocks only
+        // The in-place sub_exp below PACK-writes the last QK row group; the first V matmul then
+        // UNPACK-reads rows [0, qktv_h). Overlapping ranges need a pack->unpack rendezvous or the
+        // matmul reads stale L1. q_num_subblocks == 1 was too narrow: the granularities also diverge
+        // when the QK solver falls back to subblock_h == 1 (Sk_chunk_t not divisible by 4) while
+        // Phase 2 widens qktv_h to 2, i.e. exactly Sq_chunk_t == 2.
+        constexpr bool qktv_first_group_reads_inplace_row = (q_num_subblocks - 1) * qkt_subblock_h < qktv_h;
         constexpr uint32_t qktv_v_num_subblocks = vDHt / qktv_subblock_w;
         constexpr uint32_t qktv_output_num_tiles = Sq_chunk_t * vDHt;
         // cb_qkt_im row width is KT_stride (for pointer alignment), not Sk_chunk_t
@@ -1572,10 +1578,11 @@ static void sdpa_inner_loop_step(
                         kt_sub * actual_sbw,
                         qkt_subblock_h,
                         actual_sbw);
-                    if constexpr (q_num_subblocks == 1) {
+                    if constexpr (qktv_first_group_reads_inplace_row) {
+                        // PACK half only; SEMGET head-of-line-blocks the unpack thread, so the
+                        // UNPACK half waits just before the matmul instead of stalling the setup
+                        // below, none of which reads cb_qkt_im tile data.
                         PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
-                        UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
-                        UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
                     }
                     if (kt_sub == 0) {
                         CircularBuffer(cb_qkt_im).wait_front(qktv_in0_wait_tiles);
@@ -1595,6 +1602,11 @@ static void sdpa_inner_loop_step(
                         // still limits how many V rows are multiplied.
                         mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, KT_stride);
                         configure_row_pack_width(out_cb, qktv_subblock_w);
+                        if constexpr (qktv_first_group_reads_inplace_row) {
+                            // UNPACK half of the rendezvous posted above.
+                            UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
+                            UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
+                        }
                         for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
                             const uint32_t qktv_in1_index = kt_sub * matmul_inner * vDHt + v_index_offset;
                             blocked_matmul_and_pack<false, vDHt, vDHt>(
@@ -1635,7 +1647,7 @@ static void sdpa_inner_loop_step(
                         qkt_subblock_h,
                         actual_sbw);
                 }
-                if constexpr (q_num_subblocks == 1) {
+                if constexpr (qktv_first_group_reads_inplace_row) {
                     PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
                     UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
                     UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
@@ -2306,6 +2318,9 @@ template <
     // reader's kv_chunk_is_beyond_logical_l skip so the K/V CB producer/consumer counts stay aligned.
     bool joint_n_skip_enabled = false,
     uint32_t joint_local_padded_Nt = 0,  // Lt_local: per-device joint tile count (sharded path)
+    // Rotated Q split: the q loop runs positions, mapping each to a flat chunk id from the
+    // runtime-arg list at rotated_list_arg_base. Off by default (position is the flat id).
+    bool rotated_q_split_enabled = false,
     typename MaskCtx = LightweightMaskContext>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
@@ -2333,7 +2348,9 @@ void sdpa_ring_v2(
     // True (unpadded) joint length in tiles; joint K chunks starting at/after it are pure padding.
     const uint32_t logical_lt = 0,
     // Tile offset of this call's Q chunk within cb_q_in (head-serial passes; 0 otherwise).
-    const uint32_t q_base_tiles = 0) {
+    const uint32_t q_base_tiles = 0,
+    // Rotated Q split only: runtime-arg index of this ring iteration's flat chunk-id list.
+    [[maybe_unused]] const uint32_t rotated_list_arg_base = 0) {
     init_sdpa_streaming_semaphores();
 
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
@@ -2474,7 +2491,11 @@ void sdpa_ring_v2(
         // Compute Q chunk index (with optional zigzag remapping for causal balancing).
         // num_q_chunks is total per-head chunks (local + joint), matching the divisor the
         // writer/reader use to flatten (batch, head, q_chunk) — see ring_joint_sdpa.cpp.
-        uint32_t q_chunk = remap_q_index(q, num_q_chunks, use_zigzag_balancing) % num_q_chunks;
+        uint32_t q_flat = q;
+        if constexpr (rotated_q_split_enabled) {
+            q_flat = get_arg_val<uint32_t>(rotated_list_arg_base + q);
+        }
+        uint32_t q_chunk = remap_q_index(q_flat, num_q_chunks, use_zigzag_balancing) % num_q_chunks;
 
         // Causal K-chunk limit and Q start tile for this Q chunk
         uint32_t causal_k_limit = num_kv_chunks;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -138,7 +138,7 @@ void kernel_main() {
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t q_per_core = global_q_end - global_q_start;
+    [[maybe_unused]] const uint32_t q_per_core = global_q_end - global_q_start;
 
     const uint32_t ring_size_runtime = get_arg_val<uint32_t>(argidx++);
     const uint32_t ring_index_runtime = get_arg_val<uint32_t>(argidx++);
@@ -150,6 +150,10 @@ void kernel_main() {
     uint32_t kv_pad_q_post_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
     uint32_t kv_pad_q_valid_tile_count = get_arg_val<uint32_t>(argidx++);
     uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+
+    // Rotated Q split: first runtime arg past the scalars above. Captured here because argidx is
+    // final at this point; the compile-time sizes are derived below, next to the other CT args.
+    const uint32_t rotated_args_base = argidx;
 
     RingSDPAOpIndexer fused_op_indexer(
         ring_size_runtime, ring_index_runtime, forward_writes_expected, backward_writes_expected);
@@ -192,6 +196,23 @@ void kernel_main() {
     constexpr uint32_t cb_exp_max_diff = get_compile_time_arg_val(cb_arg_offset + 22);
     constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 23);
     constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 24);
+
+    // Rotated per-ring-iteration Q distribution. Chunk-LIST LENGTH per iteration (base chunks plus
+    // one float slot), or 0 when the host declined the rotation. Per ring iteration the factory
+    // appends [my_count, chunk ids x rotated_max_slots] at this fixed stride.
+    // The factory pushes rotated_max_slots as the final compile-time arg of every kernel, so
+    // read it from there rather than tracking a per-kernel index into the block above.
+    constexpr uint32_t rotated_max_slots = get_ct_arg<kernel_compile_time_args.size() - 1>();
+    constexpr bool rotated_q_split_enabled = rotated_max_slots > 0;
+    constexpr uint32_t rotated_iter_stride = ::rotated_iter_stride(kRotatedComputeIterHeaderWords, rotated_max_slots);
+    // Only sdpa_ring_v2 reads the rotated chunk list; the sdpa_ring branch below would keep using
+    // global_q_start/global_q_end and silently desync from the reader and writer. The host pairs
+    // latent-V with streaming compute, but only via a chain of implications, so pin it here.
+    static_assert(
+        !rotated_q_split_enabled || use_streaming_compute, "the rotated Q split requires the streaming compute path");
+    static_assert(
+        !rotated_q_split_enabled || rotated_max_slots >= 2,
+        "rotated_max_slots is rotated_base_chunks + 1, and the host requires base >= 1");
 
     if constexpr (kv_pad_from_metadata) {
         CircularBuffer cb_derived(cb_kv_pad_derived);
@@ -252,6 +273,28 @@ void kernel_main() {
     bool seen_active_iter = false;
     constexpr uint32_t sdpa_ring_iterations = has_sliding_window ? 1 : ring_size;
     for (uint32_t ring_iter = 0; ring_iter < sdpa_ring_iterations; ++ring_iter) {
+        // This iteration's [my_count, chunk ids...] block. Read once: the call below wants the
+        // count as the q-loop end and the id-list base, and takes the mode selector separately.
+        // Indexed by ACTIVE ordinal, not absolute ring_iter -- see rotated_active_ordinal. Compute reads
+        // the same device-derived mask the reader published through cb_kv_pad_derived, so the ordinal
+        // it computes is identical to the reader's and the writer's.
+        //
+        // Unlike the reader and writer, this runs BEFORE the inactive-iteration `continue` below, so
+        // on a skipped iteration it computes an ordinal it will not use and reads rotated_my_count from
+        // that slot. That read is always in bounds: for a skipped iteration the ordinal equals the
+        // number of active iterations at or before it, and since at least one iteration is inactive
+        // that count is at most ring_size - 1 -- within the ring_size entries the host emits. Kept
+        // here rather than moved after the `continue` because rotated_my_count feeds the arg decode that
+        // the ring-id sequencing below is interleaved with.
+        uint32_t rotated_my_count = 0;
+        uint32_t rotated_list_arg_base = 0;
+        if constexpr (rotated_q_split_enabled) {
+            const uint32_t rotated_ordinal = rotated_active_ordinal(active_ring_iter_mask, ring_iter);
+            const uint32_t rotated_iter_base =
+                ::rotated_iter_base(rotated_args_base, rotated_iter_stride, rotated_ordinal);
+            rotated_my_count = get_arg_val<uint32_t>(rotated_iter_base);
+            rotated_list_arg_base = rotated_iter_base + kRotatedComputeIterHeaderWords;
+        }
         // Sliding folds all local/halo source ranges into one synthetic local iteration.
         // The dataflow reader has already waited for the required halo completion signals.
         const uint32_t ring_id =
@@ -435,9 +478,13 @@ void kernel_main() {
                 use_attention_sink,
                 cb_attention_sink,
                 has_gathered_joint_k,
-                Lt_local>(
-                global_q_start,
-                global_q_end,
+                Lt_local,
+                rotated_q_split_enabled>(
+                // Rotated: iterate [0, my_count) as POSITIONS, each mapped to its flat chunk id via
+                // the per-iteration runtime-arg list at rotated_list_arg_base. Static: the flat
+                // [start, end) range is already the id range.
+                rotated_q_split_enabled ? 0u : global_q_start,
+                rotated_q_split_enabled ? rotated_my_count : global_q_end,
                 iter_num_kv_chunks,
                 num_q_chunks,
                 ring_iter,
@@ -452,13 +499,18 @@ void kernel_main() {
                 joint_n_mask_chunk_id,
                 acc_state,
                 is_last_ring_iter,
-                q_per_core,
+                // Rotated: NOT this iteration's count. q_per_core only selects L1-persistent vs
+                // DRAM-round-trip accumulators, and that choice must be the same on every iteration
+                // and must match the reader and writer. The fixed slot count (base + 1 >= 2) is.
+                rotated_q_split_enabled ? rotated_max_slots : q_per_core,
                 lw_mask,
                 skip_first_half_q,
                 use_zigzag_balancing,
                 chunked_context,
                 is_first_active_iter,
-                logical_lt);
+                logical_lt,
+                /*q_base_tiles=*/0,
+                rotated_list_arg_base);
         } else {
             assert_kv_pad_rotation_streaming_only<kv_pad_rotation_enabled>();
             sdpa_ring<

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
@@ -49,6 +49,67 @@ constexpr bool kt_inplace_v_enabled(bool v_shares_k_buffer, uint32_t Sq_chunk_t)
     return v_shares_k_buffer && (Sq_chunk_t == 1);
 }
 
+// ---------------------------------------------------------------------------
+// Rotated Q split: host/device contract. The remainder ("float") Q chunks of an uneven work split
+// change owner core between ring iterations, so no grid row pays the +1 K-mcast slot on every one.
+// Everything here is derived identically by the program factory and all three kernels.
+//
+// rotated_max_slots -- the per-iteration chunk-list length -- is not here: the factory pushes it as
+// each kernel's LAST compile-time arg, and each kernel reads it back from that position.
+// ---------------------------------------------------------------------------
+
+// Handoff semaphore ring depth. A slot is live only within one ring iteration, so slots are reused
+// instead of allocated per iteration: program semaphores cap at 16 and are shared with the chain
+// and all-gather. 3 tolerates a full iteration of inter-core skew.
+constexpr uint32_t kRotatedHandoffSemDepth = 3;
+
+// Header words each kernel's per-iteration runtime-arg block carries before its chunk-id list.
+constexpr uint32_t kRotatedReaderIterHeaderWords = 2;   // [row_slot_count, my_count]
+constexpr uint32_t kRotatedWriterIterHeaderWords = 3;   // [my_count, float_migrated_in, float_dest]
+constexpr uint32_t kRotatedComputeIterHeaderWords = 1;  // [my_count]
+
+// One iteration's block is header words + rotated_max_slots chunk ids, so blocks are a fixed stride
+// apart and iteration `ordinal` starts here.
+constexpr uint32_t rotated_iter_stride(uint32_t header_words, uint32_t max_slots) { return header_words + max_slots; }
+constexpr uint32_t rotated_iter_base(uint32_t args_base, uint32_t iter_stride, uint32_t ordinal) {
+    return args_base + ordinal * iter_stride;
+}
+
+// Ordinal of `ring_iter` within the ACTIVE subsequence. All three kernels index the schedule by
+// this rather than by absolute ring_iter: the handoff pairs a donor signal with a receiver wait in
+// the NEXT EXECUTED iteration, and consecutive ordinals cannot straddle a skipped one. Equal to
+// ring_iter for a full mask, which is what lets the device-derived kv-pad mask rotate too.
+constexpr uint32_t rotated_active_ordinal(uint32_t active_ring_iter_mask, uint32_t ring_iter) {
+    constexpr uint32_t kRingIterMaskBits = 32;
+    const uint32_t before = ring_iter >= kRingIterMaskBits ? ~0u : ((1u << ring_iter) - 1u);
+    uint32_t bits = active_ring_iter_mask & before;
+    uint32_t count = 0;
+    while (bits) {
+        bits &= bits - 1u;  // clear lowest set bit
+        ++count;
+    }
+    return count;
+}
+
+// Handoff semaphores for a given ring size. Clamped to >= 1: a degenerate ring_size <= 1 never
+// receives a float, but the kernel still declares the array and takes a modulo by this.
+constexpr uint32_t rotated_handoff_sem_count(uint32_t ring_size) {
+    const uint32_t receiving_iters = ring_size > 0 ? ring_size - 1 : 0;
+    const uint32_t depth = receiving_iters < kRotatedHandoffSemDepth ? receiving_iters : kRotatedHandoffSemDepth;
+    return depth > 0 ? depth : 1;
+}
+
+// float_dest: the float's next owner as one packed word, or kRotatedNoDest when it stays put.
+// Physical NoC coordinates are small, so y takes the low byte and x the rest.
+constexpr uint32_t kRotatedDestYBits = 8;
+constexpr uint32_t kRotatedDestYMask = (1u << kRotatedDestYBits) - 1u;
+constexpr uint32_t kRotatedNoDest = ~0u;
+constexpr uint32_t rotated_pack_dest(uint32_t phys_x, uint32_t phys_y) {
+    return (phys_x << kRotatedDestYBits) | phys_y;
+}
+constexpr uint32_t rotated_dest_x(uint32_t packed_dest) { return packed_dest >> kRotatedDestYBits; }
+constexpr uint32_t rotated_dest_y(uint32_t packed_dest) { return packed_dest & kRotatedDestYMask; }
+
 template <bool v_shares_k_buffer, bool kt_inplace_v = false>
 constexpr uint32_t dummy_kv_chunks_for_phase_alignment(uint32_t processed_chunks) {
     // Reader pushes one K entry and one V entry per real chunk; compute pops the

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
@@ -51,7 +51,9 @@ constexpr bool kt_inplace_v_enabled(bool v_shares_k_buffer, uint32_t Sq_chunk_t)
 
 // ---------------------------------------------------------------------------
 // Rotated Q split: host/device contract. The remainder ("float") Q chunks of an uneven work split
-// change owner core between ring iterations, so no grid row pays the +1 K-mcast slot on every one.
+// change owner core between ring iterations, so no LOCKSTEP GROUP pays the +1 K-mcast slot on
+// every one. A group is the set of cores one injector multicasts to while waiting for every
+// receiver -- today a full grid row, for either the shared-K (latent-V) or the GQA-grouped family.
 // Everything here is derived identically by the program factory and all three kernels.
 //
 // rotated_max_slots -- the per-iteration chunk-list length -- is not here: the factory pushes it as
@@ -64,7 +66,7 @@ constexpr bool kt_inplace_v_enabled(bool v_shares_k_buffer, uint32_t Sq_chunk_t)
 constexpr uint32_t kRotatedHandoffSemDepth = 3;
 
 // Header words each kernel's per-iteration runtime-arg block carries before its chunk-id list.
-constexpr uint32_t kRotatedReaderIterHeaderWords = 2;   // [row_slot_count, my_count]
+constexpr uint32_t kRotatedReaderIterHeaderWords = 2;   // [group_slot_count, my_count]
 constexpr uint32_t kRotatedWriterIterHeaderWords = 3;   // [my_count, float_migrated_in, float_dest]
 constexpr uint32_t kRotatedComputeIterHeaderWords = 1;  // [my_count]
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -29,14 +29,19 @@ struct RingSDPAOpReceiver {
         uint32_t forward_writes_expected = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t backward_writes_expected = get_arg_val<uint32_t>(rt_args_idx++);
 
+        // Read the whole pushed block either way, so rt_args_idx lands on the caller's own args in
+        // both modes. First semaphore is AllGather's BWD (direction 1), second its FWD (direction 0).
+        const uint32_t bwd_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t fwd_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t split_forwarding = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t split_shard = get_arg_val<uint32_t>(rt_args_idx++);
+        const uint32_t split_wait = get_arg_val<uint32_t>(rt_args_idx++);
         if (this->wait_for_op_signal) {
-            // First semaphore is AllGather's BWD semaphore. It belongs to direction 1.
-            signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
-            // Second is AllGather's FWD semaphore. It belongs to direction 0.
-            signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
-            split_forwarding_enabled = get_arg_val<uint32_t>(rt_args_idx++) == 1;
-            split_shard_id = get_arg_val<uint32_t>(rt_args_idx++);
-            split_second_half_wait = get_arg_val<uint32_t>(rt_args_idx++);
+            signal_op_semaphore_ids[1] = bwd_semaphore_id;
+            signal_op_semaphore_ids[0] = fwd_semaphore_id;
+            split_forwarding_enabled = split_forwarding == 1;
+            split_shard_id = split_shard;
+            split_second_half_wait = split_wait;
         }
 
         seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -282,7 +282,7 @@ void kernel_main() {
     constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(36) == 1;
     constexpr bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
     constexpr bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
-    constexpr bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
+    constexpr bool use_head_chain = ring_joint::uses_v_head_chain(enable_kv_chains, gqa_grouped_kv, v_shares_k_buffer);
     // In-place latent-V (single-tile Q): the compute kernel reads V straight from K^T, so the
     // reader never materializes V. Shared with the program factory and compute kernel.
     constexpr bool kt_inplace_v = kt_inplace_v_enabled(v_shares_k_buffer, Sq_chunk_t);
@@ -391,6 +391,10 @@ void kernel_main() {
         true, /* wait_for_op_signal */
         argidx);
 
+    // Rotated Q split: first runtime arg past the fused-op signaler block. Captured here because
+    // argidx is final at this point; the compile-time sizes are derived below with the other CT args.
+    const uint32_t rotated_args_base = argidx;
+
     // Compile-time semaphore ids and chain flags are appended after all TensorAccessorArgs().
     // ChainLink takes semaphore IDs directly (the new Semaphore<> wrapper resolves them to L1 addrs).
     constexpr uint32_t chain_sender_semaphore_arg_offset = ring_joint::kChainSenderSemaphoreCompileArgOffset;
@@ -462,6 +466,16 @@ void kernel_main() {
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
     constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 3);
     constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 4);
+
+    // Rotated per-ring-iteration Q distribution. Chunk-LIST LENGTH per iteration (base chunks plus
+    // one float slot), or 0 when the host declined the rotation. Per ring iteration the factory
+    // appends [row_slot_count, my_count, chunk ids x rotated_max_slots] at this fixed stride; when
+    // enabled, the static global_q_start/global_q_end range is superseded entirely.
+    // The factory pushes rotated_max_slots as the final compile-time arg of every kernel, so
+    // read it from there rather than tracking a per-kernel index into the block above.
+    constexpr uint32_t rotated_max_slots = get_ct_arg<kernel_compile_time_args.size() - 1>();
+    constexpr bool rotated_q_split_enabled = rotated_max_slots > 0;
+    constexpr uint32_t rotated_iter_stride = ::rotated_iter_stride(kRotatedReaderIterHeaderWords, rotated_max_slots);
 
     if constexpr (slot_from_metadata || kv_pad_from_metadata) {
         Noc meta_noc;
@@ -745,26 +759,54 @@ void kernel_main() {
             }
         }
 
-        // When K/V mcast is enabled, loop the per-chain max so receivers with less real Q work
-        // still participate in padded multicast handshakes without pushing compute-visible data.
-        uint32_t loop_q_count = q_per_core;
-        if constexpr (k_uses_batch_chain && batch_mcast_enabled) {
-            loop_q_count = max_q_per_core;
-        }
-        if constexpr (gqa_grouped_kv && gqa_mcast_enabled) {
-            loop_q_count = gqa_max_q_per_core;
+        // Rotated: the factory precomputes this row's mcast slot count per ring iteration (its row
+        // max, so members with less real work still run the padded handshakes), superseding the
+        // static per-chain maxima. Indexed by ACTIVE ordinal -- see rotated_active_ordinal.
+        // Static: when K/V mcast is enabled, loop the per-chain max so receivers with less real Q
+        // work still participate in padded multicast handshakes without pushing visible data.
+        uint32_t loop_q_count;
+        uint32_t rotated_my_count = 0;
+        uint32_t rotated_ids_base = 0;
+        if constexpr (rotated_q_split_enabled) {
+            const uint32_t rotated_ordinal = rotated_active_ordinal(active_ring_iter_mask, ring_iter);
+            const uint32_t rotated_iter_base =
+                ::rotated_iter_base(rotated_args_base, rotated_iter_stride, rotated_ordinal);
+            loop_q_count = get_arg_val<uint32_t>(rotated_iter_base);
+            rotated_my_count = get_arg_val<uint32_t>(rotated_iter_base + 1);
+            rotated_ids_base = rotated_iter_base + kRotatedReaderIterHeaderWords;
+        } else {
+            loop_q_count = q_per_core;
+            if constexpr (k_uses_batch_chain && batch_mcast_enabled) {
+                loop_q_count = max_q_per_core;
+            }
+            if constexpr (gqa_grouped_kv && gqa_mcast_enabled) {
+                loop_q_count = gqa_max_q_per_core;
+            }
         }
         uint32_t gqa_group_q_iter = 0;
 
         for (uint32_t q_iter = 0; q_iter < loop_q_count; ++q_iter) {
             // Check if this is a real iteration or only padded chain/mcast synchronization.
-            const bool is_padded_iter = (q_iter >= q_per_core);
+            bool is_padded_iter;
+            uint32_t flat_q_index;
+            if constexpr (rotated_q_split_enabled) {
+                is_padded_iter = (q_iter >= rotated_my_count);
+                // Padded iterations only handshake; decode a valid owned chunk so downstream index
+                // math stays in range (its values are never used for reads or pushes). Every core
+                // owns at least one chunk per iteration and never more than the pushed list holds --
+                // otherwise the rotated_my_count - 1 here underflows, or the read runs past the list.
+                ASSERT(rotated_my_count >= 1 && rotated_my_count <= rotated_max_slots);
+                flat_q_index =
+                    get_arg_val<uint32_t>(rotated_ids_base + (is_padded_iter ? rotated_my_count - 1 : q_iter));
+            } else {
+                is_padded_iter = (q_iter >= q_per_core);
+                flat_q_index = global_q_start + q_iter;
+            }
 
             // Same-core GQA uses group-major (batch, Q chunk, head) scheduling so consecutive
             // iterations reuse one K/V window.  Every other specialization retains the ordinary
             // head-major flat order and optional causal zigzag remap.
-            const auto decoded_q =
-                decompose_global_q_index(global_q_start + q_iter, num_q_chunks, NH, use_zigzag_balancing);
+            const auto decoded_q = decompose_global_q_index(flat_q_index, num_q_chunks, NH, use_zigzag_balancing);
             const uint32_t nb = decoded_q.nb;
             const uint32_t nq = decoded_q.nq;
             const uint32_t q_chunk = decoded_q.q_chunk;
@@ -833,7 +875,10 @@ void kernel_main() {
 
             // When q_per_core == 1, Q is identical across ring iterations: compute keeps it
             // fronted in the CB, so we only need to read it once on the first active ring iteration.
-            const bool need_q_read = (q_per_core > 1) || !q_pushed;
+            // Rotated: this core's owned count varies per ring iteration, so the "single Q chunk
+            // stays fronted in L1" optimization never applies -- compute derives its q_per_core from
+            // the fixed slot count and would wait on a Q chunk the reader never re-pushed.
+            const bool need_q_read = rotated_q_split_enabled || (q_per_core > 1) || !q_pushed;
 
             ring_joint::SlidingQWorkPlan sliding_q_plan;
             if constexpr (has_sliding_window) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -469,7 +469,7 @@ void kernel_main() {
 
     // Rotated per-ring-iteration Q distribution. Chunk-LIST LENGTH per iteration (base chunks plus
     // one float slot), or 0 when the host declined the rotation. Per ring iteration the factory
-    // appends [row_slot_count, my_count, chunk ids x rotated_max_slots] at this fixed stride; when
+    // appends [group_slot_count, my_count, chunk ids x rotated_max_slots] at this fixed stride; when
     // enabled, the static global_q_start/global_q_end range is superseded entirely.
     // The factory pushes rotated_max_slots as the final compile-time arg of every kernel, so
     // read it from there rather than tracking a per-kernel index into the block above.
@@ -759,9 +759,11 @@ void kernel_main() {
             }
         }
 
-        // Rotated: the factory precomputes this row's mcast slot count per ring iteration (its row
-        // max, so members with less real work still run the padded handshakes), superseding the
-        // static per-chain maxima. Indexed by ACTIVE ordinal -- see rotated_active_ordinal.
+        // Rotated: the factory precomputes this lockstep GROUP's mcast slot count per ring iteration
+        // (the group max, so members with less real work still run the padded handshakes),
+        // superseding the static per-chain maxima -- both max_q_per_core (shared-K) and
+        // gqa_max_q_per_core (GQA), which is why this branch needs no per-family case.
+        // Indexed by ACTIVE ordinal -- see rotated_active_ordinal.
         // Static: when K/V mcast is enabled, loop the per-chain max so receivers with less real Q
         // work still participate in padded multicast handshakes without pushing visible data.
         uint32_t loop_q_count;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
+#include "chunked_prefill_utils.hpp"
 #include "ring_joint_kv_pad_derivation.hpp"
 #include "metadata_scalar_read.hpp"
 #include "fused_op_receiver.hpp"
@@ -342,6 +343,60 @@ void write_output_and_lse(
     cb_lse.pop_front(Sq_chunk_t);
 }
 
+// Maps a Q slot index to the flat chunk id this core processes there. Under the rotated split the
+// mapping comes from this ring iteration's runtime-arg list; otherwise the slot index is itself the
+// offset into the static flat range. `ordinal` is an ACTIVE ordinal, so ordinal + 1 is the next
+// EXECUTED iteration -- what every cross-iteration caller here means.
+template <bool Rotated>
+struct QSlotMap {
+    uint32_t args_base;
+    uint32_t iter_stride;
+    uint32_t ordinal;
+    uint32_t flat_start;
+
+    uint32_t flat_at_ordinal(uint32_t ord, uint32_t slot) const {
+        return get_arg_val<uint32_t>(
+            rotated_iter_base(args_base, iter_stride, ord) + kRotatedWriterIterHeaderWords + slot);
+    }
+
+    // Flat chunk id at `slot` of the current iteration.
+    uint32_t at(uint32_t slot) const {
+        if constexpr (Rotated) {
+            return flat_at_ordinal(ordinal, slot);
+        } else {
+            return flat_start + slot;
+        }
+    }
+
+    // Flat chunk id processed first in the next executed iteration. Under rotation that is a base
+    // chunk this core owned all along (floats sit last), so it needs no handoff wait.
+    uint32_t next_iter_first() const {
+        if constexpr (Rotated) {
+            return flat_at_ordinal(ordinal + 1, 0);
+        } else {
+            return flat_start;
+        }
+    }
+
+    // Does the prefetch issued at `slot` target chunk `flat_q`? That is the next slot of this
+    // iteration, or slot 0 of the next executed one when `slot` is the last.
+    bool prefetch_targets(uint32_t slot, uint32_t flat_q, uint32_t q_per_core, bool is_last_ring_iter) const {
+        if (slot + 1 < q_per_core) {
+            return at(slot + 1) == flat_q;
+        }
+        return !is_last_ring_iter && next_iter_first() == flat_q;
+    }
+};
+
+// Handoff semaphore slot for active ordinal `ordinal`. Ordinal >= 1 at every call site: the first
+// active iteration neither receives a float nor has a deferred save to flush. The modulo keeps an
+// underflow in range rather than faulting, so donor and receiver would silently disagree and hang;
+// ASSERT is watcher-only, so this documents the host-schedule invariant rather than enforcing it.
+inline uint32_t rotated_sem_slot(uint32_t ordinal, uint32_t sem_count) {
+    ASSERT(ordinal >= 1);
+    return (ordinal - 1) % sem_count;
+}
+
 struct QChunkInfo {
     bool is_joint_q;
     Slice out_slice;
@@ -490,8 +545,32 @@ void kernel_main() {
         argidx);
 
     // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
+    // Declared here rather than with the other CB args below because the rotated-Q-split sizes are
+    // compile-time args off this offset, and the runtime-arg block underneath needs them.
     constexpr uint32_t cb_arg_offset =
         kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : stats_args.next_compile_time_args_offset();
+
+    // Per-iteration chunk-list length (base chunks plus one float slot), or 0 when the host
+    // declined the rotation. The offset clears the whole CB block, not just the CBs used here.
+    // The factory pushes rotated_max_slots as the final compile-time arg of every kernel, so
+    // read it from there rather than tracking a per-kernel index into the block above.
+    constexpr uint32_t rotated_max_slots = get_ct_arg<kernel_compile_time_args.size() - 1>();
+    constexpr bool rotated_q_split_enabled = rotated_max_slots > 0;
+    constexpr uint32_t rotated_iter_stride = ::rotated_iter_stride(kRotatedWriterIterHeaderWords, rotated_max_slots);
+    constexpr uint32_t rotated_sem_count = rotated_handoff_sem_count(ring_size);
+
+    // The factory appends the handoff semaphore ids, then per ring iteration
+    // [my_count, float_migrated_in, float_dest, chunk ids x rotated_max_slots]. The donor signals
+    // the receiver's semaphore once its accumulator save lands in DRAM; the receiver waits before
+    // issuing that float's restore reads.
+    uint32_t rotated_sem_ids[rotated_sem_count] = {};
+    uint32_t rotated_args_base = 0;
+    if constexpr (rotated_q_split_enabled) {
+        for (uint32_t sem_slot = 0; sem_slot < rotated_sem_count; ++sem_slot) {
+            rotated_sem_ids[sem_slot] = get_arg_val<uint32_t>(argidx++);
+        }
+        rotated_args_base = argidx;
+    }
     constexpr uint32_t cb_mask_in = get_compile_time_arg_val(cb_arg_offset + 3);
     constexpr uint32_t cb_scale_in = get_compile_time_arg_val(cb_arg_offset + 4);
     constexpr uint32_t cb_identity_scale_in = get_compile_time_arg_val(cb_arg_offset + 5);
@@ -604,6 +683,12 @@ void kernel_main() {
         uint32_t nb = 0;
         uint32_t nq = 0;
         QChunkInfo qi = {};
+        // Rotated split only. Packed physical core owning this chunk next iteration (kRotatedNoDest if
+        // it stays put), and the flat chunk id this save belongs to, so the early-flush decision
+        // below can compare chunk identity instead of slot position (slots do not map to fixed
+        // chunks under rotation).
+        uint32_t mig_dest = kRotatedNoDest;
+        uint32_t flat_q = 0;
     } deferred = {};
 
     // Track non-skipped iters so the first active iter starts with fresh accumulators (matches compute).
@@ -719,17 +804,41 @@ void kernel_main() {
             // Single Q-chunk: accumulators persist in L1, write final output on last ring_iter.
             // Multi Q-chunk: raw accumulators round-trip through DRAM between ring iterations.
             const bool is_last_ring_iter = is_last_active_ring_iter(active_ring_iter_mask, ring_iter);
-            const bool single_q_chunk = (global_q_end - global_q_start == 1);
+            // Rotated: rotated_max_slots >= 2, so accumulators always round-trip through DRAM.
+            // Deriving it from the static range would disagree with compute's per-iteration count.
+            const bool single_q_chunk = !rotated_q_split_enabled && (global_q_end - global_q_start == 1);
             constexpr uint32_t sum_offset = q_local_padded_Nt + Lt;
             constexpr uint32_t out_num_tiles = Sq_chunk_t * vDHt;
 
-            const uint32_t q_per_core = global_q_end - global_q_start;
+            // Rotated: q_per_core is the chunks owned THIS iteration (base, or base+1 with the
+            // float), shadowing the static meaning of global_q_start/_end.
+            uint32_t rotated_ordinal = 0;
+            uint32_t q_per_core;
+            uint32_t rotated_has_mig_in_float = 0;
+            uint32_t rotated_float_dest = kRotatedNoDest;
+            if constexpr (rotated_q_split_enabled) {
+                rotated_ordinal = rotated_active_ordinal(active_ring_iter_mask, ring_iter);
+                const uint32_t rotated_iter_base =
+                    ::rotated_iter_base(rotated_args_base, rotated_iter_stride, rotated_ordinal);
+                q_per_core = get_arg_val<uint32_t>(rotated_iter_base);
+                rotated_has_mig_in_float = get_arg_val<uint32_t>(rotated_iter_base + 1);
+                rotated_float_dest = get_arg_val<uint32_t>(rotated_iter_base + 2);
+            } else {
+                q_per_core = global_q_end - global_q_start;
+            }
+
+            const QSlotMap<rotated_q_split_enabled> q_slots{
+                rotated_args_base, rotated_iter_stride, rotated_ordinal, global_q_start};
+
             const uint32_t last_q_index = q_per_core - 1;
             const bool flush_before_prefetch = single_valid_kv_chunk || q_per_core == 2;
 
-            // TRID assignment by Q position: Q[0] -> TRID_FIRST, Q[N-1] -> TRID_LAST,
-            // Q[1..N-2] -> TRID_INNER. Used both for tagging the current Q's save and for
-            // selecting which TRID to barrier on for the next Q's prefetch.
+            // TRID by Q position: Q[0] -> TRID_FIRST, Q[N-1] -> TRID_LAST, else TRID_INNER. Tags
+            // the current Q's save and selects which TRID to barrier before the next Q's restore.
+            // Under rotation last_q_index varies per iteration, so slot -> TRID is not stable across
+            // the save/restore boundary. Do not "fix" that in isolation: keying off rotated_max_slots
+            // makes the map stable but breaks accuracy, because need_barrier below assumes the last
+            // slot maps to TRID_LAST and skips its barrier when nothing does.
             auto trid_for_q = [&](uint32_t qi) {
                 return qi == 0 ? TRID_FIRST : qi == last_q_index ? TRID_LAST : TRID_INNER;
             };
@@ -737,12 +846,11 @@ void kernel_main() {
             // Issue NOC reads to fill staging for Q[pf_q_index] of the current ring_iter (or
             // ring_iter+1 for cross-ring at q==last_q_index, when the caller passes 0). Optionally
             // barriers on pf_trid first to ensure the prior save with that TRID has landed.
-            auto prefetch_for = [&](uint32_t pf_q_index, uint32_t pf_trid, bool barrier_first) {
+            auto prefetch_for = [&](uint32_t pf_flat_q, uint32_t pf_trid, bool barrier_first) {
                 if (barrier_first) {
                     noc.async_write_barrier<NocOptions::TXN_ID>({.trid = pf_trid});
                 }
-                const auto decoded_q =
-                    decompose_global_q_index(global_q_start + pf_q_index, num_q_chunks, NH, use_zigzag_balancing);
+                const auto decoded_q = decompose_global_q_index(pf_flat_q, num_q_chunks, NH, use_zigzag_balancing);
                 const uint32_t nb_pf = decoded_q.nb;
                 const uint32_t nq_pf = decoded_q.nq;
                 const uint32_t qc_pf = decoded_q.q_chunk;
@@ -779,13 +887,24 @@ void kernel_main() {
             // barrier rule. Only barrier when next Q's TRID hasn't been cleared yet this ring
             // iter: Q[0] -> wB(TRID_INNER), Q[N-2] -> wB(TRID_LAST), Q[1..N-3] -> skip
             // (TRID_INNER already cleared at Q[0]).
+            // Coupled to trid_for_q above: assumes the last slot maps to TRID_LAST.
             auto prefetch_intra_ring = [&](uint32_t next_q_index) {
                 if (next_q_index >= q_per_core) {
                     return;
                 }
+                // The migrated-in float sits last. Wait for the donor's handoff signal before the
+                // restore reads, then reset the semaphore for the next (possibly cached) run.
+                if constexpr (rotated_q_split_enabled) {
+                    if (rotated_has_mig_in_float != 0 && next_q_index == last_q_index) {
+                        // Never set on the first active iteration, so ring_iter >= 1 here.
+                        Semaphore<> handoff_sem(rotated_sem_ids[rotated_sem_slot(rotated_ordinal, rotated_sem_count)]);
+                        handoff_sem.wait_min(rotated_has_mig_in_float);
+                        handoff_sem.set(0);
+                    }
+                }
                 const uint32_t next_trid = trid_for_q(next_q_index);
                 const bool need_barrier = (next_trid != TRID_INNER || next_q_index == 1);
-                prefetch_for(next_q_index, next_trid, need_barrier);
+                prefetch_for(q_slots.at(next_q_index), next_trid, need_barrier);
             };
 
             // Drain pending deferred save (raw accumulators -> DRAM) for the prior Q. Called at
@@ -821,12 +940,25 @@ void kernel_main() {
                     stats_tile_bytes,
                     out_subblock_h,
                     deferred.trid);
+                // Donor half of the float handoff. Floats sit last, so this flush runs during the
+                // receiver's use iteration and both index rotated_sem_slot() with the same ordinal.
+                // A core can be donor and receiver in one iteration; that is not a cycle, because
+                // the donor's flush at slot 0 always precedes the receiver's wait at last-1 >= 1.
+                // Barrier first: flushed-but-not-landed writes must not read as "ready".
+                if constexpr (rotated_q_split_enabled) {
+                    if (deferred.mig_dest != kRotatedNoDest) {
+                        noc.async_write_barrier<NocOptions::TXN_ID>({.trid = deferred.trid});
+                        Semaphore<>(rotated_sem_ids[rotated_sem_slot(rotated_ordinal, rotated_sem_count)])
+                            .up(noc, rotated_dest_x(deferred.mig_dest), rotated_dest_y(deferred.mig_dest), 1);
+                        deferred.mig_dest = kRotatedNoDest;
+                    }
+                }
                 deferred.pending = false;
             };
 
-            for (uint32_t q_index = 0; q_index + global_q_start < global_q_end; ++q_index) {
+            for (uint32_t q_index = 0; q_index < q_per_core; ++q_index) {
                 const auto decoded_q =
-                    decompose_global_q_index(global_q_start + q_index, num_q_chunks, NH, use_zigzag_balancing);
+                    decompose_global_q_index(q_slots.at(q_index), num_q_chunks, NH, use_zigzag_balancing);
                 const uint32_t nb = decoded_q.nb;
                 const uint32_t nq = decoded_q.nq;
                 const uint32_t q_chunk = decoded_q.q_chunk;
@@ -857,7 +989,16 @@ void kernel_main() {
                 // With >= 2 valid K chunks and q_per_core >= 3, K0 uses ping-pong accumulators
                 // (not staging CBs), so we prefetch first and flush later during the K-loop
                 // window — spreading DRAM writes to reduce bank contention.
-                if (deferred.pending && flush_before_prefetch) {
+                //
+                // q_per_core == 2 is a positional proxy for "the chunk about to be prefetched is
+                // the one still in staging", exact only while slots map to fixed chunks. Under
+                // rotation they do not, so compare chunk ids directly instead.
+                const bool early_flush =
+                    rotated_q_split_enabled
+                        ? (single_valid_kv_chunk ||
+                           q_slots.prefetch_targets(q_index, deferred.flat_q, q_per_core, is_last_ring_iter))
+                        : flush_before_prefetch;
+                if (deferred.pending && early_flush) {
                     flush_deferred_save();
                 }
 
@@ -868,13 +1009,20 @@ void kernel_main() {
                 // write_out below. Reserving space in cb_prev_out here would block until
                 // normalize finishes, creating a cycle with cb_out. Deferred prefetch below
                 // runs after write_out to break the cycle.
+                // At base == 1 the cross-ring prefetch target (slot 0 of t+1) is the chunk being
+                // processed now, whose save only exists at the end of this body -- prefetching here
+                // would restore the previous iteration's accumulators, so postpone it.
+                const bool rotated_postpone_cross_prefetch = rotated_q_split_enabled && !is_last_ring_iter &&
+                                                             q_index == last_q_index &&
+                                                             q_slots.next_iter_first() == q_slots.at(q_index);
                 const bool defer_prefetch = balanced_skip_q && is_last_ring_iter;
                 if (!single_q_chunk && !is_first_active_iter && !defer_prefetch) {
                     prefetch_intra_ring(q_index + 1);
                 }
                 // Cross-ring: Q[N-1] -> Q[0] of next ring iter.
-                if (!single_q_chunk && !is_last_ring_iter && q_index == last_q_index) {
-                    prefetch_for(/*pf_q_index=*/0, TRID_FIRST, /*barrier_first=*/true);
+                if (!single_q_chunk && !is_last_ring_iter && q_index == last_q_index &&
+                    !rotated_postpone_cross_prefetch) {
+                    prefetch_for(q_slots.next_iter_first(), TRID_FIRST, /*barrier_first=*/true);
                 }
 
                 // 4. Late flush (>= 2 valid K chunks, q_per_core >= 3): drain during K-loop
@@ -920,6 +1068,19 @@ void kernel_main() {
                     deferred.nb = nb;
                     deferred.nq = nq;
                     deferred.qi = qi;
+                    if constexpr (rotated_q_split_enabled) {
+                        // Only the last (float) slot can migrate; base chunks keep kRotatedNoDest.
+                        deferred.mig_dest = (q_index == last_q_index) ? rotated_float_dest : kRotatedNoDest;
+                        deferred.flat_q = q_slots.at(q_index);
+                    }
+                }
+
+                // Postponed cross-ring prefetch: the save now exists, so issue it and read it back.
+                // prefetch_for barriers deferred.trid first, making the save visible to the read.
+                if (rotated_postpone_cross_prefetch) {
+                    const uint32_t save_trid = deferred.trid;
+                    flush_deferred_save();
+                    prefetch_for(q_slots.next_iter_first(), save_trid, /*barrier_first=*/true);
                 }
 
                 // Delayed intra-ring prefetch for normalize-only Qs: skipped earlier to avoid

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp
@@ -27,4 +27,12 @@ constexpr bool is_gqa_grouped_kv_head_mode(bool v_shares_k_buffer, uint32_t nqh,
 // GQA with one local KV head still has NHK == 1, but it must use grouped KV-head transport.
 constexpr bool uses_shared_k_batch_chain(bool gqa_grouped_kv, uint32_t nkh) { return !gqa_grouped_kv && (nkh == 1); }
 
+// The per-head chain carries MHA K/V, or separate-V's V. Latent-V never streams V through it (V
+// rides the mcast K^T) and is validated to NKH == 1, so K already uses the batch chain and this
+// chain carried nothing -- skipping it also frees its 3 semaphores for the rotated-Q-split handoff.
+// Shared so the factory and reader cannot disagree: a mismatch shifts compile-time arg offsets.
+constexpr bool uses_v_head_chain(bool enable_kv_chains, bool gqa_grouped_kv, bool v_shares_k_buffer) {
+    return enable_kv_chains && !gqa_grouped_kv && !v_shares_k_buffer;
+}
+
 }  // namespace ttnn::operations::transformer::sdpa::ring_joint

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -16,6 +16,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <optional>
 #include <cmath>
@@ -540,7 +541,7 @@ RingJointRuntimeArgLayout get_runtime_arg_layout(
     // 2 extra buffer slots for gathered_joint_k/v when the sharded-joint path is active
     const uint32_t gathered_joint_buffer_args = joint_input_params.joint_is_sharded ? 2 : 0;
     const bool enable_kv_chains = !args.has_sliding_window();
-    const bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
+    const bool use_head_chain = ring_joint::uses_v_head_chain(enable_kv_chains, gqa_grouped_kv, v_shares_k_buffer);
     const uint32_t head_chain_args = use_head_chain ? kRingJointChainConfigArgCount : 0;
     const uint32_t batch_chain_args =
         enable_kv_chains && k_uses_batch_chain ? (kRingJointChainConfigArgCount + kReaderBatchChainExtraArgCount) : 0;
@@ -1045,7 +1046,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t vDH = tensor_args.v_head_dim(args.latent_v_head_dim);
     const bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
     const bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
-    const bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
+    const bool use_head_chain = ring_joint::uses_v_head_chain(enable_kv_chains, gqa_grouped_kv, v_shares_k_buffer);
     // The store-and-forward chains are scheduled per head, not per (batch, head).
     // Until their batch-aware scheduling is restored, multi-batch requests read K/V
     // independently on each core. This preserves the established B>1 functional path.
@@ -2216,6 +2217,474 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         }
     };
 
+    uint32_t gqa_grouped_chains = 0;
+    uint32_t gqa_grouped_participant_cores = 0;
+    uint32_t gqa_local_fallback_cores = 0;
+    bool gqa_mcast_enabled = false;
+    std::string gqa_mcast_fallback_reason;
+    std::vector<uint32_t> gqa_chain_max_q(gqa_chain_configs.size(), 0);  // per-core loop-padding count
+    if (gqa_grouped_kv && build_kv_chains) {
+        std::vector<std::vector<ChainSegment>> kv_group_segments(NHK);
+
+        for (uint32_t ci = 0; ci < num_cores; ++ci) {
+            if (core_work[ci].global_q_count == 0) {
+                continue;
+            }
+
+            bool has_single_group = false;
+            bool spans_multiple_groups = false;
+            uint32_t single_group_id = 0;
+            uint32_t q_chunk_count = 0;
+            for (const auto& hw : core_work[ci].head_work) {
+                const uint32_t kv_head = hw.head / q_heads_per_kv;
+                if (!has_single_group) {
+                    has_single_group = true;
+                    single_group_id = kv_head;
+                } else if (single_group_id != kv_head) {
+                    spans_multiple_groups = true;
+                    break;
+                }
+                q_chunk_count += hw.q_chunk_count;
+            }
+
+            if (has_single_group && !spans_multiple_groups) {
+                kv_group_segments[single_group_id].emplace_back(ci, q_chunk_count);
+                gqa_grouped_participant_cores++;
+            } else {
+                gqa_local_fallback_cores++;
+            }
+        }
+
+        for (uint32_t kv_head = 0; kv_head < static_cast<uint32_t>(kv_group_segments.size()); ++kv_head) {
+            const auto& chain_segs = kv_group_segments[kv_head];
+            if (chain_segs.size() < 2) {
+                continue;
+            }
+            if (build_linear_chain(chain_segs, kv_head, gqa_chain_configs, core_work, false)) {
+                gqa_grouped_chains++;
+            }
+        }
+
+        // Production Minimax3 GQA has one local K/V head per chip (B=1, NHK=NHV=1). In that case every
+        // active Q-head core consumes the same K and V chunks, so use row-wide multicast instead
+        // of the store-and-forward grouped chain. Idle cores in an active row participate in padded iterations.
+        if (NHK != 1) {
+            gqa_mcast_fallback_reason = "NHK != 1 (multi-KV-head GQA mcast not supported)";
+        } else if (num_cores < 2) {
+            gqa_mcast_fallback_reason = "num_cores < 2";
+        } else if (grid_size.x < 2) {
+            gqa_mcast_fallback_reason = "grid_size.x < 2 (singleton rows)";
+        } else {
+            std::deque<uint32_t> recent_cols;  // FIFO of <= grid.x-1 most-recent claimed phys_x
+            uint32_t gqa_mcast_rows = 0;
+
+            for (uint32_t row = 0; row < grid_size.y; ++row) {
+                const auto selection = select_row_wide_chain_mcast(row, recent_cols);
+                if (!selection.has_value()) {
+                    continue;
+                }
+                configure_row_wide_chain_mcast(*selection, 0, gqa_chain_configs, gqa_chain_max_q);
+                gqa_mcast_rows++;
+                log_debug(
+                    tt::LogOp,
+                    "GQA K/V mcast row {}: injector core {} phys=({},{}) max_q={}, rect ({},{})-({},{})",
+                    selection->row,
+                    selection->injector_idx,
+                    selection->injector_physical.x,
+                    selection->injector_physical.y,
+                    selection->max_q,
+                    selection->phys_start.x,
+                    selection->phys_start.y,
+                    selection->phys_end.x,
+                    selection->phys_end.y);
+            }
+
+            gqa_mcast_enabled = gqa_mcast_rows > 0;
+            if (!gqa_mcast_enabled) {
+                gqa_mcast_fallback_reason = "no active groups";
+            }
+        }
+    }
+
+    // Build the shared-K chain for separate-V/latent cases.
+    // K is shared across all heads, so all active cores form one chain.
+    // Sorted by physical position for a stable unicast ordering (overwritten by mcast pass if eligible).
+    if (k_uses_batch_chain && build_kv_chains) {
+        std::vector<uint32_t> core_indices;
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            if (core_work[i].global_q_count == 0) {
+                continue;
+            }
+            core_indices.push_back(i);
+        }
+
+        std::sort(core_indices.begin(), core_indices.end(), [&](uint32_t a, uint32_t b) {
+            const auto& pa = core_work[a].physical_core;
+            const auto& pb = core_work[b].physical_core;
+            return (pa.y < pb.y) || (pa.y == pb.y && pa.x < pb.x);
+        });
+
+        std::vector<ChainSegment> chain_segs;
+        chain_segs.reserve(core_indices.size());
+        for (uint32_t ci : core_indices) {
+            chain_segs.emplace_back(ci, core_work[ci].global_q_count);
+        }
+        if (build_linear_chain(chain_segs, 0, batch_chain_configs, core_work)) {
+            log_debug(tt::LogOp, "K unicast chain: {} cores", chain_segs.size());
+        }
+    }
+
+    // K multicast pass: one mcast chain per logical row. Shared-K keeps the all-or-nothing policy:
+    // every row must contain work, otherwise the previously built linear chain remains active.
+    bool k_mcast_enabled = false;
+    std::string k_mcast_fallback_reason;
+    std::vector<uint32_t> k_chain_max_q(batch_chain_configs.size(), 0);  // per-core loop-padding count
+
+    if (!k_uses_batch_chain || !enable_kv_chains) {
+        // No non-GQA shared-K chain to multicast.
+    } else if (num_cores < 2) {
+        k_mcast_fallback_reason = "num_cores < 2";
+    } else if (grid_size.x < 2) {
+        // Each chain would be a singleton (1 core, no sinks) — mcast is degenerate.
+        k_mcast_fallback_reason = "grid_size.x < 2 (singleton chains)";
+    } else {
+        std::vector<RowWideChainMcastSelection> row_mcast_selections;
+        row_mcast_selections.reserve(grid_size.y);
+        std::deque<uint32_t> recent_cols;  // FIFO of <= grid.x-1 most-recent claimed phys_x
+
+        bool all_chains_picked = true;
+        for (uint32_t row = 0; row < grid_size.y; ++row) {
+            const std::optional<RowWideChainMcastSelection> selection = select_row_wide_chain_mcast(row, recent_cols);
+            if (!selection.has_value()) {
+                k_mcast_fallback_reason = fmt::format("row {} has no work", row);
+                all_chains_picked = false;
+                break;
+            }
+            row_mcast_selections.push_back(*selection);
+        }
+
+        if (all_chains_picked) {
+            k_mcast_enabled = true;
+
+            for (const auto& selection : row_mcast_selections) {
+                configure_row_wide_chain_mcast(selection, 0, batch_chain_configs, k_chain_max_q);
+
+                log_debug(
+                    tt::LogOp,
+                    "K mcast row {}: injector core {} phys=({},{}) max_q={}, rect ({},{})-({},{})",
+                    selection.row,
+                    selection.injector_idx,
+                    selection.injector_physical.x,
+                    selection.injector_physical.y,
+                    selection.max_q,
+                    selection.phys_start.x,
+                    selection.phys_start.y,
+                    selection.phys_end.x,
+                    selection.phys_end.y);
+            }
+        }
+    }
+
+    // Rotated per-ring-iteration Q distribution ("rotated q split").
+    //
+    // With row-wide K mcast each grid row is a lockstep pipe paying ring_size * (row max chunks)
+    // K-stream slots, so the flat split's remainder ("float") chunks make their rows pay a +1 slot
+    // on EVERY iteration -- ring_size * ceil(U/C) against an ideal U * ring_size / C. The (m, l, O)
+    // accumulators already round-trip through DRAM addressed by chunk identity, so floats can change
+    // owner core between iterations; rotate them across rows to spread that +1. Cross-core ordering
+    // uses handoff semaphores (chunked_prefill_utils.hpp): the donor signals after a write barrier
+    // on its save TRID, the receiver waits before its restore reads. Floats sit LAST in every list,
+    // giving that pair about one ring iteration of slack.
+    // Aliased from the flat split above rather than recomputed, so the two cannot drift.
+    const uint32_t rotated_base_chunks = base_chunks_per_core;
+    const uint32_t rotated_float_chunks = cores_doing_extra_work;
+    // Grid rows hosting floats on one iteration. The win comes from float-free rows, so at
+    // rotated_rows_needed == grid_size.y ownership never actually moves.
+    const uint32_t rotated_rows_needed = grid_size.x ? tt::div_up(rotated_float_chunks, grid_size.x) : 0;
+    const uint32_t full_ring_iter_mask = ring_size >= 32 ? 0xFFFFFFFFu : ((1u << ring_size) - 1);
+    // A/B kill switch: RING_MLA_DISABLE_ROTATED_Q_SPLIT=1 forces the static flat split. Parsed
+    // rather than presence-tested so "=0" leaves the feature on, and latched once per process --
+    // toggling it between dispatches has no effect, so A/B across two runs.
+    static const bool rotated_q_split_disabled = []() {
+        const char* value = std::getenv("RING_MLA_DISABLE_ROTATED_Q_SPLIT");
+        return value != nullptr && value[0] != '\0' && std::string_view(value) != "0";
+    }();
+    // Validated by sweeping RING_MLA_SDPA_GRID_OVERRIDE on ring-8: PCC passes for base 1..9 over
+    // rows_needed 1..9 and floats 0..80, plus the decline cases, with no perf regression where it
+    // engages. The win tracks float-free rows (grid_size.y - rotated_rows_needed), not base.
+    // Per-config numbers are in the commit message; the attempt trail is on
+    // backup/ring-mla-work-split-pre-squash.
+    //
+    // Every term below is load-bearing; the first thing each one breaks:
+    //   k_mcast_enabled      the lockstep unit is the ROW, so a float costs its whole row a +1 slot
+    //                        every iteration. Without it, grid_size.x == 1 leaves injector_col unset
+    //                        for other rows and the TT_FATAL below fires. Nearly implied by the rest
+    //                        (residual content is just grid_size.x >= 2); kept for self-documentation.
+    //   build_kv_chains      carries B == 1. Removing it is a SILENT wrong answer: the row mcast
+    //                        stays live and the injector multicasts K for ITS nb to peers whose
+    //                        rotated slot decodes a different nb.
+    //   v_shares_k_buffer    separate-V turns on the per-head V chain, whose forwarding counts come
+    //                        from the STATIC split -> V relay mismatch -> hang. Also subsumes
+    //                        !use_attention_sink, use_streaming_compute and !gqa_grouped_kv.
+    //   !args.is_balanced    two independent breaks. Zigzag counts extra chunks in PAIRS while this
+    //                        schedule appends ONE float per owner, leaving ids unscheduled and a
+    //                        receiver waiting on a donor that never runs (MEASURED: HANGS). And
+    //                        balanced_skip_q's parity desyncs injector from receivers at the float
+    //                        slot -- the harder of the two; fix it first if retrying. Kept broader
+    //                        than !enable_zigzag_balancing since narrowing admits balanced chunked
+    //                        prefill, which nothing in the tree exercises and which hangs on failure.
+    //   base_chunks >= 1     definitional; at base 0 the compute static_assert fires first.
+    //
+    // Removed terms: !kv_pad_rotation_enabled and the full-mask check (both subsumed by ordinal
+    // indexing), and rotated_float_chunks != 0 / rotated_rows_needed < grid_size.y (cost guards,
+    // provable no-ops). The full-mask value still feeds the decline log line.
+    const bool use_rotated_q_split =
+        !rotated_q_split_disabled &&
+        // Path scope: latent-V (V packed into K) on the streaming compute path, with K streamed
+        // through the row-wide mcast batch chain. Only the streaming compute kernel carries the
+        // rotated-Q-split hook; on any other path compute would desync from the reader and writer,
+        // so the compute kernel static_asserts this too. These two terms also subsume
+        // !has_sliding_window, enable_kv_chains, k_uses_batch_chain and B == 1, and v_shares_k_buffer
+        // subsumes !use_attention_sink (the op rejects that pair outright).
+        k_mcast_enabled && build_kv_chains &&
+        // V transport: latent-V only. V rides the K mcast, so the rotation needs nothing extra.
+        // Separate-V rotation was implemented and REMOVED -- correct, but it helped at one core
+        // count and hurt at another, and its enablement rule predicted backwards once grid rows
+        // varied. If wanted back, the principled version is head-ALIGNED float packing (row-mcast V
+        // on the float slot reusing the head chain's idle semaphores), not a fitted perf guard.
+        v_shares_k_buffer && !args.is_balanced &&
+        // Partial active masks are handled, not excluded: the schedule is indexed by ordinal within
+        // the active subsequence (rotated_active_ordinal), so consecutive ordinals are consecutive
+        // EXECUTED iterations and a skip cannot split the donor-signal / receiver-wait pair. That is
+        // what unblocked kv-pad, where the mask is device-derived from trace metadata the host never
+        // sees: the host need not agree, since every per-ordinal entry it emits is already a valid
+        // partition of all Q chunks and the kernels choose which get used. The last active iteration
+        // needs no guard either -- it takes the final-output branch and creates no deferred save.
+        //
+        // Degenerate cases need no guard, both measured: at rotated_float_chunks == 0 each core's
+        // rotated range is identical to its static one, and at rotated_rows_needed == grid_size.y
+        // the cycle merely permutes which row hosts which float.
+        //
+        // rotated_base_chunks >= 1 is required: the reader decodes slot (rotated_my_count - 1) on
+        // padded iterations and would underflow at 0. base == 1 is the largest win, being the worst
+        // static imbalance.
+        // Reaching base == 1 took three writer/reader fixes, all no-ops at base >= 3: pinning
+        // need_q_read and single_q_chunk to the fixed slot count rather than the static one,
+        // comparing flat chunk ids for the early flush instead of the positional q_per_core == 2
+        // proxy, and postponing the cross-ring prefetch when it targets this slot's own chunk.
+        rotated_base_chunks >= 1;
+
+    struct RotatedIterSched {
+        std::vector<uint32_t> my_chunks;   // flat chunk ids; base chunks first, float (if any) last
+        uint32_t row_slot_count = 0;       // row max chunk count this iteration = K mcast slots to run
+        uint32_t float_migrated_in = 0;    // 1 if the last chunk was owned by another core last iteration
+        uint32_t float_dest = kRotatedNoDest;  // packed physical core owning this float next iteration
+    };
+    std::vector<std::vector<RotatedIterSched>> rotated_sched;  // [core][ring_iter]
+    std::vector<uint32_t> rotated_handoff_sem_ids;
+    // Appends one iteration's chunk-id list padded to the fixed rotated_max_slots length, so every
+    // ring iteration occupies the same number of runtime args and the kernels can index by stride.
+    const auto append_rot_chunk_ids = [&](CheckedRuntimeArgList& args_out, const RotatedIterSched& sched) {
+        for (uint32_t slot = 0; slot < rotated_base_chunks + 1; ++slot) {
+            args_out.push_back(slot < sched.my_chunks.size() ? sched.my_chunks[slot] : 0);
+        }
+    };
+    if (use_rotated_q_split) {
+        const uint32_t cores_per_row = grid_size.x;
+        const uint32_t num_rows = grid_size.y;
+        const uint32_t rows_needed = rotated_rows_needed;
+        // The block below indexes batch_chain_configs by core; k_mcast_enabled implies it is built
+        // per core, but that implication is ~90 lines away, and getting it wrong is out-of-bounds
+        // UB on an empty vector rather than a diagnosable failure.
+        TT_FATAL(
+            batch_chain_configs.size() == num_cores,
+            "RingJoint rotated Q split expects one batch-chain config per core, got {} for {} cores",
+            batch_chain_configs.size(),
+            num_cores);
+        // The row-wide mcast machinery assumes the injector never runs a padded iteration (it is
+        // chosen among row-max cores; padded members freeze their K-CB write phase, and the mcast
+        // lands at the injector's phase). Preserve that invariant per iteration: within a row
+        // hosting floats, the injector's column takes the first float.
+        constexpr uint32_t kNoInjectorCol = std::numeric_limits<uint32_t>::max();
+        std::vector<uint32_t> injector_col(num_rows, kNoInjectorCol);
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            for (uint32_t col = 0; col < cores_per_row; ++col) {
+                if (batch_chain_configs[row * cores_per_row + col].is_injector) {
+                    injector_col[row] = col;
+                    break;
+                }
+            }
+            // Defaulting to column 0 instead would put the first float on a non-injector core and
+            // quietly violate the invariant above, as a wrong-but-running program.
+            TT_FATAL(
+                injector_col[row] != kNoInjectorCol,
+                "RingJoint rotated Q split: row {} has no K mcast injector, but k_mcast_enabled "
+                "configures one per row",
+                row);
+        }
+        // Float f's owner at iteration t: rows rotate by rows_needed each iteration so every row
+        // hosts floats (the +1 mcast slot) an equal ~ring_size*rows_needed/num_rows share of
+        // iterations. (row, position) is unique per f within an iteration, so a core owns at most
+        // one float at a time; position 0 maps to the row's injector column.
+        auto float_owner = [&](uint32_t ring_iter, uint32_t float_idx) {
+            const uint32_t row = ((ring_iter * rows_needed) + (float_idx / cores_per_row)) % num_rows;
+            const uint32_t pos = float_idx % cores_per_row;
+            const uint32_t inj = injector_col[row];
+            const uint32_t col = pos == 0 ? inj : (pos <= inj ? pos - 1 : pos);
+            return row * cores_per_row + col;
+        };
+        rotated_sched.assign(num_cores, std::vector<RotatedIterSched>(ring_size));
+        for (uint32_t core_idx = 0; core_idx < num_cores; ++core_idx) {
+            for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
+                auto& sched = rotated_sched[core_idx][ring_iter];
+                sched.my_chunks.reserve(rotated_base_chunks + 1);
+                for (uint32_t b = 0; b < rotated_base_chunks; ++b) {
+                    sched.my_chunks.push_back(core_idx * rotated_base_chunks + b);
+                }
+            }
+        }
+        // owner_of[ring_iter][float_idx]: which core holds float `float_idx` on that iteration.
+        // Materialized because the loop below needs each float's owner in the previous and next
+        // iterations as well as this one, and re-evaluating float_owner four times per (iter, float)
+        // is what made this schedule hard to check.
+        std::vector<std::vector<uint32_t>> owner_of(ring_size, std::vector<uint32_t>(rotated_float_chunks));
+        for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
+            for (uint32_t float_idx = 0; float_idx < rotated_float_chunks; ++float_idx) {
+                owner_of[ring_iter][float_idx] = float_owner(ring_iter, float_idx);
+            }
+        }
+        for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
+            for (uint32_t float_idx = 0; float_idx < rotated_float_chunks; ++float_idx) {
+                const uint32_t owner = owner_of[ring_iter][float_idx];
+                auto& sched = rotated_sched[owner][ring_iter];
+                sched.my_chunks.push_back(rotated_base_chunks * num_cores + float_idx);
+                // (row, pos) is unique per float within an iteration, so a core holds at most one
+                // float and these two fields are assigned at most once each.
+                TT_ASSERT(sched.my_chunks.size() == rotated_base_chunks + 1);
+                sched.float_migrated_in = (ring_iter > 0 && owner_of[ring_iter - 1][float_idx] != owner) ? 1 : 0;
+                if (ring_iter + 1 < ring_size) {
+                    const uint32_t next_owner = owner_of[ring_iter + 1][float_idx];
+                    if (next_owner != owner) {
+                        const auto& dest_phys = core_work[next_owner].physical_core;
+                        // rotated_pack_dest packs y into the low 8 bits; a wider coord would alias
+                        // silently into x and signal the wrong core's handoff semaphore.
+                        TT_FATAL(
+                            dest_phys.y < 256 && dest_phys.x < (1u << 24),
+                            "Rotated Q split cannot pack physical core ({}, {}) into a handoff dest",
+                            dest_phys.x,
+                            dest_phys.y);
+                        sched.float_dest = rotated_pack_dest(dest_phys.x, dest_phys.y);
+                    }
+                }
+            }
+            // Every core in a row runs the row's max slot count, so padded members still relay the
+            // mcast handshakes.
+            for (uint32_t row = 0; row < num_rows; ++row) {
+                uint32_t row_max = 0;
+                for (uint32_t col = 0; col < cores_per_row; ++col) {
+                    row_max = std::max(
+                        row_max,
+                        static_cast<uint32_t>(rotated_sched[row * cores_per_row + col][ring_iter].my_chunks.size()));
+                }
+                for (uint32_t col = 0; col < cores_per_row; ++col) {
+                    rotated_sched[row * cores_per_row + col][ring_iter].row_slot_count = row_max;
+                }
+            }
+        }
+        // The mcast injector's forward gate (q_iter_local < next_core_q_chunks) must cover the
+        // +1-slot iterations of every row, not just the injector's static flat-split count.
+        for (auto& cfg : batch_chain_configs) {
+            if (cfg.participates && cfg.is_injector) {
+                cfg.next_core_q_chunks = rotated_base_chunks + 1;
+            }
+        }
+        // Handoff semaphores for the iterations that can RECEIVE a migrated float (1..ring_size-1;
+        // iteration 0 starts fresh). Receiver resets its slot to 0 after the wait so a cached
+        // program replays cleanly. Slots are REUSED across iterations as a ring of
+        // kRotatedHandoffSemDepth (see rotated_handoff_sem_count) rather than one per iteration: program
+        // semaphores are a scarce resource (NUM_SEMAPHORES=16, shared with the chain and fused
+        // all-gather sems), and one-per-iteration made this feature the largest single consumer
+        // (7 of 16 at ring-8) and scaled with ring length. With the V head chain skipped for
+        // latent-V, ring-8 now fits comfortably and the count no longer grows with ring_size; the
+        // TT_FATAL below keeps that true rather than leaving it to this comment.
+        for (uint32_t sem_slot = 0; sem_slot < rotated_handoff_sem_count(ring_size); ++sem_slot) {
+            const uint32_t sem_id = static_cast<uint32_t>(desc.semaphores.size());
+            // The descriptor path has no budget check of its own: an id >= NUM_SEMAPHORES surfaces
+            // later as a bare "bitset::set: __position (17) >= _Nb (16)" IndexError from whichever
+            // helper next scans for a free id, naming neither SDPA nor this feature.
+            // Mirrors tt::tt_metal::NUM_SEMAPHORES (tt_metal/impl/buffers/semaphore.hpp), which is
+            // not reachable from a ttnn op through any public header.
+            constexpr uint32_t kSemaphoresPerCore = 16;
+            TT_FATAL(
+                sem_id < kSemaphoresPerCore,
+                "Ring MLA rotated Q split needs {} handoff semaphores, but the program has already "
+                "allocated {} and a core supports {}. Free some (e.g. skip the V head chain) or set "
+                "RING_MLA_DISABLE_ROTATED_Q_SPLIT=1.",
+                rotated_handoff_sem_count(ring_size),
+                desc.semaphores.size(),
+                kSemaphoresPerCore);
+            desc.semaphores.push_back(SemaphoreDescriptor{
+                .id = sem_id,
+                .core_type = tt::CoreType::WORKER,
+                .core_ranges = core_grid_set,
+                .initial_value = 0,
+            });
+            rotated_handoff_sem_ids.push_back(sem_id);
+        }
+        // log_info, matching the decline branch below: one line per program compile (programs are
+        // cached), and it is the only way a user can confirm the rotation is actually active for a
+        // given shape and core count.
+        log_info(
+            tt::LogOp,
+            "Rotated Q split ACTIVE: base={} floats={} rows_needed={} ring_size={} active_iters={} "
+            "kv_pad_rotation={} (ideal slots {} vs flat {})",
+            rotated_base_chunks,
+            rotated_float_chunks,
+            rows_needed,
+            ring_size,
+            std::popcount(active_ring_iter_mask),
+            kv_pad_rotation_enabled,
+            total_q_chunks * ring_size / num_cores,
+            ring_size * (rotated_base_chunks + 1));
+    } else if (v_shares_k_buffer && kernel_chunked) {
+        // Latent-V chunked prefill is the shape this rotation exists for, so when it declines there
+        // say why at a level a user actually sees. Silently taking the +1-slot-every-iteration split
+        // reads as an unexplained regression.
+        log_info(
+            tt::LogOp,
+            "Ring MLA rotated Q split declined (base={} floats={} rows_needed={} of {} rows, ring_size={}, "
+            "disabled={} balanced={} kv_pad_rotation={} k_mcast={} all_iters_active={}); using the static "
+            "flat split.",
+            rotated_base_chunks,
+            rotated_float_chunks,
+            rotated_rows_needed,
+            grid_size.y,
+            ring_size,
+            rotated_q_split_disabled,
+            args.is_balanced,
+            kv_pad_rotation_enabled,
+            k_mcast_enabled,
+            active_ring_iter_mask == full_ring_iter_mask);
+    }
+
+    // Rotated Q split, compile-time: the per-iteration chunk-list length (base chunks plus one
+    // float slot), or 0 when the rotation declines. Kernels gate on `> 0` via if constexpr, so both
+    // paths always compile. Pushed unconditionally as the LAST compile-time arg of all three
+    // kernels, which is how they read it back -- no per-kernel index to keep in sync. The
+    // TT_FATAL below pins that "last" so a future append fails loudly instead of silently
+    // handing the kernels some other value.
+    const uint32_t rotated_max_slots_ct = use_rotated_q_split ? rotated_base_chunks + 1 : 0;
+    for (auto* args : {&reader_compile_time_args, &writer_compile_time_args, &compute_compile_time_args}) {
+        args->push_back(rotated_max_slots_ct);
+    }
+    const std::array<size_t, 3> ct_arg_sizes_with_rotated_last = {
+        reader_compile_time_args.size(), writer_compile_time_args.size(), compute_compile_time_args.size()};
+
+    // Head chains (MHA and separate-V shared-K) are built HERE, after the rotated-Q-split
+    // decision, because their per-(head, core) forwarding counts must describe whichever Q split
+    // actually ships. Moved down from above the K-chain pass; verified behaviour-neutral -- nothing
+    // between the old and new positions reads head_chain_configs or mcast_chains, and the K chain's
+    // own build_linear_chain call still sees the STATIC head_work it needs for its injector rule.
     // Build head chains for MHA and separate-V shared-K. GQA uses KV-head-grouped chains instead.
     if (use_head_chain && build_kv_chains) {
         for (uint32_t head_id = 0; head_id < static_cast<uint32_t>(head_segments.size()); ++head_id) {
@@ -2421,174 +2890,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             static_cast<uint32_t>(candidates.size()));
     }
 
-    uint32_t gqa_grouped_chains = 0;
-    uint32_t gqa_grouped_participant_cores = 0;
-    uint32_t gqa_local_fallback_cores = 0;
-    bool gqa_mcast_enabled = false;
-    std::string gqa_mcast_fallback_reason;
-    std::vector<uint32_t> gqa_chain_max_q(gqa_chain_configs.size(), 0);  // per-core loop-padding count
-    if (gqa_grouped_kv && build_kv_chains) {
-        std::vector<std::vector<ChainSegment>> kv_group_segments(NHK);
-
-        for (uint32_t ci = 0; ci < num_cores; ++ci) {
-            if (core_work[ci].global_q_count == 0) {
-                continue;
-            }
-
-            bool has_single_group = false;
-            bool spans_multiple_groups = false;
-            uint32_t single_group_id = 0;
-            uint32_t q_chunk_count = 0;
-            for (const auto& hw : core_work[ci].head_work) {
-                const uint32_t kv_head = hw.head / q_heads_per_kv;
-                if (!has_single_group) {
-                    has_single_group = true;
-                    single_group_id = kv_head;
-                } else if (single_group_id != kv_head) {
-                    spans_multiple_groups = true;
-                    break;
-                }
-                q_chunk_count += hw.q_chunk_count;
-            }
-
-            if (has_single_group && !spans_multiple_groups) {
-                kv_group_segments[single_group_id].emplace_back(ci, q_chunk_count);
-                gqa_grouped_participant_cores++;
-            } else {
-                gqa_local_fallback_cores++;
-            }
-        }
-
-        for (uint32_t kv_head = 0; kv_head < static_cast<uint32_t>(kv_group_segments.size()); ++kv_head) {
-            const auto& chain_segs = kv_group_segments[kv_head];
-            if (chain_segs.size() < 2) {
-                continue;
-            }
-            if (build_linear_chain(chain_segs, kv_head, gqa_chain_configs, core_work, false)) {
-                gqa_grouped_chains++;
-            }
-        }
-
-        // Production Minimax3 GQA has one local K/V head per chip (B=1, NHK=NHV=1). In that case every
-        // active Q-head core consumes the same K and V chunks, so use row-wide multicast instead
-        // of the store-and-forward grouped chain. Idle cores in an active row participate in padded iterations.
-        if (NHK != 1) {
-            gqa_mcast_fallback_reason = "NHK != 1 (multi-KV-head GQA mcast not supported)";
-        } else if (num_cores < 2) {
-            gqa_mcast_fallback_reason = "num_cores < 2";
-        } else if (grid_size.x < 2) {
-            gqa_mcast_fallback_reason = "grid_size.x < 2 (singleton rows)";
-        } else {
-            std::deque<uint32_t> recent_cols;  // FIFO of <= grid.x-1 most-recent claimed phys_x
-            uint32_t gqa_mcast_rows = 0;
-
-            for (uint32_t row = 0; row < grid_size.y; ++row) {
-                const auto selection = select_row_wide_chain_mcast(row, recent_cols);
-                if (!selection.has_value()) {
-                    continue;
-                }
-                configure_row_wide_chain_mcast(*selection, 0, gqa_chain_configs, gqa_chain_max_q);
-                gqa_mcast_rows++;
-                log_debug(
-                    tt::LogOp,
-                    "GQA K/V mcast row {}: injector core {} phys=({},{}) max_q={}, rect ({},{})-({},{})",
-                    selection->row,
-                    selection->injector_idx,
-                    selection->injector_physical.x,
-                    selection->injector_physical.y,
-                    selection->max_q,
-                    selection->phys_start.x,
-                    selection->phys_start.y,
-                    selection->phys_end.x,
-                    selection->phys_end.y);
-            }
-
-            gqa_mcast_enabled = gqa_mcast_rows > 0;
-            if (!gqa_mcast_enabled) {
-                gqa_mcast_fallback_reason = "no active groups";
-            }
-        }
-    }
-
-    // Build the shared-K chain for separate-V/latent cases.
-    // K is shared across all heads, so all active cores form one chain.
-    // Sorted by physical position for a stable unicast ordering (overwritten by mcast pass if eligible).
-    if (k_uses_batch_chain && build_kv_chains) {
-        std::vector<uint32_t> core_indices;
-        for (uint32_t i = 0; i < num_cores; ++i) {
-            if (core_work[i].global_q_count == 0) {
-                continue;
-            }
-            core_indices.push_back(i);
-        }
-
-        std::sort(core_indices.begin(), core_indices.end(), [&](uint32_t a, uint32_t b) {
-            const auto& pa = core_work[a].physical_core;
-            const auto& pb = core_work[b].physical_core;
-            return (pa.y < pb.y) || (pa.y == pb.y && pa.x < pb.x);
-        });
-
-        std::vector<ChainSegment> chain_segs;
-        chain_segs.reserve(core_indices.size());
-        for (uint32_t ci : core_indices) {
-            chain_segs.emplace_back(ci, core_work[ci].global_q_count);
-        }
-        if (build_linear_chain(chain_segs, 0, batch_chain_configs, core_work)) {
-            log_debug(tt::LogOp, "K unicast chain: {} cores", chain_segs.size());
-        }
-    }
-
-    // K multicast pass: one mcast chain per logical row. Shared-K keeps the all-or-nothing policy:
-    // every row must contain work, otherwise the previously built linear chain remains active.
-    bool k_mcast_enabled = false;
-    std::string k_mcast_fallback_reason;
-    std::vector<uint32_t> k_chain_max_q(batch_chain_configs.size(), 0);  // per-core loop-padding count
-
-    if (!k_uses_batch_chain || !enable_kv_chains) {
-        // No non-GQA shared-K chain to multicast.
-    } else if (num_cores < 2) {
-        k_mcast_fallback_reason = "num_cores < 2";
-    } else if (grid_size.x < 2) {
-        // Each chain would be a singleton (1 core, no sinks) — mcast is degenerate.
-        k_mcast_fallback_reason = "grid_size.x < 2 (singleton chains)";
-    } else {
-        std::vector<RowWideChainMcastSelection> row_mcast_selections;
-        row_mcast_selections.reserve(grid_size.y);
-        std::deque<uint32_t> recent_cols;  // FIFO of <= grid.x-1 most-recent claimed phys_x
-
-        bool all_chains_picked = true;
-        for (uint32_t row = 0; row < grid_size.y; ++row) {
-            const std::optional<RowWideChainMcastSelection> selection = select_row_wide_chain_mcast(row, recent_cols);
-            if (!selection.has_value()) {
-                k_mcast_fallback_reason = fmt::format("row {} has no work", row);
-                all_chains_picked = false;
-                break;
-            }
-            row_mcast_selections.push_back(*selection);
-        }
-
-        if (all_chains_picked) {
-            k_mcast_enabled = true;
-
-            for (const auto& selection : row_mcast_selections) {
-                configure_row_wide_chain_mcast(selection, 0, batch_chain_configs, k_chain_max_q);
-
-                log_debug(
-                    tt::LogOp,
-                    "K mcast row {}: injector core {} phys=({},{}) max_q={}, rect ({},{})-({},{})",
-                    selection.row,
-                    selection.injector_idx,
-                    selection.injector_physical.x,
-                    selection.injector_physical.y,
-                    selection.max_q,
-                    selection.phys_start.x,
-                    selection.phys_start.y,
-                    selection.phys_end.x,
-                    selection.phys_end.y);
-            }
-        }
-    }
-
     // Update mcast compile-time args
     const bool head_mcast_enabled = (mcast_chains > 0);
 
@@ -2641,6 +2942,21 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp";
     reader_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_kernel.core_ranges = core_grid_set;
+    // The kernels read rotated_max_slots as their final compile-time arg, so nothing may be
+    // appended after it (in-place patching of earlier indices is fine and does not change size).
+    TT_FATAL(
+        reader_compile_time_args.size() == ct_arg_sizes_with_rotated_last[0] &&
+            writer_compile_time_args.size() == ct_arg_sizes_with_rotated_last[1] &&
+            compute_compile_time_args.size() == ct_arg_sizes_with_rotated_last[2],
+        "rotated_max_slots must stay the last compile-time arg; args were appended after it "
+        "(reader {}->{}, writer {}->{}, compute {}->{})",
+        ct_arg_sizes_with_rotated_last[0],
+        reader_compile_time_args.size(),
+        ct_arg_sizes_with_rotated_last[1],
+        writer_compile_time_args.size(),
+        ct_arg_sizes_with_rotated_last[2],
+        compute_compile_time_args.size());
+
     reader_kernel.compile_time_args = reader_compile_time_args;
     reader_kernel.defines = kernel_defines;
     reader_kernel.config = ReaderConfigDescriptor{};
@@ -2768,6 +3084,17 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(reader_signaler_args);
         reader_args.append(reader_signaler_args);
 
+        // Rotated Q split: per ring iteration [row_slot_count, my_count, chunk ids].
+        // Header width must stay kRotatedReaderIterHeaderWords.
+        if (use_rotated_q_split) {
+            for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
+                const auto& sched = rotated_sched[i][ring_iter];
+                reader_args.push_back(sched.row_slot_count);
+                reader_args.push_back(static_cast<uint32_t>(sched.my_chunks.size()));
+                append_rot_chunk_ids(reader_args, sched);
+            }
+        }
+
         reader_kernel.emplace_runtime_args(core, reader_args.args);
 
         // Writer args
@@ -2787,6 +3114,21 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         std::vector<uint32_t> writer_signaler_args;
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(writer_signaler_args);
         writer_args.append(writer_signaler_args);
+        // Rotated Q split: the handoff semaphore ids, indexed by (ring_iter - 1) % count on both
+        // sides, then per ring iteration [my_count, float_migrated_in, float_dest, chunk ids].
+        // Header width must stay kRotatedWriterIterHeaderWords.
+        if (use_rotated_q_split) {
+            for (uint32_t sem_slot = 0; sem_slot < rotated_handoff_sem_count(ring_size); ++sem_slot) {
+                writer_args.push_back(rotated_handoff_sem_ids[sem_slot]);
+            }
+            for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
+                const auto& sched = rotated_sched[i][ring_iter];
+                writer_args.push_back(static_cast<uint32_t>(sched.my_chunks.size()));
+                writer_args.push_back(sched.float_migrated_in);
+                writer_args.push_back(sched.float_dest);
+                append_rot_chunk_ids(writer_args, sched);
+            }
+        }
         writer_kernel.emplace_runtime_args(core, writer_args.args);
 
         // Compute args
@@ -2816,6 +3158,15 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             "compute.q_valid_tile_count");
         compute_args.push_checked(
             runtime_arg_layout.compute_active_ring_iter_mask, active_ring_iter_mask, "compute.active_ring_iter_mask");
+        // Rotated Q split: per ring iteration [my_count, chunk ids].
+        // Header width must stay kRotatedComputeIterHeaderWords.
+        if (use_rotated_q_split) {
+            for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
+                const auto& sched = rotated_sched[i][ring_iter];
+                compute_args.push_back(static_cast<uint32_t>(sched.my_chunks.size()));
+                append_rot_chunk_ids(compute_args, sched);
+            }
+        }
         compute_kernel.emplace_runtime_args(core, compute_args.args);
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -2398,10 +2398,95 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // Aliased from the flat split above rather than recomputed, so the two cannot drift.
     const uint32_t rotated_base_chunks = base_chunks_per_core;
     const uint32_t rotated_float_chunks = cores_doing_extra_work;
-    // Grid rows hosting floats on one iteration. The win comes from float-free rows, so at
-    // rotated_rows_needed == grid_size.y ownership never actually moves.
-    const uint32_t rotated_rows_needed = grid_size.x ? tt::div_up(rotated_float_chunks, grid_size.x) : 0;
-    const uint32_t full_ring_iter_mask = ring_size >= 32 ? 0xFFFFFFFFu : ((1u << ring_size) - 1);
+    //
+    // LOCKSTEP GROUPS. The unit the rotation balances is not "a grid row" but "a set of cores that
+    // one injector multicasts to, waiting for every receiver before each broadcast"
+    // (chain_link.hpp sets sender_wait_count_ = mcast_num_dests for mcast, 1 otherwise). That
+    // barrier is what makes ONE +1-chunk core cost its WHOLE group an extra slot on EVERY ring
+    // iteration -- the cost this rotation exists to spread.
+    //
+    // Store-and-forward (linear) chains are deliberately NOT groups. They rendezvous pairwise and
+    // gate forwarding on the successor's own count, so their cost is a pipeline, not
+    // group_size * max(slots); rotating floats across them would balance nothing.
+    //
+    // Binding to the live family rather than to batch_chain_configs by name is what lets GQA
+    // (is_gqa_grouped_kv_head_mode, NHK == 1) use this: it runs the SAME
+    // select_row_wide_chain_mcast / configure_row_wide_chain_mcast, just into gqa_chain_configs,
+    // and has exactly one live chain family just as latent-V MLA does (uses_v_head_chain and
+    // uses_shared_k_batch_chain are both false when gqa_grouped_kv). The two families are mutually
+    // exclusive by construction, so at most one pointer is ever taken.
+    struct LockstepGroup {
+        std::vector<uint32_t> members;  // core indices in mcast rectangle order
+        uint32_t injector_pos = 0;      // index INTO members, not a core index
+    };
+    std::vector<ChainConfig>* rotated_mcast_configs = nullptr;
+    if (k_mcast_enabled) {
+        rotated_mcast_configs = &batch_chain_configs;
+    } else if (gqa_mcast_enabled) {
+        rotated_mcast_configs = &gqa_chain_configs;
+    }
+    // Both mcast passes lay a group over a full logical row (configure_row_wide_chain_mcast writes
+    // col 0..grid_size.x-1 of `row`), so groups are rows HERE -- but the schedule below only ever
+    // reads members/injector_pos, so a future non-row group (e.g. a padded head chain, which spans
+    // a sub-row segment) needs no change to the rotation itself.
+    std::vector<LockstepGroup> rotated_groups;
+    std::string rotated_group_reject;
+    if (rotated_mcast_configs == nullptr) {
+        rotated_group_reject = "no row-wide mcast family is live";
+    } else if (rotated_mcast_configs->size() != num_cores || grid_size.x == 0) {
+        rotated_group_reject = "mcast family is not built per core";
+    } else {
+        for (uint32_t row = 0; row < grid_size.y && rotated_group_reject.empty(); ++row) {
+            LockstepGroup group;
+            group.members.reserve(grid_size.x);
+            bool injector_found = false;
+            for (uint32_t col = 0; col < grid_size.x; ++col) {
+                const auto& cfg = (*rotated_mcast_configs)[row * grid_size.x + col];
+                if (!cfg.participates) {
+                    // A partially-participating row cannot host floats, and a core outside every
+                    // group would still be handed base chunks below. Reject rather than rotate a
+                    // grid the schedule does not fully describe. Unreachable while
+                    // rotated_base_chunks >= 1, which forces work onto every core.
+                    rotated_group_reject = fmt::format("row {} has a non-participating core", row);
+                    break;
+                }
+                if (cfg.is_injector) {
+                    if (injector_found) {
+                        rotated_group_reject = fmt::format("row {} has more than one mcast injector", row);
+                        break;
+                    }
+                    group.injector_pos = static_cast<uint32_t>(group.members.size());
+                    injector_found = true;
+                }
+                group.members.push_back(row * grid_size.x + col);
+            }
+            if (!rotated_group_reject.empty()) {
+                break;
+            }
+            if (!injector_found) {
+                // Defaulting to member 0 would put the first float on a non-injector core and
+                // quietly violate the injector-never-pads invariant -- a wrong-but-running program.
+                rotated_group_reject = fmt::format("row {} has no mcast injector", row);
+                break;
+            }
+            rotated_groups.push_back(std::move(group));
+        }
+    }
+    if (!rotated_group_reject.empty()) {
+        rotated_groups.clear();
+    }
+    // Uniform for row-wide mcast (always grid_size.x). Variable-size groups need a packing rule
+    // instead of the divide/modulo below; that arrives with padded head chains, not before.
+    const uint32_t rotated_group_size =
+        rotated_groups.empty() ? 0 : static_cast<uint32_t>(rotated_groups.front().members.size());
+    const bool rotated_groups_uniform =
+        !rotated_groups.empty() && std::all_of(rotated_groups.begin(), rotated_groups.end(), [&](const auto& g) {
+            return g.members.size() == rotated_group_size;
+        });
+    // Groups hosting floats on one iteration. The win comes from float-free groups, so at
+    // rotated_groups_needed == rotated_groups.size() ownership never actually moves.
+    const uint32_t rotated_groups_needed =
+        rotated_group_size ? tt::div_up(rotated_float_chunks, rotated_group_size) : 0;
     // A/B kill switch: RING_MLA_DISABLE_ROTATED_Q_SPLIT=1 forces the static flat split. Parsed
     // rather than presence-tested so "=0" leaves the feature on, and latched once per process --
     // toggling it between dispatches has no effect, so A/B across two runs.
@@ -2409,23 +2494,39 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         const char* value = std::getenv("RING_MLA_DISABLE_ROTATED_Q_SPLIT");
         return value != nullptr && value[0] != '\0' && std::string_view(value) != "0";
     }();
+    // Head-chain paths (separate-V shared-K) opt-in: RING_MLA_ROTATE_SEPARATE_V=1.
+    // The MECHANISM for these is present and was verified correct -- the head chains are built
+    // after the rotated-Q-split decision precisely so their per-(head, core) forwarding counts
+    // describe the rotated split. It was gated out (commit 409d944b14d) not because it was broken
+    // but because the rule that ENABLED it was fitted to four points and predicted backwards once
+    // grid rows were varied, while the feature measured -11.4% at 110 cores and -2.7% at 48.
+    // Restoring it as an explicit opt-in keeps all three things that mattered: the case is
+    // SUPPORTED and testable, no measured regression ships, and no unexplainable perf guard
+    // re-enters the default predicate. Do NOT re-fit an enablement rule to turn this on by
+    // default -- that is exactly what was removed.
+    static const bool rotate_head_chain_opt_in = []() {
+        const char* value = std::getenv("RING_MLA_ROTATE_SEPARATE_V");
+        return value != nullptr && value[0] != '\0' && std::string_view(value) != "0";
+    }();
     // Validated by sweeping RING_MLA_SDPA_GRID_OVERRIDE on ring-8: PCC passes for base 1..9 over
     // rows_needed 1..9 and floats 0..80, plus the decline cases, with no perf regression where it
-    // engages. The win tracks float-free rows (grid_size.y - rotated_rows_needed), not base.
+    // engages. The win tracks float-free rows (grid_size.y - rotated_groups_needed), not base.
     // Per-config numbers are in the commit message; the attempt trail is on
     // backup/ring-mla-work-split-pre-squash.
     //
     // Every term below is load-bearing; the first thing each one breaks:
-    //   k_mcast_enabled      the lockstep unit is the ROW, so a float costs its whole row a +1 slot
-    //                        every iteration. Without it, grid_size.x == 1 leaves injector_col unset
-    //                        for other rows and the TT_FATAL below fires. Nearly implied by the rest
-    //                        (residual content is just grid_size.x >= 2); kept for self-documentation.
+    //   rotated_groups       a lockstep group exists only under row-wide MCAST, whose injector
+    //                        waits for every receiver before each broadcast; that barrier is what
+    //                        makes one +1 core cost its whole group a slot every iteration. Linear
+    //                        chains rendezvous pairwise and are pipelines, so there is nothing to
+    //                        rebalance -- they are not excluded, they gain provably zero.
+    //                        `uniform` guards the divide/modulo float placement below.
     //   build_kv_chains      carries B == 1. Removing it is a SILENT wrong answer: the row mcast
     //                        stays live and the injector multicasts K for ITS nb to peers whose
     //                        rotated slot decodes a different nb.
-    //   v_shares_k_buffer    separate-V turns on the per-head V chain, whose forwarding counts come
-    //                        from the STATIC split -> V relay mismatch -> hang. Also subsumes
-    //                        !use_attention_sink, use_streaming_compute and !gqa_grouped_kv.
+    //   !use_head_chain      "exactly one live chain family". A second family (separate-V's or
+    //                        MHA's per-head V chain) takes its forwarding counts from the STATIC
+    //                        split -> V relay mismatch -> hang.
     //   !args.is_balanced    two independent breaks. Zigzag counts extra chunks in PAIRS while this
     //                        schedule appends ONE float per owner, leaving ids unscheduled and a
     //                        receiver waiting on a donor that never runs (MEASURED: HANGS). And
@@ -2436,23 +2537,40 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     //   base_chunks >= 1     definitional; at base 0 the compute static_assert fires first.
     //
     // Removed terms: !kv_pad_rotation_enabled and the full-mask check (both subsumed by ordinal
-    // indexing), and rotated_float_chunks != 0 / rotated_rows_needed < grid_size.y (cost guards,
+    // indexing), and rotated_float_chunks != 0 / rotated_groups_needed < grid_size.y (cost guards,
     // provable no-ops). The full-mask value still feeds the decline log line.
     const bool use_rotated_q_split =
         !rotated_q_split_disabled &&
-        // Path scope: latent-V (V packed into K) on the streaming compute path, with K streamed
-        // through the row-wide mcast batch chain. Only the streaming compute kernel carries the
-        // rotated-Q-split hook; on any other path compute would desync from the reader and writer,
-        // so the compute kernel static_asserts this too. These two terms also subsume
-        // !has_sliding_window, enable_kv_chains, k_uses_batch_chain and B == 1, and v_shares_k_buffer
-        // subsumes !use_attention_sink (the op rejects that pair outright).
-        k_mcast_enabled && build_kv_chains &&
-        // V transport: latent-V only. V rides the K mcast, so the rotation needs nothing extra.
-        // Separate-V rotation was implemented and REMOVED -- correct, but it helped at one core
-        // count and hurt at another, and its enablement rule predicted backwards once grid rows
-        // varied. If wanted back, the principled version is head-ALIGNED float packing (row-mcast V
-        // on the float slot reusing the head chain's idle semaphores), not a fitted perf guard.
-        v_shares_k_buffer && !args.is_balanced &&
+        // A lockstep group must exist. Groups come from whichever row-wide MCAST family is live --
+        // the shared-K batch chain (latent-V) or the GQA-grouped K/V chain -- and only mcast makes a
+        // group: its injector waits for every receiver before each broadcast, which is what makes
+        // one +1-chunk core cost its whole group a slot on EVERY ring iteration. Store-and-forward
+        // chains rendezvous pairwise and are pipelines, so they have nothing to rebalance.
+        // `uniform` guards the divide/modulo float placement below, and implies non-empty.
+        // build_kv_chains carries B == 1; dropping it is a SILENT wrong answer, because the row
+        // mcast stays live and the injector multicasts K for ITS nb to peers whose rotated slot
+        // decodes a different nb.
+        rotated_groups_uniform && build_kv_chains &&
+        // Exactly ONE chain family may be live. !use_head_chain is precisely that condition:
+        // uses_v_head_chain is false for latent-V (v_shares_k_buffer) and for GQA-grouped KV, and
+        // true for separate-V and MHA. With a head chain live, its per-(head, core) forwarding
+        // counts come from the STATIC split, so a migrated float desyncs the V relay and hangs.
+        // separate-V IS reachable, via the opt-in below: the head chains are rebuilt from the
+        // ROTATED base ranges (see the head_work/head_segments rebuild inside the rotation branch),
+        // which is what makes their forwarding counts describe the split that actually ships. That
+        // rebuild is load-bearing -- without it this deadlocks; it is not about mcast padding.
+        // MHA stays out for a different reason: it has no row-wide mcast family at all, so no
+        // group exists and the term above already excludes it.
+        (!use_head_chain ||
+         // Head-chain paths need the base/float boundary to land on a HEAD boundary, so a float
+         // never lands on a core outside its head's V chain (the B2 problem). This is the
+         // condition the removed branch carried, and it is a real structural requirement, not a
+         // perf heuristic -- unlike the even-fill rule beside it, which is NOT restored.
+         (rotate_head_chain_opt_in && num_q_chunks != 0 && (rotated_base_chunks * num_cores) % num_q_chunks == 0)) &&
+        // Both were previously subsumed by v_shares_k_buffer. GQA satisfies !use_head_chain
+        // without implying either, so they are now explicit: the compute kernel static_asserts
+        // the streaming path, and the op rejects latent-V + attention sink outright.
+        use_streaming_compute && !use_attention_sink && !args.is_balanced &&
         // Partial active masks are handled, not excluded: the schedule is indexed by ordinal within
         // the active subsequence (rotated_active_ordinal), so consecutive ordinals are consecutive
         // EXECUTED iterations and a skip cannot split the donor-signal / receiver-wait pair. That is
@@ -2462,7 +2580,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         // needs no guard either -- it takes the final-output branch and creates no deferred save.
         //
         // Degenerate cases need no guard, both measured: at rotated_float_chunks == 0 each core's
-        // rotated range is identical to its static one, and at rotated_rows_needed == grid_size.y
+        // rotated range is identical to its static one, and at rotated_groups_needed == grid_size.y
         // the cycle merely permutes which row hosts which float.
         //
         // rotated_base_chunks >= 1 is required: the reader decodes slot (rotated_my_count - 1) on
@@ -2476,7 +2594,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
 
     struct RotatedIterSched {
         std::vector<uint32_t> my_chunks;   // flat chunk ids; base chunks first, float (if any) last
-        uint32_t row_slot_count = 0;       // row max chunk count this iteration = K mcast slots to run
+        uint32_t group_slot_count = 0;     // group max chunk count this iteration = mcast slots to run
         uint32_t float_migrated_in = 0;    // 1 if the last chunk was owned by another core last iteration
         uint32_t float_dest = kRotatedNoDest;  // packed physical core owning this float next iteration
     };
@@ -2490,48 +2608,25 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         }
     };
     if (use_rotated_q_split) {
-        const uint32_t cores_per_row = grid_size.x;
-        const uint32_t num_rows = grid_size.y;
-        const uint32_t rows_needed = rotated_rows_needed;
-        // The block below indexes batch_chain_configs by core; k_mcast_enabled implies it is built
-        // per core, but that implication is ~90 lines away, and getting it wrong is out-of-bounds
-        // UB on an empty vector rather than a diagnosable failure.
-        TT_FATAL(
-            batch_chain_configs.size() == num_cores,
-            "RingJoint rotated Q split expects one batch-chain config per core, got {} for {} cores",
-            batch_chain_configs.size(),
-            num_cores);
+        const uint32_t num_groups = static_cast<uint32_t>(rotated_groups.size());
+        const uint32_t groups_needed = rotated_groups_needed;
         // The row-wide mcast machinery assumes the injector never runs a padded iteration (it is
-        // chosen among row-max cores; padded members freeze their K-CB write phase, and the mcast
-        // lands at the injector's phase). Preserve that invariant per iteration: within a row
-        // hosting floats, the injector's column takes the first float.
-        constexpr uint32_t kNoInjectorCol = std::numeric_limits<uint32_t>::max();
-        std::vector<uint32_t> injector_col(num_rows, kNoInjectorCol);
-        for (uint32_t row = 0; row < num_rows; ++row) {
-            for (uint32_t col = 0; col < cores_per_row; ++col) {
-                if (batch_chain_configs[row * cores_per_row + col].is_injector) {
-                    injector_col[row] = col;
-                    break;
-                }
-            }
-            // Defaulting to column 0 instead would put the first float on a non-injector core and
-            // quietly violate the invariant above, as a wrong-but-running program.
-            TT_FATAL(
-                injector_col[row] != kNoInjectorCol,
-                "RingJoint rotated Q split: row {} has no K mcast injector, but k_mcast_enabled "
-                "configures one per row",
-                row);
-        }
-        // Float f's owner at iteration t: rows rotate by rows_needed each iteration so every row
-        // hosts floats (the +1 mcast slot) an equal ~ring_size*rows_needed/num_rows share of
-        // iterations. (row, position) is unique per f within an iteration, so a core owns at most
-        // one float at a time; position 0 maps to the row's injector column.
+        // chosen among group-max cores; padded members freeze their K-CB write phase, and the mcast
+        // lands at the injector's phase). Preserve that invariant per iteration: within a group
+        // hosting floats, the injector takes the first float. rotated_groups already carries
+        // injector_pos, validated at construction, so there is no second scan to keep in sync.
+        // Float f's owner at iteration t: groups rotate by groups_needed each iteration so every
+        // group hosts floats (the +1 mcast slot) an equal ~ring_size*groups_needed/num_groups share
+        // of iterations. (group, position) is unique per f within an iteration, so a core owns at
+        // most one float at a time; position 0 maps to the group's injector.
+        // Identical to the previous row-indexed form when groups are rows in column order, which
+        // is what configure_row_wide_chain_mcast always produces -- latent-V output is unchanged.
         auto float_owner = [&](uint32_t ring_iter, uint32_t float_idx) {
-            const uint32_t row = ((ring_iter * rows_needed) + (float_idx / cores_per_row)) % num_rows;
-            const uint32_t pos = float_idx % cores_per_row;
-            const uint32_t inj = injector_col[row];
-            const uint32_t col = pos == 0 ? inj : (pos <= inj ? pos - 1 : pos);
-            return row * cores_per_row + col;
+            const uint32_t group_idx = ((ring_iter * groups_needed) + (float_idx / rotated_group_size)) % num_groups;
+            const auto& group = rotated_groups[group_idx];
+            const uint32_t pos = float_idx % rotated_group_size;
+            const uint32_t inj = group.injector_pos;
+            return group.members[pos == 0 ? inj : (pos <= inj ? pos - 1 : pos)];
         };
         rotated_sched.assign(num_cores, std::vector<RotatedIterSched>(ring_size));
         for (uint32_t core_idx = 0; core_idx < num_cores; ++core_idx) {
@@ -2577,25 +2672,75 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
                     }
                 }
             }
-            // Every core in a row runs the row's max slot count, so padded members still relay the
-            // mcast handshakes.
-            for (uint32_t row = 0; row < num_rows; ++row) {
-                uint32_t row_max = 0;
-                for (uint32_t col = 0; col < cores_per_row; ++col) {
-                    row_max = std::max(
-                        row_max,
-                        static_cast<uint32_t>(rotated_sched[row * cores_per_row + col][ring_iter].my_chunks.size()));
+            // Every core in a group runs the group's max slot count, so padded members still relay
+            // the mcast handshakes.
+            for (const auto& group : rotated_groups) {
+                uint32_t group_max = 0;
+                for (const uint32_t ci : group.members) {
+                    group_max =
+                        std::max(group_max, static_cast<uint32_t>(rotated_sched[ci][ring_iter].my_chunks.size()));
                 }
-                for (uint32_t col = 0; col < cores_per_row; ++col) {
-                    rotated_sched[row * cores_per_row + col][ring_iter].row_slot_count = row_max;
+                for (const uint32_t ci : group.members) {
+                    rotated_sched[ci][ring_iter].group_slot_count = group_max;
                 }
             }
         }
         // The mcast injector's forward gate (q_iter_local < next_core_q_chunks) must cover the
-        // +1-slot iterations of every row, not just the injector's static flat-split count.
-        for (auto& cfg : batch_chain_configs) {
+        // +1-slot iterations of every group, not just the injector's static flat-split count.
+        // Patched on whichever family the groups came from -- batch for latent-V, gqa for GQA.
+        for (auto& cfg : *rotated_mcast_configs) {
             if (cfg.participates && cfg.is_injector) {
                 cfg.next_core_q_chunks = rotated_base_chunks + 1;
+            }
+        }
+
+        // Separate-V: the V head chain's per-(head, core) forwarding counts come from
+        // head_work/head_segments, which were derived from the STATIC flat split. Under rotation
+        // each core instead owns the contiguous base range [i*base, (i+1)*base) on every
+        // iteration, so rebuild both from that. Floats are deliberately NOT added: they are the
+        // tail flat ids and, by the head-boundary term in the predicate, live only in heads with
+        // no base chunks -- heads whose chain is therefore never built (segs.size() < 2), so the
+        // reader's `nq != chain_head` fallback reads their V from DRAM.
+        // The K chain was already built above from the static head_work, which is what its
+        // single-head-injector rule needs; only the head chain, built below, sees this version.
+        //
+        // RECOVERED from 6c319e724e9. It was still present when separate-V rotation was gated out
+        // (409d944b14d removed only the predicate), became unreachable at that point, and was then
+        // dropped as dead code by the squash. Re-enabling the predicate WITHOUT it deadlocks the V
+        // relay -- the head chain forwards against the static split while the rotation ships a
+        // different one. Verified: that is exactly the hang seen before this was restored.
+        // GUARD IS use_head_chain, NOT !v_shares_k_buffer as in the original 6c319e724e9. Back then
+        // the predicate's separate-V disjunct implied use_head_chain, so the two agreed. This
+        // predicate also admits GQA, where !v_shares_k_buffer holds but use_head_chain is FALSE and
+        // head_segments is therefore sized 0 -- the TT_FATAL below would fire on the first chunk.
+        // use_head_chain is also the precise condition on its own terms: this block exists to make
+        // the V HEAD CHAIN describe the rotated split, so with no head chain there is nothing to
+        // rebuild, and core_work.head_work must be left alone for the GQA grouped chains that read it.
+        if (use_head_chain) {
+            for (auto& work : core_work) {
+                work.head_work.clear();
+            }
+            for (auto& segs : head_segments) {
+                segs.clear();
+            }
+            for (uint32_t i = 0; i < num_cores; ++i) {
+                auto& work = core_work.at(i);
+                uint32_t flat_chunk = i * rotated_base_chunks;
+                uint32_t remaining = rotated_base_chunks;
+                while (remaining > 0) {
+                    const auto [head_idx, q_chunk_idx] = decode_flat_chunk(flat_chunk);
+                    const uint32_t take = std::min(remaining, num_q_chunks - q_chunk_idx);
+                    work.head_work.push_back(CoreHeadWork{.head = head_idx, .q_chunk_count = take});
+                    TT_FATAL(
+                        head_idx < head_segments.size(),
+                        "Rotated head-chain segment index {} is outside {} configured query heads",
+                        head_idx,
+                        head_segments.size());
+                    head_segments[head_idx].push_back(HeadSegmentRef{
+                        .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
+                    remaining -= take;
+                    flat_chunk += take;
+                }
             }
         }
         // Handoff semaphores for the iterations that can RECEIVE a migrated float (1..ring_size-1;
@@ -2636,35 +2781,58 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         // given shape and core count.
         log_info(
             tt::LogOp,
-            "Rotated Q split ACTIVE: base={} floats={} rows_needed={} ring_size={} active_iters={} "
-            "kv_pad_rotation={} (ideal slots {} vs flat {})",
+            "Rotated Q split ACTIVE: base={} floats={} groups={}x{} groups_needed={} ring_size={} "
+            "active_iters={} kv_pad_rotation={} (ideal slots {} vs flat {})",
             rotated_base_chunks,
             rotated_float_chunks,
-            rows_needed,
+            num_groups,
+            rotated_group_size,
+            groups_needed,
             ring_size,
             std::popcount(active_ring_iter_mask),
             kv_pad_rotation_enabled,
             total_q_chunks * ring_size / num_cores,
             ring_size * (rotated_base_chunks + 1));
-    } else if (v_shares_k_buffer && kernel_chunked) {
-        // Latent-V chunked prefill is the shape this rotation exists for, so when it declines there
-        // say why at a level a user actually sees. Silently taking the +1-slot-every-iteration split
-        // reads as an unexplained regression.
+    } else if (kernel_chunked || use_head_chain) {
+        // use_head_chain covers the NON-CHUNKED head-chain paths (MHA video generation here:
+        // wan2_2, videogen_model1_*). They previously printed nothing at all -- neither ACTIVE nor
+        // declined -- so "the rotation does not apply there" was invisible rather than stated.
+        // Say why at a level a user actually sees, for EVERY chunked ring-joint program rather
+        // than only the two paths the rotation can currently take. Two different situations are
+        // worth telling apart, and a bare "not supported" conflates them:
+        //   - a lockstep group EXISTS and something else declined it (this is a missed win), and
+        //   - no lockstep group exists at all, because the K/V transport is a store-and-forward
+        //     chain or there is no chain (sliding window, B > 1). There the rotation would move
+        //     zero slots, so declining is not a gap -- `ideal == flat` below shows that directly
+        //     rather than asserting it.
+        // Silently taking the +1-slot-every-iteration split reads as an unexplained regression.
         log_info(
             tt::LogOp,
-            "Ring MLA rotated Q split declined (base={} floats={} rows_needed={} of {} rows, ring_size={}, "
-            "disabled={} balanced={} kv_pad_rotation={} k_mcast={} all_iters_active={}); using the static "
-            "flat split.",
+            "Ring joint rotated Q split declined (base={} floats={} groups_needed={} of {} groups, "
+            "ring_size={}, disabled={} balanced={} head_chain={} streaming={} groups=\"{}\"; "
+            "would-be slots ideal {} vs flat {}; cores={} num_q_chunks={} heads_per_core_exact={}); "
+            "using the static flat split.",
             rotated_base_chunks,
             rotated_float_chunks,
-            rotated_rows_needed,
-            grid_size.y,
+            rotated_groups_needed,
+            rotated_groups.size(),
             ring_size,
             rotated_q_split_disabled,
             args.is_balanced,
-            kv_pad_rotation_enabled,
-            k_mcast_enabled,
-            active_ring_iter_mask == full_ring_iter_mask);
+            use_head_chain,
+            use_streaming_compute,
+            rotated_group_reject.empty() ? "ok" : rotated_group_reject,
+            // What the rotation would have been worth here. Equal values mean there is nothing to
+            // win -- the honest form of "unsupported" for a transport with no lockstep barrier.
+            num_cores ? total_q_chunks * ring_size / num_cores : 0,
+            ring_size * (rotated_base_chunks + 1),
+            num_cores,
+            num_q_chunks,
+            // Whether each core's base range lies inside ONE head. This is the precondition for
+            // ever deriving lockstep groups from the per-head chains (the only transport MHA has):
+            // if a core straddles heads it belongs to several head chains at once, and the
+            // one-core-one-group assumption behind float_owner/group_slot_count breaks.
+            (num_q_chunks != 0 && rotated_base_chunks != 0 && num_q_chunks % rotated_base_chunks == 0));
     }
 
     // Rotated Q split, compile-time: the per-iteration chunk-list length (base chunks plus one
@@ -3084,12 +3252,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->push_ring_sdpa_fused_op_rt_args(reader_signaler_args);
         reader_args.append(reader_signaler_args);
 
-        // Rotated Q split: per ring iteration [row_slot_count, my_count, chunk ids].
+        // Rotated Q split: per ring iteration [group_slot_count, my_count, chunk ids].
         // Header width must stay kRotatedReaderIterHeaderWords.
         if (use_rotated_q_split) {
             for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
                 const auto& sched = rotated_sched[i][ring_iter];
-                reader_args.push_back(sched.row_slot_count);
+                reader_args.push_back(sched.group_slot_count);
                 reader_args.push_back(static_cast<uint32_t>(sched.my_chunks.size()));
                 append_rot_chunk_ids(reader_args, sched);
             }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -2451,6 +2451,17 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
                     break;
                 }
                 if (cfg.is_injector) {
+                    // mcast_num_dests is written only by configure_row_wide_chain_mcast, never by
+                    // build_linear_chain, so it is what actually distinguishes a lockstep group from
+                    // a store-and-forward chain. participates/is_injector are set by BOTH, and are
+                    // safe here only because every row a live mcast family skipped happens to be
+                    // all-zero-work and therefore non-participating -- a non-local invariant two
+                    // passes away. Check the distinguishing field instead, so a future change that
+                    // breaks that invariant declines loudly rather than silently rotating a pipeline.
+                    if (cfg.mcast_num_dests == 0) {
+                        rotated_group_reject = fmt::format("row {} injector is not a mcast injector", row);
+                        break;
+                    }
                     if (injector_found) {
                         rotated_group_reject = fmt::format("row {} has more than one mcast injector", row);
                         break;
@@ -2701,8 +2712,11 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         // tail flat ids and, by the head-boundary term in the predicate, live only in heads with
         // no base chunks -- heads whose chain is therefore never built (segs.size() < 2), so the
         // reader's `nq != chain_head` fallback reads their V from DRAM.
-        // The K chain was already built above from the static head_work, which is what its
-        // single-head-injector rule needs; only the head chain, built below, sees this version.
+        // Only the head chain, built below, sees this rebuilt version. The K chain was built above
+        // from the static head_work, but on this path that is moot rather than merely satisfied:
+        // the rotation requires a live row-wide mcast family, and configure_row_wide_chain_mcast
+        // rewrites every field of every batch_chain_configs entry, so the linear K chain built
+        // earlier is discarded wholesale before any of it is used.
         //
         // RECOVERED from 6c319e724e9. It was still present when separate-V rotation was gated out
         // (409d944b14d removed only the predicate), became unreachable at that point, and was then

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -2486,121 +2486,32 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     if (!rotated_group_reject.empty()) {
         rotated_groups.clear();
     }
-    // Uniform for row-wide mcast (always grid_size.x). Variable-size groups need a packing rule
-    // instead of the divide/modulo below; that arrives with padded head chains, not before.
+    // Each accepted group contains exactly grid_size.x members by construction.
+    // Variable-size groups would need a different packing rule for the divide/modulo below.
     const uint32_t rotated_group_size =
         rotated_groups.empty() ? 0 : static_cast<uint32_t>(rotated_groups.front().members.size());
-    const bool rotated_groups_uniform =
-        !rotated_groups.empty() && std::all_of(rotated_groups.begin(), rotated_groups.end(), [&](const auto& g) {
-            return g.members.size() == rotated_group_size;
-        });
     // Groups hosting floats on one iteration. The win comes from float-free groups, so at
     // rotated_groups_needed == rotated_groups.size() ownership never actually moves.
     const uint32_t rotated_groups_needed =
         rotated_group_size ? tt::div_up(rotated_float_chunks, rotated_group_size) : 0;
-    // A/B kill switch: RING_MLA_DISABLE_ROTATED_Q_SPLIT=1 forces the static flat split. Parsed
-    // rather than presence-tested so "=0" leaves the feature on, and latched once per process --
-    // toggling it between dispatches has no effect, so A/B across two runs.
-    static const bool rotated_q_split_disabled = []() {
-        const char* value = std::getenv("RING_MLA_DISABLE_ROTATED_Q_SPLIT");
-        return value != nullptr && value[0] != '\0' && std::string_view(value) != "0";
-    }();
-    // Head-chain paths (separate-V shared-K) opt-in: RING_MLA_ROTATE_SEPARATE_V=1.
-    // The MECHANISM for these is present and was verified correct -- the head chains are built
-    // after the rotated-Q-split decision precisely so their per-(head, core) forwarding counts
-    // describe the rotated split. It was gated out (commit 409d944b14d) not because it was broken
-    // but because the rule that ENABLED it was fitted to four points and predicted backwards once
-    // grid rows were varied, while the feature measured -11.4% at 110 cores and -2.7% at 48.
-    // Restoring it as an explicit opt-in keeps all three things that mattered: the case is
-    // SUPPORTED and testable, no measured regression ships, and no unexplainable perf guard
-    // re-enters the default predicate. Do NOT re-fit an enablement rule to turn this on by
-    // default -- that is exactly what was removed.
+    // Separate-V rotation is opt-in because it regressed performance on some configurations.
     static const bool rotate_head_chain_opt_in = []() {
         const char* value = std::getenv("RING_MLA_ROTATE_SEPARATE_V");
         return value != nullptr && value[0] != '\0' && std::string_view(value) != "0";
     }();
-    // Validated by sweeping RING_MLA_SDPA_GRID_OVERRIDE on ring-8: PCC passes for base 1..9 over
-    // rows_needed 1..9 and floats 0..80, plus the decline cases, with no perf regression where it
-    // engages. The win tracks float-free rows (grid_size.y - rotated_groups_needed), not base.
-    // Per-config numbers are in the commit message; the attempt trail is on
-    // backup/ring-mla-work-split-pre-squash.
-    //
-    // Every term below is load-bearing; the first thing each one breaks:
-    //   rotated_groups       a lockstep group exists only under row-wide MCAST, whose injector
-    //                        waits for every receiver before each broadcast; that barrier is what
-    //                        makes one +1 core cost its whole group a slot every iteration. Linear
-    //                        chains rendezvous pairwise and are pipelines, so there is nothing to
-    //                        rebalance -- they are not excluded, they gain provably zero.
-    //                        `uniform` guards the divide/modulo float placement below.
-    //   build_kv_chains      carries B == 1. Removing it is a SILENT wrong answer: the row mcast
-    //                        stays live and the injector multicasts K for ITS nb to peers whose
-    //                        rotated slot decodes a different nb.
-    //   !use_head_chain      "exactly one live chain family". A second family (separate-V's or
-    //                        MHA's per-head V chain) takes its forwarding counts from the STATIC
-    //                        split -> V relay mismatch -> hang.
-    //   !args.is_balanced    two independent breaks. Zigzag counts extra chunks in PAIRS while this
-    //                        schedule appends ONE float per owner, leaving ids unscheduled and a
-    //                        receiver waiting on a donor that never runs (MEASURED: HANGS). And
-    //                        balanced_skip_q's parity desyncs injector from receivers at the float
-    //                        slot -- the harder of the two; fix it first if retrying. Kept broader
-    //                        than !enable_zigzag_balancing since narrowing admits balanced chunked
-    //                        prefill, which nothing in the tree exercises and which hangs on failure.
-    //   base_chunks >= 1     definitional; at base 0 the compute static_assert fires first.
-    //
-    // Removed terms: !kv_pad_rotation_enabled and the full-mask check (both subsumed by ordinal
-    // indexing), and rotated_float_chunks != 0 / rotated_groups_needed < grid_size.y (cost guards,
-    // provable no-ops). The full-mask value still feeds the decline log line.
+    // Active-iteration indexing handles partial masks and KV padding. No remainder
+    // or no change in ownership needs no special exclusion.
     const bool use_rotated_q_split =
-        !rotated_q_split_disabled &&
-        // A lockstep group must exist. Groups come from whichever row-wide MCAST family is live --
-        // the shared-K batch chain (latent-V) or the GQA-grouped K/V chain -- and only mcast makes a
-        // group: its injector waits for every receiver before each broadcast, which is what makes
-        // one +1-chunk core cost its whole group a slot on EVERY ring iteration. Store-and-forward
-        // chains rendezvous pairwise and are pipelines, so they have nothing to rebalance.
-        // `uniform` guards the divide/modulo float placement below, and implies non-empty.
-        // build_kv_chains carries B == 1; dropping it is a SILENT wrong answer, because the row
-        // mcast stays live and the injector multicasts K for ITS nb to peers whose rotated slot
-        // decodes a different nb.
-        rotated_groups_uniform && build_kv_chains &&
-        // Exactly ONE chain family may be live. !use_head_chain is precisely that condition:
-        // uses_v_head_chain is false for latent-V (v_shares_k_buffer) and for GQA-grouped KV, and
-        // true for separate-V and MHA. With a head chain live, its per-(head, core) forwarding
-        // counts come from the STATIC split, so a migrated float desyncs the V relay and hangs.
-        // separate-V IS reachable, via the opt-in below: the head chains are rebuilt from the
-        // ROTATED base ranges (see the head_work/head_segments rebuild inside the rotation branch),
-        // which is what makes their forwarding counts describe the split that actually ships. That
-        // rebuild is load-bearing -- without it this deadlocks; it is not about mcast padding.
-        // MHA stays out for a different reason: it has no row-wide mcast family at all, so no
-        // group exists and the term above already excludes it.
-        (!use_head_chain ||
-         // Head-chain paths need the base/float boundary to land on a HEAD boundary, so a float
-         // never lands on a core outside its head's V chain (the B2 problem). This is the
-         // condition the removed branch carried, and it is a real structural requirement, not a
-         // perf heuristic -- unlike the even-fill rule beside it, which is NOT restored.
-         (rotate_head_chain_opt_in && num_q_chunks != 0 && (rotated_base_chunks * num_cores) % num_q_chunks == 0)) &&
-        // Both were previously subsumed by v_shares_k_buffer. GQA satisfies !use_head_chain
-        // without implying either, so they are now explicit: the compute kernel static_asserts
-        // the streaming path, and the op rejects latent-V + attention sink outright.
+        // Valid groups are full multicast rows with Q work, implying num_q_chunks > 0.
+        // build_kv_chains requires B == 1 so a row cannot mix batches' K/V data.
+        !rotated_groups.empty() && build_kv_chains &&
+        // Separate-V rebuilds its V chains from base work. Keep the remainder on
+        // separate heads to avoid unmatched receives from those chains.
+        (!use_head_chain || (rotate_head_chain_opt_in && (rotated_base_chunks * num_cores) % num_q_chunks == 0)) &&
+        // Only streaming compute consumes rotated IDs. Sink paths remain excluded;
+        // balanced allocation and per-Q skips are incompatible with this schedule.
         use_streaming_compute && !use_attention_sink && !args.is_balanced &&
-        // Partial active masks are handled, not excluded: the schedule is indexed by ordinal within
-        // the active subsequence (rotated_active_ordinal), so consecutive ordinals are consecutive
-        // EXECUTED iterations and a skip cannot split the donor-signal / receiver-wait pair. That is
-        // what unblocked kv-pad, where the mask is device-derived from trace metadata the host never
-        // sees: the host need not agree, since every per-ordinal entry it emits is already a valid
-        // partition of all Q chunks and the kernels choose which get used. The last active iteration
-        // needs no guard either -- it takes the final-output branch and creates no deferred save.
-        //
-        // Degenerate cases need no guard, both measured: at rotated_float_chunks == 0 each core's
-        // rotated range is identical to its static one, and at rotated_groups_needed == grid_size.y
-        // the cycle merely permutes which row hosts which float.
-        //
-        // rotated_base_chunks >= 1 is required: the reader decodes slot (rotated_my_count - 1) on
-        // padded iterations and would underflow at 0. base == 1 is the largest win, being the worst
-        // static imbalance.
-        // Reaching base == 1 took three writer/reader fixes, all no-ops at base >= 3: pinning
-        // need_q_read and single_q_chunk to the fixed slot count rather than the static one,
-        // comparing flat chunk ids for the early flush instead of the positional q_per_core == 2
-        // proxy, and postponing the cross-ring prefetch when it targets this slot's own chunk.
+        // Every core needs a real chunk: padded reader slots decode my_count - 1.
         rotated_base_chunks >= 1;
 
     struct RotatedIterSched {
@@ -2777,8 +2688,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             TT_FATAL(
                 sem_id < kSemaphoresPerCore,
                 "Ring MLA rotated Q split needs {} handoff semaphores, but the program has already "
-                "allocated {} and a core supports {}. Free some (e.g. skip the V head chain) or set "
-                "RING_MLA_DISABLE_ROTATED_Q_SPLIT=1.",
+                "allocated {} and a core supports {}. Reduce semaphore usage (e.g. skip the V head chain).",
                 rotated_handoff_sem_count(ring_size),
                 desc.semaphores.size(),
                 kSemaphoresPerCore);
@@ -2823,7 +2733,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         log_info(
             tt::LogOp,
             "Ring joint rotated Q split declined (base={} floats={} groups_needed={} of {} groups, "
-            "ring_size={}, disabled={} balanced={} head_chain={} streaming={} groups=\"{}\"; "
+            "ring_size={}, balanced={} head_chain={} streaming={} groups=\"{}\"; "
             "would-be slots ideal {} vs flat {}; cores={} num_q_chunks={} heads_per_core_exact={}); "
             "using the static flat split.",
             rotated_base_chunks,
@@ -2831,7 +2741,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             rotated_groups_needed,
             rotated_groups.size(),
             ring_size,
-            rotated_q_split_disabled,
             args.is_balanced,
             use_head_chain,
             use_streaming_compute,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -2565,7 +2565,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             TT_FATAL(
                 sem_id < kSemaphoresPerCore,
                 "Ring MLA rotated Q split needs {} handoff semaphores, but the program has already "
-                "allocated {} and a core supports {}. Reduce semaphore usage (e.g. skip the V head chain).",
+                "allocated {} and a core supports {}.",
                 rotated_handoff_sem_count(ring_size),
                 desc.semaphores.size(),
                 kSemaphoresPerCore);
@@ -2577,13 +2577,11 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             });
             rotated_handoff_sem_ids.push_back(sem_id);
         }
-        // log_info, matching the decline branch below: one line per program compile (programs are
-        // cached), and it is the only way a user can confirm the rotation is actually active for a
-        // given shape and core count.
+        // Report the selected schedule once per program compilation.
         log_info(
             tt::LogOp,
             "Rotated Q split ACTIVE: base={} floats={} groups={}x{} groups_needed={} ring_size={} "
-            "active_iters={} kv_pad_rotation={} (ideal slots {} vs flat {})",
+            "active_iters={} kv_pad_rotation={}",
             rotated_base_chunks,
             rotated_float_chunks,
             num_groups,
@@ -2591,48 +2589,23 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             groups_needed,
             ring_size,
             std::popcount(active_ring_iter_mask),
-            kv_pad_rotation_enabled,
-            total_q_chunks * ring_size / num_cores,
-            ring_size * (rotated_base_chunks + 1));
+            kv_pad_rotation_enabled);
     } else if (kernel_chunked || use_head_chain) {
-        // use_head_chain covers the NON-CHUNKED head-chain paths (MHA video generation here:
-        // wan2_2, videogen_model1_*). They previously printed nothing at all -- neither ACTIVE nor
-        // declined -- so "the rotation does not apply there" was invisible rather than stated.
-        // Say why at a level a user actually sees, for EVERY chunked ring-joint program rather
-        // than only the two paths the rotation can currently take. Two different situations are
-        // worth telling apart, and a bare "not supported" conflates them:
-        //   - a lockstep group EXISTS and something else declined it (this is a missed win), and
-        //   - no lockstep group exists at all, because the K/V transport is a store-and-forward
-        //     chain or there is no chain (sliding window, B > 1). There the rotation would move
-        //     zero slots, so declining is not a gap -- `ideal == flat` below shows that directly
-        //     rather than asserting it.
-        // Silently taking the +1-slot-every-iteration split reads as an unexplained regression.
         log_info(
             tt::LogOp,
-            "Ring joint rotated Q split declined (base={} floats={} groups_needed={} of {} groups, "
-            "ring_size={}, balanced={} head_chain={} streaming={} groups=\"{}\"; "
-            "would-be slots ideal {} vs flat {}; cores={} num_q_chunks={} heads_per_core_exact={}); "
+            "Ring joint rotated Q split declined: base={} floats={} groups_needed={} of {} groups, "
+            "balanced={} head_chain={} streaming={} attention_sink={} kv_chains={} groups=\"{}\"; "
             "using the static flat split.",
             rotated_base_chunks,
             rotated_float_chunks,
             rotated_groups_needed,
             rotated_groups.size(),
-            ring_size,
             args.is_balanced,
             use_head_chain,
             use_streaming_compute,
-            rotated_group_reject.empty() ? "ok" : rotated_group_reject,
-            // What the rotation would have been worth here. Equal values mean there is nothing to
-            // win -- the honest form of "unsupported" for a transport with no lockstep barrier.
-            num_cores ? total_q_chunks * ring_size / num_cores : 0,
-            ring_size * (rotated_base_chunks + 1),
-            num_cores,
-            num_q_chunks,
-            // Whether each core's base range lies inside ONE head. This is the precondition for
-            // ever deriving lockstep groups from the per-head chains (the only transport MHA has):
-            // if a core straddles heads it belongs to several head chains at once, and the
-            // one-core-one-group assumption behind float_owner/group_slot_count breaks.
-            (num_q_chunks != 0 && rotated_base_chunks != 0 && num_q_chunks % rotated_base_chunks == 0));
+            use_attention_sink,
+            build_kv_chains,
+            rotated_group_reject.empty() ? "ok" : rotated_group_reject);
     }
 
     // Rotated Q split, compile-time: the per-iteration chunk-list length (base chunks plus one

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -2035,6 +2035,27 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         return std::pair<uint32_t, uint32_t>{head, q_chunk};
     };
 
+    // Describe a core's flat Q range for K/V chain construction.
+    auto append_head_work = [&](uint32_t core_idx, uint32_t flat_chunk, uint32_t remaining) {
+        auto& work = core_work.at(core_idx);
+        while (remaining > 0) {
+            const auto [head_idx, q_chunk_idx] = decode_flat_chunk(flat_chunk);
+            const uint32_t take = std::min(remaining, num_q_chunks - q_chunk_idx);
+            work.head_work.push_back(CoreHeadWork{.head = head_idx, .q_chunk_count = take});
+            if (use_head_chain) {
+                TT_FATAL(
+                    head_idx < head_segments.size(),
+                    "Head-chain segment index {} is outside {} configured query heads",
+                    head_idx,
+                    head_segments.size());
+                head_segments[head_idx].push_back(HeadSegmentRef{
+                    .core_idx = core_idx, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
+            }
+            remaining -= take;
+            flat_chunk += take;
+        }
+    };
+
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
         uint32_t chunk_count = base_chunks_per_core + ((i < cores_doing_extra_work) ? extra_chunks_per_core : 0);
@@ -2049,31 +2070,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         work.global_q_start = next_global_chunk;
         work.global_q_count = chunk_count;
 
-        uint32_t remaining = chunk_count;
-        uint32_t flat_chunk = next_global_chunk;
-        while (remaining > 0) {
-            auto [head_idx, q_chunk_idx] = decode_flat_chunk(flat_chunk);
-            uint32_t chunk_capacity_in_head = num_q_chunks - q_chunk_idx;
-            uint32_t chunk_take = std::min(remaining, chunk_capacity_in_head);
-
-            if (enable_kv_chains) {
-                work.head_work.push_back(CoreHeadWork{
-                    .head = head_idx,
-                    .q_chunk_count = chunk_take,
-                });
-                if (use_head_chain) {
-                    TT_FATAL(
-                        head_idx < head_segments.size(),
-                        "Head-chain segment index {} is outside {} configured query heads",
-                        head_idx,
-                        head_segments.size());
-                    head_segments[head_idx].push_back(HeadSegmentRef{
-                        .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
-                }
-            }
-
-            remaining -= chunk_take;
-            flat_chunk += chunk_take;
+        if (enable_kv_chains) {
+            append_head_work(i, next_global_chunk, chunk_count);
         }
 
         next_global_chunk += chunk_count;
@@ -2385,36 +2383,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         }
     }
 
-    // Rotated per-ring-iteration Q distribution ("rotated q split").
-    //
-    // With row-wide K mcast each grid row is a lockstep pipe paying ring_size * (row max chunks)
-    // K-stream slots, so the flat split's remainder ("float") chunks make their rows pay a +1 slot
-    // on EVERY iteration -- ring_size * ceil(U/C) against an ideal U * ring_size / C. The (m, l, O)
-    // accumulators already round-trip through DRAM addressed by chunk identity, so floats can change
-    // owner core between iterations; rotate them across rows to spread that +1. Cross-core ordering
-    // uses handoff semaphores (chunked_prefill_utils.hpp): the donor signals after a write barrier
-    // on its save TRID, the receiver waits before its restore reads. Floats sit LAST in every list,
-    // giving that pair about one ring iteration of slack.
-    // Aliased from the flat split above rather than recomputed, so the two cannot drift.
+    // Rotate remainder Q chunks across multicast groups between active ring iterations.
+    // Saved (m, l, O) state is addressed by chunk ID; semaphore handoffs protect migration.
     const uint32_t rotated_base_chunks = base_chunks_per_core;
     const uint32_t rotated_float_chunks = cores_doing_extra_work;
-    //
-    // LOCKSTEP GROUPS. The unit the rotation balances is not "a grid row" but "a set of cores that
-    // one injector multicasts to, waiting for every receiver before each broadcast"
-    // (chain_link.hpp sets sender_wait_count_ = mcast_num_dests for mcast, 1 otherwise). That
-    // barrier is what makes ONE +1-chunk core cost its WHOLE group an extra slot on EVERY ring
-    // iteration -- the cost this rotation exists to spread.
-    //
-    // Store-and-forward (linear) chains are deliberately NOT groups. They rendezvous pairwise and
-    // gate forwarding on the successor's own count, so their cost is a pipeline, not
-    // group_size * max(slots); rotating floats across them would balance nothing.
-    //
-    // Binding to the live family rather than to batch_chain_configs by name is what lets GQA
-    // (is_gqa_grouped_kv_head_mode, NHK == 1) use this: it runs the SAME
-    // select_row_wide_chain_mcast / configure_row_wide_chain_mcast, just into gqa_chain_configs,
-    // and has exactly one live chain family just as latent-V MLA does (uses_v_head_chain and
-    // uses_shared_k_batch_chain are both false when gqa_grouped_kv). The two families are mutually
-    // exclusive by construction, so at most one pointer is ever taken.
+
+    // Only multicast groups share a row-wide barrier: linear chains do not have
+    // the same per-row cost. Use the live shared-K or GQA K/V multicast family.
     struct LockstepGroup {
         std::vector<uint32_t> members;  // core indices in mcast rectangle order
         uint32_t injector_pos = 0;      // index INTO members, not a core index
@@ -2425,10 +2400,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     } else if (gqa_mcast_enabled) {
         rotated_mcast_configs = &gqa_chain_configs;
     }
-    // Both mcast passes lay a group over a full logical row (configure_row_wide_chain_mcast writes
-    // col 0..grid_size.x-1 of `row`), so groups are rows HERE -- but the schedule below only ever
-    // reads members/injector_pos, so a future non-row group (e.g. a padded head chain, which spans
-    // a sub-row segment) needs no change to the rotation itself.
+    // Both multicast families cover full logical rows.
     std::vector<LockstepGroup> rotated_groups;
     std::string rotated_group_reject;
     if (rotated_mcast_configs == nullptr) {
@@ -2443,21 +2415,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             for (uint32_t col = 0; col < grid_size.x; ++col) {
                 const auto& cfg = (*rotated_mcast_configs)[row * grid_size.x + col];
                 if (!cfg.participates) {
-                    // A partially-participating row cannot host floats, and a core outside every
-                    // group would still be handed base chunks below. Reject rather than rotate a
-                    // grid the schedule does not fully describe. Unreachable while
-                    // rotated_base_chunks >= 1, which forces work onto every core.
+                    // Every scheduled core must belong to a multicast group.
                     rotated_group_reject = fmt::format("row {} has a non-participating core", row);
                     break;
                 }
                 if (cfg.is_injector) {
-                    // mcast_num_dests is written only by configure_row_wide_chain_mcast, never by
-                    // build_linear_chain, so it is what actually distinguishes a lockstep group from
-                    // a store-and-forward chain. participates/is_injector are set by BOTH, and are
-                    // safe here only because every row a live mcast family skipped happens to be
-                    // all-zero-work and therefore non-participating -- a non-local invariant two
-                    // passes away. Check the distinguishing field instead, so a future change that
-                    // breaks that invariant declines loudly rather than silently rotating a pipeline.
+                    // Unlike participates/is_injector, this field distinguishes multicast
+                    // injectors from linear-chain injectors.
                     if (cfg.mcast_num_dests == 0) {
                         rotated_group_reject = fmt::format("row {} injector is not a mcast injector", row);
                         break;
@@ -2515,9 +2479,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         rotated_base_chunks >= 1;
 
     struct RotatedIterSched {
-        std::vector<uint32_t> my_chunks;   // flat chunk ids; base chunks first, float (if any) last
-        uint32_t group_slot_count = 0;     // group max chunk count this iteration = mcast slots to run
-        uint32_t float_migrated_in = 0;    // 1 if the last chunk was owned by another core last iteration
+        std::vector<uint32_t> my_chunks;       // flat chunk ids; base chunks first, float (if any) last
+        uint32_t group_slot_count = 0;         // group max chunk count this iteration = mcast slots to run
+        uint32_t float_migrated_in = 0;        // 1 if the last chunk was owned by another core last iteration
         uint32_t float_dest = kRotatedNoDest;  // packed physical core owning this float next iteration
     };
     std::vector<std::vector<RotatedIterSched>> rotated_sched;  // [core][ring_iter]
@@ -2532,17 +2496,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     if (use_rotated_q_split) {
         const uint32_t num_groups = static_cast<uint32_t>(rotated_groups.size());
         const uint32_t groups_needed = rotated_groups_needed;
-        // The row-wide mcast machinery assumes the injector never runs a padded iteration (it is
-        // chosen among group-max cores; padded members freeze their K-CB write phase, and the mcast
-        // lands at the injector's phase). Preserve that invariant per iteration: within a group
-        // hosting floats, the injector takes the first float. rotated_groups already carries
-        // injector_pos, validated at construction, so there is no second scan to keep in sync.
-        // Float f's owner at iteration t: groups rotate by groups_needed each iteration so every
-        // group hosts floats (the +1 mcast slot) an equal ~ring_size*groups_needed/num_groups share
-        // of iterations. (group, position) is unique per f within an iteration, so a core owns at
-        // most one float at a time; position 0 maps to the group's injector.
-        // Identical to the previous row-indexed form when groups are rows in column order, which
-        // is what configure_row_wide_chain_mcast always produces -- latent-V output is unchanged.
+        // Put the first remainder on the injector so it never runs padded slots.
+        // Rotate groups each iteration; each core owns at most one remainder.
         auto float_owner = [&](uint32_t ring_iter, uint32_t float_idx) {
             const uint32_t group_idx = ((ring_iter * groups_needed) + (float_idx / rotated_group_size)) % num_groups;
             const auto& group = rotated_groups[group_idx];
@@ -2560,48 +2515,36 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
                 }
             }
         }
-        // owner_of[ring_iter][float_idx]: which core holds float `float_idx` on that iteration.
-        // Materialized because the loop below needs each float's owner in the previous and next
-        // iterations as well as this one, and re-evaluating float_owner four times per (iter, float)
-        // is what made this schedule hard to check.
-        std::vector<std::vector<uint32_t>> owner_of(ring_size, std::vector<uint32_t>(rotated_float_chunks));
         for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
             for (uint32_t float_idx = 0; float_idx < rotated_float_chunks; ++float_idx) {
-                owner_of[ring_iter][float_idx] = float_owner(ring_iter, float_idx);
-            }
-        }
-        for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
-            for (uint32_t float_idx = 0; float_idx < rotated_float_chunks; ++float_idx) {
-                const uint32_t owner = owner_of[ring_iter][float_idx];
+                const uint32_t owner = float_owner(ring_iter, float_idx);
                 auto& sched = rotated_sched[owner][ring_iter];
                 sched.my_chunks.push_back(rotated_base_chunks * num_cores + float_idx);
                 // (row, pos) is unique per float within an iteration, so a core holds at most one
                 // float and these two fields are assigned at most once each.
                 TT_ASSERT(sched.my_chunks.size() == rotated_base_chunks + 1);
-                sched.float_migrated_in = (ring_iter > 0 && owner_of[ring_iter - 1][float_idx] != owner) ? 1 : 0;
-                if (ring_iter + 1 < ring_size) {
-                    const uint32_t next_owner = owner_of[ring_iter + 1][float_idx];
-                    if (next_owner != owner) {
-                        const auto& dest_phys = core_work[next_owner].physical_core;
-                        // rotated_pack_dest packs y into the low 8 bits; a wider coord would alias
-                        // silently into x and signal the wrong core's handoff semaphore.
+                if (ring_iter > 0) {
+                    const uint32_t previous_owner = float_owner(ring_iter - 1, float_idx);
+                    if (previous_owner != owner) {
+                        // Record both ends of this handoff together.
+                        const auto& dest_phys = core_work[owner].physical_core;
                         TT_FATAL(
                             dest_phys.y < 256 && dest_phys.x < (1u << 24),
                             "Rotated Q split cannot pack physical core ({}, {}) into a handoff dest",
                             dest_phys.x,
                             dest_phys.y);
-                        sched.float_dest = rotated_pack_dest(dest_phys.x, dest_phys.y);
+                        sched.float_migrated_in = 1;
+                        rotated_sched[previous_owner][ring_iter - 1].float_dest =
+                            rotated_pack_dest(dest_phys.x, dest_phys.y);
                     }
                 }
             }
             // Every core in a group runs the group's max slot count, so padded members still relay
             // the mcast handshakes.
             for (const auto& group : rotated_groups) {
-                uint32_t group_max = 0;
-                for (const uint32_t ci : group.members) {
-                    group_max =
-                        std::max(group_max, static_cast<uint32_t>(rotated_sched[ci][ring_iter].my_chunks.size()));
-                }
+                // The injector owns the first remainder, so its count is the group maximum.
+                const uint32_t group_max =
+                    static_cast<uint32_t>(rotated_sched[group.members[group.injector_pos]][ring_iter].my_chunks.size());
                 for (const uint32_t ci : group.members) {
                     rotated_sched[ci][ring_iter].group_slot_count = group_max;
                 }
@@ -2616,31 +2559,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             }
         }
 
-        // Separate-V: the V head chain's per-(head, core) forwarding counts come from
-        // head_work/head_segments, which were derived from the STATIC flat split. Under rotation
-        // each core instead owns the contiguous base range [i*base, (i+1)*base) on every
-        // iteration, so rebuild both from that. Floats are deliberately NOT added: they are the
-        // tail flat ids and, by the head-boundary term in the predicate, live only in heads with
-        // no base chunks -- heads whose chain is therefore never built (segs.size() < 2), so the
-        // reader's `nq != chain_head` fallback reads their V from DRAM.
-        // Only the head chain, built below, sees this rebuilt version. The K chain was built above
-        // from the static head_work, but on this path that is moot rather than merely satisfied:
-        // the rotation requires a live row-wide mcast family, and configure_row_wide_chain_mcast
-        // rewrites every field of every batch_chain_configs entry, so the linear K chain built
-        // earlier is discarded wholesale before any of it is used.
-        //
-        // RECOVERED from 6c319e724e9. It was still present when separate-V rotation was gated out
-        // (409d944b14d removed only the predicate), became unreachable at that point, and was then
-        // dropped as dead code by the squash. Re-enabling the predicate WITHOUT it deadlocks the V
-        // relay -- the head chain forwards against the static split while the rotation ships a
-        // different one. Verified: that is exactly the hang seen before this was restored.
-        // GUARD IS use_head_chain, NOT !v_shares_k_buffer as in the original 6c319e724e9. Back then
-        // the predicate's separate-V disjunct implied use_head_chain, so the two agreed. This
-        // predicate also admits GQA, where !v_shares_k_buffer holds but use_head_chain is FALSE and
-        // head_segments is therefore sized 0 -- the TT_FATAL below would fire on the first chunk.
-        // use_head_chain is also the precise condition on its own terms: this block exists to make
-        // the V HEAD CHAIN describe the rotated split, so with no head chain there is nothing to
-        // rebuild, and core_work.head_work must be left alone for the GQA grouped chains that read it.
+        // Rebuild separate-V chains from fixed base ranges. The head-boundary guard
+        // keeps remainder heads out of these chains; their V reads go directly to DRAM.
+        // GQA must retain its original head_work for the grouped K/V chains.
         if (use_head_chain) {
             for (auto& work : core_work) {
                 work.head_work.clear();
@@ -2649,34 +2570,11 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
                 segs.clear();
             }
             for (uint32_t i = 0; i < num_cores; ++i) {
-                auto& work = core_work.at(i);
-                uint32_t flat_chunk = i * rotated_base_chunks;
-                uint32_t remaining = rotated_base_chunks;
-                while (remaining > 0) {
-                    const auto [head_idx, q_chunk_idx] = decode_flat_chunk(flat_chunk);
-                    const uint32_t take = std::min(remaining, num_q_chunks - q_chunk_idx);
-                    work.head_work.push_back(CoreHeadWork{.head = head_idx, .q_chunk_count = take});
-                    TT_FATAL(
-                        head_idx < head_segments.size(),
-                        "Rotated head-chain segment index {} is outside {} configured query heads",
-                        head_idx,
-                        head_segments.size());
-                    head_segments[head_idx].push_back(HeadSegmentRef{
-                        .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
-                    remaining -= take;
-                    flat_chunk += take;
-                }
+                append_head_work(i, i * rotated_base_chunks, rotated_base_chunks);
             }
         }
-        // Handoff semaphores for the iterations that can RECEIVE a migrated float (1..ring_size-1;
-        // iteration 0 starts fresh). Receiver resets its slot to 0 after the wait so a cached
-        // program replays cleanly. Slots are REUSED across iterations as a ring of
-        // kRotatedHandoffSemDepth (see rotated_handoff_sem_count) rather than one per iteration: program
-        // semaphores are a scarce resource (NUM_SEMAPHORES=16, shared with the chain and fused
-        // all-gather sems), and one-per-iteration made this feature the largest single consumer
-        // (7 of 16 at ring-8) and scaled with ring length. With the V head chain skipped for
-        // latent-V, ring-8 now fits comfortably and the count no longer grows with ring_size; the
-        // TT_FATAL below keeps that true rather than leaving it to this comment.
+        // Reuse a bounded ring of handoff semaphores; receivers reset their slots
+        // after waiting, including across cached program replays.
         for (uint32_t sem_slot = 0; sem_slot < rotated_handoff_sem_count(ring_size); ++sem_slot) {
             const uint32_t sem_id = static_cast<uint32_t>(desc.semaphores.size());
             // The descriptor path has no budget check of its own: an id >= NUM_SEMAPHORES surfaces

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -16,7 +16,6 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <map>
 #include <optional>
 #include <cmath>
@@ -2458,20 +2457,14 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // rotated_groups_needed == rotated_groups.size() ownership never actually moves.
     const uint32_t rotated_groups_needed =
         rotated_group_size ? tt::div_up(rotated_float_chunks, rotated_group_size) : 0;
-    // Separate-V rotation is opt-in because it regressed performance on some configurations.
-    static const bool rotate_head_chain_opt_in = []() {
-        const char* value = std::getenv("RING_MLA_ROTATE_SEPARATE_V");
-        return value != nullptr && value[0] != '\0' && std::string_view(value) != "0";
-    }();
     // Active-iteration indexing handles partial masks and KV padding. No remainder
     // or no change in ownership needs no special exclusion.
     const bool use_rotated_q_split =
-        // Valid groups are full multicast rows with Q work, implying num_q_chunks > 0.
+        // Valid groups are full multicast rows with Q work.
         // build_kv_chains requires B == 1 so a row cannot mix batches' K/V data.
         !rotated_groups.empty() && build_kv_chains &&
-        // Separate-V rebuilds its V chains from base work. Keep the remainder on
-        // separate heads to avoid unmatched receives from those chains.
-        (!use_head_chain || (rotate_head_chain_opt_in && (rotated_base_chunks * num_cores) % num_q_chunks == 0)) &&
+        // Separate-V head chains use static forwarding counts and cannot follow migrated chunks.
+        !use_head_chain &&
         // Only streaming compute consumes rotated IDs. Sink paths remain excluded;
         // balanced allocation and per-Q skips are incompatible with this schedule.
         use_streaming_compute && !use_attention_sink && !args.is_balanced &&
@@ -2559,20 +2552,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             }
         }
 
-        // Rebuild separate-V chains from fixed base ranges. The head-boundary guard
-        // keeps remainder heads out of these chains; their V reads go directly to DRAM.
-        // GQA must retain its original head_work for the grouped K/V chains.
-        if (use_head_chain) {
-            for (auto& work : core_work) {
-                work.head_work.clear();
-            }
-            for (auto& segs : head_segments) {
-                segs.clear();
-            }
-            for (uint32_t i = 0; i < num_cores; ++i) {
-                append_head_work(i, i * rotated_base_chunks, rotated_base_chunks);
-            }
-        }
         // Reuse a bounded ring of handoff semaphores; receivers reset their slots
         // after waiting, including across cached program replays.
         for (uint32_t sem_slot = 0; sem_slot < rotated_handoff_sem_count(ring_size); ++sem_slot) {
@@ -2669,12 +2648,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const std::array<size_t, 3> ct_arg_sizes_with_rotated_last = {
         reader_compile_time_args.size(), writer_compile_time_args.size(), compute_compile_time_args.size()};
 
-    // Head chains (MHA and separate-V shared-K) are built HERE, after the rotated-Q-split
-    // decision, because their per-(head, core) forwarding counts must describe whichever Q split
-    // actually ships. Moved down from above the K-chain pass; verified behaviour-neutral -- nothing
-    // between the old and new positions reads head_chain_configs or mcast_chains, and the K chain's
-    // own build_linear_chain call still sees the STATIC head_work it needs for its injector rule.
-    // Build head chains for MHA and separate-V shared-K. GQA uses KV-head-grouped chains instead.
+    // Build static MHA/shared-K V head chains. GQA uses KV-head-grouped chains instead.
     if (use_head_chain && build_kv_chains) {
         for (uint32_t head_id = 0; head_id < static_cast<uint32_t>(head_segments.size()); ++head_id) {
             const auto& segs = head_segments[head_id];


### PR DESCRIPTION
Uneven Q work leaves some multicast rows processing an extra chunk on every ring iteration. This change rotates those remainder chunks between rows, spreading the extra work across the ring.

The factory builds a shared per-iteration schedule for the reader, compute and writer kernels. Attention state stays indexed by Q chunk; semaphore handoffs ensure the previous owner finishes saving it before the next owner reads it. The factory records each handoff once.

### When it applies

- **Ring MLA**, including Kimi chunked prefill, and **single-KV-head GQA**, including Minimax3 shapes with enough Q work.
- Requires batch 1, streaming compute, unbalanced scheduling, row-wide K/V multicast, and at least one base Q chunk per core. Sliding windows and attention sinks remain excluded.
- Supports partial active ring masks and KV-padding/cache reuse by following executed ring iterations.
- Separate-V attention keeps the static split because rotation can regress its performance.

Other configurations retain the static split. The change also fixes a PACK-to-UNPACK synchronization issue affecting MLA q64.

### Results

QB GQA measurements and earlier 110-core MLA measurements:

| Case | Before | After | Speedup |
|---|---:|---:|---:|
| Minimax3 GQA q32/k512, QB, 100 cores, ring-4 | 1.919 ms | 1.572 ms | 1.22x |
| Kimi-K3 MLA q32/k640, 110 cores, ring-8 | 9.711 ms | 8.683 ms | 1.12x |
| Kimi-K3 MLA q64/k448, 110 cores, ring-8 | 11.351 ms | 8.687 ms | 1.31x |

Added GQA q32 accuracy and performance coverage with a 32.43% expected utilization and relative +/-1% band on QB. Updated Galaxy Kimi-K3 q32 expected utilization to the previously measured 68.04%.

QB validation covered GQA/MLA performance gates and targeted separate-V, dense, KV-padding and MHA checks. After removing the separate-V opt-in, the rebuild and all six focused validation tests passed. The factory cleanup produced identical schedules in 16,200 comparisons.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring-mla-work-split_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/ring-mla-work-split_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/ring-mla-work-split_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/ring-mla-work-split_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-mla-work-split_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/ring-mla-work-split_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/ring-mla-work-split_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/ring-mla-work-split_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/ring-mla-work-split_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/ring-mla-work-split_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/ring-mla-work-split_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/ring-mla-work-split_v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/ring-mla-work-split_v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/ring-mla-work-split_v2)
