### PR TITLE
[Cleanup] llk_io: hold the Tensix register address as an integer, not a pointer

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -45,9 +45,8 @@ inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num
     std::uint32_t output = operand;
 
     // Tensix uses 4B addresses (tiles_received_ptr byte address but div-by-4)
-    volatile tt_l1_ptr std::uint32_t* tiles_received_ptr_tensix =
-        (volatile tt_l1_ptr std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_received_ptr(operand)) >> 2) &
-                                            0x3ffff);
+    const std::uint32_t tiles_received_addr_tensix = static_cast<std::uint32_t>(
+        (reinterpret_cast<std::uintptr_t>(get_cb_tiles_received_ptr(operand)) >> 2) & 0x3ffff);
 
     // get_local_cb_interface(output).tiles_received is used only by the TRISC2 (the one driving packer)
     // we need it because tiles_received_ptr is updated by the packer, and in cb_reserve_back func (see above) we want
@@ -65,7 +64,7 @@ inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num
     // and it will eventually see the updated value
     TT_SETDMAREG(0, tiles_received_new, 0, LO_16(p_gpr_pack::NUM_MSGS_RECEIVED));
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);  // wait for pack to finish
-    TT_STOREREG(p_gpr_pack::NUM_MSGS_RECEIVED, (uint32_t)&tiles_received_ptr_tensix[0]);
+    TT_STOREREG(p_gpr_pack::NUM_MSGS_RECEIVED, tiles_received_addr_tensix);
 }
 
 // Push N tiles to stream buffer (increment write pointer)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -44,7 +44,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {
     std::uint32_t output = operand;
 
-    // Tensix uses 4B addresses (tiles_received_ptr byte address but div-by-4)
+    // Convert the counter's byte address to a Tensix 4-byte word address, masked to 18 bits.
     const std::uint32_t tiles_received_addr_tensix = static_cast<std::uint32_t>(
         (reinterpret_cast<std::uintptr_t>(get_cb_tiles_received_ptr(operand)) >> 2) & 0x3ffff);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -36,14 +36,15 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
-        (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
+    // Tensix uses 4B addresses (tiles_acked_ptr byte address but div-by-4)
+    const std::uint32_t tiles_acked_addr_tensix =
+        static_cast<std::uint32_t>((reinterpret_cast<std::uintptr_t>(get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
 
     get_local_cb_interface(input).tiles_acked += num_tiles;
     TT_SETDMAREG(0, get_local_cb_interface(input).tiles_acked, 0, LO_16(4));
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
+    TT_STOREREG(4, tiles_acked_addr_tensix);
     auto& cb = get_local_cb_interface(input);
 
     LLK_ASSERT(cb.fifo_rd_ptr < cb.fifo_limit, "CB pop_front: fifo_rd_ptr already at or past fifo_limit");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -36,7 +36,7 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    // Tensix uses 4B addresses (tiles_acked_ptr byte address but div-by-4)
+    // Convert the counter's byte address to a Tensix 4-byte word address, masked to 18 bits.
     const std::uint32_t tiles_acked_addr_tensix =
         static_cast<std::uint32_t>((reinterpret_cast<std::uintptr_t>(get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -44,9 +44,8 @@ inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num
     std::uint32_t output = operand;
 
     // Tensix uses 4B addresses (tiles_received_ptr byte address but div-by-4)
-    volatile tt_l1_ptr std::uint32_t* tiles_received_ptr_tensix =
-        (volatile tt_l1_ptr std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_received_ptr(operand)) >> 2) &
-                                            0x3ffff);
+    const std::uint32_t tiles_received_addr_tensix = static_cast<std::uint32_t>(
+        (reinterpret_cast<std::uintptr_t>(get_cb_tiles_received_ptr(operand)) >> 2) & 0x3ffff);
 
     // get_local_cb_interface(output).tiles_received is used only by the TRISC2 (the one driving packer)
     // we need it because tiles_received_ptr is updated by the packer, and in cb_reserve_back func (see above) we want
@@ -64,7 +63,7 @@ inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num
     // and it will eventually see the updated value
     TT_SETDMAREG(0, tiles_received_new, 0, LO_16(p_gpr_pack::NUM_MSGS_RECEIVED));
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);  // wait for pack to finish
-    TT_STOREREG(p_gpr_pack::NUM_MSGS_RECEIVED, (uint32_t)&tiles_received_ptr_tensix[0]);
+    TT_STOREREG(p_gpr_pack::NUM_MSGS_RECEIVED, tiles_received_addr_tensix);
 }
 
 // Push N tiles to stream buffer (increment write pointer)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -43,7 +43,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {
     std::uint32_t output = operand;
 
-    // Tensix uses 4B addresses (tiles_received_ptr byte address but div-by-4)
+    // Convert the counter's byte address to a Tensix 4-byte word address, masked to 18 bits.
     const std::uint32_t tiles_received_addr_tensix = static_cast<std::uint32_t>(
         (reinterpret_cast<std::uintptr_t>(get_cb_tiles_received_ptr(operand)) >> 2) & 0x3ffff);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -87,14 +87,15 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
-        (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
+    // Tensix uses 4B addresses (tiles_acked_ptr byte address but div-by-4)
+    const std::uint32_t tiles_acked_addr_tensix =
+        static_cast<std::uint32_t>((reinterpret_cast<std::uintptr_t>(get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
 
     get_local_cb_interface(input).tiles_acked += num_tiles;
     TT_SETDMAREG(0, get_local_cb_interface(input).tiles_acked, 0, LO_16(4));
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
+    TT_STOREREG(4, tiles_acked_addr_tensix);
     auto& cb = get_local_cb_interface(input);
 
     LLK_ASSERT(cb.fifo_rd_ptr < cb.fifo_limit, "CB pop_front: fifo_rd_ptr already at or past fifo_limit");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -87,7 +87,7 @@ inline void llk_pop_tiles(
     const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t block_c_dim = 0) {
     std::uint32_t input = operand;
 
-    // Tensix uses 4B addresses (tiles_acked_ptr byte address but div-by-4)
+    // Convert the counter's byte address to a Tensix 4-byte word address, masked to 18 bits.
     const std::uint32_t tiles_acked_addr_tensix =
         static_cast<std::uint32_t>((reinterpret_cast<std::uintptr_t>(get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
     std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

clang-tidy's `performance-no-int-to-ptr` flagged four sites in `llk_io_pack.h` / `llk_io_unpack.h`. Reading them, the cast turned out to be a symptom of something more worth fixing: a variable whose declared type does not describe what it holds.

`llk_pop_tiles` and `llk_push_to_brisc` need a **Tensix register address** — the circular-buffer counter's L1 byte address divided by four and masked to 18 bits, because Tensix instructions address memory in 4-byte words. That value is not a pointer and must never be dereferenced. It was nonetheless stored in one:

```cpp
volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr =
    (volatile std::uint32_t*)((((volatile std::uint32_t)get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
...
TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
```

The pointer is never dereferenced, and its single use converts it straight back to an integer. Giving the value its real type removes four separate pieces of misdirection:

- a cast to a pointer type that is never used as a pointer;
- `&ptr[0]`, which reads as taking the address of an array element but merely recovers the pointer value — and which would silently change meaning if the element type were ever changed;
- `volatile` applied to a *value* cast, where it has no effect;
- the `tt_reg_ptr` / `tt_l1_ptr` address-space attributes on something that never accesses memory.

```cpp
// Tensix uses 4B addresses (tiles_acked_ptr byte address but div-by-4)
const std::uint32_t tiles_acked_addr_tensix = static_cast<std::uint32_t>(
    (reinterpret_cast<std::uintptr_t>(get_cb_tiles_acked_ptr(operand)) >> 2) & 0x3ffff);
...
TT_STOREREG(4, tiles_acked_addr_tensix);
```

**This makes no performance claim.** It is a readability and static-analysis cleanup. The arithmetic is unchanged, the same `uint32_t` reaches `TT_STOREREG`, and no memory access is added or removed.

`reinterpret_cast<std::uintptr_t>` matches the idiom already used for this conversion in `tt_metal/hw/inc/api/dataflow/cross_node_dfb.h`.

### Notes for reviewers

- **Four sites**, in `llk_io_unpack.h` and `llk_io_pack.h` under both `wormhole_b0` and `blackhole`. Only wormhole was flagged, because that is what the analysis runs on; blackhole carries byte-identical code and is changed alongside it so the two do not drift.
- **Equivalence does not depend on pointer width.** `& 0x3ffff` confines the result to bits 2–19, so the truncation the old `(uint32_t)` cast performed on the pointer is not observable. I verified old and new produce identical values across the operand range and under a bit-pattern sweep of synthetic addresses.
- **One deliberate non-change.** `llk_io_pack.h` has a second, unrelated `tiles_acked_ptr` in `llk_wait_for_free_tiles` that is a genuine pointer, assigned directly from the getter and actually dereferenced. It is untouched.
- The two `unpack` files gain the explanatory comment the `pack` files already carried; previously the `>> 2` was unexplained on the unpack side.
- I have **not** run this on hardware — it relies on CI. The change is confined to these four expressions and is format-clean under the pinned clang-format 19.1.4.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk-io-drop-pointer-typed-register-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk-io-drop-pointer-typed-register-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk-io-drop-pointer-typed-register-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk-io-drop-pointer-typed-register-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk-io-drop-pointer-typed-register-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk-io-drop-pointer-typed-register-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk-io-drop-pointer-typed-register-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk-io-drop-pointer-typed-register-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk-io-drop-pointer-typed-register-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk-io-drop-pointer-typed-register-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk-io-drop-pointer-typed-register-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk-io-drop-pointer-typed-register-address)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk-io-drop-pointer-typed-register-address)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk-io-drop-pointer-typed-register-address)