### PR TITLE
[Cleanup] batch_norm: reach compute unpack_modes via the arch-agnostic accessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -465,6 +465,10 @@ ttnn::device_operation::ProgramArtifacts BatchNormOperation::BatchNormFactory::c
         // Re-key of the legacy unpack_to_dest_mode vector, which was indexed by CB id. Every DFB the
         // compute kernel consumes is listed; the writer-facing output is producer-only, so it gets no
         // entry. An omitted DFB keeps the UnpackToSrc default.
+        // Reach unpack_modes through the generation-neutral accessor rather than
+        // std::get<ComputeGen1Config>: the helper above returns whichever alternative matches
+        // `arch`, so naming Gen1 here would throw std::bad_variant_access on Quasar. (The local is
+        // named dfb_unpack_modes so it does not shadow the accessor.)
         // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
         auto& dfb_unpack_modes = unpack_modes(compute_hw_config);
         for (const auto& dfb_name :

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -465,13 +465,14 @@ ttnn::device_operation::ProgramArtifacts BatchNormOperation::BatchNormFactory::c
         // Re-key of the legacy unpack_to_dest_mode vector, which was indexed by CB id. Every DFB the
         // compute kernel consumes is listed; the writer-facing output is producer-only, so it gets no
         // entry. An omitted DFB keeps the UnpackToSrc default.
-        auto& unpack_modes = std::get<ComputeGen1Config>(compute_hw_config).unpack_modes;
+        // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
+        auto& dfb_unpack_modes = unpack_modes(compute_hw_config);
         for (const auto& dfb_name :
              {INPUT_DFB, BATCH_MEAN_DFB, BATCH_VAR_DFB, EPS_DFB, DEN_DFB, WEIGHT_DFB, TEMP_1_DFB, BIAS_DFB}) {
-            unpack_modes[dfb_name] = UnpackMode::UnpackToDest;
+            dfb_unpack_modes[dfb_name] = UnpackMode::UnpackToDest;
         }
         if (needs_output_typecast) {
-            unpack_modes[OUT_DFB] = UnpackMode::UnpackToDest;
+            dfb_unpack_modes[OUT_DFB] = UnpackMode::UnpackToDest;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -521,7 +521,8 @@ ttnn::device_operation::ProgramArtifacts RunningStatistics::RunningStatisticsPro
         // Re-key of the legacy unpack_to_dest_mode vector, which was indexed by CB id. The
         // writer-facing stat buffers are producer-only for this kernel, so they get no entry. An
         // omitted DFB keeps the UnpackToSrc default.
-        auto& unpack_modes = std::get<ComputeGen1Config>(compute_hw_config).unpack_modes;
+        // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
+        auto& dfb_unpack_modes = unpack_modes(compute_hw_config);
         for (const auto& dfb_name :
              {BATCH_MEAN_DFB,
               BATCH_VAR_DFB,
@@ -535,7 +536,7 @@ ttnn::device_operation::ProgramArtifacts RunningStatistics::RunningStatisticsPro
               TMP1_DFB,
               TMP2_DFB,
               TMP3_DFB}) {
-            unpack_modes[dfb_name] = UnpackMode::UnpackToDest;
+            dfb_unpack_modes[dfb_name] = UnpackMode::UnpackToDest;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -521,6 +521,10 @@ ttnn::device_operation::ProgramArtifacts RunningStatistics::RunningStatisticsPro
         // Re-key of the legacy unpack_to_dest_mode vector, which was indexed by CB id. The
         // writer-facing stat buffers are producer-only for this kernel, so they get no entry. An
         // omitted DFB keeps the UnpackToSrc default.
+        // Reach unpack_modes through the generation-neutral accessor rather than
+        // std::get<ComputeGen1Config>: the helper above returns whichever alternative matches
+        // `arch`, so naming Gen1 here would throw std::bad_variant_access on Quasar. (The local is
+        // named dfb_unpack_modes so it does not shadow the accessor.)
         // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
         auto& dfb_unpack_modes = unpack_modes(compute_hw_config);
         for (const auto& dfb_name :


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/55735

### Summary

Post-port `gen2_hardware_configs` pass on an already-Metal-2.0-ported op. Both `batch_norm` factories reached `unpack_modes` through `std::get<ComputeGen1Config>` on the variant returned by the arch-agnostic `to_compute_hardware_config` — which returns the Gen2 alternative on Quasar, so the `std::get` throws `std::bad_variant_access` there. Replaced with the common-field accessor `unpack_modes(config)`, which resolves whichever alternative the helper chose; no `arch` branch needed.

Nothing changes on Wormhole/Blackhole. On Quasar the old `std::get` throws outright rather than
misbehaving quietly, so it is latent only in the sense that no supported target reaches that path
today. What is deferred is the Quasar *values* (#52269), not the access path.

### Notes for reviewers

- **Gen1 is bit-identical.** Normalizing away the accessor call and the local's name, both files differ from their pre-change versions *only* by the added `TODO` comment — the DFB entry sets are untouched (same names, order, `UnpackToDest`).
- **The `unpack_modes` → `dfb_unpack_modes` rename is forced**, not cosmetic: the old local shadowed the accessor. The spelling matches the idiom documented in `compute_hardware_config.hpp`.
- **Gen1 sentinels green and unchanged** — 1588 passed / 786 xfailed, identical before and after. Nothing here exercises the Gen2 *values*; that branch never runs on a WH/BH bench.

Follow-up: #52269 — the `TODO` in both files points there.
https://github.com/tenstorrent/tt-metal/pull/51974 - BN Porting PR

---

### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Test
- [x] Nightly for fused, DM

---

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/norm_post)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/norm_post)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/norm_post)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/norm_post)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/norm_post)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/norm_post)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/norm_post)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/norm_post)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/norm_post)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/norm_post)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/norm_post)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/norm_post)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/norm_post)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/norm_post)

