### PR TITLE
[Bug Fix] Metal 2.0 program cache: binding aliased tensor arguments on a cache hit

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Program-cache keying tests for ttnn.batch_norm(training=True).
+Program-cache tests driven through ttnn.batch_norm.
 
-In training mode batch_norm drives the RunningStatistics device op, which updates
-running_mean/running_var in place. These tests pin two invariants the suite must uphold:
+The training-mode tests pin two invariants of the RunningStatistics device op, which
+batch_norm(training=True) drives and which updates running_mean/running_var in place:
 
   * Cache-key granularity of RunningStatistics. Runs that share its program key (same
     per-channel tensor specs, momentum, and optional-stat presence) must reuse a cached
@@ -20,6 +20,9 @@ running_mean/running_var in place. These tests pin two invariants the suite must
 
 The RunningStatistics device op has no direct Python binding, so it is exercised through
 ttnn.batch_norm(training=True), which is its only public entry point.
+
+The eval-mode test at the end pins a framework invariant instead: a cache hit must rebind every
+tensor parameter to the tensor the current call passed, even if an earlier call aliased two of them.
 """
 
 import pytest
@@ -198,3 +201,75 @@ def test_bn_cache_optional_stat_presence(device, isolate_program_cache):
     assert n_neither == n_var_only  # no running_statistics dispatch -> no new entry
     _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=False, seed=7)
     assert device.cache_entries_counter.total == n_neither  # still no growth
+
+
+def test_bn_cache_aliased_then_distinct_tensor_args(device, isolate_program_cache):
+    """Two tensor parameters aliased on one call must not collapse the cached bindings for a later
+    call that passes distinct tensors.
+
+    Eval-mode batch_norm computes (input - mean) / sqrt(var + eps), so with input=5, mean=1, var=4
+    the correct result is 2.0 and a collapsed binding gives (5 - 1) / sqrt(1) = 4.0.
+    """
+    channels = BASE_SHAPE[1]
+    eps = 0.0
+    input_tt = ttnn.from_torch(
+        torch.full(BASE_SHAPE, 5.0, dtype=torch.bfloat16), device=device, layout=ttnn.TILE_LAYOUT
+    )
+    mean_tt = _stat_tensor(1.0, channels, device)
+    var_tt = _stat_tensor(4.0, channels, device)
+
+    # mean and var are genuinely equal here, so 4.0 is correct for this call; the binding it leaves
+    # in the cache is what matters.
+    with device.cache_entries_counter.measure():
+        aliased = ttnn.batch_norm(input_tt, running_mean=mean_tt, running_var=mean_tt, training=False, eps=eps)
+    aliased_out = ttnn.to_torch(aliased)[0, 0, 0, 0].item()
+    assert aliased_out == pytest.approx(4.0, abs=0.05), f"aliased call is itself wrong: {aliased_out}"
+    entries_after_aliased = device.cache_entries_counter.total
+
+    # Distinct tensors, identical specs -> must reuse the entry above.
+    with device.cache_entries_counter.measure():
+        distinct = ttnn.batch_norm(input_tt, running_mean=mean_tt, running_var=var_tt, training=False, eps=eps)
+    assert (
+        device.cache_entries_counter.total == entries_after_aliased
+    ), "call 2 compiled a new program; the invariant is only exercised on a cache hit"
+
+    distinct_out = ttnn.to_torch(distinct)[0, 0, 0, 0].item()
+    assert distinct_out == pytest.approx(
+        2.0, abs=0.05
+    ), f"got {distinct_out}; 4.0 means running_var was rebound to the mean tensor"
+
+
+def test_bn_cache_alias_pattern_flips_both_ways(device, isolate_program_cache):
+    """One cache entry must serve alternating aliased and distinct stats, in both directions.
+
+    A hit whose io aliasing differs from the miss re-derives its tensor bindings from the factory;
+    a hit that aliases the same way replays the cached index map. Alternating exercises both, and
+    no repeat may compile a new program.
+    """
+    channels = BASE_SHAPE[1]
+    eps = 0.0
+    input_tt = ttnn.from_torch(
+        torch.full(BASE_SHAPE, 5.0, dtype=torch.bfloat16), device=device, layout=ttnn.TILE_LAYOUT
+    )
+    mean_tt = _stat_tensor(1.0, channels, device)
+    var_tt = _stat_tensor(4.0, channels, device)
+
+    def run(var):
+        with device.cache_entries_counter.measure():
+            out = ttnn.batch_norm(input_tt, running_mean=mean_tt, running_var=var, training=False, eps=eps)
+        return ttnn.to_torch(out)[0, 0, 0, 0].item()
+
+    # (running_var tensor, expected result): aliased pairs mean with itself -> sqrt(1); distinct
+    # pairs it with var=4 -> sqrt(4).
+    sequence = [(mean_tt, 4.0), (var_tt, 2.0), (mean_tt, 4.0), (var_tt, 2.0), (var_tt, 2.0)]
+
+    entries_after_first = None
+    for step, (var, expected) in enumerate(sequence):
+        got = run(var)
+        assert got == pytest.approx(expected, abs=0.05), f"step {step}: got {got}, expected {expected}"
+        if entries_after_first is None:
+            entries_after_first = device.cache_entries_counter.total
+        else:
+            assert (
+                device.cache_entries_counter.total == entries_after_first
+            ), f"step {step} compiled a new program instead of reusing the cached one"

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -790,7 +790,9 @@ public:
     // stored indices, and applies via experimental::UpdateTensorArgs — no Program
     // rebuild. Op-owned tensors are re-patched even though their address is
     // unchanged, because UpdateTensorArgs is currently all-or-nothing; this
-    // stepping-stone concept accepts that redundancy.
+    // stepping-stone concept accepts that redundancy. A hit whose io aliasing
+    // differs from the miss re-derives tensor args from the factory instead,
+    // since the stored indices cannot place aliased parameters.
     //
     // Contract: every TensorArgument returned by the factory must reference a
     // MeshTensor reachable from tensor_args / tensor_return_value, or one of the
@@ -817,6 +819,8 @@ public:
             // outlive the cache miss and every program on the occupied ranges can reference them.
             // Shared ownership keeps the device allocation alive for the life of the cache entry.
             std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
+            // The io aliasing the bindings above were resolved under; see io_alias_signature.
+            std::vector<std::size_t> io_alias_signature;
         };
 
         // Cache-hit tensor refresh, shared so the two adapters' hit paths cannot drift apart.
@@ -882,6 +886,11 @@ public:
         // Match each TensorArgument's MeshTensor reference back to its index in the combined
         // enumeration (io tensors followed by op-owned tensors). Cache-miss path only.
         //
+        // Two TensorArguments referencing the same MeshTensor both resolve to its first
+        // occurrence, which loses which io tensor each one meant. Pointer identity cannot recover
+        // it, so the index map is only replayed on a hit whose io aliasing matches the miss (see
+        // io_alias_signature); otherwise the caller re-derives from the factory.
+        //
         // NOTE on host perf: the index-based binding scheme is what makes a fast cache-hit path
         // possible, but the current straightforward implementation isn't there yet -- the
         // enumeration returns a heap std::vector, and apply_descriptor builds a fresh
@@ -907,6 +916,40 @@ public:
                     {tensor_parameter_name, static_cast<std::size_t>(std::distance(mesh_tensors.begin(), it))});
             }
             return bindings;
+        }
+
+        // Which io slots hold the same MeshTensor: entry i is the index of the first slot holding
+        // slot i's tensor, so a slot with a tensor of its own maps to itself. Two calls with equal
+        // signatures bind identically under a shared index map, even where that map collapsed
+        // aliased parameters onto one slot; unequal signatures make the stored map unusable.
+        // Only io tensors are tracked, since op-owned aliasing is the factory's own and is
+        // reproduced identically on every call.
+        static std::vector<std::size_t> io_alias_signature(
+            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& io_mesh_tensors) {
+            std::vector<std::size_t> signature(io_mesh_tensors.size());
+            for (std::size_t i = 0; i < io_mesh_tensors.size(); ++i) {
+                signature[i] = i;
+                for (std::size_t j = 0; j < i; ++j) {
+                    if (&io_mesh_tensors[j].get() == &io_mesh_tensors[i].get()) {
+                        signature[i] = j;
+                        break;
+                    }
+                }
+            }
+            return signature;
+        }
+
+        // True when every cached entry was resolved under this call's io aliasing, so the stored
+        // index maps can be replayed.
+        template <typename CachedWorkload>
+        static bool bindings_replayable(
+            const CachedWorkload& cached_workload,
+            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& io_mesh_tensors) {
+            const auto signature = io_alias_signature(io_mesh_tensors);
+            return std::all_of(
+                cached_workload.shared_variables.begin(),
+                cached_workload.shared_variables.end(),
+                [&signature](const auto& entry) { return entry.second.io_alias_signature == signature; });
         }
     };
 
@@ -946,7 +989,8 @@ public:
             return shared_variables_t{
                 .bindings = SpecBindingSupport::resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors),
                 .op_owned_tensors =
-                    std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors))};
+                    std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors)),
+                .io_alias_signature = SpecBindingSupport::io_alias_signature(io_mesh_tensors)};
         }
 
         static auto create_mesh_workload(
@@ -993,10 +1037,33 @@ public:
         // dispatcher's historical naming, not a reference to ProgramDescriptor.
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& /*attrs*/,
+            const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            SpecBindingSupport::refresh_tensor_args(cached_workload, tensor_args, tensor_return_value);
+            const auto io_mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
+            if (SpecBindingSupport::bindings_replayable(cached_workload, io_mesh_tensors)) {
+                SpecBindingSupport::refresh_tensor_args(cached_workload, tensor_args, tensor_return_value);
+                return;
+            }
+
+            // This call aliases its io tensors differently than the cached entry was built with
+            // (e.g. batch_norm(x, mean=t, var=t) cached, now called with distinct stats), so the
+            // stored index map cannot say which tensor each parameter wants. Re-derive from the
+            // factory, whose TensorArguments name this call's tensors directly -- the slow path the
+            // legacy ProgramDescriptor lane takes for the same case. Only the tensor bindings are
+            // applied; the rebuilt spec is discarded, since the cached programs already match it.
+            auto artifacts = SpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+            // A vector move preserves element addresses, so the run_params references stay valid.
+            // Parking replaces the previously cached op-owned tensors, whose device allocation the
+            // rebuilt bindings no longer point at.
+            auto op_owned_tensors =
+                std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                tt::tt_metal::experimental::UpdateTensorArgs(
+                    program, artifacts.run_params.tensor_args, skip_validation);
+                cached_workload.shared_variables.at(coordinate_range).op_owned_tensors = op_owned_tensors;
+            }
         }
     };
 
@@ -1104,7 +1171,8 @@ public:
                     per_coord.range,
                     shared_variables_t{
                         .bindings =
-                            SpecBindingSupport::resolve_bindings(per_coord.run_params.tensor_args, mesh_tensors)});
+                            SpecBindingSupport::resolve_bindings(per_coord.run_params.tensor_args, mesh_tensors),
+                        .io_alias_signature = SpecBindingSupport::io_alias_signature(mesh_tensors)});
                 run_params.emplace(per_coord.range, std::move(per_coord.run_params));
             }
 
@@ -1128,6 +1196,15 @@ public:
                     tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args, skip_validation);
                 }
             } else {
+                const auto io_mesh_tensors = SpecBindingSupport::collect_mesh_tensors(tensor_args, tensor_return_value);
+                // Unlike the SPMD adapter, this one cannot re-derive on a mismatch: rebuilding
+                // needs the tensor_coords that only the miss path receives. Refuse loudly rather
+                // than replay an index map that cannot place this call's aliased tensors.
+                TT_FATAL(
+                    SpecBindingSupport::bindings_replayable(cached_workload, io_mesh_tensors),
+                    "This call aliases its io tensors differently than the cached programs were built with. A "
+                    "MeshWorkloadSpecFactory cannot rebind that on a cache hit; declare "
+                    "override_runtime_arguments so the factory supplies this call's tensor arguments");
                 SpecBindingSupport::refresh_tensor_args(cached_workload, tensor_args, tensor_return_value);
             }
         }


### PR DESCRIPTION
### Problem

Closes #55605.

`ProgramSpecMeshWorkloadFactoryAdapter::resolve_bindings` resolved each of a factory's `TensorParameter`s to an io-tensor index by first-match pointer lookup. If a caller passed the same tensor for two of an op's tensor parameters, both collapsed onto the first matching slot. A tensor's program hash covers only storage type and spec, so a later call with distinct but same-spec tensors hit that cache entry and replayed the collapsed index map — silently feeding the first tensor to both parameters.

Using `batch_norm` (`input`, `batch_mean`, `batch_var`):

| | slot 0 | slot 1 | slot 2 |
|---|---|---|---|
| enumeration | `input` | `batch_mean` | `batch_var` |
| **Call 1** `mean=t, var=t` (miss) | x | t | t |
| stored bindings | `INPUT→0` | `BATCH_MEAN→1` | `BATCH_VAR→1` ← collapsed |
| **Call 2** `mean=m, var=v` (hit) | x | m | v |
| replayed on hit | `INPUT=x` | `BATCH_MEAN=m` | `BATCH_VAR=m` ← wrong |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fix-spec-adapter-tensor-aliasing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fix-spec-adapter-tensor-aliasing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fix-spec-adapter-tensor-aliasing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fix-spec-adapter-tensor-aliasing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fix-spec-adapter-tensor-aliasing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fix-spec-adapter-tensor-aliasing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fix-spec-adapter-tensor-aliasing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fix-spec-adapter-tensor-aliasing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fix-spec-adapter-tensor-aliasing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fix-spec-adapter-tensor-aliasing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fix-spec-adapter-tensor-aliasing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fix-spec-adapter-tensor-aliasing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fix-spec-adapter-tensor-aliasing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fix-spec-adapter-tensor-aliasing)