### PR TITLE
[Bug fix] Honour memory_config in quasar outer

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_outer.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_outer.py
@@ -123,17 +123,45 @@ def test_outer_row_major_layout(a_shape, b_shape, dtype, device):
 # block-float dtype with a working code path through reshape.
 
 
-def test_outer_default_memory_config(device):
-    # Smoke test: ttnn.outer(a, b) with no memory_config kwarg uses the default.
+@pytest.mark.parametrize(
+    "requested_memcfg, expected_memcfg",
+    (
+        (ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+        (ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        (None, ttnn.DRAM_MEMORY_CONFIG),
+    ),
+    ids=["explicit_DRAM", "explicit_L1", "unset_defaults_to_DRAM"],
+)
+def test_outer_honours_memory_config(device, requested_memcfg, expected_memcfg):
+    """outer must return in the requested memory config.
+
+    The other tests in this file pass an explicit config but assert only shape and
+    values, so they still pass if the placement argument is dropped on the way to
+    matmul. Both inputs are placed in L1 and DRAM is requested, so the requested and
+    inherited configs differ; with matching configs this cannot discriminate.
+
+    The unset case expects DRAM, not the input's L1: `outer` dispatches to `matmul`,
+    whose default is DRAM, unlike the eltwise ops that inherit their input's config.
+    That default is unchanged by threading the config, and is pinned here so the
+    difference from the eltwise convention is deliberate rather than assumed.
+
+    This pins the main path, which is the executable half of the contract. The quasar
+    copy of `outer` is the same function and cannot be exercised on this hardware.
+    """
     torch.manual_seed(0)
     a_pt = torch.rand([32], dtype=torch.bfloat16)
     b_pt = torch.rand([64], dtype=torch.bfloat16)
 
-    a_tt = ttnn.from_torch(a_pt, device=device, layout=ttnn.TILE_LAYOUT)
-    b_tt = ttnn.from_torch(b_pt, device=device, layout=ttnn.TILE_LAYOUT)
+    a_tt = ttnn.from_torch(a_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+    b_tt = ttnn.from_torch(b_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-    out_tt = ttnn.outer(a_tt, b_tt)
-    out_pt = _golden(a_pt, b_pt)
+    out_tt = (
+        ttnn.outer(a_tt, b_tt) if requested_memcfg is None else ttnn.outer(a_tt, b_tt, memory_config=requested_memcfg)
+    )
 
-    assert tuple(ttnn.to_torch(out_tt).shape) == tuple(out_pt.shape)
-    assert_with_pcc(out_pt, ttnn.to_torch(out_tt), pcc=0.9999)
+    assert (
+        out_tt.memory_config() == expected_memcfg
+    ), f"requested {requested_memcfg}: expected {expected_memcfg} but landed in {out_tt.memory_config()}"
+
+    # values must be unaffected by placement
+    assert_with_pcc(_golden(a_pt, b_pt), ttnn.to_torch(out_tt), pcc=_pcc_threshold(ttnn.bfloat16))

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -489,6 +489,8 @@ std::vector<std::optional<Tensor>> assign_bw(
     const std::optional<MemoryConfig>& /*output_mem_config*/,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<ttnn::Tensor>> grad_tensor_res = {std::nullopt};
+    // Passthrough gradient, see #53874: no eltwise backward op relocates it.
+    // With no preallocated input_grad, grad is returned and keeps its own config.
     grad_tensor_res[0] = input_grad.has_value() ? ttnn::assign(grad_tensor, input_grad.value()) : grad_tensor;
     return grad_tensor_res;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -23,6 +23,8 @@ std::vector<Tensor> addcmul_bw(
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     std::vector<Tensor> grad_tensor;
     grad_tensor.reserve(3);
+    // Passthrough gradient, see #53874: no eltwise backward op relocates it.
+    // output[0] keeps grad's own memory config rather than output_mem_config.
     grad_tensor.emplace_back(grad);
     Tensor grad_a = ttnn::multiply(
         ttnn::multiply(grad, tensor2, std::nullopt, output_mem_config), value, std::nullopt, output_mem_config);
@@ -43,9 +45,8 @@ std::vector<Tensor> addcdiv_bw(
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     std::vector<Tensor> grad_tensor;
     grad_tensor.reserve(3);
-    // grad is passed through unchanged, so output[0] keeps grad's memory config rather
-    // than output_mem_config. Intentional: no eltwise backward op relocates the
-    // passthrough gradient. See #53874.
+    // Passthrough gradient, see #53874: no eltwise backward op relocates it.
+    // output[0] keeps grad's own memory config rather than output_mem_config.
     grad_tensor.emplace_back(grad);
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -391,6 +391,9 @@ std::vector<Tensor> lgamma_bw(
 std::vector<Tensor> frac_bw(
     const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& /*output_mem_config*/) {
     std::vector<Tensor> grad_tensor;
+    // Passthrough gradient, see #53874: no eltwise backward op relocates it.
+    // grad is returned as-is and keeps its own config; honouring the request here would
+    // mean materialising a copy where none is needed.
     grad_tensor.emplace_back(grad);
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary/device/binary_composite_op.cpp
@@ -551,7 +551,7 @@ Tensor floor_div(const Tensor& input_a, const Tensor& input_b, const std::option
  * - implementation supports any 1D "squeezable tensor" at input operands
  *   by running reshape.
  */
-Tensor outer(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+Tensor outer(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     const ttnn::Shape& s_a = input_a.logical_shape();
     const ttnn::Shape& s_b = input_b.logical_shape();
     auto num_ones = [](const ttnn::Shape& s) -> uint32_t {
@@ -595,7 +595,7 @@ Tensor outer(const Tensor& input_a, const Tensor& input_b, const std::optional<M
         }
     }
 
-    return ttnn::matmul(a_slim, b_slim);
+    return ttnn::matmul(a_slim, b_slim, /*transpose_a=*/false, /*transpose_b=*/false, output_mem_config);
 }
 
 Tensor polyval(


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/55616

### What

- Quasar `outer`: thread `output_mem_config` to the `matmul` call
- Main-path placement regression for `outer` — the executable half of the contract
- Passthrough gradients: documented across all four sites, **no behaviour change**

### Why

- Quasar `outer` had the parameter commented out and never threaded it, so an explicit `memory_config` was ignored. The main copy honours it correctly — a **twin divergence** between two copies of the same function, not a shared bug. The config now reaches `matmul` in the main copy's exact form: `matmul(a, b, /*transpose_a=*/false, /*transpose_b=*/false, output_mem_config)`.
- `frac_bw` returns `grad` itself, so its config is ignored by **aliasing**, not allocation. The same shape exists in `addcdiv_bw`, `addcmul_bw` and `assign_bw`'s single-input overload; two were undocumented.

### Measured (Wormhole, bfloat16/TILE)

| Case | Result |
| --- | --- |
| `outer`, main copy, input L1 → req DRAM | DRAM — control, isolates the quasar side |
| `outer`, input L1 → req L1 | L1 — the discriminating case |
| `outer`, input L1 → unset | DRAM — `matmul`'s default, **not** the input's config |
| `frac_bw`, input L1 → req DRAM | L1 — unchanged, by design |

### Notes

- **The unset case expects DRAM, not L1.** `outer` dispatches to `matmul`, whose default is DRAM, unlike the eltwise ops that inherit their input's config. Unchanged by this PR and pinned, so the divergence from the eltwise convention is deliberate rather than assumed. My first draft asserted L1 and failed — the expectation was wrong, not the code.
- **No test for the quasar change.** Quasar is a different architecture and is not executable on this hardware, so it remains a source-level mirror of the main copy. Worth a reviewer with quasar access confirming.
- **Passthrough gradients are deliberately not "fixed".** Honouring the config means materialising a copy where none is needed, and no eltwise backward op relocates a passthrough gradient — changing one alone would make it the sole outlier. All four sites now carry one single-line marker so the invariant is checkable by grep rather than by memory:
  ```
  grep -rn 'Passthrough gradient, see #53874' ttnn/cpp/ttnn/operations/eltwise/
  ```
  If passthrough ops should honour the config, they move together.
- `test_outer_default_memory_config` is **removed**: the new unset case has the same shapes, dtype, call and threshold, and additionally places inputs in L1 and asserts `memory_config()`, so it strictly subsumes it. The value check uses the file's `_pcc_threshold` helper rather than a hardcoded floor.

### Tests

The pre-existing `outer` tests pass an explicit output config but assert only shape and values, so **all of them still pass when the placement argument is dropped**. Verified by dropping it from main `outer`'s matmul call:

| | Result |
| --- | --- |
| pre-existing `outer` tests, arg dropped | **183 passed** — the gap |
| new placement test, arg dropped | **1 failed** (`explicit_L1`) |

`explicit_DRAM` passes even with the arg dropped, since DRAM is `matmul`'s default — the L1 case is what makes the test discriminating.

- `outer` suite: **185 passed**
- `frac_bw` / `addcdiv_bw` / `addcmul_bw` / `assign_bw` backward: **51 passed** — comment-only, behaviour unchanged

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/d)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/d)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/d)



