### PR TITLE
[Performance] Remove indexer weight permute with native layout support

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -480,13 +480,13 @@ class TtIndexer:
 
     def _tp_all_reduce_via_gather(self, t):
         """All-reduce over TP via gather (dim 1) + local reduce, instead of _tp_rs_ag's reduce-scatter
-        (dim 3) + all-gather. For a narrow dim-3 width (e.g. wts' H_idx=32) that doesn't divide evenly
+        (dim 3) + all-gather. For a narrow dim-3 width (e.g. weights' H_idx=32) that doesn't divide evenly
         into tile-sized TP shards, _tp_rs_ag's reduce-scatter hits ttnn's composite fallback
         (use_composite_reduce_scatter) and balloons into ~30 tilize/pad/slice ops. Gathering on dim 1 —
         the batch/placeholder axis, always size 1 here — has no tile-alignment constraint, so it always
         takes the fused fast path; fast_reduce_nc then sums the gathered TP axis locally (pure on-device
         compute, no fabric traffic). Mirrors ttMLA._kv_stem's kv_a_proj_with_mqa all-reduce (mla.py:
-        917-929), measured cheaper even on an 18x-wider tensor than wts."""
+        917-929), measured cheaper even on an 18x-wider tensor than weights."""
         if self.tp_factor == 1:
             return t
         assert self._weights_all_gather_output is not None
@@ -796,7 +796,7 @@ class TtIndexer:
         # weights_proj: device stem -> FULL all-reduce over tp (all H_idx heads, matching the replicated
         # wq_b heads) -> scale -> [1, 1, S/sp, H_idx].
         wproj_cfg = self._resolve_mm_cfg("indexer.weights_proj", seq_len)
-        wts = ttnn.linear(
+        weights = ttnn.linear(
             hidden_states,
             self._idx_wproj,
             compute_kernel_config=self.default_compute_kernel_config,
@@ -806,14 +806,15 @@ class TtIndexer:
         # H_idx=32 doesn't divide evenly into tile-sized TP=4 shards (8 < tile width), so _tp_rs_ag's
         # dim-3 reduce-scatter would hit ttnn's composite fallback (~30 extra tilize/pad/slice ops, see
         # use_composite_reduce_scatter). Gather-then-local-reduce on dim 1 has no such tile constraint.
-        wts = self._tp_all_reduce_via_gather(wts)  # full all-reduce over tp -> all H_idx head-weights, replicated
+        weights = self._tp_all_reduce_via_gather(
+            weights
+        )  # full all-reduce over tp -> all H_idx head-weights, replicated
         # Indexer softmax scale = index_head_dim**-0.5 (NO mscale), matching the reference IndexerCPU
         # (model.py: softmax_scale = head_dim**-0.5). Distinct from MLA's qk_head_dim*mscale**2 scale —
         # though as a uniform positive multiplier it cannot change the top-k selection regardless.
-        wts = ttnn.multiply(wts, a.index_n_heads**-0.5 * a.index_head_dim**-0.5)  # [1,1,S/sp,H_idx] repl on tp
-
-        # indexer_score wants per-head weights [1, H_idx, S/sp, 1]; wts is [1, 1, S/sp, H_idx].
-        weights = ttnn.permute(wts, (0, 3, 2, 1))
+        weights = ttnn.multiply(
+            weights, a.index_n_heads**-0.5 * a.index_head_dim**-0.5
+        )  # [1,1,S/sp,H_idx] repl on tp
 
         # TP×SP query parallelism (rope-then-split). q_dev/weights were roped on the FULL S/sp slab
         # (block-cyclic-correct, cluster_axis=sp_axis), so every row already carries its true position; now
@@ -829,7 +830,7 @@ class TtIndexer:
                 weights,
             )  # release the full-S slabs once TP-split (mesh_partition allocates new)
             q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),D_idx]
-            weights = ttnn.mesh_partition(weights, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),1]
+            weights = ttnn.mesh_partition(weights, dim=2, cluster_axis=self.tp_axis)  # [1,1,S/(sp·tp),H_idx]
             ttnn.deallocate(q_full)
             ttnn.deallocate(weights_full)
             sq_local = seq_len // self.tp_factor

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_indexer_score.py
@@ -5,7 +5,7 @@
 Tests for the two lightning-indexer scorers that share one device op:
 
   indexer_score_dsa - DeepSeek-V3.2 DSA / GLM-5:
-      score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * w[b,h,s]
+      score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * w[b,0,s,h]
       ReLU + learned per-head gates, ALL heads summed into one row [B,1,Sq,T].
 
   indexer_score_msa - MiniMax M3 MSA:
@@ -58,7 +58,7 @@ def indexer_score_dsa_ref(q, k, w, chunk_start):
     q, k, w = q.float(), k.float(), w.float()
     score = torch.zeros(b, sq, t)
     for h in range(hi):
-        score += torch.relu(q[:, h] @ k[:, 0].transpose(-2, -1)) * w[:, h]
+        score += torch.relu(q[:, h] @ k[:, 0].transpose(-2, -1)) * w[:, 0, :, h : h + 1]
     future = torch.arange(t).unsqueeze(0) > chunk_start + torch.arange(sq).unsqueeze(1)
     return score.masked_fill(future, float("-inf")).unsqueeze(1)
 
@@ -100,7 +100,7 @@ def indexer_score_msa_ref(q, k, w, chunk_start, num_groups=1, block_size=0):
 
 
 def make_inputs(heads, dim, sq, t, seed=42):
-    """q [1,Hi,Sq,D], k [1,1,T,D], weights [1,Hi,Sq,1], all bf16.
+    """q [1,Hi,Sq,D], k [1,1,T,D], weights [1,1,Sq,Hi], all bf16.
 
     Weights are random so some gates are negative: -inf padding must stay distinguishable from
     low-but-valid (negative) scores by topk.
@@ -108,12 +108,12 @@ def make_inputs(heads, dim, sq, t, seed=42):
     g = torch.Generator().manual_seed(seed)
     q = torch.randn(1, heads, sq, dim, generator=g, dtype=torch.bfloat16)
     k = torch.randn(1, 1, t, dim, generator=g, dtype=torch.bfloat16)
-    w = torch.randn(1, heads, sq, 1, generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, 1, sq, heads, generator=g, dtype=torch.bfloat16)
     return q, k, w
 
 
-def to_device(t, device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT):
-    return ttnn.from_torch(t, device=device, layout=layout, dtype=dtype)
+def to_device(t, device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, *, mesh_mapper=None):
+    return ttnn.from_torch(t, device=device, layout=layout, dtype=dtype, mesh_mapper=mesh_mapper)
 
 
 def _extra_kwargs(program_config, compute_kernel_config):
@@ -147,6 +147,31 @@ def run_dsa(
         **_extra_kwargs(program_config, compute_kernel_config),
     )
     return ttnn.to_torch(out)
+
+
+@pytest.mark.parametrize("heads", [1, 3, 8, 16, 32, 40, 64])
+@pytest.mark.parametrize("q_chunk,k_chunk,head_group", [(32, 64, 0), (64, 32, 1)])
+def test_indexer_score_weights(device, heads, q_chunk, k_chunk, head_group):
+    """Signed gates, odd head counts and overlapping in-place tile expansion, on two cached dispatches.
+
+    Resident and streamed heads cover both gate-multiply implementations.
+    """
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
+    for seed in (42, 123):
+        q, k, w = make_inputs(heads, 64, 64, 256, seed=seed)
+        q_dev, k_dev = to_device(q, device), to_device(k, device)
+        w_dev = to_device(w, device)
+        out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=192, program_config=cfg)
+        assert_indexer_match(ttnn.to_torch(out), indexer_score_dsa_ref(q, k, w, 192), 64, 256, check_neg=True)
+
+
+def test_indexer_score_weights_shape(device, expect_error):
+    q, k, _ = make_inputs(8, 64, 64, 256)
+    w = torch.zeros(1, 8, 64, 1, dtype=torch.bfloat16)  # Unsupported head-major layout.
+    with expect_error(RuntimeError, "weights must be"):
+        ttnn.experimental.indexer_score_dsa(
+            to_device(q, device), to_device(k, device), to_device(w, device), chunk_start_idx=192
+        )
 
 
 def run_msa(
@@ -341,12 +366,12 @@ IDX_CACHE = dict(heads=64, dim=128, sq=64, t=256, chunk_start=128)  # small all-
 
 
 def _indexed_inputs(num_slots, seed=11):
-    """q [1,Hi,Sq,D], a shared k cache [B,1,T,D], weights [1,Hi,Sq,1], all bf16. Slots differ so a
+    """q [1,Hi,Sq,D], a shared k cache [B,1,T,D], weights [1,1,Sq,Hi], all bf16. Slots differ so a
     wrong-slot read would change the scores (and fail the per-slot reference)."""
     c = IDX_CACHE
     g = torch.Generator().manual_seed(seed)
     q = torch.randn(1, c["heads"], c["sq"], c["dim"], generator=g, dtype=torch.bfloat16)
-    w = torch.randn(1, c["heads"], c["sq"], 1, generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, 1, c["sq"], c["heads"], generator=g, dtype=torch.bfloat16)
     k_cache = torch.randn(num_slots, 1, c["t"], c["dim"], generator=g, dtype=torch.bfloat16)
     return q, w, k_cache
 
@@ -493,11 +518,11 @@ KV_LEN = dict(heads=64, dim=128, sq=64, t=512, chunk_start=0)  # oversized T=512
 
 
 def _kv_len_inputs(seed=23):
-    """q [1,Hi,Sq,D], an oversized k buffer [1,1,T,D], weights [1,Hi,Sq,1], all bf16."""
+    """q [1,Hi,Sq,D], an oversized k buffer [1,1,T,D], weights [1,1,Sq,Hi], all bf16."""
     c = KV_LEN
     g = torch.Generator().manual_seed(seed)
     q = torch.randn(1, c["heads"], c["sq"], c["dim"], generator=g, dtype=torch.bfloat16)
-    w = torch.randn(1, c["heads"], c["sq"], 1, generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, 1, c["sq"], c["heads"], generator=g, dtype=torch.bfloat16)
     k = torch.randn(1, 1, c["t"], c["dim"], generator=g, dtype=torch.bfloat16)
     return q, w, k
 
@@ -636,7 +661,7 @@ def test_indexer_score_dsa_msa_differ(device):
     scale = 1.0
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
     q, k, _ = make_inputs(heads, dim, sq, t)
-    w_const = torch.full((1, heads, sq, 1), scale, dtype=torch.bfloat16)  # match MSA's gate so only relu differs
+    w_const = torch.full((1, 1, sq, heads), scale, dtype=torch.bfloat16)  # match MSA's gate so only relu differs
     out_dsa = run_dsa(q, k, w_const, chunk_start, device, program_config=cfg)
     out_msa = run_msa(q, k, chunk_start, device, scale=scale, program_config=cfg)
     visible = out_dsa > torch.finfo(torch.bfloat16).min  # exclude the -inf causal mask
@@ -1009,7 +1034,7 @@ def _global_inputs(heads, chunk, t, seed):
     g = torch.Generator().manual_seed(seed)
     q = torch.randn(1, heads, chunk, QB_DIM, generator=g, dtype=torch.bfloat16)
     k = torch.randn(1, 1, t, QB_DIM, generator=g, dtype=torch.bfloat16)
-    w = torch.randn(1, heads, chunk, 1, generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, 1, chunk, heads, generator=g, dtype=torch.bfloat16)
     return q, k, w
 
 
@@ -1038,7 +1063,7 @@ def _shard_1d(mesh_device, heads, seed):
     q_g, k_g, w_g = _global_inputs(heads, QB_CHUNK, QB_T, seed)
     shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    w_dev = to_device(w_g, mesh_device, mesh_mapper=shard)
     k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
     return q_g, k_g, w_g, q_dev, k_dev, w_dev
 
@@ -1748,7 +1773,7 @@ def _straddle_ref(q_g, k_nat, w_g, sp, chunk_global, chunk_start, t_len):
         qh, kh, wh = q_g[:, :, sl, :].float(), k_nat[:, 0].float(), w_g[:, :, sl, :].float()
         score = torch.zeros(1, sq, t_len)
         for h in range(heads):
-            score += torch.relu(qh[:, h] @ kh.transpose(-2, -1)) * wh[:, h]
+            score += torch.relu(qh[:, h] @ kh.transpose(-2, -1)) * wh[:, 0, :, h : h + 1]
         lr = update_idxt + torch.arange(sq)
         pos = (lr // cl) * chunk_global + r * cl + (lr % cl)  # block-cyclic home (writer rotation)
         future = torch.arange(t_len).unsqueeze(0) > pos.unsqueeze(1)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
@@ -22,6 +22,7 @@ import ttnn
 
 from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_indexer_score import (
     assert_indexer_match,
+    to_device,
     glx_config,
     indexer_score_dsa_ref,
     _global_inputs,
@@ -82,7 +83,7 @@ def _fused_dev_inputs(submesh, q_g, w_g, k_host, *, k_dtype=ttnn.bfloat16):
     both k_local and k_gathered (the op requires them equal)."""
     shard = ttnn.ShardTensorToMesh(submesh, dim=2)
     q_dev = ttnn.from_torch(q_g, device=submesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
-    w_dev = ttnn.from_torch(w_g, device=submesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
+    w_dev = to_device(w_g, submesh, mesh_mapper=shard)
     k_local = _shard_k(submesh, k_host, dtype=k_dtype)  # [B,1,sll,D] per chip (the all-gather INPUT)
     # Indexed mode gathers one selected input slot into slot 0; batch-1 scratch also covers the ordinary B=1 path.
     k_gathered = _persistent_buffer(submesh, torch.zeros_like(k_host[:1]), dtype=k_dtype)
@@ -134,7 +135,7 @@ def _full_mesh_inputs(mesh, q_g, w_g, k_host, *, k_dtype=ttnn.bfloat16):
     """Canonical flat row-major sequence shards plus a complete-mesh replicated gather scratch."""
     shard = ttnn.ShardTensorToMesh(mesh, dim=2)
     q_dev = ttnn.from_torch(q_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
-    w_dev = ttnn.from_torch(w_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
+    w_dev = to_device(w_g, mesh, mesh_mapper=shard)
     k_local = ttnn.from_torch(k_host, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=k_dtype, mesh_mapper=shard)
     k_gathered = ttnn.from_torch(
         torch.zeros_like(k_host[:1]),
@@ -1166,9 +1167,7 @@ def test_indexer_score_ring8_partial_readiness_reference_cache_hit(mesh_device):
         q_dev = ttnn.from_torch(
             q_g, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard
         )
-        w_dev = ttnn.from_torch(
-            w_g, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard
-        )
+        w_dev = to_device(w_g, mesh_device, mesh_mapper=sp_shard)
         k_local = ttnn.from_torch(
             k_bc,
             device=mesh_device,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py
@@ -26,6 +26,7 @@ import ttnn
 from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_indexer_score import (
     assert_pooled_match,
     assert_indexer_match,
+    to_device,
     glx_config,
     indexer_score_dsa_ref,
     indexer_score_msa_ref,
@@ -160,7 +161,11 @@ def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
     qw_dims = _axis_dims(sp_dim=2, tp_dim=1)
     shard_qw = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_qw)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_qw)
+    w_dev = to_device(
+        w_g,
+        mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=_axis_dims(sp_dim=2, tp_dim=3)),
+    )
     k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
 
     out = ttnn.experimental.indexer_score_dsa(
@@ -230,7 +235,7 @@ def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
     mesh_shape = tuple(mesh_device.shape)
     shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    w_dev = to_device(w_g, mesh_device, mesh_mapper=shard)
     k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
 
     out = ttnn.experimental.indexer_score_dsa(
@@ -256,7 +261,7 @@ def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_erro
     k_bc = _to_slab(k_nat, sp, chunk_global)
     shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    w_dev = to_device(w_g, mesh_device, mesh_mapper=shard)
     k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
     kwargs = {
         "block_cyclic_sp_axis": 0,
@@ -281,7 +286,7 @@ def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
     mesh_shape = tuple(mesh_device.shape)
     shard_tp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(None, 2))
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_tp_seq)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_tp_seq)
+    w_dev = to_device(w_g, mesh_device, mesh_mapper=shard_tp_seq)
     k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
     kwargs = {
         "seq_shard_axes": [0, 1],
@@ -312,7 +317,7 @@ def test_indexer_score_sp2_tp2_seq_subshard_rotated(mesh_device):
     mesh_shape = tuple(mesh_device.shape)
     shard_sp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_sp_seq)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_sp_seq)
+    w_dev = to_device(w_g, mesh_device, mesh_mapper=shard_sp_seq)
     k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
     q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=1)
     w_dev = ttnn.mesh_partition(w_dev, dim=2, cluster_axis=1)
@@ -344,7 +349,7 @@ def test_indexer_score_qb_straddle(mesh_device, case_id, heads):
     mesh_shape = tuple(mesh_device.shape)
     shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
     q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    w_dev = to_device(w_g, mesh_device, mesh_mapper=shard)
     k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
 
@@ -452,7 +457,7 @@ def test_indexer_score_ring4_fused_4d(case_id, heads, block_cyclic):
 
         shard = ttnn.ShardTensorToMesh(mesh, dim=2)  # SP-shard seq over the 4 devices
         q_dev = ttnn.from_torch(q_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
-        w_dev = ttnn.from_torch(w_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
+        w_dev = to_device(w_g, mesh, mesh_mapper=shard)
         k_local = ttnn.from_torch(k_host, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
         # Gathered buffer: full T per device, zero-seeded (AG fills remote bands; zeros prove local sourcing).
         k_gathered = ttnn.from_torch(
@@ -489,7 +494,8 @@ def test_indexer_score_ring4_fused_4d(case_id, heads, block_cyclic):
 
 
 @pytest.mark.requires_host_iommu
-def test_indexer_score_ring4_true_ring_bfp8_bank_owned_reference_cache_hit():
+@pytest.mark.parametrize("heads", [4, 32])
+def test_indexer_score_ring4_true_ring_bfp8_bank_owned_reference_cache_hit(heads):
     """Reference-check the production BFP8 bank-owned path on a true QuietBox Ring.
 
     The large BFP8 K capacity exercises the bank-owned schedule's midpoint/completion protocol. Two runtime
@@ -499,7 +505,6 @@ def test_indexer_score_ring4_true_ring_bfp8_bank_owned_reference_cache_hit():
     """
     sp = 4
     sp_axis = 0
-    heads = 4
     q_per_rank = 32
     chunk_global = sp * q_per_rank
     k_capacity = 256 * 1024
@@ -513,7 +518,7 @@ def test_indexer_score_ring4_true_ring_bfp8_bank_owned_reference_cache_hit():
         k_bc = _to_slab(k_nat, sp, chunk_global)
         sp_shard = ttnn.ShardTensor2dMesh(mesh, mesh_shape=(sp, 1), dims=(2, None))
         q_dev = ttnn.from_torch(q_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
-        w_dev = ttnn.from_torch(w_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
+        w_dev = to_device(w_g, mesh, mesh_mapper=sp_shard)
         k_local = ttnn.from_torch(
             k_bc,
             device=mesh,
@@ -609,7 +614,7 @@ def test_indexer_score_ring4_small_capacity_has_no_empty_lane_deadlock():
         k_bc = _to_slab(k_nat, sp, chunk_global)
         sp_shard = ttnn.ShardTensor2dMesh(mesh, mesh_shape=(sp, 1), dims=(2, None))
         q_dev = ttnn.from_torch(q_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
-        w_dev = ttnn.from_torch(w_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard)
+        w_dev = to_device(w_g, mesh, mesh_mapper=sp_shard)
         k_local = ttnn.from_torch(
             k_bc,
             device=mesh,
@@ -959,7 +964,7 @@ def test_indexer_score_sptp_fused_4d(case_id, heads):
         # q/w: SP-shard seq (dim 2), then split those rows over TP (mesh_partition) -> each device owns Sq_sp/tp rows.
         qw_shard = ttnn.ShardTensor2dMesh(mesh, mesh_shape=(SP2, TP2), dims=(2, None))
         q_dev = ttnn.from_torch(q_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=qw_shard)
-        w_dev = ttnn.from_torch(w_g, device=mesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=qw_shard)
+        w_dev = to_device(w_g, mesh, mesh_mapper=qw_shard)
         q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=TP2_AXIS)
         w_dev = ttnn.mesh_partition(w_dev, dim=2, cluster_axis=TP2_AXIS)
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py
@@ -29,8 +29,8 @@ from models.common.utility_functions import run_for_blackhole, skip_with_llk_ass
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.tt.mla.mla_config import get_indexer_key_chunk
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_indexer_score import to_device
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program_merged, require_realtime_profiler
-
 
 # 55 Ki tokens is the GLM chunked-prefill width (50 Ki history + 5 Ki chunk).
 # 512 Ki is the long-context target; both are tile-aligned.
@@ -208,15 +208,13 @@ def test_ring_indexer_score_dsa_perf(mesh_device, kv_len):
     q_rows = sp * GLM52_Q_PER_CHIP
     chunk_start = kv_len - q_rows
     q_host = torch.randn((1, GLM52_INDEX_HEADS, q_rows, GLM52_INDEX_DIM), dtype=torch.bfloat16)
-    w_host = torch.randn((1, GLM52_INDEX_HEADS, q_rows, 1), dtype=torch.bfloat16)
+    w_host = torch.randn((1, 1, q_rows, GLM52_INDEX_HEADS), dtype=torch.bfloat16)
 
     sp_shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(sp, tp), dims=(2, None))
     q_dev = ttnn.from_torch(
         q_host, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b, mesh_mapper=sp_shard
     )
-    w_dev = ttnn.from_torch(
-        w_host, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=sp_shard
-    )
+    w_dev = to_device(w_host, mesh_device, mesh_mapper=sp_shard)
     # The production GLM-5.2 cache is 1 Mi tokens wide, ND-sharded in DRAM,
     # and has one slot per full indexer layer. The fused program is compiled
     # from this *capacity* (not kv_len): kv_len bounds the populated prefix,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -442,7 +442,7 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
             "indexer_score fused: head_group_size must be 0 or Hi (no head streaming)");
     }
 
-    // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
+    // Weights use projection order [B, 1, Sq, Hi].
     TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4, "q, k must be rank 4");
     TT_FATAL(k_shape[1] == 1, "k must be single-head [B, 1, T, D], got {} heads", k_shape[1]);
     TT_FATAL(q_shape[3] == k_shape[3], "q head dim {} != k head dim {}", q_shape[3], k_shape[3]);
@@ -452,8 +452,8 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     if (!attrs.synthesize_gate) {
         TT_FATAL(w_shape.rank() == 4, "weights must be rank 4");
         TT_FATAL(
-            w_shape[1] == q_shape[1] && w_shape[2] == q_shape[2] && w_shape[3] == 1,
-            "weights must be [B, Hi, Sq, 1] matching q [B, Hi, Sq, D]");
+            w_shape[1] == 1 && w_shape[2] == q_shape[2] && w_shape[3] == q_shape[1],
+            "weights must be [B, 1, Sq, Hi] matching q [B, Hi, Sq, D]");
         TT_FATAL(q_shape[0] == w_shape[0], "q/weights batch mismatch ({} vs {})", q_shape[0], w_shape[0]);
         TT_FATAL(w.dtype() == DataType::BFLOAT16, "weights must be bfloat16 (got {})", w.dtype());
         TT_FATAL(w.layout() == Layout::TILE, "weights must be TILE layout");

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -90,8 +90,8 @@ namespace ttnn::experimental {
 // second axis's seq offset). The two axis roles map internally to (cluster_axis, seq_subshard_axis).
 
 // DeepSeek-V3.2 DSA / GLM-5 (ttnn.experimental.indexer_score_dsa):
-//   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
-// q [B,Hi,Sq,D], k [B,1,T,D], weights [B,Hi,Sq,1] -> score [B,1,Sq,T] (all heads relu'd + summed).
+//   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,0,t,:]) * weights[b,0,s,h]
+// q [B,Hi,Sq,D], k [B,1,T,D], weights [B,1,Sq,Hi] -> score [B,1,Sq,T] (all heads relu'd + summed).
 // cache_batch_idx/kv_len/chunk_start_idx are re-applied each dispatch and hash-excluded (no recompile); see
 // the nanobind docs for their full semantics. OMIT chunk_start_idx on a mesh (deduced as T - sp_ring*Sq).
 ttnn::Tensor indexer_score_dsa(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -10,6 +10,8 @@
 // sender reads DRAM + mcasts; receiver takes the L1->L1 copy; none is a plain DRAM read. q/w (row) and k
 // (column) mcast are independent; either may be off.
 
+#include <tt-metalium/constants.hpp>
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/noc_semaphore.h"
@@ -237,6 +239,50 @@ inline void fill_w_group_const() {
     cb.push_back(w_group_tiles);
 }
 
+// Prepare gate columns after the first K read so their local preparation overlaps QK matmul.
+// The weight row multicast must still complete before any column multicast or fabric wait.
+inline void expand_w_group() {
+    constexpr uint32_t head_tiles = (num_heads + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
+    using namespace tt::constants;
+    constexpr uint32_t bf16_per_word = sizeof(uint32_t) / sizeof(uint16_t);
+    constexpr uint32_t face_row_words = FACE_WIDTH / bf16_per_word;
+    constexpr uint32_t face_words = FACE_HW / bf16_per_word;
+    constexpr uint32_t tile_words = TILE_HW / bf16_per_word;
+    constexpr uint32_t bf16_bits = sizeof(uint16_t) * 8;
+    // read_w_group reserved the output group; compute waits until expansion finishes.
+    // Walk input tiles and head pairs backward: expanded destinations are at or after their
+    // source tile. The final head-0 store aliases its original column without changing it.
+    CircularBuffer gates(cb_w);
+    const uint32_t addr = gates.get_write_ptr();
+    for (uint32_t row_end = q_tiles_per_unit; row_end > 0; --row_end) {
+        const uint32_t q_row = row_end - 1;
+        for (uint32_t tile_end = head_tiles; tile_end > 0; --tile_end) {
+            const uint32_t ht = tile_end - 1;
+            auto* src =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr + (q_row * head_tiles + ht) * bf16_tile_bytes);
+            const uint32_t heads_in_tile = std::min<uint32_t>(TILE_WIDTH, num_heads - ht * TILE_WIDTH);
+            for (uint32_t pair_end = (heads_in_tile + bf16_per_word - 1) / bf16_per_word; pair_end > 0; --pair_end) {
+                const uint32_t h = bf16_per_word * (pair_end - 1);
+                auto* dst = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    addr + (q_row * num_heads + ht * TILE_WIDTH + h) * bf16_tile_bytes);
+                // Extract two BF16 heads per word. Word stores also set the unused column 1;
+                // this avoids narrow L1 accesses.
+                for (uint32_t r = 0; r < TILE_HEIGHT; ++r) {
+                    const uint32_t row_offset =
+                        (r / FACE_HEIGHT) * (TILE_WIDTH / FACE_WIDTH) * face_words + (r % FACE_HEIGHT) * face_row_words;
+                    const uint32_t pair =
+                        src[row_offset + (h / FACE_WIDTH) * face_words + (h % FACE_WIDTH) / bf16_per_word];
+                    dst[row_offset] = pair;
+                    if (ht * TILE_WIDTH + h + 1 < num_heads) {
+                        dst[tile_words + row_offset] = pair >> bf16_bits;
+                    }
+                }
+            }
+        }
+    }
+    gates.push_back(w_group_tiles);
+}
+
 /** resident w (gates) group [q_tiles_per_unit][num_heads], role-aware (q row mcast). MSA fills a constant
  *  scale in L1 instead (no weights tensor); the q placeholder accessor is then unused. */
 template <typename WAcc>
@@ -245,21 +291,32 @@ inline void read_w_group(Noc noc, const WAcc& w_acc, uint32_t q_row_start, const
         fill_w_group_const();
         return;
     }
-    read_block_or_mcast<cb_w, q_mcast_on, q_send_sem, q_recv_sem, q_valid_sem>(
-        noc, w_group_tiles, w_group_tiles * bf16_tile_bytes, q_dir, [&](uint32_t addr) {
-            uint32_t ptr = addr;
-            for (uint32_t q_row = 0; q_row < q_tiles_per_unit; ++q_row) {
-                for (uint32_t head = 0; head < num_heads; ++head) {
-                    noc.async_read(
-                        w_acc,
-                        CoreLocalMem<uint32_t>(ptr),
-                        bf16_tile_bytes,
-                        {.page_id = head * q_len_tiles + q_row_start + q_row},
-                        {});
-                    ptr += bf16_tile_bytes;
-                }
-            }
-        });
+    // Transport [query, head] weight tiles, then prepare each core's resident gate columns.
+    // Multicasting before expansion avoids broadcasting 31 padding columns per head.
+    constexpr uint32_t head_tiles = (num_heads + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
+    constexpr uint32_t input_tiles = q_tiles_per_unit * head_tiles;
+    CircularBuffer cb(cb_w);
+    cb.reserve_back(w_group_tiles);
+    const uint32_t addr = cb.get_write_ptr();
+    if (q_mcast_on && q_dir.role == iscore::mcast_role_receiver) {
+        mcast_recv<q_send_sem, q_recv_sem>(noc, q_dir);
+    } else {
+        for (uint32_t tile = 0; tile < input_tiles; ++tile) {
+            noc.async_read(
+                w_acc,
+                CoreLocalMem<uint32_t>(addr + tile * bf16_tile_bytes),
+                bf16_tile_bytes,
+                {.page_id = q_row_start * head_tiles + tile},
+                {});
+        }
+        noc.async_read_barrier();
+        if (q_mcast_on && q_dir.role == iscore::mcast_role_sender) {
+            mcast_send<q_send_sem, q_recv_sem, q_valid_sem>(noc, q_dir, addr, input_tiles * bf16_tile_bytes);
+        }
+    }
+    if constexpr (stream_heads || fuse_single) {
+        expand_w_group();
+    }
 }
 
 /** Read one k tile's head_dim_tiles pages [base, base+head_dim_tiles) from `acc` into the CB at `ptr`,
@@ -543,6 +600,9 @@ void kernel_main() {
                     // the same work list, so skipping an empty runtime-prefix unit preserves both
                     // the fabric gate and the local CB protocol.
                     if (k_tiles_in_unit == 0) {
+                        if (band_i == 0) {
+                            expand_w_group();
+                        }
                         continue;
                     }
                     uint32_t gathered_shard_tiles = gate->tiles_per_shard;
@@ -591,6 +651,11 @@ void kernel_main() {
                                 read_q_block(noc, q_acc, q_row_start, first_head, q_dir);
                             }
                         }
+                    }
+                }
+                if constexpr (!synthesize_gate && !stream_heads && !fuse_single) {
+                    if (band_i == 0) {
+                        expand_w_group();
                     }
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -29,7 +29,7 @@ void bind_indexer_score(nb::module_& mod) {
         R"doc(
         DeepSeek-V3.2 DSA / GLM-5 lightning-indexer scorer.
 
-        score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
+        score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,0,t,:]) * weights[b,0,s,h]
 
         ReLU(q.kT) gated by the learned per-head weights and summed over ALL Hi
         index heads into one shared selection row [B, 1, Sq, T]. For MiniMax M3's
@@ -38,8 +38,8 @@ void bind_indexer_score(nb::module_& mod) {
         Args:
             q: [B, Hi, Sq, D] bf16 or bfp8_b tiled (post non-interleaved RoPE)
             k: [B, 1, T, D] bf16 or bfp8_b tiled, single shared head
-            weights: [B, Hi, Sq, 1] bf16 tiled learned per-head gates (scale
-                pre-folded)
+            weights: [B, 1, Sq, Hi] bf16 tiled learned per-head gates (scale
+                pre-folded).
             chunk_start_idx: absolute global position of rank 0's query row 0
                 (rank 0 = lowest seq_shard_axes[0] (SP) coord; causality: key t
                 visible to query s iff t <= chunk_start + s). OMIT on a mesh ->
@@ -213,7 +213,7 @@ void bind_indexer_score(nb::module_& mod) {
             q: [B, Hi, Sq, D] bf16/bfp8_b tiled (post non-interleaved RoPE); see indexer_score_dsa
             k: [B, 1, T, D] bf16/bfp8_b tiled PERSISTENT all-gather OUTPUT buffer, T = sp*sll. B must be 1
                 when cache_batch_idx is set; the gather fills remote SP shards in place
-            weights: [B, Hi, Sq, 1] bf16 tiled learned per-head gates (scale pre-folded)
+            weights: [B, 1, Sq, Hi] bf16 tiled learned per-head gates (scale pre-folded)
             k_local: [B, 1, sll, D] bf16/bfp8_b tiled, interleaved or ND-sharded DRAM -- this chip's SP
                 shard and the all-gather INPUT; sll = T/sp; must match k's dtype
             ag_multi_device_global_semaphore: list of the all-gather's out-ready global semaphores; requires


### PR DESCRIPTION
### PR Category
Performance

### Summary
Remove the weight permute op before indexer and ring indexer scoring to reduce dispatch overhead. Consume the projection's native `[B, 1, Sq, Hi]` layout and prepare per-head gates in the existing L1 buffer, overlapping expansion with QK matmul. Update validation, documentation, and tests to use the native layout.

### CI runs

| Pipeline | Status |
| --- | --- |
| Sanity · Blackhole | [![Sanity · Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic%2Findexer-native-weight-layout&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/34109284391) |
| L2 · Experimental | [![L2 · Experimental (WH + BH)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic%2Findexer-native-weight-layout&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/34109288980) |
| Blaze · Prefill | [![Blaze · Prefill (all)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=skrstic%2Findexer-native-weight-layout&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/34145782530) |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer-native-weight-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer-native-weight-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer-native-weight-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer-native-weight-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer-native-weight-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer-native-weight-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer-native-weight-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer-native-weight-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer-native-weight-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer-native-weight-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer-native-weight-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer-native-weight-layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer-native-weight-layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer-native-weight-layout)