### PR TITLE
[Bug fix] Fix TP-sharded KV ring indexer hang

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
@@ -88,10 +88,10 @@ def _fused_dev_inputs(submesh, q_g, w_g, k_host, *, k_dtype=ttnn.bfloat16):
     return q_dev, w_dev, k_local, k_gathered
 
 
-def _open_full_mesh_ccl(mesh_shape):
-    """Open the complete physical 2D mesh with the torus links needed by the snake's closing edge."""
+def _open_full_mesh_ccl(mesh_shape, *, fabric_config=ttnn.FabricConfig.FABRIC_2D_TORUS_XY):
+    """Open the complete physical 2D mesh with the requested fabric configuration."""
     ttnn.set_fabric_config(
-        ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        fabric_config,
         ttnn.FabricReliabilityMode.STRICT_INIT,
         None,
         ttnn.FabricTensixConfig.DISABLED,
@@ -679,6 +679,324 @@ def test_indexer_score_full_mesh_loudbox_accuracy_placement_and_cache_reuse(bloc
     if ttnn.get_num_devices() != 8:
         pytest.skip("2x4 full-mesh indexer coverage requires the exact physical eight-device LoudBox")
     _run_full_mesh_accuracy_case((2, 4), block_cyclic=block_cyclic)
+
+
+# ---- 2D SP x TP LoudBox: TP-inner reconstructed KV -----------------------------------------------
+LB_SPTP_SP = 2
+LB_SPTP_TP = 4
+LB_SPTP_SP_AXIS = 0
+LB_SPTP_TP_AXIS = 1
+LB_SPTP_HEADS = 32
+LB_SPTP_CHUNK = 1280
+LB_SPTP_CHUNK_LOCAL = LB_SPTP_CHUNK // LB_SPTP_SP
+LB_SPTP_K_CHUNK = 320
+
+
+def _to_tp_inner_reconstructed(
+    k_natural,
+    *,
+    sp=LB_SPTP_SP,
+    tp=LB_SPTP_TP,
+    chunk_local=LB_SPTP_CHUNK_LOCAL,
+):
+    """Pack natural K in the physical order produced by a TP-inner then SP-outer gather."""
+    capacity = k_natural.shape[2]
+    assert capacity % (sp * tp) == 0
+    assert chunk_local % tp == 0
+    physical_shard_capacity = capacity // sp
+    tp_stripe_capacity = physical_shard_capacity // tp
+    stripe_chunk = chunk_local // tp
+    assert tp_stripe_capacity % stripe_chunk == 0
+
+    physical_to_logical = []
+    for sp_rank in range(sp):
+        physical_offset = torch.arange(physical_shard_capacity)
+        tp_rank = physical_offset // tp_stripe_capacity
+        within_tp = physical_offset % tp_stripe_capacity
+        slab = within_tp // stripe_chunk
+        within_chunk = within_tp % stripe_chunk
+        logical = (slab * sp + sp_rank) * chunk_local + tp_rank * stripe_chunk + within_chunk
+        physical_to_logical.append(logical)
+    physical_to_logical = torch.cat(physical_to_logical)
+    assert torch.equal(torch.sort(physical_to_logical).values, torch.arange(capacity))
+
+    reconstructed = k_natural.clone()
+    reconstructed[0, 0] = k_natural[0, 0, physical_to_logical]
+    return reconstructed
+
+
+def _sptp_loudbox_inputs(
+    mesh,
+    k_capacity,
+    seed,
+    *,
+    sp=LB_SPTP_SP,
+    tp=LB_SPTP_TP,
+    sp_axis=LB_SPTP_SP_AXIS,
+    tp_axis=LB_SPTP_TP_AXIS,
+    heads=LB_SPTP_HEADS,
+    chunk_global=LB_SPTP_CHUNK,
+):
+    chunk_local = chunk_global // sp
+    q_host, k_natural, w_host = _global_inputs(heads, chunk_global, k_capacity, seed=seed)
+    k_reconstructed = _to_tp_inner_reconstructed(k_natural, sp=sp, tp=tp, chunk_local=chunk_local)
+    mesh_shape = [0, 0]
+    mesh_shape[sp_axis] = sp
+    mesh_shape[tp_axis] = tp
+    shard_dims = [None, None]
+    shard_dims[sp_axis] = 2
+    sp_shard = ttnn.ShardTensor2dMesh(mesh, mesh_shape=tuple(mesh_shape), dims=tuple(shard_dims))
+    k_local = ttnn.from_torch(
+        k_reconstructed,
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        mesh_mapper=sp_shard,
+    )
+    k_gathered = ttnn.from_torch(
+        torch.zeros_like(k_natural),
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh),
+    )
+    q_dev = ttnn.from_torch(
+        q_host,
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        mesh_mapper=sp_shard,
+    )
+    w_dev = ttnn.from_torch(
+        w_host,
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=sp_shard,
+    )
+    q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=tp_axis)
+    w_dev = ttnn.mesh_partition(w_dev, dim=2, cluster_axis=tp_axis)
+    return q_host, k_natural, w_host, q_dev, k_local, k_gathered, w_dev
+
+
+def _sptp_loudbox_ref(
+    q_host,
+    k_natural,
+    w_host,
+    chunk_start,
+    *,
+    sp=LB_SPTP_SP,
+    tp=LB_SPTP_TP,
+    sp_axis=LB_SPTP_SP_AXIS,
+    tp_axis=LB_SPTP_TP_AXIS,
+):
+    chunk_local = q_host.shape[2] // sp
+    q_per_device = chunk_local // tp
+    mesh_shape = [0, 0]
+    mesh_shape[sp_axis] = sp
+    mesh_shape[tp_axis] = tp
+    refs = []
+    for mesh_row in range(mesh_shape[0]):
+        for mesh_col in range(mesh_shape[1]):
+            coord = (mesh_row, mesh_col)
+            sp_rank = coord[sp_axis]
+            tp_rank = coord[tp_axis]
+            q_start = sp_rank * chunk_local + tp_rank * q_per_device
+            q_slice = slice(q_start, q_start + q_per_device)
+            refs.append(
+                indexer_score_dsa_ref(
+                    q_host[:, :, q_slice, :],
+                    k_natural,
+                    w_host[:, :, q_slice, :],
+                    chunk_start + q_start,
+                )
+            )
+    return torch.cat(refs, dim=2)
+
+
+def _run_sptp_loudbox_score(
+    semaphores,
+    subdevice_id,
+    q_dev,
+    k_local,
+    k_gathered,
+    w_dev,
+    *,
+    chunk_start,
+    kv_len,
+    tp_sharded,
+    sp_axis=LB_SPTP_SP_AXIS,
+    tp_axis=LB_SPTP_TP_AXIS,
+    topology=ttnn.Topology.Linear,
+    num_links=1,
+    chunk_local=LB_SPTP_CHUNK_LOCAL,
+):
+    return ttnn.experimental.ring_indexer_score_dsa(
+        q_dev,
+        k_gathered,
+        w_dev,
+        k_local,
+        semaphores,
+        cluster_axis=sp_axis,
+        topology=topology,
+        num_links=num_links,
+        ag_sub_device_id=subdevice_id,
+        chunk_start_idx=chunk_start,
+        kv_len=kv_len,
+        seq_subshard_axis=tp_axis,
+        block_cyclic_sp_axis=sp_axis,
+        block_cyclic_chunk_local=chunk_local,
+        block_cyclic_cache_tp_sharded=tp_sharded,
+        program_config=ttnn.IndexerScoreProgramConfig(
+            q_chunk_size=32,
+            k_chunk_size=LB_SPTP_K_CHUNK,
+            head_group_size=0,
+        ),
+    )
+
+
+def _sptp_loudbox_output(out):
+    shards = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(out.cpu())]
+    return torch.cat(shards, dim=2)
+
+
+@pytest.mark.parametrize("tp_sharded", [False, True], ids=["control", "tp_sharded"])
+def test_indexer_score_sptp_loudbox_tp_sharded_kv_repro(tp_sharded):
+    """Reduced SP2 x TP4 fused score; the TP-enabled variant hung before the mapping fix."""
+    if ttnn.get_num_devices() != 8:
+        pytest.skip("SP2 x TP4 fused indexer reproduction requires an exact eight-device LoudBox")
+    assert LB_SPTP_CHUNK_LOCAL == 640
+    assert LB_SPTP_CHUNK_LOCAL // LB_SPTP_TP == 160
+    assert LB_SPTP_K_CHUNK // 32 == 10
+
+    mesh, semaphores, subdevice_id, stall_group = _open_full_mesh_ccl(
+        (LB_SPTP_SP, LB_SPTP_TP), fabric_config=ttnn.FabricConfig.FABRIC_1D
+    )
+    try:
+        q_host, k_natural, w_host, q_dev, k_local, k_gathered, w_dev = _sptp_loudbox_inputs(
+            mesh, LB_SPTP_CHUNK, seed=42
+        )
+        out = _run_sptp_loudbox_score(
+            semaphores,
+            subdevice_id,
+            q_dev,
+            k_local,
+            k_gathered,
+            w_dev,
+            chunk_start=0,
+            kv_len=LB_SPTP_CHUNK,
+            tp_sharded=tp_sharded,
+        )
+        ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+        out_host = _sptp_loudbox_output(out)
+        reference = _sptp_loudbox_ref(q_host, k_natural, w_host, chunk_start=0)
+        assert_indexer_match(out_host, reference, LB_SPTP_CHUNK, LB_SPTP_CHUNK, check_neg=True)
+    finally:
+        _close_full_mesh_ccl(mesh)
+
+
+def test_indexer_score_sptp_loudbox_tp_sharded_multislab_partial_prefix_cache_reuse():
+    """Cover TP-stripe resets inside a KC unit and runtime-scalar cache hits."""
+    if ttnn.get_num_devices() != 8:
+        pytest.skip("SP2 x TP4 fused indexer reproduction requires an exact eight-device LoudBox")
+    k_capacity = 3 * LB_SPTP_CHUNK
+    # Each TP stripe is 15 tiles wide, so the KC=10 unit at physical offset 10 crosses a stripe
+    # boundary. At kv_len=960 its first five columns are invalid and its last five reset to valid keys.
+    assert (k_capacity // (LB_SPTP_SP * LB_SPTP_TP)) // 32 == 15
+
+    mesh, semaphores, subdevice_id, stall_group = _open_full_mesh_ccl(
+        (LB_SPTP_SP, LB_SPTP_TP), fabric_config=ttnn.FabricConfig.FABRIC_1D
+    )
+    try:
+        q_host, k_natural, w_host, q_dev, k_local, k_gathered, w_dev = _sptp_loudbox_inputs(mesh, k_capacity, seed=43)
+        mesh.enable_program_cache()
+        entries_before = mesh.num_program_cache_entries()
+        entries_after_compile = None
+        for dispatch, (chunk_start, kv_len) in enumerate(((0, 960), (LB_SPTP_CHUNK, 1920))):
+            out = _run_sptp_loudbox_score(
+                semaphores,
+                subdevice_id,
+                q_dev,
+                k_local,
+                k_gathered,
+                w_dev,
+                chunk_start=chunk_start,
+                kv_len=kv_len,
+                tp_sharded=True,
+            )
+            ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+            out_host = _sptp_loudbox_output(out)
+            ttnn.deallocate(out)
+
+            reference = _sptp_loudbox_ref(q_host, k_natural[:, :, :kv_len], w_host, chunk_start=chunk_start)
+            assert_indexer_match(out_host[:, :, :, :kv_len], reference, LB_SPTP_CHUNK, kv_len, check_neg=True)
+            if dispatch == 0:
+                entries_after_compile = mesh.num_program_cache_entries()
+                assert entries_after_compile > entries_before
+            else:
+                assert (
+                    mesh.num_program_cache_entries() == entries_after_compile
+                ), "changing kv_len/chunk_start recompiled the fused Ring program"
+    finally:
+        _close_full_mesh_ccl(mesh)
+
+
+def test_indexer_score_sptp_loudbox_ring_partial_readiness():
+    """Exercise TP-inner K on two four-rank rings, including the AG midpoint readiness gate."""
+    if ttnn.get_num_devices() != 8:
+        pytest.skip("SP4 x TP2 fused indexer readiness coverage requires an exact eight-device LoudBox")
+    sp, tp = 4, 2
+    sp_axis, tp_axis = 1, 0
+    chunk_global = LB_SPTP_CHUNK
+    chunk_local = chunk_global // sp
+    k_capacity = 3 * chunk_global
+    kv_len = 960
+    assert chunk_local // tp == 160
+    assert (k_capacity // (sp * tp)) // 32 == 15
+
+    mesh, semaphores, subdevice_id, stall_group = _open_full_mesh_ccl((tp, sp))
+    try:
+        q_host, k_natural, w_host, q_dev, k_local, k_gathered, w_dev = _sptp_loudbox_inputs(
+            mesh,
+            k_capacity,
+            seed=44,
+            sp=sp,
+            tp=tp,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            chunk_global=chunk_global,
+        )
+        out = _run_sptp_loudbox_score(
+            semaphores,
+            subdevice_id,
+            q_dev,
+            k_local,
+            k_gathered,
+            w_dev,
+            chunk_start=0,
+            kv_len=kv_len,
+            tp_sharded=True,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            topology=ttnn.Topology.Ring,
+            num_links=2,
+            chunk_local=chunk_local,
+        )
+        ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+        out_host = _sptp_loudbox_output(out)
+        reference = _sptp_loudbox_ref(
+            q_host,
+            k_natural[:, :, :kv_len],
+            w_host,
+            chunk_start=0,
+            sp=sp,
+            tp=tp,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+        )
+        assert_indexer_match(out_host[:, :, :, :kv_len], reference, chunk_global, kv_len, check_neg=True)
+    finally:
+        _close_full_mesh_ccl(mesh)
 
 
 @pytest.mark.skipif(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -342,6 +342,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     // Keep the shared reader's full-mesh rank-mapping CT tail canonical for the classic path.
     reader_ct.insert(reader_ct.end(), {0u, 0u, 0u, 0u});
     reader_ct.push_back(0u);  // partial all-gather readiness off (non-fused path)
+    reader_ct.push_back(1u);  // unused physical SP size
 
     std::vector<uint32_t> writer_ct = common_ct;
     writer_ct.push_back(0u);                             // fused_ring off
@@ -351,7 +352,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     writer_ct.push_back(out_row_elems * out_elem_bytes);
     writer_ct.push_back(0u);  // shard-major mapping off
     writer_ct.push_back(1u);  // unused block-cyclic run width
-    writer_ct.push_back(1u);  // unused SP size
+    writer_ct.push_back(1u);  // unused logical key stripe count
+    writer_ct.push_back(1u);  // unused physical SP size
     tt::tt_metal::TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
 
     std::vector<uint32_t> compute_ct = common_ct;
@@ -366,7 +368,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     compute_ct.push_back(0u);                        // fused_ring off
     compute_ct.push_back(0u);                        // shard-major block-cyclic mapping off
     compute_ct.push_back(1u);                        // unused block-cyclic run width
-    compute_ct.push_back(1u);                        // unused SP size
+    compute_ct.push_back(1u);                        // unused logical key stripe count
+    compute_ct.push_back(1u);                        // unused physical SP size
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     auto reader_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -44,7 +44,8 @@ constexpr bool fused_stream_k = get_compile_time_arg_val(num_common_ct_args + 5)
 constexpr bool fused_ring_enabled = get_compile_time_arg_val(num_common_ct_args + 6) != 0;
 constexpr bool shard_block_cyclic = get_compile_time_arg_val(num_common_ct_args + 7) != 0;
 constexpr uint32_t shard_chunk_local = get_compile_time_arg_val(num_common_ct_args + 8);
-constexpr uint32_t shard_sp = get_compile_time_arg_val(num_common_ct_args + 9);
+constexpr uint32_t shard_key_stripes = get_compile_time_arg_val(num_common_ct_args + 9);
+constexpr uint32_t shard_physical_sp = get_compile_time_arg_val(num_common_ct_args + 10);
 
 // k-cols sharing ONE dest acquire in the blocked-custom mul (dest-bounded). One unpack context per head
 // (w[h] + ct_dim qk cols), so unpack-context sync is paid 1/ct_dim of the per-tile bcast-mul rate.
@@ -421,10 +422,12 @@ inline void stamp_masked_suffix(
     }
 }
 
-/** Causal mask for a shard-major packed unit. Its logical tile ids are monotone but may jump between
- *  block-cyclic runs, so find the prefix below the diagonal using the inverse physical mapping. */
+/** Causal and runtime-prefix mask for a shard-major packed unit. Retain the monotonic prefix walk for
+ *  contiguous/SP-only layouts. TP-striped logical tile ids can reset at stripe-capacity boundaries, so
+ *  classify every physical column independently there. */
 inline void stamp_masked_shard_major(
-    const ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp>& shard_span,
+    const ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_key_stripes, shard_physical_sp>&
+        shard_span,
     uint32_t q_row,
     uint32_t slot_base,
     uint32_t k_tiles_in_unit,
@@ -434,14 +437,23 @@ inline void stamp_masked_shard_major(
     const uint32_t q_row_abs = shard_span.q_tile_start() + q_row;
     const uint32_t diag_tile =
         iscore::causal_diag_tile(q_row_abs, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles);
-    uint32_t valid = 0;
-    while (valid < k_tiles_in_unit && shard_span.logical_tile(valid) < diag_tile) {
-        ++valid;
-    }
     const uint32_t capacity = shard_span.capacity_tiles();
-    for (uint32_t k_col = valid; k_col < k_tiles_per_unit; ++k_col) {
-        const uint32_t logical_tile = k_col < capacity ? shard_span.logical_tile(k_col) : 0xFFFFFFFFu;
-        stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, logical_tile, diag_tile);
+    if constexpr (!shard_block_cyclic || shard_key_stripes == shard_physical_sp) {
+        uint32_t valid = 0;
+        while (valid < k_tiles_in_unit && shard_span.logical_tile(valid) < diag_tile) {
+            ++valid;
+        }
+        for (uint32_t k_col = valid; k_col < k_tiles_per_unit; ++k_col) {
+            const uint32_t logical_tile = k_col < capacity ? shard_span.logical_tile(k_col) : 0xFFFFFFFFu;
+            stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, logical_tile, diag_tile);
+        }
+    } else {
+        for (uint32_t k_col = 0; k_col < k_tiles_per_unit; ++k_col) {
+            const uint32_t logical_tile = k_col < capacity ? shard_span.logical_tile(k_col) : 0xFFFFFFFFu;
+            if (k_col >= k_tiles_in_unit || logical_tile >= shard_span.valid_k_len_tiles || logical_tile >= diag_tile) {
+                stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + k_col, logical_tile, diag_tile);
+            }
+        }
     }
 }
 
@@ -482,7 +494,7 @@ void kernel_main() {
 
     WorkUnitSpan span;
     span.set_valid_k_len_tiles(kv_len_tiles);
-    ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp> shard_span;
+    ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_key_stripes, shard_physical_sp> shard_span;
     shard_span.set_valid_k_len_tiles(kv_len_tiles);
 
     constexpr uint32_t unit_strip = q_tiles_per_unit * k_tiles_per_unit;  // QC x KC accumulator slots
@@ -500,7 +512,7 @@ void kernel_main() {
             uint32_t k_tiles_in_unit = 0;
             if constexpr (fused_ring_enabled) {
                 const uint32_t physical_start = get_arg_val<uint32_t>(10 + band_i);
-                shard_span.set(group, physical_start, k_len_tiles / shard_sp);
+                shard_span.set(group, physical_start, k_len_tiles / shard_physical_sp);
                 k_tiles_in_unit = shard_span.k_tiles();
             } else {
                 span.set(group, band0 + band);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -111,18 +111,28 @@ struct WorkUnitSpan {
 
 /** One fused Ring Indexer work unit in shard-major physical order. Consecutive physical tiles stay within
  *  one SP shard, so the local shard can run without a Fabric dependency and every remote unit has exactly
- *  one readiness source. The block-cyclic inverse maps packed compute columns back to logical K positions. */
-template <bool BlockCyclic, uint32_t ChunkLocal, uint32_t Sp>
+ *  one readiness source. The block-cyclic inverse maps packed compute columns back to logical K positions.
+ *
+ *  KeyStripes may be finer than the physical SP sharding after a TP-inner gather. PhysicalSp remains the
+ *  ring size while KeyStripes == PhysicalSp * TP and KeyStripeChunk == ChunkLocal / TP. Keep both geometries:
+ *  using KeyStripes as the physical shard count shrinks tiles_per_shard, while using PhysicalSp for the
+ *  logical inverse loses the TP stripe ordering. */
+template <bool BlockCyclic, uint32_t KeyStripeChunk, uint32_t KeyStripes, uint32_t PhysicalSp>
 struct ShardMajorWorkUnitSpan {
     uint32_t group = 0;
     uint32_t physical_tile_start = 0;
     uint32_t tiles_per_shard = 0;
+    uint32_t key_stripe_capacity = 0;
     uint32_t valid_k_len_tiles = k_len_tiles;
 
     void set(uint32_t g, uint32_t physical_start, uint32_t shard_tiles) {
         group = g;
         physical_tile_start = physical_start;
         tiles_per_shard = shard_tiles;
+        if constexpr (BlockCyclic && KeyStripes != PhysicalSp) {
+            constexpr uint32_t key_stripe_split = KeyStripes / PhysicalSp;
+            key_stripe_capacity = tiles_per_shard / key_stripe_split;
+        }
     }
     void set_valid_k_len_tiles(uint32_t tiles) { valid_k_len_tiles = tiles; }
 
@@ -133,11 +143,20 @@ struct ShardMajorWorkUnitSpan {
     uint32_t logical_tile(uint32_t col) const {
         if constexpr (!BlockCyclic) {
             return physical_tile_start + col;
-        } else {
+        } else if constexpr (KeyStripes == PhysicalSp) {
             const uint32_t local = shard_offset() + col;
-            const uint32_t slab = local / ChunkLocal;
-            const uint32_t slab_offset = local - slab * ChunkLocal;
-            return (slab * Sp + shard()) * ChunkLocal + slab_offset;
+            const uint32_t slab = local / KeyStripeChunk;
+            const uint32_t slab_offset = local - slab * KeyStripeChunk;
+            return (slab * PhysicalSp + shard()) * KeyStripeChunk + slab_offset;
+        } else {
+            constexpr uint32_t key_stripe_split = KeyStripes / PhysicalSp;
+            const uint32_t local = shard_offset() + col;
+            const uint32_t tp_stripe = local / key_stripe_capacity;
+            const uint32_t within_stripe = local - tp_stripe * key_stripe_capacity;
+            const uint32_t slab = within_stripe / KeyStripeChunk;
+            const uint32_t within_chunk = within_stripe - slab * KeyStripeChunk;
+            const uint32_t chunk_local = KeyStripeChunk * key_stripe_split;
+            return (slab * PhysicalSp + shard()) * chunk_local + tp_stripe * KeyStripeChunk + within_chunk;
         }
     }
 
@@ -146,14 +165,37 @@ struct ShardMajorWorkUnitSpan {
         return shard_left < k_tiles_per_unit ? shard_left : k_tiles_per_unit;
     }
 
-    // Logical positions increase monotonically within one physical shard, though they jump between local
-    // block-cyclic runs. Therefore the runtime KV prefix is still a packed prefix of this work unit.
+    bool valid(uint32_t col) const { return col < capacity_tiles() && logical_tile(col) < valid_k_len_tiles; }
+
+    // Preserve the packed-prefix fast path when logical positions are monotonic (contiguous or SP-only).
+    // TP-striped positions can reset at a stripe-capacity boundary; there, if any column is valid, read and
+    // compute the whole in-capacity physical unit. Compute masks and writer suppresses each invalid column.
+    // Entirely invalid units still return zero so all three kernels skip them together.
     uint32_t k_tiles() const {
         const uint32_t capacity = capacity_tiles();
-        uint32_t valid = 0;
-        while (valid < capacity && logical_tile(valid) < valid_k_len_tiles) {
-            ++valid;
+        if constexpr (!BlockCyclic) {
+            const uint32_t left = valid_k_len_tiles > physical_tile_start ? valid_k_len_tiles - physical_tile_start : 0;
+            return left < capacity ? left : capacity;
         }
-        return valid;
+        if constexpr (KeyStripes == PhysicalSp) {
+            uint32_t valid_prefix = 0;
+            while (valid_prefix < capacity && valid(valid_prefix)) {
+                ++valid_prefix;
+            }
+            return valid_prefix;
+        }
+        // Within one TP stripe logical positions increase monotonically. Only the first column of each
+        // stripe segment can make an otherwise-empty unit active, so avoid scanning every KC column in
+        // capacity-sized schedules whose runtime prefix is short (the common Galaxy prefill case).
+        uint32_t col = 0;
+        while (col < capacity) {
+            if (valid(col)) {
+                return capacity;
+            }
+            const uint32_t local = shard_offset() + col;
+            const uint32_t within_stripe = local % key_stripe_capacity;
+            col += key_stripe_capacity - within_stripe;
+        }
+        return 0;
     }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -70,6 +70,7 @@ constexpr auto snake_orientation =
 constexpr uint32_t rank_mapping_mesh_rows = get_compile_time_arg_val(bc_ct_base + 7);
 constexpr uint32_t rank_mapping_mesh_cols = get_compile_time_arg_val(bc_ct_base + 8);
 constexpr bool partial_readiness_enabled = get_compile_time_arg_val(bc_ct_base + 9) != 0;
+constexpr uint32_t fused_physical_sp = get_compile_time_arg_val(bc_ct_base + 10);
 
 FORCE_INLINE constexpr uint32_t tensor_rank_from_transport_rank(uint32_t transport_rank) {
     return ttnn::ring_attention_all_gather::tensor_rank_from_transport_rank<full_mesh_rank_mapping>(
@@ -515,7 +516,7 @@ void kernel_main() {
 
         WorkUnitSpan span;
         span.set_valid_k_len_tiles(kv_len_tiles);
-        ShardMajorWorkUnitSpan<block_cyclic, bc_chunk_local, bc_sp> shard_span;
+        ShardMajorWorkUnitSpan<block_cyclic, bc_chunk_local, bc_sp, fused_physical_sp> shard_span;
         shard_span.set_valid_k_len_tiles(kv_len_tiles);
         const uint32_t band_iters = stream_heads ? max_bands : num_bands;
         for (uint32_t phase = 0; phase < num_groups; ++phase) {
@@ -537,23 +538,29 @@ void kernel_main() {
                 if constexpr (fused_ring_enabled) {
                     const uint32_t physical_start = gate->physical_start(band_i);
                     shard_span.set(group, physical_start, gate->tiles_per_shard);
+                    const uint32_t k_tiles_in_unit = shard_span.k_tiles();
                     // q/w were multicasted before this loop. Every row of this K-mcast column has
                     // the same work list, so skipping an empty runtime-prefix unit preserves both
                     // the fabric gate and the local CB protocol.
-                    if (shard_span.k_tiles() == 0) {
+                    if (k_tiles_in_unit == 0) {
                         continue;
                     }
                     uint32_t gathered_shard_tiles = gate->tiles_per_shard;
                     if constexpr (block_cyclic) {
-                        const uint32_t global_slab_tiles = bc_chunk_local * bc_sp;
-                        const uint32_t valid_slabs = (kv_len_tiles + global_slab_tiles - 1) / global_slab_tiles;
-                        gathered_shard_tiles = std::min(valid_slabs * bc_chunk_local, gate->tiles_per_shard);
+                        // Partial-height gathers are enabled only for the ordinary SP-only layout. A
+                        // TP-inner reconstructed cache (bc_sp > ring_size) gathers the full physical
+                        // shard, so its midpoint must stay at half that shard as well.
+                        if (bc_sp == gate->ring_size) {
+                            const uint32_t global_slab_tiles = bc_chunk_local * bc_sp;
+                            const uint32_t valid_slabs = (kv_len_tiles + global_slab_tiles - 1) / global_slab_tiles;
+                            gathered_shard_tiles = std::min(valid_slabs * bc_chunk_local, gate->tiles_per_shard);
+                        }
                     }
                     // KEEP IN SYNC with the AG writer's row-aligned midpoint_prefix_pages() and the host's
                     // gather_valid_height_tiles(). Units crossing this boundary wait for completion.
                     const uint32_t midpoint_tiles = (gathered_shard_tiles + 1) / 2;
                     gate->read_k(
-                        noc, k_acc, physical_start, shard_span.k_tiles(), midpoint_tiles, k_dir, k_batch_page_offset);
+                        noc, k_acc, physical_start, k_tiles_in_unit, midpoint_tiles, k_dir, k_batch_page_offset);
                 } else {
                     const uint32_t band = band_i;
                     const bool real_band = band < num_bands;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -19,7 +19,8 @@ constexpr bool fused_ring_enabled = get_compile_time_arg_val(num_common_ct_args)
 constexpr uint32_t page_bytes = get_compile_time_arg_val(num_common_ct_args + 1);  // row-major page = T*2 bytes
 constexpr bool shard_block_cyclic = get_compile_time_arg_val(num_common_ct_args + 2) != 0;
 constexpr uint32_t shard_chunk_local = get_compile_time_arg_val(num_common_ct_args + 3);
-constexpr uint32_t shard_sp = get_compile_time_arg_val(num_common_ct_args + 4);
+constexpr uint32_t shard_key_stripes = get_compile_time_arg_val(num_common_ct_args + 4);
+constexpr uint32_t shard_physical_sp = get_compile_time_arg_val(num_common_ct_args + 5);
 
 constexpr uint32_t frag_bytes = tt::constants::TILE_WIDTH * sizeof(uint16_t);  // one bf16 tile row
 
@@ -56,7 +57,8 @@ inline void write_shard_major_strip(
     Noc noc,
     const OutAcc& out_acc,
     uint32_t page_row_start,
-    const ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp>& shard_span,
+    const ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_key_stripes, shard_physical_sp>&
+        shard_span,
     uint32_t valid_w) {
     CircularBuffer cb(cb_out_strip);
     cb.wait_front(k_tiles_per_unit);
@@ -68,8 +70,22 @@ inline void write_shard_major_strip(
         for (uint32_t col = 0; col < valid_w;) {
             const uint32_t logical_start = shard_span.logical_tile(col);
             uint32_t width = 1;
-            while (col + width < valid_w && shard_span.logical_tile(col + width) == logical_start + width) {
-                ++width;
+            if constexpr (!shard_block_cyclic || shard_key_stripes == shard_physical_sp) {
+                while (col + width < valid_w && shard_span.logical_tile(col + width) == logical_start + width) {
+                    ++width;
+                }
+            } else {
+                if (logical_start >= shard_span.valid_k_len_tiles) {
+                    ++col;
+                    continue;
+                }
+                while (col + width < valid_w) {
+                    const uint32_t next_logical = shard_span.logical_tile(col + width);
+                    if (next_logical >= shard_span.valid_k_len_tiles || next_logical != logical_start + width) {
+                        break;
+                    }
+                    ++width;
+                }
             }
             fragment_col[num_fragments] = col;
             fragment_logical[num_fragments] = logical_start;
@@ -186,14 +202,14 @@ void kernel_main() {
     const uint32_t straddle_q_keys = get_arg_val<uint32_t>(9) * tt::constants::TILE_WIDTH;
     const uint32_t straddle_jump_keys = get_arg_val<uint32_t>(10) * tt::constants::TILE_WIDTH;
 
-    constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 5>();
+    constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 6>();
     const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
 
     Noc noc;
 
     WorkUnitSpan span;
     span.set_valid_k_len_tiles(kv_len_tiles);
-    ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_sp> shard_span;
+    ShardMajorWorkUnitSpan<shard_block_cyclic, shard_chunk_local, shard_key_stripes, shard_physical_sp> shard_span;
     shard_span.set_valid_k_len_tiles(kv_len_tiles);
 
     // Output [B, num_out_groups, Sq, T]: plane g occupies rows [g*Sq, (g+1)*Sq). Compute pushes
@@ -208,7 +224,7 @@ void kernel_main() {
             uint32_t valid_w = 0;
             if constexpr (fused_ring_enabled) {
                 const uint32_t physical_start = get_arg_val<uint32_t>(11 + band_i);
-                shard_span.set(group, physical_start, k_len_tiles / shard_sp);
+                shard_span.set(group, physical_start, k_len_tiles / shard_physical_sp);
                 k_tile0 = physical_start;
                 valid_w = shard_span.k_tiles();
             } else {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -22,7 +22,7 @@
 #include "ttnn/operations/transformer/sdpa/device/ring_fusion.hpp"  // RingSDPAFusedOpSignaler
 #include "ttnn/operations/ccl/ccl_common.hpp"                       // linearized index / neighbor / fwd-bwd config
 #include "ttnn/operations/ccl/common/host/mesh_ring_plan.hpp"
-#include "ttnn/operations/ccl/ccl_op_fusion.hpp"                    // AllGatherFusedOpSignaler
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"  // AllGatherFusedOpSignaler
 // the fused AG helper (the only Linear+fuse-capable all-gather):
 #include "ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp"
 
@@ -401,6 +401,7 @@ ProgramDescriptor build_ring_program_descriptor(
     reader_ct.push_back(rank_mapping.mesh_rows);
     reader_ct.push_back(rank_mapping.mesh_cols);
     reader_ct.push_back(static_cast<uint32_t>(partial_readiness_enabled));
+    reader_ct.push_back(ring_size);  // physical SP shard count for shard-major specialization
 
     std::vector<uint32_t> writer_ct = common_ct;
     writer_ct.push_back(1u);  // fused_ring on
@@ -408,7 +409,8 @@ ProgramDescriptor build_ring_program_descriptor(
     writer_ct.push_back(T * out_elem_bytes);  // row-major page = one output row (no pooling)
     writer_ct.push_back(block_cyclic_ct[0]);  // shard-major physical -> logical output mapping
     writer_ct.push_back(block_cyclic_ct[1]);
-    writer_ct.push_back(ring_size);  // physical shard count (also block-cyclic SP when enabled)
+    writer_ct.push_back(block_cyclic_ct[2]);  // logical key stripe count (SP * TP for TP-sharded KV)
+    writer_ct.push_back(ring_size);           // physical SP shard count
     tt::tt_metal::TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
 
     std::vector<uint32_t> compute_ct = common_ct;
@@ -421,7 +423,8 @@ ProgramDescriptor build_ring_program_descriptor(
     compute_ct.push_back(1u);                  // fused_ring on
     compute_ct.push_back(block_cyclic_ct[0]);  // shard-major physical -> logical causal mapping
     compute_ct.push_back(block_cyclic_ct[1]);
-    compute_ct.push_back(ring_size);  // physical shard count (also block-cyclic SP when enabled)
+    compute_ct.push_back(block_cyclic_ct[2]);  // logical key stripe count (SP * TP for TP-sharded KV)
+    compute_ct.push_back(ring_size);           // physical SP shard count
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     KernelDescriptor reader_kernel{};


### PR DESCRIPTION
## Regression

PR #51968 (0f3403d239c) introduced TP-sharded KV caches, so logical key stripes became SP x TP while the physical gather ring remained SP. PR #54741 (f010a178807) then added shard-major fused scheduling under the previous equal-count assumption. The reader mapped work with SP x TP while compute/writer used SP, allowing it to skip K tiles that compute awaited and deadlocking the CB pipeline.

## Fix

- Carry physical SP and logical key-stripe geometry separately.
- Correct TP stripe-tail masking/scattering and Ring readiness while preserving the SP-only fast path.
- Fold LoudBox regressions for the original hang, partial-prefix cache reuse, and SP4 x TP2 Ring readiness into the existing suite.

### Targeted CI

- [![Blackhole E2E prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-glm52-indexer-tp-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Apjosipovic%2Ffix-glm52-indexer-tp-hang)
- [![Blaze GLM 5.2 prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/fix-glm52-indexer-tp-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch%3Apjosipovic%2Ffix-glm52-indexer-tp-hang)
- [![Blackhole sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-glm52-indexer-tp-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Apjosipovic%2Ffix-glm52-indexer-tp-hang)
- [![Blackhole experimental L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-glm52-indexer-tp-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Apjosipovic%2Ffix-glm52-indexer-tp-hang)