### PR TITLE
fix for Hang when running Llama-3.1-8B-Instruct in NO_DISPATCH mode. issue 29004

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
@@ -545,6 +545,7 @@ def test_program_cache_invalidation_across_dispatch_modes(device):
         )
 
     try:
+        test_conv(device)
         ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NO_DISPATCH)
         test_conv(device)
         ttnn.graph.end_graph_capture()

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -58,6 +58,15 @@ template <typename... Ts>
     return table[i];
 }
 
+inline bool graph_capture_blocks_dispatch() {
+    if (auto hook = tt::tt_metal::GraphTracker::instance().get_hook()) {
+        if (auto* processor_hooks = dynamic_cast<ttnn::graph::ProcessorHooks*>(hook.get())) {
+            return processor_hooks->get_block();
+        }
+    }
+    return false;
+}
+
 template <typename device_operation_t>
 auto compute_program_hash(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
@@ -283,12 +292,14 @@ void handle_mesh_adapter_cache_hit(
         using cached_mesh_workload_t = typename WorkloadFactory::cached_mesh_workload_t;
         auto& cached_mesh_workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
 
-        if constexpr (requires { &WorkloadFactory::apply_descriptor; }) {
-            WorkloadFactory::apply_descriptor(
-                cached_mesh_workload, operation_attributes, tensor_args, tensor_return_value);
-        } else {
-            WorkloadFactory::override_runtime_arguments(
-                cached_mesh_workload, operation_attributes, tensor_args, tensor_return_value);
+        if (!graph_capture_blocks_dispatch()) {
+            if constexpr (requires { &WorkloadFactory::apply_descriptor; }) {
+                WorkloadFactory::apply_descriptor(
+                    cached_mesh_workload, operation_attributes, tensor_args, tensor_return_value);
+            } else {
+                WorkloadFactory::override_runtime_arguments(
+                    cached_mesh_workload, operation_attributes, tensor_args, tensor_return_value);
+            }
         }
 
         enqueue_mesh_workload<mesh_device_operation_t>(
@@ -338,14 +349,7 @@ void create_and_cache_mesh_workload(
             // buffer addresses are invalid (address=0). Caching such programs would
             // cause issues when later running in NORMAL mode.
             // In NORMAL capture mode, the hook exists but is non-blocking, so caching is safe.
-            bool hook_blocks = false;
-            if (auto hook = tt::tt_metal::GraphTracker::instance().get_hook()) {
-                auto* processor_hooks = dynamic_cast<ttnn::graph::ProcessorHooks*>(hook.get());
-                if (processor_hooks) {
-                    hook_blocks = processor_hooks->get_block();
-                }
-            }
-            bool should_cache = program_cache.is_enabled() && !hook_blocks;
+            bool should_cache = program_cache.is_enabled() && !graph_capture_blocks_dispatch();
             if (should_cache) {
                 program_cache.insert(
                     program_key, CachedProgramFactory{std::move(cached_workload), program_factory_index});


### PR DESCRIPTION
### PR Category
bug fix for issue  #29004 

### Summary
Fixes #29004. A NO_DISPATCH graph capture after a real run still takes the program-cache hit path and calls override_runtime_arguments / apply_descriptor with hooked buffer address 0. That poisons cached programs, so the next NORMAL dispatch hangs (Llama decode is compiled first, then captured, then run again).

#36772 already skipped inserting programs during NO_DISPATCH. This PR also skips mutating already-cached workloads while the graph hook is blocking. Enqueue still runs so capture can track the program; hook_program still skips device dispatch.

test_program_cache_invalidation_across_dispatch_modes now warms up the conv once before capture so the test hits a cached program, matching the issue sequence.

### Notes for reviewers
* Change is in handle_mesh_adapter_cache_hit in ttnn/api/ttnn/device_operation.hpp. The graph_capture_blocks_dispatch() helper is the same check previously inlined on the cache-miss insert path.
* Verified on Blackhole P150 after rebuild: copy+matmul to_torch PASS; NO_DISPATCH then NORMAL matmul+gelu PASS; warmup → NO_DISPATCH → NORMAL PASS (max abs vs warmup 0); the updated conv graph-capture test PASSED in 1.78s.
* The original Llama-3.1-8B-Instruct / Wormhole N150 recipe was not re-run here (gated weights; this host is P150). On-device compute wait cannot be proven on CI without silicon.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/issue/29004_hang_in_no_dispatch)