### PR TITLE
tt_transformers: span cached tokens in untraced prefill page table

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1181,6 +1181,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # For batched prefill: pass full page_table (function handles slot placement)
                 # For non-batched prefill: pass sliced page_table for current user (like original code)
                 page_table_for_user = page_table if use_batched_prefill else page_table[idx : idx + 1]
+                # A resumed chunk needs a page table spanning the cached tokens
+                # too: ``prefill_forward_single_user_text`` slices
+                # ``chunk_page_table`` at an absolute block offset, so a
+                # chunk-width table leaves that slice inside its own zero pad and
+                # ``paged_fill_cache`` writes the chunk into physical block 0.
+                # ``seq_len`` is the cumulative prompt length; ``prefill_seq_len``
+                # is only this chunk's padded width.
+                page_table_use_full_len = bool(
+                    not use_batched_prefill and not enable_trace_current_prompt and num_cached_tokens
+                )
                 page_table_user = self._get_prefill_user_page_table(
                     page_table_for_user,
                     kv_cache[model_id],
@@ -1190,6 +1200,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     use_batched_prefill=use_batched_prefill,
                     user_id=batch_user_ids if use_batched_prefill else user_id,
                     padded_batch_size=padded_batch if use_batched_prefill else None,
+                    use_full_prompt_len=page_table_use_full_len,
                 )
                 full_page_table_user = None
                 if enable_trace_current_prompt and not use_batched_prefill:


### PR DESCRIPTION
### What this fixes

A chunked prefill that resumes on the **untraced** path answered from a prefix
that was not its own, emitting degenerate text. No exception, no warning, no
crash.

`models/tt_transformers/tt/generator.py` walks a long prompt in chunks inside
`prefill_forward_single_user_text`. For each chunk it slices the physical KV
block ids belonging to that chunk into `chunk_page_table` and hands them to
`ttnn.experimental.paged_fill_cache`, which writes the chunk's K and V into
those blocks.

### Mechanism

1. `prefill_forward_text` builds the per-user page table through
   `_get_prefill_user_page_table`, and passes `use_full_prompt_len` only
   alongside the traced path, because `full_page_table_user` next to it is
   computed under `if enable_trace_current_prompt and not use_batched_prefill:`.
2. Without that flag, `_get_prefill_user_page_table` takes
   `target_prefill_len = prefill_seq_len`, this chunk's padded width, and
   returns `page_table[:, :num_blocks]`. For a 2048-token chunk with
   `block_size` 64 that is 32 entries, holding the request's **first** 32 block
   ids rather than the current chunk's.
3. `prefill_forward_single_user_text` then computes
   `needed_blocks = num_blocks_in_seq(seq_len + num_cached_tokens, block_size)`,
   which is correct and cumulative, and pads the narrow table up to that width
   with `torch.zeros`.
4. `chunk_page_table = page_table_user_padded[:, chunk_start // block_size :
   chunk_end // block_size]` is an absolute-offset slice, so once any tokens are
   cached it lands wholly inside that zero pad.
5. `paged_fill_cache` takes every zero as physical block 0, so each chunk
   overwrites the request's own first block.

Diagnostic logging at the `paged_fill_cache` call site, `--max-num-batched-tokens
2048`, `trace_mode: none`, prefix caching off, one request, 12452-token prompt:

```
GEN  incoming_page_table.shape=(1, 32) needed_blocks=64 num_padding_blocks=32
     seq_len=2048 num_cached_tokens=2048 user_row=[1, 2, 3, ... 32]
     padded=[1..32, 0, 0, ... 0]
FILL path=eager seq_len=2048 chunk_start_idx=2048 page_table.shape=(1, 64)
     chunk_page_table=[0, 0, 0, ... 0]  fill_blocks=[0, 0, 0, ... 0]
```

`chunk_page_table` was all zeros at every resume offset: 2048, 4096, 6144, 8192,
10240 and 12288. After the fix it carries real block ids, for example
`[127, 128, 129, ...]`.

### The change

Set `use_full_prompt_len` for an untraced, non-batched resumed chunk so the
table spans the cumulative prompt length.

`seq_len` is already cumulative in `prefill_forward_text`
(`seq_len = int(prompt_lens[idx])`, and line 1168 slices
`tokens[..., num_cached_tokens:seq_len]`), while `prefill_seq_len` is per-chunk.
Adding `num_cached_tokens` to `seq_len` would double-count; the flag alone is
sufficient.

### Testing

CI: https://github.com/tenstorrent/tt-metal/actions/runs/34124674909

`meta-llama/Llama-3.1-8B-Instruct` on a T3K (4x n300), vllm-tt-plugin
`bef89e429e2`, vLLM 0.26.0, `--no-enable-prefix-caching`, greedy decoding,
`max_tokens 64`, a 12452-token needle-recall prompt, 3 rounds per cell.

Server:

```
python3 examples/server_example_tt.py --model meta-llama/Llama-3.1-8B-Instruct \
  --max_num_seqs 32 --block_size 64 --max_model_len 32768 --async-scheduling \
  --enable-chunked-prefill --max-num-batched-tokens <BUDGET> \
  --no-enable-prefix-caching \
  --additional-config '{"tt": {"fabric_config": "FABRIC_1D", "sample_on_device_mode": "all", "trace_region_size": 85000000, "trace_mode": "<MODE>"}}'
```

| Configuration | Before | After |
|---|---|---|
| `trace_mode: none`, budget 2048 | 0/3 at concurrency 1 | 3/3 at concurrency 1, 12/12 at concurrency 4 |
| `trace_mode: none`, budget 8192 | 0/3 at concurrency 1, 0/12 at concurrency 4 | 3/3 at concurrency 1, 12/12 at concurrency 4 |
| `trace_mode: all`, budget 2048 | 12/12 at concurrency 4 | 12/12 at concurrency 4 (regression check) |

`pre-commit run --files models/tt_transformers/tt/generator.py` passes.

### Why CI did not catch this

The T3K chunked-prefill leg in `tests/pipeline_reorg/vllm_model_tests.yaml` sets
`tt-config` without a `trace_mode` key, so it runs the default `"all"` and
exercises only the traced path. The untraced path has no chunked-prefill
coverage. Adding a leg with `trace_mode: decode_only` would close that gap; I
have not added one here.

### Out of scope

A separate defect remains on the **traced** path, where a per-request prefill
chunk above 4096 tokens corrupts output. That is unaffected by this change and
its root cause is not established. Measured on the same setup with
`trace_mode: all`: chunks of 2048 through 3840 are correct at concurrency 1, 2
and 4, chunk 4096 is correct alone but wrong when prefills share a step (3/6 at
concurrency 2, 4/12 at concurrency 4), and every chunk from 4352 up is wrong
even alone. `--long-prefill-token-threshold 3840` or lower avoids it. The
`vllm serve` default budget of 2048 is unaffected.

### AI assistance

Claude Code was used for this investigation and change. The mechanism above was
proposed by the submitter from a code reading, then confirmed on device by
instrumenting the `paged_fill_cache` and SDPA call sites. Every number in the
tables was measured on hardware, not inferred.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-untraced-chunked-prefill-page-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-untraced-chunked-prefill-page-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-untraced-chunked-prefill-page-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/fix-untraced-chunked-prefill-page-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-untraced-chunked-prefill-page-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-untraced-chunked-prefill-page-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/fix-untraced-chunked-prefill-page-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/fix-untraced-chunked-prefill-page-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-untraced-chunked-prefill-page-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-untraced-chunked-prefill-page-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-untraced-chunked-prefill-page-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-untraced-chunked-prefill-page-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-untraced-chunked-prefill-page-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-untraced-chunked-prefill-page-table)