### PR TITLE
[LLK] DO NOT MERGE: no-op probe to exercise RTL Sim CI

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+// CI probe for RTL Sim flakiness -- comment-only, no functional change. DO NOT MERGE.
+
 #include <cstdint>
 #include <type_traits>
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+// CI probe for RTL Sim flakiness -- comment-only, no functional change. DO NOT MERGE.
+
 #include <cstdint>
 #include <type_traits>
 


### PR DESCRIPTION
## What this is

A deliberate no-op PR, opened to get an independent reading on the `RTL Sim CI test` check. **DO NOT MERGE** — close it once the RTL Sim result is in.

## The change

Two comment lines, one in each arch's `ckernel_defs.h`:

```c
// CI probe for RTL Sim flakiness -- comment-only, no functional change. DO NOT MERGE.
```

Nothing else. Every translation unit compiles to the same code as `main`.

`ckernel_defs.h` was chosen on purpose: it is included by effectively every LLK kernel, so touching it invalidates the kernel build cache and forces the sim pipeline to do real work. A docs-only probe could pass simply by skipping the sim, which would be a false green.

## Why

`RTL Sim CI test` has failed on both non-draft PRs in the LLK sanitizer stack, on four different commits across two days:

| PR | commit | started | result |
|----|--------|---------|--------|
| #54467 | `52a507e` | 2026-09-04 16:23Z | failure |
| #55062 | `2ce0300` | 2026-09-04 17:54Z | failure |
| #54467 | `b62fd8a` | 2026-09-07 11:33Z | failure |
| #55062 | `47c7c99` | 2026-09-07 11:33Z | failure |

Meanwhile the same check is green on unrelated non-draft PRs (#55625, #55621, #55614). This PR is the control: since it changes no behaviour, a failure here points at the sim pipeline, and a pass points at the code under test in the stack.

## Reading the result

- **Fails** → the pipeline fails independently of the change under test; the stack's failures are not evidence about the stack.
- **Passes** → the pipeline is healthy for a no-op, so the stack's failures deserve investigation on their merits.

Note that `detailsUrl` on the posted check currently points at `https://github.com/tenstorrernt` (typo'd host), so the result has to be read from the check's own output rather than by following the link.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sstanisic/rtl-ci-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sstanisic/rtl-ci-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sstanisic/rtl-ci-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sstanisic/rtl-ci-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sstanisic/rtl-ci-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sstanisic/rtl-ci-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sstanisic/rtl-ci-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sstanisic/rtl-ci-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sstanisic/rtl-ci-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sstanisic/rtl-ci-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sstanisic/rtl-ci-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sstanisic/rtl-ci-probe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sstanisic/rtl-ci-probe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sstanisic/rtl-ci-probe)