### PR TITLE
[Performance] Take the Sanity test environments from prebuilt images

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -37,6 +37,13 @@ inputs:
     description: 'Skip download and installation of build artifacts and wheel as theyre pre-installed in evaluation image'
     default: false
     type: boolean
+  env-from-image:
+    description: >-
+      The job takes its source tree and build output from a prebuilt image at
+      /work, so skip fetching them. Also moves the triage script paths to /work,
+      since the workspace checkout is then sparse.
+    default: false
+    type: boolean
   auto-triage:
     description: 'Enable detection of timeout on fast dispatch and automatically call tt-triage'
     default: true
@@ -56,7 +63,7 @@ runs:
       shell: bash
 
     - name: 📦 Download Build Artifact
-      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
+      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == 'false' && inputs.env-from-image == 'false' }}
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.build-artifact-name }}
@@ -64,13 +71,13 @@ runs:
         digest-mismatch: error
 
     - name: 📂 Extract Build Files
-      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
+      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == 'false' && inputs.env-from-image == 'false' }}
       working-directory: ${{ inputs.path }}
       run: tar --zstd -xf ttm_any.tar.zst
       shell: bash
 
     - name: 🧪 Download Python Wheel
-      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
+      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == 'false' && inputs.env-from-image == 'false' }}
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.wheel-artifact-name }}
@@ -78,7 +85,7 @@ runs:
         digest-mismatch: error
 
     - name: 💿 Install Wheel
-      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
+      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == 'false' && inputs.env-from-image == 'false' }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "📂 In directory: $(pwd)"
@@ -154,8 +161,11 @@ runs:
         TT_TRIAGE_OUTPUT_PATH=/work/generated/triage_output.txt
         TT_TRIAGE_LLM_OUTPUT_PATH=/work/generated/triage_llm_output.txt
         TT_TRIAGE_SQLITE_OUTPUT_PATH=/work/generated/triage_sqlite_output.sqlite
-        HANG_REPORT="/opt/venv/bin/python3 $(pwd)/.github/scripts/utils/hang_report.py"
-        TRIAGE="/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress --path=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH --triage-summary-path=generated/triage_summary.txt --llm-output-path=$TT_TRIAGE_LLM_OUTPUT_PATH --sqlite-output-path=$TT_TRIAGE_SQLITE_OUTPUT_PATH"
+        # /work when the environment came from an image: the workspace checkout is
+        # then sparse and carries no tools/ directory.
+        SRC_ROOT=$([ "${{ inputs.env-from-image }}" = "true" ] && echo /work || pwd)
+        HANG_REPORT="/opt/venv/bin/python3 $SRC_ROOT/.github/scripts/utils/hang_report.py"
+        TRIAGE="/opt/venv/bin/python3 $SRC_ROOT/tools/tt-triage.py --disable-progress --path=$TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH --triage-summary-path=generated/triage_summary.txt --llm-output-path=$TT_TRIAGE_LLM_OUTPUT_PATH --sqlite-output-path=$TT_TRIAGE_SQLITE_OUTPUT_PATH"
         # Only run triage on the first hang of a job: the device isn't reset between
         # tests, so subsequent tests and hangs are on a poisoned device and produce unreliable triage.
         TRIAGE_SENTINEL=generated/.tt_triage_already_ran

--- a/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
@@ -61,6 +61,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          # Same commit as the tests, the binaries and the image: an unpinned
+          # matrix load can select tests from one revision and run them against
+          # another on a targeted run.
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: |
             .github
             tests/pipeline_reorg

--- a/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
@@ -6,6 +6,15 @@ on:
       build-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       wheel-artifact-name:
         required: true
         type: string
@@ -85,16 +94,23 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved' }}
       env:
         ARCH_NAME: blackhole
         LOGURU_LEVEL: INFO
         LD_LIBRARY_PATH: /work/build/lib
-        PYTHONPATH: /work
+        # /work/ttnn and /work/tools as well as /work: these tests are pytest and
+        # import ttnn, which a full-profile image supplies from the tree rather than
+        # a wheel. Sanity builds with tracy=true, so _ttnn imports the `tracy` module
+        # at init; the wheel maps it in via package_dir (setup.py), while in place it
+        # is only importable from /work/tools.
+        PYTHONPATH: /work:/work/ttnn:/work/tools
         TT_METAL_HOME: /work
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }} # Subdir to workaround https://github.com/actions/runner/issues/691
         - ${{ (!contains(join(matrix.test-group.runs_on, ' '), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       options: "--device /dev/tenstorrent"
     defaults:
@@ -106,7 +122,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          submodules: recursive
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          submodules: ${{ inputs.prebuilt-image == '' && 'recursive' || 'false' }}
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
           ref: ${{ inputs.ref || github.sha }}
       - name: ⬇️  Setup Job
@@ -115,6 +134,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
           # PERF jobs (tracy profiler on) need a wider hang-detection window because
@@ -150,7 +170,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "workspace": "/work",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}"

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -165,6 +165,13 @@ jobs:
             echo "::error::source-ref must be a full 40-character commit sha, got '$SOURCE_REF'"
             exit 1
           fi
+          # Taking the artifact from another run says nothing about which commit
+          # built it, so defaulting the source to this workflow's sha would pair
+          # this commit's source with someone else's binaries under a valid tag.
+          if [ "$CHECKOUT_SOURCE" = "true" ] && [ -n "$ARTIFACT_RUN_ID" ] && [ -z "$SOURCE_REF" ]; then
+            echo "::error::source-ref is required when checkout-source is on and the artifact comes from another run, or src/ and artifact/ are from different commits"
+            exit 1
+          fi
           # Names end in <ref><sep><runid>, but packages joins with '-' and the
           # tarball with '_', so strip by shape rather than by position.
           CONFIG=$(printf '%s' "$ARTIFACT_NAME" | sed -E 's/[-_][0-9a-f]{7,40}[-_][0-9]+$//')

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -59,9 +59,12 @@ on:
         type: string
         default: ""
         description: >-
-          Commit to bake the source from, when checkout-source is on. Defaults to
-          this workflow's own commit. A caller testing a non-default ref must pass
-          the same one it gave build-artifact, or src/ and artifact/ disagree.
+          Commit to bake the source from, when checkout-source is on. Must be a
+          full 40-character sha, not a branch or tag: a movable ref would let a
+          re-run recompute the same tag while checking out different source, and
+          overwrite the image with it. Defaults to this workflow's own commit. A
+          caller testing a non-default ref must pass the same one it gave
+          build-artifact, or src/ and artifact/ disagree.
       runner-label:
         required: false
         type: string
@@ -114,7 +117,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "Commit to bake the source from; defaults to this workflow's commit"
+        description: "Full 40-character commit sha to bake the source from; defaults to this workflow's commit"
       runner-label:
         required: false
         type: string
@@ -154,6 +157,12 @@ jobs:
           # download-artifact fetch every artifact in the run.
           if [ -z "$ARTIFACT_NAME" ]; then
             echo "::error::artifact-name is empty; the upstream build did not produce one"
+            exit 1
+          fi
+          # A branch or tag can move, so re-running would recompute the same tag
+          # while checking out different source and overwrite the image with it.
+          if [ -n "$SOURCE_REF" ] && ! printf '%s' "$SOURCE_REF" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::source-ref must be a full 40-character commit sha, got '$SOURCE_REF'"
             exit 1
           fi
           # Names end in <ref><sep><runid>, but packages joins with '-' and the
@@ -209,13 +218,13 @@ jobs:
           path: src
           submodules: recursive
 
-      # context: is the whole workspace, so without this the source checkout
-      # ships its own .git and every submodule's - multiple GB of context.
-      - name: Exclude .git from the build context
-        if: ${{ inputs.checkout-source }}
+      # context: is the whole workspace, so every .git in it is transferred. The
+      # Dockerfile checkout puts one at the root even when no source is checked
+      # out, and a source checkout adds its own plus every submodule's.
+      - name: Exclude git metadata from the build context
         run: |
           set -euo pipefail
-          printf 'src/.git\nsrc/**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
+          printf '.git\n**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
           cat "$GITHUB_WORKSPACE/.dockerignore"
 
       - name: Download the build artifact

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -165,6 +165,12 @@ jobs:
             echo "::error::artifact-name is empty; the upstream build did not produce one"
             exit 1
           fi
+          # source-ref cannot affect the image when no source is checked out, so
+          # neither validate nor hash it there: doing so would mint a distinct tag
+          # for a byte-identical image and churn retention for nothing.
+          if [ "$CHECKOUT_SOURCE" != "true" ]; then
+            SOURCE_REF=""
+          fi
           # A branch or tag can move, so re-running would recompute the same tag
           # while checking out different source and overwrite the image with it.
           if [ -n "$SOURCE_REF" ] && ! printf '%s' "$SOURCE_REF" | grep -qE '^[0-9a-f]{40}$'; then

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -54,6 +54,14 @@ on:
           Check the source tree out to src/ for Dockerfiles that need it. Off by
           default: it is a multi-GB recursive clone that the package-based paths
           have no use for.
+      source-ref:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Commit to bake the source from, when checkout-source is on. Defaults to
+          this workflow's own commit. A caller testing a non-default ref must pass
+          the same one it gave build-artifact, or src/ and artifact/ disagree.
       runner-label:
         required: false
         type: string
@@ -102,6 +110,11 @@ on:
         type: boolean
         default: false
         description: "Check the source tree out to src/ for Dockerfiles that need it"
+      source-ref:
+        required: false
+        type: string
+        default: ""
+        description: "Commit to bake the source from; defaults to this workflow's commit"
       runner-label:
         required: false
         type: string
@@ -134,6 +147,7 @@ jobs:
           BUILD_ARGS: ${{ inputs.build-args }}
           CHECKOUT_SOURCE: ${{ inputs.checkout-source }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
+          SOURCE_REF: ${{ inputs.source-ref }}
         run: |
           set -euo pipefail
           # required: true still lets '' through, and an empty name would make
@@ -156,9 +170,11 @@ jobs:
           # is the raw input, so it is empty on the same-run path and changes
           # nothing there, but it separates two cross-run calls that share a
           # build config and would otherwise collide on different payloads.
-          RECIPE=$(printf '%s\n%s\n%s\n%s\n%s\n%s' \
+          # SOURCE_REF included, or two calls differing only in the source they
+          # bake would share a tag and the second would overwrite the first.
+          RECIPE=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s' \
             "$CONFIG" "$BASE_IMAGE" "$DOCKERFILE" "$BUILD_ARGS" "$CHECKOUT_SOURCE" \
-            "$ARTIFACT_RUN_ID" \
+            "$ARTIFACT_RUN_ID" "$SOURCE_REF" \
             | sha256sum | cut -c1-8)
           # The readable parts are truncated so the tag is bounded by construction.
           # Real configs reach 142 chars untruncated, over Docker's 128 limit, and
@@ -187,11 +203,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          # The workflow's commit: a caller baking another run's artifact must
-          # ensure it matches, or src/ and artifact/ disagree.
-          ref: ${{ github.sha }}
+          # Must match the commit the artifact was built from, or src/ and
+          # artifact/ disagree; defaults to this workflow's own commit.
+          ref: ${{ inputs.source-ref || github.sha }}
           path: src
           submodules: recursive
+
+      # context: is the whole workspace, so without this the source checkout
+      # ships its own .git and every submodule's - multiple GB of context.
+      - name: Exclude .git from the build context
+        if: ${{ inputs.checkout-source }}
+        run: |
+          set -euo pipefail
+          printf 'src/.git\nsrc/**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
+          cat "$GITHUB_WORKSPACE/.dockerignore"
 
       - name: Download the build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -62,9 +62,11 @@ on:
           Commit to bake the source from, when checkout-source is on. Must be a
           full 40-character sha, not a branch or tag: a movable ref would let a
           re-run recompute the same tag while checking out different source, and
-          overwrite the image with it. Defaults to this workflow's own commit. A
-          caller testing a non-default ref must pass the same one it gave
-          build-artifact, or src/ and artifact/ disagree.
+          overwrite the image with it. Defaults to this workflow's own commit,
+          which is only meaningful when the artifact comes from this run too.
+          Baking another run's artifact (artifact-run-id) alongside a source
+          checkout requires this, since the default would pair this commit's
+          source with someone else's binaries.
       runner-label:
         required: false
         type: string
@@ -117,7 +119,11 @@ on:
         required: false
         type: string
         default: ""
-        description: "Full 40-character commit sha to bake the source from; defaults to this workflow's commit"
+        description: >-
+          Full 40-character commit sha to bake the source from. Required whenever
+          checkout-source is on here, because a dispatched run always takes its
+          artifact from another run, so there is no commit to default to. Unused
+          when checkout-source is off.
       runner-label:
         required: false
         type: string

--- a/.github/workflows/build-prebuilt-tests-image.yaml
+++ b/.github/workflows/build-prebuilt-tests-image.yaml
@@ -243,7 +243,11 @@ jobs:
       - name: Exclude git metadata from the build context
         run: |
           set -euo pipefail
-          printf '.git\n**/.git\n' > "$GITHUB_WORKSPACE/.dockerignore"
+          # tech_reports is 69 MiB of the source tree and nothing a test leg runs
+          # reads it: the only references are a comment, an error string pointing
+          # at the docs, and a release-notes path classifier that runs elsewhere.
+          # Every consumer pulls the source layer, so this comes off every leg.
+          printf '.git\n**/.git\nsrc/tech_reports\n' > "$GITHUB_WORKSPACE/.dockerignore"
           cat "$GITHUB_WORKSPACE/.dockerignore"
 
       - name: Download the build artifact
@@ -314,7 +318,7 @@ jobs:
           # would leave behind holding the layers alive.
           provenance: false
           outputs: |
-            type=registry,push=true,compression=zstd,compression-level=3,oci-mediatypes=true
+            type=registry,push=true,compression=zstd,compression-level=7,oci-mediatypes=true
 
       # Runs only if the push succeeded, so a failed build yields an empty ref
       # and the consumer falls back to the artifact path instead of pulling a

--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -33,15 +33,16 @@ name: "Cleanup prebuilt tests images"
 # Recompute N if the push rate changes: wiring more consumers raises it, and
 # building one image per run instead of two would halve it.
 #
-# The producer also creates prebuilt-tests-env-image, whose payload is a source
-# tree plus build output rather than packages. It is swept separately because its
-# push rate is nothing like the gates': the producer test plus the nightly
-# consumers put it on the order of ten a day, so a much smaller N buys more
-# retention than 4,800 buys for the gate images. Recompute it when a high-volume
-# caller is wired, the same way the figure above is derived from a rate.
+# One matrix entry per package the producer creates, each with its own N, because
+# their push rates differ by two orders of magnitude. prebuilt-tests-env-image
+# carries a source tree plus build output rather than packages, and is pushed by
+# the producer test and the nightly consumers on the order of ten a day, so N=100
+# buys it more retention than N=4,800 buys the gate images. Recompute either when
+# a high-volume caller is wired, the same way the figure above is derived.
 #
-# This deletes irreversibly. It is scoped to the two packages the
-# build-prebuilt-tests-image producer creates, and never touches a base image.
+# This deletes irreversibly. The package list is fixed in the matrix below and
+# never derives from event context, so this cannot resolve to a package it should
+# not touch, and it never touches a base image.
 
 permissions:
   packages: write
@@ -52,66 +53,48 @@ on:
   workflow_dispatch:
     inputs:
       min-versions-to-keep:
-        description: "Newest versions to keep. Set very high for a safe no-op run."
+        description: "Override retention for every package. Set very high for a safe no-op run. Empty uses each package's own default."
         required: false
         type: string
-        default: "4800"
-      env-min-versions-to-keep:
-        description: "Newest env-image versions to keep. Set very high for a safe no-op run."
-        required: false
-        type: string
-        default: "100"
+        default: ""
 
 jobs:
   cleanup:
-    name: "Delete aged-out prebuilt tests images"
+    name: "Delete aged-out ${{ matrix.package }}"
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    strategy:
+      # One package failing must not stop the others being swept.
+      fail-fast: false
+      matrix:
+        include:
+          - package: tt-metal/prebuilt-tests-image
+            keep: "4800"
+          - package: tt-metal/prebuilt-tests-env-image
+            keep: "100"
     steps:
       - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
-          # Literal, not a context expression: this is what stops the job ever
-          # resolving to a package it should not touch.
           owner: tenstorrent
-          package-name: tt-metal/prebuilt-tests-image
+          package-name: ${{ matrix.package }}
           package-type: container
-          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '4800' }}
+          min-versions-to-keep: ${{ inputs.min-versions-to-keep || matrix.keep }}
 
       # A GC that silently falls behind looks exactly like one that is working.
       - name: Report what is left
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KEEP: ${{ inputs.min-versions-to-keep || '4800' }}
+          KEEP: ${{ inputs.min-versions-to-keep || matrix.keep }}
+          PACKAGE: ${{ matrix.package }}
         run: |
           set -euo pipefail
-          COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-image" --jq '.version_count')
-          echo "versions remaining: ${COUNT}" | tee -a "$GITHUB_STEP_SUMMARY"
+          # The API takes the package name path-encoded.
+          COUNT=$(gh api "/orgs/tenstorrent/packages/container/${PACKAGE//\//%2F}" --jq '.version_count')
+          echo "${PACKAGE}: ${COUNT} versions remaining" | tee -a "$GITHUB_STEP_SUMMARY"
           # Steady state sits near the retention value, so warn relative to it
           # rather than at a fixed number. A deliberate high-retention no-op run
           # would otherwise report falling behind.
           THRESHOLD=$(( KEEP * 2 ))
           if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
-            echo "::warning::${COUNT} versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
-          fi
-
-      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          # Literal for the same reason as above.
-          owner: tenstorrent
-          package-name: tt-metal/prebuilt-tests-env-image
-          package-type: container
-          min-versions-to-keep: ${{ inputs.env-min-versions-to-keep || '100' }}
-
-      - name: Report what is left of the env images
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KEEP: ${{ inputs.env-min-versions-to-keep || '100' }}
-        run: |
-          set -euo pipefail
-          # 404 until the first env image is pushed, which is not an error here.
-          COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-env-image" --jq '.version_count' 2>/dev/null || echo 0)
-          echo "env image versions remaining: ${COUNT}" | tee -a "$GITHUB_STEP_SUMMARY"
-          THRESHOLD=$(( KEEP * 2 ))
-          if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
-            echo "::warning::${COUNT} env image versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
+            echo "::warning::${PACKAGE}: ${COUNT} versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
           fi

--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -33,7 +33,14 @@ name: "Cleanup prebuilt tests images"
 # Recompute N if the push rate changes: wiring more consumers raises it, and
 # building one image per run instead of two would halve it.
 #
-# This deletes irreversibly. It is scoped to the one package the
+# The producer also creates prebuilt-tests-env-image, whose payload is a source
+# tree plus build output rather than packages. It is swept separately because its
+# push rate is nothing like the gates': the producer test plus the nightly
+# consumers put it on the order of ten a day, so a much smaller N buys more
+# retention than 4,800 buys for the gate images. Recompute it when a high-volume
+# caller is wired, the same way the figure above is derived from a rate.
+#
+# This deletes irreversibly. It is scoped to the two packages the
 # build-prebuilt-tests-image producer creates, and never touches a base image.
 
 permissions:
@@ -49,6 +56,11 @@ on:
         required: false
         type: string
         default: "4800"
+      env-min-versions-to-keep:
+        description: "Newest env-image versions to keep. Set very high for a safe no-op run."
+        required: false
+        type: string
+        default: "100"
 
 jobs:
   cleanup:
@@ -80,4 +92,26 @@ jobs:
           THRESHOLD=$(( KEEP * 2 ))
           if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
             echo "::warning::${COUNT} versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
+          fi
+
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          # Literal for the same reason as above.
+          owner: tenstorrent
+          package-name: tt-metal/prebuilt-tests-env-image
+          package-type: container
+          min-versions-to-keep: ${{ inputs.env-min-versions-to-keep || '100' }}
+
+      - name: Report what is left of the env images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: ${{ inputs.env-min-versions-to-keep || '100' }}
+        run: |
+          set -euo pipefail
+          # 404 until the first env image is pushed, which is not an error here.
+          COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-env-image" --jq '.version_count' 2>/dev/null || echo 0)
+          echo "env image versions remaining: ${COUNT}" | tee -a "$GITHUB_STEP_SUMMARY"
+          THRESHOLD=$(( KEEP * 2 ))
+          if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
+            echo "::warning::${COUNT} env image versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
           fi

--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -34,11 +34,12 @@ name: "Cleanup prebuilt tests images"
 # building one image per run instead of two would halve it.
 #
 # One matrix entry per package the producer creates, each with its own N, because
-# their push rates differ by two orders of magnitude. prebuilt-tests-env-image
-# carries a source tree plus build output rather than packages, and is pushed by
-# the producer test and the nightly consumers on the order of ten a day, so N=100
-# buys it more retention than N=4,800 buys the gate images. Recompute either when
-# a high-volume caller is wired, the same way the figure above is derived.
+# their push rates differ. prebuilt-tests-env-image carries a source tree plus
+# build output rather than packages. Sanity runs about 250 times a day and bakes
+# two of these per run, one per (base, profile) its impls need; runtime sanity
+# adds about 20 runs a day with one more. So roughly 520 a day, and N=1500 buys
+# about three days. Recompute if a caller is added, the same way the figure above
+# is derived from a rate.
 #
 # This deletes irreversibly. The package list is fixed in the matrix below and
 # never derives from event context, so this cannot resolve to a package it should
@@ -71,7 +72,7 @@ jobs:
           - package: tt-metal/prebuilt-tests-image
             keep: "4800"
           - package: tt-metal/prebuilt-tests-env-image
-            keep: "100"
+            keep: "1500"
     steps:
       - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -54,8 +54,31 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       collect-coverage: true
 
+  bake-test-env:
+    needs: build-artifact
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      # Canonical ghcr ref: harbor-prefix only reaches bake layer contexts, never
+      # this output, so the GitHub-hosted producer can pull it.
+      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+
   run-metal-runtime-tests:
-    needs: [build-artifact]
+    # bake-test-env is needed for its output, but an explicit `if` is required or
+    # a failed bake would skip this job by default. An empty ref instead falls
+    # back to the artifact path, so coverage still gets collected.
+    needs: [build-artifact, bake-test-env]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/runtime-unit-tests-impl.yaml
     secrets: inherit
     with:
@@ -64,6 +87,7 @@ jobs:
       # wh_n150_civ2: single-card WH — sufficient for runtime unit tests
       enabled-skus: "wh_n150_civ2"
       collect-coverage: true
+      prebuilt-image: ${{ needs.bake-test-env.outputs.image }}
 
   aggregate-coverage:
     name: "Aggregate & publish coverage"

--- a/.github/workflows/fabric-sanity-tests-impl.yaml
+++ b/.github/workflows/fabric-sanity-tests-impl.yaml
@@ -18,6 +18,15 @@ on:
       build-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       wheel-artifact-name:
         required: true
         type: string
@@ -87,7 +96,7 @@ jobs:
     # run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh trip their -z guards on
     # unrecognized SKUs.
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
@@ -99,7 +108,10 @@ jobs:
         # cost on non-TTNN entries; set universally rather than per-SKU.
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path, the same idiom
+        # as the hugepages opt-out below.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }} # Subdir to workaround https://github.com/actions/runner/issues/691
         # Coverage: mount /dev/hugepages-1G on non-viommu runners only. Viommu SKUs
         # (e.g. bh_p150b_civ2_viommu) bypass the hugepages path and must not have
         # the mount.
@@ -117,7 +129,10 @@ jobs:
         timeout-minutes: 20
         with:
           ref: ${{ inputs.ref || github.sha }}
-          submodules: recursive
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          submodules: ${{ inputs.prebuilt-image == '' && 'recursive' || 'false' }}
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
@@ -125,6 +140,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
           # Coverage: enable runtime kernel ccache (Redis-backed) on WH-LB legs
           # where JIT compile amortizes across the run. Other SKUs skip ccache

--- a/.github/workflows/models-sanity-tests-impl.yaml
+++ b/.github/workflows/models-sanity-tests-impl.yaml
@@ -48,6 +48,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          # Same commit as the tests, the binaries and the image: an unpinned
+          # matrix load can select tests from one revision and run them against
+          # another on a targeted run.
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: |
             .github
             tests/pipeline_reorg

--- a/.github/workflows/models-sanity-tests-impl.yaml
+++ b/.github/workflows/models-sanity-tests-impl.yaml
@@ -6,6 +6,15 @@ on:
       docker-image:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       wheel-artifact-name:
         required: true
         type: string
@@ -71,16 +80,23 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
-        PYTHONPATH: /work
+        # /work/ttnn and /work/tools as well as /work: these tests are pytest and
+        # import ttnn, which a full-profile image supplies from the tree rather than
+        # a wheel. Sanity builds with tracy=true, so _ttnn imports the `tracy` module
+        # at init; the wheel maps it in via package_dir (setup.py), while in place it
+        # is only importable from /work/tools.
+        PYTHONPATH: /work:/work/ttnn:/work/tools
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }} # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - ${{ contains(matrix.test-group.sku, 'perf') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: --device /dev/tenstorrent
@@ -93,7 +109,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          submodules: recursive
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          submodules: ${{ inputs.prebuilt-image == '' && 'recursive' || 'false' }}
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
           ref: ${{ inputs.ref || github.sha }}
       - name: Mark repository as safe directory
@@ -105,6 +124,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         uses: ./docker-job/.github/actions/run-with-log
@@ -127,7 +147,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "workspace": "/work",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}"

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -11,6 +11,15 @@ on:
       docker-image:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       build-artifact-name:
         required: true
         type: string
@@ -91,14 +100,20 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
         LOGURU_LEVEL: INFO
-        PYTHONPATH: /work
+        # /work/ttnn and /work/tools as well as /work: this bucket is pytest and
+        # imports ttnn, which a full-profile image supplies from the tree. Sanity
+        # builds with tracy=true, so _ttnn imports the `tracy` module at init, which
+        # in place is only importable from /work/tools.
+        PYTHONPATH: /work:/work/ttnn:/work/tools
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
-        - ${{ github.workspace }}/docker-job:/work
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }}
         - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
     defaults:
@@ -112,6 +127,9 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           filter: blob:none
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
@@ -119,6 +137,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
@@ -158,7 +177,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: power-report-${{ matrix.test-group.name }}
-          path: ${{ github.workspace }}/docker-job/power_report.json
+          # The sidecar's --out path. Steps run inside the container, so this holds
+          # whether or not /work is a bind mount.
+          path: /work/power_report.json
           if-no-files-found: warn
           retention-days: 30
 
@@ -184,7 +205,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "workspace": "/work",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}"

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -69,6 +69,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          # Same commit as the tests, the binaries and the image: an unpinned
+          # matrix load can select tests from one revision and run them against
+          # another on a targeted run.
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: |
             .github
             tests/pipeline_reorg

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -110,6 +110,10 @@ jobs:
         # in place is only importable from /work/tools.
         PYTHONPATH: /work:/work/ttnn:/work/tools
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
+        # This bucket merges device perf results, and the image carries no .git, so
+        # the merge cannot read the commit from the tree. GITHUB_SHA is the ref the
+        # workflow ran on rather than the commit under test, so pass the tested one.
+        TT_METAL_TESTED_SHA: ${{ inputs.ref || github.sha }}
       volumes:
         # The image owns /work, so no bind mount: one would mask the payload. A
         # single-path entry is an anonymous volume on an unused path.

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -13,6 +13,15 @@ on:
         required: false
         type: string
         default: ""
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       enabled-skus:
         required: true
         type: string
@@ -110,7 +119,7 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         # Quasar is checked first: sim_quasar contains neither 'bh_' nor 'blackhole' and would
@@ -123,7 +132,9 @@ jobs:
         LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
-        - ${{ github.workspace }}/docker-job:/work
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }}
         - /dev/hugepages-1G:/dev/hugepages-1G
       options: ${{ startsWith(matrix.test-group.sku, 'sim_') && '--label runner-mode=sim' || '--device /dev/tenstorrent' }}
     defaults:
@@ -135,7 +146,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          submodules: recursive
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          submodules: ${{ inputs.prebuilt-image == '' && 'recursive' || 'false' }}
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
           ref: ${{ inputs.ref || github.sha }}
       - name: ⬇️  Setup Job
@@ -144,6 +158,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
       - name: ⬇️  Setup TTSim
         if: ${{ startsWith(matrix.test-group.sku, 'sim_') }}
         uses: ./docker-job/.github/actions/setup-ttsim

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -203,10 +203,8 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: mem-report-${{ matrix.test-group.name }}
-          # /docker-job/ is the host-side mount of the container's /work/. The host-load sidecar
-          # writes its CPU/memory/disk/network report to --output /work/mem_report.json; this
-          # host path is what upload-artifact reads.
-          path: ${{ github.workspace }}/docker-job/mem_report.json
+          # The host-load sidecar's --output path.
+          path: /work/mem_report.json
           if-no-files-found: warn
           retention-days: 30
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
@@ -222,7 +220,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "workspace": "/work",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}",

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -53,6 +53,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          # Same commit as the tests, the binaries and the image: an unpinned
+          # matrix load can select tests from one revision and run them against
+          # another on a targeted run.
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: |
             .github
             tests/pipeline_reorg

--- a/.github/workflows/runtime-sanity-tests.yaml
+++ b/.github/workflows/runtime-sanity-tests.yaml
@@ -143,8 +143,30 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
 
+  bake-env-dev-full:
+    needs: build-artifact
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+      # No source-ref: this caller takes no ref input, so build-artifact builds at
+      # this workflow's commit and the producer's default resolves to the same one.
+
   runtime-sanity-tests:
-    needs: [check-harbor, build-artifact, resolve-skus]
+    # The bake feeds prebuilt-image but is deliberately absent from `if`: a failed
+    # bake yields an empty ref and the legs fall back to the artifact path, rather
+    # than skipping and counting as success in workflow-status.
+    needs: [check-harbor, build-artifact, resolve-skus, bake-env-dev-full]
     if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     uses: ./.github/workflows/runtime-sanity-tests-impl.yaml
     secrets: inherit
@@ -152,3 +174,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
+      prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}

--- a/.github/workflows/runtime-unit-tests-impl.yaml
+++ b/.github/workflows/runtime-unit-tests-impl.yaml
@@ -9,6 +9,15 @@ on:
       build-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       enabled-skus:
         required: true
         type: string
@@ -70,7 +79,7 @@ jobs:
       # actually pulls (DNS split-brain). GHCR-direct is the path the multi-host SKUs
       # and the Harbor-outage fallback already use, so harbor-prefix is intentionally
       # not applied here.
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         ARCH_NAME: ${{ contains(matrix.test-group.sku, 'bh_') && 'blackhole' || 'wormhole_b0' }}
@@ -80,7 +89,9 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
       volumes:
-        - ${{ github.workspace }}/docker-job:/work
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }}
         - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
@@ -92,13 +103,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          submodules: recursive
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          submodules: ${{ inputs.prebuilt-image == '' && 'recursive' || 'false' }}
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
       - name: Ensure BH links online
         if: ${{ contains(matrix.test-group.sku, 'bh_loudbox') || contains(matrix.test-group.sku, 'bh_galaxy') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
@@ -132,7 +147,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: profdata-metal-runtime-${{ matrix.test-group.name }}
-          path: ${{ github.workspace }}/docker-job/coverage/job.profdata
+          # /work, not the workspace: that path only resolved through the bind
+          # mount, and if-no-files-found: ignore would hide the miss.
+          path: /work/coverage/job.profdata
           if-no-files-found: ignore
           retention-days: 1
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -176,16 +176,3 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
       prebuilt-image: ${{ needs.bake-test-env.outputs.image }}
-
-  # TEMPORARY, remove before review. The artifact-path arm: same run, same build,
-  # same SKU as the job above, differing only in prebuilt-image being unset, so
-  # setup timings can be compared without a cross-run baseline.
-  ab-artifact-arm:
-    needs: [check-harbor, build-artifact, resolve-skus, bake-test-env]
-    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
-    uses: ./.github/workflows/runtime-unit-tests-impl.yaml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -144,8 +144,44 @@ jobs:
       tracy: true
       enable-lto: ${{ inputs.enable-lto || false }}
 
+  bake-test-env:
+    needs: build-artifact
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      # Canonical ghcr ref: harbor-prefix only reaches bake layer contexts, never
+      # this output, so the GitHub-hosted producer can pull it.
+      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+
   runtime-unit-tests:
-    needs: [check-harbor, build-artifact, resolve-skus]
+    # bake-test-env is needed for its output but deliberately not in `if`: a failed
+    # bake yields an empty ref and the legs fall back to the artifact path, rather
+    # than skipping and counting as success in workflow-status.
+    needs: [check-harbor, build-artifact, resolve-skus, bake-test-env]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
+    uses: ./.github/workflows/runtime-unit-tests-impl.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
+      prebuilt-image: ${{ needs.bake-test-env.outputs.image }}
+
+  # TEMPORARY, remove before review. The artifact-path arm: same run, same build,
+  # same SKU as the job above, differing only in prebuilt-image being unset, so
+  # setup timings can be compared without a cross-run baseline.
+  ab-artifact-arm:
+    needs: [check-harbor, build-artifact, resolve-skus, bake-test-env]
     if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     uses: ./.github/workflows/runtime-unit-tests-impl.yaml
     secrets: inherit

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -339,6 +339,66 @@ jobs:
       build-args: PROFILE=full
       source-ref: ${{ inputs.ref || github.sha }}
 
+  # TEMP measurement, revert after: is pulling the env image through Harbor's
+  # pull-through cache faster than ghcr direct? Uses images an earlier run already
+  # published, so it needs no bake and no test hardware and reports in ~2 minutes.
+  probe-harbor-env:
+    name: "TEMP probe: Harbor vs ghcr for the env image"
+    needs: [check-harbor]
+    if: ${{ !cancelled() }}
+    runs-on: tt-ubuntu-2204-large-stable
+    timeout-minutes: 40
+    steps:
+      - name: Time ghcr direct against Harbor for both profiles
+        env:
+          PREFIX: ${{ needs.check-harbor.outputs.harbor-prefix }}
+          WHEEL_IMG: ghcr.io/tenstorrent/tt-metal/prebuilt-tests-env-image:036f8c92e9ee-ttnn-dist-inplace-cp310-Release-profiler-ubuntu-22.04-ci-test-amd64-66c6be85
+          FULL_IMG: ghcr.io/tenstorrent/tt-metal/prebuilt-tests-env-image:036f8c92e9ee-TTMetal_build_any_22.04_amd64_x86_64-linux-clang-ubuntu-22.04-dev-amd64-b2f317e2
+        run: |
+          set -uo pipefail
+          if [ -z "$PREFIX" ]; then
+            echo "::warning::Harbor reported unhealthy, so there is nothing to compare"
+            exit 0
+          fi
+
+          # Both refs resolve to identical layer digests, so dropping one tag leaves
+          # the layers in the local store and the next pull is a no-op. Untag both,
+          # then prune the now-dangling layers; other jobs' images stay tagged and
+          # are therefore untouched.
+          clear_local() {
+            docker rmi -f "$1" "$2" >/dev/null 2>&1 || true
+            docker image prune -f >/dev/null 2>&1 || true
+          }
+
+          timed_pull() {
+            label="$1"; ref="$2"
+            start=$SECONDS
+            if ! out=$(docker pull "$ref" 2>&1); then
+              echo "  ${label}: FAILED"
+              printf '%s\n' "$out" | tail -4 | sed 's/^/        /'
+              return 0
+            fi
+            dur=$((SECONDS - start))
+            dl=$(printf '%s\n' "$out" | grep -c 'Pull complete' || true)
+            ae=$(printf '%s\n' "$out" | grep -c 'Already exists' || true)
+            sz=$(docker image inspect "$ref" --format '{{.Size}}' 2>/dev/null || echo 0)
+            printf '  %s: %3ds  downloaded=%-3s cached=%-3s image=%sMiB\n' \
+              "$label" "$dur" "$dl" "$ae" "$((sz / 1048576))"
+          }
+
+          for pair in "wheel:$WHEEL_IMG" "full:$FULL_IMG"; do
+            profile="${pair%%:*}"; direct="${pair#*:}"; harbor="${PREFIX}${direct}"
+            echo "::group::${profile} profile"
+            echo "  direct: $direct"
+            echo "  harbor: $harbor"
+            # Harbor first: its cache is cold for any tag nothing has pulled yet.
+            clear_local "$direct" "$harbor"; timed_pull "harbor cold" "$harbor"
+            clear_local "$direct" "$harbor"; timed_pull "ghcr direct" "$direct"
+            clear_local "$direct" "$harbor"; timed_pull "harbor warm" "$harbor"
+            clear_local "$direct" "$harbor"
+            echo "::endgroup::"
+          done
+
   # Single SKU list that gates every suite (L2-nightly style). Each impl filters this list against
   # its own tests yaml via prepare_test_matrix.py, so an empty intersection just yields no jobs.
   generate-sku-matrix:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -505,12 +505,16 @@ jobs:
   # Single source of truth for fabric coverage in the sanity pipeline.
   fabric-sanity-tests:
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && (needs.generate-sku-matrix.outputs.run-wormhole == 'true' || needs.generate-sku-matrix.outputs.run-blackhole == 'true') && toJSON(inputs.run-fabric-sanity-tests) != 'false' }}
-    needs: [build-artifact, generate-sku-matrix]
+    # bake-env-dev-full is in needs but deliberately absent from the if: above.
+    # A failed bake leaves the ref empty and the leg falls back to the artifact
+    # path, which a gate on the bake would turn into a skipped suite instead.
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
     secrets: inherit
     uses: ./.github/workflows/fabric-sanity-tests-impl.yaml
     with:
       enabled-skus: ${{ format('{0}{1}', needs.generate-sku-matrix.outputs.sanity-skus, needs.generate-sku-matrix.outputs.run-wormhole == 'true' && ',wh_llmbox_civ2' || '') }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -282,15 +282,28 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Percent-encode the whole ref, not just its slashes. Each of these is a
+          # legal branch name and each fails silently with a valid sha for the
+          # wrong commit, which the 40-character check below cannot catch:
+          #   `main#foo`   -> '#' starts a URL fragment, so this addresses `main`
+          #   `foo%2Fbar`  -> the '%' is decoded, so this addresses `foo/bar`
+          #   `x/comments` -> reaches the /commits/{ref}/comments sub-resource
+          # Written out rather than shelling to jq so the job needs nothing extra.
+          encode_ref() {
+            local s="$1" out="" i c
+            for (( i = 0; i < ${#s}; i++ )); do
+              c="${s:i:1}"
+              case "$c" in
+                [a-zA-Z0-9.~_-]) out+="$c" ;;
+                *) out+=$(printf '%%%02X' "'$c") ;;
+              esac
+            done
+            printf '%s' "$out"
+          }
           if [ -z "$REF" ]; then
             SHA="$FALLBACK"
           else
-            # Percent-encode the slashes. A slash-containing branch does resolve
-            # literally, because {ref} is greedy, but the endpoint has sub-resources
-            # (/status, /comments, /pulls, /check-runs), so a branch named like
-            # `x/comments` would address one of those instead and return an array
-            # where a commit is expected. Encoding keeps the ref one path segment.
-            SHA=$(gh api "repos/${REPO}/commits/${REF//\//%2F}" --jq '.sha')
+            SHA=$(gh api "repos/${REPO}/commits/$(encode_ref "$REF")" --jq '.sha')
           fi
           printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$' \
             || { echo "::error::could not resolve '${REF:-HEAD}' to a full commit sha, got '${SHA}'"; exit 1; }

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -298,6 +298,27 @@ jobs:
       test-docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       llk-ci-docker-image: ${{ needs.build-artifact.outputs.llk-ci-docker-image }}
 
+  bake-env-ci-test-wheel:
+    needs: build-artifact
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      # Canonical, never a resolve-docker-pull-refs output: that one is
+      # Harbor-prefixed and the producer runs GitHub-hosted with no Harbor access.
+      base-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=wheel
+      # Must match what build-artifact was given, or src/ and the wheel disagree.
+      source-ref: ${{ inputs.ref || github.sha }}
+
   # Single SKU list that gates every suite (L2-nightly style). Each impl filters this list against
   # its own tests yaml via prepare_test_matrix.py, so an empty intersection just yields no jobs.
   generate-sku-matrix:
@@ -412,7 +433,10 @@ jobs:
 
   # TTNN sanity tests
   ttnn-sanity-tests:
-    needs: [build-artifact, generate-sku-matrix]
+    # The bake feeds prebuilt-image but is deliberately absent from `if`: a failed
+    # bake yields an empty ref and the legs fall back to the artifact path, rather
+    # than skipping and counting as success in workflow-status.
+    needs: [build-artifact, generate-sku-matrix, bake-env-ci-test-wheel]
     secrets: inherit
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.sanity-skus != '' && toJSON(inputs.run-ttnn-sanity-tests) != 'false' }}
     uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -428,6 +452,7 @@ jobs:
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       ref: ${{ inputs.ref || github.sha }}
+      prebuilt-image: ${{ needs.bake-env-ci-test-wheel.outputs.image }}
 
   t3000-sanity-tests:
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-wormhole == 'true' && toJSON(inputs.run-t3000-sanity-tests) != 'false' }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -319,6 +319,26 @@ jobs:
       # Must match what build-artifact was given, or src/ and the wheel disagree.
       source-ref: ${{ inputs.ref || github.sha }}
 
+  bake-env-dev-full:
+    needs: build-artifact
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      # Canonical, never a resolve-docker-pull-refs output: that one is
+      # Harbor-prefixed and the producer runs GitHub-hosted with no Harbor access.
+      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+      source-ref: ${{ inputs.ref || github.sha }}
+
   # Single SKU list that gates every suite (L2-nightly style). Each impl filters this list against
   # its own tests yaml via prepare_test_matrix.py, so an empty intersection just yields no jobs.
   generate-sku-matrix:
@@ -456,7 +476,10 @@ jobs:
 
   t3000-sanity-tests:
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-wormhole == 'true' && toJSON(inputs.run-t3000-sanity-tests) != 'false' }}
-    needs: [build-artifact, generate-sku-matrix]
+    # bake-env-dev-full is in needs but deliberately absent from the if: above.
+    # A failed bake leaves the ref empty and the leg falls back to the artifact
+    # path, which a gate on the bake would turn into a skipped suite instead.
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
     secrets: inherit
     uses: ./.github/workflows/t3000-sanity-tests-impl.yaml
     with:
@@ -469,6 +492,7 @@ jobs:
       # SKU set lacking a wh_llmbox entry.
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.sanity-skus }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -257,8 +257,38 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   # NOTE: build-artifact.yaml handles platform parsing internally.
   # Just pass platform and enable-lto inputs directly.
+  # `ref` is documented as a commit SHA, but nothing enforces that and
+  # actions/checkout accepts a branch or tag. The producer requires a full
+  # 40-character SHA for source-ref, because a ref that can move would recompute
+  # the same image tag over different source. Resolve once here so build-artifact
+  # and both bakes pin the identical immutable commit; resolving separately per job
+  # would reintroduce the mismatch on a branch that moves mid-run.
+  resolve-ref:
+    name: "Resolve the ref to a commit"
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ inputs.ref }}
+          FALLBACK: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "$REF" ]; then
+            SHA="$FALLBACK"
+          else
+            SHA=$(gh api "repos/${REPO}/commits/${REF}" --jq '.sha')
+          fi
+          printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$' \
+            || { echo "::error::could not resolve '${REF:-HEAD}' to a full commit sha, got '${SHA}'"; exit 1; }
+          echo "sha=${SHA}" | tee -a "$GITHUB_OUTPUT"
+
   build-artifact:
-    needs: check-harbor
+    needs: [check-harbor, resolve-ref]
     # A failed/errored check-harbor must not skip the whole pipeline: an empty
     # harbor-prefix output already means "fall back to direct GHCR pulls".
     if: ${{ !cancelled() }}
@@ -282,7 +312,7 @@ jobs:
       # CI-internal only: consumers of these packages all run in docker images that
       # already stage SFPI, so skip the redundant download. Never set for release builds.
       use-system-sfpi: true
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
       checkout-filter: tree:0
 
   resolve-docker-pull-refs:
@@ -299,7 +329,7 @@ jobs:
       llk-ci-docker-image: ${{ needs.build-artifact.outputs.llk-ci-docker-image }}
 
   bake-env-ci-test-wheel:
-    needs: build-artifact
+    needs: [build-artifact, resolve-ref]
     if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/build-prebuilt-tests-image.yaml
     permissions:
@@ -317,10 +347,10 @@ jobs:
       checkout-source: true
       build-args: PROFILE=wheel
       # Must match what build-artifact was given, or src/ and the wheel disagree.
-      source-ref: ${{ inputs.ref || github.sha }}
+      source-ref: ${{ needs.resolve-ref.outputs.sha }}
 
   bake-env-dev-full:
-    needs: build-artifact
+    needs: [build-artifact, resolve-ref]
     if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/build-prebuilt-tests-image.yaml
     permissions:
@@ -337,7 +367,7 @@ jobs:
       image-name: prebuilt-tests-env-image
       checkout-source: true
       build-args: PROFILE=full
-      source-ref: ${{ inputs.ref || github.sha }}
+      source-ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # Single SKU list that gates every suite (L2-nightly style). Each impl filters this list against
   # its own tests yaml via prepare_test_matrix.py, so an empty intersection just yields no jobs.
@@ -525,7 +555,7 @@ jobs:
     # bake-env-dev-full is in needs but deliberately absent from the if: above.
     # A failed bake leaves the ref empty and the leg falls back to the artifact
     # path, which a gate on the bake would turn into a skipped suite instead.
-    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix, bake-env-dev-full]
+    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix, bake-env-dev-full, resolve-ref]
     secrets: inherit
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' && needs.build-artifact.result == 'success' && (needs.generate-sku-matrix.outputs.run-wormhole == 'true' || needs.generate-sku-matrix.outputs.run-blackhole == 'true') && toJSON(inputs.run-ops-sanity-tests) != 'false' }}
     uses: ./.github/workflows/ops-sanity-impl.yaml
@@ -539,7 +569,7 @@ jobs:
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # UMD sanity (Blackhole only)
   umd-sanity-tests:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -267,6 +267,10 @@ jobs:
     name: "Resolve the ref to a commit"
     runs-on: ubuntu-slim
     timeout-minutes: 5
+    # Only a read-only commits lookup happens here, so drop the workflow-wide
+    # write grants: naming one scope sets every other to none.
+    permissions:
+      contents: read
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
     steps:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -290,7 +290,11 @@ jobs:
           #   `x/comments` -> reaches the /commits/{ref}/comments sub-resource
           # Written out rather than shelling to jq so the job needs nothing extra.
           encode_ref() {
-            local s="$1" out="" i c
+            # LC_ALL=C so the loop walks bytes rather than characters: percent
+            # encoding is defined over the UTF-8 bytes, and a character-wise loop
+            # emits the code point instead, turning `café` into caf%E9 rather than
+            # caf%C3%A9. ASCII refs encode identically either way.
+            local LC_ALL=C s="$1" out="" i c
             for (( i = 0; i < ${#s}; i++ )); do
               c="${s:i:1}"
               case "$c" in

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -291,7 +291,11 @@ jobs:
     needs: [check-harbor, resolve-ref]
     # A failed/errored check-harbor must not skip the whole pipeline: an empty
     # harbor-prefix output already means "fall back to direct GHCR pulls".
-    if: ${{ !cancelled() }}
+    # resolve-ref is the opposite: its output is the commit everything else is
+    # pinned to, so an empty one would silently build this workflow's own sha
+    # instead of the requested ref and burn the whole build and hardware budget
+    # against the wrong commit.
+    if: ${{ !cancelled() && needs.resolve-ref.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -486,7 +490,7 @@ jobs:
     # The bake feeds prebuilt-image but is deliberately absent from `if`: a failed
     # bake yields an empty ref and the legs fall back to the artifact path, rather
     # than skipping and counting as success in workflow-status.
-    needs: [build-artifact, generate-sku-matrix, bake-env-ci-test-wheel]
+    needs: [build-artifact, generate-sku-matrix, bake-env-ci-test-wheel, resolve-ref]
     secrets: inherit
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.sanity-skus != '' && toJSON(inputs.run-ttnn-sanity-tests) != 'false' }}
     uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -501,7 +505,7 @@ jobs:
       timeout-minutes-override: ${{ inputs.enable-watcher && 240 || 0 }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
       prebuilt-image: ${{ needs.bake-env-ci-test-wheel.outputs.image }}
 
   t3000-sanity-tests:
@@ -509,7 +513,7 @@ jobs:
     # bake-env-dev-full is in needs but deliberately absent from the if: above.
     # A failed bake leaves the ref empty and the leg falls back to the artifact
     # path, which a gate on the bake would turn into a skipped suite instead.
-    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full, resolve-ref]
     secrets: inherit
     uses: ./.github/workflows/t3000-sanity-tests-impl.yaml
     with:
@@ -529,7 +533,7 @@ jobs:
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       timeout-minutes-override: ${{ inputs.enable-watcher && 80 || 0 }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # Fabric sanity (via fabric_sanity_tests.yaml).
   # Single source of truth for fabric coverage in the sanity pipeline.
@@ -538,7 +542,7 @@ jobs:
     # bake-env-dev-full is in needs but deliberately absent from the if: above.
     # A failed bake leaves the ref empty and the leg falls back to the artifact
     # path, which a gate on the bake would turn into a skipped suite instead.
-    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full, resolve-ref]
     secrets: inherit
     uses: ./.github/workflows/fabric-sanity-tests-impl.yaml
     with:
@@ -548,7 +552,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # Ops sanity (Wormhole + Blackhole via ops_sanity_tests.yaml)
   ops-sanity-tests:
@@ -576,7 +580,7 @@ jobs:
     # bake-env-dev-full is in needs but deliberately absent from the if: above.
     # A failed bake leaves the ref empty and the leg falls back to the artifact
     # path, which a gate on the bake would turn into a skipped suite instead.
-    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix, bake-env-dev-full]
+    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix, bake-env-dev-full, resolve-ref]
     secrets: inherit
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-blackhole == 'true' && toJSON(inputs.run-umd-sanity-tests) != 'false' }}
     uses: ./.github/workflows/umd-sanity-tests-impl.yaml
@@ -588,10 +592,10 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   ttsim-sanity-tests:
-    needs: [build-artifact, generate-sku-matrix]
+    needs: [build-artifact, generate-sku-matrix, resolve-ref]
     if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-sim == 'true' && toJSON(inputs.run-ttsim-sanity-tests) != 'false' }}
     uses: ./.github/workflows/ttsim-sanity-tests-impl.yaml
     secrets: inherit
@@ -599,10 +603,10 @@ jobs:
       summary-scope: ${{ inputs.platform }}
       basic-docker-image: ${{ needs.build-artifact.outputs.basic-dev-docker-image }}
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   runtime-sim-sanity-tests:
-    needs: [build-artifact, generate-sku-matrix]
+    needs: [build-artifact, generate-sku-matrix, resolve-ref]
     if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-sim == 'true' && toJSON(inputs.run-ttsim-sanity-tests) != 'false' }}
     uses: ./.github/workflows/runtime-sanity-tests-impl.yaml
     secrets: inherit
@@ -613,7 +617,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       # runtime_sanity_tests.yaml also covers HW SKUs; this job is the sim half only.
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.sim-skus }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # Blackhole multi-card post-commit tests (QB2/P300 box).
   blackhole-multi-card-fast-sanity-tests:
@@ -621,7 +625,7 @@ jobs:
     # bake-env-dev-full is in needs but deliberately absent from the if: above.
     # A failed bake leaves the ref empty and the leg falls back to the artifact
     # path, which a gate on the bake would turn into a skipped suite instead.
-    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full, resolve-ref]
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
     with:
@@ -632,7 +636,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # Model sanity tests (WH Galaxy). The gate requires an explicit true, so a push to
   # main and the scheduled runs leave this leg out: `inputs` is null on those events.
@@ -641,7 +645,7 @@ jobs:
     # bake-env-dev-full is in needs but deliberately absent from the if: above.
     # A failed bake leaves the ref empty and the leg falls back to the artifact
     # path, which a gate on the bake would turn into a skipped suite instead.
-    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full, resolve-ref]
     secrets: inherit
     uses: ./.github/workflows/models-sanity-tests-impl.yaml
     with:
@@ -649,7 +653,7 @@ jobs:
       prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
       summary-scope: ${{ inputs.platform }}
 
   # LLK sanity (tt-llk python_tests smoke, WH + BH). Opt-in: run-llk-sanity-tests defaults
@@ -658,7 +662,7 @@ jobs:
   # gate only excludes push/schedule, where `inputs` is null; here it excludes those events
   # *and* every call that does not opt in.
   llk-sanity-tests:
-    needs: [resolve-docker-pull-refs, generate-sku-matrix]
+    needs: [resolve-docker-pull-refs, generate-sku-matrix, resolve-ref]
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' &&
      (needs.generate-sku-matrix.outputs.run-wormhole == 'true' || needs.generate-sku-matrix.outputs.run-blackhole == 'true') &&
      toJSON(inputs.run-llk-sanity-tests) == 'true' }}
@@ -680,11 +684,11 @@ jobs:
       # as every other sanity impl does, rather than the PR gate's — otherwise widening
       # one pipeline's markers would silently eat into the other's budget.
       test-category: sanity
-      ref: ${{ inputs.ref || github.sha }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
 
   # LLK Quasar build check (compile-only, no hardware). Mirrors pr-gate's llk-build-quasar.
   llk-build-quasar:
-    needs: [resolve-docker-pull-refs]
+    needs: [resolve-docker-pull-refs, resolve-ref]
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' && toJSON(inputs.run-llk-sanity-tests) == 'true' }}
     runs-on: tt-ubuntu-2204-xlarge-stable
     timeout-minutes: 20
@@ -694,7 +698,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
       - uses: ./.github/actions/llk-compile-quasar
         with:
           pytest-markers: "quasar"

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -285,7 +285,12 @@ jobs:
           if [ -z "$REF" ]; then
             SHA="$FALLBACK"
           else
-            SHA=$(gh api "repos/${REPO}/commits/${REF}" --jq '.sha')
+            # Percent-encode the slashes. A slash-containing branch does resolve
+            # literally, because {ref} is greedy, but the endpoint has sub-resources
+            # (/status, /comments, /pulls, /check-runs), so a branch named like
+            # `x/comments` would address one of those instead and return an array
+            # where a commit is expected. Encoding keeps the ref one path segment.
+            SHA=$(gh api "repos/${REPO}/commits/${REF//\//%2F}" --jq '.sha')
           fi
           printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$' \
             || { echo "::error::could not resolve '${REF:-HEAD}' to a full commit sha, got '${SHA}'"; exit 1; }

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -339,66 +339,6 @@ jobs:
       build-args: PROFILE=full
       source-ref: ${{ inputs.ref || github.sha }}
 
-  # TEMP measurement, revert after: is pulling the env image through Harbor's
-  # pull-through cache faster than ghcr direct? Uses images an earlier run already
-  # published, so it needs no bake and no test hardware and reports in ~2 minutes.
-  probe-harbor-env:
-    name: "TEMP probe: Harbor vs ghcr for the env image"
-    needs: [check-harbor]
-    if: ${{ !cancelled() }}
-    runs-on: tt-ubuntu-2204-large-stable
-    timeout-minutes: 40
-    steps:
-      - name: Time ghcr direct against Harbor for both profiles
-        env:
-          PREFIX: ${{ needs.check-harbor.outputs.harbor-prefix }}
-          WHEEL_IMG: ghcr.io/tenstorrent/tt-metal/prebuilt-tests-env-image:036f8c92e9ee-ttnn-dist-inplace-cp310-Release-profiler-ubuntu-22.04-ci-test-amd64-66c6be85
-          FULL_IMG: ghcr.io/tenstorrent/tt-metal/prebuilt-tests-env-image:036f8c92e9ee-TTMetal_build_any_22.04_amd64_x86_64-linux-clang-ubuntu-22.04-dev-amd64-b2f317e2
-        run: |
-          set -uo pipefail
-          if [ -z "$PREFIX" ]; then
-            echo "::warning::Harbor reported unhealthy, so there is nothing to compare"
-            exit 0
-          fi
-
-          # Both refs resolve to identical layer digests, so dropping one tag leaves
-          # the layers in the local store and the next pull is a no-op. Untag both,
-          # then prune the now-dangling layers; other jobs' images stay tagged and
-          # are therefore untouched.
-          clear_local() {
-            docker rmi -f "$1" "$2" >/dev/null 2>&1 || true
-            docker image prune -f >/dev/null 2>&1 || true
-          }
-
-          timed_pull() {
-            label="$1"; ref="$2"
-            start=$SECONDS
-            if ! out=$(docker pull "$ref" 2>&1); then
-              echo "  ${label}: FAILED"
-              printf '%s\n' "$out" | tail -4 | sed 's/^/        /'
-              return 0
-            fi
-            dur=$((SECONDS - start))
-            dl=$(printf '%s\n' "$out" | grep -c 'Pull complete' || true)
-            ae=$(printf '%s\n' "$out" | grep -c 'Already exists' || true)
-            sz=$(docker image inspect "$ref" --format '{{.Size}}' 2>/dev/null || echo 0)
-            printf '  %s: %3ds  downloaded=%-3s cached=%-3s image=%sMiB\n' \
-              "$label" "$dur" "$dl" "$ae" "$((sz / 1048576))"
-          }
-
-          for pair in "wheel:$WHEEL_IMG" "full:$FULL_IMG"; do
-            profile="${pair%%:*}"; direct="${pair#*:}"; harbor="${PREFIX}${direct}"
-            echo "::group::${profile} profile"
-            echo "  direct: $direct"
-            echo "  harbor: $harbor"
-            # Harbor first: its cache is cold for any tag nothing has pulled yet.
-            clear_local "$direct" "$harbor"; timed_pull "harbor cold" "$harbor"
-            clear_local "$direct" "$harbor"; timed_pull "ghcr direct" "$direct"
-            clear_local "$direct" "$harbor"; timed_pull "harbor warm" "$harbor"
-            clear_local "$direct" "$harbor"
-            echo "::endgroup::"
-          done
-
   # Single SKU list that gates every suite (L2-nightly style). Each impl filters this list against
   # its own tests yaml via prepare_test_matrix.py, so an empty intersection just yields no jobs.
   generate-sku-matrix:
@@ -582,13 +522,17 @@ jobs:
 
   # Ops sanity (Wormhole + Blackhole via ops_sanity_tests.yaml)
   ops-sanity-tests:
-    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix]
+    # bake-env-dev-full is in needs but deliberately absent from the if: above.
+    # A failed bake leaves the ref empty and the leg falls back to the artifact
+    # path, which a gate on the bake would turn into a skipped suite instead.
+    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix, bake-env-dev-full]
     secrets: inherit
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' && needs.build-artifact.result == 'success' && (needs.generate-sku-matrix.outputs.run-wormhole == 'true' || needs.generate-sku-matrix.outputs.run-blackhole == 'true') && toJSON(inputs.run-ops-sanity-tests) != 'false' }}
     uses: ./.github/workflows/ops-sanity-impl.yaml
     with:
       summary-scope: ${{ inputs.platform }}
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
+      prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.sanity-skus }}
@@ -599,7 +543,10 @@ jobs:
 
   # UMD sanity (Blackhole only)
   umd-sanity-tests:
-    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix]
+    # bake-env-dev-full is in needs but deliberately absent from the if: above.
+    # A failed bake leaves the ref empty and the leg falls back to the artifact
+    # path, which a gate on the bake would turn into a skipped suite instead.
+    needs: [resolve-docker-pull-refs, build-artifact, generate-sku-matrix, bake-env-dev-full]
     secrets: inherit
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-blackhole == 'true' && toJSON(inputs.run-umd-sanity-tests) != 'false' }}
     uses: ./.github/workflows/umd-sanity-tests-impl.yaml
@@ -607,6 +554,7 @@ jobs:
       summary-scope: ${{ inputs.platform }}
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.bh-skus }}
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
+      prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
@@ -640,13 +588,17 @@ jobs:
   # Blackhole multi-card post-commit tests (QB2/P300 box).
   blackhole-multi-card-fast-sanity-tests:
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-blackhole == 'true' && toJSON(inputs.run-blackhole-multi-card-sanity-tests) != 'false' }}
-    needs: [build-artifact, generate-sku-matrix]
+    # bake-env-dev-full is in needs but deliberately absent from the if: above.
+    # A failed bake leaves the ref empty and the leg falls back to the artifact
+    # path, which a gate on the bake would turn into a skipped suite instead.
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
     with:
       summary-scope: ${{ inputs.platform }}
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.sanity-skus }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
@@ -656,11 +608,15 @@ jobs:
   # main and the scheduled runs leave this leg out: `inputs` is null on those events.
   models-sanity-tests:
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-wormhole == 'true' && toJSON(inputs.run-models-sanity-tests) == 'true' }}
-    needs: [build-artifact, generate-sku-matrix]
+    # bake-env-dev-full is in needs but deliberately absent from the if: above.
+    # A failed bake leaves the ref empty and the leg falls back to the artifact
+    # path, which a gate on the bake would turn into a skipped suite instead.
+    needs: [build-artifact, generate-sku-matrix, bake-env-dev-full]
     secrets: inherit
     uses: ./.github/workflows/models-sanity-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      prebuilt-image: ${{ needs.bake-env-dev-full.outputs.image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -135,9 +135,12 @@ jobs:
       image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
-        # /work/ttnn as well as /work: the ccl tests are pytest and import ttnn,
-        # which a full-profile image supplies from the tree rather than a wheel.
-        PYTHONPATH: /work:/work/ttnn
+        # /work/ttnn and /work/tools as well as /work: the ccl tests are pytest and
+        # import ttnn, which a full-profile image supplies from the tree rather than
+        # a wheel. Sanity builds with tracy=true, so _ttnn imports the `tracy` module
+        # at init; the wheel maps it in via package_dir (setup.py), while in place it
+        # is only importable from /work/tools. Same list as bisect-dispatch.yaml.
+        PYTHONPATH: /work:/work/ttnn:/work/tools
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -12,6 +12,15 @@ on:
       build-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       wheel-artifact-name:
         required: true
         type: string
@@ -123,17 +132,21 @@ jobs:
     runs-on: ${{ matrix.test-group.runs_on }}
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
-        PYTHONPATH: /work
+        # /work/ttnn as well as /work: the ccl tests are pytest and import ttnn,
+        # which a full-profile image supplies from the tree rather than a wheel.
+        PYTHONPATH: /work:/work/ttnn
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }}
         - /dev/hugepages-1G:/dev/hugepages-1G
       # Memory reduction in WH LB coming up: https://github.com/tenstorrent/metal-internal-workflows/issues/786
       options: --device /dev/tenstorrent --memory 256g
@@ -148,12 +161,16 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           filter: blob:none
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
@@ -185,8 +202,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: power-report-${{ matrix.test-group.name }}
-          # /docker-job/ is the host-side mount of the Docker runner's /work/ directory.
-          path: ${{ github.workspace }}/docker-job/power_report.json
+          # The sidecar's --out path. Steps run inside the container, so this holds
+          # whether or not /work is a bind mount.
+          path: /work/power_report.json
           if-no-files-found: warn
           retention-days: 30
 
@@ -255,7 +273,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "workspace": "/work",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}"

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -224,7 +224,9 @@ jobs:
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       build-type: "Release"
       publish-artifact: true
-      build-wheel: true
+      # In-place, not build-wheel: that one runs cibuildwheel for a second full
+      # compile, and the consumers this serves get the in-place wheel anyway.
+      build-inplace-wheel: true
       use-system-sfpi: true
 
   bake-env-full:

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/build-prebuilt-tests-image.yaml"
       - ".github/workflows/test-build-prebuilt-tests-image.yaml"
       - "dockerfile/Dockerfile.prebuilt-tests-packages"
+      - "dockerfile/Dockerfile.prebuilt-tests-env"
   workflow_dispatch:
 
 permissions:
@@ -204,3 +205,152 @@ jobs:
         run: |
           /usr/bin/tt-metalium-validation-smoke \
             --gtest_filter="MeshDispatchFixture.TensixFailOnDuplicateKernelCreationDataflow"
+
+  # The packages arm above sets publish-artifact: false, so it makes no tarball
+  # and no wheel. The env image needs both, hence a second build rather than
+  # widening the one whose inputs are already proven.
+  build-env:
+    name: "Build tarball and wheel"
+    if: ${{ github.event.pull_request.head.repo.fork != true && !github.event.pull_request.draft }}
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      # 22.04: the setup-job consumers this serves pull the 22.04 ci-test base,
+      # and the hardware leg below runs on a 22.04 runner.
+      platform: "Ubuntu 22.04"
+      toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
+      build-type: "Release"
+      publish-artifact: true
+      build-wheel: true
+      use-system-sfpi: true
+
+  bake-env-full:
+    name: "Bake env image / full"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.build-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      # Own ghcr package: the env payload is sized nothing like the packages one,
+      # so its retention must not be shared with theirs.
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+
+  bake-env-wheel:
+    name: "Bake env image / wheel"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.wheel-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=wheel
+
+  # Payload shape is what breaks silently: a wrong one still builds and publishes.
+  # Checking both costs no hardware, so only the full image needs a real leg below.
+  verify-env-payloads:
+    name: "Check both env images carry the right payload"
+    needs: [bake-env-full, bake-env-wheel]
+    if: ${{ needs.bake-env-full.outputs.image != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assert each payload
+        env:
+          FULL: ${{ needs.bake-env-full.outputs.image }}
+          WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
+        run: |
+          set -euo pipefail
+          echo "::group::${FULL}"
+          docker run --rm --entrypoint cat "$FULL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=full$'
+          docker run --rm --entrypoint sh "$FULL" -c 'test -d /work/build && test -d /work/tests'
+          # A COPYed payload would leave the tarball in a layer and eat the saving.
+          test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'find / -xdev -name "*.tar.zst" 2>/dev/null')"
+          # Proves the .dockerignore worked; otherwise .git rides along unnoticed.
+          test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'ls -d /work/.git 2>/dev/null')"
+          echo "::endgroup::"
+          echo "::group::${WHEEL}"
+          docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'
+          docker run --rm --entrypoint sh "$WHEEL" -c 'test ! -d /work/build && test -d /work/tests'
+          echo "::endgroup::"
+
+  verify-env:
+    name: "Run a test from the env image"
+    needs: bake-env-full
+    # Runs freshly built native code from the PR on hardware, and only needs to
+    # pull an image. Do not let it inherit packages: write.
+    permissions:
+      contents: read
+      packages: read
+    # Empty ref means the producer was skipped (fork); nothing to verify.
+    if: ${{ needs.bake-env-full.outputs.image != '' }}
+    runs-on: tt-ubuntu-2204-N150-viommu-stable
+    timeout-minutes: 20
+    container:
+      image: ${{ needs.bake-env-full.outputs.image }}
+      # The runner pulls before any step runs, so no login step can help here.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: wormhole_b0
+        LOGURU_LEVEL: INFO
+      # No /work volume on purpose: the image owns /work, and a bind mount would
+      # mask the payload, which is the whole point of this arm.
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    steps:
+      - name: The environment came from the image, not from a checkout
+        run: |
+          set -euo pipefail
+          test -s /etc/prebuilt-tests-env-manifest
+          cat /etc/prebuilt-tests-env-manifest
+          # Source, build output, and the .so the tarball merges into the source
+          # package dir - the three things a consumer stops fetching.
+          test -d /work/tests && test -d /work/build/lib
+          test -f /work/tools/tt-triage.py
+          ls /work/ttnn/ttnn/*.so >/dev/null
+          # .git is deliberately absent; scripts shelling out to git cannot run here.
+          test ! -d /work/.git
+          ls -la /work/build/test/tt_metal/
+
+      - name: Run a runtime test against the baked build
+        timeout-minutes: 10
+        env:
+          GTEST_COLOR: yes
+        run: |
+          # Same fixture as the runtime_sanity_api leg: DRAM R/W, L1 R/W, and a
+          # JIT kernel compile, so it exercises the baked tree end to end.
+          ./build/test/tt_metal/unit_tests_api \
+            --gtest_filter='*DRAMLoopbackSingleCore*:*TestSimpleL1*:*CompileProgram*'

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -406,7 +406,9 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
       env:
         TT_METAL_HOME: /work
-        PYTHONPATH: /work
+        # /work/ttnn as well as /work: /work/ttnn is a namespace dir and the
+        # package is /work/ttnn/ttnn. Same in-place layout as bisect-dispatch.
+        PYTHONPATH: /work:/work/ttnn
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
@@ -431,6 +433,13 @@ jobs:
           # .git is deliberately absent; scripts shelling out to git cannot run here.
           test ! -d /work/.git
           ls -la /work/build/test/tt_metal/
+
+      - name: The in-place ttnn package imports
+        run: |
+          set -euo pipefail
+          # The C++ leg below would pass even if the Python payload were unusable,
+          # so import it explicitly. This is the full profile's advertised path.
+          python3 -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
 
       - name: Run a runtime test against the baked build
         timeout-minutes: 10

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -265,12 +265,35 @@ jobs:
       checkout-source: true
       build-args: PROFILE=wheel
 
+  # source-ref would otherwise only ever be exercised through its github.sha
+  # fallback. Same commit as bake-env-full, spelled explicitly: the content must
+  # come out identical while the tag must differ, since source-ref feeds the
+  # recipe hash. A DIFFERENT ref would also work but would publish an image whose
+  # source and artifact disagree, which is the thing the input exists to prevent.
+  bake-env-source-ref:
+    name: "Bake env image / explicit source-ref"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.build-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.ci-test-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+      source-ref: ${{ github.sha }}
+
   # Payload shape is what breaks silently: a wrong one still builds and publishes.
   # Checking both costs no hardware, so only the full image needs a real leg below.
   verify-env-payloads:
     name: "Check both env images carry the right payload"
     # build-env too: the base ref is needed to tell payload layers from base ones.
-    needs: [build-env, bake-env-full, bake-env-wheel]
+    needs: [build-env, bake-env-full, bake-env-wheel, bake-env-source-ref]
     if: ${{ needs.bake-env-full.outputs.image != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -335,6 +358,31 @@ jobs:
             [ "$n" -eq 2 ] || { echo "::error::${name} adds ${n} layers, expected 2 (source + payload); a new COPY would do this"; exit 1; }
             [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
           done
+
+      - name: Assert source-ref separates the tag without changing the content
+        env:
+          FULL: ${{ needs.bake-env-full.outputs.image }}
+          EXPLICIT: ${{ needs.bake-env-source-ref.outputs.image }}
+        run: |
+          set -euo pipefail
+          # Same commit, one defaulted and one passed explicitly.
+          [ "$FULL" != "$EXPLICIT" ] \
+            || { echo "::error::source-ref does not separate the tag: both are ${FULL}"; exit 1; }
+          # Only the recipe hash may differ; sha12, CONFIG and the base slug must not.
+          [ "${FULL%-*}" = "${EXPLICIT%-*}" ] \
+            || { echo "::error::tags differ outside the recipe hash: ${FULL} vs ${EXPLICIT}"; exit 1; }
+          # And the payload must be byte-identical, or the explicit ref checked out
+          # something other than the commit the default resolves to.
+          layers() {
+            local ref="$1" repo="${1%:*}" child
+            child=$(docker manifest inspect "$ref" \
+              | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+            [ -n "$child" ] && ref="${repo}@${child}"
+            docker manifest inspect "$ref" | jq -r '.layers[].digest'
+          }
+          diff <(layers "$FULL") <(layers "$EXPLICIT") \
+            || { echo "::error::explicit source-ref produced different layers than the default"; exit 1; }
+          echo "source-ref separates the tag (${FULL##*-} vs ${EXPLICIT##*-}) with identical layers"
 
   verify-env:
     name: "Run a test from the env image"

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -269,7 +269,8 @@ jobs:
   # Checking both costs no hardware, so only the full image needs a real leg below.
   verify-env-payloads:
     name: "Check both env images carry the right payload"
-    needs: [bake-env-full, bake-env-wheel]
+    # build-env too: the base ref is needed to tell payload layers from base ones.
+    needs: [build-env, bake-env-full, bake-env-wheel]
     if: ${{ needs.bake-env-full.outputs.image != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -286,20 +287,54 @@ jobs:
         env:
           FULL: ${{ needs.bake-env-full.outputs.image }}
           WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
+          BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
         run: |
           set -euo pipefail
           echo "::group::${FULL}"
           docker run --rm --entrypoint cat "$FULL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=full$'
           docker run --rm --entrypoint sh "$FULL" -c 'test -d /work/build && test -d /work/tests'
-          # A COPYed payload would leave the tarball in a layer and eat the saving.
-          test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'find / -xdev -name "*.tar.zst" 2>/dev/null')"
           # Proves the .dockerignore worked; otherwise .git rides along unnoticed.
           test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'ls -d /work/.git 2>/dev/null')"
           echo "::endgroup::"
           echo "::group::${WHEEL}"
           docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'
           docker run --rm --entrypoint sh "$WHEEL" -c 'test ! -d /work/build && test -d /work/tests'
+          # Directory shape says nothing about whether the wheel actually works:
+          # an ABI or missing-library problem installs fine and imports never.
+          docker run --rm --entrypoint python3 "$WHEEL" -c 'import ttnn; print("ttnn imported")'
           echo "::endgroup::"
+
+      # Layer sizes, not the merged filesystem: a COPY followed by an rm leaves the
+      # payload bytes in a lower layer while `find` sees nothing, which is exactly
+      # the regression that would silently undo the saving.
+      - name: Assert the payload rides in two layers and stays small
+        env:
+          FULL: ${{ needs.bake-env-full.outputs.image }}
+          WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
+          BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
+          # Release with system SFPI measures 296 MiB (full) and 250 MiB (wheel).
+          # Generous headroom: this guards against a COPYed payload, not drift.
+          MAX_MIB: "600"
+        run: |
+          set -euo pipefail
+          layers() {  # digest<TAB>size for the amd64 image, one per line
+            local ref="$1" repo="${1%:*}" child
+            child=$(docker manifest inspect "$ref" \
+              | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+            [ -n "$child" ] && ref="${repo}@${child}"
+            docker manifest inspect "$ref" | jq -r '.layers[] | "\(.digest)\t\(.size)"'
+          }
+          layers "$BASE" | cut -f1 | sort > /tmp/base.txt
+          for pair in "full:$FULL" "wheel:$WHEEL"; do
+            name="${pair%%:*}"; ref="${pair#*:}"
+            layers "$ref" > /tmp/img.txt
+            extra=$(join -v1 -t"$(printf '\t')" <(sort -k1,1 /tmp/img.txt) /tmp/base.txt || true)
+            n=$(printf '%s' "$extra" | grep -c . || true)
+            mib=$(printf '%s' "$extra" | awk -F'\t' '{s+=$2} END {printf "%d", s/1048576}')
+            echo "${name}: ${n} layers beyond the base, ${mib} MiB"
+            [ "$n" -eq 2 ] || { echo "::error::${name} adds ${n} layers, expected 2 (source + payload); a new COPY would do this"; exit 1; }
+            [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
+          done
 
   verify-env:
     name: "Run a test from the env image"

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -224,6 +224,9 @@ jobs:
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       build-type: "Release"
       publish-artifact: true
+      # The env images bake the tarball and the wheel; the debs would be an upload
+      # and a retention cost that nothing in this arm reads.
+      publish-package: false
       # In-place, not build-wheel: that one runs cibuildwheel for a second full
       # compile, and the consumers this serves get the in-place wheel anyway.
       build-inplace-wheel: true

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -371,18 +371,20 @@ jobs:
           # Only the recipe hash may differ; sha12, CONFIG and the base slug must not.
           [ "${FULL%-*}" = "${EXPLICIT%-*}" ] \
             || { echo "::error::tags differ outside the recipe hash: ${FULL} vs ${EXPLICIT}"; exit 1; }
-          # And the payload must be byte-identical, or the explicit ref checked out
-          # something other than the commit the default resolves to.
-          layers() {
-            local ref="$1" repo="${1%:*}" child
-            child=$(docker manifest inspect "$ref" \
-              | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
-            [ -n "$child" ] && ref="${repo}@${child}"
-            docker manifest inspect "$ref" | jq -r '.layers[].digest'
+          # The contents must match, or the explicit ref checked out something other
+          # than the commit the default resolves to. Compare paths and sizes rather
+          # than layer digests: these are independent builds, so tar header mtimes
+          # differ and the digests differ with them even when the files do not.
+          # Measured on two same-run bakes of the same commit: 211,190,989 vs
+          # 211,181,760 bytes for the same source layer.
+          tree() {
+            docker run --rm --entrypoint sh "$1" -c \
+              'find /work -type f -printf "%p %s\n" | LC_ALL=C sort | sha256sum | cut -d" " -f1'
           }
-          diff <(layers "$FULL") <(layers "$EXPLICIT") \
-            || { echo "::error::explicit source-ref produced different layers than the default"; exit 1; }
-          echo "source-ref separates the tag (${FULL##*-} vs ${EXPLICIT##*-}) with identical layers"
+          a=$(tree "$FULL"); b=$(tree "$EXPLICIT")
+          [ "$a" = "$b" ] \
+            || { echo "::error::explicit source-ref produced different /work contents (${a} vs ${b})"; exit 1; }
+          echo "source-ref separates the tag (${FULL##*-} vs ${EXPLICIT##*-}) with identical /work contents (${a})"
 
   verify-env:
     name: "Run a test from the env image"

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -223,6 +223,10 @@ jobs:
       platform: "Ubuntu 22.04"
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       build-type: "Release"
+      # Sanity builds with tracy, and a tracy-enabled _ttnn imports the `tracy`
+      # Python module during module init. Without this the import checks below
+      # pass on a payload shaped unlike the one consumers actually get.
+      tracy: true
       publish-artifact: true
       # The env images bake the tarball and the wheel; the debs would be an upload
       # and a retention cost that nothing in this arm reads.
@@ -346,7 +350,7 @@ jobs:
           # about whether in-place import works. It needs deps the base image may not
           # carry, so this fails here on a GitHub runner rather than on a hardware leg.
           docker run --rm \
-            -e PYTHONPATH=/work:/work/ttnn \
+            -e PYTHONPATH=/work:/work/ttnn:/work/tools \
             -e TT_METAL_HOME=/work \
             -e LD_LIBRARY_PATH=/work/build/lib \
             --entrypoint python3 "$FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
@@ -357,7 +361,7 @@ jobs:
           # The base a consumer actually uses. Bases differ in what their venv carries,
           # so an import that works on ci-test says nothing about this one.
           docker run --rm \
-            -e PYTHONPATH=/work:/work/ttnn \
+            -e PYTHONPATH=/work:/work/ttnn:/work/tools \
             -e TT_METAL_HOME=/work \
             -e LD_LIBRARY_PATH=/work/build/lib \
             --entrypoint python3 "$DEV_FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
@@ -451,7 +455,9 @@ jobs:
         TT_METAL_HOME: /work
         # /work/ttnn as well as /work: /work/ttnn is a namespace dir and the
         # package is /work/ttnn/ttnn. Same in-place layout as bisect-dispatch.
-        PYTHONPATH: /work:/work/ttnn
+        # /work/tools carries the `tracy` module, which a tracy-enabled _ttnn
+        # imports at init. The wheel gets it via package_dir; in place it is here.
+        PYTHONPATH: /work:/work/ttnn:/work/tools
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -386,12 +386,15 @@ jobs:
           # beyond the base. Generous headroom: this guards against a COPYed
           # payload, not drift.
           MAX_MIB: "600"
-          # One per layer-adding instruction in Dockerfile.prebuilt-tests-env:
-          # the pyproject COPY, the dependency RUN, seven churn-tier COPYs, the
-          # excluding COPY of the remainder, and the payload RUN. Bump this only
-          # when that file deliberately changes shape - it is what catches an
+          # Expected per profile, because they differ by one: the dependency RUN
+          # is guarded on PROFILE=full, so under wheel it changes nothing and
+          # BuildKit omits the empty layer entirely. full counts the pyproject
+          # COPY, the dependency RUN, the source COPY and the payload RUN; wheel
+          # is the same less the dependency RUN. Bump these only when the
+          # Dockerfile deliberately changes shape - they are what catches an
           # accidental COPY, which is the regression that would undo the saving.
-          EXPECT_LAYERS: "11"
+          EXPECT_LAYERS_FULL: "4"
+          EXPECT_LAYERS_WHEEL: "3"
         run: |
           set -euo pipefail
           layers() {  # digest<TAB>size for the amd64 image, one per line
@@ -402,14 +405,14 @@ jobs:
             docker manifest inspect "$ref" | jq -r '.layers[] | "\(.digest)\t\(.size)"'
           }
           layers "$BASE" | cut -f1 | sort > /tmp/base.txt
-          for pair in "full:$FULL" "wheel:$WHEEL"; do
-            name="${pair%%:*}"; ref="${pair#*:}"
+          for pair in "full:$FULL:$EXPECT_LAYERS_FULL" "wheel:$WHEEL:$EXPECT_LAYERS_WHEEL"; do
+            name="${pair%%:*}"; rest="${pair#*:}"; ref="${rest%:*}"; want="${rest##*:}"
             layers "$ref" > /tmp/img.txt
             extra=$(join -v1 -t"$(printf '\t')" <(sort -k1,1 /tmp/img.txt) /tmp/base.txt || true)
             n=$(printf '%s' "$extra" | grep -c . || true)
             mib=$(printf '%s' "$extra" | awk -F'\t' '{s+=$2} END {printf "%d", s/1048576}')
             echo "${name}: ${n} layers beyond the base, ${mib} MiB"
-            [ "$n" -eq "$EXPECT_LAYERS" ] || { echo "::error::${name} adds ${n} layers, expected ${EXPECT_LAYERS}; an unintended COPY would do this, and a deliberate one means updating EXPECT_LAYERS"; exit 1; }
+            [ "$n" -eq "$want" ] || { echo "::error::${name} adds ${n} layers, expected ${want}; an unintended COPY would do this, and a deliberate one means updating EXPECT_LAYERS_${name}"; exit 1; }
             [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
           done
 

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -377,14 +377,21 @@ jobs:
       # Layer sizes, not the merged filesystem: a COPY followed by an rm leaves the
       # payload bytes in a lower layer while `find` sees nothing, which is exactly
       # the regression that would silently undo the saving.
-      - name: Assert the payload rides in two layers and stays small
+      - name: Assert the payload rides in the expected layers and stays small
         env:
           FULL: ${{ needs.bake-env-full.outputs.image }}
           WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
           BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
-          # Release with system SFPI measures 296 MiB (full) and 250 MiB (wheel).
-          # Generous headroom: this guards against a COPYed payload, not drift.
+          # Release with system SFPI measures 501 MiB (full) and 250 MiB (wheel)
+          # beyond the base. Generous headroom: this guards against a COPYed
+          # payload, not drift.
           MAX_MIB: "600"
+          # One per layer-adding instruction in Dockerfile.prebuilt-tests-env:
+          # the pyproject COPY, the dependency RUN, seven churn-tier COPYs, the
+          # excluding COPY of the remainder, and the payload RUN. Bump this only
+          # when that file deliberately changes shape - it is what catches an
+          # accidental COPY, which is the regression that would undo the saving.
+          EXPECT_LAYERS: "11"
         run: |
           set -euo pipefail
           layers() {  # digest<TAB>size for the amd64 image, one per line
@@ -402,7 +409,7 @@ jobs:
             n=$(printf '%s' "$extra" | grep -c . || true)
             mib=$(printf '%s' "$extra" | awk -F'\t' '{s+=$2} END {printf "%d", s/1048576}')
             echo "${name}: ${n} layers beyond the base, ${mib} MiB"
-            [ "$n" -eq 2 ] || { echo "::error::${name} adds ${n} layers, expected 2 (source + payload); a new COPY would do this"; exit 1; }
+            [ "$n" -eq "$EXPECT_LAYERS" ] || { echo "::error::${name} adds ${n} layers, expected ${EXPECT_LAYERS}; an unintended COPY would do this, and a deliberate one means updating EXPECT_LAYERS"; exit 1; }
             [ "$mib" -le "$MAX_MIB" ] || { echo "::error::${name} payload is ${mib} MiB, over ${MAX_MIB}"; exit 1; }
           done
 

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -251,6 +251,26 @@ jobs:
       checkout-source: true
       build-args: PROFILE=full
 
+  # Every Sanity impl that consumes an env image uses the dev base, so testing only
+  # ci-test leaves the wave's actual base unexercised. Full profile on dev is where
+  # in-place import has to work.
+  bake-env-dev-full:
+    name: "Bake env image / dev full"
+    needs: build-env
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-env.outputs.build-artifact-name }}
+      base-image: ${{ needs.build-env.outputs.dev-docker-image }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-env
+      image-name: prebuilt-tests-env-image
+      checkout-source: true
+      build-args: PROFILE=full
+
   bake-env-wheel:
     name: "Bake env image / wheel"
     needs: build-env
@@ -292,11 +312,11 @@ jobs:
       source-ref: ${{ github.sha }}
 
   # Payload shape is what breaks silently: a wrong one still builds and publishes.
-  # Checking both costs no hardware, so only the full image needs a real leg below.
+  # Checking them costs no hardware, so only the full image needs a real leg below.
   verify-env-payloads:
-    name: "Check both env images carry the right payload"
+    name: "Check the env images carry the right payload"
     # build-env too: the base ref is needed to tell payload layers from base ones.
-    needs: [build-env, bake-env-full, bake-env-wheel, bake-env-source-ref]
+    needs: [build-env, bake-env-full, bake-env-dev-full, bake-env-wheel, bake-env-source-ref]
     if: ${{ needs.bake-env-full.outputs.image != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -312,6 +332,7 @@ jobs:
       - name: Assert each payload
         env:
           FULL: ${{ needs.bake-env-full.outputs.image }}
+          DEV_FULL: ${{ needs.bake-env-dev-full.outputs.image }}
           WHEEL: ${{ needs.bake-env-wheel.outputs.image }}
           BASE: ${{ needs.build-env.outputs.ci-test-docker-image }}
         run: |
@@ -329,6 +350,17 @@ jobs:
             -e TT_METAL_HOME=/work \
             -e LD_LIBRARY_PATH=/work/build/lib \
             --entrypoint python3 "$FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
+          echo "::endgroup::"
+          echo "::group::${DEV_FULL}"
+          docker run --rm --entrypoint cat "$DEV_FULL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=full$'
+          docker run --rm --entrypoint sh "$DEV_FULL" -c 'test -d /work/build && test -d /work/tests'
+          # The base a consumer actually uses. Bases differ in what their venv carries,
+          # so an import that works on ci-test says nothing about this one.
+          docker run --rm \
+            -e PYTHONPATH=/work:/work/ttnn \
+            -e TT_METAL_HOME=/work \
+            -e LD_LIBRARY_PATH=/work/build/lib \
+            --entrypoint python3 "$DEV_FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
           echo "::endgroup::"
           echo "::group::${WHEEL}"
           docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'

--- a/.github/workflows/test-build-prebuilt-tests-image.yaml
+++ b/.github/workflows/test-build-prebuilt-tests-image.yaml
@@ -321,6 +321,14 @@ jobs:
           docker run --rm --entrypoint sh "$FULL" -c 'test -d /work/build && test -d /work/tests'
           # Proves the .dockerignore worked; otherwise .git rides along unnoticed.
           test -z "$(docker run --rm --entrypoint sh "$FULL" -c 'ls -d /work/.git 2>/dev/null')"
+          # Same reasoning as the wheel image below: the directory shape says nothing
+          # about whether in-place import works. It needs deps the base image may not
+          # carry, so this fails here on a GitHub runner rather than on a hardware leg.
+          docker run --rm \
+            -e PYTHONPATH=/work:/work/ttnn \
+            -e TT_METAL_HOME=/work \
+            -e LD_LIBRARY_PATH=/work/build/lib \
+            --entrypoint python3 "$FULL" -c 'import ttnn; print("ttnn imported from", ttnn.__file__)'
           echo "::endgroup::"
           echo "::group::${WHEEL}"
           docker run --rm --entrypoint cat "$WHEEL" /etc/prebuilt-tests-env-manifest | grep -q '^profile=wheel$'

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -389,8 +389,8 @@ jobs:
             )
             # Non-profiled path (default): run the group cmd directly under the power sidecar.
             # Profiled path (experiment): wrap the group cmd in `perf record -g -F <freq> -o <out>`,
-            # writing perf.data to /work so the host mount at ${{ github.workspace }}/docker-job can
-            # upload it. Only wrap when the recording-capability probe (perf-probe step) succeeded;
+            # writing perf.data to /work, which the upload step reads. Only wrap when the
+            # recording-capability probe (perf-probe step) succeeded;
             # otherwise fall back to running the cmd unwrapped so the group still tests.
             #
             # The whole group cmd is wrapped in `bash -c "$TEST_GROUP_CMD"` so that a group command
@@ -567,10 +567,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: power-report-${{ matrix.test-group.name }}
-          # /docker-job/ is the host-side mount of the Docker runner's /work/ directory.
-          # The power sidecar writes --out /work/power_report.json inside the container;
-          # this host path is what the upload-artifact action reads.
-          path: ${{ github.workspace }}/docker-job/power_report.json
+          # The sidecar's --out path. Steps run inside the container, so this holds
+          # whether or not /work is a bind mount.
+          path: /work/power_report.json
           if-no-files-found: warn
           retention-days: 30
 
@@ -643,12 +642,12 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: perf-host-profile-${{ matrix.test-group.name }}
-          # /docker-job/ is the host-side mount of the container's /work/ directory. The profiled
-          # test step writes perf_<sanitized>.data (and an optional .report.txt / .svg) to /work.
+          # The profiled test step writes perf_<sanitized>.data (and an optional
+          # .report.txt / .svg) to /work.
           path: |
-            ${{ github.workspace }}/docker-job/perf_*.data
-            ${{ github.workspace }}/docker-job/perf_*.report.txt
-            ${{ github.workspace }}/docker-job/perf_*.svg
+            /work/perf_*.data
+            /work/perf_*.report.txt
+            /work/perf_*.svg
           if-no-files-found: warn
           retention-days: 14
 
@@ -657,10 +656,8 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: mem-report-${{ matrix.test-group.name }}
-          # Sim analogue of the HW power report: the host-load sidecar writes its CPU/memory/
-          # disk/network usage report to --output /work/mem_report.json inside the container;
-          # this host path is what the upload-artifact action reads.
-          path: ${{ github.workspace }}/docker-job/mem_report.json
+          # Sim analogue of the HW power report: the host-load sidecar's --output path.
+          path: /work/mem_report.json
           if-no-files-found: warn
           retention-days: 30
 
@@ -680,7 +677,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: profdata-ttnn-${{ matrix.test-group.name }}
-          path: ${{ github.workspace }}/docker-job/coverage/job.profdata
+          path: /work/coverage/job.profdata
           if-no-files-found: ignore
           retention-days: 1
 
@@ -721,7 +718,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "workspace": "/work",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}",

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -17,6 +17,15 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       enable-watcher:
         required: false
         type: boolean
@@ -184,14 +193,18 @@ jobs:
     runs-on: ${{ matrix.test-group.runs_on }}
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
-      image: ${{ (startsWith(matrix.test-group.sku, 'sim_') || matrix.test-group.sku == 'bh_p100') && (inputs.docker-image || 'docker-image-unresolved!') || format('{0}{1}', inputs.harbor-prefix, inputs.docker-image) }}
+      # The prebuilt ref comes first so it short-circuits the harbor-prefix
+      # expression below: a per-commit image is canonical ghcr and never prefixed.
+      image: ${{ inputs.prebuilt-image || ((startsWith(matrix.test-group.sku, 'sim_') || matrix.test-group.sku == 'bh_p100') && (inputs.docker-image || 'docker-image-unresolved!') || format('{0}{1}', inputs.harbor-prefix, inputs.docker-image)) }}
       env:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
         TT_LOGGER_LEVEL: warn
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }}
         - /dev/hugepages-1G:/dev/hugepages-1G
       options: ${{ startsWith(matrix.test-group.sku, 'sim_') && '--label runner-mode=sim' || (inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku)) && '--cap-add CAP_PERFMON --device /dev/tenstorrent -e TT_GH_CI_INFRA' || '--device /dev/tenstorrent -e TT_GH_CI_INFRA' }}
     defaults:
@@ -205,13 +218,17 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           filter: blob:none
-          submodules: recursive
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          submodules: ${{ inputs.prebuilt-image == '' && 'recursive' || 'false' }}
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
       - name: ⬇️  Setup Job
         uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          # Same commit as the tests, the binaries and the image: an unpinned
+          # matrix load can select tests from one revision and run them against
+          # another on a targeted run.
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: |
             .github
             tests/pipeline_reorg

--- a/.github/workflows/umd-sanity-tests-impl.yaml
+++ b/.github/workflows/umd-sanity-tests-impl.yaml
@@ -6,6 +6,15 @@ on:
       docker-image:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Env image carrying the source tree and build output at /work. When set,
+          the job mounts no /work, checks out only .github, and fetches no
+          artifact. Empty falls back to the artifact path, which is what forks and
+          a failed bake get.
       build-artifact-name:
         required: true
         type: string
@@ -80,7 +89,7 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
         LD_LIBRARY_PATH: /work/build/lib
@@ -88,7 +97,9 @@ jobs:
         TT_LOGGER_LEVEL: warn
         PYTHONPATH: /work
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        # The image owns /work, so no bind mount: one would mask the payload. A
+        # single-path entry is an anonymous volume on an unused path.
+        - ${{ inputs.prebuilt-image != '' && '/no_work_mount' || format('{0}/docker-job:/work', github.workspace) }} # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
@@ -100,7 +111,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          submodules: recursive
+          # With an image the source is already at /work; the workspace copy only
+          # has to satisfy `uses: ./docker-job/...`, which resolves against it.
+          submodules: ${{ inputs.prebuilt-image == '' && 'recursive' || 'false' }}
+          sparse-checkout: ${{ inputs.prebuilt-image != '' && '.github' || '' }}
           path: docker-job
           ref: ${{ inputs.ref || github.sha }}
       - name: ⬇️  Setup Job
@@ -108,6 +122,7 @@ jobs:
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
+          env-from-image: ${{ inputs.prebuilt-image != '' }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       - name: ${{ matrix.test-group.name }}
@@ -124,7 +139,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "workspace": "/work",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}"

--- a/.github/workflows/umd-sanity-tests-impl.yaml
+++ b/.github/workflows/umd-sanity-tests-impl.yaml
@@ -58,6 +58,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          # Same commit as the tests, the binaries and the image: an unpinned
+          # matrix load can select tests from one revision and run them against
+          # another on a targeted run.
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: |
             .github
             tests/pipeline_reorg

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -1,0 +1,48 @@
+# Test environment image: the source tree and the build output merged at /work,
+# so a hardware test job needs no /work bind mount, no artifact download and no
+# full source checkout. Built by build-prebuilt-tests-image.yaml, which puts the
+# source at src/ and the payload at artifact/ in the build context.
+
+# The producer always passes BASE; the default is only so this builds standalone.
+ARG BASE=ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-ci-test-amd64:latest
+FROM ${BASE}
+
+# full  = source tree plus the build tarball unpacked over it; tests run the C++
+#         binaries from /work/build and import ttnn in place via PYTHONPATH=/work.
+# wheel = source tree plus the wheel installed; no build tree.
+ARG PROFILE=full
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# Source first, payload second: the tarball carries ttnn/ttnn/*.so that has to
+# land inside the source's package directory.
+COPY src/ /work/
+
+# Bind-mounted, not COPYed: a COPYed payload stays in its layer forever and a
+# later rm reclaims nothing, which would eat most of the saving.
+RUN --mount=type=bind,source=artifact,target=/tmp/payload \
+    shopt -s nullglob \
+    && case "${PROFILE}" in \
+        full) \
+            tarballs=( /tmp/payload/*.tar.zst ); \
+            if [ "${#tarballs[@]}" -ne 1 ]; then \
+                echo "::error::PROFILE=full wants exactly one .tar.zst in artifact/, found ${#tarballs[@]}" >&2; \
+                exit 1; \
+            fi; \
+            tar --zstd -xf "${tarballs[0]}" -C /work; \
+            test -d /work/build \
+                || { echo "::error::the tarball produced no /work/build" >&2; exit 1; }; \
+            printf 'profile=full\npayload=%s\n' "$(basename "${tarballs[0]}")" \
+                > /etc/prebuilt-tests-env-manifest ;; \
+        wheel) \
+            wheels=( /tmp/payload/*.whl ); \
+            if [ "${#wheels[@]}" -ne 1 ]; then \
+                echo "::error::PROFILE=wheel wants exactly one .whl in artifact/, found ${#wheels[@]}" >&2; \
+                exit 1; \
+            fi; \
+            uv pip install "${wheels[0]}"; \
+            printf 'profile=wheel\npayload=%s\n' "$(basename "${wheels[0]}")" \
+                > /etc/prebuilt-tests-env-manifest ;; \
+        *) echo "::error::Unsupported PROFILE=${PROFILE}" >&2; exit 1 ;; \
+       esac \
+    && test -s /work/.github/actions/setup-job/action.yml

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -8,7 +8,9 @@ ARG BASE=ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-ci-test-amd64:lat
 FROM ${BASE}
 
 # full  = source tree plus the build tarball unpacked over it; tests run the C++
-#         binaries from /work/build and import ttnn in place via PYTHONPATH=/work.
+#         binaries from /work/build and import ttnn in place. That import needs
+#         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
+#         namespace dir and the package itself is /work/ttnn/ttnn.
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -1,3 +1,4 @@
+# syntax=ghcr.io/tenstorrent/tt-metal/tt-metalium/tools/dockerfile-frontend:1.25
 # Test environment image: the source tree and the build output merged at /work,
 # so a hardware test job needs no /work bind mount, no artifact download and no
 # full source checkout. Built by build-prebuilt-tests-image.yaml, which puts the
@@ -12,17 +13,47 @@ FROM ${BASE}
 #         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
 #         namespace dir and the package itself is /work/ttnn/ttnn. Nothing here
 #         runs pip, so ttnn's declared dependencies are installed from the tree's
-#         pyproject.toml: no base image is guaranteed to carry them already. Both
-#         ci-test and dev lack graphviz and ml_dtypes; an import error names only
-#         the first one missing, so do not read it as the whole gap.
+#         pyproject.toml, in its own layer above: no base image is guaranteed to
+#         carry them already. Both ci-test and dev lack graphviz and ml_dtypes; an
+#         import error names only the first one missing, so do not read it as the
+#         whole gap.
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# The dependency manifest alone, before the tree: installing from it here means a
+# source edit no longer re-runs the install, which it did while this lived inside
+# the payload RUN below. pyproject.toml changes far less often than the tree.
+COPY src/pyproject.toml /work/pyproject.toml
+RUN if [ "${PROFILE}" = "full" ]; then uv pip install -r /work/pyproject.toml; fi
+
 # Source first, payload second: the tarball carries ttnn/ttnn/*.so that has to
 # land inside the source's package directory.
-COPY src/ /work/
+#
+# Split by how often each path changes rather than as one COPY. Measured over 199
+# commits, these seven trees are 84 MiB that change in under 3% of commits, so
+# giving them their own layers keeps them cached on a runner across commits and
+# only the volatile remainder is re-pulled.
+COPY src/models/experimental/ /work/models/experimental/
+COPY src/infra/ /work/infra/
+COPY src/tt-train/ /work/tt-train/
+COPY src/tests/sweep_framework/ /work/tests/sweep_framework/
+COPY src/models/sample_data/ /work/models/sample_data/
+COPY src/models/tt_transformers/ /work/models/tt_transformers/
+COPY src/models/tt_dit/ /work/models/tt_dit/
+
+# Everything else. The excludes are relative to the COPIED ROOT, not the build
+# context: `--exclude=src/infra` is silently ignored and ships those bytes twice,
+# which defeats the split. Verified before writing this.
+COPY --exclude=models/experimental \
+     --exclude=infra \
+     --exclude=tt-train \
+     --exclude=tests/sweep_framework \
+     --exclude=models/sample_data \
+     --exclude=models/tt_transformers \
+     --exclude=models/tt_dit \
+     src/ /work/
 
 # Bind-mounted, not COPYed: a COPYed payload stays in its layer forever and a
 # later rm reclaims nothing, which would eat most of the saving.
@@ -38,7 +69,6 @@ RUN --mount=type=bind,source=artifact,target=/tmp/payload \
             tar --zstd -xf "${tarballs[0]}" -C /work; \
             test -d /work/build \
                 || { echo "::error::the tarball produced no /work/build" >&2; exit 1; }; \
-            uv pip install -r /work/pyproject.toml; \
             printf 'profile=full\npayload=%s\n' "$(basename "${tarballs[0]}")" \
                 > /etc/prebuilt-tests-env-manifest ;; \
         wheel) \

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -12,8 +12,9 @@ FROM ${BASE}
 #         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
 #         namespace dir and the package itself is /work/ttnn/ttnn. Nothing here
 #         runs pip, so ttnn's declared dependencies are installed from the tree's
-#         pyproject.toml: no base image is guaranteed to carry them already (the
-#         dev image lacks graphviz and ml_dtypes, and ci-test lacks graphviz).
+#         pyproject.toml: no base image is guaranteed to carry them already. Both
+#         ci-test and dev lack graphviz and ml_dtypes; an import error names only
+#         the first one missing, so do not read it as the whole gap.
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -10,7 +10,10 @@ FROM ${BASE}
 # full  = source tree plus the build tarball unpacked over it; tests run the C++
 #         binaries from /work/build and import ttnn in place. That import needs
 #         /work/ttnn on PYTHONPATH as well as /work, since /work/ttnn is a
-#         namespace dir and the package itself is /work/ttnn/ttnn.
+#         namespace dir and the package itself is /work/ttnn/ttnn. Nothing here
+#         runs pip, so ttnn's declared dependencies are installed from the tree's
+#         pyproject.toml: no base image is guaranteed to carry them already (the
+#         dev image lacks graphviz and ml_dtypes, and ci-test lacks graphviz).
 # wheel = source tree plus the wheel installed; no build tree.
 ARG PROFILE=full
 
@@ -34,6 +37,7 @@ RUN --mount=type=bind,source=artifact,target=/tmp/payload \
             tar --zstd -xf "${tarballs[0]}" -C /work; \
             test -d /work/build \
                 || { echo "::error::the tarball produced no /work/build" >&2; exit 1; }; \
+            uv pip install -r /work/pyproject.toml; \
             printf 'profile=full\npayload=%s\n' "$(basename "${tarballs[0]}")" \
                 > /etc/prebuilt-tests-env-manifest ;; \
         wheel) \

--- a/dockerfile/Dockerfile.prebuilt-tests-env
+++ b/dockerfile/Dockerfile.prebuilt-tests-env
@@ -1,4 +1,3 @@
-# syntax=ghcr.io/tenstorrent/tt-metal/tt-metalium/tools/dockerfile-frontend:1.25
 # Test environment image: the source tree and the build output merged at /work,
 # so a hardware test job needs no /work bind mount, no artifact download and no
 # full source checkout. Built by build-prebuilt-tests-image.yaml, which puts the
@@ -31,29 +30,12 @@ RUN if [ "${PROFILE}" = "full" ]; then uv pip install -r /work/pyproject.toml; f
 # Source first, payload second: the tarball carries ttnn/ttnn/*.so that has to
 # land inside the source's package directory.
 #
-# Split by how often each path changes rather than as one COPY. Measured over 199
-# commits, these seven trees are 84 MiB that change in under 3% of commits, so
-# giving them their own layers keeps them cached on a runner across commits and
-# only the volatile remainder is re-pulled.
-COPY src/models/experimental/ /work/models/experimental/
-COPY src/infra/ /work/infra/
-COPY src/tt-train/ /work/tt-train/
-COPY src/tests/sweep_framework/ /work/tests/sweep_framework/
-COPY src/models/sample_data/ /work/models/sample_data/
-COPY src/models/tt_transformers/ /work/models/tt_transformers/
-COPY src/models/tt_dit/ /work/models/tt_dit/
-
-# Everything else. The excludes are relative to the COPIED ROOT, not the build
-# context: `--exclude=src/infra` is silently ignored and ships those bytes twice,
-# which defeats the split. Verified before writing this.
-COPY --exclude=models/experimental \
-     --exclude=infra \
-     --exclude=tt-train \
-     --exclude=tests/sweep_framework \
-     --exclude=models/sample_data \
-     --exclude=models/tt_transformers \
-     --exclude=models/tt_dit \
-     src/ /work/
+# One COPY, deliberately. Splitting this by how often each path changes was tried
+# and measured: across two commits the seven low-churn layers were byte-identical
+# in size yet every compressed digest differed, so consumers re-pulled all of them
+# and the split bought nothing for nine extra layers. Reproducible layer blobs
+# would be a prerequisite, not the split itself.
+COPY src/ /work/
 
 # Bind-mounted, not COPYed: a COPYed payload stays in its layer forever and a
 # later rm reclaims nothing, which would eat most of the saving.

--- a/models/perf/perf_utils.py
+++ b/models/perf/perf_utils.py
@@ -5,7 +5,7 @@
 import csv
 import re
 import time
-from os import listdir
+from os import environ, listdir
 from os.path import isfile, join
 
 import git
@@ -16,6 +16,22 @@ from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 today = time.strftime("%Y_%m_%d")
 
 
+def get_branch_and_hash():
+    """Branch and commit for the report header.
+
+    A prebuilt test image carries the source tree without `.git`, so GitPython
+    raises instead of returning metadata. Fall back to what CI already exports
+    rather than failing a perf merge over two header lines.
+    """
+    try:
+        repo = git.Repo(search_parent_directories=True)
+    except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
+        return environ.get("GITHUB_REF_NAME", "unknown"), environ.get("GITHUB_SHA", "unknown")
+
+    branch = "detached HEAD" if repo.head.is_detached else str(repo.active_branch)
+    return branch, repo.head.object.hexsha
+
+
 def merge_perf_files(fname, perf_fname, expected_cols):
     mypath = "./"
     csvfiles = [
@@ -24,14 +40,11 @@ def merge_perf_files(fname, perf_fname, expected_cols):
         if isfile(join(mypath, f)) and re.match(f"{perf_fname}_.*_{today}.csv", f) is not None
     ]
 
-    repo = git.Repo(search_parent_directories=True)
+    branch, commit = get_branch_and_hash()
 
     merge_res = open(fname, "w")
-    if not repo.head.is_detached:
-        merge_res.write(f"branch: {repo.active_branch} \n")
-    else:
-        merge_res.write(f"branch: detached HEAD \n")
-    merge_res.write(f"hash: {repo.head.object.hexsha} \n")
+    merge_res.write(f"branch: {branch} \n")
+    merge_res.write(f"hash: {commit} \n")
     cols = ", ".join(expected_cols)
     merge_res.write(f"{cols} \n")
 

--- a/models/perf/perf_utils.py
+++ b/models/perf/perf_utils.py
@@ -31,10 +31,16 @@ def get_branch_and_hash():
         # under test: GITHUB_SHA is the ref the workflow ran on, which is not the
         # tested commit when the caller passes an explicit ref, and attributing a
         # perf result to the wrong revision is worse than having no metadata.
-        return (
-            environ.get("GITHUB_REF_NAME", "unknown"),
-            environ.get("TT_METAL_TESTED_SHA") or environ.get("GITHUB_SHA", "unknown"),
-        )
+        #
+        # It is reported as a detached HEAD rather than against GITHUB_REF_NAME,
+        # because that is what git said before the tree lost its `.git`: a caller
+        # passing an explicit commit checks it out detached, and the event's branch
+        # need not even contain it. Naming that branch beside another commit's hash
+        # would be a more confident claim than the data supports.
+        tested_sha = environ.get("TT_METAL_TESTED_SHA")
+        if tested_sha:
+            return "detached HEAD", tested_sha
+        return environ.get("GITHUB_REF_NAME", "unknown"), environ.get("GITHUB_SHA", "unknown")
 
     branch = "detached HEAD" if repo.head.is_detached else str(repo.active_branch)
     return branch, repo.head.object.hexsha

--- a/models/perf/perf_utils.py
+++ b/models/perf/perf_utils.py
@@ -20,13 +20,21 @@ def get_branch_and_hash():
     """Branch and commit for the report header.
 
     A prebuilt test image carries the source tree without `.git`, so GitPython
-    raises instead of returning metadata. Fall back to what CI already exports
-    rather than failing a perf merge over two header lines.
+    raises instead of returning metadata. Fall back to what CI exports rather than
+    failing a perf merge over two header lines, preferring TT_METAL_TESTED_SHA when
+    the caller has told us which commit is actually under test.
     """
     try:
         repo = git.Repo(search_parent_directories=True)
     except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
-        return environ.get("GITHUB_REF_NAME", "unknown"), environ.get("GITHUB_SHA", "unknown")
+        # TT_METAL_TESTED_SHA takes precedence where a caller knows which commit is
+        # under test: GITHUB_SHA is the ref the workflow ran on, which is not the
+        # tested commit when the caller passes an explicit ref, and attributing a
+        # perf result to the wrong revision is worse than having no metadata.
+        return (
+            environ.get("GITHUB_REF_NAME", "unknown"),
+            environ.get("TT_METAL_TESTED_SHA") or environ.get("GITHUB_SHA", "unknown"),
+        )
 
     branch = "detached HEAD" if repo.head.is_detached else str(repo.active_branch)
     return branch, repo.head.object.hexsha

--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -91,6 +91,15 @@ def get_git_home_dir_str():
     result = run_process_and_get_result("git rev-parse --show-toplevel")
     git_home_dir_str = result.stdout.decode("utf-8").replace("\n", "")
 
+    # A source tree without .git (a prebuilt test image, an export) leaves git with
+    # no answer; TT_METAL_HOME is the repo root by contract and is what this feeds.
+    if not git_home_dir_str:
+        git_home_dir_str = os.environ.get("TT_METAL_HOME", "")
+
+    # Without this, an empty string becomes Path("") == Path("."), which passes both
+    # checks below and silently yields paths like /build/test/... at the filesystem root.
+    assert git_home_dir_str, "Could not find the repo root: git rev-parse failed and TT_METAL_HOME is not set"
+
     git_home_dir = pathlib.Path(git_home_dir_str)
 
     assert git_home_dir.exists(), f"{git_home_dir} doesn't exist"


### PR DESCRIPTION
### PR Category

Performance

### Summary

Sanity legs download the build output from artifact storage and do a recursive source checkout before they can run anything. This wires them to the prebuilt environment image from #55329, following the recipe validated on one impl in #55451, so a leg mounts no `/work`, checks out only `.github`, and fetches no artifact.

All eight Sanity impls are wired. Two bake jobs cover them, since what varies is the (base, profile) pair rather than the impl:

| impl | base | profile | PYTHONPATH | validated against `main` |
|---|---|---|---|---|
| `ttnn-sanity-tests-impl` | ci-test | wheel | `/work` | legs green, `import ttnn` from the image |
| `runtime-sanity-tests-impl` | dev | full | `/work` | 7 legs, counts match |
| `fabric-sanity-tests-impl` | dev | full | `/work` | 314 tests / 11 suites on t3k, 120 / 3 on N300 |
| `t3000-sanity-tests-impl` | dev | full | `/work:/work/ttnn:/work/tools` | 15 pytest calls, 17 passed, same deselects and xfail |
| `models-sanity-tests-impl` | dev | full | `/work:/work/ttnn:/work/tools` | Deepseek V3 on `wh_galaxy_perf` |
| `blackhole-multi-card-sanity-tests-impl` | dev | full | `/work:/work/ttnn:/work/tools` | 4 legs, skip counts identical |
| `ops-sanity-impl` | dev | full | `/work:/work/ttnn:/work/tools` | 12 passed / 12 deselected |
| `umd-sanity-tests-impl` | dev | full | `/work` | 386 gtests |

Every suite was compared per leg against a `main` run by test count rather than exit status, because a suite that collects nothing still passes.

Setup collapses as expected: Checkout Repository 15-17s to 3s, Setup Job 19-36s to 1s.

Sized against fourteen days of job data rather than sampled runs. The eight impls wired here carry about 5,065 hardware legs a day, with checkout plus Setup Job averaging 68.6s; subtracting the ~4s that remains after wiring and the +14.1s container-init penalty measured in #55451 leaves roughly 50s a leg, or about **69 hardware runner hours a day**.

Just over half of that comes from the nightly debug callers, whose watcher and assert artifacts push some bundles past 300s, and it needs no extra wiring: each bake consumes whichever artifact its own run produced, so a debug invocation bakes a debug image by itself.

Counted separately because they are not the constrained resource: the same wiring saves roughly 19 hours a day of GitHub-hosted time on the `sim_*` legs, against about 7 hours a day spent on the two bake jobs at 89-137s each.

An earlier draft of this section quoted 10 to 24 runner hours from a handful of sampled runs. That undercounted twice over — the sampled bundles were 26-52s against a 68.6s fourteen-day mean, and 51 legs per push run counts the cloud `sim_*` legs alongside the 20 that run on hardware.

Note that the PR gate caller only invokes this workflow for forks, so 293 of 334 `PR - Sanity tests` runs in a sampled day skipped entirely and contribute nothing either way.

Env image retention is resized from 100 to 1500 in the scheduled cleanup, derived from this suite's push rate rather than picked round: about 250 Sanity runs a day at two bakes each plus about 20 runtime sanity runs at one, so roughly 520 pushes a day, which N=1500 covers for about three days.

### Notes for reviewers

- Every job in the run is pinned to one immutable commit. `ref` is documented as a commit SHA but nothing enforced it, and `actions/checkout` accepts a branch or a tag, while the producer requires a full 40-character SHA for `source-ref` because a ref that can move would recompute the same image tag over different source. A `resolve-ref` job resolves the input once and `build-artifact`, both bakes and all ten test callers take that SHA. Resolving per job would reintroduce the mismatch for a branch that moves mid-run, which is the case the producer guard exists to catch.
- That resolver gates the run rather than degrading. A failed `check-harbor` must not stop the pipeline, since an empty prefix legitimately means "pull from GHCR", but an empty resolved SHA is not a graceful fallback: it would silently substitute this workflow's own commit. `build-artifact` therefore requires `needs.resolve-ref.result == 'success'`.
- The ref is percent-encoded byte-wise before it reaches the API, and the reason is worth keeping. `main#foo` is a legal branch name whose `#` starts a URL fragment, so it resolved to `main`'s SHA; `foo%2Fbar` is legal too and its `%` is decoded, addressing `foo/bar`; `x/comments` reaches the `/commits/{ref}/comments` sub-resource. Each returns a valid 40-character SHA for the wrong commit, so the length check cannot catch any of them. Encoding runs under `LC_ALL=C` so the loop walks UTF-8 bytes rather than code points.
- `ttsim-sanity-tests-impl.yaml` is in the diff without being wired to an image, and so are the `llk` and `runtime-sim` callers. They consume the same pinned build artifact, so they take the resolved SHA and have their matrix load pinned, but they gain no prebuilt image. Eight impls are wired; nine have their matrix pinned.
- Each impl's `load-test-matrix` checkout is pinned too. Six of the nine loaded their test list from the event commit while executing against `inputs.ref`, so a targeted run could select tests from one revision and run them against another's binaries. This predates the PR; pinning everything else made it the last hole of that shape.
- `models/perf/perf_utils.py` reads `TT_METAL_TESTED_SHA` in preference to `GITHUB_SHA`. `merge_device_perf_results.py` runs after the ops tests and called `git.Repo`, which raises with no `.git` in the image, so ops legs went red after every test had passed. The fallback then had to name the right commit: `GITHUB_SHA` is the ref the workflow ran on, and a caller passing an explicit commit checks it out detached, so the header reports `detached HEAD` and the tested SHA, matching what git wrote before. A real repository still wins, so behaviour off the image path is unchanged.
- The resolver declares `permissions: contents: read`. Its only authenticated call is a read-only commit lookup, and a job added to this workflow otherwise inherits the file's write grants for contents, pull requests, pages, packages, checks and OIDC.

- Each bake job is in the consuming job's `needs` but deliberately absent from its `if`. A failed bake then yields an empty ref and the legs fall back to the artifact path. Gating on the bake would skip the suite instead, and a skipped optional job counts as success in the status check, so a registry blip would produce a green run with no coverage.
- Bake jobs take the canonical `build-artifact` image output, never a Harbor-resolved one, because the producer runs GitHub-hosted with no Harbor access. `ops` and `umd` receive an already-prefixed ref from their callers, so they need no special handling in the impl.
- `PYTHONPATH` is not uniform and the differences are load-bearing. The wheel profile installs ttnn, so `/work` suffices. `fabric` and `umd` never import it: both run only `./build/test/...` binaries, verified by following the shell indirection rather than reading the test list, since a `cmd` can be `source <script>` with the function name on the next line and the pytest calls one level down.
- The four suites that do import ttnn in place need **`/work/tools`** as well as `/work/ttnn`, and this one is worth reading. Sanity builds with `tracy=true`, so `_ttnn` imports the `tracy` Python module during module init. The wheel makes that importable through `package_dir` in `setup.py`, which maps `tracy` to `tools/tracy`; in place it resolves only from `/work/tools`. Without it a leg fails as `ImportError: Encountered an error while initializing the extension`, which names neither `tracy` nor a path, because pytest discards the chained `ModuleNotFoundError` while loading conftest. `bisect-dispatch.yaml` has always used this same three-entry path for in-place runs.
- `models/perf/perf_utils.py` needed a fix that is worth reading on its own. `merge_perf_files` calls `git.Repo(search_parent_directories=True)` for two CSV header lines, and the image carries the source without `.git`, so `ops` failed with `InvalidGitRepositoryError` **after every one of its tests had passed**. It now falls back to `GITHUB_REF_NAME` and `GITHUB_SHA`, which CI always exports; a real repo and a detached HEAD still produce byte-identical output. This is the same class as the `common.py` fix in #55451 but a different mechanism: that one shells out to `git`, this uses GitPython. The only other `git.Repo(` call site is `tt-train/scripts/run_models.py`, which no Sanity suite reaches.
- Several upload steps read the host-side spelling of a `/work` path, which only ever worked as a second name for the bind mount. Every step of a container job runs inside the container, so with no mount they find nothing, and they are all `if-no-files-found: warn` or `continue-on-error: true`. Test counts cannot detect this: the legs stay green and the counts still match. Confirmed on a real run before fixing, where the power report warned `No files were found` and the AI summary reported `Missing/empty log dirs`. The power report, perf profile, mem report, coverage profdata and `ai_summary` workspace now all use the container path, which is correct with or without a mount and is already the repo idiom.
- The profile per impl is decided by two constraints, neither visible in the workflow file. `runtime/` and `build/` are not git-tracked, so any impl setting `TT_METAL_HOME=/work` needs the full profile or metal's JIT has no runtime directory. The full profile runs no pip, so ttnn's dependencies come from the tree's `pyproject.toml`.
- The per-leg saving is smaller here than in #55451, because it scales with how much setup an impl has. Runtime unit tests had 213s of setup; fabric has 36-52s. Do not read a per-leg figure off this branch, though: it re-mints the base image, so nothing is cached and the container init penalty looks far worse than it is. The paired same-run measurement in #55451 is the one to trust.
- Proxying the env image through Harbor was measured and rejected. Pulling the same image on a self-hosted runner gave 13s via ghcr against 15s warm and 19s cold through Harbor, since ghcr already serves the payload at roughly 20 MB/s and a relay of the same bytes has nothing to add. Harbor does serve the repo, so this stays available if the picture changes.

Stacked on #55451 and targeting its branch.
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-sanity-prebuilt-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdabasinskas/ci-sanity-prebuilt-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-sanity-prebuilt-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdabasinskas/ci-sanity-prebuilt-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdabasinskas/ci-sanity-prebuilt-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdabasinskas/ci-sanity-prebuilt-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdabasinskas/ci-sanity-prebuilt-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdabasinskas/ci-sanity-prebuilt-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdabasinskas/ci-sanity-prebuilt-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdabasinskas/ci-sanity-prebuilt-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdabasinskas/ci-sanity-prebuilt-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdabasinskas/ci-sanity-prebuilt-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdabasinskas/ci-sanity-prebuilt-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdabasinskas/ci-sanity-prebuilt-env)




