### PR TITLE
[Tests] Consolidate QB2 indexer and SDPA coverage

### DIFF
--- a/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
@@ -34,30 +34,14 @@
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 
-- name: sdpa nightly tests (QB2 only)
-  cmd: pytest tests/nightly/blackhole/sdpa/ -svv
-  skus:
-    bh_quietbox_2:
-      timeout: 20
-  owner_id: U05ACKAJTHS # Naif Tarafdar
-  team: ttnn
-
 - name: TTNN multi-device CCL, SDPA PERF, and indexer tests (QB2 only)
-  # Group these short QuietBox-only checks to amortize the multi-card job setup,
-  # checkout, and link-health check. All three use the same Blackhole runtime.
-  # The SDPA checks measure device kernel duration via the realtime device profiler.
-  # On Blackhole the RT profiler's D2H socket uses 64-bit PCIe addressing, which
-  # requires host IOMMU (there is no hugepage fallback) — see
-  # evaluate_realtime_profiler_eligibility in realtime_profiler_manager.cpp.
   cmd: |
+    pytest tests/nightly/blackhole/sdpa/ -svv
     pytest tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py::test_high_bw_all_gather_quietbox_ci_perf -q
-    pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
-    pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_mla_chunked_perf_check -svv
-    pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
-    pytest tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_indexer_score.py -k indexer_score_qb -svv
     pytest tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_perf.py -svv
+    pytest tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py -svv
   skus:
     bh_quietbox_2:
-      timeout: 15
-  owner_id: U05ACKAJTHS # Naif Tarafdar
+      timeout: 30
+  owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/ring_indexer_score_test_utils.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/ring_indexer_score_test_utils.py
@@ -9,6 +9,8 @@ recipe lives in exactly one place. The 4-chip variant (`test_ring_indexer_score_
 directly and keeps its own copy of `_open_ccl` (no (2,4)->(1,4) submesh carve).
 """
 
+import torch
+
 import ttnn
 
 from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_indexer_score import (
@@ -42,6 +44,33 @@ DRAM = ttnn.DRAM_MEMORY_CONFIG
 _INPUT_DIMS = (None, 2)
 # Persistent AG buffer: full T on every device -> replicate along the SP axis; axis 0 shards the size-1 dim 1.
 _BUF_DIMS = (1, None)
+
+
+def _to_tp_inner_reconstructed(k_natural, *, sp, tp, chunk_local):
+    """Pack natural K in the physical order produced by a TP-inner then SP-outer gather."""
+    capacity = k_natural.shape[2]
+    assert capacity % (sp * tp) == 0
+    assert chunk_local % tp == 0
+    physical_shard_capacity = capacity // sp
+    tp_stripe_capacity = physical_shard_capacity // tp
+    stripe_chunk = chunk_local // tp
+    assert tp_stripe_capacity % stripe_chunk == 0
+
+    physical_to_logical = []
+    for sp_rank in range(sp):
+        physical_offset = torch.arange(physical_shard_capacity)
+        tp_rank = physical_offset // tp_stripe_capacity
+        within_tp = physical_offset % tp_stripe_capacity
+        slab = within_tp // stripe_chunk
+        within_chunk = within_tp % stripe_chunk
+        logical = (slab * sp + sp_rank) * chunk_local + tp_rank * stripe_chunk + within_chunk
+        physical_to_logical.append(logical)
+    physical_to_logical = torch.cat(physical_to_logical)
+    assert torch.equal(torch.sort(physical_to_logical).values, torch.arange(capacity))
+
+    reconstructed = k_natural.clone()
+    reconstructed[0, 0] = k_natural[0, 0, physical_to_logical]
+    return reconstructed
 
 
 def _open_ring4_ccl():

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_indexer_score.py
@@ -18,9 +18,9 @@ Both share the factory + kernels (the flavour is compile-time args). Causality: 
 visible to query ``s`` iff ``t <= chunk_start + s``; future columns/blocks are -inf.
 
 Deployments are Galaxy chunked prefill (50K history + 5K chunk = 55K keys; the chunk is SP=8
--> 640 q/device): GLM5 (8h), M3 (MSA per-GQA-group,
-block-max-pooled). Most cases run on one chip with explicit ``chunk_start`` (``sp_rank`` =
-ring position); the QuietBox tests derive ``chunk_start`` per device from the mesh coordinate.
+-> 640 q/device): GLM5 (8h), M3 (MSA per-GQA-group, block-max-pooled). These tests run on one
+chip with explicit ``chunk_start`` (``sp_rank`` = ring position). Multi-device coverage lives in
+``test_ring_indexer_score_dsa_4d.py``.
 
 Run all (the perf-check needs the real-time profiler, i.e. a host-IOMMU sku; it fails fast otherwise):
     scripts/run_safe_pytest.sh --run-all <this file>
@@ -929,9 +929,7 @@ INDEXER_PERF_CORES = 11 * 10
     ],
 )
 def test_indexer_score_genmcast_regimes(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
-    """Banded-product scheduler regimes beyond the original knobs/shapes coverage: G>grid.y phase
-    stacking, prime G, uneven k-band columns, partial bands, and streaming -- all checked for exact
-    causality + PCC like the deployments."""
+    """Cover G>grid.y phase stacking, prime G, uneven k-band columns, partial bands, and streaming."""
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
 
 
@@ -993,15 +991,7 @@ def test_indexer_score_block_split_fill(device, heads, dim, sq, t, chunk_start, 
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
 
 
-# ==============================================================================================
-# Multi-device (QuietBox, 4 BH) tests: PER-DEVICE chunk_start derived from the mesh coordinate.
-# ==============================================================================================
-# Use the `mesh_device` fixture (auto-skips on a single chip). A SINGLE mesh dispatch where each device is
-# a different SP rank: chunk_start = chunk_start_idx + r*Sq (r = linearized index along cluster_axis), one
-# hash-excluded program for all. Two layouts:
-#   - 1D SP=4 (flat mesh): history 25600 + chunk 4*640 -> T 28160; cluster_axis unset (linear order).
-#   - 2D SP=2 x TP=2:      history 25600 + chunk 2*640 -> T 26880; cluster_axis = SP axis, heads split.
-# Functional only (exact -inf map + PCC >= 0.999 per SP rank).
+# Shared input constants and helpers used by the four-device Ring indexer suite.
 
 QB_DIM = 128  # indexer head dim
 QB_SQ = 640  # queries per SP rank (preserved from the SP=8 deployment)
@@ -1053,42 +1043,6 @@ def _shard_1d(mesh_device, heads, seed):
     return q_g, k_g, w_g, q_dev, k_dev, w_dev
 
 
-@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
-@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
-def test_indexer_score_qb_per_device_chunk_start(mesh_device, case_id, heads):
-    """One mesh dispatch over 4 BH devices, each deriving its own chunk_start from its coordinate.
-    Validate each device's output against its own chunk_start reference."""
-    q_g, k_g, w_g, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=42)
-
-    # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY (sp_ring = 4 devices,
-    # cluster_axis unset), then device r gets base + r*Sq. No chunk_start passed at all.
-    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, program_config=glx_config(heads))
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
-
-    ref = _per_sp_ref(q_g, k_g, w_g, QB_SP, QB_HISTORY)
-    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
-
-
-@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
-@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
-def test_indexer_score_qb_one_compile_all_chunk_starts(mesh_device, case_id, heads):
-    """chunk_start is excluded from the program hash: running several different bases must add exactly
-    ONE program-cache entry (the first compile), proving no per-value recompile."""
-    _, _, _, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=7)
-
-    # Three distinct chunk-start bases (all within the causal window). Only the first should compile.
-    bases = [QB_HISTORY, QB_HISTORY - QB_SQ, QB_HISTORY - 2 * QB_SQ]
-
-    entries_before = mesh_device.num_program_cache_entries()
-    for base in bases:
-        ttnn.experimental.indexer_score_dsa(
-            q_dev, k_dev, w_dev, chunk_start_idx=base, program_config=glx_config(heads)
-        ).deallocate()
-
-    added = mesh_device.num_program_cache_entries() - entries_before
-    assert added == 1, f"expected 1 program-cache entry across 3 distinct chunk_start bases, got {added}"
-
-
 # ---- 2D mesh: SP=2 (one axis) x TP=2 (the other, head-split) ----------------------------------
 # Exercises cluster_axis on a real 2D mesh, which a 1xN mesh can't: chunk_start must vary along the
 # SP axis only, while the two TP devices sharing an SP position get the SAME chunk_start.
@@ -1108,48 +1062,7 @@ def _axis_dims(sp_dim, tp_dim):
     return tuple(dims)
 
 
-@pytest.mark.parametrize("mesh_device", [(QB2_SP, QB2_TP)], ids=["2x2"], indirect=True)
-@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
-def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
-    """One mesh dispatch over a 2x2 mesh: chunk_start derived per-device from the coordinate along
-    cluster_axis (SP), constant across the TP axis; heads split across TP. Each TP device computes a
-    partial head-sum, which the test sums back (the TP all-reduce) and validates per SP rank against
-    its own full-head, own-chunk_start reference."""
-    q_g, k_g, w_g = _global_inputs(heads, QB2_CHUNK, QB2_T, seed=42)
-
-    # q/w: seq (dim 2) sharded along the SP axis, heads (dim 1) along the TP axis. k replicated.
-    mesh_shape = tuple(mesh_device.shape)
-    qw_dims = _axis_dims(sp_dim=2, tp_dim=1)
-    shard_qw = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_qw)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_qw)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    # chunk_start_idx OMITTED: the op deduces base = T - sp_ring*Sq, where sp_ring is the mesh extent
-    # along cluster_axis (2, the SP axis) -- NOT the total device count (4). Device (sp, tp) then gets
-    # chunk_start = base + sp*Sq -- identical for both TP devices at SP position sp.
-    out = ttnn.experimental.indexer_score_dsa(
-        q_dev,
-        k_dev,
-        w_dev,
-        seq_shard_axes=[QB2_SP_AXIS],
-        program_config=glx_config(heads // QB2_TP),  # per-device head count
-    )
-    # Concat SP shards along seq (dim 2) and the TP head-partials along the size-1 head dim (dim 1), then
-    # SUM the partials (the TP all-reduce) -> full [1,1,1280,T] score.
-    out_t = ttnn.to_torch(
-        out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
-    )
-    out_t = out_t.float().sum(dim=1, keepdim=True)
-
-    ref = _per_sp_ref(q_g, k_g, w_g, QB2_SP, QB_HISTORY)
-    assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)
-
-
-# ==============================================================================================
-# Multichip MSA (MiniMax M3): the same per-device chunk_start mechanism as the DSA QB tests, through the
-# indexer_score_msa frontend (raw dot, constant 1/sqrt(d) scale, no weights). num_groups=1 head-sums into
-# one [1,1,Sq,T] plane; the 2x2 case splits heads across TP and sums the partials back. Functional only.
+# Shared MiniMax M3 constants and reference used by the four-device suite.
 M3_QB_HEADS = 4  # MiniMax M3 sparse_num_index_heads
 M3_QB_SCALE = QB_DIM**-0.5  # 1/sqrt(d), the M3 indexer scale (folded into the constant gate)
 
@@ -1163,57 +1076,6 @@ def _msa_per_sp_ref(q_g, k_g, sp_count, history):
         sl = slice(sp * QB_SQ, (sp + 1) * QB_SQ)
         refs.append(indexer_score_msa_ref(q_g[:, :, sl, :], k_g, w, history + sp * QB_SQ))
     return torch.cat(refs, dim=2)
-
-
-@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
-def test_indexer_score_qb_msa_per_device_chunk_start(mesh_device):
-    """MSA over 4 BH devices (SP=4), each deriving its own chunk_start from its coordinate (cluster_axis
-    unset -> linear order). Raw dot + constant scale, num_groups=1 -> one head-summed [1,1,Sq,T] plane."""
-    q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
-    shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    # chunk_start_idx OMITTED -> the op deduces base = T - sp_ring*Sq = QB_HISTORY, then device r gets
-    # base + r*Sq (r = linearized index, cluster_axis unset). The constant gate is synthesized per-device.
-    out = ttnn.experimental.indexer_score_msa(
-        q_dev, k_dev, scale=M3_QB_SCALE, num_groups=1, program_config=glx_config(M3_QB_HEADS)
-    )
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
-
-    ref = _msa_per_sp_ref(q_g, k_g, QB_SP, QB_HISTORY)
-    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
-
-
-@pytest.mark.parametrize("mesh_device", [(QB2_SP, QB2_TP)], ids=["2x2"], indirect=True)
-def test_indexer_score_qb_msa_sp2_tp2(mesh_device):
-    """MSA over a 2x2 mesh: chunk_start derived per-device along cluster_axis (SP), constant across TP; the
-    M3 index heads split across TP. Each device head-sums its half (num_groups=1); the test sums the TP
-    partials (the all-reduce) and validates per SP rank against its own raw-dot, own-chunk_start reference."""
-    q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB2_CHUNK, QB2_T, seed=42)
-
-    # q: seq (dim 2) sharded along the SP axis, heads (dim 1) along the TP axis. k replicated.
-    mesh_shape = tuple(mesh_device.shape)
-    q_dims = _axis_dims(sp_dim=2, tp_dim=1)
-    shard_q = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=q_dims)
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_q)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    # chunk_start_idx OMITTED: base deduced as T - sp_ring*Sq, sp_ring = mesh extent along cluster_axis (2,
-    # the SP axis). Device (sp, tp) gets chunk_start = base + sp*Sq -- identical for both TP devices at sp.
-    out = ttnn.experimental.indexer_score_msa(
-        q_dev,
-        k_dev,
-        seq_shard_axes=[QB2_SP_AXIS],
-        scale=M3_QB_SCALE,
-        num_groups=1,
-        program_config=glx_config(M3_QB_HEADS // QB2_TP),  # per-device head count
-    )
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=q_dims))
-    out_t = out_t.float().sum(dim=1, keepdim=True)  # TP all-reduce: sum the head-partials
-
-    ref = _msa_per_sp_ref(q_g, k_g, QB2_SP, QB_HISTORY)
-    assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)
 
 
 # MiniMax M3 MSA math-utilization perf check (tracy; no accuracy check). ONE device of an SP=8 x TP=4 mesh:
@@ -1855,157 +1717,7 @@ def test_indexer_score_slab_invp_math(ring_size, chunk_local, t):
     assert torch.equal(invP[P], ident), "invP[P(r)] != r -- not a bijection"
 
 
-# ---- Real-mesh block-cyclic remap: sp DERIVED from block_cyclic_sp_axis on an (sp, 1) mesh ----
-# The remap is the identity at sp=1, so the natural->physical PERMUTATION arithmetic only runs on a real SP
-# mesh. K is stored block-cyclic and REPLICATED; q/w are SP-sharded on seq (per-chip chunk_local rows). The
-# reader remaps each logical K-tile so the score matches the contiguous-K, natural-order per-SP reference.
-# Reuses the QB constants (QB_HISTORY % (QB_SP*QB_SQ) == 0 -> T is a whole number of global chunks, and
-# T/QB_SP spans many slabs so the permutation is non-trivial).
-@pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
-@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
-def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
-    """DSA over a REAL SP=4 mesh with a block-cyclic K cache. sp is read from block_cyclic_sp_axis=0 (the mesh
-    rows); block_cyclic_chunk_local = QB_SQ (per-chip seq). chunk_start OMITTED -> the slab path deduces base =
-    T - global_chunk = QB_HISTORY, device r gets base + r*QB_SQ. Score must match the natural-order reference."""
-    q_g, k_nat, w_g = _global_inputs(heads, QB_CHUNK, QB_T, seed=42)
-    k_bc = _to_slab(k_nat, QB_SP, QB_CHUNK)  # global chunk = QB_SP * QB_SQ = QB_CHUNK
-    mesh_shape = tuple(mesh_device.shape)
-    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))  # seq on SP axis, repl. axis 1
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    out = ttnn.experimental.indexer_score_dsa(
-        q_dev,
-        k_dev,
-        w_dev,
-        seq_shard_axes=[0],  # SP axis (same axis the cache was striped over)
-        block_cyclic_sp_axis=0,
-        block_cyclic_chunk_local=QB_SQ,
-        program_config=glx_config(heads),
-    )
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
-    ref = _per_sp_ref(q_g, k_nat, w_g, QB_SP, QB_HISTORY)
-    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
-
-
-# ---- Q sequence sharded across BOTH mesh axes via seq_shard_axes=[] (block_cyclic_chunk_local == tp*q_isl) ----
-# On a 2x2 mesh with K block-cyclic over ONE axis (sp=2, tp=2), Q's sequence is split across all 4 devices.
-# seq_shard_axes=[] ranks device (a,b) by its row-major position in the device list (a*B+b), so the flat
-# linearization IS a row-major nested 2D seq shard: device r's q-row 0 sits at base + r*Sq. For a slab-aligned
-# base every device stays inside its slab (no straddle), so the flat shard + block-cyclic remap reassembles to
-# a plain contiguous natural-order scoring of the whole chunk. A NAMED cluster_axis is rejected (its rank would
-# miss the second axis's offset).
-@pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["2x2"], indirect=True)
-@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
-def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_error):
-    """Q seq sharded across both axes (all 4 devices) with seq_shard_axes=[]: chunk_local == tp*q_isl (tp=2),
-    which the guard allows only for seq_shard_axes=[] (flat). K block-cyclic over sp=2, aligned base -> no
-    straddle, so the reassembled score equals the contiguous natural-order reference. Also asserts a lone SP
-    axis (seq_shard_axes=[sp], which would mis-rank) is still rejected."""
-    sp, chunk_global, t = 2, 256, 512  # cl=128, Sq per device = 256/4 = 64 (2 tiles); 2 chunks -> >1 slab/shard
-    q_g, k_nat, w_g = _global_inputs(heads, chunk_global, t, seed=42)
-    k_bc = _to_slab(k_nat, sp, chunk_global)
-    shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)  # flat row-major over all 4 devices == None's device order
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-    kw = dict(block_cyclic_sp_axis=0, block_cyclic_chunk_local=chunk_global // sp, program_config=glx_config(heads))
-
-    # seq_shard_axes=[] -> Q linearized row-major over all 4 devices (both axes). chunk_start OMITTED ->
-    # base = T - global_chunk = 256 (slab-aligned). Reassembled == contiguous natural scoring at base.
-    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, seq_shard_axes=[], **kw)
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
-    ref = indexer_score_dsa_ref(q_g, k_nat, w_g, t - chunk_global)
-    assert_indexer_match(out_t, ref, chunk_global, t, check_neg=True)
-
-    # A lone SP axis with tp*q_isl is rejected (rank would miss the second axis's seq offset).
-    with expect_error(RuntimeError, "needs the TP axis"):
-        ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, seq_shard_axes=[0], **kw)
-
-
-@pytest.mark.parametrize("mesh_device", [(1, 4)], ids=["sp1xtp4"], indirect=True)
-def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
-    """A size-one SP axis is still a valid SP×TP query shard: TP rank t owns rows [t*Sq,(t+1)*Sq),
-    so its causal diagonal must start at chunk_start + t*Sq even though the block-cyclic K permutation is
-    the identity for sp=1. An omitted chunk_start must likewise deduct the full TP-sharded chunk from T.
-    This is the QuietBox chunked-indexer layout."""
-    heads, chunk, t, chunk_start = 8, 256, 512, 128
-    q_g, k_g, w_g = _global_inputs(heads, chunk, t, seed=42)
-    mesh_shape = tuple(mesh_device.shape)
-    shard_tp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(None, 2))
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_tp_seq)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_tp_seq)
-    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    out = ttnn.experimental.indexer_score_dsa(
-        q_dev,
-        k_dev,
-        w_dev,
-        chunk_start_idx=chunk_start,
-        seq_shard_axes=[0, 1],
-        block_cyclic_sp_axis=0,
-        block_cyclic_chunk_local=chunk,
-        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
-    )
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(1, 2)))
-    ref = indexer_score_dsa_ref(q_g, k_g, w_g, chunk_start)
-    assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
-
-    out_default = ttnn.experimental.indexer_score_dsa(
-        q_dev,
-        k_dev,
-        w_dev,
-        seq_shard_axes=[0, 1],
-        block_cyclic_sp_axis=0,
-        block_cyclic_chunk_local=chunk,
-        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
-    )
-    out_default_t = ttnn.to_torch(
-        out_default, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(1, 2))
-    )
-    default_start = t - chunk
-    ref_default = indexer_score_dsa_ref(q_g, k_g, w_g, default_start)
-    assert_indexer_match(out_default_t, ref_default, chunk, t, check_neg=True)
-
-
-@pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["sp2xtp2"], indirect=True)
-def test_indexer_score_sp2_tp2_seq_subshard_rotated(mesh_device):
-    """Named SP + TP seq-subshard must reproduce the prefill writer's mapping for a rotated chunk."""
-    heads, sp, chunk, t, chunk_start = 8, 2, 256, 512, 160
-    q_g, k_nat, w_g = _global_inputs(heads, chunk, t, seed=42)
-    k_bc = _to_slab(k_nat, sp, chunk)
-    mesh_shape = tuple(mesh_device.shape)
-    shard_sp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_sp_seq)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_sp_seq)
-    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
-    q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=1)
-    w_dev = ttnn.mesh_partition(w_dev, dim=2, cluster_axis=1)
-
-    out = ttnn.experimental.indexer_score_dsa(
-        q_dev,
-        k_dev,
-        w_dev,
-        chunk_start_idx=chunk_start,
-        seq_shard_axes=[0, 1],
-        block_cyclic_sp_axis=0,
-        block_cyclic_chunk_local=chunk // sp,
-        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
-    )
-    shards = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(out.cpu())]
-    per_sp = [torch.cat(shards[r * 2 : (r + 1) * 2], dim=2) for r in range(sp)]
-    out_t = torch.cat(per_sp, dim=2)
-    ref = _straddle_ref(q_g, k_nat, w_g, sp, chunk, chunk_start, t)
-    assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
-
-
-# ---- Mid-slab-boundary STRADDLE (drives the need for the straddle geometry, #48500 slice #2) ----
-# A NON-slab-aligned chunk_start makes each device's queries cross a cache-slab boundary, so the causal
-# diagonal must JUMP by (chunk_global - cl) at q-row (cl - offset). Scaled-down stand-in for the maxedge
-# iter2 case in test_mla (iters_isl=[2560,2592,5120] -> chunk_start 5152, offset 32): here sp=2,
-# chunk_global=1280, cl=640, chunk_start=704 (= cumulative 384+320) -> offset 64 (2 tiles), so q-tiles 18-19
-# straddle. The CURRENT op has no straddle (linear diagonal) -> this FAILS until the straddle is carved in.
+# Shared mid-slab geometry used by the four-device block-cyclic tests.
 ST_CHUNK = 1280  # global chunk (tokens); per-shard cl = ST_CHUNK/sp
 ST_CS = 704  # mid-slab chunk_start (704 % 640 = 64 offset); the 384+320 cumulative of the maxedge stand-in
 ST_T = 3840  # cache length: whole chunks (3*1280) covering the fullest device's straddled window
@@ -2078,121 +1790,6 @@ def _straddle_msa_pooled_ref(q_g, k_nat, sp, chunk_global, chunk_start, t_len, s
         pooled[:, torch.arange(sq), pos // block_size] = float("inf")  # forced-local: own block
         refs.append(pooled.unsqueeze(1))
     return torch.cat(refs, dim=2)
-
-
-@pytest.mark.parametrize("mesh_device", [(2, 1)], ids=["sp2"], indirect=True)
-@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
-def test_indexer_score_qb_straddle(mesh_device, case_id, heads):
-    """Mid-slab-boundary straddle + block-cyclic chip rotation on a REAL SP mesh: block-cyclic K + a
-    non-slab-aligned chunk_start (704) makes each device's queries straddle a slab boundary AND (when the
-    start block index isn't a multiple of sp) rotates which chip owns which block. The causal diagonal must
-    use the writer's rotation (rotated_chip_positions), not the linear chunk_start + r*Sq (sp2 here: cl=640,
-    boundary_chip=1, offset=64). Geometry is sp-generic (sp derived from the mesh); also verified locally at
-    sp=8 (cl=160, boundary_chip=4 mid-ring) to guard against overfitting to sp=2 -- kept at sp=2 in CI to
-    avoid an 8-chip reservation. Scaled stand-in for the maxedge rotated-prefill case (test_mla).
-
-    Also a PROGRAM-CACHE regression: chunk_start (and the derived per-device chunk_start_tiles / straddle)
-    are hash-EXCLUDED runtime args, re-patched by override_runtime_arguments on a hit. Two chunk_starts with
-    a DIFFERENT boundary_chip run through ONE cached program -- ST_CS (mid-slab: rotation + straddle) then 0
-    (aligned: linear) -- so the second call must be a cache hit (no recompile) yet still correct, exercising
-    the re-patch and not just create_at."""
-    sp = mesh_device.shape[0]
-    q_g, k_nat, w_g = _global_inputs(heads, ST_CHUNK, ST_T, seed=42)
-    k_bc = _to_slab(k_nat, sp, ST_CHUNK)
-    mesh_shape = tuple(mesh_device.shape)
-    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
-
-    def run(chunk_start):
-        out = ttnn.experimental.indexer_score_dsa(
-            q_dev,
-            k_dev,
-            w_dev,
-            chunk_start_idx=chunk_start,
-            seq_shard_axes=[0],
-            block_cyclic_sp_axis=0,
-            block_cyclic_chunk_local=ST_CHUNK // sp,
-            program_config=cfg,
-        )
-        out_t = ttnn.to_torch(
-            out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1))
-        )
-        ref = _straddle_ref(q_g, k_nat, w_g, sp, ST_CHUNK, chunk_start, ST_T)
-        assert_indexer_match(out_t, ref, ST_CHUNK, ST_T, check_neg=True)
-
-    mesh_device.enable_program_cache()
-    run(ST_CS)  # miss: boundary_chip=1 (sp2), offset 64 -> rotation + straddle
-    entries = mesh_device.num_program_cache_entries()
-    run(0)  # hit: boundary_chip=0, offset 0 -> linear; must re-patch the geometry, not recompile
-    assert (
-        mesh_device.num_program_cache_entries() == entries
-    ), "switching boundary_chip recompiled -- chunk_start / straddle must be hash-excluded runtime args"
-
-
-@pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
-def test_indexer_score_qb_msa_block_cyclic(mesh_device):
-    """MSA (raw dot, constant scale, num_groups=1) over a REAL SP=4 block-cyclic K cache: sp read from
-    block_cyclic_sp_axis=0, the reader remaps each logical K-tile so the head-summed per-SP score matches the
-    natural-order reference. The reader remap is block_size-independent (it presents natural-order K; pooling
-    then runs over that), so block-max-pool-over-block-cyclic is covered by composition of this remap test and
-    the single-chip contiguous pooled tests -- no separate pooled mesh case needed."""
-    q_g, k_nat, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
-    k_bc = _to_slab(k_nat, QB_SP, QB_CHUNK)
-    mesh_shape = tuple(mesh_device.shape)
-    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    out = ttnn.experimental.indexer_score_msa(
-        q_dev,
-        k_dev,
-        seq_shard_axes=[0],
-        scale=M3_QB_SCALE,
-        num_groups=1,
-        block_cyclic_sp_axis=0,
-        block_cyclic_chunk_local=QB_SQ,
-        program_config=glx_config(M3_QB_HEADS),
-    )
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
-    ref = _msa_per_sp_ref(q_g, k_nat, QB_SP, QB_HISTORY)
-    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
-
-
-@pytest.mark.parametrize("mesh_device", [(2, 1)], ids=["sp2"], indirect=True)
-def test_indexer_score_qb_msa_block_cyclic_straddle(mesh_device):
-    """Mid-slab-boundary straddle on the MSA BLOCK-POOL path (real sp=2 mesh): block-cyclic K + a non-slab-
-    aligned chunk_start (704, offset 64) makes each device's queries straddle a slab boundary. The DSA straddle
-    test above covers the compute-side causal diagonal (full-strip write); THIS pins the writer's block-pool
-    forced-local +inf stamp, which must jump to the query's OWN block ACROSS the boundary -- a path the DSA
-    (write_strip) test never exercises. Fails on the pre-straddle op (linear diagonal -> +inf stamped on the
-    wrong block)."""
-    sp = 2
-    bs = BLOCK_POOL_BS  # 128; cl (640) / chunk_global (1280) / bs all block-aligned -> jump moves whole blocks
-    q_g, k_nat, _ = _global_inputs(M3_QB_HEADS, ST_CHUNK, ST_MSA_T, seed=42)
-    k_bc = _to_slab(k_nat, sp, ST_CHUNK)
-    mesh_shape = tuple(mesh_device.shape)
-    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
-    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
-    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
-
-    out = ttnn.experimental.indexer_score_msa(
-        q_dev,
-        k_dev,
-        chunk_start_idx=ST_CS,  # explicit, mid-slab -> offset 64 -> straddle
-        seq_shard_axes=[0],
-        scale=M3_QB_SCALE,
-        num_groups=1,
-        block_size=bs,
-        block_cyclic_sp_axis=0,
-        block_cyclic_chunk_local=ST_CHUNK // sp,
-        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0),
-    )
-    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
-    ref = _straddle_msa_pooled_ref(q_g, k_nat, sp, ST_CHUNK, ST_CS, ST_MSA_T, M3_QB_SCALE, bs)
-    assert_pooled_match(out_t, ref, 1, ST_CHUNK, ST_MSA_T // bs, pcc_floor=0.995)
 
 
 def test_indexer_score_rejects_partial_block_cyclic_args(device, expect_error):

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
@@ -3,8 +3,8 @@
 
 """
 Correctness of the ring-fused indexer_score op (ttnn.experimental.ring_indexer_score_dsa) on Blackhole.
-The legacy suite covers the LoudBox 2x4 -> 1x4 axis ring; full-mesh coverage uses the complete 2x4 as one
-snake and adds exact-physical 2x2 plus opt-in 8x4 Galaxy gates. One op co-schedules the ring_attention
+Coverage includes a LoudBox 2x4 -> 1x4 axis ring, the complete 2x4 mesh, exact-physical 2x2, and opt-in
+8x4 Galaxy gates. One op co-schedules the ring_attention
 all-gather with the score; the reader gates each K band on only the SP shards it touches and dual-sources its
 own slab from k_local. Checked against the same DSA references as the two-op path, including both K layouts,
 indexed caches, straddle, kv_len, program-cache reuse, placement, and host validation.
@@ -43,6 +43,7 @@ from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.ring_in
     _close_ring4_ccl,
     _persistent_buffer,
     _shard_k,
+    _to_tp_inner_reconstructed,
     RING,
     SP_AXIS,
     CHUNK_GLOBAL,
@@ -692,39 +693,6 @@ LB_SPTP_CHUNK_LOCAL = LB_SPTP_CHUNK // LB_SPTP_SP
 LB_SPTP_K_CHUNK = 320
 
 
-def _to_tp_inner_reconstructed(
-    k_natural,
-    *,
-    sp=LB_SPTP_SP,
-    tp=LB_SPTP_TP,
-    chunk_local=LB_SPTP_CHUNK_LOCAL,
-):
-    """Pack natural K in the physical order produced by a TP-inner then SP-outer gather."""
-    capacity = k_natural.shape[2]
-    assert capacity % (sp * tp) == 0
-    assert chunk_local % tp == 0
-    physical_shard_capacity = capacity // sp
-    tp_stripe_capacity = physical_shard_capacity // tp
-    stripe_chunk = chunk_local // tp
-    assert tp_stripe_capacity % stripe_chunk == 0
-
-    physical_to_logical = []
-    for sp_rank in range(sp):
-        physical_offset = torch.arange(physical_shard_capacity)
-        tp_rank = physical_offset // tp_stripe_capacity
-        within_tp = physical_offset % tp_stripe_capacity
-        slab = within_tp // stripe_chunk
-        within_chunk = within_tp % stripe_chunk
-        logical = (slab * sp + sp_rank) * chunk_local + tp_rank * stripe_chunk + within_chunk
-        physical_to_logical.append(logical)
-    physical_to_logical = torch.cat(physical_to_logical)
-    assert torch.equal(torch.sort(physical_to_logical).values, torch.arange(capacity))
-
-    reconstructed = k_natural.clone()
-    reconstructed[0, 0] = k_natural[0, 0, physical_to_logical]
-    return reconstructed
-
-
 def _sptp_loudbox_inputs(
     mesh,
     k_capacity,
@@ -862,7 +830,7 @@ def _sptp_loudbox_output(out):
 
 @pytest.mark.parametrize("tp_sharded", [False, True], ids=["control", "tp_sharded"])
 def test_indexer_score_sptp_loudbox_tp_sharded_kv_repro(tp_sharded):
-    """Reduced SP2 x TP4 fused score; the TP-enabled variant hung before the mapping fix."""
+    """Score a TP-inner reconstructed K cache on a LoudBox SP2 x TP4 mesh."""
     if ttnn.get_num_devices() != 8:
         pytest.skip("SP2 x TP4 fused indexer reproduction requires an exact eight-device LoudBox")
     assert LB_SPTP_CHUNK_LOCAL == 640

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py
@@ -1,18 +1,18 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Ring-fused indexer_score correctness on a 4-device Blackhole box (QuietBox-class), covering the two mesh
-layouts that fit in 4 chips:
+"""Multi-device indexer_score correctness on a four-device Blackhole box.
 
-  * SP-only ring-of-4 on a (1, 4) mesh -- the same fused op the LoudBox suite runs, here on 4 chips directly.
+This module covers the classic and Ring-fused frontends on the mesh layouts that fit in four chips:
+
+  * SP-only on a (1, 4) or (4, 1) mesh.
   * 2D SP×TP on a (2, 2) mesh: sp=2 ring (cluster_axis) × tp=2 query seq sub-shard (seq_subshard_axis). K
     stays SP-sharded + TP-replicated so the AG is unchanged; TP sub-shards the query rows and seq_subshard_axis
     threads each device's tp sub-offset into the causal score. Fused analogue of the classic-path
     test_indexer_score.py::test_indexer_score_sp2_tp2_seq_subshard_rotated.
 
-Unlike the LoudBox suite these open the target mesh DIRECTLY (no (2,4)->(1,4) carve), so they run on any
-4-device Blackhole box. Gathered buffer seeded with ZEROS -> a correct score proves device-side local sourcing.
+The Ring tests open the target mesh directly. Gathered buffers are seeded with zeros so correct scores also
+verify device-side local sourcing.
 
 Run:  scripts/run_safe_pytest.sh tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa_4d.py
 """
@@ -24,20 +24,46 @@ from loguru import logger
 import ttnn
 
 from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_indexer_score import (
+    assert_pooled_match,
     assert_indexer_match,
     glx_config,
     indexer_score_dsa_ref,
+    indexer_score_msa_ref,
     _global_inputs,
+    _axis_dims,
+    _msa_per_sp_ref,
     _per_sp_ref,
+    _shard_1d,
+    _straddle_msa_pooled_ref,
+    _straddle_ref,
+    _to_mesh,
     _to_slab,
+    BLOCK_POOL_BS,
+    M3_QB_HEADS,
+    M3_QB_SCALE,
+    QB_CHUNK,
     QB_SQ,
+    QB_SP,
+    QB_T,
     QB_HISTORY,
     QB_DIM,
     QB_CASES,
     QB_IDS,
+    QB2_CHUNK,
+    QB2_SP,
+    QB2_SP_AXIS,
+    QB2_T,
+    QB2_TP,
+    ST_CHUNK,
+    ST_CS,
+    ST_MSA_T,
+    ST_T,
 )
 from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.test_ring_indexer_score_dsa import (
     _run_full_mesh_accuracy_case,
+)
+from tests.ttnn.nightly.unit_tests.operations.experimental.indexer_score.ring_indexer_score_test_utils import (
+    _to_tp_inner_reconstructed,
 )
 
 DRAM = ttnn.DRAM_MEMORY_CONFIG
@@ -90,6 +116,314 @@ def _close_ccl(mesh):
             ttnn.close_mesh_device(mesh)
     finally:
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
+# ---- Classic multi-device frontend ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_per_device_chunk_start(mesh_device, case_id, heads):
+    """Derive each SP rank's causal start from its mesh coordinate."""
+    q_g, k_g, w_g, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=42)
+
+    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, program_config=glx_config(heads))
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+
+    ref = _per_sp_ref(q_g, k_g, w_g, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_one_compile_all_chunk_starts(mesh_device, case_id, heads):
+    """Patch different causal starts without recompiling the program."""
+    _, _, _, q_dev, k_dev, w_dev = _shard_1d(mesh_device, heads, seed=7)
+    bases = [QB_HISTORY, QB_HISTORY - QB_SQ, QB_HISTORY - 2 * QB_SQ]
+
+    entries_before = mesh_device.num_program_cache_entries()
+    for base in bases:
+        ttnn.experimental.indexer_score_dsa(
+            q_dev, k_dev, w_dev, chunk_start_idx=base, program_config=glx_config(heads)
+        ).deallocate()
+
+    added = mesh_device.num_program_cache_entries() - entries_before
+    assert added == 1, f"expected 1 program-cache entry across 3 distinct chunk_start bases, got {added}"
+
+
+@pytest.mark.parametrize("mesh_device", [(QB2_SP, QB2_TP)], ids=["2x2"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
+    """Shard sequence over SP and heads over TP while keeping causal starts constant across TP."""
+    q_g, k_g, w_g = _global_inputs(heads, QB2_CHUNK, QB2_T, seed=42)
+    mesh_shape = tuple(mesh_device.shape)
+    qw_dims = _axis_dims(sp_dim=2, tp_dim=1)
+    shard_qw = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_qw)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_qw)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        seq_shard_axes=[QB2_SP_AXIS],
+        program_config=glx_config(heads // QB2_TP),
+    )
+    out_t = ttnn.to_torch(
+        out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=qw_dims)
+    )
+    out_t = out_t.float().sum(dim=1, keepdim=True)
+
+    ref = _per_sp_ref(q_g, k_g, w_g, QB2_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [QB_SP], indirect=True)
+def test_indexer_score_qb_msa_per_device_chunk_start(mesh_device):
+    """Run MSA over SP=4 with one causal start per rank."""
+    q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
+    shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev, k_dev, scale=M3_QB_SCALE, num_groups=1, program_config=glx_config(M3_QB_HEADS)
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+
+    ref = _msa_per_sp_ref(q_g, k_g, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(QB2_SP, QB2_TP)], ids=["2x2"], indirect=True)
+def test_indexer_score_qb_msa_sp2_tp2(mesh_device):
+    """Run MSA on SP=2 x TP=2 and sum the TP head partials."""
+    q_g, k_g, _ = _global_inputs(M3_QB_HEADS, QB2_CHUNK, QB2_T, seed=42)
+    mesh_shape = tuple(mesh_device.shape)
+    q_dims = _axis_dims(sp_dim=2, tp_dim=1)
+    shard_q = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=q_dims)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_q)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        seq_shard_axes=[QB2_SP_AXIS],
+        scale=M3_QB_SCALE,
+        num_groups=1,
+        program_config=glx_config(M3_QB_HEADS // QB2_TP),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=q_dims))
+    out_t = out_t.float().sum(dim=1, keepdim=True)
+
+    ref = _msa_per_sp_ref(q_g, k_g, QB2_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB2_CHUNK, QB2_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
+    """Read an SP=4 block-cyclic K cache in natural token order."""
+    q_g, k_nat, w_g = _global_inputs(heads, QB_CHUNK, QB_T, seed=42)
+    k_bc = _to_slab(k_nat, QB_SP, QB_CHUNK)
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        seq_shard_axes=[0],
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=QB_SQ,
+        program_config=glx_config(heads),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
+    ref = _per_sp_ref(q_g, k_nat, w_g, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["2x2"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_error):
+    """Shard query sequence over both axes of a 2x2 mesh."""
+    sp, chunk_global, t = 2, 256, 512
+    q_g, k_nat, w_g = _global_inputs(heads, chunk_global, t, seed=42)
+    k_bc = _to_slab(k_nat, sp, chunk_global)
+    shard = ttnn.ShardTensorToMesh(mesh_device, dim=2)
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    kwargs = {
+        "block_cyclic_sp_axis": 0,
+        "block_cyclic_chunk_local": chunk_global // sp,
+        "program_config": glx_config(heads),
+    }
+
+    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, seq_shard_axes=[], **kwargs)
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
+    ref = indexer_score_dsa_ref(q_g, k_nat, w_g, t - chunk_global)
+    assert_indexer_match(out_t, ref, chunk_global, t, check_neg=True)
+
+    with expect_error(RuntimeError, "needs the TP axis"):
+        ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, seq_shard_axes=[0], **kwargs)
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 4)], ids=["sp1xtp4"], indirect=True)
+def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
+    """Apply each TP rank's query offset when the SP extent is one."""
+    heads, chunk, t, chunk_start = 8, 256, 512, 128
+    q_g, k_g, w_g = _global_inputs(heads, chunk, t, seed=42)
+    mesh_shape = tuple(mesh_device.shape)
+    shard_tp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(None, 2))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_tp_seq)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_tp_seq)
+    k_dev = _to_mesh(mesh_device, k_g, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
+    kwargs = {
+        "seq_shard_axes": [0, 1],
+        "block_cyclic_sp_axis": 0,
+        "block_cyclic_chunk_local": chunk,
+        "program_config": ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
+    }
+
+    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, **kwargs)
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(1, 2)))
+    ref = indexer_score_dsa_ref(q_g, k_g, w_g, chunk_start)
+    assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
+
+    out_default = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, **kwargs)
+    out_default_t = ttnn.to_torch(
+        out_default, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(1, 2))
+    )
+    ref_default = indexer_score_dsa_ref(q_g, k_g, w_g, t - chunk)
+    assert_indexer_match(out_default_t, ref_default, chunk, t, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["sp2xtp2"], indirect=True)
+def test_indexer_score_sp2_tp2_seq_subshard_rotated(mesh_device):
+    """Match the block-cyclic writer mapping for a rotated SP x TP chunk."""
+    heads, sp, chunk, t, chunk_start = 8, 2, 256, 512, 160
+    q_g, k_nat, w_g = _global_inputs(heads, chunk, t, seed=42)
+    k_bc = _to_slab(k_nat, sp, chunk)
+    mesh_shape = tuple(mesh_device.shape)
+    shard_sp_seq = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard_sp_seq)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard_sp_seq)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat16, ttnn.ReplicateTensorToMesh(mesh_device))
+    q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=1)
+    w_dev = ttnn.mesh_partition(w_dev, dim=2, cluster_axis=1)
+
+    out = ttnn.experimental.indexer_score_dsa(
+        q_dev,
+        k_dev,
+        w_dev,
+        chunk_start_idx=chunk_start,
+        seq_shard_axes=[0, 1],
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=chunk // sp,
+        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
+    )
+    shards = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(out.cpu())]
+    per_sp = [torch.cat(shards[r * 2 : (r + 1) * 2], dim=2) for r in range(sp)]
+    out_t = torch.cat(per_sp, dim=2)
+    ref = _straddle_ref(q_g, k_nat, w_g, sp, chunk, chunk_start, t)
+    assert_indexer_match(out_t, ref, chunk, t, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 1)], ids=["sp2"], indirect=True)
+@pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
+def test_indexer_score_qb_straddle(mesh_device, case_id, heads):
+    """Patch aligned and mid-slab causal geometry through one cached program."""
+    sp = mesh_device.shape[0]
+    q_g, k_nat, w_g = _global_inputs(heads, ST_CHUNK, ST_T, seed=42)
+    k_bc = _to_slab(k_nat, sp, ST_CHUNK)
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    w_dev = _to_mesh(mesh_device, w_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=128, head_group_size=0)
+
+    def run(chunk_start):
+        out = ttnn.experimental.indexer_score_dsa(
+            q_dev,
+            k_dev,
+            w_dev,
+            chunk_start_idx=chunk_start,
+            seq_shard_axes=[0],
+            block_cyclic_sp_axis=0,
+            block_cyclic_chunk_local=ST_CHUNK // sp,
+            program_config=cfg,
+        )
+        out_t = ttnn.to_torch(
+            out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1))
+        )
+        ref = _straddle_ref(q_g, k_nat, w_g, sp, ST_CHUNK, chunk_start, ST_T)
+        assert_indexer_match(out_t, ref, ST_CHUNK, ST_T, check_neg=True)
+
+    mesh_device.enable_program_cache()
+    run(ST_CS)
+    entries = mesh_device.num_program_cache_entries()
+    run(0)
+    assert mesh_device.num_program_cache_entries() == entries, "changing causal geometry recompiled the program"
+
+
+@pytest.mark.parametrize("mesh_device", [(QB_SP, 1)], ids=["sp4"], indirect=True)
+def test_indexer_score_qb_msa_block_cyclic(mesh_device):
+    """Read an SP=4 block-cyclic K cache through the MSA frontend."""
+    q_g, k_nat, _ = _global_inputs(M3_QB_HEADS, QB_CHUNK, QB_T, seed=42)
+    k_bc = _to_slab(k_nat, QB_SP, QB_CHUNK)
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        seq_shard_axes=[0],
+        scale=M3_QB_SCALE,
+        num_groups=1,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=QB_SQ,
+        program_config=glx_config(M3_QB_HEADS),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
+    ref = _msa_per_sp_ref(q_g, k_nat, QB_SP, QB_HISTORY)
+    assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 1)], ids=["sp2"], indirect=True)
+def test_indexer_score_qb_msa_block_cyclic_straddle(mesh_device):
+    """Apply the MSA forced-local stamp across a block-cyclic slab boundary."""
+    sp = 2
+    block_size = BLOCK_POOL_BS
+    q_g, k_nat, _ = _global_inputs(M3_QB_HEADS, ST_CHUNK, ST_MSA_T, seed=42)
+    k_bc = _to_slab(k_nat, sp, ST_CHUNK)
+    mesh_shape = tuple(mesh_device.shape)
+    shard = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None))
+    q_dev = _to_mesh(mesh_device, q_g, ttnn.bfloat16, shard)
+    k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
+
+    out = ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        chunk_start_idx=ST_CS,
+        seq_shard_axes=[0],
+        scale=M3_QB_SCALE,
+        num_groups=1,
+        block_size=block_size,
+        block_cyclic_sp_axis=0,
+        block_cyclic_chunk_local=ST_CHUNK // sp,
+        program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0),
+    )
+    out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=(2, 1)))
+    ref = _straddle_msa_pooled_ref(q_g, k_nat, sp, ST_CHUNK, ST_CS, ST_MSA_T, M3_QB_SCALE, block_size)
+    assert_pooled_match(out_t, ref, 1, ST_CHUNK, ST_MSA_T // block_size, pcc_floor=0.995)
 
 
 # ---- SP-only ring-of-4 on a (1, 4) mesh ------------------------------------------------------------
@@ -256,10 +590,8 @@ def test_indexer_score_ring4_true_ring_bfp8_bank_owned_reference_cache_hit():
 def test_indexer_score_ring4_small_capacity_has_no_empty_lane_deadlock():
     """Keep every multicast participant productive when one shard has fewer KC units than the full grid.
 
-    Eleven query groups force multiple phases while eighteen KC units per shard are too few for the old
-    ring-wide lane sizing. An empty compute lane would return while its reader blocks on the next single-buffered
-    q/w multicast phase, hanging the row. The sampled reference checks that the reduced nonempty lane geometry
-    also preserves semantics.
+    Eleven query groups force multiple phases while eighteen KC units per shard require reduced nonempty lane
+    geometry. The sampled reference verifies the resulting score.
     """
     sp = 4
     sp_axis = 0
@@ -343,6 +675,7 @@ SP2_AXIS = 0  # mesh rows == SP ring (cluster_axis / block_cyclic_sp_axis)
 TP2_AXIS = 1  # mesh cols == TP seq sub-shard (seq_subshard_axis)
 CHUNK_SPTP = SP2 * QB_SQ  # 1280 global chunk; per-SP-shard chunk_local = QB_SQ (640), per-device Sq = 320
 T_SPTP = QB_HISTORY + CHUNK_SPTP  # 26880 keys
+K_CHUNK_SPTP = 320
 
 
 def _per_sp_tp_ref(q_g, k_g, w_g, sp, tp, history, sq_sp):
@@ -356,6 +689,247 @@ def _per_sp_tp_ref(q_g, k_g, w_g, sp, tp, history, sq_sp):
             sl = slice(g0, g0 + sq_dev)
             refs.append(indexer_score_dsa_ref(q_g[:, :, sl, :], k_g, w_g[:, :, sl, :], history + g0))
     return torch.cat(refs, dim=2)
+
+
+def _sptp_tp_sharded_inputs(
+    mesh,
+    k_capacity,
+    seed,
+    *,
+    chunk_global=CHUNK_SPTP,
+    sp=SP2,
+    tp=TP2,
+    sp_axis=SP2_AXIS,
+    tp_axis=TP2_AXIS,
+):
+    """Build SP x TP query shards and a TP-inner reconstructed K cache."""
+    chunk_local = chunk_global // sp
+    q_g, k_nat, w_g = _global_inputs(32, chunk_global, k_capacity, seed=seed)
+    k_reconstructed = _to_tp_inner_reconstructed(k_nat, sp=sp, tp=tp, chunk_local=chunk_local)
+    mesh_shape = [0, 0]
+    mesh_shape[sp_axis] = sp
+    mesh_shape[tp_axis] = tp
+    shard_dims = [None, None]
+    shard_dims[sp_axis] = 2
+    sp_shard = ttnn.ShardTensor2dMesh(mesh, mesh_shape=tuple(mesh_shape), dims=tuple(shard_dims))
+    k_local = ttnn.from_torch(
+        k_reconstructed,
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        mesh_mapper=sp_shard,
+    )
+    k_gathered = ttnn.from_torch(
+        torch.zeros_like(k_nat),
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh),
+    )
+    q_dev = ttnn.from_torch(
+        q_g,
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        mesh_mapper=sp_shard,
+    )
+    w_dev = ttnn.from_torch(
+        w_g,
+        device=mesh,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=sp_shard,
+    )
+    if tp > 1:
+        q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=tp_axis)
+        w_dev = ttnn.mesh_partition(w_dev, dim=2, cluster_axis=tp_axis)
+    return q_g, k_nat, w_g, q_dev, k_local, k_gathered, w_dev
+
+
+def _run_sptp_tp_sharded_score(
+    ccl_semaphores,
+    subdevice_id,
+    q_dev,
+    k_local,
+    k_gathered,
+    w_dev,
+    *,
+    chunk_start,
+    kv_len,
+    tp_sharded,
+    chunk_global=CHUNK_SPTP,
+    topology=ttnn.Topology.Linear,
+    num_links=1,
+    sp=SP2,
+    sp_axis=SP2_AXIS,
+    tp_axis=TP2_AXIS,
+):
+    return ttnn.experimental.ring_indexer_score_dsa(
+        q_dev,
+        k_gathered,
+        w_dev,
+        k_local,
+        ccl_semaphores,
+        cluster_axis=sp_axis,
+        topology=topology,
+        num_links=num_links,
+        ag_sub_device_id=subdevice_id,
+        chunk_start_idx=chunk_start,
+        kv_len=kv_len,
+        seq_subshard_axis=tp_axis,
+        block_cyclic_sp_axis=sp_axis,
+        block_cyclic_chunk_local=chunk_global // sp,
+        block_cyclic_cache_tp_sharded=tp_sharded,
+        program_config=ttnn.IndexerScoreProgramConfig(
+            q_chunk_size=32,
+            k_chunk_size=K_CHUNK_SPTP,
+            head_group_size=0,
+        ),
+    )
+
+
+def _sptp_output(out):
+    return torch.cat([ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(out.cpu())], dim=2)
+
+
+@pytest.mark.parametrize("tp_sharded", [False, True], ids=["control", "tp_sharded"])
+def test_indexer_score_sptp_tp_sharded_kv_repro_4d(tp_sharded):
+    """Score a TP-inner reconstructed K cache on a QuietBox SP2 x TP2 mesh."""
+    chunk_local = CHUNK_SPTP // SP2
+    assert chunk_local == 640
+    assert chunk_local // TP2 == 320
+    assert K_CHUNK_SPTP // 32 == 10
+
+    mesh, ccl_semaphores, subdevice_id, stall_group = _open_ccl((SP2, TP2))
+    try:
+        q_g, k_nat, w_g, q_dev, k_local, k_gathered, w_dev = _sptp_tp_sharded_inputs(mesh, CHUNK_SPTP, seed=45)
+        out = _run_sptp_tp_sharded_score(
+            ccl_semaphores,
+            subdevice_id,
+            q_dev,
+            k_local,
+            k_gathered,
+            w_dev,
+            chunk_start=0,
+            kv_len=CHUNK_SPTP,
+            tp_sharded=tp_sharded,
+        )
+        ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+        out_t = _sptp_output(out)
+        ref = _per_sp_tp_ref(q_g, k_nat, w_g, SP2, TP2, history=0, sq_sp=chunk_local)
+        assert_indexer_match(out_t, ref, CHUNK_SPTP, CHUNK_SPTP, check_neg=True)
+    finally:
+        _close_ccl(mesh)
+
+
+def test_indexer_score_sptp_tp_sharded_multislab_partial_prefix_cache_reuse_4d():
+    """QuietBox coverage for a valid TP stripe after an invalid one and runtime-scalar cache reuse."""
+    chunk_global = CHUNK_SPTP // 2
+    chunk_local = chunk_global // SP2
+    k_capacity = 3 * chunk_global
+    kv_cases = ((0, 960), (chunk_global, 1280))
+    # KC [10,20) crosses a 15-tile TP stripe boundary. At kv_len=960 its first five
+    # columns are invalid [40,45) and its last five map to valid keys [5,10).
+    assert (k_capacity // (SP2 * TP2)) // 32 == 15
+
+    mesh, ccl_semaphores, subdevice_id, stall_group = _open_ccl((SP2, TP2))
+    try:
+        q_g, k_nat, w_g, q_dev, k_local, k_gathered, w_dev = _sptp_tp_sharded_inputs(
+            mesh, k_capacity, seed=46, chunk_global=chunk_global
+        )
+        mesh.enable_program_cache()
+        entries_before = mesh.num_program_cache_entries()
+        entries_after_compile = None
+        for dispatch, (chunk_start, kv_len) in enumerate(kv_cases):
+            out = _run_sptp_tp_sharded_score(
+                ccl_semaphores,
+                subdevice_id,
+                q_dev,
+                k_local,
+                k_gathered,
+                w_dev,
+                chunk_start=chunk_start,
+                kv_len=kv_len,
+                tp_sharded=True,
+                chunk_global=chunk_global,
+            )
+            ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+            out_t = _sptp_output(out)
+            ttnn.deallocate(out)
+            ref = _per_sp_tp_ref(
+                q_g,
+                k_nat[:, :, :kv_len],
+                w_g,
+                SP2,
+                TP2,
+                history=chunk_start,
+                sq_sp=chunk_local,
+            )
+            assert_indexer_match(out_t[:, :, :, :kv_len], ref, chunk_global, kv_len, check_neg=True)
+            if dispatch == 0:
+                entries_after_compile = mesh.num_program_cache_entries()
+                assert entries_after_compile > entries_before
+            else:
+                assert (
+                    mesh.num_program_cache_entries() == entries_after_compile
+                ), "changing kv_len/chunk_start recompiled the QuietBox fused Ring program"
+    finally:
+        mesh.disable_and_clear_program_cache()
+        _close_ccl(mesh)
+
+
+def test_indexer_score_ring_partial_readiness_4d():
+    """Score a partial prefix while a four-rank SP-only ring advances its readiness state."""
+    sp, tp = 4, 1
+    sp_axis, tp_axis = 1, 0
+    chunk_global = CHUNK_SPTP
+    chunk_local = chunk_global // sp
+    k_capacity = 3 * chunk_global
+    kv_len = 960
+
+    mesh, ccl_semaphores, subdevice_id, stall_group = _open_ccl(
+        (tp, sp), fabric_config=ttnn.FabricConfig.FABRIC_2D_TORUS_XY
+    )
+    try:
+        q_g, k_nat, w_g, q_dev, k_local, k_gathered, w_dev = _sptp_tp_sharded_inputs(
+            mesh,
+            k_capacity,
+            seed=47,
+            sp=sp,
+            tp=tp,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+        )
+        out = _run_sptp_tp_sharded_score(
+            ccl_semaphores,
+            subdevice_id,
+            q_dev,
+            k_local,
+            k_gathered,
+            w_dev,
+            chunk_start=0,
+            kv_len=kv_len,
+            tp_sharded=False,
+            topology=ttnn.Topology.Ring,
+            num_links=2,
+            sp=sp,
+            sp_axis=sp_axis,
+            tp_axis=None,
+        )
+        ttnn.synchronize_device(mesh, sub_device_ids=stall_group)
+        out_t = _sptp_output(out)
+        ref = _per_sp_tp_ref(
+            q_g,
+            k_nat[:, :, :kv_len],
+            w_g,
+            sp,
+            tp,
+            history=0,
+            sq_sp=chunk_local,
+        )
+        assert_indexer_match(out_t[:, :, :, :kv_len], ref, chunk_global, kv_len, check_neg=True)
+    finally:
+        _close_ccl(mesh)
 
 
 @pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)


### PR DESCRIPTION
## Summary

- Merge the QB2 SDPA nightly lane into the existing CCL/SDPA perf/indexer job now that IOMMU is standard; retain its stable name and assign it to Pavle Josipovic.
- Keep single-chip indexer coverage in `test_indexer_score.py` and move its multi-device cases into the four-device suite.
- Add QuietBox counterparts for the GLM 5.2 regressions introduced with #55617.

The four-chip partial-readiness case isolates SP Ring readiness; the exact TP-sharded Ring combination remains covered by the eight-device LoudBox test.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/cleanup-qb2-indexer-sdpa-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/cleanup-qb2-indexer-sdpa-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/cleanup-qb2-indexer-sdpa-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/cleanup-qb2-indexer-sdpa-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/cleanup-qb2-indexer-sdpa-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/cleanup-qb2-indexer-sdpa-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/cleanup-qb2-indexer-sdpa-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/cleanup-qb2-indexer-sdpa-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/cleanup-qb2-indexer-sdpa-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/cleanup-qb2-indexer-sdpa-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/cleanup-qb2-indexer-sdpa-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/cleanup-qb2-indexer-sdpa-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/cleanup-qb2-indexer-sdpa-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/cleanup-qb2-indexer-sdpa-tests)