### PR TITLE
[LLK][BH][WH] Do not enter the throttled matmul MOP on a non-full tile

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
@@ -81,7 +81,9 @@ TINY_TILES_MATMUL_COMBINATIONS = sweep_tiny_tiles_matmul(
 )
 
 
-TINY_TILE_THROTTLE_LEVELS = [0, 1] if get_chip_architecture() == ChipArchitecture.BLACKHOLE else [0]
+TINY_TILE_THROTTLE_LEVELS = (
+    [0, 1] if get_chip_architecture() == ChipArchitecture.BLACKHOLE else [0]
+)
 
 ALL_TEST_PARAMS = list(
     chain(
@@ -98,7 +100,9 @@ ALL_TEST_PARAMS = list(
         (
             (fidelity, combinations, throttle)
             for fidelity, combinations, throttle in product(
-                MATH_FIDELITIES, TINY_TILES_MATMUL_COMBINATIONS, TINY_TILE_THROTTLE_LEVELS
+                MATH_FIDELITIES,
+                TINY_TILES_MATMUL_COMBINATIONS,
+                TINY_TILE_THROTTLE_LEVELS,
             )
         ),
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
@@ -89,11 +89,12 @@ ALL_TEST_PARAMS = list(
                 MATH_FIDELITIES, MATMUL_COMBINATIONS, [1, 2, 3, 4, 5]
             )
         ),
-        # Tiny tiles matmul with throttle level 0 only
+        # Tiny tiles: throttle 0, plus one throttled level. A non-full tile falls back to the
+        # unthrottled MOP regardless of level, so level 1 covers the whole throttled range.
         (
-            (fidelity, combinations, 0)
-            for fidelity, combinations in product(
-                MATH_FIDELITIES, TINY_TILES_MATMUL_COMBINATIONS
+            (fidelity, combinations, throttle)
+            for fidelity, combinations, throttle in product(
+                MATH_FIDELITIES, TINY_TILES_MATMUL_COMBINATIONS, [0, 1]
             )
         ),
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
@@ -5,6 +5,7 @@ from itertools import chain, product
 
 import pytest
 import torch
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     TILE_DIM,
@@ -80,6 +81,8 @@ TINY_TILES_MATMUL_COMBINATIONS = sweep_tiny_tiles_matmul(
 )
 
 
+TINY_TILE_THROTTLE_LEVELS = [0, 1] if get_chip_architecture() == ChipArchitecture.BLACKHOLE else [0]
+
 ALL_TEST_PARAMS = list(
     chain(
         # Regular matmul with all throttle levels
@@ -89,12 +92,13 @@ ALL_TEST_PARAMS = list(
                 MATH_FIDELITIES, MATMUL_COMBINATIONS, [1, 2, 3, 4, 5]
             )
         ),
-        # Tiny tiles: throttle 0, plus one throttled level. A non-full tile falls back to the
-        # unthrottled MOP regardless of level, so level 1 covers the whole throttled range.
+        # Tiny tiles: throttle 0 everywhere, plus one throttled level where a non-full tile
+        # falls back to the unthrottled MOP. Wormhole still calls the throttled path for these
+        # shapes, so a throttled tiny tile would assert (or wedge) there.
         (
             (fidelity, combinations, throttle)
             for fidelity, combinations, throttle in product(
-                MATH_FIDELITIES, TINY_TILES_MATMUL_COMBINATIONS, [0, 1]
+                MATH_FIDELITIES, TINY_TILES_MATMUL_COMBINATIONS, TINY_TILE_THROTTLE_LEVELS
             )
         ),
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
@@ -5,7 +5,6 @@ from itertools import chain, product
 
 import pytest
 import torch
-from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     TILE_DIM,
@@ -81,10 +80,6 @@ TINY_TILES_MATMUL_COMBINATIONS = sweep_tiny_tiles_matmul(
 )
 
 
-TINY_TILE_THROTTLE_LEVELS = (
-    [0, 1] if get_chip_architecture() == ChipArchitecture.BLACKHOLE else [0]
-)
-
 ALL_TEST_PARAMS = list(
     chain(
         # Regular matmul with all throttle levels
@@ -95,14 +90,13 @@ ALL_TEST_PARAMS = list(
             )
         ),
         # Tiny tiles: throttle 0 everywhere, plus one throttled level where a non-full tile
-        # falls back to the unthrottled MOP. Wormhole still calls the throttled path for these
-        # shapes, so a throttled tiny tile would assert (or wedge) there.
+        # falls back to the unthrottled MOP.
         (
             (fidelity, combinations, throttle)
             for fidelity, combinations, throttle in product(
                 MATH_FIDELITIES,
                 TINY_TILES_MATMUL_COMBINATIONS,
-                TINY_TILE_THROTTLE_LEVELS,
+                [0, 1],
             )
         ),
     )

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -677,8 +677,20 @@ inline void _llk_math_matmul_init_(
 
     if constexpr (THROTTLE_LEVEL > 0)
     {
-        matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        // The throttled MOP's replay sequences are written for a full 32x32 tile only; on any other
+        // geometry its record window and emitted sequence disagree and the matmul wedges. Throttling
+        // is a throughput cap, so fall back to the unthrottled MOP rather than corrupt the loop.
+        const bool throttle_supported_tile = (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) &&
+                                             (in1_tile_c_dim == TILE_C_DIM) && !partial_face;
+        if (throttle_supported_tile)
+        {
+            matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
+                ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        }
+        else
+        {
+            matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        }
     }
     else
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -540,6 +540,24 @@ void run_throttled_sequence<5>()
 }
 
 /**
+ * @brief Whether the throttled matmul MOP supports this operand geometry.
+ *
+ * Its replay sequences are hand-written for a full 32x32 tile; on any other geometry the recorded
+ * window and the emitted sequence disagree. Single source of truth for both the assert inside
+ * matmul_configure_mop_throttled and the dispatch guard in _llk_math_matmul_init_.
+ */
+inline constexpr bool matmul_throttle_supports_tile(
+    const std::uint32_t in0_tile_r_dim,
+    const std::uint32_t in0_tile_c_dim,
+    const std::uint32_t in1_tile_r_dim,
+    const std::uint32_t in1_tile_c_dim,
+    const bool partial_face)
+{
+    return (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) &&
+           !partial_face;
+}
+
+/**
  * @brief Build the throttled matmul MOP, inserting NOPs between MVMULs to cap compute throughput.
  *
  * Records a per-level @ref run_throttled_sequence into the replay buffer and wraps it in a ckernel_template.
@@ -576,7 +594,7 @@ inline void matmul_configure_mop_throttled(
     constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
     LLK_ASSERT(
-        (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
+        matmul_throttle_supports_tile(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face),
         "MM throttling only enabled for full 32x32 tile size");
 
     const bool reuse_a = ct_dim >= rt_dim;
@@ -677,19 +695,24 @@ inline void _llk_math_matmul_init_(
 
     if constexpr (THROTTLE_LEVEL > 0)
     {
-        // The throttled MOP's replay sequences are written for a full 32x32 tile only; on any other
-        // geometry its record window and emitted sequence disagree and the matmul wedges. Throttling
-        // is a throughput cap, so fall back to the unthrottled MOP rather than corrupt the loop.
-        const bool throttle_supported_tile = (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) &&
-                                             (in1_tile_c_dim == TILE_C_DIM) && !partial_face;
-        if (throttle_supported_tile)
+        // On a geometry the throttled MOP does not support, fall back to the unthrottled one:
+        // throttling is only a throughput cap, and the throttled sequence wedges there.
+        //
+        // Sound only while the execute path is a single ckernel_template::run(). For
+        // THROTTLE_LEVEL > 3 with high fidelity, _llk_math_matmul_ runs the MOP once per fidelity
+        // phase, whereas the unthrottled MOP already walks the phases in its own inner loop -- so
+        // falling back there would execute every phase math_fidelity times over. Those levels keep
+        // the throttled path (and its assert) until the execute side can be told which MOP is live.
+        constexpr bool fallback_matches_execute = !(THROTTLE_LEVEL > 3 && is_high_fidelity(math_fidelity));
+
+        if (fallback_matches_execute && !matmul_throttle_supports_tile(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face))
         {
-            matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-                ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+            matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
         }
         else
         {
-            matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+            matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
+                ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
         }
     }
     else

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -626,6 +626,24 @@ void run_throttled_sequence(const std::uint32_t t_dim, const bool reuse_a)
     }
 }
 
+/**
+ * @brief Whether the throttled matmul MOP supports this operand geometry.
+ *
+ * Its replay sequences are hand-written for a full 32x32 tile; on any other geometry the recorded
+ * window and the emitted sequence disagree. Single source of truth for both the assert inside
+ * matmul_configure_mop_throttled and the dispatch guard in _llk_math_matmul_init_.
+ */
+inline constexpr bool matmul_throttle_supports_tile(
+    const std::uint32_t in0_tile_r_dim,
+    const std::uint32_t in0_tile_c_dim,
+    const std::uint32_t in1_tile_r_dim,
+    const std::uint32_t in1_tile_c_dim,
+    const bool partial_face)
+{
+    return (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) &&
+           !partial_face;
+}
+
 /*
  * Programming of the MOP for the case we limit matmul compute throughput
  * Done by inserting NOP instructions between MVMUL instructions of matmul kernel
@@ -675,7 +693,7 @@ inline void matmul_configure_mop_throttled(
     constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
     LLK_ASSERT(
-        (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
+        matmul_throttle_supports_tile(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face),
         "MM throttling only enabled for full 32x32 tile size");
 
     const bool reuse_a        = ct_dim >= rt_dim;
@@ -799,8 +817,25 @@ inline void _llk_math_matmul_init_(
 
     if constexpr (THROTTLE_LEVEL > 0)
     {
-        matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        // On a geometry the throttled MOP does not support, fall back to the unthrottled one:
+        // throttling is only a throughput cap, and the throttled sequence wedges there.
+        //
+        // Sound only while the execute path is a single ckernel_template::run(). For
+        // THROTTLE_LEVEL > 3 with high fidelity, _llk_math_matmul_ runs the MOP once per fidelity
+        // phase, whereas the unthrottled MOP already walks the phases in its own inner loop -- so
+        // falling back there would execute every phase math_fidelity times over. Those levels keep
+        // the throttled path (and its assert) until the execute side can be told which MOP is live.
+        constexpr bool fallback_matches_execute = !(THROTTLE_LEVEL > 3 && is_high_fidelity(math_fidelity));
+
+        if (fallback_matches_execute && !matmul_throttle_supports_tile(in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face))
+        {
+            matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        }
+        else
+        {
+            matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
+                ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        }
     }
     else
     {


### PR DESCRIPTION
### Problem

`matmul_configure_mop_throttled`'s hand-written MOP/replay sequences are written for a full 32x32 tile. `_llk_math_matmul_init_` called it for **any** geometry whenever `THROTTLE_LEVEL > 0`, and on a non-full tile the matmul wedges Unpacker, Math and Packer. **Blackhole and Wormhole are both affected, and both are fixed here.**

The only thing preventing that was an `LLK_ASSERT`, which expands to `((void)sizeof(condition))` without `ENABLE_LLK_ASSERT` — i.e. in every tt-metal production build. The tt-llk test build defines it, so CI sees a loud assert exactly where production hangs.

Fixes tenstorrent/tt-llk#1687

### Change

Dispatch to the unthrottled `matmul_configure_mop` when the tile is not full 32x32. Throttling is a throughput cap, so losing it on a geometry the throttled path never supported is preferable to a wedge.

The same change lands in `tt_llk_blackhole/` and `tt_llk_wormhole_b0/`, sharing a `matmul_throttle_supports_tile` predicate of the same name in each tree so the two stay in step.

`matmul_configure_addrmod`'s only throttle-dependent action is programming an extra `ADDR_MOD_6`, which the unthrottled MOP never references, so it is left as is. The `LLK_ASSERT` stays so debug builds still flag the caller.

**Scope: levels 1-3, and any level at LoFi.** `_llk_math_matmul_` receives only `(dst_index, ct_dim, rt_dim)`, so the execute path cannot see this init-time decision — and for `THROTTLE_LEVEL > 3` with high fidelity it runs the MOP once per fidelity phase (`:752`), whereas the unthrottled MOP already walks the phases in its own inner loop (`:434-435`). Falling back there would execute every phase `math_fidelity` times over, i.e. trade a wedge for wrong results. So those levels keep the throttled path and its assert, and this PR does not fix them.

Completing it means telling the execute side which MOP is live — plumbing the geometry (or a flag) into `_llk_math_matmul_`, which changes a public LLK signature that Wormhole and Quasar also implement. That felt like an owner's call rather than something to slip into this PR; happy to do it here if preferred.

**Trade-off worth a maintainer's opinion:** this silently drops the throughput cap for such shapes rather than failing loudly. Given the alternative today is a three-thread hang, degrading seemed the right default — happy to change it to a hard failure if you'd prefer.

### Why guard the entry instead of repairing the sequence

Inside the throttled path, `replay_buf_len` is 4 or 8 whenever any of `is_in0_16x32 / is_in1_32x16 / is_in0_32x16 / is_in1_16x32` is set, while the recording body is guarded by the negation of all four — disjoint, so those geometries open a record window and record nothing (`lltt::record` defaults to `NoExec`, and `load_replay_buf` issues it before invoking the callable).

That mismatch is real, but it is **not** the whole cause: forcing `replay_buf_len = replay_buff_len_throttle` **and** emitting the body unconditionally — window length equal to body, window filled — still hangs identically, verified with a rebuilt `math.elf`. The outer/inner counts and replay slot budget also assume a full tile. So this PR guards the entry rather than claiming a fix to the sequence.

### Verification (p100a, Blackhole)

| arm | before | after |
|---|---|---|
| tiny tile x throttle 1 | `LLK ASSERT HIT` (TRISC1 trace at `llk_math_matmul.h:579`), or `TENSIX TIMED OUT ... Unpacker, Math, Packer` with the assert removed | PASS |
| tiny tile x throttle 0 | PASS | PASS |
| full 32x32 x throttle 1, 2 | PASS | PASS |

Fail-without/pass-with: reverting only the LLK change with the new test in place makes it fail.

### Test plan

`test_math_matmul.py` built its matrix so the combination could not occur — full tiles got throttle `[1,2,3,4,5]`, tiny-tile combinations got **throttle 0 only**. It now also runs one throttled level for tiny tiles, on **both** architectures — the earlier Blackhole-only gate is removed, which adds 11,320 previously-skipped Wormhole cases. A non-full tile takes the same unthrottled path for every level, so level 1 covers the throttled range without multiplying the matrix by five.

### Verification (n150, Wormhole)

Wormhole was previously out of scope here for want of a board. It has since been validated on an n150, on the same tiny-tile combination (`in0_tile_r_dim=1, in0_tile_c_dim=32`, `partial_face`), varying one thing at a time:

| arm | result |
|---|---|
| tiny tile x throttle 0 (shipped matrix) | PASS |
| tiny tile x throttle 1, shipped header | `LLK ASSERT HIT`, TRISC1 trace at `llk_math_matmul.h:677` |
| tiny tile x throttle 1, assert neutralised (= any build without `ENABLE_LLK_ASSERT`) | `TENSIX TIMED OUT ... waited 2 seconds for Math, Packer, Unpacker` |
| tiny tile x throttle 1, with this change | PASS |
| 20 tiny-tile geometries x throttle {0,1}, with this change | 40/40 PASS |
| full 32x32 x throttle {1,2,3,4,5} x 4 fidelities | 120/120 PASS |
| HiFi4 x tiny tile x throttle 4 (the documented carve-out) | `LLK ASSERT HIT` — throttled path deliberately kept |

Same signature as Blackhole, so the Blackhole reasoning carries over unchanged.

On flakiness: running several of these back-to-back on one card without a reset between them fails a few, but the **already-shipped** throttle-0 tiny-tile cases fail at the same rate and in the same positions under the identical protocol (5/8 either way). That is pre-existing device-state behaviour on the box, not something these new cases introduce; run individually with a reset, all 8 sampled cases pass.

Separately noted in the issue: the non-throttled `matmul_configure_mop` has the inverse mismatch (window 4, body 8) for `partial_face` with a tiny **in1** operand. The current test infra never generates a tiny in1, so it is not reproducible here and not addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/bh-matmul-throttle-nonfull-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/bh-matmul-throttle-nonfull-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/bh-matmul-throttle-nonfull-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/bh-matmul-throttle-nonfull-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/bh-matmul-throttle-nonfull-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/bh-matmul-throttle-nonfull-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/bh-matmul-throttle-nonfull-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/bh-matmul-throttle-nonfull-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/bh-matmul-throttle-nonfull-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/bh-matmul-throttle-nonfull-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/bh-matmul-throttle-nonfull-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/bh-matmul-throttle-nonfull-tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/bh-matmul-throttle-nonfull-tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/bh-matmul-throttle-nonfull-tile)
