### PR TITLE
[Performance] Optimize GLM-5.2 indexer data flow

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -35,6 +35,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
     resolve_has_indexer,
 )
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
+from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
@@ -178,6 +179,58 @@ def test_reuse_indexer_forward_raises(expect_error):
     rather than silently return None (which would drop the layer to a dense path)."""
     with expect_error(RuntimeError, "reused top-k"):
         ReuseIndexer().forward()
+
+
+def test_glm52_persistent_indexer_indices_are_replaced_without_deallocation(monkeypatch):
+    """A new full layer overwrites persistent scratch before the previous wrapper is replaced.
+
+    Explicitly deallocating that wrapper would invalidate the new result backed by the same buffer;
+    ordinary reference replacement must carry layer 6's indices safely into shared layer 7.
+    """
+    import models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer as transformer_module
+
+    modes = GLM52Config.indexer_types()[:8]
+    full_outputs = {layer_idx: object() for layer_idx, mode in enumerate(modes) if mode == "full"}
+    latest_full = None
+
+    class FakeLayer:
+        def __init__(self, layer_idx, mode):
+            self.layer_idx = layer_idx
+            self.mode = mode
+
+        def __call__(self, hidden, *args, indexer_indices, **kwargs):
+            nonlocal latest_full
+            if self.mode == "full":
+                assert indexer_indices is None
+                latest_full = full_outputs[self.layer_idx]
+                result = latest_full
+            else:
+                assert indexer_indices is latest_full
+                result = indexer_indices
+            return hidden, None, result
+
+    transformer = object.__new__(TtPrefillTransformer)
+    transformer.is_chunked = True
+    transformer.indexed_rope = object()
+    transformer._has_indexer = True
+    transformer.is_first_rank = False
+    transformer.indexer_types = modes
+    transformer.first_layer_idx = 0
+    transformer.layers = [FakeLayer(layer_idx, mode) for layer_idx, mode in enumerate(modes)]
+    transformer.padding_side = "right"
+    transformer.kv_only_last_layer = False
+    transformer.is_last_rank = False
+
+    monkeypatch.setattr(transformer_module, "signpost", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        ttnn,
+        "deallocate",
+        lambda tensor: pytest.fail("persistent indexer indices must not be explicitly deallocated"),
+    )
+
+    hidden = object()
+    assert transformer.forward(hidden, kvpe_cache=object(), actual_isl=0, actual_start=0) is hidden
+    assert latest_full is full_outputs[6]
 
 
 def test_matches_config_rejects_dense():

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -233,6 +233,34 @@ def test_glm52_persistent_indexer_indices_are_replaced_without_deallocation(monk
     assert latest_full is full_outputs[6]
 
 
+def test_indexer_gate_reduce_scatter_uses_fp32_accumulation(monkeypatch):
+    """The sequence reduce-scatter must preserve the previous gate reduction's FP32 accumulation."""
+    compute_config = object()
+    reduced = object()
+    call = {}
+
+    def fake_reduce_scatter(tensor, **kwargs):
+        call.update(kwargs)
+        return reduced
+
+    tt_ccl = SimpleNamespace(
+        get_and_cycle_rs_semaphore_handles=lambda **kwargs: "rs_semaphores",
+        get_and_cycle_barrier_semaphore_handle=lambda **kwargs: "barrier_semaphore",
+    )
+    indexer = SimpleNamespace(
+        tp_factor=4,
+        tp_axis=1,
+        tt_ccl=tt_ccl,
+        ccl_num_links=2,
+        tp_ccl_topology="topology",
+        hifi4_fp32_compute_kernel_config=compute_config,
+    )
+    monkeypatch.setattr(ttnn.experimental, "reduce_scatter_minimal_async", fake_reduce_scatter)
+
+    assert TtIndexer._tp_reduce_scatter_sequence(indexer, object()) is reduced
+    assert call["compute_kernel_config"] is compute_config
+
+
 def test_matches_config_rejects_dense():
     """A dense DeepSeek-V3 / R1-style config (no index_* fields) must not look sparse."""
     dense = SimpleNamespace(q_lora_rank=1536, hidden_size=7168)

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -380,7 +380,6 @@ class TtIndexer:
         # buffer across them.  This keeps the high-bandwidth gathers allocation-free and their output
         # address fixed on the hot forward path.
         self._k_all_gather_output = None
-        self._weights_all_gather_output = None
         self._topk_indices_all_gather_output = None
         if self.tp_factor > 1:
             assert (
@@ -397,12 +396,6 @@ class TtIndexer:
             self._k_all_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
                 name="indexer_k_all_reduce",
                 shape=[1, 1, self.active_seq_len_local, self.index_args.index_head_dim],
-                dtype=ttnn.bfloat16,
-                layout=ttnn.TILE_LAYOUT,
-            )
-            self._weights_all_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
-                name="indexer_weights_all_reduce",
-                shape=[1, self.tp_factor, self.active_seq_len_local, self.index_args.index_n_heads],
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
             )
@@ -478,28 +471,20 @@ class TtIndexer:
             cluster_axis=self.tp_axis,
         )
 
-    def _tp_all_reduce_via_gather(self, t):
-        """All-reduce over TP via gather (dim 1) + local reduce, instead of _tp_rs_ag's reduce-scatter
-        (dim 3) + all-gather. For a narrow dim-3 width (e.g. weights' H_idx=32) that doesn't divide evenly
-        into tile-sized TP shards, _tp_rs_ag's reduce-scatter hits ttnn's composite fallback
-        (use_composite_reduce_scatter) and balloons into ~30 tilize/pad/slice ops. Gathering on dim 1 —
-        the batch/placeholder axis, always size 1 here — has no tile-alignment constraint, so it always
-        takes the fused fast path; fast_reduce_nc then sums the gathered TP axis locally (pure on-device
-        compute, no fabric traffic). Mirrors ttMLA._kv_stem's kv_a_proj_with_mqa all-reduce (mla.py:
-        917-929), measured cheaper even on an 18x-wider tensor than weights."""
+    def _tp_reduce_scatter_sequence(self, t):
+        """Sum TP partials while retaining only this rank's downstream query rows."""
         if self.tp_factor == 1:
             return t
-        assert self._weights_all_gather_output is not None
-        assert tuple(t.shape) == (1, 1, self.active_seq_len_local, self.index_args.index_n_heads)
-        t = ttnn.experimental.high_bw_all_gather(
+        return ttnn.experimental.reduce_scatter_minimal_async(
             t,
-            dim=1,
-            output_tensor=self._weights_all_gather_output,
+            persistent_output_buffers=None,
+            dim=2,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=self.tp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
             num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.tp_ccl_topology,
             cluster_axis=self.tp_axis,
-        )
-        return ttnn.experimental.fast_reduce_nc(
-            t, dims=[1], output=None, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
         )
 
     def _tp_all_gather(self, t, dim):
@@ -539,7 +524,12 @@ class TtIndexer:
         )
         self._idx_wq_b = w["wq_b"]
         self._idx_wk = w["wk"]
-        self._idx_wproj = w["weights_proj"]
+        # Apply the static indexer scale to the persistent projection weight.
+        wproj = w["weights_proj"]
+        self._idx_wproj = ttnn.multiply(
+            wproj, self.index_args.index_n_heads**-0.5 * self.index_args.index_head_dim**-0.5
+        )
+        ttnn.deallocate(wproj)
         self._idx_knorm_w = w["k_norm"]
         self._idx_knorm_b = w["k_norm_bias"]
 
@@ -791,8 +781,8 @@ class TtIndexer:
         ttnn.deallocate(q_dev)
         q_dev = q_h
 
-        # weights_proj: device stem -> FULL all-reduce over tp (all H_idx heads, matching the replicated
-        # wq_b heads) -> scale -> [1, 1, S/sp, H_idx].
+        # weights_proj: device stem -> reduce TP partials and scatter query rows. The static scale is
+        # already folded into the persistent projection weight in _upload_weights().
         wproj_cfg = self._resolve_mm_cfg("indexer.weights_proj", seq_len)
         weights = ttnn.linear(
             hidden_states,
@@ -801,40 +791,25 @@ class TtIndexer:
             memory_config=wproj_cfg["out_mem_config"] if wproj_cfg is not None else ttnn.DRAM_MEMORY_CONFIG,
             **({"program_config": wproj_cfg["program_config"]} if wproj_cfg is not None else {}),
         )
-        # H_idx=32 doesn't divide evenly into tile-sized TP=4 shards (8 < tile width), so _tp_rs_ag's
-        # dim-3 reduce-scatter would hit ttnn's composite fallback (~30 extra tilize/pad/slice ops, see
-        # use_composite_reduce_scatter). Gather-then-local-reduce on dim 1 has no such tile constraint.
-        weights = self._tp_all_reduce_via_gather(
-            weights
-        )  # full all-reduce over tp -> all H_idx head-weights, replicated
-        # Indexer softmax scale = index_head_dim**-0.5 (NO mscale), matching the reference IndexerCPU
-        # (model.py: softmax_scale = head_dim**-0.5). Distinct from MLA's qk_head_dim*mscale**2 scale —
-        # though as a uniform positive multiplier it cannot change the top-k selection regardless.
-        weights = ttnn.multiply(
-            weights, a.index_n_heads**-0.5 * a.index_head_dim**-0.5
-        )  # [1,1,S/sp,H_idx] repl on tp
-
-        # TP×SP query parallelism (rope-then-split). q_dev/weights were roped on the FULL S/sp slab
-        # (block-cyclic-correct, cluster_axis=sp_axis), so every row already carries its true position; now
+        # Sum TP partials and scatter the sequence rows consumed by local scoring.
+        tpsp = self.tp_factor > 1
+        weights = self._tp_reduce_scatter_sequence(weights)
+        # TP×SP query parallelism (rope-then-split). q_dev was roped on the FULL S/sp slab
+        # (block-cyclic-correct, cluster_axis=sp_axis), so every query row already carries its true position; now
         # split those rows over TP so each chip scores only S/(sp·tp) of them — indexer_score + topk shrink
         # ~TP×. RoPE is per-row so the split is safe (no 2-D rope op needed). The score is told the TP axis via
         # seq_shard_axes below, so its EXACT block-cyclic geometry adds each device's tp_rank*Sq' sub-offset
         # (rotation-safe). topk runs on the sub-rows; indices are all-gathered back over TP to the [1,1,S/sp,k]
         # contract so mla.py / sparse_sdpa are unchanged (both DeepSeek and GLM ride this one path).
-        tpsp = self.tp_factor > 1
         if tpsp:
-            q_full, weights_full = (
-                q_dev,
-                weights,
-            )  # release the full-S slabs once TP-split (mesh_partition allocates new)
+            q_full = q_dev  # release the full-S slab once TP-split (mesh_partition allocates new)
             q_dev = ttnn.mesh_partition(q_dev, dim=2, cluster_axis=self.tp_axis)  # [1,H_idx,S/(sp·tp),D_idx]
-            weights = ttnn.mesh_partition(weights, dim=2, cluster_axis=self.tp_axis)  # [1,1,S/(sp·tp),H_idx]
             ttnn.deallocate(q_full)
-            ttnn.deallocate(weights_full)
             sq_local = seq_len // self.tp_factor
             qc = 64 if sq_local % 64 == 0 else 32  # q_chunk must divide the per-chip query tile count
         else:
             qc = 64
+
         # Causality is fused inside indexer_score (future columns -> -inf from chunk_start_idx), so no triu
         # mask here. All H_idx heads are resident on-chip (wq_b replicated), so head_group_size=0 reads the
         # key cache ONCE — but that needs L1 headroom, so k_chunk is bounded by resident head count

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -494,6 +494,7 @@ class TtIndexer:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=self.tp_ccl_topology,
             cluster_axis=self.tp_axis,
+            compute_kernel_config=self.hifi4_fp32_compute_kernel_config,
         )
 
     def _tp_all_gather(self, t, dim):

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -376,9 +376,9 @@ class TtIndexer:
                 if first_layer_idx is None
                 else full_indexer_rank(config, first_layer_idx + self.layer_num) - base
             )
-        # Stable, worst-case TP gather outputs.  Indexer layers execute serially, so TT_CCL shares each
-        # buffer across them.  This keeps the high-bandwidth gathers allocation-free and their output
-        # address fixed on the hot forward path.
+        # Stable, worst-case TP gather outputs. Indexer layers execute serially, so they share each
+        # buffer through TT_CCL. Allocate on first use because distributed ops may return a tensor owned
+        # by a child mesh; high_bw_all_gather requires its persistent output to have that exact owner.
         self._k_all_gather_output = None
         self._topk_indices_all_gather_output = None
         if self.tp_factor > 1:
@@ -392,18 +392,6 @@ class TtIndexer:
             assert self.index_args.index_head_dim % (self.tp_factor * ttnn.TILE_SIZE) == 0, (
                 "the TP-local index head dimension must be tile aligned for high_bw_all_gather; "
                 f"got {self.index_args.index_head_dim // self.tp_factor}"
-            )
-            self._k_all_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
-                name="indexer_k_all_reduce",
-                shape=[1, 1, self.active_seq_len_local, self.index_args.index_head_dim],
-                dtype=ttnn.bfloat16,
-                layout=ttnn.TILE_LAYOUT,
-            )
-            self._topk_indices_all_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
-                name="indexer_topk_indices",
-                shape=[1, 1, self.active_seq_len_local, self.index_topk_capacity],
-                dtype=ttnn.uint32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
             )
         self._upload_weights(idx_host)
         # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
@@ -444,6 +432,21 @@ class TtIndexer:
 
     # Inlined TP/SP collectives — the indexer owns its own copy so it depends on tt_ccl, not on ttMLA
     # (the dense MLA forward keeps its own equivalents; both go through the same tt_ccl handles).
+    def _get_high_bw_all_gather_buffer(self, *, name, shape, dtype, layout, device):
+        """Return a shared persistent output owned by the collective input's exact mesh."""
+        key = (name, tuple(shape), dtype, layout, device.id())
+        output = self.tt_ccl.mla_high_bw_all_gather_buffers.get(key)
+        if output is None or not output.is_allocated():
+            output = ttnn.empty(
+                shape,
+                dtype=dtype,
+                layout=layout,
+                device=device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            self.tt_ccl.mla_high_bw_all_gather_buffers[key] = output
+        return output
+
     def _tp_rs_ag(self, t, rs_only=False):
         """All-reduce over TP = reduce-scatter (dim 3) then all-gather; rs_only stops after the RS."""
         if self.tp_factor == 1:
@@ -461,8 +464,14 @@ class TtIndexer:
         )
         if rs_only:
             return t
-        assert self._k_all_gather_output is not None
         assert tuple(t.shape) == (1, 1, self.active_seq_len_local, self.index_args.index_head_dim // self.tp_factor)
+        self._k_all_gather_output = self._get_high_bw_all_gather_buffer(
+            name="indexer_k_all_reduce",
+            shape=[1, 1, self.active_seq_len_local, self.index_args.index_head_dim],
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=t.device(),
+        )
         return ttnn.experimental.high_bw_all_gather(
             t,
             dim=3,
@@ -492,12 +501,18 @@ class TtIndexer:
         if self.tp_factor == 1:
             return t
         assert dim == 2, "TtIndexer only regathers TP-split sequence rows"
-        assert self._topk_indices_all_gather_output is not None
         assert tuple(t.shape) == (
             1,
             1,
             self.active_seq_len_local // self.tp_factor,
             self.index_topk_capacity,
+        )
+        self._topk_indices_all_gather_output = self._get_high_bw_all_gather_buffer(
+            name="indexer_topk_indices",
+            shape=[1, 1, self.active_seq_len_local, self.index_topk_capacity],
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=t.device(),
         )
         return ttnn.experimental.high_bw_all_gather(
             t,
@@ -589,11 +604,12 @@ class TtIndexer:
         assert (
             index_kbuf.shape[2] % ttnn.TILE_SIZE == 0
         ), f"the TP-local index cache slab must be tile aligned for high_bw_all_gather; got {index_kbuf.shape[2]}"
-        out = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
+        out = self._get_high_bw_all_gather_buffer(
             name="indexer_kbuf_tp_replicate",
             shape=[1, 1, index_kbuf.shape[2] * self.tp_factor, index_kbuf.shape[3]],
             dtype=index_kbuf.dtype,
             layout=index_kbuf.layout,
+            device=index_kbuf.device(),
         )
         return ttnn.experimental.high_bw_all_gather(
             index_kbuf,

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -410,7 +410,7 @@ class TtIndexer:
                 name="indexer_topk_indices",
                 shape=[1, 1, self.active_seq_len_local, self.index_topk_capacity],
                 dtype=ttnn.uint32,
-                layout=ttnn.TILE_LAYOUT,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
             )
         self._upload_weights(idx_host)
         # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
@@ -503,9 +503,7 @@ class TtIndexer:
         )
 
     def _tp_all_gather(self, t, dim):
-        """All-gather across the TP axis → the TP-seq-shards reassembled to the SP block's full rows,
-        replicated on TP. tp=1: no-op. (Spike helper for TP×SP query parallelism: regathers the top-k
-        indices that were computed on TP-seq-sharded query rows back to the [1,1,S/sp,k] contract.)"""
+        """Gather TP-sequence shards into [1,1,S/sp,k], replicated across TP."""
         if self.tp_factor == 1:
             return t
         assert dim == 2, "TtIndexer only regathers TP-split sequence rows"
@@ -901,24 +899,12 @@ class TtIndexer:
         # ranked. topk_large_indices also requires valid_length <= T, which valid_pos satisfies.
         topk_valid_length = valid_pos
         idx = ttnn.experimental.topk_large_indices(logits, k=self.index_topk_capacity, valid_length=topk_valid_length)
-        # TP×SP: topk ran on the TP-seq-sharded rows ([1,1,S/(sp·tp),k]); regather over TP back to the
-        # [1,1,S/sp,k] contract so sparse_sdpa/mla.py are unchanged. (Redundant TP-round-trip for GLM's
-        # head→seq reshard, which re-splits it; correct regardless. tp=1: no-op.)
+        # TP×SP: restore the [1,1,S/sp,k] sparse-SDPA contract after top-k runs on TP-sequence shards.
         if tpsp:
-            # Regather the TP-seq-sharded top-k indices back to [1,1,S/sp,k]. topk_large_indices emits
-            # ROW_MAJOR uint32, and an all-gather on a ROW_MAJOR tensor is routed by use_composite_all_gather
-            # to composite_all_gather -> all_broadcast, whose multicast over a partial cluster-axis line of a
-            # 2D (SP×TP) mesh DEADLOCKS the fabric (erisc routers stall in run_receiver_channel_step; device
-            # unrecoverable, system_memory_manager.cpp TIMEOUT). Gather in TILE layout so it takes the NATIVE
-            # minimal all-gather instead — the tile-aligned gather dim keeps it off the composite path, and
-            # the native path handles this TP cluster-axis correctly (as _tp_rs_ag does, and as the canonical
-            # top-k-index gather in tt_sampling.py does). Round-trip RM->TILE->gather->RM.
+            # The dedicated gather supports ROW_MAJOR uint32 on a partial axis of the 2D mesh.
             idx_local = idx
-            idx_tiled = ttnn.to_layout(idx, ttnn.TILE_LAYOUT)
-            idx_gathered = self._tp_all_gather(idx_tiled, dim=2)  # native all-gather over TP; [1,1,S/sp,k] TILE
-            idx = ttnn.to_layout(idx_gathered, ttnn.ROW_MAJOR_LAYOUT)
+            idx = self._tp_all_gather(idx_local, dim=2)  # [1,1,S/sp,k] ROW_MAJOR
             ttnn.deallocate(idx_local)
-            ttnn.deallocate(idx_tiled)
             # high_bw_all_gather returns a fresh wrapper around model-owned scratch; do not
             # deallocate its backing buffer on the hot path.
         return idx

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -496,8 +496,9 @@ class TtPrefillTransformer(LightweightModule):
             if reuse:
                 h, _, new_idx = ret
                 if mode == "full":
-                    if indexer_indices is not None:
-                        ttnn.deallocate(indexer_indices)
+                    # TP top-k all-gather results alias model-owned persistent scratch. Replacing the
+                    # Python reference is sufficient: explicitly deallocating the previous wrapper
+                    # would invalidate the same backing buffer that ``new_idx`` now references.
                     indexer_indices = new_idx
             else:
                 h, _ = ret
@@ -512,9 +513,9 @@ class TtPrefillTransformer(LightweightModule):
                 intermediates[f"layer_{i}"] = self._to_host(h)
             if read_profiler:
                 ttnn.ReadDeviceProfiler(self.mesh_device)
-        # GLM-5.2 reuse: free the last full layer's held top-k indices after the final layer.
-        if reuse and indexer_indices is not None:
-            ttnn.deallocate(indexer_indices)
+        # Drop only the temporary wrapper. The TP gather buffer remains owned by TT_CCL and is released
+        # with the model; on TP=1 normal Python reference counting releases the non-persistent result.
+        indexer_indices = None
 
         # Non-last pipeline ranks stop here: the layer slice's output activation is
         # handed to the next rank, which continues from this hidden state. The norm /

--- a/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
@@ -314,8 +314,11 @@ def _run_high_bw_all_gather_accuracy(
 ):
     collective_size = mesh_device.get_num_devices() if cluster_axis is None else mesh_device.shape[cluster_axis]
     global_shape = (1, 1, rows_per_device * collective_size, width)
-    torch.manual_seed(0)
-    host_input = torch.rand(global_shape, dtype=torch.bfloat16)
+    if dtype == ttnn.uint32:
+        host_input = torch.arange(math.prod(global_shape), dtype=torch.int32).reshape(global_shape)
+    else:
+        torch.manual_seed(0)
+        host_input = torch.rand(global_shape, dtype=torch.bfloat16)
     mesh_mapper = (
         ttnn.ShardTensorToMesh(mesh_device, dim=2)
         if cluster_axis is None
@@ -351,7 +354,10 @@ def _run_high_bw_all_gather_accuracy(
     )
     ttnn.synchronize_device(mesh_device)
 
-    _assert_exact_all_gather(device_input, persistent_output, mesh_device, dtype)
+    if collective_size == mesh_device.get_num_devices():
+        _assert_exact_all_gather(device_input, persistent_output, mesh_device, dtype)
+    else:
+        _assert_exact_replicated_output(host_input, persistent_output, mesh_device, dtype, layout)
 
 
 @run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
@@ -373,6 +379,42 @@ def test_high_bw_all_gather_single_page_bank_owned_packet(mesh_device):
         expected_page_size=4096,
         cluster_axis=cluster_axis,
         rows_per_device=640,
+    )
+
+
+@run_for_blackhole("high_bw_all_gather requires Blackhole fabric")
+@pytest.mark.parametrize(
+    "device_params,mesh_device",
+    [
+        pytest.param(
+            _device_params(ttnn.FabricConfig.FABRIC_2D, 6144),
+            (2, 4),
+            id="loudbox_fabric_2d_6k_payload",
+        ),
+        pytest.param(
+            {
+                **_device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_X, 6144),
+                "require_exact_physical_num_devices": True,
+            },
+            (1, 4),
+            id="quietbox_torus_x_6k_payload",
+        ),
+    ],
+    indirect=["device_params", "mesh_device"],
+)
+def test_high_bw_all_gather_glm_topk_uint32_page_larger_than_fabric_payload(mesh_device):
+    """Reproduce GLM's TP-axis top-k gather when an 8 KiB RM page exceeds the 6 KiB fabric payload."""
+    assert tuple(mesh_device.shape) in ((1, 4), (2, 4))
+    assert ttnn.get_tt_fabric_max_payload_size_bytes() == 6144
+    _run_high_bw_all_gather_accuracy(
+        mesh_device,
+        dtype=ttnn.uint32,
+        width=2048,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        expected_page_size=8192,
+        cluster_axis=1,
+        rows_per_device=160,
+        num_links=2,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_common.hpp
@@ -158,16 +158,16 @@ public:
         std::array<uint64_t, max_pages_per_packet> dummy_addrs{};  // init to 0s
         std::array<uint16_t, max_pages_per_packet - 1> chunk_sizes{};
         chunk_sizes.fill(page_size);
-        // The scatter command has fixed-size address/chunk arrays even when the
-        // contiguous-page path below uses a larger terminal unicast payload.
-        // Only initialize the entries the scatter command can represent.
-        constexpr uint32_t scatter_header_pages_per_packet = std::min(pages_per_packet, max_pages_per_packet);
+        // Scatter-write requires at least two chunks. The single-page, split-page, and contiguous-page paths
+        // use the unicast header instead, so do not initialize an invalid or unused scatter header for them.
 #ifdef FABRIC_2D
-        fabric_api::fabric_unicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
-            scatter_packet_header,
-            dst_dev_id,
-            dst_mesh_id,
-            NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), scatter_header_pages_per_packet));
+        if constexpr (use_scatter_write && !coalesce_contiguous_pages) {
+            fabric_api::fabric_unicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
+                scatter_packet_header,
+                dst_dev_id,
+                dst_mesh_id,
+                NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), pages_per_packet));
+        }
 
         fabric_api::fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::None>(
             unicast_packet_header, dst_dev_id, dst_mesh_id);
@@ -175,10 +175,12 @@ public:
             fused_unicast_packet_header, dst_dev_id, dst_mesh_id);
 #else
         constexpr uint8_t num_hops = 1;
-        fabric_api::fabric_unicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
-            scatter_packet_header,
-            num_hops,
-            NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), scatter_header_pages_per_packet));
+        if constexpr (use_scatter_write && !coalesce_contiguous_pages) {
+            fabric_api::fabric_unicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
+                scatter_packet_header,
+                num_hops,
+                NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), pages_per_packet));
+        }
 
         fabric_api::fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::None>(
             unicast_packet_header, num_hops);


### PR DESCRIPTION
### PR Category

Performance

### Summary

Optimize the GLM-5.2 sparse MLA indexer data flow in two places:

- Keep top-k indices in row-major layout through the TP high-bandwidth all-gather, removing the surrounding tilize and untilize programs while preserving the sparse-SDPA input contract.
- Replace the replicated TP all-gather plus local gate reduction with a sequence-axis reduce-scatter. Fold the static indexer scale into the persistent projection weight so the forward path no longer dispatches a separate multiply.

Recorded profiler results on LoudBox 2x4 with GLM-5.2 fp8 warm:

- Top-k flow: 171.7 us to 103.2 us (-39.9%), with two fewer programs.
- Gate-reduction proxy: 3.551 ms to 3.431 ms median (-3.4%), with three fewer programs.

### Additional model CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/glm52_indexer_optimization)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/glm52_indexer_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/glm52_indexer_optimization)
