### PR TITLE
[Bug fix] gather: route row-major to RmSingleRowSingleCore (#55450)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_gather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_gather.py
@@ -86,3 +86,16 @@ def test_gather_negative_dim_equals_positive(device, shape, dim):
 
     assert_with_pcc(ttnn_output_neg, ttnn_output_pos, 0.9999)
     assert_with_pcc(torch_output_neg, ttnn_output_neg, 0.999)
+
+
+@pytest.mark.parametrize("N", [2048, 4096])
+def test_gather_row_major_wide(device, N):
+    torch.manual_seed(0)
+    x = torch.rand([1, N], dtype=torch.bfloat16)
+    idx = torch.randint(0, N, [1, N], dtype=torch.int32)
+    xt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    it = ttnn.from_torch(idx, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    out = ttnn.gather(xt, dim=-1, index=it)
+    ref = torch.gather(x, -1, idx.long())
+    assert torch.equal(ttnn.to_torch(out), ref)
+

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_gather_codegen_routing.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_gather_codegen_routing.py
@@ -73,22 +73,9 @@ _ROUTING_IDS = [
 ]
 
 
-# Native selects RmSingleRowMultiCore for a row-major index row wider than this
-# (device/gather_device_operation.cpp), and that factory returns wrong elements. Both legs below are
-# native, so the wrongness is identical on each side and the value comparison reports agreement
-# rather than the defect -- except where the wrong elements decode to NaN, which differs per
-# platform and which exact equality can never pass. Above this width the routing property is the
-# only thing the comparison can honestly assert.
-_RM_MULTI_CORE_W = 60 * 32
-
-
 @pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
 @pytest.mark.parametrize("shape,kwargs,layout", _ROUTING, ids=_ROUTING_IDS)
 def test_gather_codegen_routing(device, shape, kwargs, dtype, layout):
-    index_spec = kwargs.get("index")
-    wide_native_rm_row = (
-        layout == ttnn.ROW_MAJOR_LAYOUT and isinstance(index_spec, list) and index_spec[-1] > _RM_MULTI_CORE_W
-    )
     x = _make_input(shape, dtype)
     xt = ttnn.from_torch(x, dtype=dtype, layout=layout, device=device)
     kwargs = _materialize_index(shape, kwargs, layout, device)
@@ -97,8 +84,7 @@ def test_gather_codegen_routing(device, shape, kwargs, dtype, layout):
     native = _force_native(xt, **kwargs)
     entries_before = device.num_program_cache_entries()
     out = ttnn.gather(xt, **kwargs)
-    if not wide_native_rm_row:
-        assert_equal(ttnn.to_torch(native), ttnn.to_torch(out))
+    assert_equal(ttnn.to_torch(native), ttnn.to_torch(out))
     msg = "auto routed an out-of-scope case to codegen (program cache grew); expected native fallback"
     assert device.num_program_cache_entries() == entries_before, msg
 

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
@@ -22,13 +22,8 @@ GatherDeviceOperation::program_factory_t GatherDeviceOperation::select_program_f
     const auto input_index_tensor_shape = tensor_args.input_index_tensor.padded_shape();
 
     if (tensor_args.input_tensor.layout() == Layout::ROW_MAJOR) {
-        // Multi-core splits over W_index only (each core owns a slice of every output row);
-        // W_input is mirrored in full to every core, so it gives no parallelism gain.
-        const uint32_t W_index = input_index_tensor_shape[-1];
-        constexpr uint32_t rm_w_threshold = GATHER_WT_THRESHOLD * tt::constants::TILE_WIDTH;
-        if (W_index > rm_w_threshold) {
-            return RmSingleRowMultiCore{};
-        }
+        // RmSingleRowSingleCore distributes work across cores by rows H safely.
+        // RmSingleRowMultiCore column-splits W_index, which causes data corruption from concurrent unaligned DRAM writes (#55450).
         return RmSingleRowSingleCore{};
     }
 


### PR DESCRIPTION
Fixes #55450 by routing row-major gather dispatches to `RmSingleRowSingleCore`. `RmSingleRowMultiCore` splits columns along W, causing concurrent unaligned NoC writes from multiple cores to the same interleaved DRAM page, which clobbers elements when W > 1920. `RmSingleRowSingleCore` safely distributes work across cores by rows H without intra-row DRAM collisions, and this restores full value comparison for wide row-major cases in the codegen routing tests.