### PR TITLE
[Feature] high_bw_all_gather: linearize a full mesh as an open path where no ring closes

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -548,12 +548,11 @@ def _build_mla_tp(config, state_dict, mesh_device, *, tp_shard_kv):
     [
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
+            fabric2d_device_params(
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
+            id="fabric2d-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -651,12 +650,11 @@ def _run_chunked(mla, mesh_device, rope_tensors, kvpe_cache, index_kv_cache, hid
     [
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
+            fabric2d_device_params(
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
+            id="fabric2d-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1407,12 +1407,28 @@ def test_mistral4_prefill_transformer_chunked_no_pcc(
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),
+        # Same 8x4 mesh on a PLAIN 2D fabric, which wraps neither axis. The snake's closing edge spans a
+        # whole axis, so no cycle closes here and the full mesh resolves as an open Hamiltonian path --
+        # the tier the torus row above can never reach, because a torus always closes the ring. Both
+        # rows must produce the same PCCs: the transport-to-tensor mapping is the same row-major
+        # linearization either way, only the closing edge differs.
+        pytest.param(
+            (8, 4),
+            fabric2d_device_params(
+                fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE,
+                l1_small_size=GLM_L1_SMALL_SIZE,
+                trace_region_size=GLM_TRACE_REGION_SIZE,
+            ),
+            2,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="fabric2d-8x4",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
 # KV dedup end-to-end through the full chunked transformer: tp_sharded must match the sp_only PCC, since
-# the deduped caches reconstruct the same block-cyclic buffer via the TP-inner all-gather. The 8x4 torus
-# always closes the snake ring, so this row covers the snake route only.
+# the deduped caches reconstruct the same block-cyclic buffer via the TP-inner all-gather. The torus row
+# covers the snake RING route; the fabric2d row covers the open PATH, where no cycle closes.
 @pytest.mark.parametrize("tp_shard_kv", [False, True], ids=["sp_only", "tp_sharded"])
 @pytest.mark.parametrize("variant", ["glm_5_1", "glm_5_2"], indirect=True, ids=["glm51", "glm52"])
 @pytest.mark.skipif(not is_blackhole(), reason="GLM DSA ops (indexer / sparse SDPA) are Blackhole-only")

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -25,35 +25,6 @@ from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat, MlaKvCacheGeometry
 
 # Axis 0 is N/S (mesh rows), axis 1 is E/W (mesh cols) -- the same convention high_bw_all_gather uses.
-# A fabric only wraps the axis its torus flag names (see ccl_common.cpp get_axis_topology).
-_SNAKE_CLOSING_TORUS_CONFIGS = {
-    0: (ttnn.FabricConfig.FABRIC_2D_TORUS_Y, ttnn.FabricConfig.FABRIC_2D_TORUS_XY),
-    1: (ttnn.FabricConfig.FABRIC_2D_TORUS_X, ttnn.FabricConfig.FABRIC_2D_TORUS_XY),
-}
-
-
-def _snake_ring_can_close(mesh_shape) -> bool:
-    """Whether SOME snake orientation closes its ring on a direct physical hop.
-
-    Mirrors the orientation search in resolve_mesh_ring_plan (mesh_ring_plan.cpp). The ring order is a
-    boustrophedon, so its last device is (rows-1, 0) for a Row snake and (0, cols-1) for a Column one:
-    the closing edge always spans the WHOLE closing axis. That edge is a direct hop only when the axis
-    is a torus ring, or its extent is 2 -- in which case the "wrap" is just the neighbour. An odd extent
-    has no boustrophedon cycle at all and the op skips that orientation.
-
-    Checked here because the op does not degrade on an unclosable ring: it TT_FATALs
-    ("neighbor unicast requires a host-proved direct physical line/ring").
-
-    Conservative in one direction only: the fabric flag names an axis, but the closing link must also be
-    physically wired, which the op verifies (is_axis_wrap_wired) and Python cannot see."""
-    fabric_config = ttnn.get_fabric_config()
-    for closing_axis in (0, 1):
-        extent = mesh_shape[closing_axis]
-        if extent % 2 != 0:
-            continue
-        if extent == 2 or fabric_config in _SNAKE_CLOSING_TORUS_CONFIGS[closing_axis]:
-            return True
-    return False
 
 
 class ttMLA:
@@ -591,7 +562,6 @@ class ttMLA:
         # dense-run V3.2 key on this, not _has_indexer (see _get_sdpa_program_config).
         self._is_dsa_family = TtIndexer.matches_config(config)
         self._sparse_kv_gather_buffer = None
-        self._kvpe_tp_stage_buffer = None
         # KV dedup shards the cache over BOTH axes, so its gather needs the scratch even at sp == 1.
         self._kv_dedup = self.tp_shard_kv and self.tp_factor > 1
         if self._has_indexer and not self.kv_only and (self.sp_factor > 1 or self._kv_dedup):
@@ -602,15 +572,6 @@ class ttMLA:
                 dtype=self.sparse_kv_cache_format.storage_dtype,
                 layout=self.sparse_kv_cache_format.storage_layout,
             )
-            if self._kv_dedup and self.sp_factor > 1:
-                # high_bw_all_gather writes a caller-owned output, so the TP stage needs its own
-                # persistent intermediate: one SP row's slab (seq_len/sp rows), ~1/sp of the scratch.
-                self._kvpe_tp_stage_buffer = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
-                    name="kvpe_tp_stage",
-                    shape=[1, 1, seq_len // self.sp_factor, kvpe_row_width],
-                    dtype=self.sparse_kv_cache_format.storage_dtype,
-                    layout=self.sparse_kv_cache_format.storage_layout,
-                )
         # GLM-5.2 indexer reuse: a "shared" layer is sparse but owns no indexer weights — it reuses the
         # most recent "full" layer's top-k indices, injected at forward, and binds a weight-less
         # ReuseIndexer (never computes). Absent indexer_types (v3.1 / v3.2 / GLM-5.1) every layer is
@@ -1953,15 +1914,12 @@ class ttMLA:
 
         if self._kv_dedup:
             # GLM-5.2 KV dedup: the cache is dim-2 sharded across BOTH mesh axes, and row-major over the
-            # mesh IS the sp*tp linearization, so ONE full-mesh (snake-ring) gather rebuilds the slab in
-            # the same order the TP-inner -> SP-outer route produces. Where the snake cannot close its
-            # ring, _gather_kvpe_prefix_tp_sharded_high_bw does it in two axis gathers instead.
-            gather = (
-                self._gather_kvpe_prefix_full_mesh
-                if self._can_full_mesh_gather_kvpe(kvpe_cache.storage)
-                else self._gather_kvpe_prefix_tp_sharded_high_bw
-            )
-            return gather(
+            # mesh IS the sp*tp linearization, so ONE full-mesh gather rebuilds the slab in the order the
+            # old TP-inner -> SP-outer route produced. The op linearizes every mesh: a cycle where one
+            # exists (comb, so no torus needed) and an open path otherwise, which on the 1xN shape this
+            # path can take is the axis line itself. There is no geometry left for a second route to
+            # cover, so there is no second route -- see the asserts in _gather_kvpe_prefix_full_mesh.
+            return self._gather_kvpe_prefix_full_mesh(
                 kvpe_cache,
                 cache_batch_idx,
                 populated_global,
@@ -2044,73 +2002,6 @@ class ttMLA:
             geometry=kvpe_cache.geometry,
         )
 
-    def _can_full_mesh_gather_kvpe(self, cache_storage) -> bool:
-        """Whether one snake ring can replace the two-stage sp*tp KV-prefix gather. Memoized.
-
-        The sole caller is _gather_kvpe_prefix, reached from _sparse_chunked_attn for every
-        full-attention layer of every chunk -- 78 x 11 = 858 times on a GLM-5.2 prefill. The answer is a
-        property of the mesh, the axis roles and the cache layout, none of which change between chunks, so
-        evaluate it once per distinct cache shape: without this the whole predicate (tensor_topology()
-        included) re-ran per chunk, and on any mesh that fails a condition it also logged 858 identical
-        lines."""
-        memo = getattr(self, "_full_mesh_gather_memo", None)
-        if memo is None:
-            memo = self._full_mesh_gather_memo = {}
-        key = (tuple(cache_storage.padded_shape), self._sparse_kv_gather_buffer is not None)
-        if key not in memo:
-            memo[key] = self._can_full_mesh_gather_kvpe_uncached(cache_storage)
-        return memo[key]
-
-    def _can_full_mesh_gather_kvpe_uncached(self, cache_storage) -> bool:
-        """Every condition here mirrors a hard TT_FATAL in high_bw_all_gather, so the guard degrades to the
-        two-stage route instead of crashing. The op does not fail softly on any of them."""
-
-        def _no(reason):
-            # Name which condition rejected the snake rather than degrading silently: it decides whether
-            # this mesh takes the snake or the two-stage fallback, and the two differ in gather volume.
-            # Logged once per distinct cache shape thanks to the memo on the wrapper above.
-            logger.info(f"[kvpe gather] full-mesh snake unavailable, using two-stage TP gather: {reason}")
-            return False
-
-        if self._sparse_kv_gather_buffer is None:
-            return _no("no persistent sparse-KV gather buffer")
-        # The snake lands the gather in mesh row-major order, which equals the sp*tp order only for the
-        # (sp_axis=0, tp_axis=1) layout this path already asserts.
-        if self.sp_axis != 0 or self.tp_axis != 1:
-            return _no(f"needs (sp_axis=0, tp_axis=1); got ({self.sp_axis}, {self.tp_axis})")
-        # The snake linearizes the COMPLETE 2D mesh, so it needs both axes populated, and a boustrophedon
-        # cycle exists only when some lane count is even.
-        shape = tuple(self.mesh_device.shape)
-        if len(shape) != 2 or shape[0] < 2 or shape[1] < 2:
-            return _no(f"mesh shape {shape} is not 2D with both extents >= 2")
-        if not (shape[0] % 2 == 0 or shape[1] % 2 == 0):
-            return _no(f"mesh shape {shape} has no even lane count (no boustrophedon cycle)")
-        # An even lane count is necessary but not sufficient: the ring still has to CLOSE on a direct hop.
-        # On 8x4 that needs a torus; on 8x2 the Column snake closes across an extent-2 axis without one.
-        if not _snake_ring_can_close(shape):
-            return _no(f"snake ring cannot close on shape {shape} (needs a torus on 8x4)")
-        # The op requires the input's DECLARED dim-2 shard factor to span every device: a full-mesh gather
-        # is only sound if the metadata says the sequence really is split sp*tp ways. A TP-deduped KVPE
-        # cache that still declares the legacy kv-head-on-TP layout (Shard(2), Shard(1)) reports 8, not 32.
-        declared = self._declared_seq_shard_factor(cache_storage)
-        if declared != self.sp_factor * self.tp_factor:
-            return _no(
-                f"cache declares dim-2 shard factor {declared}, expected sp*tp="
-                f"{self.sp_factor * self.tp_factor} (a deduped cache still declaring the legacy "
-                "kv-head-on-TP layout reports sp only)"
-            )
-        # The op requires input and output on the same mesh handle. MeshDevice binds no __eq__, so `==`
-        # on the wrappers is object identity and .device() need not return the same wrapper twice --
-        # compare the device id. An unallocated tensor reports .device() None; treat that as a mismatch
-        # rather than crashing.
-        buffer_device = self._sparse_kv_gather_buffer.device()
-        cache_device = cache_storage.device()
-        if buffer_device is None or cache_device is None:
-            return _no("gather buffer or cache reports no device")
-        if buffer_device.id() != cache_device.id():
-            return _no("gather buffer and cache are on different mesh handles")
-        return True
-
     @staticmethod
     def _declared_seq_shard_factor(t) -> int:
         """Product of mesh extents over the axes whose placement shards tensor dim 2 (mirrors the op's
@@ -2176,6 +2067,17 @@ class ttMLA:
             else {"input_batch_index": slot_lo}
         )
         assert self._sparse_kv_gather_buffer is not None
+        # These used to select between two gather routes; with one route they are invariants, so state
+        # them loudly here instead of silently rerouting when they do not hold.
+        # Row-major over the mesh equals the sp*tp linearization only for this axis assignment.
+        assert self.sp_axis == 0 and self.tp_axis == 1, "full-mesh KVPE gather assumes sp_axis=0, tp_axis=1"
+        # The op gathers across every device, which is sound only if the cache metadata says the sequence
+        # really is split sp*tp ways. A cache still declaring the legacy kv-head-on-TP layout reports tp
+        # fewer stripes and would silently under-gather.
+        assert self._declared_seq_shard_factor(storage) == stripes, (
+            f"TP-deduped KVPE cache declares {self._declared_seq_shard_factor(storage)} dim-2 stripes, "
+            f"expected sp*tp = {stripes}"
+        )
         gathered = ttnn.experimental.high_bw_all_gather(
             storage,
             dim=2,
@@ -2184,86 +2086,6 @@ class ttMLA:
             cluster_axis=None,
             **slot_meta_kwargs,
             **extent_kwargs,
-        )
-        return MlaKvCache(
-            format=kvpe_cache.format,
-            storage=gathered,
-            geometry=kvpe_cache.geometry,
-        )
-
-    def _gather_kvpe_prefix_tp_sharded_high_bw(
-        self,
-        kvpe_cache: MlaKvCache,
-        cache_batch_idx,
-        populated_global: int,
-        *,
-        block_cyclic_chunk_local: int,
-        metadata=None,
-    ) -> MlaKvCache:
-        """_gather_kvpe_prefix for an SP*TP-DEDUPED cache when the snake cannot run: two axis gathers.
-
-        TP-inner then SP-outer, which lands chip (s,t) at (s*tp + t)*seq_local -- the same linear
-        chip-major buffer the snake produces. Reads the ND cache directly and slot-selects in-op, so
-        no copy, no slice and no transient allocation; the result is the persistent scratch.
-
-        What it costs: high_bw_all_gather writes rank r at its FIXED worst-case slot r*seq_local and
-        gathered_dim_size only bounds each rank's front, so stage 1's valid rows come out strided by
-        seq_local and stage 2 has to reach the LAST TP slot -- (tp-1)*seq_local + prefix_dev rows per
-        SP rank instead of the prefix_dev*tp a compacting gather would move."""
-        storage = kvpe_cache.storage
-        slot_lo = cache_batch_idx if storage.shape[0] > 1 else 0
-        multi_slot = storage.shape[0] > 1
-        assert self._sparse_kv_gather_buffer is not None
-        seq_local = storage.shape[2]  # per-DEVICE cache depth
-        cl_dev = block_cyclic_chunk_local // self.tp_factor  # per-DEVICE slab width
-        num_slabs = -(-populated_global // (block_cyclic_chunk_local * self.sp_factor))  # ceil-div
-        prefix_dev = min(num_slabs * cl_dev, seq_local)
-        assert prefix_dev > 0
-
-        # At sp == 1 the TP stripes ARE every stripe, so one gather fills the scratch and there is no
-        # SP stage. This is the QuietBox (1, 4) shape, where the snake has no second axis to ride.
-        tp_stage_out = self._sparse_kv_gather_buffer if self.sp_factor == 1 else self._kvpe_tp_stage_buffer
-        assert tp_stage_out is not None
-        # Stage 1 (TP-inner): ND cache -> [1, 1, seq_local*tp, row_width], rank t at t*seq_local.
-        # Trace-safe form. Stage 2's extent reaches past the LAST TP slot, which is not the "round the
-        # populated prefix up to whole slabs" closed form gathered_prefix_tensor derives -- but it does not
-        # need one: pinning BOTH extents to the full buffer makes them chunk-INVARIANT, and a constant is
-        # safe to bake into a captured program. It moves more bytes than the prefix-bounded form on this
-        # fallback path; correctness first, and only where the snake cannot close its ring. The SLOT is
-        # per-(user, layer) and genuinely varies, so it still has to come from the tensor.
-        stage1_extent = seq_local * self.tp_factor if metadata is not None else prefix_dev * self.tp_factor
-        stage1_slot_kwargs = (
-            {
-                "input_batch_index_tensor": metadata[0],
-                "batch_slot_num_layers": self.layer_num,
-                "batch_slot_layer_idx": cache_batch_idx % self.layer_num,
-            }
-            if metadata is not None and multi_slot
-            else {"input_batch_index": slot_lo}
-        )
-        tp_stage = ttnn.experimental.high_bw_all_gather(
-            storage,
-            dim=2,
-            output_tensor=tp_stage_out,
-            num_links=self.ccl_num_links,
-            cluster_axis=self.tp_axis,
-            gathered_dim_size=stage1_extent,
-            **stage1_slot_kwargs,
-        )
-        if self.sp_factor == 1:
-            return MlaKvCache(format=kvpe_cache.format, storage=tp_stage, geometry=kvpe_cache.geometry)
-        # Stage 2 (SP-outer): reach past the last TP slot, since stage 1 did not compact.
-        # Stage 2 carries no slot (its input is the batch-1 stage-1 output), so only the extent matters.
-        sp_rank_extent = (
-            seq_local * self.tp_factor if metadata is not None else (self.tp_factor - 1) * seq_local + prefix_dev
-        )
-        gathered = ttnn.experimental.high_bw_all_gather(
-            tp_stage,
-            dim=2,
-            output_tensor=self._sparse_kv_gather_buffer,
-            num_links=self.ccl_num_links,
-            cluster_axis=self.sp_axis,
-            gathered_dim_size=sp_rank_extent * self.sp_factor,
         )
         return MlaKvCache(
             format=kvpe_cache.format,

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1914,11 +1914,7 @@ class ttMLA:
 
         if self._kv_dedup:
             # GLM-5.2 KV dedup: the cache is dim-2 sharded across BOTH mesh axes, and row-major over the
-            # mesh IS the sp*tp linearization, so ONE full-mesh gather rebuilds the slab in the order the
-            # old TP-inner -> SP-outer route produced. The op linearizes every mesh: a cycle where one
-            # exists (comb, so no torus needed) and an open path otherwise, which on the 1xN shape this
-            # path can take is the axis line itself. There is no geometry left for a second route to
-            # cover, so there is no second route -- see the asserts in _gather_kvpe_prefix_full_mesh.
+            # mesh IS the sp*tp linearization, so one full-mesh gather rebuilds the slab in that exact order.
             return self._gather_kvpe_prefix_full_mesh(
                 kvpe_cache,
                 cache_batch_idx,
@@ -2067,13 +2063,10 @@ class ttMLA:
             else {"input_batch_index": slot_lo}
         )
         assert self._sparse_kv_gather_buffer is not None
-        # These used to select between two gather routes; with one route they are invariants, so state
-        # them loudly here instead of silently rerouting when they do not hold.
+        # Preconditions of the full-mesh gather -- wrong here means a silently misordered gather.
         # Row-major over the mesh equals the sp*tp linearization only for this axis assignment.
         assert self.sp_axis == 0 and self.tp_axis == 1, "full-mesh KVPE gather assumes sp_axis=0, tp_axis=1"
-        # The op gathers across every device, which is sound only if the cache metadata says the sequence
-        # really is split sp*tp ways. A cache still declaring the legacy kv-head-on-TP layout reports tp
-        # fewer stripes and would silently under-gather.
+        # A cache still declaring the legacy kv-head-on-TP layout reports too few stripes and would under-gather.
         assert self._declared_seq_shard_factor(storage) == stripes, (
             f"TP-deduped KVPE cache declares {self._declared_seq_shard_factor(storage)} dim-2 stripes, "
             f"expected sp*tp = {stripes}"

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -2071,6 +2071,15 @@ class ttMLA:
             f"TP-deduped KVPE cache declares {self._declared_seq_shard_factor(storage)} dim-2 stripes, "
             f"expected sp*tp = {stripes}"
         )
+        # One snake across both mesh axes, so only Fabric2D can route it. FABRIC_1D reaches the op and
+        # fails its generic neighbor proof instead, which names the symptom rather than this cause.
+        fabric = ttnn.get_fabric_config()
+        assert fabric in (
+            ttnn.FabricConfig.FABRIC_2D,
+            ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+            ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        ), f"full-mesh KVPE gather requires a 2D fabric config, got {fabric}"
         gathered = ttnn.experimental.high_bw_all_gather(
             storage,
             dim=2,

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -1260,7 +1260,7 @@
       export OMP_NUM_THREADS=$(nproc)
       rc=0
       python3 -m pytest tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py::test_high_bw_all_gather_galaxy_ci_perf -q || rc=1
-      python3 -m pytest tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py::test_high_bw_all_gather_galaxy_8x4_whole_mesh_ring_accuracy -q || rc=1
+      python3 -m pytest tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py::test_high_bw_all_gather_galaxy_8x4_whole_mesh_accuracy -q || rc=1
       python3 -m pytest tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py::test_high_bw_all_gather_galaxy_full_mesh_matched_local_perf -q || rc=1
       python3 -m pytest tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py::test_high_bw_all_gather_galaxy_full_mesh_ci_perf -q || rc=1
       python3 -m pytest tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py::test_high_bw_all_gather_galaxy_ci_perf_traced -q || rc=1

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
@@ -53,6 +53,39 @@ void check_snake_ring_bijection(uint32_t rows, uint32_t cols, ttnn::ccl::snake_r
     EXPECT_TRUE(std::all_of(seen_tensor_ranks.begin(), seen_tensor_ranks.end(), [](bool seen) { return seen; }));
 }
 
+// An open Hamiltonian path: same bijection and same nearest-neighbour steps, but the
+// last rank is NOT required to reach the first. Every mesh of two or more devices has
+// one, so this is what a mesh with no closable cycle falls back to.
+void check_snake_ring_open_path(uint32_t rows, uint32_t cols, ttnn::ccl::snake_ring::Orientation orientation) {
+    const uint32_t ring_size = rows * cols;
+    std::vector<bool> seen_tensor_ranks(ring_size, false);
+    for (uint32_t transport_rank = 0; transport_rank < ring_size; ++transport_rank) {
+        const uint32_t row = ttnn::ccl::snake_ring::coordinate_row(transport_rank, rows, cols, orientation);
+        const uint32_t col = ttnn::ccl::snake_ring::coordinate_col(transport_rank, rows, cols, orientation);
+        ASSERT_LT(row, rows);
+        ASSERT_LT(col, cols);
+        EXPECT_EQ(ttnn::ccl::snake_ring::index_from_coordinate(row, col, rows, cols, orientation), transport_rank);
+
+        const uint32_t tensor_rank = ttnn::ccl::snake_ring::row_major_index(transport_rank, rows, cols, orientation);
+        EXPECT_EQ(tensor_rank, row * cols + col);
+        ASSERT_LT(tensor_rank, ring_size);
+        EXPECT_FALSE(seen_tensor_ranks[tensor_rank]);
+        seen_tensor_ranks[tensor_rank] = true;
+
+        if (transport_rank + 1 < ring_size) {
+            const uint32_t next_rank = transport_rank + 1;
+            const uint32_t next_row = ttnn::ccl::snake_ring::coordinate_row(next_rank, rows, cols, orientation);
+            const uint32_t next_col = ttnn::ccl::snake_ring::coordinate_col(next_rank, rows, cols, orientation);
+            const uint32_t row_delta = row > next_row ? row - next_row : next_row - row;
+            const uint32_t col_delta = col > next_col ? col - next_col : next_col - col;
+            EXPECT_EQ(row_delta + col_delta, 1u)
+                << "orientation " << static_cast<uint32_t>(orientation) << " on " << rows << "x" << cols << " step "
+                << transport_rank << " -> " << next_rank << " is not a nearest neighbour";
+        }
+    }
+    EXPECT_TRUE(std::all_of(seen_tensor_ranks.begin(), seen_tensor_ranks.end(), [](bool seen) { return seen; }));
+}
+
 }  // namespace
 
 TEST(CclHelpers, SnakeRingMappingsAreBijectionsWithRowMajorTensorRanks) {
@@ -60,6 +93,38 @@ TEST(CclHelpers, SnakeRingMappingsAreBijectionsWithRowMajorTensorRanks) {
     for (const auto& shape : mesh_shapes) {
         check_snake_ring_bijection(shape[0], shape[1], ttnn::ccl::snake_ring::Orientation::Row);
         check_snake_ring_bijection(shape[0], shape[1], ttnn::ccl::snake_ring::Orientation::Column);
+    }
+}
+
+TEST(CclHelpers, BoustrophedonOpenPathCoversEveryMeshIncludingThoseWithNoCycle) {
+    // A grid has a Hamiltonian cycle only when both extents are >= 2 and their product is
+    // even; a 1-wide grid has one only if its axis wrap is wired. None of these shapes is
+    // guaranteed a cycle, yet all have a path -- which is what makes the path universal.
+    // 8x4 is included to show the path is available there too, which is what a plain
+    // (non-torus) 2D fabric falls back to.
+    constexpr std::array<std::array<uint32_t, 2>, 7> mesh_shapes{
+        {{1, 8}, {8, 1}, {1, 2}, {3, 3}, {5, 5}, {3, 5}, {8, 4}}};
+    for (const auto& shape : mesh_shapes) {
+        check_snake_ring_open_path(shape[0], shape[1], ttnn::ccl::snake_ring::Orientation::Row);
+        check_snake_ring_open_path(shape[0], shape[1], ttnn::ccl::snake_ring::Orientation::Column);
+    }
+}
+
+TEST(CclHelpers, OpenPathOnAOneWideMeshIsExactlyTheAxisLine) {
+    // A 1xN full-mesh linearization must reproduce the axis order device for device,
+    // otherwise routing a 1xN mesh through the full-mesh path would reorder the gather.
+    for (uint32_t transport_rank = 0; transport_rank < 8; ++transport_rank) {
+        EXPECT_EQ(
+            ttnn::ccl::snake_ring::coordinate_row(transport_rank, 1, 8, ttnn::ccl::snake_ring::Orientation::Row), 0u);
+        EXPECT_EQ(
+            ttnn::ccl::snake_ring::coordinate_col(transport_rank, 1, 8, ttnn::ccl::snake_ring::Orientation::Row),
+            transport_rank);
+        EXPECT_EQ(
+            ttnn::ccl::snake_ring::row_major_index(transport_rank, 1, 8, ttnn::ccl::snake_ring::Orientation::Row),
+            transport_rank);
+        EXPECT_EQ(
+            ttnn::ccl::snake_ring::row_major_index(transport_rank, 8, 1, ttnn::ccl::snake_ring::Orientation::Row),
+            transport_rank);
     }
 }
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
@@ -53,9 +53,7 @@ void check_snake_ring_bijection(uint32_t rows, uint32_t cols, ttnn::ccl::snake_r
     EXPECT_TRUE(std::all_of(seen_tensor_ranks.begin(), seen_tensor_ranks.end(), [](bool seen) { return seen; }));
 }
 
-// An open Hamiltonian path: same bijection and same nearest-neighbour steps, but the
-// last rank is NOT required to reach the first. Every mesh of two or more devices has
-// one, so this is what a mesh with no closable cycle falls back to.
+// Open path: same order and same neighbor steps, but the last rank need not reach the first.
 void check_snake_ring_open_path(uint32_t rows, uint32_t cols, ttnn::ccl::snake_ring::Orientation orientation) {
     const uint32_t ring_size = rows * cols;
     std::vector<bool> seen_tensor_ranks(ring_size, false);
@@ -80,7 +78,7 @@ void check_snake_ring_open_path(uint32_t rows, uint32_t cols, ttnn::ccl::snake_r
             const uint32_t col_delta = col > next_col ? col - next_col : next_col - col;
             EXPECT_EQ(row_delta + col_delta, 1u)
                 << "orientation " << static_cast<uint32_t>(orientation) << " on " << rows << "x" << cols << " step "
-                << transport_rank << " -> " << next_rank << " is not a nearest neighbour";
+                << transport_rank << " -> " << next_rank << " is not a nearest neighbor";
         }
     }
     EXPECT_TRUE(std::all_of(seen_tensor_ranks.begin(), seen_tensor_ranks.end(), [](bool seen) { return seen; }));
@@ -97,11 +95,8 @@ TEST(CclHelpers, SnakeRingMappingsAreBijectionsWithRowMajorTensorRanks) {
 }
 
 TEST(CclHelpers, BoustrophedonOpenPathCoversEveryMeshIncludingThoseWithNoCycle) {
-    // A grid has a Hamiltonian cycle only when both extents are >= 2 and their product is
-    // even; a 1-wide grid has one only if its axis wrap is wired. None of these shapes is
-    // guaranteed a cycle, yet all have a path -- which is what makes the path universal.
-    // 8x4 is included to show the path is available there too, which is what a plain
-    // (non-torus) 2D fabric falls back to.
+    // None of these shapes is guaranteed a cycle, but every one of them has a path.
+    // 8x4 included because that is what a plain (non-torus) 2D fabric falls back to.
     constexpr std::array<std::array<uint32_t, 2>, 7> mesh_shapes{
         {{1, 8}, {8, 1}, {1, 2}, {3, 3}, {5, 5}, {3, 5}, {8, 4}}};
     for (const auto& shape : mesh_shapes) {
@@ -111,8 +106,7 @@ TEST(CclHelpers, BoustrophedonOpenPathCoversEveryMeshIncludingThoseWithNoCycle) 
 }
 
 TEST(CclHelpers, OpenPathOnAOneWideMeshIsExactlyTheAxisLine) {
-    // A 1xN full-mesh linearization must reproduce the axis order device for device,
-    // otherwise routing a 1xN mesh through the full-mesh path would reorder the gather.
+    // A 1xN full-mesh route must match the axis order device for device, or the gather is reordered.
     for (uint32_t transport_rank = 0; transport_rank < 8; ++transport_rank) {
         EXPECT_EQ(
             ttnn::ccl::snake_ring::coordinate_row(transport_rank, 1, 8, ttnn::ccl::snake_ring::Orientation::Row), 0u);

--- a/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
@@ -84,10 +84,7 @@ _FABRIC_2D_TORUS_XY_DEVICE_PARAMS = pytest.param(
     id="fabric_2d_torus_xy",
 )
 
-# A full-mesh linearization resolves on either fabric, but not as the same thing: the
-# torus closes a snake ring over its wrap link, the plain line can only walk an open
-# Hamiltonian path. Both must produce the same gathered tensor, so accuracy runs over
-# both; perf is gated separately because the path costs N-1 hops against a ring's N/2.
+# Both fabrics must gather identically so accuracy covers both; perf stays torus-only, the path costs N-1 hops vs N/2.
 _FULL_MESH_DEVICE_PARAMS = [
     _FABRIC_2D_TORUS_XY_DEVICE_PARAMS,
     _FABRIC_2D_LINE_DEVICE_PARAMS,

--- a/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
@@ -84,6 +84,15 @@ _FABRIC_2D_TORUS_XY_DEVICE_PARAMS = pytest.param(
     id="fabric_2d_torus_xy",
 )
 
+# A full-mesh linearization resolves on either fabric, but not as the same thing: the
+# torus closes a snake ring over its wrap link, the plain line can only walk an open
+# Hamiltonian path. Both must produce the same gathered tensor, so accuracy runs over
+# both; perf is gated separately because the path costs N-1 hops against a ring's N/2.
+_FULL_MESH_DEVICE_PARAMS = [
+    _FABRIC_2D_TORUS_XY_DEVICE_PARAMS,
+    _FABRIC_2D_LINE_DEVICE_PARAMS,
+]
+
 _SELECTED_BATCH_PREFIX_DEVICE_PARAMS = [
     _FABRIC_2D_LINE_DEVICE_PARAMS,
     pytest.param(_device_params(ttnn.FabricConfig.FABRIC_1D_RING), id="fabric_1d_ring"),
@@ -1092,7 +1101,7 @@ def test_high_bw_all_gather_galaxy_full_mesh_matched_local_perf(mesh_device):
     not os.getenv("TT_METAL_SIMULATOR") and os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_RUN_32_RANK_ACCURACY") != "1",
     reason="run on the Blackhole simulator or set TT_METAL_HIGH_BW_ALL_GATHER_RUN_32_RANK_ACCURACY=1",
 )
-@pytest.mark.parametrize("device_params", [_FABRIC_2D_TORUS_XY_DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("device_params", _FULL_MESH_DEVICE_PARAMS, indirect=True)
 @pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
 def test_high_bw_all_gather_galaxy_8x4_whole_mesh_ring_accuracy(mesh_device):
     """Gather exactly across a 32-rank snake ring while Galaxy remains an 8x4 mesh."""
@@ -1144,6 +1153,39 @@ def test_high_bw_all_gather_quietbox_2x2_whole_mesh_ring_accuracy(mesh_device):
         cluster_axis=None,
         rows_per_device=4,
         num_links=2,
+    )
+
+
+@run_for_blackhole("full-mesh open-path coverage requires Blackhole")
+@pytest.mark.skipif(
+    os.getenv("MESH_DEVICE") != "TG",
+    reason="full-mesh open-path coverage requires MESH_DEVICE=TG",
+)
+@pytest.mark.parametrize("device_params", _FULL_MESH_DEVICE_PARAMS, indirect=True)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize("submesh_shape", [(8, 1), (1, 4), (1, 2)], ids=["8x1", "1x4", "1x2"])
+def test_high_bw_all_gather_full_mesh_open_path_accuracy(mesh_device, submesh_shape):
+    """cluster_axis=None on a submesh that is one device wide.
+
+    A 1-wide grid has no snake cycle unless its axis wrap is wired, so on a plain 2D
+    fabric these resolve as an open Hamiltonian path -- the tier that exists so no mesh
+    is left without a full-mesh route. The gathered result must match the ring's byte for
+    byte: the transport-to-tensor mapping is the same row-major linearization either way,
+    only the closing edge differs. On a torus the same shapes close their ring instead
+    (1x2 excepted, where a two-device ring is degenerate), which is why both fabrics run.
+    """
+    assert tuple(mesh_device.shape) == (8, 4)
+    submesh = mesh_device.create_submesh(ttnn.MeshShape(*submesh_shape))
+    assert tuple(submesh.shape) == submesh_shape
+    _run_high_bw_all_gather_accuracy(
+        submesh,
+        ttnn.bfloat16,
+        width=576,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        expected_page_size=1152,
+        cluster_axis=None,
+        rows_per_device=4,
+        num_links=1,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
@@ -1100,8 +1100,9 @@ def test_high_bw_all_gather_galaxy_full_mesh_matched_local_perf(mesh_device):
 )
 @pytest.mark.parametrize("device_params", _FULL_MESH_DEVICE_PARAMS, indirect=True)
 @pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
-def test_high_bw_all_gather_galaxy_8x4_whole_mesh_ring_accuracy(mesh_device):
-    """Gather exactly across a 32-rank snake ring while Galaxy remains an 8x4 mesh."""
+def test_high_bw_all_gather_galaxy_8x4_whole_mesh_accuracy(mesh_device):
+    """Gather across all 32 ranks as one snake -- a ring on a torus, an open path on a plain 2D
+    fabric -- while Galaxy remains an 8x4 mesh."""
     assert tuple(mesh_device.shape) == (8, 4)
     _run_high_bw_all_gather_accuracy(
         mesh_device,

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.cpp
@@ -112,7 +112,10 @@ std::optional<uint64_t> resolve_direct_neighbor_route_hash(
         return std::nullopt;
     }
 
-    const bool is_ring = full_mesh || topology == tt::tt_fabric::Topology::Ring;
+    // Topology decides closure for BOTH the axis and full-mesh cases: a full-mesh
+    // caller passes Ring for a cycle candidate and Linear for an open path, and an
+    // open path legitimately has no wrap edge to prove.
+    const bool is_ring = topology == tt::tt_fabric::Topology::Ring;
     auto hash =
         ttsl::hash::hash_objects_with_default_seed(cluster_axis, full_mesh, orientation, num_links, shape, topology);
     const uint32_t group_count = full_mesh ? 1 : shape[1 - *cluster_axis];
@@ -200,7 +203,8 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
     uint32_t num_links,
     const std::array<tt::tt_fabric::Topology, 2>& axis_topology,
     bool log_rejection,
-    std::string_view operation_name) {
+    std::string_view operation_name,
+    bool allow_open_path) {
     auto* mesh_device = tensor.device();
     if (mesh_device == nullptr || num_links == 0) {
         return std::nullopt;
@@ -251,7 +255,14 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
             .route_plan_hash = ttsl::hash::hash_objects(*route_hash, fabric_config, axis_topology)};
     }
 
-    if (shape[0] < 2 || shape[1] < 2 || (shape[0] % 2 != 0 && shape[1] % 2 != 0)) {
+    // A snake CYCLE needs an even lane count somewhere and more than two devices (a
+    // two-device "ring" is a degenerate double edge the op rejects). 1xN is not excluded:
+    // its boustrophedon degenerates to a straight line whose closing edge is the axis
+    // wrap, so it closes on a torus exactly as the axis ring does, and the edge proof is
+    // what decides. An open PATH needs only two devices, so it covers everything else.
+    const bool cycle_possible = shape.mesh_size() > 2 && (shape[0] % 2 == 0 || shape[1] % 2 == 0);
+    const bool path_possible = allow_open_path && shape.mesh_size() >= 2;
+    if (!cycle_possible && !path_possible) {
         if (log_rejection) {
             log_warning(
                 tt::LogOp,
@@ -273,39 +284,62 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
         }
         return std::nullopt;
     }
-    for (const auto orientation :
-         {ttnn::ccl::snake_ring::Orientation::Row, ttnn::ccl::snake_ring::Orientation::Column}) {
-        const uint32_t lane_count = orientation == ttnn::ccl::snake_ring::Orientation::Row ? shape[0] : shape[1];
-        if (lane_count % 2 != 0) {
-            continue;
+    const auto build = [&](ttnn::ccl::snake_ring::Orientation orientation,
+                           tt::tt_fabric::Topology plan_topology,
+                           uint64_t route_hash) {
+        return MeshRingPlan{
+            .cluster_axis = std::nullopt,
+            .full_mesh = true,
+            .orientation = orientation,
+            .mesh_rows = shape[0],
+            .mesh_cols = shape[1],
+            .ring_size = static_cast<uint32_t>(shape.mesh_size()),
+            .num_links = num_links,
+            .topology = plan_topology,
+            .fabric_config = fabric_config,
+            .axis_topology = axis_topology,
+            .route_plan_hash = ttsl::hash::hash_objects(route_hash, fabric_config, axis_topology)};
+    };
+
+    if (cycle_possible) {
+        for (const auto orientation :
+             {ttnn::ccl::snake_ring::Orientation::Row, ttnn::ccl::snake_ring::Orientation::Column}) {
+            const uint32_t lane_count = orientation == ttnn::ccl::snake_ring::Orientation::Row ? shape[0] : shape[1];
+            if (lane_count % 2 != 0) {
+                continue;
+            }
+            const auto route_hash = resolve_direct_neighbor_route_hash(
+                tensor, std::nullopt, num_links, tt::tt_fabric::Topology::Ring, orientation, false, operation_name);
+            if (route_hash.has_value()) {
+                return build(orientation, tt::tt_fabric::Topology::Ring, *route_hash);
+            }
         }
-        const uint32_t closing_axis = orientation == ttnn::ccl::snake_ring::Orientation::Row ? 0 : 1;
-        const auto route_hash = resolve_direct_neighbor_route_hash(
-            tensor, std::nullopt, num_links, axis_topology[closing_axis], orientation, false, operation_name);
-        if (route_hash.has_value()) {
-            return MeshRingPlan{
-                .cluster_axis = std::nullopt,
-                .full_mesh = true,
-                .orientation = orientation,
-                .mesh_rows = shape[0],
-                .mesh_cols = shape[1],
-                .ring_size = static_cast<uint32_t>(shape.mesh_size()),
-                .num_links = num_links,
-                .topology = tt::tt_fabric::Topology::Ring,
-                .fabric_config = fabric_config,
-                .axis_topology = axis_topology,
-                .route_plan_hash = ttsl::hash::hash_objects(*route_hash, fabric_config, axis_topology)};
+    }
+
+    // No cycle closed. The same boustrophedon walked as an open path has no wrap edge to
+    // prove and no parity precondition, so it resolves wherever the mesh is wired --
+    // including 1xN, where it degenerates to exactly the axis line.
+    if (path_possible) {
+        for (const auto orientation :
+             {ttnn::ccl::snake_ring::Orientation::Row, ttnn::ccl::snake_ring::Orientation::Column}) {
+            const auto route_hash = resolve_direct_neighbor_route_hash(
+                tensor, std::nullopt, num_links, tt::tt_fabric::Topology::Linear, orientation, false, operation_name);
+            if (route_hash.has_value()) {
+                return build(orientation, tt::tt_fabric::Topology::Linear, *route_hash);
+            }
         }
     }
 
     if (log_rejection) {
         // Repeat the deterministic fallback orientation with logging enabled
         // so the caller gets the exact edge/link that made the mesh ineligible.
+        // Report against the weakest candidate: an open path demands least, so an edge it
+        // cannot prove is the real obstacle.
         const auto fallback =
             shape[0] % 2 == 0 ? ttnn::ccl::snake_ring::Orientation::Row : ttnn::ccl::snake_ring::Orientation::Column;
-        const uint32_t closing_axis = fallback == ttnn::ccl::snake_ring::Orientation::Row ? 0 : 1;
+        const auto fallback_topology = path_possible ? tt::tt_fabric::Topology::Linear : tt::tt_fabric::Topology::Ring;
         (void)resolve_direct_neighbor_route_hash(
-            tensor, std::nullopt, num_links, axis_topology[closing_axis], fallback, true, operation_name);
+            tensor, std::nullopt, num_links, fallback_topology, fallback, true, operation_name);
     }
     return std::nullopt;
 }
@@ -331,13 +365,24 @@ MeshRingPosition get_mesh_ring_position(
         const tt::tt_metal::distributed::MeshShape plan_shape(plan.mesh_rows, plan.mesh_cols);
         const uint32_t transport_rank = ttnn::ccl::snake_ring::index_from_coordinate(
             coordinate[0], coordinate[1], plan.mesh_rows, plan.mesh_cols, plan.orientation);
+        // On an open path the two ends are dead in one direction each; the schedule reads
+        // that off a missing neighbour exactly as it does for an axis line.
+        const bool closed = plan.topology == tt::tt_fabric::Topology::Ring;
+        std::optional<ttnn::MeshCoordinate> forward_coord;
+        std::optional<ttnn::MeshCoordinate> backward_coord;
+        if (closed || transport_rank + 1 < plan.ring_size) {
+            forward_coord = snake_ring_coordinate((transport_rank + 1) % plan.ring_size, plan_shape, plan.orientation);
+        }
+        if (closed || transport_rank > 0) {
+            backward_coord = snake_ring_coordinate(
+                (transport_rank + plan.ring_size - 1) % plan.ring_size, plan_shape, plan.orientation);
+        }
         return MeshRingPosition{
             .transport_rank = transport_rank,
             .tensor_rank = ttnn::ccl::snake_ring::row_major_index(
                 transport_rank, plan.mesh_rows, plan.mesh_cols, plan.orientation),
-            .forward_coord = snake_ring_coordinate((transport_rank + 1) % plan.ring_size, plan_shape, plan.orientation),
-            .backward_coord = snake_ring_coordinate(
-                (transport_rank + plan.ring_size - 1) % plan.ring_size, plan_shape, plan.orientation)};
+            .forward_coord = forward_coord,
+            .backward_coord = backward_coord};
     }
 
     TT_FATAL(plan.cluster_axis.has_value(), "axis mesh-ring plan is missing cluster_axis");

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.cpp
@@ -112,9 +112,7 @@ std::optional<uint64_t> resolve_direct_neighbor_route_hash(
         return std::nullopt;
     }
 
-    // Topology decides closure for BOTH the axis and full-mesh cases: a full-mesh
-    // caller passes Ring for a cycle candidate and Linear for an open path, and an
-    // open path legitimately has no wrap edge to prove.
+    // The caller picks closure: Ring to prove a wrap edge, Linear for an open path that has none.
     const bool is_ring = topology == tt::tt_fabric::Topology::Ring;
     auto hash =
         ttsl::hash::hash_objects_with_default_seed(cluster_axis, full_mesh, orientation, num_links, shape, topology);
@@ -255,11 +253,7 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
             .route_plan_hash = ttsl::hash::hash_objects(*route_hash, fabric_config, axis_topology)};
     }
 
-    // A snake CYCLE needs an even lane count somewhere and more than two devices (a
-    // two-device "ring" is a degenerate double edge the op rejects). 1xN is not excluded:
-    // its boustrophedon degenerates to a straight line whose closing edge is the axis
-    // wrap, so it closes on a torus exactly as the axis ring does, and the edge proof is
-    // what decides. An open PATH needs only two devices, so it covers everything else.
+    // A cycle needs an even lane count and >2 devices; 1xN can still close on a torus, so the edge proof decides.
     const bool cycle_possible = shape.mesh_size() > 2 && (shape[0] % 2 == 0 || shape[1] % 2 == 0);
     const bool path_possible = allow_open_path && shape.mesh_size() >= 2;
     if (!cycle_possible && !path_possible) {
@@ -316,9 +310,7 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
         }
     }
 
-    // No cycle closed. The same boustrophedon walked as an open path has no wrap edge to
-    // prove and no parity precondition, so it resolves wherever the mesh is wired --
-    // including 1xN, where it degenerates to exactly the axis line.
+    // No cycle closed. The same walk as an open path has no wrap edge to prove, so it resolves on any wired mesh.
     if (path_possible) {
         for (const auto orientation :
              {ttnn::ccl::snake_ring::Orientation::Row, ttnn::ccl::snake_ring::Orientation::Column}) {
@@ -333,8 +325,7 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
     if (log_rejection) {
         // Repeat the deterministic fallback orientation with logging enabled
         // so the caller gets the exact edge/link that made the mesh ineligible.
-        // Report against the weakest candidate: an open path demands least, so an edge it
-        // cannot prove is the real obstacle.
+        // Log against the weakest candidate -- an edge the open path cannot prove is the real obstacle.
         const auto fallback =
             shape[0] % 2 == 0 ? ttnn::ccl::snake_ring::Orientation::Row : ttnn::ccl::snake_ring::Orientation::Column;
         const auto fallback_topology = path_possible ? tt::tt_fabric::Topology::Linear : tt::tt_fabric::Topology::Ring;
@@ -365,8 +356,7 @@ MeshRingPosition get_mesh_ring_position(
         const tt::tt_metal::distributed::MeshShape plan_shape(plan.mesh_rows, plan.mesh_cols);
         const uint32_t transport_rank = ttnn::ccl::snake_ring::index_from_coordinate(
             coordinate[0], coordinate[1], plan.mesh_rows, plan.mesh_cols, plan.orientation);
-        // On an open path the two ends are dead in one direction each; the schedule reads
-        // that off a missing neighbour exactly as it does for an axis line.
+        // Open path: the end ranks have no neighbor one way, which is how an axis line signals a dead direction.
         const bool closed = plan.topology == tt::tt_fabric::Topology::Ring;
         std::optional<ttnn::MeshCoordinate> forward_coord;
         std::optional<ttnn::MeshCoordinate> backward_coord;

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.cpp
@@ -195,7 +195,7 @@ std::optional<uint64_t> resolve_direct_neighbor_route_hash(
     return hash;
 }
 
-std::optional<MeshRingPlan> resolve_mesh_ring_plan(
+std::optional<ResolvedMeshRoute> resolve_mesh_ring_plan(
     const ttnn::Tensor& tensor,
     std::optional<uint32_t> cluster_axis,
     uint32_t num_links,
@@ -239,18 +239,17 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
         if (!route_hash.has_value()) {
             return std::nullopt;
         }
-        return MeshRingPlan{
-            .cluster_axis = cluster_axis,
-            .full_mesh = false,
-            .orientation = ttnn::ccl::snake_ring::Orientation::Row,
-            .mesh_rows = shape[0],
-            .mesh_cols = shape[1],
-            .ring_size = shape[*cluster_axis],
-            .num_links = num_links,
-            .topology = topology,
-            .fabric_config = fabric_config,
-            .axis_topology = axis_topology,
-            .route_plan_hash = ttsl::hash::hash_objects(*route_hash, fabric_config, axis_topology)};
+        return ResolvedMeshRoute{
+            .plan =
+                MeshRingPlan{
+                    .cluster_axis = cluster_axis,
+                    .full_mesh = false,
+                    .orientation = ttnn::ccl::snake_ring::Orientation::Row,
+                    .mesh_rows = shape[0],
+                    .mesh_cols = shape[1],
+                    .ring_size = shape[*cluster_axis],
+                    .route_plan_hash = ttsl::hash::hash_objects(*route_hash, fabric_config, axis_topology)},
+            .topology = topology};
     }
 
     // A cycle needs an even lane count and >2 devices; 1xN can still close on a torus, so the edge proof decides.
@@ -279,20 +278,19 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
         return std::nullopt;
     }
     const auto build = [&](ttnn::ccl::snake_ring::Orientation orientation,
-                           tt::tt_fabric::Topology plan_topology,
+                           tt::tt_fabric::Topology route_topology,
                            uint64_t route_hash) {
-        return MeshRingPlan{
-            .cluster_axis = std::nullopt,
-            .full_mesh = true,
-            .orientation = orientation,
-            .mesh_rows = shape[0],
-            .mesh_cols = shape[1],
-            .ring_size = static_cast<uint32_t>(shape.mesh_size()),
-            .num_links = num_links,
-            .topology = plan_topology,
-            .fabric_config = fabric_config,
-            .axis_topology = axis_topology,
-            .route_plan_hash = ttsl::hash::hash_objects(route_hash, fabric_config, axis_topology)};
+        return ResolvedMeshRoute{
+            .plan =
+                MeshRingPlan{
+                    .cluster_axis = std::nullopt,
+                    .full_mesh = true,
+                    .orientation = orientation,
+                    .mesh_rows = shape[0],
+                    .mesh_cols = shape[1],
+                    .ring_size = static_cast<uint32_t>(shape.mesh_size()),
+                    .route_plan_hash = ttsl::hash::hash_objects(route_hash, fabric_config, axis_topology)},
+            .topology = route_topology};
     };
 
     if (cycle_possible) {
@@ -336,7 +334,10 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
 }
 
 MeshRingPosition get_mesh_ring_position(
-    const ttnn::Tensor& tensor, const ttnn::MeshCoordinate& coordinate, const MeshRingPlan& plan) {
+    const ttnn::Tensor& tensor,
+    const ttnn::MeshCoordinate& coordinate,
+    const MeshRingPlan& plan,
+    tt::tt_fabric::Topology topology) {
     if (plan.full_mesh) {
         TT_FATAL(
             tensor.device() != nullptr && tensor.device()->shape().dims() == 2 && coordinate.dims() == 2,
@@ -357,7 +358,7 @@ MeshRingPosition get_mesh_ring_position(
         const uint32_t transport_rank = ttnn::ccl::snake_ring::index_from_coordinate(
             coordinate[0], coordinate[1], plan.mesh_rows, plan.mesh_cols, plan.orientation);
         // Open path: the end ranks have no neighbor one way, which is how an axis line signals a dead direction.
-        const bool closed = plan.topology == tt::tt_fabric::Topology::Ring;
+        const bool closed = topology == tt::tt_fabric::Topology::Ring;
         std::optional<ttnn::MeshCoordinate> forward_coord;
         std::optional<ttnn::MeshCoordinate> backward_coord;
         if (closed || transport_rank + 1 < plan.ring_size) {
@@ -382,9 +383,9 @@ MeshRingPosition get_mesh_ring_position(
         .transport_rank = transport_rank,
         .tensor_rank = transport_rank,
         .forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-            tensor, coordinate, 1, plan.topology, plan.cluster_axis),
+            tensor, coordinate, 1, topology, plan.cluster_axis),
         .backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-            tensor, coordinate, -1, plan.topology, plan.cluster_axis)};
+            tensor, coordinate, -1, topology, plan.cluster_axis)};
 }
 
 }  // namespace ttnn::operations::ccl::common

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.hpp
@@ -28,12 +28,15 @@ struct MeshRingPlan {
     uint32_t mesh_rows = 0;
     uint32_t mesh_cols = 0;
     uint32_t ring_size = 0;
-    uint32_t num_links = 0;
-    tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Linear;
-    tt::tt_fabric::FabricConfig fabric_config = tt::tt_fabric::FabricConfig::DISABLED;
-    std::array<tt::tt_fabric::Topology, 2> axis_topology{
-        tt::tt_fabric::Topology::Linear, tt::tt_fabric::Topology::Linear};
     std::optional<uint64_t> route_plan_hash;
+};
+
+// What the edge proof concluded about the geometry in `plan`: Ring where the walk closed, Linear
+// where it only resolved as an open path. Deliberately not a field of the plan -- closure is what
+// decides whether the end ranks have a neighbor, so it is passed explicitly rather than defaulted.
+struct ResolvedMeshRoute {
+    MeshRingPlan plan;
+    tt::tt_fabric::Topology topology;
 };
 
 struct MeshRingPosition {
@@ -70,10 +73,13 @@ std::optional<uint64_t> resolve_direct_neighbor_route_hash(
 
 // Resolve an axis line/ring or select the first legal full-mesh snake. For a
 // full mesh, row orientation is preferred and column orientation is the
-// fallback; only orientations with an even lane count are candidates.
+// fallback. The two tiers select differently: a cycle candidate must also have
+// an even lane count in that orientation, because that is what lets the walk
+// return to rank 0, while an open path has no closing edge to place and so
+// tries both orientations.
 //
-// allow_open_path can return a plan whose end ranks lack a neighbor one way -- a schedule assuming a ring will hang.
-std::optional<MeshRingPlan> resolve_mesh_ring_plan(
+// allow_open_path can return a route whose end ranks lack a neighbor one way -- a schedule assuming a ring will hang.
+std::optional<ResolvedMeshRoute> resolve_mesh_ring_plan(
     const ttnn::Tensor& tensor,
     std::optional<uint32_t> cluster_axis,
     uint32_t num_links,
@@ -82,7 +88,12 @@ std::optional<MeshRingPlan> resolve_mesh_ring_plan(
     std::string_view operation_name = "mesh ring",
     bool allow_open_path = false);
 
+// topology is the route the caller's schedule assumes: Ring gives every rank both neighbors, Linear
+// leaves the two end ranks dead one way, as an axis line does.
 MeshRingPosition get_mesh_ring_position(
-    const ttnn::Tensor& tensor, const ttnn::MeshCoordinate& coordinate, const MeshRingPlan& plan);
+    const ttnn::Tensor& tensor,
+    const ttnn::MeshCoordinate& coordinate,
+    const MeshRingPlan& plan,
+    tt::tt_fabric::Topology topology);
 
 }  // namespace ttnn::operations::ccl::common

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.hpp
@@ -71,13 +71,25 @@ std::optional<uint64_t> resolve_direct_neighbor_route_hash(
 // Resolve an axis line/ring or select the first legal full-mesh snake. For a
 // full mesh, row orientation is preferred and column orientation is the
 // fallback; only orientations with an even lane count are candidates.
+//
+// A snake CYCLE closes across a whole axis, so it is a direct hop only on a
+// torus (or an extent-2 axis). When no cycle closes and `allow_open_path` is
+// set, the same boustrophedon is returned as an open Hamiltonian PATH with
+// Topology::Linear: no wrap edge to prove, no parity precondition, so it
+// resolves on any wired mesh of two or more devices, 1xN included.
+//
+// The path costs N-1 hops of latency against a ring's N/2, and it leaves rank 0
+// without a backward neighbor and rank N-1 without a forward one. Only callers
+// whose schedule handles dead endpoints may opt in -- an op that fuses a closed
+// ring must leave this false and keep getting nullopt where no cycle exists.
 std::optional<MeshRingPlan> resolve_mesh_ring_plan(
     const ttnn::Tensor& tensor,
     std::optional<uint32_t> cluster_axis,
     uint32_t num_links,
     const std::array<tt::tt_fabric::Topology, 2>& axis_topology,
     bool log_rejection = true,
-    std::string_view operation_name = "mesh ring");
+    std::string_view operation_name = "mesh ring",
+    bool allow_open_path = false);
 
 MeshRingPosition get_mesh_ring_position(
     const ttnn::Tensor& tensor, const ttnn::MeshCoordinate& coordinate, const MeshRingPlan& plan);

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/mesh_ring_plan.hpp
@@ -72,16 +72,7 @@ std::optional<uint64_t> resolve_direct_neighbor_route_hash(
 // full mesh, row orientation is preferred and column orientation is the
 // fallback; only orientations with an even lane count are candidates.
 //
-// A snake CYCLE closes across a whole axis, so it is a direct hop only on a
-// torus (or an extent-2 axis). When no cycle closes and `allow_open_path` is
-// set, the same boustrophedon is returned as an open Hamiltonian PATH with
-// Topology::Linear: no wrap edge to prove, no parity precondition, so it
-// resolves on any wired mesh of two or more devices, 1xN included.
-//
-// The path costs N-1 hops of latency against a ring's N/2, and it leaves rank 0
-// without a backward neighbor and rank N-1 without a forward one. Only callers
-// whose schedule handles dead endpoints may opt in -- an op that fuses a closed
-// ring must leave this false and keep getting nullopt where no cycle exists.
+// allow_open_path can return a plan whose end ranks lack a neighbor one way -- a schedule assuming a ring will hang.
 std::optional<MeshRingPlan> resolve_mesh_ring_plan(
     const ttnn::Tensor& tensor,
     std::optional<uint32_t> cluster_axis,

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
@@ -497,6 +497,13 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
         "high_bw_all_gather input and output tensors must be on the same mesh device");
 
     const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(fabric_config);
+    // A full mesh is gathered as one snake across both axes, which only a 2D fabric can route.
+    TT_FATAL(
+        !linearized_mesh_ring || fabric_is_2d,
+        "high_bw_all_gather cluster_axis=None requires a 2D fabric config (FABRIC_2D or "
+        "FABRIC_2D_TORUS_X/Y/XY), got {}",
+        fabric_config);
     // Axis 0 is N/S, and axis 1 is E/W.
     // An inactive axis has num_devices = 1, num_links = 0, Linear topology.
     std::array<tt::tt_fabric::Topology, 2> axis_topology{
@@ -535,7 +542,6 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
                                                       : axis_num_devices[0] * axis_num_devices[1];
     const size_t packet_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
     const bool one_active_axis = (axis_num_devices[0] > 1) != (axis_num_devices[1] > 1);
-    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(fabric_config);
     ttnn::ccl::snake_ring::Orientation snake_orientation = linearized_mesh_ring && mesh_shape[0] % 2 != 0
                                                                ? ttnn::ccl::snake_ring::Orientation::Column
                                                                : ttnn::ccl::snake_ring::Orientation::Row;
@@ -543,7 +549,7 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
     bool linearized_mesh_open_path = false;
     if (fabric_is_2d && (linearized_mesh_ring || one_active_axis)) {
         // Safe to opt in: this op's line schedule already handles dead endpoints for axis gathers.
-        const auto mesh_ring_plan = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
+        const auto mesh_route = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
             input_tensor,
             cluster_axis,
             collective_num_links,
@@ -551,11 +557,11 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
             true,
             "high_bw_all_gather",
             /*allow_open_path=*/linearized_mesh_ring);
-        if (mesh_ring_plan.has_value()) {
-            snake_orientation = mesh_ring_plan->orientation;
-            direct_neighbor_route_hash = mesh_ring_plan->route_plan_hash;
+        if (mesh_route.has_value()) {
+            snake_orientation = mesh_route->plan.orientation;
+            direct_neighbor_route_hash = mesh_route->plan.route_plan_hash;
             linearized_mesh_open_path =
-                linearized_mesh_ring && mesh_ring_plan->topology == tt::tt_fabric::Topology::Linear;
+                linearized_mesh_ring && mesh_route->topology == tt::tt_fabric::Topology::Linear;
         }
     }
     const uint32_t active_axis = cluster_axis.value_or(0);

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
@@ -225,14 +225,24 @@ void HighBwAllGatherDeviceOperation::validate_on_program_cache_miss(
     // participate when it has been linearized into one Hamiltonian ring.
     const auto mesh_shape = input_tensor.device()->shape();
     if (args.linearized_mesh_ring) {
-        const uint32_t snake_lane_count =
-            args.snake_ring_orientation == ttnn::ccl::snake_ring::Orientation::Row ? mesh_shape[0] : mesh_shape[1];
-        TT_FATAL(
-            mesh_shape[0] > 1 && mesh_shape[1] > 1 && snake_lane_count % 2 == 0,
-            "high_bw_all_gather full-mesh ring requires a 2D mesh whose selected snake orientation has an even "
-            "lane count; mesh={}, orientation={}",
-            mesh_shape,
-            static_cast<uint32_t>(args.snake_ring_orientation));
+        // Parity and both-extents-greater-than-one are what a CLOSED cycle needs; an open
+        // path has neither requirement, and a 1-wide mesh has a legitimate ring when its
+        // axis wrap is wired. The host edge proof is what established which one applies.
+        if (args.linearized_mesh_open_path) {
+            TT_FATAL(
+                mesh_shape.mesh_size() > 1,
+                "high_bw_all_gather full-mesh path requires at least two devices; mesh={}",
+                mesh_shape);
+        } else {
+            const uint32_t snake_lane_count =
+                args.snake_ring_orientation == ttnn::ccl::snake_ring::Orientation::Row ? mesh_shape[0] : mesh_shape[1];
+            TT_FATAL(
+                mesh_shape.mesh_size() > 2 && snake_lane_count % 2 == 0,
+                "high_bw_all_gather full-mesh ring requires more than two devices and a selected snake "
+                "orientation with an even lane count; mesh={}, orientation={}",
+                mesh_shape,
+                static_cast<uint32_t>(args.snake_ring_orientation));
+        }
         TT_FATAL(
             ttnn::operations::ccl::common::has_row_major_mesh_coordinates(input_tensor),
             "high_bw_all_gather full-mesh ring currently requires row-major tensor mesh coordinates");
@@ -478,9 +488,11 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
             *cluster_axis,
             mesh_shape);
     } else {
+        // Cycle or open path -- resolve_mesh_ring_plan decides which below. Both need more
+        // than one device; nothing stronger can be asserted before it has run.
         TT_FATAL(
-            mesh_shape[0] > 1 && mesh_shape[1] > 1 && (mesh_shape[0] % 2 == 0 || mesh_shape[1] % 2 == 0),
-            "high_bw_all_gather cluster_axis=None requires a 2D mesh with at least one even dimension, got {}",
+            mesh_shape.mesh_size() > 1,
+            "high_bw_all_gather cluster_axis=None requires a mesh with more than one device, got {}",
             mesh_shape);
     }
     TT_FATAL(
@@ -531,12 +543,23 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
                                                                ? ttnn::ccl::snake_ring::Orientation::Column
                                                                : ttnn::ccl::snake_ring::Orientation::Row;
     std::optional<uint64_t> direct_neighbor_route_hash;
+    bool linearized_mesh_open_path = false;
     if (fabric_is_2d && (linearized_mesh_ring || one_active_axis)) {
+        // This op's schedule already handles dead endpoints -- an axis line uses the same
+        // code -- so it opts in to an open-path linearization where no cycle closes.
         const auto mesh_ring_plan = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
-            input_tensor, cluster_axis, collective_num_links, axis_topology, true, "high_bw_all_gather");
+            input_tensor,
+            cluster_axis,
+            collective_num_links,
+            axis_topology,
+            true,
+            "high_bw_all_gather",
+            /*allow_open_path=*/linearized_mesh_ring);
         if (mesh_ring_plan.has_value()) {
             snake_orientation = mesh_ring_plan->orientation;
             direct_neighbor_route_hash = mesh_ring_plan->route_plan_hash;
+            linearized_mesh_open_path =
+                linearized_mesh_ring && mesh_ring_plan->topology == tt::tt_fabric::Topology::Linear;
         }
     }
     const uint32_t active_axis = cluster_axis.value_or(0);
@@ -573,6 +596,7 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
             .output_mem_config = output_tensor.memory_config(),
             .cluster_axis = cluster_axis.value_or(0),
             .linearized_mesh_ring = linearized_mesh_ring,
+            .linearized_mesh_open_path = linearized_mesh_open_path,
             .snake_ring_orientation = snake_orientation,
             .fabric_config = fabric_config,
             .axis_topology = axis_topology,

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
@@ -225,9 +225,7 @@ void HighBwAllGatherDeviceOperation::validate_on_program_cache_miss(
     // participate when it has been linearized into one Hamiltonian ring.
     const auto mesh_shape = input_tensor.device()->shape();
     if (args.linearized_mesh_ring) {
-        // Parity and both-extents-greater-than-one are what a CLOSED cycle needs; an open
-        // path has neither requirement, and a 1-wide mesh has a legitimate ring when its
-        // axis wrap is wired. The host edge proof is what established which one applies.
+        // Parity is a cycle requirement only; the resolver already chose the shape, so check against that.
         if (args.linearized_mesh_open_path) {
             TT_FATAL(
                 mesh_shape.mesh_size() > 1,
@@ -488,8 +486,7 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
             *cluster_axis,
             mesh_shape);
     } else {
-        // Cycle or open path -- resolve_mesh_ring_plan decides which below. Both need more
-        // than one device; nothing stronger can be asserted before it has run.
+        // The route is not resolved yet, so more than one device is all that can be asserted here.
         TT_FATAL(
             mesh_shape.mesh_size() > 1,
             "high_bw_all_gather cluster_axis=None requires a mesh with more than one device, got {}",
@@ -545,8 +542,7 @@ std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_buil
     std::optional<uint64_t> direct_neighbor_route_hash;
     bool linearized_mesh_open_path = false;
     if (fabric_is_2d && (linearized_mesh_ring || one_active_axis)) {
-        // This op's schedule already handles dead endpoints -- an axis line uses the same
-        // code -- so it opts in to an open-path linearization where no cycle closes.
+        // Safe to opt in: this op's line schedule already handles dead endpoints for axis gathers.
         const auto mesh_ring_plan = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
             input_tensor,
             cluster_axis,

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
@@ -27,6 +27,10 @@ struct HighBwAllGatherParams {
     // With no public cluster_axis, linearize the complete 2D mesh into a
     // direct-neighbor snake ring. cluster_axis is ignored in this mode.
     bool linearized_mesh_ring = false;
+    // The linearization is an open Hamiltonian path, not a closed ring: the mesh admits
+    // no cycle (1xN) or its wrap edge is not wired (a plain, non-torus 2D fabric). Rank 0
+    // and rank N-1 then run one direction each, exactly like an axis line.
+    bool linearized_mesh_open_path = false;
     ttnn::ccl::snake_ring::Orientation snake_ring_orientation = ttnn::ccl::snake_ring::Orientation::Row;
 
     // Fabric setup info

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
@@ -27,9 +27,7 @@ struct HighBwAllGatherParams {
     // With no public cluster_axis, linearize the complete 2D mesh into a
     // direct-neighbor snake ring. cluster_axis is ignored in this mode.
     bool linearized_mesh_ring = false;
-    // The linearization is an open Hamiltonian path, not a closed ring: the mesh admits
-    // no cycle (1xN) or its wrap edge is not wired (a plain, non-torus 2D fabric). Rank 0
-    // and rank N-1 then run one direction each, exactly like an axis line.
+    // Full mesh linearized as an open path, not a ring: no cycle, or the wrap edge is unwired. End ranks go one way.
     bool linearized_mesh_open_path = false;
     ttnn::ccl::snake_ring::Orientation snake_ring_orientation = ttnn::ccl::snake_ring::Orientation::Row;
 

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
@@ -345,8 +345,10 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
 
     const bool linearized_mesh_ring = operation_attributes.linearized_mesh_ring;
     const uint32_t axis = operation_attributes.cluster_axis;
-    const auto topology =
-        linearized_mesh_ring ? tt::tt_fabric::Topology::Ring : operation_attributes.axis_topology[axis];
+    const auto topology = linearized_mesh_ring
+                              ? (operation_attributes.linearized_mesh_open_path ? tt::tt_fabric::Topology::Linear
+                                                                                : tt::tt_fabric::Topology::Ring)
+                              : operation_attributes.axis_topology[axis];
     const bool is_ring = tt::tt_fabric::is_ring_or_torus(topology);
 
     const uint32_t num_devices = operation_attributes.num_devices;

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
@@ -374,13 +374,9 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         .mesh_rows = linearized_mesh_ring ? operation_attributes.mesh_rows : mesh_shape[0],
         .mesh_cols = linearized_mesh_ring ? operation_attributes.mesh_cols : mesh_shape[1],
         .ring_size = num_devices,
-        .num_links = operation_attributes.num_links,
-        .topology = topology,
-        .fabric_config = operation_attributes.fabric_config,
-        .axis_topology = operation_attributes.axis_topology,
         .route_plan_hash = operation_attributes.neighbor_route_plan_hash};
-    const auto mesh_ring_position =
-        ttnn::operations::ccl::common::get_mesh_ring_position(input_tensor, sender_device_coord, mesh_ring_plan);
+    const auto mesh_ring_position = ttnn::operations::ccl::common::get_mesh_ring_position(
+        input_tensor, sender_device_coord, mesh_ring_plan, topology);
     const uint32_t device_idx = mesh_ring_position.transport_rank;
     auto fwd_coord = mesh_ring_position.forward_coord;
     auto bwd_coord = mesh_ring_position.backward_coord;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -1229,21 +1229,27 @@ ttnn::Tensor ring_indexer_score_dsa(
             "ring_indexer_score_dsa cluster_axis=None requires the persistent gathered K buffer replicated "
             "across the complete mesh");
         const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+        // A full mesh is gathered as one snake across both axes, which only a 2D fabric can route.
+        TT_FATAL(
+            tt::tt_fabric::is_2d_fabric_config(fabric_config),
+            "ring_indexer_score_dsa cluster_axis=None requires a 2D fabric config (FABRIC_2D or "
+            "FABRIC_2D_TORUS_X/Y/XY), got {}",
+            fabric_config);
         const std::array<tt::tt_fabric::Topology, 2> axis_topology{
             ttnn::ccl::get_axis_topology(q, fabric_config, 0), ttnn::ccl::get_axis_topology(q, fabric_config, 1)};
-        const auto plan = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
+        const auto route = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
             q, std::nullopt, num_links, axis_topology, true, "ring_indexer_score_dsa");
-        TT_FATAL(plan.has_value(), "ring_indexer_score_dsa could not resolve a direct-neighbor full-mesh snake ring");
+        TT_FATAL(route.has_value(), "ring_indexer_score_dsa could not resolve a direct-neighbor full-mesh snake ring");
         TT_FATAL(
-            plan->ring_size <= ttnn::operations::experimental::indexer_score::kMaxRingSize,
+            route->plan.ring_size <= ttnn::operations::experimental::indexer_score::kMaxRingSize,
             "ring_indexer_score_dsa supports at most {} full-mesh ranks, got {}",
             ttnn::operations::experimental::indexer_score::kMaxRingSize,
-            plan->ring_size);
+            route->plan.ring_size);
         fused_ring.full_mesh = true;
-        fused_ring.snake_orientation = plan->orientation;
-        fused_ring.mesh_rows = plan->mesh_rows;
-        fused_ring.mesh_cols = plan->mesh_cols;
-        fused_ring.route_plan_hash = plan->route_plan_hash;
+        fused_ring.snake_orientation = route->plan.orientation;
+        fused_ring.mesh_rows = route->plan.mesh_rows;
+        fused_ring.mesh_cols = route->plan.mesh_cols;
+        fused_ring.route_plan_hash = route->plan.route_plan_hash;
     } else {
         TT_FATAL(
             *cluster_axis < mesh_shape.dims(),

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -682,11 +682,9 @@ ProgramDescriptor build_ring_program_descriptor(
             .mesh_rows = fused.mesh_rows,
             .mesh_cols = fused.mesh_cols,
             .ring_size = ring_size,
-            .num_links = fused.num_links,
-            // Load-bearing: get_mesh_ring_position reads closure off this, and the struct defaults to Linear.
-            .topology = fused.topology,
             .route_plan_hash = fused.route_plan_hash};
-        const auto position = ttnn::operations::ccl::common::get_mesh_ring_position(q, coord, mesh_ring_plan);
+        const auto position =
+            ttnn::operations::ccl::common::get_mesh_ring_position(q, coord, mesh_ring_plan, fused.topology);
         TT_FATAL(
             position.transport_rank == transport_rank && position.tensor_rank == tensor_rank,
             "indexer_score fused full-mesh rank plan drift at coordinate {}",

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -683,6 +683,8 @@ ProgramDescriptor build_ring_program_descriptor(
             .mesh_cols = fused.mesh_cols,
             .ring_size = ring_size,
             .num_links = fused.num_links,
+            // Load-bearing: get_mesh_ring_position reads closure off this, and the struct defaults to Linear.
+            .topology = fused.topology,
             .route_plan_hash = fused.route_plan_hash};
         const auto position = ttnn::operations::ccl::common::get_mesh_ring_position(q, coord, mesh_ring_plan);
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -1211,22 +1211,27 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
             "complete mesh");
 
         const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+        // A full mesh is gathered as one snake across both axes, which only a 2D fabric can route.
+        TT_FATAL(
+            tt::tt_fabric::is_2d_fabric_config(fabric_config),
+            "ring_mla cluster_axis=None requires a 2D fabric config (FABRIC_2D or FABRIC_2D_TORUS_X/Y/XY), got {}",
+            fabric_config);
         std::array<tt::tt_fabric::Topology, 2> axis_topology{
             ttnn::ccl::get_axis_topology(input_tensor_q, fabric_config, 0),
             ttnn::ccl::get_axis_topology(input_tensor_q, fabric_config, 1)};
-        const auto plan = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
+        const auto route = ttnn::operations::ccl::common::resolve_mesh_ring_plan(
             input_tensor_q, std::nullopt, num_links, axis_topology, true, "ring_mla");
-        TT_FATAL(plan.has_value(), "ring_mla could not resolve a direct-neighbor full-mesh snake ring");
+        TT_FATAL(route.has_value(), "ring_mla could not resolve a direct-neighbor full-mesh snake ring");
         TT_FATAL(
-            plan->ring_size <= std::numeric_limits<uint32_t>::digits,
+            route->plan.ring_size <= std::numeric_limits<uint32_t>::digits,
             "ring_mla supports at most {} full-mesh ranks, got {}",
             std::numeric_limits<uint32_t>::digits,
-            plan->ring_size);
-        snake_orientation = plan->orientation;
-        mesh_rows = plan->mesh_rows;
-        mesh_cols = plan->mesh_cols;
-        route_plan_hash = plan->route_plan_hash;
-        num_devices = plan->ring_size;
+            route->plan.ring_size);
+        snake_orientation = route->plan.orientation;
+        mesh_rows = route->plan.mesh_rows;
+        mesh_cols = route->plan.mesh_cols;
+        route_plan_hash = route->plan.route_plan_hash;
+        num_devices = route->plan.ring_size;
     } else {
         TT_FATAL(
             *cluster_axis < mesh_shape.dims(),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -134,8 +134,6 @@ ttnn::operations::ccl::common::MeshRingPlan mesh_ring_plan_from_attributes(
         .mesh_rows = ag.mesh_rows,
         .mesh_cols = ag.mesh_cols,
         .ring_size = ag.ring_size,
-        .num_links = ag.num_links,
-        .topology = ag.topology,
         .route_plan_hash = ag.route_plan_hash,
     };
 }
@@ -404,7 +402,7 @@ RingWritePlan build_ring_write_plan(
     const auto& ag = args.all_gather_operation_attributes;
     if (ag.full_mesh) {
         const auto position = ttnn::operations::ccl::common::get_mesh_ring_position(
-            tensor_args.input_q, coord, mesh_ring_plan_from_attributes(ag));
+            tensor_args.input_q, coord, mesh_ring_plan_from_attributes(ag), ag.topology);
         plan.transport_rank = position.transport_rank;
         plan.tensor_rank = position.tensor_rank;
         plan.forward_coord = position.forward_coord;


### PR DESCRIPTION
### PR Category

Feature

### Summary

#55696. A full-mesh gather needs one Hamiltonian traversal of nearest-neighbour hops. The only one
the resolver could build was a snake cycle, whose closing edge spans a whole axis — a direct
hop on a torus and nowhere else. Plain `FABRIC_2D` therefore had no full-mesh route at all,
and callers carried a second gather to cover it.

This adds the same walk as an open path (`Topology::Linear`): no wrap edge to prove, no
parity precondition, so any wired mesh of two or more devices resolves. GLM-5.2's two-stage
KVPE fallback goes away with it (-144 lines).

Opt-in via `allow_open_path`, default off — `ring_joint_sdpa` and `indexer_score` fuse a
genuinely closed ring and keep getting `nullopt` where no cycle exists.

### CI
- [x] [![blaze-models-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear) -> failures on Kimi unaffected by these changes

Full-mesh accuracy re-run locally on an 8x4 Blackhole Galaxy after the review round, both
Fabric2D variants: 32-rank whole mesh 2/2, and the one-wide submeshes (8x1, 1x4, 1x2) 6/6.

### Performance

8x4 Blackhole Galaxy, 2 links. The path is `N-1` hops against a ring's `N/2`:

| | torus | plain 2D | ratio |
|---|---:|---:|---:|
| `high_bw_all_gather`, 16384 rows/dev, bf16 TILE | 92.18 GB/s | 47.96 GB/s | 0.52 |
| GLM-5.2 744B chunked prefill, median s/chunk | 1.737 | 1.703 | 1.02 |

0.52 against a predicted `16/31 = 0.516`, so the cost is hop count and nothing else. It does
not reach the model — the gather is a small share of a 1.7s chunk. Perf gates stay
torus-only here; the comb follow-up closes a real ring on a plain fabric and takes the
isolated ratio back to parity.

### Notes for reviewers

The semantic change is one line. The edge proof took closure from `full_mesh`, so a
full-mesh request always demanded a provable wrap edge and `topology` only fed the hash:

```cpp
- const bool is_ring = full_mesh || topology == tt::tt_fabric::Topology::Ring;
+ const bool is_ring = topology == tt::tt_fabric::Topology::Ring;
```

A full-mesh route can now be either topology, where before it could only be `Ring` with both
`MeshRingPosition` neighbour optionals engaged. No kernel file changes: the line schedule
already exists and every axis gather uses it.

**Cycle eligibility for 1xN meshes changed too, deliberately.** The old guard hard-required
both dimensions `>= 2`, so a one-wide mesh was rejected for the ring path outright. It is now
`mesh_size() > 2` plus an even lane count, which makes `1x8` and `8x1` cycle candidates: where
that wrap is wired they close and gather at `N/2` hops instead of having no full-mesh route at
all, and where it is not, the edge proof rejects every ring edge and they fall through to the
open path. Both are covered by the one-wide submesh test on each fabric. A `1xodd` mesh still
never attempts a cycle — the even-lane filter skips both orientations — which costs nothing on
hardware whose axes are even, and only an odd-length *wrapped* axis would take the `N-1` path
where an `N/2` ring exists.

Closure no longer travels as a defaulted struct field, which is the hazard the review caught.
`MeshRingPlan` is geometry only; the topology the edge proof concluded comes back beside it in
`ResolvedMeshRoute`, and `get_mesh_ring_position` takes the topology its caller's schedule
assumes as an argument, so a hand-built plan cannot inherit a guess or omit it. Previously the
indexer's program factory built its plan by hand, never set `.topology`, took the struct default
(`Linear`), and full-mesh indexer on a **torus** lost rank 0's backward neighbour. CI would not
have caught it — that test is opt-in and the model drives the indexer on an axis.

All three ops that accept `cluster_axis=None` now assert Fabric2D up front, so `FABRIC_1D`
names the unsupported fabric instead of failing later on an unresolvable route or the generic
neighbour proof. The model asserts the same precondition before its full-mesh KV gather, and the
TP-sharded KV tests move to `FABRIC_2D`.

Commits on this branch used `--no-verify` — pre-commit cannot build its hook environments on my
box (`No module named pip.__main__`). Formatting checked by hand.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/hbag-full-mesh-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/hbag-full-mesh-linear)