### PR TITLE
[MiniMax M3] profile intra-galaxy pipeline stages with the prefill zone profiler

### DIFF
--- a/models/demos/minimax_m3/scripts/run_prefill_profile.sh
+++ b/models/demos/minimax_m3/scripts/run_prefill_profile.sh
@@ -13,8 +13,24 @@
 # re-rendered without paying for it again.
 #
 # Usage:  LEVEL=1 LAYERS=8 CACHE=25600 ./models/demos/minimax_m3/scripts/run_prefill_profile.sh
+#         STAGES=2 STAGE=1 LAYER_IDS=30,33 CACHE=51200 ./models/demos/minimax_m3/scripts/run_prefill_profile.sh
+#
+# Each successful capture's ops CSV is MOVED to RESULTS_DIR/<stamp>_stages<S>_stage<k>_layers<..>_cache<N>_<fabric>_<dtype>/
+# together with a copy of the log, so generated/profiler/ can be wiped between experiments and every
+# capture stays re-renderable.
 #
 # Flags (all optional, all env vars):
+#   STAGES=1|2|4    intra-galaxy pipeline depth: 1 = whole 8x4 galaxy (EP32), 2 = (4,4) sub-meshes
+#                   (EP16), 4 = (2,4) sub-meshes (EP8). The galaxy is opened whole and one stage's
+#                   sub-mesh carved out of it.                                          [default 1]
+#   STAGE=k         which stage to profile, 0..STAGES-1. Stage k owns global layers
+#                   [k*60/STAGES, (k+1)*60/STAGES); LAYER_IDS must fall inside that range and LAYERS
+#                   takes the first N of it. Only stage 0 has dense layers.          [default 0]
+#   FABRIC=1d|1d_ring|2d|2d_torus_xy   fabric config. 1d matches the whole-galaxy baseline; the
+#                   pipeline runner's intra-galaxy bindings use 2d.                  [default 1d]
+#   TT_CACHE_PATH   tilized weight-cache root; the sub-mesh shapes need their own
+#                   tensor_cache_bfp8_MeshShape([4, 4]) / ([2, 4]) (see docs/PIPELINE_PREFILL_TESTING.md).
+#   RESULTS_DIR     where finished captures are moved.        [default $TT_METAL_HOME/prefill_profile_results]
 #   LEVEL=1|2|3     zone detail. 1 = attn vs mlp only (~3 zones/layer), 2 = every block that costs
 #                   real time (~20), 3 = everything incl. norms and sub-splits (~35).   [default 2]
 #   LAYERS=N        build/run only the first N layers. Layers 0-2 are dense and 3+ sparse, so N>=4
@@ -37,8 +53,18 @@ set -uo pipefail
 # script is portable across checkouts and users instead of hard-coding one person's home.
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "$_SCRIPT_DIR/../../../.." && pwd)}"
-export TT_MESH_GRAPH_DESC_PATH="${TT_MESH_GRAPH_DESC_PATH:-$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto}"
 export HF_MODEL="${HF_MODEL:-/mnt/models/MiniMaxAI/MiniMax-M3-ref}"
+STAGES="${STAGES:-1}"
+STAGE="${STAGE:-0}"
+FABRIC="${FABRIC:-1d}"
+export PROFILE_STAGES="$STAGES" PROFILE_STAGE="$STAGE" PROFILE_FABRIC="$FABRIC"
+# TODO(profiling): 2d / 2d_torus_xy are passed through but not yet validated on a carved sub-mesh; the
+# torus descriptor below is the untested guess at what FABRIC_2D_TORUS_XY needs.
+_DESC_DEFAULT="$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto"
+case "$FABRIC" in
+  2d_torus_*) _DESC_DEFAULT="$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto" ;;
+esac
+export TT_MESH_GRAPH_DESC_PATH="${TT_MESH_GRAPH_DESC_PATH:-$_DESC_DEFAULT}"
 export EXPERT_DTYPE="${EXPERT_DTYPE:-bf4}"
 export LOGURU_LEVEL=INFO       # suppress python DEBUG logs at the source
 export M3_PROFILE_ZONES=1      # arm the zone markers (utils/profiler_utils.py reads this at import)
@@ -57,8 +83,10 @@ FAILED=0
 WORKDIR="${PERF_WORKDIR:-/tmp/m3_prefill_perf_traces}"
 LOGDIR="${LOGDIR:-$TT_METAL_HOME/prefill_profile_logs}"
 REPORTS="${REPORTS:-$TT_METAL_HOME/generated/profiler/reports}"
+RESULTS_DIR="${RESULTS_DIR:-$TT_METAL_HOME/prefill_profile_results}"
+DESTS=()
 STAMP="$(date +%Y%m%d_%H%M%S)"
-LOG="$LOGDIR/prefill_profile_${EXPERT_DTYPE}_${STAMP}.log"
+LOG="$LOGDIR/prefill_profile_${EXPERT_DTYPE}_stages${STAGES}_stage${STAGE}_${FABRIC}_${STAMP}.log"
 CHUNK="${CHUNK:-${PROFILE_CHUNK:-5120}}"
 export M3_PROFILE_LEVEL="${LEVEL:-${M3_PROFILE_LEVEL:-2}}"
 # Default to 6 layers (3 dense + 3 sparse). Bare `./run_prefill_profile.sh` used to build all 60,
@@ -69,6 +97,9 @@ export M3_PROFILE_LEVEL="${LEVEL:-${M3_PROFILE_LEVEL:-2}}"
 [ -n "${LAYER_IDS:-}" ] && export PROFILE_LAYER_IDS="$LAYER_IDS"
 [ -n "${CACHE:-}" ] && PROFILE_CACHE="$CACHE"
 [ -n "${SKIP_PREFIX:-}" ] && export PROFILE_SKIP_PREFIX="$SKIP_PREFIX"
+# Layer tag for the results folder name: "0+3" for LAYER_IDS=0,3, "first6" for LAYERS=6.
+LAYER_TAG="${LAYER_IDS:+${LAYER_IDS//,/+}}"
+LAYER_TAG="${LAYER_TAG:-first${LAYERS:-}}"
 
 # Source of the tokens the synthetic traces are tiled from. Defined before the preflight below, which
 # checks it exists.
@@ -83,8 +114,29 @@ die () { echo "ERROR: $*" >&2; exit 1; }
 [ -d "$HF_MODEL" ]               || die "HF_MODEL does not exist: $HF_MODEL (set HF_MODEL=<weights dir>)"
 [ -f "$SRC_TRACE" ]              || die "source trace not found: $SRC_TRACE (set GOLDEN_DIR or SRC_TRACE)"
 command -v tt-smi >/dev/null     || die "tt-smi not on PATH — needed to reset the galaxy between runs"
+case "$STAGES" in 1|2|4) ;; *) die "STAGES must be 1, 2 or 4 (got $STAGES)" ;; esac
+[ "$STAGE" -ge 0 ] && [ "$STAGE" -lt "$STAGES" ] || die "STAGE=$STAGE out of range for STAGES=$STAGES"
+# The stage's sub-mesh needs its own tilized cache (keyed by mesh shape); check the first requested layer
+# is there instead of discovering a ~869 GB bf16 fallback read several minutes in. self_attn is the last
+# subtree the populate run writes, so its presence distinguishes a finished layer from an aborted one.
+STAGE_ROWS=$((8 / STAGES))
+STAGE_CACHE="${TT_CACHE_PATH:-$HF_MODEL}/tensor_cache_bfp8_MeshShape([$STAGE_ROWS, 4])"
+FIRST_LAYER="${LAYER_IDS:-}"
+FIRST_LAYER="${FIRST_LAYER%%,*}"
+FIRST_LAYER="${FIRST_LAYER:-$((STAGE * 60 / STAGES))}"
+[ -d "$STAGE_CACHE/model.layers.$FIRST_LAYER/self_attn" ] || \
+  die "no tilized cache for layer $FIRST_LAYER at $STAGE_CACHE — set TT_CACHE_PATH to a root that has the" \
+      "([$STAGE_ROWS, 4]) cache (see models/demos/minimax_m3/docs/PIPELINE_PREFILL_TESTING.md)"
 
 cd "$TT_METAL_HOME"
+# tracy-capture and tracy-csvexport are siblings of the harness, spawned by `python3 -m tracy`, so the
+# harness raising its own RLIMIT_NPROC does not cover them. Saving a capture spawns one compression thread
+# per core; at the per-user default (512 on the galaxy hosts, counted across every process the user owns)
+# that fails with "Resource temporarily unavailable" and the trace is lost AFTER the run. Raise the soft
+# limit to the hard limit for everything launched from here.
+NPROC_HARD="$(ulimit -Hu)"
+ulimit -Su "$NPROC_HARD" 2>/dev/null || echo "WARNING: could not raise RLIMIT_NPROC (soft $(ulimit -Su), hard $NPROC_HARD)"
+NPROC_IN_USE="$(ps -L -u "$(id -un)" --no-headers 2>/dev/null | wc -l)"
 # shellcheck disable=SC1091
 source python_env/bin/activate
 export PYTHONPATH="$TT_METAL_HOME"   # after venv activate so model imports resolve
@@ -161,6 +213,11 @@ run_cfg () {  # $1=label  $2=cache_tokens
   # expensive part, and you will want to re-render it more than once.
   local csv; csv="$(find "$REPORTS" -name 'ops_perf_results_*.csv' -newermt "@$before" 2>/dev/null | sort | tail -1)"
   if [ -n "$csv" ]; then
+    # Park the CSV under RESULTS_DIR so generated/profiler/ can be wiped between experiments. The log
+    # is copied in once the whole run has finished (see the end of the script).
+    local dest="$RESULTS_DIR/${STAMP}_stages${STAGES}_stage${STAGE}_layers${LAYER_TAG}_cache${cache}_${FABRIC}_${EXPERT_DTYPE}"
+    mkdir -p "$dest" && mv "$csv" "$dest/" && csv="$dest/$(basename "$csv")"
+    DESTS+=("$dest")
     { echo "# [$label] CSV: $csv"
       echo "# [$label] visualize: python3 $VISUALIZE $csv"; } | tee -a "$LOG"
     CSVS+=("$csv")
@@ -175,13 +232,17 @@ echo "logging to $LOG"
   echo "MiniMax-M3 prefill zone profile"
   echo "  HF_MODEL=$HF_MODEL  EXPERT_DTYPE=$EXPERT_DTYPE  CHUNK=$CHUNK  NOC_TRACES=${NOC_TRACES:-0}"
   echo "  LAYERS=${PROFILE_LAYER_IDS:-${PROFILE_NUM_LAYERS:-all}}  ZONE LEVEL=$M3_PROFILE_LEVEL  SKIP_PREFIX=${PROFILE_SKIP_PREFIX:-0}"
+  echo "  STAGES=$STAGES  STAGE=$STAGE  FABRIC=$FABRIC  MESH=($STAGE_ROWS, 4)  CACHE_DIR=$STAGE_CACHE"
+  echo "  RESULTS_DIR=$RESULTS_DIR"
+  echo "  RLIMIT_NPROC soft=$(ulimit -Su) hard=$NPROC_HARD  user threads in use=$NPROC_IN_USE"
 } | tee "$LOG"
 
+STAGE_LABEL="stage $STAGE/$STAGES $FABRIC"
 if [ -n "${PROFILE_CACHE:-}" ]; then
-  run_cfg "5k at ${PROFILE_CACHE}" "$PROFILE_CACHE"
+  run_cfg "$STAGE_LABEL 5k at ${PROFILE_CACHE}" "$PROFILE_CACHE"
 else
-  run_cfg "5k at 25k" 25600   # 5 prefix chunks + 1 profiled = 30720 capacity
-  run_cfg "5k at 55k" 56320   # 11 prefix chunks + 1 profiled = 61440 capacity
+  run_cfg "$STAGE_LABEL 5k at 25k" 25600   # 5 prefix chunks + 1 profiled = 30720 capacity
+  run_cfg "$STAGE_LABEL 5k at 55k" 56320   # 11 prefix chunks + 1 profiled = 61440 capacity
 fi
 
 {
@@ -191,6 +252,7 @@ fi
 } | tee -a "$LOG"
 echo ""
 echo "full log: $LOG"
+for d in "${DESTS[@]}"; do cp "$LOG" "$d/"; echo "results: $d"; done
 echo ""
 if [ "$FAILED" -ne 0 ]; then
   echo "=================== FAILED ==================="

--- a/models/demos/minimax_m3/scripts/run_prefill_profile.sh
+++ b/models/demos/minimax_m3/scripts/run_prefill_profile.sh
@@ -58,11 +58,14 @@ STAGES="${STAGES:-1}"
 STAGE="${STAGE:-0}"
 FABRIC="${FABRIC:-1d}"
 export PROFILE_STAGES="$STAGES" PROFILE_STAGE="$STAGE" PROFILE_FABRIC="$FABRIC"
-# TODO(profiling): 2d / 2d_torus_xy are passed through but not yet validated on a carved sub-mesh; the
-# torus descriptor below is the untested guess at what FABRIC_2D_TORUS_XY needs.
+# TODO(profiling): 1d_ring / 2d / 2d_torus_xy are passed through but not yet validated on a carved sub-mesh.
+# FABRIC_1D_RING refuses a plain mesh descriptor on Blackhole (tt_metal/fabric/topology_mapper.cpp,
+# ring_requires_torus), so ring and torus modes select the torus-XY descriptor. The M3 CCLs still run
+# with Topology.Linear (TtPrefillRuntimeConfig.topology), so a ring fabric alone does not make them ring
+# collectives.
 _DESC_DEFAULT="$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto"
 case "$FABRIC" in
-  2d_torus_*) _DESC_DEFAULT="$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto" ;;
+  1d_ring|2d_torus_*) _DESC_DEFAULT="$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto" ;;
 esac
 export TT_MESH_GRAPH_DESC_PATH="${TT_MESH_GRAPH_DESC_PATH:-$_DESC_DEFAULT}"
 export EXPERT_DTYPE="${EXPERT_DTYPE:-bf4}"
@@ -116,17 +119,21 @@ die () { echo "ERROR: $*" >&2; exit 1; }
 command -v tt-smi >/dev/null     || die "tt-smi not on PATH — needed to reset the galaxy between runs"
 case "$STAGES" in 1|2|4) ;; *) die "STAGES must be 1, 2 or 4 (got $STAGES)" ;; esac
 [ "$STAGE" -ge 0 ] && [ "$STAGE" -lt "$STAGES" ] || die "STAGE=$STAGE out of range for STAGES=$STAGES"
-# The stage's sub-mesh needs its own tilized cache (keyed by mesh shape); check the first requested layer
-# is there instead of discovering a ~869 GB bf16 fallback read several minutes in. self_attn is the last
-# subtree the populate run writes, so its presence distinguishes a finished layer from an aborted one.
+# The tilized cache is keyed by mesh shape; check the first requested layer is there instead of
+# discovering a ~869 GB bf16 source read several minutes in. self_attn is the last subtree the populate
+# run writes, so its presence distinguishes a finished layer from an aborted one. M3_FORCE_LOAD_WEIGHTS=1
+# (cache populate) is the one case that means to read the source.
+M3_NUM_LAYERS=60   # MiniMax-M3 num_hidden_layers; the harness reads the real value from hf_config
 STAGE_ROWS=$((8 / STAGES))
 STAGE_CACHE="${TT_CACHE_PATH:-$HF_MODEL}/tensor_cache_bfp8_MeshShape([$STAGE_ROWS, 4])"
 FIRST_LAYER="${LAYER_IDS:-}"
 FIRST_LAYER="${FIRST_LAYER%%,*}"
-FIRST_LAYER="${FIRST_LAYER:-$((STAGE * 60 / STAGES))}"
-[ -d "$STAGE_CACHE/model.layers.$FIRST_LAYER/self_attn" ] || \
+FIRST_LAYER="${FIRST_LAYER:-$((STAGE * M3_NUM_LAYERS / STAGES))}"
+if [ "${M3_FORCE_LOAD_WEIGHTS:-0}" != "1" ] && [ ! -d "$STAGE_CACHE/model.layers.$FIRST_LAYER/self_attn" ]; then
   die "no tilized cache for layer $FIRST_LAYER at $STAGE_CACHE — set TT_CACHE_PATH to a root that has the" \
-      "([$STAGE_ROWS, 4]) cache (see models/demos/minimax_m3/docs/PIPELINE_PREFILL_TESTING.md)"
+      "([$STAGE_ROWS, 4]) cache (see models/demos/minimax_m3/docs/PIPELINE_PREFILL_TESTING.md), or" \
+      "M3_FORCE_LOAD_WEIGHTS=1 to populate it from the bf16 source"
+fi
 
 cd "$TT_METAL_HOME"
 # tracy-capture and tracy-csvexport are siblings of the harness, spawned by `python3 -m tracy`, so the
@@ -216,8 +223,13 @@ run_cfg () {  # $1=label  $2=cache_tokens
     # Park the CSV under RESULTS_DIR so generated/profiler/ can be wiped between experiments. The log
     # is copied in once the whole run has finished (see the end of the script).
     local dest="$RESULTS_DIR/${STAMP}_stages${STAGES}_stage${STAGE}_layers${LAYER_TAG}_cache${cache}_${FABRIC}_${EXPERT_DTYPE}"
-    mkdir -p "$dest" && mv "$csv" "$dest/" && csv="$dest/$(basename "$csv")"
-    DESTS+=("$dest")
+    if mkdir -p "$dest" && mv "$csv" "$dest/"; then
+      csv="$dest/$(basename "$csv")"
+      DESTS+=("$dest")
+    else
+      echo "# [$label] FAILED to move $csv into $dest — the capture is still at its original path" | tee -a "$LOG"
+      FAILED=1
+    fi
     { echo "# [$label] CSV: $csv"
       echo "# [$label] visualize: python3 $VISUALIZE $csv"; } | tee -a "$LOG"
     CSVS+=("$csv")
@@ -233,6 +245,7 @@ echo "logging to $LOG"
   echo "  HF_MODEL=$HF_MODEL  EXPERT_DTYPE=$EXPERT_DTYPE  CHUNK=$CHUNK  NOC_TRACES=${NOC_TRACES:-0}"
   echo "  LAYERS=${PROFILE_LAYER_IDS:-${PROFILE_NUM_LAYERS:-all}}  ZONE LEVEL=$M3_PROFILE_LEVEL  SKIP_PREFIX=${PROFILE_SKIP_PREFIX:-0}"
   echo "  STAGES=$STAGES  STAGE=$STAGE  FABRIC=$FABRIC  MESH=($STAGE_ROWS, 4)  CACHE_DIR=$STAGE_CACHE"
+  echo "  TT_MESH_GRAPH_DESC_PATH=$TT_MESH_GRAPH_DESC_PATH"
   echo "  RESULTS_DIR=$RESULTS_DIR"
   echo "  RLIMIT_NPROC soft=$(ulimit -Su) hard=$NPROC_HARD  user threads in use=$NPROC_IN_USE"
 } | tee "$LOG"

--- a/models/demos/minimax_m3/tests/perf/README_profiling.md
+++ b/models/demos/minimax_m3/tests/perf/README_profiling.md
@@ -10,8 +10,8 @@ MLP on the dense layers (0-2), and the full MSA + MoE breakdown on the sparse la
 cd $TT_METAL_HOME
 ```
 
-Needs: the tilized weight cache at `$HF_MODEL/tensor_cache_bfp8_MeshShape([8, 4])` (without it the run
-falls back to the ~869 GB bf16 source read), a golden trace to tile tokens from (defaults to
+Needs: the tilized weight cache at `$HF_MODEL/tensor_cache_bfp8_MeshShape([8, 4])` (the wrapper refuses to start without it;
+`M3_FORCE_LOAD_WEIGHTS=1` populates it from the ~869 GB bf16 source), a golden trace to tile tokens from (defaults to
 `$GOLDEN_DIR/longbook_qa_eng_prefill_56320_nopad`), ~50 GB free disk and ~150 GB free RAM.
 
 ## Two commands
@@ -78,7 +78,7 @@ Opening that path in an editor shows you HTML source, not the report — it need
 | `SKIP_PREFIX=1` | skip the prefill, attend a zeroed cache — fast but MoE routing is unrepresentative | off |
 | `STAGES=1\|2\|4` | intra-galaxy pipeline depth — see *Profiling a pipeline stage* | 1 |
 | `STAGE=k` | which stage's sub-mesh and layer slice to profile | 0 |
-| `FABRIC=1d\|1d_ring\|2d\|2d_torus_xy` | fabric config | 1d |
+| `FABRIC=1d\|1d_ring\|2d\|2d_torus_xy` | fabric config; ring and torus modes also switch to the torus-XY mesh descriptor | 1d |
 | `RESULTS_DIR=path` | where finished captures are moved | `prefill_profile_results/` |
 
 ### Detail levels

--- a/models/demos/minimax_m3/tests/perf/README_profiling.md
+++ b/models/demos/minimax_m3/tests/perf/README_profiling.md
@@ -22,11 +22,16 @@ falls back to the ~869 GB bf16 source read), a golden trace to tile tokens from 
 LEVEL=2 LAYERS=6 CACHE=25600 ./models/demos/minimax_m3/scripts/run_prefill_profile.sh
 ```
 
+Each finished capture is moved out of `generated/profiler/` into
+`prefill_profile_results/<stamp>_stages<S>_stage<k>_layers<..>_cache<N>_<fabric>_<dtype>/` (the ops
+CSV plus a copy of the log), so the tracy intermediates can be wiped between experiments and every
+capture stays re-renderable. `RESULTS_DIR` overrides the root.
+
 **2. View.** Renders the report and serves it — `--open` prints a URL you can click.
 
 ```bash
 python3 models/demos/minimax_m3/tests/perf/visualize_zones.py \
-    "$(ls -t generated/profiler/reports/*/ops_perf_results_*.csv | head -1)" --open
+    "$(ls -t prefill_profile_results/*/ops_perf_results_*.csv | head -1)" --open
 ```
 
 ```
@@ -71,6 +76,10 @@ Opening that path in an editor shows you HTML source, not the report — it need
 | `EXPERT_DTYPE=bf4\|bf8` | MoE routed-expert weight dtype | bf4 |
 | `NOC_TRACES=1` | + DRAM/NOC utilization per op. Requires tt-npe installed separately (see *Reading the report*) | off |
 | `SKIP_PREFIX=1` | skip the prefill, attend a zeroed cache — fast but MoE routing is unrepresentative | off |
+| `STAGES=1\|2\|4` | intra-galaxy pipeline depth — see *Profiling a pipeline stage* | 1 |
+| `STAGE=k` | which stage's sub-mesh and layer slice to profile | 0 |
+| `FABRIC=1d\|1d_ring\|2d\|2d_torus_xy` | fabric config | 1d |
+| `RESULTS_DIR=path` | where finished captures are moved | `prefill_profile_results/` |
 
 ### Detail levels
 
@@ -103,6 +112,41 @@ layers, so a 1-sparse-layer run gives you one draw from that distribution rather
 use 6 or 8 layers when the answer depends on them.
 
 Do not scale past ~8 layers — see below.
+
+## Profiling a pipeline stage
+
+The intra-galaxy pipeline (`docs/PIPELINE_PREFILL_TESTING.md`) carves the 8×4 galaxy into 2 stages of
+(4,4) (EP16, 30 layers each) or 4 stages of (2,4) (EP8, 15 layers each). `STAGES=S STAGE=k` profiles
+stage k standalone: the harness opens the whole galaxy, carves stage k's sub-mesh out of it, and builds
+only that stage's layer slice with the sub-mesh's own tilized cache. Same chunk, same zones, same
+report — only the mesh, EP/SP and layer range change.
+
+```bash
+# stage 0 of 2: one dense + one sparse layer, 5k attending 50k, like the whole-galaxy baseline
+TT_CACHE_PATH=<pp-cache-root> STAGES=2 STAGE=0 LAYER_IDS=0,3 CACHE=51200 \
+    ./models/demos/minimax_m3/scripts/run_prefill_profile.sh
+# stage 1 of 2 (layers 30-59, all sparse)
+TT_CACHE_PATH=<pp-cache-root> STAGES=2 STAGE=1 LAYER_IDS=30,33 CACHE=51200 \
+    ./models/demos/minimax_m3/scripts/run_prefill_profile.sh
+```
+
+What to know:
+
+- **Weight cache.** The tilized cache is keyed by mesh shape, so a stage needs
+  `tensor_cache_bfp8_MeshShape([4, 4])` or `([2, 4])`. The checkpoint dir only has stubs for those;
+  point `TT_CACHE_PATH` at a root that carries them (`docs/PIPELINE_PREFILL_TESTING.md` names the
+  currently populated one). The wrapper checks the first requested layer is present before starting.
+- **Layer selection is in global indices.** `LAYER_IDS` must fall inside the stage's range
+  (`[k·60/S, (k+1)·60/S)`); `LAYERS=N` takes the first N of the stage. Only stage 0 has dense layers.
+- **Fabric.** `FABRIC=1d` (default) matches the whole-galaxy baseline, so a stage capture compares
+  like-for-like. The pipeline runner's intra-galaxy bindings use 2D fabric; `FABRIC=2d` /
+  `2d_torus_xy` are passed through for that comparison but not yet validated on a carved sub-mesh.
+- **Every stage embeds its own tokens.** A standalone stage has no upstream stage to hand it a hidden
+  state, and the zero placeholder a real middle rank warms up with would collapse the MoE router onto
+  one expert. So stage k>0 runs real-token embeddings straight into layer 30 (or 15/45): shapes and
+  compute zones are exact, MoE routing is not the real stage's — same caveat as `SKIP_PREFIX`.
+- **Capture volume scales with device count**, so a (4,4) stage halves the trace and the
+  post-process RSS of the table below for the same layer count.
 
 ## Memory and disk
 
@@ -209,6 +253,13 @@ means the device idles waiting for dispatch — an 8-layer chunk measured 5 061 
 unprofiled. `DEVICE KERNEL DURATION` and `DEVICE FW DURATION` are on-device and unaffected;
 `OP TO OP LATENCY` is not, and the report excludes it. Latency numbers come from
 `scripts/run_prefill_perf.sh`.
+
+**`Saving trace...terminate called ... Resource temporarily unavailable`.** The capture tool ran out of
+the per-user process/thread budget (`ulimit -u`, 512 by default on the galaxy hosts, counted across every
+process you own on the node) while spawning its compression threads — after the run, so the whole capture
+is lost. The wrapper raises the soft limit to the hard limit before launching anything, and logs
+`RLIMIT_NPROC soft/hard/in use` in its header. If it still fails, leftover processes are eating the
+budget: `ps -L -u $USER | wc -l`, then kill stale runs and `pkill -f tools/tracy/serve_wasm.py`.
 
 **Tracy caps a trace at 32K source locations.** Each zone entry allocates one, as does each ttnn op.
 A long capture will hit it and silently start dropping zones — use a lower `LEVEL`, fewer `LAYERS`, or

--- a/models/demos/minimax_m3/tests/perf/profile_prefill.py
+++ b/models/demos/minimax_m3/tests/perf/profile_prefill.py
@@ -47,6 +47,13 @@ Env:
   PROFILE_READ_EVERY  call ttnn.ReadDeviceProfiler every N layers (<1000 ops/read!)   [default 1]
   PROFILE_SKIP_PREFIX "1" -> skip the prefix fill and attend a ZEROED cache. Shapes (and op costs)
                       are identical but MoE routing is not representative — bring-up only  [default 0]
+  PROFILE_STAGES      intra-galaxy pipeline depth: 1 (whole 8x4 galaxy), 2 ((4,4) sub-meshes, EP16) or
+                      4 ((2,4) sub-meshes, EP8). The galaxy is opened whole and stage PROFILE_STAGE's
+                      sub-mesh is carved out of it, so one process profiles one stage           [default 1]
+  PROFILE_STAGE       which stage to profile, 0..PROFILE_STAGES-1. Stage k owns global layers
+                      [k*60/S, (k+1)*60/S); PROFILE_LAYER_IDS must fall inside that range and
+                      PROFILE_NUM_LAYERS takes the first N of it                             [default 0]
+  PROFILE_FABRIC      fabric config: 1d | 1d_ring | 2d | 2d_torus_xy                        [default 1d]
   EXPERT_DTYPE        MoE routed-expert weight dtype: "bf4" or "bf8"                  [default bf4]
   HF_MODEL            real MiniMax-M3 weights dir (read by ModelArgs)
   M3_PROFILE_ZONES    set to 1 by this script before the model is imported
@@ -107,6 +114,16 @@ def _raise_nproc_limit():
 # so a chunk must cover at least this many tokens. Keep in sync with tt/attention/msa.py.
 MSA_MIN_TOKENS = 16 * 128  # 2048
 
+# sparse_attention_freq marks layers 0-2 dense and 3-59 sparse (tt/layer.py).
+FIRST_SPARSE_LAYER = 3
+
+FABRIC_CONFIGS = {
+    "1d": ttnn.FabricConfig.FABRIC_1D,
+    "1d_ring": ttnn.FabricConfig.FABRIC_1D_RING,
+    "2d": ttnn.FabricConfig.FABRIC_2D,
+    "2d_torus_xy": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+}
+
 
 def load_tokens(n: int):
     """Read PREFILL_TRACE_DIR/metadata.json's token_ids and tile them to exactly `n` tokens.
@@ -143,38 +160,60 @@ def plan(chunk: int, cache: int):
     return n_chunks, cache_aligned, n_chunks * chunk
 
 
-def build_runtime(mesh, chunk, total, num_layers_override, layer_ids=None):
-    """Build the real-weights model + KV cache. Returns (runtime, kv_cache, hf_config, num_layers)."""
+def build_runtime(mesh, chunk, total, num_layers_override, layer_ids=None, stages=1, stage=0):
+    """Build the real-weights model + KV cache for pipeline stage `stage` of `stages` on `mesh` (the
+    whole galaxy or one carved sub-mesh). Returns (runtime, kv_cache, hf_config, global_layer_indices)."""
     from models.demos.minimax_m3.tt.attention import allocate_kv_caches
     from models.demos.minimax_m3.tt.model_config import ModelArgs
     from models.demos.minimax_m3.tt.tt_prefill_runtime import TtPrefillRuntime, TtPrefillRuntimeConfig
     from models.demos.minimax_m3.tt.weight_cache import weight_cache_is_complete
 
-    rows, cols = 8, 4  # SP=8 (rows) x TP=4 (cols), EP=32
-
-    model_args = ModelArgs(mesh_device=mesh)  # HF_MODEL
+    model_args = ModelArgs(mesh_device=mesh)  # HF_MODEL; the tilized-cache path is keyed by mesh.shape
     hf_config = model_args.hf_config
-    num_layers = hf_config.num_hidden_layers
+    total_layers = hf_config.num_hidden_layers
+    assert total_layers % stages == 0, f"{total_layers} layers do not split evenly into {stages} stages"
+    per_stage = total_layers // stages
+    stage_first, stage_end = stage * per_stage, (stage + 1) * per_stage
+    is_last_stage = stage == stages - 1
+    first_layer_idx = stage_first
+    num_layers = per_stage
     if layer_ids:
         # Explicit layer selection, e.g. [0, 3] = one dense + one sparse. The layers keep their real
         # global indices (so weights, cache keys and the dense/sparse decision are the real ones) but
         # are stacked back to back, which makes a 2-layer run cover both classes. Needs the tilized
         # cache: a non-contiguous index may not live in the shards M3_LOAD_NLAYERS would read.
+        outside = [i for i in layer_ids if not stage_first <= i < stage_end]
+        assert (
+            not outside
+        ), f"PROFILE_LAYER_IDS {outside} lie outside stage {stage}/{stages}'s layers [{stage_first}, {stage_end})"
         num_layers = len(layer_ids)
-        hf_config.num_hidden_layers = num_layers
         os.environ.setdefault("M3_WEIGHTS_FROM_CACHE", "1")
         print(f"[zone-prof] PROFILE_LAYER_IDS={layer_ids}: building global layers {layer_ids}", flush=True)
-    if num_layers_override and not layer_ids:
+    elif num_layers_override:
         num_layers = int(num_layers_override)
-        hf_config.num_hidden_layers = num_layers
+        assert num_layers <= per_stage, f"PROFILE_NUM_LAYERS={num_layers} exceeds the {per_stage} layers of a stage"
         os.environ.setdefault("M3_LOAD_NLAYERS", str(num_layers))
-        print(f"[zone-prof] PROFILE_NUM_LAYERS={num_layers}: first {num_layers} layers only", flush=True)
-        if num_layers < 4:
+        os.environ.setdefault("M3_LOAD_LAYER_START", str(first_layer_idx))
+        print(
+            f"[zone-prof] PROFILE_NUM_LAYERS={num_layers}: global layers "
+            f"[{first_layer_idx}, {first_layer_idx + num_layers}) only",
+            flush=True,
+        )
+        if first_layer_idx + num_layers <= FIRST_SPARSE_LAYER:
             print(
-                f"[zone-prof] WARNING: {num_layers} layers covers no sparse layer "
-                f"(layers 0-2 are dense, sparse starts at 3) — use >=4 to profile both classes.",
+                f"[zone-prof] WARNING: layers [{first_layer_idx}, {first_layer_idx + num_layers}) cover no sparse "
+                f"layer (layers 0-{FIRST_SPARSE_LAYER - 1} are dense) — use >={FIRST_SPARSE_LAYER + 1} to profile "
+                "both classes.",
                 flush=True,
             )
+    hf_config.num_hidden_layers = num_layers
+    global_layer_indices = list(layer_ids or range(first_layer_idx, first_layer_idx + num_layers))
+    if stages > 1:
+        print(
+            f"[zone-prof] stage {stage}/{stages}: mesh {tuple(mesh.shape)}, stage layers [{stage_first}, {stage_end}), "
+            f"building {global_layer_indices}",
+            flush=True,
+        )
 
     expert_dtype = ttnn.bfloat8_b if os.getenv("EXPERT_DTYPE", "bf4") == "bf8" else ttnn.bfloat4_b
     cache_path = model_args.weight_cache_path(ttnn.bfloat8_b)
@@ -184,7 +223,15 @@ def build_runtime(mesh, chunk, total, num_layers_override, layer_ids=None):
     force_load = os.getenv("M3_FORCE_LOAD_WEIGHTS") == "1"
     cache_only = not force_load and (
         os.getenv("M3_WEIGHTS_FROM_CACHE") == "1"
-        or weight_cache_is_complete(cache_path, hf_config, num_layers, expert_dtype)
+        or weight_cache_is_complete(
+            cache_path,
+            hf_config,
+            num_layers,
+            expert_dtype,
+            first_layer_idx=first_layer_idx,
+            is_first_rank=True,
+            is_last_rank=is_last_stage,
+        )
     )
     if cache_only:
         print("[zone-prof] tilized weight cache complete -> loading from cache", flush=True)
@@ -193,15 +240,22 @@ def build_runtime(mesh, chunk, total, num_layers_override, layer_ids=None):
         print("[zone-prof] loading real bf16 weights (slow: ~869GB source read) ...", flush=True)
         state_dict = ModelArgs.load_state_dict(model_args.weights_path)
 
+    # Every stage embeds its own tokens (is_first_rank=True): there is no upstream stage to hand over a
+    # hidden state, and the zero placeholder a real middle rank warms up with would collapse the MoE
+    # router onto one expert per layer. The embedding runs outside the layer zones, so the per-layer
+    # report is unaffected. The tail (final norm + LM head) follows the real stage layout.
     cfg = TtPrefillRuntimeConfig(
         num_layers=num_layers,
         max_seq_len=total,
-        mesh_shape=(rows, cols),
+        mesh_shape=tuple(mesh.shape),
         chunk_size=chunk,
         num_users=1,
         expert_weight_dtype=expert_dtype,
         weight_cache_path=cache_path,
+        first_layer_idx=first_layer_idx,
         layer_indices=layer_ids,
+        is_first_rank=True,
+        is_last_rank=is_last_stage,
     )
     runtime = TtPrefillRuntime(mesh, hf_config, state_dict, cfg)
     del state_dict
@@ -209,16 +263,18 @@ def build_runtime(mesh, chunk, total, num_layers_override, layer_ids=None):
     kv_cache = allocate_kv_caches(
         mesh, num_layers=num_layers, max_seq_len=total, num_users=1, head_dim=hf_config.head_dim
     )
-    return runtime, kv_cache, hf_config, num_layers
+    return runtime, kv_cache, hf_config, global_layer_indices
 
 
-def cache_traffic_note(hf_config, num_layers, total, sp=8):
+def cache_traffic_note(hf_config, global_layer_indices, total, sp):
     """Log the whole-cache de-shard traffic the `cache_read/deshard` zone should be moving.
 
     The packed cache is [num_users*num_layers, 1, seq_local, head_dim] per chip (kv_cache.py), and the
     MSA cache-read converts the WHOLE tensor per layer, for each of K / V / index_k. Printing the
     expected bytes up front makes the measured GB/s in the report immediately interpretable.
     """
+    num_layers = len(global_layer_indices)
+    n_sparse = sum(1 for i in global_layer_indices if i >= FIRST_SPARSE_LAYER)
     seq_local = total // sp
     elems = num_layers * seq_local * hf_config.head_dim  # per chip, per cache tensor
     kv_bytes = elems * 1.0625  # bf8_b: 1 byte + 1/16 block scale
@@ -230,8 +286,7 @@ def cache_traffic_note(hf_config, num_layers, total, sp=8):
         f"{elems/1e6:.1f}M elems/tensor ({kv_bytes/2**20:.0f} MiB K, {kv_bytes/2**20:.0f} MiB V, "
         f"{ik_bytes/2**20:.0f} MiB index_k)\n"
         f"    per sparse layer (read+write x3 tensors): {per_layer/2**20:.0f} MiB\n"
-        f"    x {max(0, num_layers - 3)} sparse layers: {per_layer * max(0, num_layers - 3)/2**30:.1f} GiB "
-        f"per chunk, per chip"
+        f"    x {n_sparse} sparse layers: {per_layer * n_sparse/2**30:.1f} GiB per chunk, per chip"
     )
 
 
@@ -243,6 +298,14 @@ def main():
     read_every = int(os.getenv("PROFILE_READ_EVERY", "1"))
     num_layers_override = os.getenv("PROFILE_NUM_LAYERS")
     layer_ids = [int(x) for x in os.getenv("PROFILE_LAYER_IDS", "").split(",") if x.strip()] or None
+    stages = int(os.getenv("PROFILE_STAGES", "1"))
+    stage = int(os.getenv("PROFILE_STAGE", "0"))
+    assert stages in (1, 2, 4), f"PROFILE_STAGES must be 1, 2 or 4 (got {stages})"
+    assert 0 <= stage < stages, f"PROFILE_STAGE={stage} out of range for {stages} stages"
+    fabric_name = os.getenv("PROFILE_FABRIC", "1d")
+    assert (
+        fabric_name in FABRIC_CONFIGS
+    ), f"PROFILE_FABRIC must be one of {sorted(FABRIC_CONFIGS)} (got {fabric_name!r})"
 
     n_chunks, cache, total = plan(chunk, cache_req)
     print(
@@ -256,14 +319,34 @@ def main():
         print("[zone-prof] PROFILE_DRY_RUN=1 -> chunk math + tokens only, exiting before device open", flush=True)
         return 0
 
-    ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
-    mesh = ttnn.open_mesh_device(ttnn.MeshShape(8, 4))
-    print(f"[zone-prof] mesh opened {tuple(mesh.shape)} ndev={mesh.get_num_devices()}", flush=True)
+    # TODO(profiling): the pipeline runner's intra-galaxy bindings use 2D fabric (PREFILL_FABRIC_MODE=2d);
+    # 1d is the default here so stage captures compare like-for-like with the whole-galaxy baseline.
+    # 2d / 2d_torus_xy are wired through but not yet validated on a carved sub-mesh (torus also needs the
+    # matching *_torus_xy mesh graph descriptor).
+    ttnn.set_fabric_config(FABRIC_CONFIGS[fabric_name])
+    galaxy = ttnn.open_mesh_device(ttnn.MeshShape(8, 4))
+    print(
+        f"[zone-prof] galaxy opened {tuple(galaxy.shape)} ndev={galaxy.get_num_devices()} fabric={fabric_name}",
+        flush=True,
+    )
+    mesh = galaxy
     try:
         from models.demos.minimax_m3.utils.profiler_utils import COARSE, ZONES_ENABLED, read_profiler, zone
 
-        runtime, kv_cache, hf_config, num_layers = build_runtime(mesh, chunk, total, num_layers_override, layer_ids)
-        cache_traffic_note(hf_config, num_layers, total)
+        if stages > 1:
+            # Contiguous row-block sub-meshes, in the same order the pipeline bindings assign stages.
+            mesh = galaxy.create_submeshes(ttnn.MeshShape(8 // stages, 4))[stage]
+            print(
+                f"[zone-prof] stage {stage}/{stages} sub-mesh {tuple(mesh.shape)} ndev={mesh.get_num_devices()}",
+                flush=True,
+            )
+        sp, tp = tuple(mesh.shape)
+
+        runtime, kv_cache, hf_config, global_layer_indices = build_runtime(
+            mesh, chunk, total, num_layers_override, layer_ids, stages=stages, stage=stage
+        )
+        num_layers = len(global_layer_indices)
+        cache_traffic_note(hf_config, global_layer_indices, total, sp)
 
         # Per-layer ReadDeviceProfiler for the UN-profiled phases only (warmup + prefix). The device
         # profiler buffer must be drained or it overflows and the next phase's data is dropped — but a
@@ -289,7 +372,7 @@ def main():
 
         # --- 1. WARMUP: JIT-compiles every op and populates the program cache. Its ops land in the CSV
         # too, but outside the `profiled_chunk` zone, so the parser drops them.
-        print(f"[zone-prof] warmup / compile ({num_layers}L, SP=8 x TP=4 + EP=32) ...", flush=True)
+        print(f"[zone-prof] warmup / compile ({num_layers}L, SP={sp} x TP={tp} + EP={sp * tp}) ...", flush=True)
         t0 = time.perf_counter()
         runtime.compile(kv_cache)
         print(f"[zone-prof] warmup done in {(time.perf_counter()-t0):.1f}s", flush=True)
@@ -299,7 +382,9 @@ def main():
         def prefill_chunk(c):
             a = c * chunk
             inp = runtime.make_chunk_input(tokens[a : a + chunk])
-            runtime.prefill_chunk(inp, kv_cache, slot_id=0, actual_start=a, actual_end=a + chunk)
+            out = runtime.prefill_chunk(inp, kv_cache, slot_id=0, actual_start=a, actual_end=a + chunk)
+            if out is not None:  # a non-last stage returns the hidden state meant for the next stage
+                out.deallocate(True)
 
         # --- 2. fill the cache to `cache` tokens. Not inside the `profiled_chunk` zone, so these ops are
         # excluded from the report; synced before the profiled chunk so it pays for no leftover barrier.
@@ -346,7 +431,8 @@ def main():
         chunk_reads = state["reads"] - prefix_reads
 
         print(
-            f"\n[zone-prof] PROFILED CHUNK: {chunk} tok @ {cache} cache, {num_layers} layers\n"
+            f"\n[zone-prof] PROFILED CHUNK: {chunk} tok @ {cache} cache, {num_layers} layers "
+            f"(stage {stage}/{stages}, mesh {sp}x{tp}, fabric {fabric_name})\n"
             f"  wall-clock: {wall*1e3:.1f} ms  ({chunk_reads} profiler reads inside the chunk, "
             f"{prefix_reads} before it)\n"
             f"  device-kernel time per zone: parse the ops CSV with\n"
@@ -356,7 +442,11 @@ def main():
         )
         print("[zone-prof] DONE", flush=True)
     finally:
-        ttnn.close_mesh_device(mesh)
+        # Sub-mesh first: closing the parent runs a final profiler read on the parent's command queue,
+        # and MeshDevice::close then refuses to close a mesh whose child still holds an in-use queue.
+        for sub in galaxy.get_submeshes():
+            ttnn.close_mesh_device(sub)
+        ttnn.close_mesh_device(galaxy)
     return 0
 
 

--- a/models/demos/minimax_m3/tests/perf/profile_prefill.py
+++ b/models/demos/minimax_m3/tests/perf/profile_prefill.py
@@ -192,8 +192,8 @@ def build_runtime(mesh, chunk, total, num_layers_override, layer_ids=None, stage
     elif num_layers_override:
         num_layers = int(num_layers_override)
         assert num_layers <= per_stage, f"PROFILE_NUM_LAYERS={num_layers} exceeds the {per_stage} layers of a stage"
-        os.environ.setdefault("M3_LOAD_NLAYERS", str(num_layers))
-        os.environ.setdefault("M3_LOAD_LAYER_START", str(first_layer_idx))
+        os.environ["M3_LOAD_NLAYERS"] = str(num_layers)
+        os.environ["M3_LOAD_LAYER_START"] = str(first_layer_idx)
         print(
             f"[zone-prof] PROFILE_NUM_LAYERS={num_layers}: global layers "
             f"[{first_layer_idx}, {first_layer_idx + num_layers}) only",


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The MiniMax-M3 prefill zone profiler (`tests/perf/profile_prefill.py` + `scripts/run_prefill_profile.sh`) was hard-wired to the whole 8x4 galaxy. This adds `STAGES=1|2|4` / `STAGE=k` so one intra-galaxy pipeline stage can be profiled standalone: the harness opens the galaxy, carves stage k's (4,4) or (2,4) sub-mesh, and builds only that stage's layer slice from the sub-mesh's own tilized cache. Same chunk, cache depth, layers and zones as the whole-galaxy run, so per-zone kernel time compares directly at EP32 vs EP16 vs EP8.

Also in the wrapper: finished captures are moved to `prefill_profile_results/<stamp>_stages<S>_stage<k>_...`, the stage's cache is preflighted, and `RLIMIT_NPROC` is raised for the whole process tree (tracy-capture was aborting while saving the trace at the 512 default).

Validated on a Blackhole galaxy: whole-galaxy and 2-stage/stage-0 captures of layers 0 and 3 at 5k@50k both parse into the same 32 zones.

### Notes for reviewers
- Sub-meshes are closed before the parent; the reverse order throws in `MeshDevice::close` because the parent's final profiler read marks its command queue in use while the child still holds one.
- Every stage embeds its own tokens (`is_first_rank=True`) since there is no upstream stage; a zero placeholder would collapse MoE routing. Compute zones are exact, routing imbalance is not the real stage's.
- `FABRIC=2d|2d_torus_xy` is passed through but not yet validated on a carved sub-mesh; `1d` stays the default to match the baseline.

A nice comparison artifact (note - 1d topology was used): https://claude.ai/code/artifact/07c674fd-605a-4b8c-8532-f8762ceda9b3 

<img width="1074" height="1622" alt="image" src="https://github.com/user-attachments/assets/f0615439-c6a1-486e-b9ac-1f5f1012f5b2" />


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=philei/m3-profile-intragalaxy-stages)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:philei/m3-profile-intragalaxy-stages)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=philei/m3-profile-intragalaxy-stages)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:philei/m3-profile-intragalaxy-stages)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=philei/m3-profile-intragalaxy-stages)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:philei/m3-profile-intragalaxy-stages)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=philei/m3-profile-intragalaxy-stages)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:philei/m3-profile-intragalaxy-stages)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=philei/m3-profile-intragalaxy-stages)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:philei/m3-profile-intragalaxy-stages)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=philei/m3-profile-intragalaxy-stages)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:philei/m3-profile-intragalaxy-stages)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=philei/m3-profile-intragalaxy-stages)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:philei/m3-profile-intragalaxy-stages)