### PR TITLE
[skip ci] Remove stray semicolons after control-flow blocks in device code

### DIFF
--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
@@ -122,7 +122,7 @@ FORCE_INLINE constexpr static std::uint32_t MUL_WITH_TILE_SIZE(uint format, uint
 #endif
         // Keep default as Bfp8?
         default: return ((index << datum_shift) + (index << (exp_shift)));
-    };
+    }
 }
 
 // Check for get_noc_addr method

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_interface.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_interface.h
@@ -400,7 +400,7 @@ inline bool assert_check(uint32_t stream_id, bool hang) {
     uint32_t debug_assert = NOC_STREAM_READ_REG(stream_id, STREAM_DEBUG_ASSERTIONS_REG_INDEX);
     if (debug_assert > 0 && hang) {
         while (true) {
-        };
+        }
     }
     return debug_assert > 0;
 }

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/stream_interface.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/stream_interface.h
@@ -287,7 +287,7 @@ inline bool assert_check(uint32_t stream_id, bool hang) {
     uint32_t debug_assert = NOC_STREAM_READ_REG(stream_id, STREAM_DEBUG_ASSERTIONS_REG_INDEX);
     if (debug_assert > 0 && hang) {
         while (true) {
-        };
+        }
     }
     return debug_assert > 0;
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/stream_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/stream_interface.h
@@ -402,7 +402,7 @@ inline bool assert_check(uint32_t stream_id, bool hang) {
     uint32_t debug_assert = NOC_STREAM_READ_REG(stream_id, STREAM_DEBUG_ASSERTIONS_REG_INDEX);
     if (debug_assert > 0 && hang) {
         while (true) {
-        };
+        }
     }
     return debug_assert > 0;
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -124,7 +124,7 @@ inline void dbg_thread_halt()
         // Wait for previous packs to finish
         while (semaphore_read(semaphore::MATH_PACK) > 0)
         {
-        };
+        }
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -186,7 +186,7 @@ constexpr static std::uint32_t GET_L1_HEADERLESS_TILE_SIZE(std::uint32_t format)
             return (1024 >> 4);
         default:
             return ((1024 >> 4) + (64 >> 4));
-    };
+    }
 }
 
 constexpr static bool IS_BFP_FORMAT(std::uint32_t format)
@@ -202,7 +202,7 @@ constexpr static bool IS_BFP_FORMAT(std::uint32_t format)
             return true;
         default:
             return false;
-    };
+    }
 }
 
 constexpr static bool IS_BFP_A_FORMAT(std::uint32_t format)
@@ -215,7 +215,7 @@ constexpr static bool IS_BFP_A_FORMAT(std::uint32_t format)
             return true;
         default:
             return false;
-    };
+    }
 }
 
 constexpr static bool IS_A_FORMAT(std::uint32_t format)
@@ -230,7 +230,7 @@ constexpr static bool IS_A_FORMAT(std::uint32_t format)
             return true;
         default:
             return false;
-    };
+    }
 }
 
 constexpr static bool IS_8BIT_FORMAT(std::uint32_t format)
@@ -246,7 +246,7 @@ constexpr static bool IS_8BIT_FORMAT(std::uint32_t format)
             return true;
         default:
             return false;
-    };
+    }
 }
 
 constexpr static std::uint32_t SCALE_DATUM_SIZE(std::uint32_t format, std::uint32_t datum_count)
@@ -264,7 +264,7 @@ constexpr static std::uint32_t SCALE_DATUM_SIZE(std::uint32_t format, std::uint3
 
         default:
             return datum_count;
-    };
+    }
 }
 
 // Datum byte size from a data format's low 2 bits: Float32 -> 4, Float16 -> 2, else 1.

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -77,7 +77,7 @@ inline void _llk_math_reconfig_remap_(const bool remap_enable)
     tensix_sync();
     while (semaphore_read(semaphore::MATH_PACK) > 0)
     {
-    }; // Wait for previous packs to finish before claiming all dest
+    } // Wait for previous packs to finish before claiming all dest
 
     // Untilize mode needs dest read access with a stride of 16
     // Following bits are needed for enabling stride of 16
@@ -133,7 +133,7 @@ inline void _llk_math_pack_sync_init_()
     tensix_sync();
     while (semaphore_read(semaphore::MATH_PACK) > 0)
     {
-    }; // Wait for previous packs to finish before claiming all dest
+    } // Wait for previous packs to finish before claiming all dest
     if constexpr (Dst == DstSync::SyncFull)
     {
         TTI_SEMINIT(1, 0, p_stall::SEMAPHORE_1);

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -321,7 +321,7 @@ inline void _llk_math_pack_sync_init_()
     // Wait for previous packs to finish before claiming all dest
     while (semaphore_read(semaphore::MATH_PACK) > 0)
     {
-    };
+    }
 
     _reset_dest_register_offset_();
     _set_dest_section_base_<TRISC_ID>(_get_dest_buffer_base_());

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_debug.h
@@ -123,7 +123,7 @@ inline void dbg_thread_halt()
         // Wait for previous packs to finish
         while (semaphore_read(semaphore::MATH_PACK) > 0)
         {
-        };
+        }
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -184,7 +184,7 @@ constexpr static std::uint32_t GET_L1_HEADERLESS_TILE_SIZE(std::uint32_t format)
             return (1024 >> 4);
         default:
             return ((1024 >> 4) + (64 >> 4));
-    };
+    }
 }
 
 constexpr static bool IS_BFP_FORMAT(std::uint32_t format)
@@ -200,7 +200,7 @@ constexpr static bool IS_BFP_FORMAT(std::uint32_t format)
             return true;
         default:
             return false;
-    };
+    }
 }
 
 constexpr static bool IS_BFP_A_FORMAT(std::uint32_t format)
@@ -213,7 +213,7 @@ constexpr static bool IS_BFP_A_FORMAT(std::uint32_t format)
             return true;
         default:
             return false;
-    };
+    }
 }
 
 constexpr static bool IS_A_FORMAT(std::uint32_t format)
@@ -228,7 +228,7 @@ constexpr static bool IS_A_FORMAT(std::uint32_t format)
             return true;
         default:
             return false;
-    };
+    }
 }
 
 constexpr static std::uint32_t SCALE_DATUM_SIZE(std::uint32_t format, std::uint32_t datum_count)
@@ -246,7 +246,7 @@ constexpr static std::uint32_t SCALE_DATUM_SIZE(std::uint32_t format, std::uint3
 
         default:
             return datum_count;
-    };
+    }
 }
 
 // Datum byte size from a data format's low 2 bits: Float32 -> 4, Float16 -> 2, else 1.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -107,7 +107,7 @@ inline void _llk_math_pack_sync_init_()
     tensix_sync();
     while (semaphore_read(semaphore::MATH_PACK) > 0)
     {
-    }; // Wait for previous packs to finish before claiming all dest
+    } // Wait for previous packs to finish before claiming all dest
     if constexpr (Dst == DstSync::SyncFull)
     {
         TTI_SEMINIT(1, 0, p_stall::SEMAPHORE_1);


### PR DESCRIPTION
### Ticket
N/A — static analysis cleanup.

### Problem description

A `clang-tidy` run over kernel (device) sources reports 347
`clang-diagnostic-extra-semi-stmt` findings ("empty expression statement has no
effect; remove unnecessary ';'"). The overwhelming majority are unavoidable —
they come from the SFPI predication macros (`v_endif;`, `v_endblock;`) and from
function-like macros that legitimately expand to nothing, such as
`PREPROCESS_0(...)` in the eltwise kernels, where the semicolon is required by
the sibling expansion.

A small number are not macro-related. They are plain stray semicolons that were
written after a closing brace:

```cpp
while (semaphore_read(semaphore::MATH_PACK) > 0)
{
}; // Wait for previous packs to finish before claiming all dest
```

and after `switch` blocks:

```cpp
    default:
        return ((1024 >> 4) + (64 >> 4));
};
```

### What's changed

Removed 21 such null statements across 11 device headers: the files the report
names, plus the same functions in the other architecture trees so the LLK
sources stay in sync.

This is a syntactic cleanup with no behavioural component. In statement
position a semicolon after a closing brace is a separate empty statement, not
part of the preceding block, so deleting it cannot change what the code does.
No performance claim is made or intended.

Every changed site was verified to close a `switch` or a `while`, and
`git clang-format` reports no formatting change.

### Checklist
- [x] No functional change; syntactic only
- [x] `git clang-format` clean
- [ ] Post-commit CI

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/kernel-tidy-stray-semicolons)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/kernel-tidy-stray-semicolons)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/kernel-tidy-stray-semicolons)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/kernel-tidy-stray-semicolons)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/kernel-tidy-stray-semicolons)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/kernel-tidy-stray-semicolons)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/kernel-tidy-stray-semicolons)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/kernel-tidy-stray-semicolons)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/kernel-tidy-stray-semicolons)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/kernel-tidy-stray-semicolons)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/kernel-tidy-stray-semicolons)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/kernel-tidy-stray-semicolons)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/kernel-tidy-stray-semicolons)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/kernel-tidy-stray-semicolons)