### PR TITLE
Declare kernel_main() in the generated kernel header

### DIFF
--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -58,11 +58,15 @@ namespace tt::tt_metal {
 namespace {
 
 string get_kernel_source_to_include(const KernelSource& kernel_src) {
+    // Kernels define kernel_main() with no prior declaration (-Wmissing-prototypes). Not static:
+    // that lets the compiler inline the only call and drop the symbol, which dump-consts.py and
+    // llk-audit resolve by name.
+    constexpr const char* kernel_main_decl = "void kernel_main();\n";
     switch (kernel_src.source_type_) {
         case KernelSource::FILE_PATH: {
-            return "#include \"" + kernel_src.path_.string() + "\"\n";
+            return kernel_main_decl + ("#include \"" + kernel_src.path_.string() + "\"\n");
         }
-        case KernelSource::SOURCE_CODE: return kernel_src.source_;
+        case KernelSource::SOURCE_CODE: return kernel_main_decl + kernel_src.source_;
     }
     ttsl::unreachable();
 }


### PR DESCRIPTION
### Ticket
N/A — static analysis cleanup.

### Problem description

Every kernel defines `kernel_main()` at global scope, and nothing declares it
first. Clang reports that as `-Wmissing-prototypes`:

```
kernel.cpp:1:6: warning: no previous prototype for function 'kernel_main'
```

It accounts for 461 findings in the kernel `clang-tidy` report — the largest
single diagnostic in it — one per kernel translation unit.

The warning is legitimate but the underlying situation is benign: the firmware
calls `kernel_main()` from the *same* translation unit, because the generated
header `#include`s the kernel body into it (`dmk.cc`/`brisck.cc` via
`kernel_includes.hpp`, `run_kernel()` via `chlkc_list.h`). All that is missing
is a declaration.

### What's changed

`get_kernel_source_to_include()` now emits `void kernel_main();` ahead of the
kernel body. Both entry paths share that helper, so one line covers
`kernel_includes.hpp` for data-movement/ethernet kernels and all four
`chlkc_*.cpp` for compute. The declaration precedes the `#include`, so a kernel
keeps its own line numbering in diagnostics.

### Why a declaration rather than `static`

Marking the entry `static` (or putting it in an anonymous namespace) would also
silence the warning, and needs no change to any kernel source — a `static`
forward declaration alone gives the later definition internal linkage. It was
rejected because the symbol has to survive:

| | `-Wmissing-prototypes` | `kernel_main` in ELF | `.text` |
| --- | --- | --- | --- |
| today | 1 warning per TU | present | — |
| `void kernel_main();` | none | present | 4,431 B |
| `static void kernel_main();` | none | **gone, inlined away** | 4,423 B |

With one in-TU call site the compiler inlines the body at `-O2` and the symbol
disappears. Two in-repo tools resolve it by name and would break silently:
`tt_metal/tools/dump-consts.py` (`--function=kernel_main`) and
`llk-audit`, whose `registry.py` sets `KERNEL_ENTRY_NAMES = ("kernel_main",)`.

Internal linkage would also buy nothing in exchange. The definition is already
in the same translation unit as its only caller, so the optimiser has full
visibility either way; `static` only adds permission to drop the out-of-line
copy, measured above at 8 bytes on a realistically-sized body. No performance
claim is made or intended.

### Checklist
- [x] Verified end to end on the generated file layout: warning cleared, symbol retained, kernel line numbers preserved
- [x] `git clang-format` clean
- [ ] Post-commit CI

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/kernel-main-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/kernel-main-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/kernel-main-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/kernel-main-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/kernel-main-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/kernel-main-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/kernel-main-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/kernel-main-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/kernel-main-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/kernel-main-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/kernel-main-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/kernel-main-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/kernel-main-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/kernel-main-prototype)