### PR TITLE
[skip ci] Fix model targets link in transformer performance docs

### DIFF
--- a/models/tt_transformers/PERF.md
+++ b/models/tt_transformers/PERF.md
@@ -1,4 +1,4 @@
-Note: DEPRECATED. PLEASE CHECK THE YAML FILE [models/model_targets.yaml](models/model_targets.yaml)
+Note: DEPRECATED. PLEASE CHECK THE YAML FILE [models/model_targets.yaml](../model_targets.yaml)
 
 # Model performance and accuracy
 


### PR DESCRIPTION
Codex: Fix the broken `model_targets.yaml` link in the deprecation warning in `models/tt_transformers/PERF.md`.

## Summary
Use `../model_targets.yaml` so the link resolves to the existing file in `models/` from the document's directory.

## Testing
- `pre-commit run --files models/tt_transformers/PERF.md` — passed.
- `git diff --check` — passed.
- Verified the relative link resolves to the existing `models/model_targets.yaml`, also confirmed through the GitHub API.
- Documentation-only change; no build or device tests required. Uses the repository's `[skip ci]` convention.
