### PR TITLE
[LLK][Quasar] Round the direct-indexed eltwise replay length up, not down

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -143,9 +143,10 @@ template <EltwiseBinaryType ELTWISE_BINARY_TYPE, ckernel::MathFidelity MATH_FIDE
 inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& tensor_shape, bool acc_to_dest = false)
 {
     const std::uint32_t total_num_rows_per_tile = tensor_shape.total_num_faces() * tensor_shape.face_r_dim;
-    const std::uint32_t REPLAY_BUF_LEN          = (total_num_rows_per_tile >> rows_log2(ELTWISE_MATH_ROWS));
-    constexpr std::uint32_t MOP_INNER_LOOP      = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
-    constexpr bool high_fidelity                = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
+    // One ELW instruction covers ELTWISE_MATH_ROWS rows, so a tile with fewer rows than that still needs one.
+    const std::uint32_t REPLAY_BUF_LEN     = ((total_num_rows_per_tile + ELTWISE_MATH_ROWS - 1) >> rows_log2(ELTWISE_MATH_ROWS));
+    constexpr std::uint32_t MOP_INNER_LOOP = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
+    constexpr bool high_fidelity           = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     static_assert(!(high_fidelity && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
     const std::uint32_t EN_DST_ACC = acc_to_dest ? 1u : static_cast<std::uint32_t>(high_fidelity);
 


### PR DESCRIPTION
Fixes tenstorrent/tt-llk#1691

`REPLAY_BUF_LEN` in `_llk_math_eltwise_di_binary_mop_config_` is the count of `ELW` instructions needed to cover a tile, at `ELTWISE_MATH_ROWS` (8) rows each. It was a floored shift, so any tile with fewer than 8 total rows asked for **zero** instructions — 6 of the 15 shapes `validate_tensor_shape_tile_dependent_ops_` accepts.

At zero, the recording loop bound `REPLAY_BUF_LEN - 1` underflows on an unsigned to `0xFFFFFFFF`, and each iteration writes `instrn_buffer[0]` — about four billion real instruction issues. The operand addresses derived from the same expression are garbage, and `TT_OP_REPLAY` is installed with a length of 0.

Round up instead.

## Why this is safe

Every legal row count is a power of two (`num_faces` in {1,2,4} x `face_r_dim` in {1,2,4,8,16}), so `ceil == floor` for every shape that already worked — those are bit-identical. Only the six shapes that produced zero change:

| num_faces | face_r_dim | rows | before | after |
|---|---|---|---|---|
| 1 | 1 / 2 / 4 | 1 / 2 / 4 | **0** | 1 |
| 2 | 1 / 2 | 2 / 4 | **0** | 1 |
| 4 | 1 | 4 | **0** | 1 |
| 1 | 8 | 8 | 1 | 1 |
| 2 | 4 | 8 | 1 | 1 |
| 4 | 16 | 64 | 8 | 8 |

Quasar automotive is also fixed: `ELTWISE_MATH_ROWS` is 4 there, which moves the threshold rather than removing it — 3 shapes underflowed, now none do.

## Testing

The path is currently **dead** — `_llk_math_eltwise_di_binary_mop_config_` is reachable only via `_llk_math_eltwise_binary_init_<..., ENABLE_DIRECT_INDEXING = true>`, and nothing in `tt_metal/`, `ttnn/` or the tt-llk tests instantiates it with `true`. So there is no behavioural test to run and nothing that can regress; no Quasar silicon or simulator was available here either.

What was verified:

- **Arithmetic**, over all 15 legal `(num_faces, face_r_dim)` shapes for both `MATH_ROWS` = 8 and = 4: shapes yielding 0 go 6 -> 0 and 3 -> 0 respectively, with every other shape unchanged.
- **Compiles for Quasar**, before and after, with a probe TU that instantiates `_llk_math_eltwise_binary_init_<ELWADD, LoFi, NONE, /*ENABLE_DIRECT_INDEXING=*/true>` — the first thing to build this path. Zero errors in both arms.
- **The probe genuinely reaches the function**: a temporary poisoned `static_assert` inside it fired, so the clean compile is not vacuous.

Wormhole and Blackhole have no direct-indexing eltwise path and are untouched.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/quasar-di-eltwise-replay-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/quasar-di-eltwise-replay-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-di-eltwise-replay-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/quasar-di-eltwise-replay-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/quasar-di-eltwise-replay-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/quasar-di-eltwise-replay-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/quasar-di-eltwise-replay-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/quasar-di-eltwise-replay-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/quasar-di-eltwise-replay-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/quasar-di-eltwise-replay-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/quasar-di-eltwise-replay-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/quasar-di-eltwise-replay-len)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/quasar-di-eltwise-replay-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/quasar-di-eltwise-replay-len)