### PR TITLE
Drop [[maybe_unused]] from template parameters in device code

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -121,7 +121,7 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
-    [[maybe_unused]] MathFidelity math_fidelity,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
     const std::uint32_t operand_A,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -121,7 +121,7 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
-    /*unused*/ MathFidelity math_fidelity,
+    MathFidelity math_fidelity /*maybe_unused*/,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
     const std::uint32_t operand_A,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -121,7 +121,7 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
-    MathFidelity math_fidelity,
+    /*unused*/ MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
     const std::uint32_t operand_A,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -169,27 +169,27 @@ inline void llk_math_pack_sync_init() {
 // Math has no per-tile data-format state on Quasar; format reconfig is unpack-only.
 // The wrappers below are intentionally empty no-ops, kept so reconfig_data_format.h
 // can issue MATH((...)) uniformly across arches.
-template <bool EN_32BIT_DEST, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t /*srca_new_operand*/) {}
 
-template <bool EN_32BIT_DEST, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t /*srcb_new_operand*/) {}
 
-template <bool EN_32BIT_DEST, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t /*srca_new_operand*/, const std::uint32_t /*srcb_new_operand*/) {}
 
-template <bool EN_32BIT_DEST, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t /*srca_old_operand*/,
     const std::uint32_t /*srca_new_operand*/,
     const std::uint32_t /*srcb_old_operand*/,
     const std::uint32_t /*srcb_new_operand*/) {}
 
-template <bool EN_32BIT_DEST, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t /*srca_old_operand*/, const std::uint32_t /*srca_new_operand*/) {}
 
-template <bool EN_32BIT_DEST, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t /*srcb_old_operand*/, const std::uint32_t /*srcb_new_operand*/) {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -169,27 +169,27 @@ inline void llk_math_pack_sync_init() {
 // Math has no per-tile data-format state on Quasar; format reconfig is unpack-only.
 // The wrappers below are intentionally empty no-ops, kept so reconfig_data_format.h
 // can issue MATH((...)) uniformly across arches.
-template <[[maybe_unused]] bool EN_32BIT_DEST, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t /*srca_new_operand*/) {}
 
-template <[[maybe_unused]] bool EN_32BIT_DEST, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t /*srcb_new_operand*/) {}
 
-template <[[maybe_unused]] bool EN_32BIT_DEST, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t /*srca_new_operand*/, const std::uint32_t /*srcb_new_operand*/) {}
 
-template <[[maybe_unused]] bool EN_32BIT_DEST, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t /*srca_old_operand*/,
     const std::uint32_t /*srca_new_operand*/,
     const std::uint32_t /*srcb_old_operand*/,
     const std::uint32_t /*srcb_new_operand*/) {}
 
-template <[[maybe_unused]] bool EN_32BIT_DEST, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t /*srca_old_operand*/, const std::uint32_t /*srca_new_operand*/) {}
 
-template <[[maybe_unused]] bool EN_32BIT_DEST, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t /*srcb_old_operand*/, const std::uint32_t /*srcb_new_operand*/) {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -169,27 +169,27 @@ inline void llk_math_pack_sync_init() {
 // Math has no per-tile data-format state on Quasar; format reconfig is unpack-only.
 // The wrappers below are intentionally empty no-ops, kept so reconfig_data_format.h
 // can issue MATH((...)) uniformly across arches.
-template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST /*maybe_unused*/, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t /*srca_new_operand*/) {}
 
-template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST /*maybe_unused*/, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t /*srcb_new_operand*/) {}
 
-template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST /*maybe_unused*/, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t /*srca_new_operand*/, const std::uint32_t /*srcb_new_operand*/) {}
 
-template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST /*maybe_unused*/, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t /*srca_old_operand*/,
     const std::uint32_t /*srca_new_operand*/,
     const std::uint32_t /*srcb_old_operand*/,
     const std::uint32_t /*srcb_new_operand*/) {}
 
-template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST /*maybe_unused*/, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t /*srca_old_operand*/, const std::uint32_t /*srca_new_operand*/) {}
 
-template <bool EN_32BIT_DEST /*unused*/, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST /*maybe_unused*/, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t /*srcb_old_operand*/, const std::uint32_t /*srcb_new_operand*/) {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -31,8 +31,8 @@ template <
     bool EN_32BIT_DEST,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false,
-    [[maybe_unused]] bool is_int_fpu_en = false,
-    [[maybe_unused]] bool tilize = false>
+    bool is_int_fpu_en = false,
+    bool tilize = false>
 inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
@@ -131,7 +131,5 @@ inline void llk_math_eltwise_unary_datacopy_block(
     }
 }
 
-template <
-    [[maybe_unused]] BroadcastType src_b_bcast_type = BroadcastType::NONE,
-    [[maybe_unused]] bool unpack_to_dest = false>
+template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy_uninit() {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -31,8 +31,8 @@ template <
     bool EN_32BIT_DEST,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false,
-    bool is_int_fpu_en = false,
-    bool tilize = false>
+    bool is_int_fpu_en /*unused*/ = false,
+    bool tilize /*unused*/ = false>
 inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
@@ -131,5 +131,5 @@ inline void llk_math_eltwise_unary_datacopy_block(
     }
 }
 
-template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
+template <BroadcastType src_b_bcast_type /*unused*/ = BroadcastType::NONE, bool unpack_to_dest /*unused*/ = false>
 inline void llk_math_eltwise_unary_datacopy_uninit() {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -31,8 +31,8 @@ template <
     bool EN_32BIT_DEST,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false,
-    bool is_int_fpu_en /*unused*/ = false,
-    bool tilize /*unused*/ = false>
+    bool is_int_fpu_en /*maybe_unused*/ = false,
+    bool tilize /*maybe_unused*/ = false>
 inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
@@ -131,5 +131,7 @@ inline void llk_math_eltwise_unary_datacopy_block(
     }
 }
 
-template <BroadcastType src_b_bcast_type /*unused*/ = BroadcastType::NONE, bool unpack_to_dest /*unused*/ = false>
+template <
+    BroadcastType src_b_bcast_type /*maybe_unused*/ = BroadcastType::NONE,
+    bool unpack_to_dest /*maybe_unused*/ = false>
 inline void llk_math_eltwise_unary_datacopy_uninit() {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -75,7 +75,7 @@ inline bool should_reconfig_pack_in_data_format(const std::uint32_t old_output, 
 /**
  * Reprograms packer THCON IN_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
  */
-template <[[maybe_unused]] bool EN_32BIT_DEST>
+template <bool EN_32BIT_DEST>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     _llk_pack_reconfig_data_format_<p_pacr::PACK0>(pack_src_format[output_id], pack_dst_format[output_id]);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -75,7 +75,7 @@ inline bool should_reconfig_pack_in_data_format(const std::uint32_t old_output, 
 /**
  * Reprograms packer THCON IN_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
  */
-template <bool EN_32BIT_DEST>
+template <bool EN_32BIT_DEST /*unused*/>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     _llk_pack_reconfig_data_format_<p_pacr::PACK0>(pack_src_format[output_id], pack_dst_format[output_id]);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -75,7 +75,7 @@ inline bool should_reconfig_pack_in_data_format(const std::uint32_t old_output, 
 /**
  * Reprograms packer THCON IN_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
  */
-template <bool EN_32BIT_DEST /*unused*/>
+template <bool EN_32BIT_DEST /*maybe_unused*/>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     _llk_pack_reconfig_data_format_<p_pacr::PACK0>(pack_src_format[output_id], pack_dst_format[output_id]);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
@@ -19,7 +19,7 @@
  * @tparam pack_mode: Unused on Quasar
  * @param ocb: The output Dataflow Buffer identifier
  */
-template <ReduceDim reduce_dim, [[maybe_unused]] PackMode pack_mode = PackMode::Default>
+template <ReduceDim reduce_dim, PackMode pack_mode = PackMode::Default>
 inline void llk_pack_reduce_mask_config(std::uint32_t ocb) {
     static_assert(pack_mode == PackMode::Default, "Quasar pack reduce mask does not support pack_mode != Default");
     const ckernel::TensorShape tensor_shape = get_output_tensor_shape(ocb);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
@@ -19,7 +19,7 @@
  * @tparam pack_mode: Unused on Quasar
  * @param ocb: The output Dataflow Buffer identifier
  */
-template <ReduceDim reduce_dim, PackMode pack_mode = PackMode::Default>
+template <ReduceDim reduce_dim, PackMode pack_mode /*maybe_unused*/ = PackMode::Default>
 inline void llk_pack_reduce_mask_config(std::uint32_t ocb) {
     static_assert(pack_mode == PackMode::Default, "Quasar pack reduce mask does not support pack_mode != Default");
     const ckernel::TensorShape tensor_shape = get_output_tensor_shape(ocb);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -62,7 +62,7 @@ sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
  * @tparam TILE_SHAPE: destination tile shape used to calculate operand offsets
  */
 template <
-    bool APPROXIMATION_MODE,
+    bool APPROXIMATION_MODE /*unused*/,
     BinaryOp BINOP,
     bool is_fp32_dest_acc_en,
     DstRoundingMode dst_rounding_mode = DstRoundingMode::Default,
@@ -129,7 +129,7 @@ inline void calculate_sfpu_binary(
  * @tparam APPROXIMATION_MODE: forwarded to the op-specific init
  * @tparam BINOP: selects which op's init to run
  */
-template <bool APPROXIMATION_MODE, BinaryOp BINOP>
+template <bool APPROXIMATION_MODE /*unused unless BINOP is DIV*/, BinaryOp BINOP>
 inline void sfpu_binary_init() {
     if constexpr (BINOP == BinaryOp::DIV) {
         _init_reciprocal_<APPROXIMATION_MODE>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -129,7 +129,7 @@ inline void calculate_sfpu_binary(
  * @tparam APPROXIMATION_MODE: forwarded to the op-specific init
  * @tparam BINOP: selects which op's init to run
  */
-template <[[maybe_unused]] bool APPROXIMATION_MODE, BinaryOp BINOP>
+template <bool APPROXIMATION_MODE, BinaryOp BINOP>
 inline void sfpu_binary_init() {
     if constexpr (BINOP == BinaryOp::DIV) {
         _init_reciprocal_<APPROXIMATION_MODE>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -62,7 +62,7 @@ sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
  * @tparam TILE_SHAPE: destination tile shape used to calculate operand offsets
  */
 template <
-    [[maybe_unused]] bool APPROXIMATION_MODE,
+    bool APPROXIMATION_MODE,
     BinaryOp BINOP,
     bool is_fp32_dest_acc_en,
     DstRoundingMode dst_rounding_mode = DstRoundingMode::Default,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -62,7 +62,7 @@ sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
  * @tparam TILE_SHAPE: destination tile shape used to calculate operand offsets
  */
 template <
-    bool APPROXIMATION_MODE /*unused*/,
+    bool APPROXIMATION_MODE /*maybe_unused*/,
     BinaryOp BINOP,
     bool is_fp32_dest_acc_en,
     DstRoundingMode dst_rounding_mode = DstRoundingMode::Default,
@@ -129,7 +129,7 @@ inline void calculate_sfpu_binary(
  * @tparam APPROXIMATION_MODE: forwarded to the op-specific init
  * @tparam BINOP: selects which op's init to run
  */
-template <bool APPROXIMATION_MODE /*unused unless BINOP is DIV*/, BinaryOp BINOP>
+template <bool APPROXIMATION_MODE /*maybe_unused*/, BinaryOp BINOP>
 inline void sfpu_binary_init() {
     if constexpr (BINOP == BinaryOp::DIV) {
         _init_reciprocal_<APPROXIMATION_MODE>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -117,9 +117,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
 template <
     bool APPROXIMATION_MODE,
     bool EN_32BIT_DEST,
-    [[maybe_unused]] bool SCALE_EN = false,
+    bool SCALE_EN = false,
     int ITERATIONS = SFPU_ITERATIONS,
-    [[maybe_unused]] bool CLAMP_NEGATIVE = true>
+    bool CLAMP_NEGATIVE = true>
 void calculate_exponential([[maybe_unused]] const std::uint32_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     static_assert(SCALE_EN == false, "Non-default SCALE_EN not supported in Quasar exp");
     static_assert(CLAMP_NEGATIVE == true, "Non-default CLAMP_NEGATIVE not supported in Quasar exp");
@@ -142,11 +142,7 @@ void calculate_exponential([[maybe_unused]] const std::uint32_t exp_base_scale_f
     }
 }
 
-template <
-    [[maybe_unused]] bool APPROXIMATION_MODE,
-    [[maybe_unused]] uint32_t scale = 0x3F800000,
-    [[maybe_unused]] bool CLAMP_NEGATIVE = true,
-    [[maybe_unused]] bool EN_32BIT_DEST>
+template <bool APPROXIMATION_MODE, uint32_t scale = 0x3F800000, bool CLAMP_NEGATIVE = true, bool EN_32BIT_DEST>
 void exp_init() {
     static_assert(scale == 0x3F800000, "Non-default scale not supported in Quasar exp");
     static_assert(CLAMP_NEGATIVE == true, "Non-default CLAMP_NEGATIVE not supported in Quasar exp");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -142,7 +142,11 @@ void calculate_exponential([[maybe_unused]] const std::uint32_t exp_base_scale_f
     }
 }
 
-template <bool APPROXIMATION_MODE, uint32_t scale = 0x3F800000, bool CLAMP_NEGATIVE = true, bool EN_32BIT_DEST>
+template <
+    bool APPROXIMATION_MODE /*unused*/,
+    uint32_t scale = 0x3F800000,
+    bool CLAMP_NEGATIVE = true,
+    bool EN_32BIT_DEST /*unused*/>
 void exp_init() {
     static_assert(scale == 0x3F800000, "Non-default scale not supported in Quasar exp");
     static_assert(CLAMP_NEGATIVE == true, "Non-default CLAMP_NEGATIVE not supported in Quasar exp");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -117,9 +117,9 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
 template <
     bool APPROXIMATION_MODE,
     bool EN_32BIT_DEST,
-    bool SCALE_EN = false,
+    bool SCALE_EN /*maybe_unused*/ = false,
     int ITERATIONS = SFPU_ITERATIONS,
-    bool CLAMP_NEGATIVE = true>
+    bool CLAMP_NEGATIVE /*maybe_unused*/ = true>
 void calculate_exponential([[maybe_unused]] const std::uint32_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     static_assert(SCALE_EN == false, "Non-default SCALE_EN not supported in Quasar exp");
     static_assert(CLAMP_NEGATIVE == true, "Non-default CLAMP_NEGATIVE not supported in Quasar exp");
@@ -143,10 +143,10 @@ void calculate_exponential([[maybe_unused]] const std::uint32_t exp_base_scale_f
 }
 
 template <
-    bool APPROXIMATION_MODE /*unused*/,
-    uint32_t scale = 0x3F800000,
-    bool CLAMP_NEGATIVE = true,
-    bool EN_32BIT_DEST /*unused*/>
+    bool APPROXIMATION_MODE /*maybe_unused*/,
+    uint32_t scale /*maybe_unused*/ = 0x3F800000,
+    bool CLAMP_NEGATIVE /*maybe_unused*/ = true,
+    bool EN_32BIT_DEST /*maybe_unused*/>
 void exp_init() {
     static_assert(scale == 0x3F800000, "Non-default scale not supported in Quasar exp");
     static_assert(CLAMP_NEGATIVE == true, "Non-default CLAMP_NEGATIVE not supported in Quasar exp");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -79,11 +79,7 @@ inline void _init_reciprocal_() {
  * @note Call @ref recip_init with matching template args first — it programs the Newton-Raphson
  *       constant (vConstFloatPrgm0) that @ref _sfpu_reciprocal_ refines with.
  */
-template <
-    bool APPROXIMATION_MODE,
-    bool EN_32BIT_DEST,
-    int ITERATIONS = SFPU_ITERATIONS,
-    [[maybe_unused]] bool legacy_compat = true>
+template <bool APPROXIMATION_MODE, bool EN_32BIT_DEST, int ITERATIONS = SFPU_ITERATIONS, bool legacy_compat = true>
 inline void calculate_reciprocal() {
     static_assert(legacy_compat == true, "Non-default legacy_compat (false) not supported in Quasar reciprocal");
     constexpr int max_iter = (!EN_32BIT_DEST || APPROXIMATION_MODE) ? 0 : 2;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -95,7 +95,7 @@ inline void calculate_reciprocal() {
     }
 }
 
-template <bool APPROXIMATION_MODE, [[maybe_unused]] bool EN_32BIT_DEST, [[maybe_unused]] bool legacy_compat = true>
+template <bool APPROXIMATION_MODE, bool EN_32BIT_DEST, bool legacy_compat = true>
 void recip_init() {
     static_assert(legacy_compat == true, "Non-default legacy_compat (false) not supported in Quasar reciprocal");
     llk_math_eltwise_unary_sfpu_init<SfpuType::reciprocal>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -91,7 +91,7 @@ inline void calculate_reciprocal() {
     }
 }
 
-template <bool APPROXIMATION_MODE, bool EN_32BIT_DEST, bool legacy_compat = true>
+template <bool APPROXIMATION_MODE, bool EN_32BIT_DEST /*unused*/, bool legacy_compat = true>
 void recip_init() {
     static_assert(legacy_compat == true, "Non-default legacy_compat (false) not supported in Quasar reciprocal");
     llk_math_eltwise_unary_sfpu_init<SfpuType::reciprocal>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -79,7 +79,11 @@ inline void _init_reciprocal_() {
  * @note Call @ref recip_init with matching template args first — it programs the Newton-Raphson
  *       constant (vConstFloatPrgm0) that @ref _sfpu_reciprocal_ refines with.
  */
-template <bool APPROXIMATION_MODE, bool EN_32BIT_DEST, int ITERATIONS = SFPU_ITERATIONS, bool legacy_compat = true>
+template <
+    bool APPROXIMATION_MODE,
+    bool EN_32BIT_DEST,
+    int ITERATIONS = SFPU_ITERATIONS,
+    bool legacy_compat /*maybe_unused*/ = true>
 inline void calculate_reciprocal() {
     static_assert(legacy_compat == true, "Non-default legacy_compat (false) not supported in Quasar reciprocal");
     constexpr int max_iter = (!EN_32BIT_DEST || APPROXIMATION_MODE) ? 0 : 2;
@@ -91,7 +95,7 @@ inline void calculate_reciprocal() {
     }
 }
 
-template <bool APPROXIMATION_MODE, bool EN_32BIT_DEST /*unused*/, bool legacy_compat = true>
+template <bool APPROXIMATION_MODE, bool EN_32BIT_DEST /*maybe_unused*/, bool legacy_compat /*maybe_unused*/ = true>
 void recip_init() {
     static_assert(legacy_compat == true, "Non-default legacy_compat (false) not supported in Quasar reciprocal");
     llk_math_eltwise_unary_sfpu_init<SfpuType::reciprocal>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -118,7 +118,7 @@ inline void calculate_rsqrt() {
 
 // Signature mirrors Blackhole/Wormhole rsqrt_init (<APPROXIMATION_MODE, legacy_compat>); the init
 // itself does not depend on the Dest width, so no fp32 template arg is threaded here.
-template <bool APPROXIMATION_MODE, [[maybe_unused]] bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, bool legacy_compat = false>
 void rsqrt_init() {
     static_assert(!legacy_compat, "Non-default legacy_compat (true) not supported in Quasar rsqrt");
     llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -95,8 +95,8 @@ template <
     bool APPROXIMATION_MODE,
     int ITERATIONS = SFPU_ITERATIONS,
     bool EN_32BIT_DEST = false,
-    [[maybe_unused]] bool FAST_APPROX = false,
-    [[maybe_unused]] bool legacy_compat = false>
+    bool FAST_APPROX = false,
+    bool legacy_compat = false>
 inline void calculate_rsqrt() {
     static_assert(!FAST_APPROX, "Non-default FAST_APPROX (true) not supported in Quasar rsqrt");
     static_assert(!legacy_compat, "Non-default legacy_compat (true) not supported in Quasar rsqrt");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -95,8 +95,8 @@ template <
     bool APPROXIMATION_MODE,
     int ITERATIONS = SFPU_ITERATIONS,
     bool EN_32BIT_DEST = false,
-    bool FAST_APPROX = false,
-    bool legacy_compat = false>
+    bool FAST_APPROX /*maybe_unused*/ = false,
+    bool legacy_compat /*maybe_unused*/ = false>
 inline void calculate_rsqrt() {
     static_assert(!FAST_APPROX, "Non-default FAST_APPROX (true) not supported in Quasar rsqrt");
     static_assert(!legacy_compat, "Non-default legacy_compat (true) not supported in Quasar rsqrt");
@@ -118,7 +118,7 @@ inline void calculate_rsqrt() {
 
 // Signature mirrors Blackhole/Wormhole rsqrt_init (<APPROXIMATION_MODE, legacy_compat>); the init
 // itself does not depend on the Dest width, so no fp32 template arg is threaded here.
-template <bool APPROXIMATION_MODE, bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, bool legacy_compat /*maybe_unused*/ = false>
 void rsqrt_init() {
     static_assert(!legacy_compat, "Non-default legacy_compat (true) not supported in Quasar rsqrt");
     llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -11,11 +11,7 @@
 namespace ckernel {
 namespace sfpu {
 
-template <
-    bool APPROXIMATION_MODE,
-    int ITERATIONS = SFPU_ITERATIONS,
-    [[maybe_unused]] bool EN_32BIT_DEST,
-    [[maybe_unused]] bool FAST_APPROX = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS = SFPU_ITERATIONS, bool EN_32BIT_DEST, bool FAST_APPROX = false>
 inline void calculate_sqrt() {
     static_assert(FAST_APPROX == false, "Non-default FAST_APPROX (true) not supported in Quasar sqrt");
     _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -21,7 +21,7 @@ inline void calculate_sqrt() {
     _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
-template <[[maybe_unused]] bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE>
 void sqrt_init() {
     // Empty function kept for backwards compatibility
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -11,13 +11,17 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = SFPU_ITERATIONS, bool EN_32BIT_DEST, bool FAST_APPROX = false>
+template <
+    bool APPROXIMATION_MODE,
+    int ITERATIONS = SFPU_ITERATIONS,
+    bool EN_32BIT_DEST /*unused*/,
+    bool FAST_APPROX = false>
 inline void calculate_sqrt() {
     static_assert(FAST_APPROX == false, "Non-default FAST_APPROX (true) not supported in Quasar sqrt");
     _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE /*unused*/>
 void sqrt_init() {
     // Empty function kept for backwards compatibility
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -14,14 +14,14 @@ namespace sfpu {
 template <
     bool APPROXIMATION_MODE,
     int ITERATIONS = SFPU_ITERATIONS,
-    bool EN_32BIT_DEST /*unused*/,
-    bool FAST_APPROX = false>
+    bool EN_32BIT_DEST /*maybe_unused*/,
+    bool FAST_APPROX /*maybe_unused*/ = false>
 inline void calculate_sqrt() {
     static_assert(FAST_APPROX == false, "Non-default FAST_APPROX (true) not supported in Quasar sqrt");
     _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
-template <bool APPROXIMATION_MODE /*unused*/>
+template <bool APPROXIMATION_MODE /*maybe_unused*/>
 void sqrt_init() {
     // Empty function kept for backwards compatibility
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
@@ -23,12 +23,12 @@
 
 namespace ckernel {
 
-template <SfpuType sfpu_op>
+template <SfpuType sfpu_op /*unused*/>
 inline void llk_math_eltwise_binary_sfpu_init() {
     _llk_math_eltwise_sfpu_init_();
 }
 
-template <SfpuType sfpu_op, class F, class... ARGS>
+template <SfpuType sfpu_op /*unused*/, class F, class... ARGS>
 inline void llk_math_eltwise_binary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_sfpu_init_();
     init_func(std::forward<ARGS>(args)...);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
@@ -23,12 +23,12 @@
 
 namespace ckernel {
 
-template <[[maybe_unused]] SfpuType sfpu_op>
+template <SfpuType sfpu_op>
 inline void llk_math_eltwise_binary_sfpu_init() {
     _llk_math_eltwise_sfpu_init_();
 }
 
-template <[[maybe_unused]] SfpuType sfpu_op, class F, class... ARGS>
+template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_binary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_sfpu_init_();
     init_func(std::forward<ARGS>(args)...);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_init.h
@@ -23,12 +23,12 @@
 
 namespace ckernel {
 
-template <SfpuType sfpu_op /*unused*/>
+template <SfpuType sfpu_op /*maybe_unused*/>
 inline void llk_math_eltwise_binary_sfpu_init() {
     _llk_math_eltwise_sfpu_init_();
 }
 
-template <SfpuType sfpu_op /*unused*/, class F, class... ARGS>
+template <SfpuType sfpu_op /*maybe_unused*/, class F, class... ARGS>
 inline void llk_math_eltwise_binary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_sfpu_init_();
     init_func(std::forward<ARGS>(args)...);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_ternary_sfpu_where_init() {
  * @param odst        DEST tile index that receives the result.
  * @param vector_mode Must be @c VectorMode::RC; Quasar only supports full-tile mode.
  */
-template <bool APPROXIMATE, [[maybe_unused]] DataFormat data_format>
+template <bool APPROXIMATE, DataFormat data_format>
 inline void llk_math_eltwise_ternary_sfpu_where(
     std::uint32_t dst_index0,
     std::uint32_t dst_index1,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_ternary_sfpu_where_init() {
  * @param odst        DEST tile index that receives the result.
  * @param vector_mode Must be @c VectorMode::RC; Quasar only supports full-tile mode.
  */
-template <bool APPROXIMATE, DataFormat data_format>
+template <bool APPROXIMATE, DataFormat data_format /*unused*/>
 inline void llk_math_eltwise_ternary_sfpu_where(
     std::uint32_t dst_index0,
     std::uint32_t dst_index1,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_ternary_sfpu_where_init() {
  * @param odst        DEST tile index that receives the result.
  * @param vector_mode Must be @c VectorMode::RC; Quasar only supports full-tile mode.
  */
-template <bool APPROXIMATE, DataFormat data_format /*unused*/>
+template <bool APPROXIMATE, DataFormat data_format /*maybe_unused*/>
 inline void llk_math_eltwise_ternary_sfpu_where(
     std::uint32_t dst_index0,
     std::uint32_t dst_index1,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -9,7 +9,7 @@
 namespace ckernel {
 
 // sfpu_op template parameter is unused, but kept for backwards compatibility
-template <SfpuType sfpu_op>
+template <SfpuType sfpu_op /*unused*/>
 inline void llk_math_eltwise_unary_sfpu_init() {
     _llk_math_eltwise_sfpu_init_();
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -9,7 +9,7 @@
 namespace ckernel {
 
 // sfpu_op template parameter is unused, but kept for backwards compatibility
-template <[[maybe_unused]] SfpuType sfpu_op>
+template <SfpuType sfpu_op>
 inline void llk_math_eltwise_unary_sfpu_init() {
     _llk_math_eltwise_sfpu_init_();
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -9,7 +9,7 @@
 namespace ckernel {
 
 // sfpu_op template parameter is unused, but kept for backwards compatibility
-template <SfpuType sfpu_op /*unused*/>
+template <SfpuType sfpu_op /*maybe_unused*/>
 inline void llk_math_eltwise_unary_sfpu_init() {
     _llk_math_eltwise_sfpu_init_();
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -20,8 +20,8 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
 template <
     bool APPROXIMATE,
     bool is_fp32_dest_acc_en,
-    [[maybe_unused]] bool FAST_APPROX = false,
-    [[maybe_unused]] bool legacy_compat = false,
+    bool FAST_APPROX = false,
+    bool legacy_compat = false,
     int ITERATIONS = SFPU_ITERATIONS>
 inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index) {
     static_assert(FAST_APPROX == false, "Non-default FAST_APPROX (true) not supported in Quasar rsqrt");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -9,7 +9,7 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, [[maybe_unused]] bool legacy_compat = false>
+template <bool APPROXIMATE, bool legacy_compat = false>
 inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
     static_assert(legacy_compat == false, "Non-default legacy_compat (true) not supported in Quasar rsqrt");
     // Run the global SFPU config init followed by rsqrt_init, which programs the full-precision

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -9,7 +9,7 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool legacy_compat = false>
+template <bool APPROXIMATE, bool legacy_compat /*maybe_unused*/ = false>
 inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
     static_assert(legacy_compat == false, "Non-default legacy_compat (true) not supported in Quasar rsqrt");
     // Run the global SFPU config init followed by rsqrt_init, which programs the full-precision
@@ -20,8 +20,8 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
 template <
     bool APPROXIMATE,
     bool is_fp32_dest_acc_en,
-    bool FAST_APPROX = false,
-    bool legacy_compat = false,
+    bool FAST_APPROX /*maybe_unused*/ = false,
+    bool legacy_compat /*maybe_unused*/ = false,
     int ITERATIONS = SFPU_ITERATIONS>
 inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index) {
     static_assert(FAST_APPROX == false, "Non-default FAST_APPROX (true) not supported in Quasar rsqrt");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -124,7 +124,7 @@ inline void llk_unpack_A_init(
  */
 template <
     BroadcastType BType = BroadcastType::NONE,
-    bool acc_to_dest = false,
+    bool acc_to_dest /*unused*/ = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
@@ -165,7 +165,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 // TODO: AM; Optimize block calls by using ntiles per unpack, issue #40798
 template <
     BroadcastType BType = BroadcastType::NONE,
-    bool acc_to_dest = false,
+    bool acc_to_dest /*unused*/ = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A_block(

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -36,7 +36,7 @@
  */
 template <
     BroadcastType BType = BroadcastType::NONE,
-    [[maybe_unused]] bool acc_to_dest = false,
+    bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A_init(
@@ -124,7 +124,7 @@ inline void llk_unpack_A_init(
  */
 template <
     BroadcastType BType = BroadcastType::NONE,
-    [[maybe_unused]] bool acc_to_dest = false,
+    bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
@@ -165,7 +165,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 // TODO: AM; Optimize block calls by using ntiles per unpack, issue #40798
 template <
     BroadcastType BType = BroadcastType::NONE,
-    [[maybe_unused]] bool acc_to_dest = false,
+    bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A_block(

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -36,7 +36,7 @@
  */
 template <
     BroadcastType BType = BroadcastType::NONE,
-    bool acc_to_dest = false,
+    bool acc_to_dest /*maybe_unused*/ = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A_init(
@@ -124,7 +124,7 @@ inline void llk_unpack_A_init(
  */
 template <
     BroadcastType BType = BroadcastType::NONE,
-    bool acc_to_dest /*unused*/ = false,
+    bool acc_to_dest /*maybe_unused*/ = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
@@ -165,7 +165,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 // TODO: AM; Optimize block calls by using ntiles per unpack, issue #40798
 template <
     BroadcastType BType = BroadcastType::NONE,
-    bool acc_to_dest /*unused*/ = false,
+    bool acc_to_dest /*maybe_unused*/ = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A_block(

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -78,7 +78,7 @@ inline bool should_reconfig_src_reg_df(std::uint32_t old_operand, std::uint32_t 
 /**
  * Reprograms unpacker THCON OUT_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
  */
-template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 /*unused*/ = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     static_assert(
         dim_stride_target == p_dim_stride_target::IGNORE,
@@ -88,7 +88,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
-template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 /*unused*/ = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     static_assert(
         dim_stride_target == p_dim_stride_target::IGNORE,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -78,7 +78,7 @@ inline bool should_reconfig_src_reg_df(std::uint32_t old_operand, std::uint32_t 
 /**
  * Reprograms unpacker THCON OUT_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
  */
-template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     static_assert(
         dim_stride_target == p_dim_stride_target::IGNORE,
@@ -88,7 +88,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
-template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, [[maybe_unused]] bool to_from_int8 = false>
+template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     static_assert(
         dim_stride_target == p_dim_stride_target::IGNORE,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -78,7 +78,7 @@ inline bool should_reconfig_src_reg_df(std::uint32_t old_operand, std::uint32_t 
 /**
  * Reprograms unpacker THCON OUT_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
  */
-template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     static_assert(
         dim_stride_target == p_dim_stride_target::IGNORE,
@@ -88,7 +88,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
-template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 /*unused*/ = false>
+template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 /*maybe_unused*/ = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     static_assert(
         dim_stride_target == p_dim_stride_target::IGNORE,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -122,10 +122,10 @@ inline void llk_unpack_tilize_uninit([[maybe_unused]] const std::uint32_t operan
  * @param  ct_dim           Number of column tiles in the tilize block.
  */
 template <
-    bool neginf_srcA = false,
+    bool neginf_srcA /*unused*/ = false,
     std::uint32_t reload_srcB = false,
     bool zero_srcA = false,
-    bool zero_srcA_reduce = false>
+    bool zero_srcA_reduce /*unused*/ = false>
 inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t ct_dim) {
     static_assert(!zero_srcA, "zero_srcA = true does not trigger any functionality on Quasar.");
@@ -173,10 +173,10 @@ inline void llk_unpack_tilizeA_B_init(
  * @param  block_ct_dim Number of column tiles in the tilize block.
  */
 template <
-    bool neginf_srcA = false,
+    bool neginf_srcA /*unused*/ = false,
     std::uint32_t reload_srcB = false,
     bool zero_srcA = false,
-    bool zero_srcA_reduce = false>
+    bool zero_srcA_reduce /*unused*/ = false>
 inline void llk_unpack_tilizeA_B(
     const std::uint32_t operandA,
     const std::uint32_t operandB,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -122,10 +122,10 @@ inline void llk_unpack_tilize_uninit([[maybe_unused]] const std::uint32_t operan
  * @param  ct_dim           Number of column tiles in the tilize block.
  */
 template <
-    bool neginf_srcA [[maybe_unused]] = false,
-    std::uint32_t reload_srcB [[maybe_unused]] = false,
-    bool zero_srcA [[maybe_unused]] = false,
-    bool zero_srcA_reduce [[maybe_unused]] = false>
+    bool neginf_srcA = false,
+    std::uint32_t reload_srcB = false,
+    bool zero_srcA = false,
+    bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t ct_dim) {
     static_assert(!zero_srcA, "zero_srcA = true does not trigger any functionality on Quasar.");
@@ -173,10 +173,10 @@ inline void llk_unpack_tilizeA_B_init(
  * @param  block_ct_dim Number of column tiles in the tilize block.
  */
 template <
-    bool neginf_srcA [[maybe_unused]] = false,
-    std::uint32_t reload_srcB [[maybe_unused]] = false,
-    bool zero_srcA [[maybe_unused]] = false,
-    bool zero_srcA_reduce [[maybe_unused]] = false>
+    bool neginf_srcA = false,
+    std::uint32_t reload_srcB = false,
+    bool zero_srcA = false,
+    bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -237,10 +237,10 @@ inline void llk_unpack_tilizeA_B(
  * @param  tile_idx_b      Tile index within operand B.
  */
 template <
-    bool neginf_srcA [[maybe_unused]] = false,
-    std::uint32_t reload_srcB [[maybe_unused]] = false,
-    bool zero_srcA [[maybe_unused]] = false,
-    bool zero_srcA_reduce [[maybe_unused]] = false>
+    bool neginf_srcA = false,
+    std::uint32_t reload_srcB = false,
+    bool zero_srcA = false,
+    bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B_block(
     const std::uint32_t operandA,
     const std::uint32_t operandB,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -122,10 +122,10 @@ inline void llk_unpack_tilize_uninit([[maybe_unused]] const std::uint32_t operan
  * @param  ct_dim           Number of column tiles in the tilize block.
  */
 template <
-    bool neginf_srcA /*unused*/ = false,
-    std::uint32_t reload_srcB = false,
-    bool zero_srcA = false,
-    bool zero_srcA_reduce /*unused*/ = false>
+    bool neginf_srcA /*maybe_unused*/ = false,
+    std::uint32_t reload_srcB /*maybe_unused*/ = false,
+    bool zero_srcA /*maybe_unused*/ = false,
+    bool zero_srcA_reduce /*maybe_unused*/ = false>
 inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t ct_dim) {
     static_assert(!zero_srcA, "zero_srcA = true does not trigger any functionality on Quasar.");
@@ -173,10 +173,10 @@ inline void llk_unpack_tilizeA_B_init(
  * @param  block_ct_dim Number of column tiles in the tilize block.
  */
 template <
-    bool neginf_srcA /*unused*/ = false,
-    std::uint32_t reload_srcB = false,
-    bool zero_srcA = false,
-    bool zero_srcA_reduce /*unused*/ = false>
+    bool neginf_srcA /*maybe_unused*/ = false,
+    std::uint32_t reload_srcB /*maybe_unused*/ = false,
+    bool zero_srcA /*maybe_unused*/ = false,
+    bool zero_srcA_reduce /*maybe_unused*/ = false>
 inline void llk_unpack_tilizeA_B(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -237,10 +237,10 @@ inline void llk_unpack_tilizeA_B(
  * @param  tile_idx_b      Tile index within operand B.
  */
 template <
-    bool neginf_srcA = false,
-    std::uint32_t reload_srcB = false,
-    bool zero_srcA = false,
-    bool zero_srcA_reduce = false>
+    bool neginf_srcA /*maybe_unused*/ = false,
+    std::uint32_t reload_srcB /*maybe_unused*/ = false,
+    bool zero_srcA /*maybe_unused*/ = false,
+    bool zero_srcA_reduce /*maybe_unused*/ = false>
 inline void llk_unpack_tilizeA_B_block(
     const std::uint32_t operandA,
     const std::uint32_t operandB,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -119,7 +119,7 @@ inline void calculate_reciprocal() {
     }
 }
 
-template <bool APPROXIMATION_MODE, [[maybe_unused]] bool is_fp32_dest_acc_en, bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>
 void recip_init() {
     // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
     // reciprocal setup below -- one self-contained init, matching exp_init. SDPA runs reciprocal in its

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -119,7 +119,7 @@ inline void calculate_reciprocal() {
     }
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en /*unused*/, bool legacy_compat = false>
 void recip_init() {
     // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
     // reciprocal setup below -- one self-contained init, matching exp_init. SDPA runs reciprocal in its

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -119,7 +119,7 @@ inline void calculate_reciprocal() {
     }
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en /*unused*/, bool legacy_compat = false>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en /*maybe_unused*/, bool legacy_compat = false>
 void recip_init() {
     // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
     // reciprocal setup below -- one self-contained init, matching exp_init. SDPA runs reciprocal in its

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -47,7 +47,7 @@ inline void _llk_math_eltwise_unary_datacopy_wrapper_(
     _llk_math_eltwise_unary_datacopy_<type, Dst, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(dst_index, src_format, dst_format);
 }
 
-template <[[maybe_unused]] bool is_fp32_dest_acc_en, bool transpose_of_faces = true, bool is_32bit = false>
+template <bool is_fp32_dest_acc_en, bool transpose_of_faces = true, bool is_32bit = false>
 inline void _llk_math_transpose_dest_wrapper_(const std::uint32_t dst_index)
 {
     _llk_math_transpose_dest_<transpose_of_faces, is_32bit>(dst_index);
@@ -97,7 +97,7 @@ inline void _llk_math_reconfig_remap_wrapper_(const bool remap_enable)
     _llk_math_reconfig_remap_(remap_enable);
 }
 
-template <[[maybe_unused]] std::uint32_t block_ct_dim, [[maybe_unused]] bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_reinit_wrapper_([[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod_reinit_minimal();

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -29,9 +29,9 @@ inline constexpr PackMode llk_test_pack_mode_v = untilize ? PackMode::Untilize
 template <
     DataCopyType type,
     bool is_fp32_dest_acc_en,
-    BroadcastType src_b_bcast_type      = BroadcastType::NONE,
-    bool is_int_fpu_en                  = false,
-    [[maybe_unused]] PackMode pack_mode = PackMode::Default>
+    BroadcastType src_b_bcast_type = BroadcastType::NONE,
+    bool is_int_fpu_en             = false,
+    PackMode pack_mode             = PackMode::Default>
 inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
 {
     static_assert(

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -47,7 +47,7 @@ inline void _llk_math_eltwise_unary_datacopy_wrapper_(
     _llk_math_eltwise_unary_datacopy_<type, Dst, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(dst_index, src_format, dst_format);
 }
 
-template <bool is_fp32_dest_acc_en, bool transpose_of_faces = true, bool is_32bit = false>
+template <bool is_fp32_dest_acc_en /*unused*/, bool transpose_of_faces = true, bool is_32bit = false>
 inline void _llk_math_transpose_dest_wrapper_(const std::uint32_t dst_index)
 {
     _llk_math_transpose_dest_<transpose_of_faces, is_32bit>(dst_index);
@@ -97,7 +97,7 @@ inline void _llk_math_reconfig_remap_wrapper_(const bool remap_enable)
     _llk_math_reconfig_remap_(remap_enable);
 }
 
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim /*unused*/, bool is_fp32_dest_acc_en /*unused*/ = false>
 inline void _llk_math_reduce_block_max_row_reinit_wrapper_([[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod_reinit_minimal();

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -29,9 +29,9 @@ inline constexpr PackMode llk_test_pack_mode_v = untilize ? PackMode::Untilize
 template <
     DataCopyType type,
     bool is_fp32_dest_acc_en,
-    BroadcastType src_b_bcast_type = BroadcastType::NONE,
-    bool is_int_fpu_en             = false,
-    PackMode pack_mode             = PackMode::Default>
+    BroadcastType src_b_bcast_type      = BroadcastType::NONE,
+    bool is_int_fpu_en                  = false,
+    PackMode pack_mode /*maybe_unused*/ = PackMode::Default>
 inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
 {
     static_assert(
@@ -47,7 +47,7 @@ inline void _llk_math_eltwise_unary_datacopy_wrapper_(
     _llk_math_eltwise_unary_datacopy_<type, Dst, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(dst_index, src_format, dst_format);
 }
 
-template <bool is_fp32_dest_acc_en /*unused*/, bool transpose_of_faces = true, bool is_32bit = false>
+template <bool is_fp32_dest_acc_en /*maybe_unused*/, bool transpose_of_faces = true, bool is_32bit = false>
 inline void _llk_math_transpose_dest_wrapper_(const std::uint32_t dst_index)
 {
     _llk_math_transpose_dest_<transpose_of_faces, is_32bit>(dst_index);
@@ -97,7 +97,7 @@ inline void _llk_math_reconfig_remap_wrapper_(const bool remap_enable)
     _llk_math_reconfig_remap_(remap_enable);
 }
 
-template <std::uint32_t block_ct_dim /*unused*/, bool is_fp32_dest_acc_en /*unused*/ = false>
+template <std::uint32_t block_ct_dim /*maybe_unused*/, bool is_fp32_dest_acc_en /*maybe_unused*/ = false>
 inline void _llk_math_reduce_block_max_row_reinit_wrapper_([[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
     reduce_max_row_configure_addrmod_reinit_minimal();

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -38,7 +38,7 @@ inline bool _llk_pack_skip_bh_tilize_workaround_wrapper_([[maybe_unused]] const 
 
 /// Pack configure/init \ref PackMode for unpack-tilize sweep-style tests. Wormhole B0 pack does not support
 /// \c PackMode::Tilize in \c configure_pack / \c _llk_pack_init_; Blackhole uses \ref llk_test_pack_mode_v.
-template <[[maybe_unused]] bool untilize, [[maybe_unused]] bool tilize>
+template <bool untilize, bool tilize>
 inline constexpr PackMode llk_unpack_tilize_sweep_pack_cfg_mode_v = PackMode::Default;
 
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
@@ -58,7 +58,7 @@ inline void _llk_pack_hw_configure_wrapper_(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile, relu_config);
 }
 
-template <bool is_fp32_dest_acc_en, [[maybe_unused]] bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -180,7 +180,7 @@ inline void _llk_pack_hw_configure_wrapper_(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, relu_config);
 }
 
-template <bool is_fp32_dest_acc_en, [[maybe_unused]] bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -229,7 +229,7 @@ inline void _llk_pack_init_with_src_wrapper_(
     _llk_pack_init_<pack_mode, zero_output>(pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles, skip_bh_tilize_workaround);
 }
 
-template <DstSync Dst, bool is_fp32_dest_acc_en, [[maybe_unused]] PackMode pack_mode = PackMode::Default>
+template <DstSync Dst, bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
 inline void _llk_pack_dest_init_wrapper_([[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM, [[maybe_unused]] const bool narrow_tile = false)
 {
     _llk_pack_dest_init_<Dst, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -38,7 +38,7 @@ inline bool _llk_pack_skip_bh_tilize_workaround_wrapper_([[maybe_unused]] const 
 
 /// Pack configure/init \ref PackMode for unpack-tilize sweep-style tests. Wormhole B0 pack does not support
 /// \c PackMode::Tilize in \c configure_pack / \c _llk_pack_init_; Blackhole uses \ref llk_test_pack_mode_v.
-template <bool untilize, bool tilize>
+template <bool untilize /*unused*/, bool tilize /*unused*/>
 inline constexpr PackMode llk_unpack_tilize_sweep_pack_cfg_mode_v = PackMode::Default;
 
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
@@ -58,7 +58,7 @@ inline void _llk_pack_hw_configure_wrapper_(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile, relu_config);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en /*unused*/ = false>
 inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -116,7 +116,7 @@ template <
     bool diagonal                = false,
     bool narrow_row              = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    bool dense                   = false>
+    bool dense /*unused*/        = false>
 inline void _llk_pack_untilize_init_wrapper_(
     [[maybe_unused]] const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -133,7 +133,7 @@ template <
     bool narrow_row                  = false,
     std::uint32_t row_num_datums     = TILE_C_DIM,
     std::uint32_t tile_dst_ct_offset = 0,
-    bool dense                       = false>
+    bool dense /*unused*/            = false>
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     const std::uint32_t pack_dst_format,
@@ -180,7 +180,7 @@ inline void _llk_pack_hw_configure_wrapper_(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, relu_config);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en /*unused*/ = false>
 inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -229,7 +229,7 @@ inline void _llk_pack_init_with_src_wrapper_(
     _llk_pack_init_<pack_mode, zero_output>(pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles, skip_bh_tilize_workaround);
 }
 
-template <DstSync Dst, bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
+template <DstSync Dst, bool is_fp32_dest_acc_en, PackMode pack_mode /*unused*/ = PackMode::Default>
 inline void _llk_pack_dest_init_wrapper_([[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM, [[maybe_unused]] const bool narrow_tile = false)
 {
     _llk_pack_dest_init_<Dst, is_fp32_dest_acc_en>();
@@ -254,12 +254,12 @@ inline void _llk_pack_untilize_init_wrapper_(
 
 template <
     std::uint32_t block_ct_dim,
-    std::uint32_t full_ct_dim        = block_ct_dim,
-    bool diagonal                    = false,
-    bool narrow_row                  = false,
-    std::uint32_t row_num_datums     = TILE_C_DIM,
-    std::uint32_t tile_dst_ct_offset = 0,
-    bool dense                       = false>
+    std::uint32_t full_ct_dim               = block_ct_dim,
+    bool diagonal                           = false,
+    bool narrow_row                         = false,
+    std::uint32_t row_num_datums /*unused*/ = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset        = 0,
+    bool dense                              = false>
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     [[maybe_unused]] const std::uint32_t pack_dst_format,

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -116,7 +116,7 @@ template <
     bool diagonal                = false,
     bool narrow_row              = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    [[maybe_unused]] bool dense  = false>
+    bool dense                   = false>
 inline void _llk_pack_untilize_init_wrapper_(
     [[maybe_unused]] const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -133,7 +133,7 @@ template <
     bool narrow_row                  = false,
     std::uint32_t row_num_datums     = TILE_C_DIM,
     std::uint32_t tile_dst_ct_offset = 0,
-    [[maybe_unused]] bool dense      = false>
+    bool dense                       = false>
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     const std::uint32_t pack_dst_format,
@@ -254,12 +254,12 @@ inline void _llk_pack_untilize_init_wrapper_(
 
 template <
     std::uint32_t block_ct_dim,
-    std::uint32_t full_ct_dim                     = block_ct_dim,
-    bool diagonal                                 = false,
-    bool narrow_row                               = false,
-    [[maybe_unused]] std::uint32_t row_num_datums = TILE_C_DIM,
-    std::uint32_t tile_dst_ct_offset              = 0,
-    bool dense                                    = false>
+    std::uint32_t full_ct_dim        = block_ct_dim,
+    bool diagonal                    = false,
+    bool narrow_row                  = false,
+    std::uint32_t row_num_datums     = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset = 0,
+    bool dense                       = false>
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     [[maybe_unused]] const std::uint32_t pack_dst_format,

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -38,7 +38,7 @@ inline bool _llk_pack_skip_bh_tilize_workaround_wrapper_([[maybe_unused]] const 
 
 /// Pack configure/init \ref PackMode for unpack-tilize sweep-style tests. Wormhole B0 pack does not support
 /// \c PackMode::Tilize in \c configure_pack / \c _llk_pack_init_; Blackhole uses \ref llk_test_pack_mode_v.
-template <bool untilize /*unused*/, bool tilize /*unused*/>
+template <bool untilize /*maybe_unused*/, bool tilize /*maybe_unused*/>
 inline constexpr PackMode llk_unpack_tilize_sweep_pack_cfg_mode_v = PackMode::Default;
 
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
@@ -58,7 +58,7 @@ inline void _llk_pack_hw_configure_wrapper_(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile, relu_config);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en /*unused*/ = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en /*maybe_unused*/ = false>
 inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -116,7 +116,7 @@ template <
     bool diagonal                = false,
     bool narrow_row              = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    bool dense /*unused*/        = false>
+    bool dense /*maybe_unused*/  = false>
 inline void _llk_pack_untilize_init_wrapper_(
     [[maybe_unused]] const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -133,7 +133,7 @@ template <
     bool narrow_row                  = false,
     std::uint32_t row_num_datums     = TILE_C_DIM,
     std::uint32_t tile_dst_ct_offset = 0,
-    bool dense /*unused*/            = false>
+    bool dense /*maybe_unused*/      = false>
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     const std::uint32_t pack_dst_format,
@@ -180,7 +180,7 @@ inline void _llk_pack_hw_configure_wrapper_(
         pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, relu_config);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en /*unused*/ = false>
+template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en /*maybe_unused*/ = false>
 inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
@@ -229,7 +229,7 @@ inline void _llk_pack_init_with_src_wrapper_(
     _llk_pack_init_<pack_mode, zero_output>(pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles, skip_bh_tilize_workaround);
 }
 
-template <DstSync Dst, bool is_fp32_dest_acc_en, PackMode pack_mode /*unused*/ = PackMode::Default>
+template <DstSync Dst, bool is_fp32_dest_acc_en, PackMode pack_mode /*maybe_unused*/ = PackMode::Default>
 inline void _llk_pack_dest_init_wrapper_([[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM, [[maybe_unused]] const bool narrow_tile = false)
 {
     _llk_pack_dest_init_<Dst, is_fp32_dest_acc_en>();
@@ -254,12 +254,12 @@ inline void _llk_pack_untilize_init_wrapper_(
 
 template <
     std::uint32_t block_ct_dim,
-    std::uint32_t full_ct_dim               = block_ct_dim,
-    bool diagonal                           = false,
-    bool narrow_row                         = false,
-    std::uint32_t row_num_datums /*unused*/ = TILE_C_DIM,
-    std::uint32_t tile_dst_ct_offset        = 0,
-    bool dense                              = false>
+    std::uint32_t full_ct_dim                     = block_ct_dim,
+    bool diagonal                                 = false,
+    bool narrow_row                               = false,
+    std::uint32_t row_num_datums /*maybe_unused*/ = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset              = 0,
+    bool dense                                    = false>
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     [[maybe_unused]] const std::uint32_t pack_dst_format,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -378,7 +378,7 @@ inline void _llk_pack_hw_configure_(
  *       (@ref _llk_pack_reconfig_data_format_), one of which must run before this init.
  * @note Pair with @ref _llk_pack_uninit_ after the matching @ref _llk_pack_ execute calls.
  */
-template <PackMode pack_mode = PackMode::Default, bool zero_output = false, bool skip_addrmod_config = false, [[maybe_unused]] bool skip_packer_strides = false>
+template <PackMode pack_mode = PackMode::Default, bool zero_output = false, bool skip_addrmod_config = false, bool skip_packer_strides = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim = FACE_R_DIM,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -378,7 +378,7 @@ inline void _llk_pack_hw_configure_(
  *       (@ref _llk_pack_reconfig_data_format_), one of which must run before this init.
  * @note Pair with @ref _llk_pack_uninit_ after the matching @ref _llk_pack_ execute calls.
  */
-template <PackMode pack_mode = PackMode::Default, bool zero_output = false, bool skip_addrmod_config = false, bool skip_packer_strides = false>
+template <PackMode pack_mode = PackMode::Default, bool zero_output = false, bool skip_addrmod_config = false, bool skip_packer_strides /*maybe_unused*/ = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
     const std::uint32_t face_r_dim = FACE_R_DIM,


### PR DESCRIPTION
### Ticket
N/A — portability / static analysis cleanup.

### Problem description

Kernel headers apply `[[maybe_unused]]` to *template parameters*:

```cpp
template <bool APPROXIMATION_MODE, [[maybe_unused]] bool is_fp32_dest_acc_en, bool legacy_compat = false>
```

GCC accepts this silently, even under `-Wall -Wextra -Wpedantic`, which is why
the device build has never flagged it. Clang rejects it outright, and because it
is a parse error it takes the whole translation unit with it:

```
error: an attribute list cannot appear here
```

That surfaced when kernel sources were analysed with clang: these headers
blocked more translation units than any other error in the report — 30 instances
in a single CI leg, ahead of every other cause.

### Is it actually non-conforming?

Yes, though the reason is narrower than "attributes aren't allowed there", and
the two compilers disagree for a reason worth stating.

**Grammar.** A *type* parameter (`typename T`) has no attribute slot at all, and
both compilers reject it. A *non-type* parameter is different: C++17
[temp.param]/1 gives `template-parameter: type-parameter | parameter-declaration`,
and `parameter-declaration` ([dcl.fct]/1) does begin with
`attribute-specifier-seq_opt`. So on a non-type parameter the attribute is
grammatically admissible, which is why GCC parses it.

**Appertainment.** What makes it ill-formed is the rule for this specific
attribute. C++17 (ISO/IEC 14882:2017, N4659) §10.6.6 [dcl.attr.unused]/2:

> The attribute may be applied to the declaration of a class, a typedef-name, a
> variable, a non-static data member, a function, an enumeration, or an
> enumerator.

A template parameter is none of those, and it is not a "variable" either —
[basic]/6 defines a variable as introduced by the declaration of an object or a
reference. The list was not extended by CWG 2360 (which added structured
bindings) and template parameters are still absent in C++20 §9.12.7 and C++23
§9.12.8.

So the attribute does not appertain to the entity it is written on. Clang
diagnoses it at parse time; GCC accepts and ignores it. Measured:

| | g++ 17 | clang 17 | clang 20 |
| --- | --- | --- | --- |
| `template <[[maybe_unused]] typename T>` | reject | reject | reject |
| `template <[[maybe_unused]] bool B>` | **accept** | reject | reject |
| `void f([[maybe_unused]] int x)` | accept | accept | accept |

### Is it safe to remove?

Yes, on two counts.

It was never suppressing anything. `maybe_unused` only silences unused-entity
diagnostics, and an unused *template* parameter draws no diagnostic from either
compiler — 0 warnings from g++ and clang at `-Wall -Wextra -Wpedantic` with the
attribute absent. It is silencing a warning that does not exist.

And it has no effect on the generated program. Attributes do not participate in
name mangling, so removing it leaves symbols and code identical; compiling a
template with and without it under `g++ -O2` gives byte-identical `.text` and an
identical symbol table.

### What's changed

All 65 occurrences removed, across Quasar and Wormhole `llk_api`,
`tt_llk_wormhole_b0/llk_lib` and the LLK test helpers — not only the two the
current report names, so the same wall is not hit when the other architectures
are analysed.

Thanks to the review comments for catching that the first pass was incomplete:
it matched only single-line `template<...>`, and 38 of the 65 are in parameter
lists that span lines. The scan is now brace-balanced over the whole parameter
list, and `clang-format` re-aligned the columns it had been padding, which
accounts for the insertion/deletion counts not matching.

Function parameters are untouched: `[[maybe_unused]]` is valid there and is used
correctly throughout, including in the very functions being edited here.

### Checklist
- [x] Verified no occurrence remains inside any template parameter list, multi-line included
- [x] Behaviour-neutral: identical mangling and byte-identical `.text`
- [x] `git clang-format` clean
- [ ] Post-commit CI

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/drop-attrs-on-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/drop-attrs-on-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/drop-attrs-on-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/drop-attrs-on-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/drop-attrs-on-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/drop-attrs-on-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/drop-attrs-on-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/drop-attrs-on-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/drop-attrs-on-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/drop-attrs-on-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/drop-attrs-on-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/drop-attrs-on-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/drop-attrs-on-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/drop-attrs-on-template-params)