### PR TITLE
[Bug fix] Saturate int32 div by zero instead of returning 65536

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -932,6 +932,80 @@ def test_div_inf_nan_cases(device):
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0, allow_nonfinite=True)
 
 
+def _int32_div_by_zero_numerators():
+    # Every int32 magnitude binade in both signs (2**k, 2**k - 1, 2**k + 1), the
+    # extremes, zero, and a deterministic random fill: one 32x32 tile, all
+    # lanes divided by zero.
+    special = [0, 2147483647, -2147483648]
+    for k in range(31):
+        for m in (2**k, 2**k - 1, 2**k + 1):
+            special += [m, -m]
+    special = sorted({v for v in special if -2147483648 <= v <= 2147483647})
+    generator = torch.Generator().manual_seed(55323)
+    fill = torch.randint(-2147483648, 2147483647, (1024 - len(special),), dtype=torch.int64, generator=generator)
+    return torch.cat([torch.tensor(special, dtype=torch.int64), fill]).to(torch.int32).reshape(1, 1, 32, 32)
+
+
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize("scalar_divisor", [False, True])
+def test_div_int32_by_zero(rounding_mode, scalar_divisor, device):
+    # No int32 quotient exists for a zero divisor; the kernel saturates the way
+    # the float path's +inf/-inf/NaN would: INT32_MAX, INT32_MIN, or 0 for 0/0.
+    torch_input_tensor_a = _int32_div_by_zero_numerators()
+    expected = torch.where(
+        torch_input_tensor_a > 0,
+        torch.tensor(2147483647, dtype=torch.int32),
+        torch.where(
+            torch_input_tensor_a < 0, torch.tensor(-2147483648, dtype=torch.int32), torch.tensor(0, dtype=torch.int32)
+        ),
+    )
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, dtype=ttnn.int32, device=device, layout=ttnn.TILE_LAYOUT)
+    if scalar_divisor:
+        input_tensor_b = 0
+    else:
+        input_tensor_b = ttnn.from_torch(
+            torch.zeros_like(torch_input_tensor_a), dtype=ttnn.int32, device=device, layout=ttnn.TILE_LAYOUT
+        )
+
+    output_tensor = ttnn.to_torch(ttnn.div(input_tensor_a, input_tensor_b, rounding_mode=rounding_mode))
+
+    assert output_tensor.dtype == torch.int32
+    assert_equal(expected, output_tensor)
+
+
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+def test_div_int32_zero_divisor_lanes_do_not_disturb_neighbours(rounding_mode, device):
+    # Zero and non-zero divisors interleaved in one tile: the zero lanes saturate,
+    # every other lane still matches the golden integer quotient.
+    torch_input_tensor_a = _int32_div_by_zero_numerators()
+    generator = torch.Generator().manual_seed(55323)
+    torch_input_tensor_b = torch.randint(
+        -1000, 1000, torch_input_tensor_a.shape, dtype=torch.int32, generator=generator
+    )
+    torch_input_tensor_b[torch_input_tensor_b == 0] = 1
+    torch_input_tensor_b[..., ::3] = 0
+
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    safe_b = torch.where(torch_input_tensor_b == 0, torch.tensor(1, dtype=torch.int32), torch_input_tensor_b)
+    expected = golden_function(torch_input_tensor_a, safe_b, rounding_mode=rounding_mode, device=device)
+    saturated = torch.where(
+        torch_input_tensor_a > 0,
+        torch.tensor(2147483647, dtype=torch.int32),
+        torch.where(
+            torch_input_tensor_a < 0, torch.tensor(-2147483648, dtype=torch.int32), torch.tensor(0, dtype=torch.int32)
+        ),
+    )
+    expected = torch.where(torch_input_tensor_b == 0, saturated, expected)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, dtype=ttnn.int32, device=device, layout=ttnn.TILE_LAYOUT)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, dtype=ttnn.int32, device=device, layout=ttnn.TILE_LAYOUT)
+
+    output_tensor = ttnn.to_torch(ttnn.div(input_tensor_a, input_tensor_b, rounding_mode=rounding_mode))
+
+    assert_equal(expected, output_tensor)
+
+
 def test_div_exact_quotient_cases(device):
     pairs = [
         (28, 14),

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <limits>
+
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -117,6 +120,20 @@ sfpi_inline void calculate_div_int32_body(
             v_if(r != 0) { result -= 1; }
             v_endif;
         }
+    }
+    v_endif;
+
+    // Division by zero: no integer quotient exists, and without this guard the
+    // reciprocal above overflows and the result is a plausible-looking ~65536.
+    // Saturate instead, mirroring the +inf/-inf/NaN of the float path:
+    // INT32_MAX for a > 0, INT32_MIN for a < 0, and 0 for 0 / 0.
+    sfpi::vInt a_s = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+    sfpi::vInt b_s = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+    v_if(b_s == 0) {
+        result = 0;
+        v_if(a_s > 0) { result = std::numeric_limits<std::int32_t>::max(); }
+        v_elseif(a_s < 0) { result = std::numeric_limits<std::int32_t>::min(); }
+        v_endif;
     }
     v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <limits>
+
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
@@ -161,6 +164,18 @@ sfpi_inline void calculate_div_int32_body(
             v_if(r != 0) { result -= 1; }
             v_endif;
         }
+    }
+    v_endif;
+
+    // Division by zero: no integer quotient exists, and without this guard the
+    // reciprocal above overflows and the result is a plausible-looking ~65536.
+    // Saturate instead, mirroring the +inf/-inf/NaN of the float path:
+    // INT32_MAX for a > 0, INT32_MIN for a < 0, and 0 for 0 / 0.
+    v_if(b_s == 0) {
+        result = 0;
+        v_if(a_s > 0) { result = std::numeric_limits<std::int32_t>::max(); }
+        v_elseif(a_s < 0) { result = std::numeric_limits<std::int32_t>::min(); }
+        v_endif;
     }
     v_endif;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -98,6 +98,7 @@ constexpr auto kDivideFastApproxPostNote =
         When the inputs are INT32, the outputs are FLOAT32 and output datatype conversion is not supported.)doc";
 constexpr auto kDivFastApproxPostNote =
     R"doc(With INT32 inputs, rounding_mode `None` produces a FLOAT32 output and output datatype conversion is not supported, while `floor` and `trunc` produce an INT32 output.
+        With INT32 inputs and rounding_mode `floor` or `trunc`, a zero divisor saturates: INT32_MAX for a positive numerator, INT32_MIN for a negative numerator, and 0 for 0/0.
         When :attr:`fast_and_approximate_mode` is `True`, operation assumes that :attr:`input_tensor_b` is not zero for fast approximation.
         When :attr:`fast_and_approximate_mode` is `False` (default), operation properly handles division by zero (accurate mode).)doc";
 constexpr auto kMultiplyInplaceFastApproxPostNote =


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #55323

`ttnn.div` with INT32 inputs and `rounding_mode="floor"|"trunc"` had no zero-divisor guard in `calculate_div_int32_body`: `1/b` overflows to 2^127, the quotient estimate becomes `inf`, and the `uint16` correction saturates, so every numerator came back as ±65536 (±65537 in floor mode).

The kernel now selects a saturating sentinel where the operands are already in hand at the end of the body. Same change on Wormhole and Blackhole; docstring updated.

| arch | op | input | before | after |
|---|---|---|---|---|
| WH, BH | div trunc/floor | `a > 0`, `b = 0` | 65536 | **2147483647 (INT32_MAX)** |
| WH, BH | div trunc/floor | `a < 0`, `b = 0` | -65536 / -65537 | **-2147483648 (INT32_MIN)** |
| WH, BH | div trunc/floor | `0 / 0` | 65536 | **0** |
| WH, BH | div trunc/floor | `INT32_MIN / 0` | 65535 / 65534 | **-2147483648** |
| WH, BH | div trunc/floor | `b != 0` | unchanged | unchanged (94 existing int32 div tests pass) |

### Notes for reviewers

- Semantics: INT32_MAX / INT32_MIN / 0 is the int32 image of the float path's +inf / -inf / NaN (same as the original kernel comment intends, and as saturating float->int conversion does). torch raises on CPU and is undefined on CUDA, so there is no reference value to match; a host-side TT_FATAL would add a reduction per call.
- Cost: 2 compares + 2 conditional moves per row; on Blackhole two extra `dst_reg` loads rather than extending `a_orig`/`b_orig` live ranges across the body.
- New tests sweep every int32 binade (±2^k, ±(2^k±1)) plus extremes and random fill for both rounding modes, tensor and scalar divisors, and a mixed-lane test checks that zero lanes do not disturb neighbours.
- Verified on ttsim Blackhole; Wormhole kernel compiles but ttsim rejects int32 unpack (`UndefinedBehavior: tensix_unpacr: unpack_to_dst=0 in_data_format=8`), so WH is CI-only.
- Will rebase once #55506 (INT32_MIN work in the same file) merges; the guard is 12 lines at the end of the body.


## Evidence

ttsim Blackhole (`libttsim_bh.so` v1.10.6, `TT_METAL_SLOW_DISPATCH_MODE=1`): the repro script on `main` (`ce94a27c`) vs this branch, followed by the new tests (`-k "test_div_int32_by_zero or zero_divisor_lanes"`, 6 passed). Non-zero-divisor lanes are unchanged.

![int32 div-by-zero before/after and new tests on ttsim Blackhole](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55323-tests.png)

Raw text: https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55323-tests.txt
