### PR TITLE
[Bug fix] atan2: rescale operands so max(|x|,|y|) >= 2^126 no longer collapses to 0 or pi/2

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -171,7 +171,7 @@ def test_binary_atan2_large_magnitude_all_bitpatterns(ttnn_dtype, torch_dtype, o
         golden, output = golden[keep], output[keep]
 
     # The fp32 minimax polynomial itself is good to ~2.5 ULP (see test_unary_fp32.py::test_atan).
-    assert_with_ulp(golden, output, ulp_threshold=3, allow_nonfinite=True)
+    assert_with_ulp(expected_result=golden, actual_result=output, ulp_threshold=3, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -12,7 +12,13 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     compare_pcc,
     compare_equal,
 )
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_div_by_zero_outputs
+from tests.ttnn.utils_for_testing import (
+    assert_with_pcc,
+    assert_with_ulp,
+    assert_div_by_zero_outputs,
+    generate_all_bfloat16_bitpatterns,
+    flush_subnormal_values_to_zero,
+)
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -123,6 +129,49 @@ def test_binary_atan2_special_values(input_shapes, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     torch.testing.assert_close(output_tensor, golden_tensor)
+
+
+@pytest.mark.parametrize(
+    "ttnn_dtype, torch_dtype",
+    [(ttnn.bfloat16, torch.bfloat16), (ttnn.float32, torch.float32)],
+)
+@pytest.mark.parametrize("other", [3e38, -3e38, 2.0**126, -(2.0**126)])
+@pytest.mark.parametrize("sweep_operand", ["y", "x"])
+def test_binary_atan2_large_magnitude_all_bitpatterns(ttnn_dtype, torch_dtype, other, sweep_operand, device):
+    """Regression test for #55124: atan2 returned exactly 0 (or pi/2) whenever max(|x|, |y|) >= 2^126.
+
+    The kernel forms min/max as min * recip(max), and recip(max) flushes to 0 in the top two
+    binades.  One operand is fixed in that band and the other sweeps every bfloat16 bit pattern
+    (promoted for float32), so the sweep covers both orderings of |x| and |y|, both signs, zero,
+    inf and the whole magnitude range.  Subnormal inputs are flushed to zero, as on device.
+    """
+    sweep = flush_subnormal_values_to_zero(generate_all_bfloat16_bitpatterns(torch.float32))
+    fixed = torch.full_like(sweep, other)
+    y, x = (sweep, fixed) if sweep_operand == "y" else (fixed, sweep)
+
+    golden = torch.atan2(y, x).to(torch_dtype)
+
+    tt_y = ttnn.from_torch(
+        y.to(torch_dtype), dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device, preserve_nan_values=True
+    )
+    tt_x = ttnn.from_torch(
+        x.to(torch_dtype), dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device, preserve_nan_values=True
+    )
+    output = ttnn.to_torch(ttnn.atan2(tt_y, tt_x)).to(torch_dtype)
+
+    # The bfloat16 path's ~7-bit reciprocal can push results in the lowest normal binade under the
+    # hardware flush threshold, so results below 2^-125 are ignored on both sides.
+    tiny = golden.abs() < 2.0**-125
+    golden[tiny] = 0.0
+    output[tiny] = 0.0
+
+    if ttnn_dtype == ttnn.bfloat16:
+        # NaN is not preserved on the bfloat16 (fp16_b Dest) path; NaN propagation is covered by float32.
+        keep = ~torch.isnan(golden)
+        golden, output = golden[keep], output[keep]
+
+    # The fp32 minimax polynomial itself is good to ~2.5 ULP (see test_unary_fp32.py::test_atan).
+    assert_with_ulp(golden, output, ulp_threshold=3, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -25,6 +25,19 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
     // case handling.
     auto [min, max] = sfpi::min_max(sfpi::setsgn(x, 0), sfpi::setsgn(y, 0));
 
+    // sfpu_reciprocal flushes 1/max to 0 for max >= 2^126, which would collapse a (below) to 0
+    // for ordinary operands.  Scale min, max and x by 2^-2 in that band: the ratio and the
+    // |x| vs |y| ordering are unchanged (exact power-of-two scaling), and max * 2^-2 < 2^126 for
+    // every finite max.  A multiply (rather than addexp) keeps inf and NaN intact for the special
+    // cases below.  y is left alone: only its sign is used later, and a multiply would turn -0
+    // into +0.  x is scaled in place (rather than into a copy) to avoid an SFPU register spill.
+    v_if(sfpi::as<sfpi::vInt>(max) >= sfpi::as<sfpi::vInt>(sfpi::vFloat(0x1p126f))) {
+        x = x * 0.25f;
+        min = min * 0.25f;
+        max = max * 0.25f;
+    }
+    v_endif;
+
     // a = min(|x|, |y|) / max(|x|, |y|), i.e. a is on [0, 1].
     sfpi::vFloat a = min * sfpu_reciprocal<is_bf16>(max);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -25,6 +25,19 @@ sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
     // case handling.
     auto [min, max] = sfpi::min_max(sfpi::setsgn(x, 0), sfpi::setsgn(y, 0));
 
+    // sfpu_reciprocal flushes 1/max to 0 for max >= 2^126, which would collapse a (below) to 0
+    // for ordinary operands.  Scale min, max and x by 2^-2 in that band: the ratio and the
+    // |x| vs |y| ordering are unchanged (exact power-of-two scaling), and max * 2^-2 < 2^126 for
+    // every finite max.  A multiply (rather than addexp) keeps inf and NaN intact for the special
+    // cases below.  y is left alone: only its sign is used later, and a multiply would turn -0
+    // into +0.  x is scaled in place (rather than into a copy) to avoid an SFPU register spill.
+    v_if(sfpi::as<sfpi::vInt>(max) >= sfpi::as<sfpi::vInt>(sfpi::vFloat(0x1p126f))) {
+        x = x * 0.25f;
+        min = min * 0.25f;
+        max = max * 0.25f;
+    }
+    v_endif;
+
     // a = min(|x|, |y|) / max(|x|, |y|), i.e. a is on [0, 1].
     sfpi::vFloat a = min * sfpu_reciprocal<is_bf16>(max);
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #55124

`ttnn.atan2` returned exactly `0` (or exactly `pi/2`) for every operand pair with `max(|x|, |y|) >= 2^126`, up to 0.785 rad off. The kernel forms `min/max` as `min * sfpu_reciprocal(max)`, and the reciprocal flushes to 0 in the top two binades, so the ratio collapsed to 0 and the quadrant fix-ups turned that into `0` or `pi/2`.

The kernel now scales `min`, `max` and `x` by `2^-2` when `max >= 2^126`. The ratio and the `|x|` vs `|y|` ordering are unchanged (exact power-of-two scaling), and `max * 2^-2 < 2^126` for every finite `max`. Same change on Wormhole and Blackhole.

| arch | dtype | inputs | before max ULP | after max ULP |
|---|---|---|---|---|
| WH, BH | float32 | one operand in {±3e38, ±2^126}, other sweeps all bf16 bit patterns | 16,777,215 (result 0 instead of 0.499) | **2** |
| WH, BH | bfloat16 | same sweep | 255 (result 0 instead of 0.498) | **2** |
| WH, BH | float32 | `atan2(1e38, 2e38)` | 0.0 (want 0.463648) | **0.463648** |
| WH, BH | float32 | `atan2(2e38, -1e38)` | 3.141593 (want 2.677945) | **2.677945** |
| WH, BH | both | `max < 2^126`, inf, NaN, ±0 | unchanged | unchanged |

## Evidence

Before/after on ttsim Blackhole, plus the new test (16 cases, 65,536 patterns each) going from 16 failed to 20 passed:

![atan2 large-magnitude before/after and new tests on ttsim Blackhole](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55124-atan2.png)

Raw text: https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55124-atan2.txt

### Notes for reviewers

- Cost: one integer compare plus three conditional multiplies per row, no extra live registers. A first version that scaled into copies of `min`/`max` hit an SFPU register spill in the fp32 path, which is why `x` is scaled in place.
- `y` is not scaled: only its sign is used (`copysgn` at the end), and an SFPU multiply turns `-0` into `+0`, which would have flipped `atan2(-0, -3e38)` from `-pi` to `+pi`. `x = -0` in the band is harmless because `|y|` is then the max and the result is `pi/2` regardless of the sign of `x`.
- Multiplying instead of `addexp` keeps `inf` and `NaN` intact for the existing special-case handling (`addexp(inf, -2)` would turn inf into 2^126 and `addexp(NaN, -2)` into a finite value).
- The new test fixes one operand at ±3e38 / ±2^126 and sweeps all bf16 bit patterns through the other, for bf16 and fp32, 3 ULP threshold (the fp32 atan polynomial is ~2.5 ULP on its own). Results below 2^-125 are masked on both sides because the bf16 path's 7-bit reciprocal can push results in the lowest normal binade under the flush threshold; NaN inputs are skipped for bf16 only, where NaN is not preserved in the fp16_b Dest path (pre-existing, unrelated to this change).
- Verified on ttsim Blackhole (v1.10.6, `TT_METAL_DISABLE_SFPLOADMACRO=1`). The Wormhole kernel compiles but the Wormhole simulator rejects fp32 unpack, so Wormhole is CI-only; the two headers are identical.

