### PR TITLE
[Bug fix] Reject NaN in the Quasar comparison-to-zero SFPU kernel

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -310,7 +310,16 @@ vector<uint32_t> generate_packed_sfpu_input(const unsigned int numel, const std:
         (op_name == "lez")) {
         // Include exact zeros so the eqz/nez/lez/gez at-zero branches are exercised.
         auto possible_values = vector<bfloat16>({-1.0f, -0.5f, 0.0f, 0.5f, 1.0f});
-        return generate_packed_random_vector_from_vector<uint32_t, bfloat16>(possible_values, numel, seed);
+        auto packed = generate_packed_random_vector_from_vector<uint32_t, bfloat16>(possible_values, numel, seed);
+        // Pin the IEEE special values (raw bf16 bits, since bfloat16(float) canonicalises NaN) in the
+        // first lanes: NaN of either sign is neither <0, >0, >=0 nor <=0; +/-inf compare like any
+        // finite value; -0 counts as zero.
+        auto unpacked = unpack_vector<bfloat16, uint32_t>(packed);
+        const vector<uint16_t> special_bits = {0x7FC0, 0xFFC0, 0x7F80, 0xFF80, 0x0000, 0x8000};
+        for (size_t i = 0; i < special_bits.size() && i < unpacked.size(); ++i) {
+            unpacked[i] = std::bit_cast<bfloat16>(special_bits[i]);
+        }
+        return pack_vector<uint32_t, bfloat16>(unpacked);
     }
     if (op_name == "softplus") {
         return generate_packed_uniform_random_vector<uint32_t, bfloat16>(-5.0f, 30.0f, numel, seed);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -98,14 +98,21 @@ struct zero_comp_traits {
  * gtez/ltez return their strict complement (ltz/gtz) predicate; the loop defaults those lanes' result
  * to 1 and writes 0 here (see @ref _zero_comp_writes_zero_).
  *
+ * For float formats the four sign-sensitive modes also reject NaN, so ltz/gtz/gtez/ltez(NaN) = 0 as on
+ * Wormhole/Blackhole (which compare |v| against the inf bit pattern for the same reason). NaN is any
+ * magnitude above +inf (0x7F800000), tested as an integer compare because SFPSETCC does not
+ * special-case NaN. eqz/nez need no NaN term: |NaN| != 0 already gives eqz 0 / nez 1. Integer formats
+ * skip the term entirely (a large sign-magnitude int would otherwise look like NaN).
+ *
  * @note Do NOT use @c abs(vInt) for the magnitude — that is two's-complement abs and leaves
  *       sign-magnitude -0 (0x80000000) unchanged (nonzero), breaking eqz(-0). Clearing the sign bit
  *       (SFPSETSGN with sign=0) is the correct, format-agnostic primitive.
  *
  * @tparam COMP_MODE: Comparison-to-zero mode, values =
  *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
+ * @tparam IS_FLOAT: true when @c v holds IEEE float bits (enables the NaN term), false for integer formats.
  */
-template <SfpuType COMP_MODE>
+template <SfpuType COMP_MODE, bool IS_FLOAT>
 inline __attribute__((always_inline)) sfpi::vBool _zero_comp_pred_(sfpi::vInt v) {
     static_assert(
         COMP_MODE == SfpuType::equal_zero || COMP_MODE == SfpuType::not_equal_zero ||
@@ -121,14 +128,29 @@ inline __attribute__((always_inline)) sfpi::vBool _zero_comp_pred_(sfpi::vInt v)
         return mag == 0;  // ±0
     } else if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
         return mag != 0;
-    } else if constexpr (COMP_MODE == SfpuType::less_than_zero) {
-        return (v < 0) && (mag != 0);  // sign set and nonzero -> excludes -0.0
-    } else if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
-        return (v >= 0) && (mag != 0);  // sign clear and nonzero
-    } else if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
-        return (v < 0) && (mag != 0);   // strict-negative (ltz) lanes; loop defaults 1 and writes 0 here -> gtez
-    } else {                            // less_than_equal_zero
-        return (v >= 0) && (mag != 0);  // strict-positive (gtz) lanes; loop defaults 1 and writes 0 here -> ltez
+    } else if constexpr (!IS_FLOAT) {
+        // Integer formats: sign-magnitude, no NaN to reject.
+        if constexpr (COMP_MODE == SfpuType::less_than_zero || COMP_MODE == SfpuType::greater_than_equal_zero) {
+            return (v < 0) && (mag != 0);   // strict-negative (excludes -0); gtez defaults 1 and writes 0 here
+        } else {                            // greater_than_zero / less_than_equal_zero
+            return (v >= 0) && (mag != 0);  // strict-positive; ltez defaults 1 and writes 0 here
+        }
+    } else {
+        // Smallest magnitude above +inf: every IEEE NaN bit pattern has |v| >= this (sign cleared).
+        constexpr int32_t NAN_MIN_MAGNITUDE = 0x7F800001;
+        const sfpi::vInt mag_bits = sfpi::as<sfpi::vInt>(mag);
+
+        if constexpr (COMP_MODE == SfpuType::less_than_zero) {
+            return (v < 0) && (mag != 0) && (mag_bits < NAN_MIN_MAGNITUDE);  // sign set, nonzero, not NaN
+        } else if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
+            return (v >= 0) && (mag != 0) && (mag_bits < NAN_MIN_MAGNITUDE);  // sign clear, nonzero, not NaN
+        } else if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
+            // strict-negative (ltz) lanes or NaN; loop defaults 1 and writes 0 here -> gtez
+            return ((v < 0) && (mag != 0)) || (mag_bits >= NAN_MIN_MAGNITUDE);
+        } else {  // less_than_equal_zero
+            // strict-positive (gtz) lanes or NaN; loop defaults 1 and writes 0 here -> ltez
+            return ((v >= 0) && (mag != 0)) || (mag_bits >= NAN_MIN_MAGNITUDE);
+        }
     }
 }
 
@@ -202,7 +224,9 @@ inline void calculate_zero_comp() {
         sfpi::vInt bits = traits::load();
 
         typename traits::result_t result = writes_zero ? traits::one() : traits::zero();
-        v_if(_zero_comp_pred_<COMP_MODE>(bits)) { result = writes_zero ? traits::zero() : traits::one(); }
+        v_if((_zero_comp_pred_<COMP_MODE, traits::is_float>(bits))) {  // extra parens: comma inside a macro arg
+            result = writes_zero ? traits::zero() : traits::one();
+        }
         v_endif;
 
         traits::store(result);


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #55273

On Quasar, `ltz/gtz/gez/lez` classify a lane from the sign bit and "magnitude != 0" only, so `gtz(NaN)`/`gez(NaN)` return 1 and `ltz(-NaN)`/`lez(-NaN)` return 1. Wormhole and Blackhole compare `|v|` against the inf bit pattern for exactly this case and return 0. This adds the same term to the four sign-sensitive float predicates in `quasar/.../ckernel_sfpu_comp.h`: NaN is any magnitude above `+inf` (`0x7F800000`), tested as an integer compare because SFPSETCC does not special-case NaN. `eqz`/`nez` and every integer format are untouched (their generated code is byte-identical).

| arch | op | input | before | after |
|---|---|---|---|---|
| Quasar | gtz, gez | `+NaN` (0x7FC0) | 1 | **0** |
| Quasar | ltz, lez | `-NaN` (0xFFC0) | 1 | **0** |
| Quasar | ltz/gtz/gez/lez | `±inf`, `±0`, finite | unchanged | unchanged |
| Quasar | eqz, nez (any) / all int formats | unchanged | unchanged (byte-identical kernel) |
| WH, BH | gtz/gez/ltz/lez | `±NaN` | 0 | 0 (reference, ttsim Blackhole) |

`tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp` now pins `±NaN`, `±inf`, `±0` (raw bf16 bits) in the first lanes of the comparison-to-zero stimuli, so the `TensixSfpuCompute` eqz/nez/ltz/gtz/gez/lez cases cover the NaN rows on every arch.

### Notes for reviewers

- Cost: ltz/gtz +3 SFPU instructions per row (SFPLOADI of the inf pattern + one SFPIADD compare), gez/lez +5 (second write-0 chain), same shape as the WH/BH `TTI_SFPIADD(INF, ABS_V, ...)` chains. The NaN term is gated on `zero_comp_traits::is_float`, so the 30 integer instantiations compile to exactly the same code as before.
- Quasar is pre-silicon and I have no Quasar device; ttsim's `libttsim_qsr.so` opens a device but ttnn eltwise ops abort before any kernel is built (`DataMovementKernel is not supported on Quasar`). Verification was therefore: (1) host-side SFPI compile of all 6 modes x 6 dst formats with the tt-llk Quasar test-harness flags (`-mcpu=tt-qsr32-tensix -Wall -Werror`), before and after; (2) objdump diff showing only the four Float32 sign-sensitive instantiations change; (3) the same inputs on ttsim Blackhole, which is the behaviour this aligns Quasar to. Someone with Quasar access should confirm the boundary case; the merge-gate `llk-quasar` / weekly Quasar ttsim jobs compile this header.
- Same shape as #54857 / #54858 (a WH/BH correctness fix the Quasar copy never received).

## Evidence

![Quasar comp NaN: compile check, objdump diff, Blackhole reference](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55273-evidence.png)

Raw text: https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55273-evidence.txt
