### PR TITLE
[Bug fix] Round the Quasar bf16 SFPU multiply to nearest-even

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -347,6 +347,20 @@ std::pair<vector<uint32_t>, vector<uint32_t>> generate_packed_sfpu_binary_inputs
         // is simply well-conditioned, finite bf16 input with independent lhs/rhs signs.
         auto lhs = generate_div_operand(numel, seed);
         auto rhs = generate_div_operand(numel, seed + 1);
+        if (op_name == "mul_float") {
+            // Pin operand pairs whose exact product is not representable in bf16, so
+            // round-to-nearest-even and truncation give different results regardless of seed.
+            const vector<std::pair<float, float>> pinned = {
+                {1.25f, 1.609375f}, {0.1064453125f, -2.359375f}, {3.25f, 1.1953125f}, {0.75f, 2.703125f}};
+            auto lhs_unpacked = unpack_vector<bfloat16, uint32_t>(lhs);
+            auto rhs_unpacked = unpack_vector<bfloat16, uint32_t>(rhs);
+            for (size_t i = 0; i < pinned.size() && i < lhs_unpacked.size(); ++i) {
+                lhs_unpacked[i] = bfloat16(pinned[i].first);
+                rhs_unpacked[i] = bfloat16(pinned[i].second);
+            }
+            lhs = pack_vector<uint32_t, bfloat16>(lhs_unpacked);
+            rhs = pack_vector<uint32_t, bfloat16>(rhs_unpacked);
+        }
         return {lhs, rhs};
     }
     if (op_name == "atan2") {
@@ -410,6 +424,11 @@ std::pair<float, float> sfpu_tolerance(const std::string& op_name, bool fp32_des
 bool is_close_packed_sfpu_output(
     const std::vector<uint32_t>& vec_a, const std::vector<uint32_t>& vec_b, const std::string& op_name) {
     if (is_int8_binary_sfpu_op(op_name) || op_name == "binary_max" || op_name == "binary_min") {
+        return vec_a == vec_b;
+    }
+    if (op_name == "mul_float") {
+        // A bf16 x bf16 product is exact in fp32, so the bf16 result must be bit-identical to the
+        // round-to-nearest-even golden: a 1-ULP truncation error would pass the rtol/atol check.
         return vec_a == vec_b;
     }
     if (op_name == "where") {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -55,9 +55,9 @@ sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
  *
  * @tparam APPROXIMATION_MODE: unused, preserved to match the BH metal signature
  * @tparam BINOP: selects which binary op to compute (ADD, SUB, MUL or DIV)
- * @tparam is_fp32_dest_acc_en: enables FP32 DEST accumulation (skips bf16 RNE for DIV, ADD, SUB)
+ * @tparam is_fp32_dest_acc_en: enables FP32 DEST accumulation (skips bf16 RNE for MUL, DIV, ADD, SUB)
  * @tparam dst_rounding_mode: bf16 narrowing applied to ADD/SUB results (no-op if is_fp32_dest_acc_en).
- *         DIV ignores this and always rounds RNE, to match BH semantics.
+ *         MUL and DIV ignore this and always round RNE, to match BH semantics.
  * @tparam ITERATIONS: number of sfpi rows to process (one call per face)
  * @tparam TILE_SHAPE: destination tile shape used to calculate operand offsets
  */
@@ -85,6 +85,16 @@ inline void calculate_sfpu_binary(
 
         if constexpr (BINOP == BinaryOp::MUL) {
             result = in0 * in1;
+
+            if constexpr (!is_fp32_dest_acc_en) {
+                // Software RNE conversion to match FPU bf16 rounding (Quasar SFPSTORE
+                // truncates by default); same as calculate_sfpu_binary_mul on WH/BH.
+                result = float32_to_bf16_rne(result);
+
+                // To match FPU behaviour for bfloat16 multiplication, 0 * x = 0 and x * 0 = 0
+                v_if(in0 == 0 || in1 == 0) { result = 0.0f; }
+                v_endif;
+            }
         } else if constexpr (BINOP == BinaryOp::ADD) {
             result = in0 + in1;
         } else if constexpr (BINOP == BinaryOp::SUB) {


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #55355

`mul_binary_tile`'s `ARCH_QUASAR` branch goes through `calculate_sfpu_binary`, whose MUL arm never narrows the fp32 product: SFPSTORE truncates it to bf16, so every product that is not exactly representable is biased toward zero by up to one bf16 ULP. Wormhole and Blackhole round to nearest-even in software (`calculate_sfpu_binary_mul`), and the Quasar file already does so for DIV with the same `float32_to_bf16_rne` helper. This applies it to MUL when fp32 DEST accumulation is off, together with the `0 * x = 0` guard WH/BH carry for FPU parity. The fp32-DEST MUL, DIV, ADD/SUB and integer paths are byte-identical to before.

| arch | op | a, b (bf16) | exact | before (truncate) | after (RNE) |
|---|---|---|---|---|---|
| Quasar | mul, bf16 dest | 1.25, 1.609375 | 2.01171875 | 2.0 | **2.015625** |
| Quasar | mul, bf16 dest | 0.1064453125, -2.359375 | -0.251144409 | -0.25 | **-0.251953125** |
| Quasar | mul, bf16 dest | 3.25, 1.1953125 | 3.88476562 | 3.875 | **3.890625** |
| Quasar | mul, bf16 dest | 0.75, 2.703125 | 2.02734375 | 2.015625 | **2.03125** |
| Quasar | mul, fp32 dest | any | unchanged | unchanged (byte-identical kernel) |
| WH, BH | mul, bf16 dest | same pairs | RNE | RNE (reference, ttsim Blackhole) |

`tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp` now compares `mul_float` bit-exactly against the RNE golden (a bf16 x bf16 product is exact in fp32, so there is nothing to tolerate) and pins the four operand pairs above, so the `TensixSfpuBinaryCompute/mul_float_1tiles` case fails on truncation regardless of seed.

### Notes for reviewers

- Cost: the same shift/and/iadd chain DIV already pays on every bf16 divide, plus two SFPSETCC for the zero guard; elided by `if constexpr` on the fp32-dest path. Doc comment on `is_fp32_dest_acc_en` / `dst_rounding_mode` updated to list MUL.
- Quasar is pre-silicon and I have no Quasar device; ttsim's `libttsim_qsr.so` opens a device but ttnn eltwise ops abort before any kernel is built (`DataMovementKernel is not supported on Quasar`). Verification was therefore: (1) host-side SFPI compile of MUL (bf16 and fp32 dest), DIV and ADD<NearestEven> with the tt-llk Quasar test-harness flags (`-mcpu=tt-qsr32-tensix -Wall -Werror`), before and after; (2) objdump diff showing only the bf16-dest MUL instantiation changes (32 -> 58 instructions); (3) the same pairs on ttsim Blackhole, which returns the RNE values. Someone with Quasar access should confirm; the merge-gate `llk-quasar` / weekly Quasar ttsim jobs compile this header.

## Evidence

![Quasar bf16 mul RNE: compile check, objdump diff, Blackhole reference](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55355-evidence.png)

Raw text: https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55355-evidence.txt
