### PR TITLE
[Bug fix] polygamma: fold n! scale into the terms so large x does not flush to zero

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -10,7 +10,7 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     compare_pcc,
     data_gen_with_range,
 )
-from tests.ttnn.utils_for_testing import assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_ulp, generate_all_bfloat16_bitpatterns
 
 pytestmark = pytest.mark.use_module_device
 
@@ -227,6 +227,34 @@ def test_unary_polygamma_boundary_ttnn(input_shapes, k, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_ulp(golden_tensor, output_tensor, ulp_threshold=2)
+
+
+# Every bfloat16 in [0.5, bf16 max] for every supported order. Before the (-1)^(n+1) * n! scale
+# was folded into the accumulated terms, the raw Hurwitz sum sat n! below the result and flushed
+# to zero (Tensix has no subnormals) while psi^(n)(x) was still a normal fp32: every n >= 2 had a
+# band of large x returning exactly 0 (n = 11: x in [2256, 11072]).
+@pytest.mark.parametrize("k", list(range(1, 12)))
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_unary_polygamma_large_x_all_bitpatterns(k, dtype, device):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    x = generate_all_bfloat16_bitpatterns()
+    # Only x >= 0.5 is supported; park everything else on an in-domain value.
+    x = torch.where((x >= 0.5) & torch.isfinite(x), x, torch.ones_like(x)).to(torch_dtype)
+    golden64 = torch.special.polygamma(k, x.to(torch.float64))
+
+    input_tensor = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.polygamma(input_tensor, k)).to(torch_dtype)
+
+    # The result is a normal fp32 (with margin for the last exact term): it must not flush to 0.
+    normal = golden64.abs() >= 2.0**-125
+    zeros = (output_tensor == 0) & normal
+    assert not zeros.any(), f"{int(zeros.sum())} lanes return 0 for a normal result, first x={x[zeros][0]}"
+
+    # ULP check above the flush region, where the six exact terms are all still representable.
+    keep = golden64.abs() >= 2.0**-100
+    golden = torch.where(keep, golden64.to(torch_dtype), torch.zeros_like(x))
+    output_tensor = torch.where(keep, output_tensor, torch.zeros_like(x))
+    assert_with_ulp(golden, output_tensor, ulp_threshold=2 if dtype == ttnn.bfloat16 else 32)
 
 
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -59,13 +59,21 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
     float n4 = n + 4;
     float n5 = n + 5;
     float nf = n;
-    float inv_nf = 1.0f / nf;
-    float c_b2 = n1 / 12.0f;                           // B_2 term coefficient
-    float c_b4 = -(n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
-    float c_b6 = (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    // The scale (-1)^(n+1) * n! is folded into every term rather than applied to the final
+    // sum: the raw Hurwitz sum sits n! below the result (7.6 decades for n = 11) and flushes
+    // to zero on Tensix (no subnormals) while the result itself is still a normal fp32.
+    float inv_nf = scale / nf;
+    float c_b2 = scale * n1 / 12.0f;                           // B_2 term coefficient
+    float c_b4 = -scale * (n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
+    float c_b6 = scale * (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    float half_scale = 0.5f * scale;
 
     constexpr auto RECIP = APPROXIMATION_MODE ? 0 : is_fp32_dest_acc_en ? 2 : 1;
 
+    // val * x^pwr by binary exponentiation. The final x^2 is applied as two multiplies into val
+    // instead of squaring x first: every intermediate is then >= the result, so nothing flushes to
+    // zero before the (scaled) result itself would (e.g. inv_z^8 alone underflows at z > 2^15.75
+    // while n!/n * inv_z^8 is still normal for n = 8).
     auto power = [] __attribute__((always_inline)) (sfpi::vFloat x, int pwr, sfpi::vFloat val = 1.0f) {
         for (;;) {
             if (pwr & 1) {
@@ -73,6 +81,11 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
             }
             pwr >>= 1;
             if (!pwr) {
+                break;
+            }
+            if (pwr == 1) {
+                val *= x;
+                val *= x;
                 break;
             }
             x *= x;
@@ -86,13 +99,13 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
         sfpi::vFloat sum = 0.0f;
 
         // Part 1: Exact summation of first NUM_TERMS terms
-        // Σ_{k=0}^{NUM_TERMS-1} 1/(x+k)^(n+1)
+        // Σ_{k=0}^{NUM_TERMS-1} scale/(x+k)^(n+1)
         for (int k = 0; k < NUM_TERMS; k++) {
             sfpi::vFloat xi = x + float(k);
 
             // Compute reciprocal first, then raise to power (avoids overflow of large intermediates)
             sfpi::vFloat inv_xi = sfpu_reciprocal_iter<RECIP>(xi);
-            sfpi::vFloat inv_power = power(inv_xi, n, inv_xi);
+            sfpi::vFloat inv_power = power(inv_xi, n, inv_xi * scale);
 
             sum += inv_power;
         }
@@ -107,7 +120,7 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
         // Use PolynomialEvaluator for the Bernoulli polynomial in the tail:
         // E = inv_nf + c_b2*inv_z2 + c_b4*inv_z2^2 + c_b6*inv_z2^3
         sfpi::vFloat E = PolynomialEvaluator::eval(inv_z2, inv_nf, c_b2, c_b4, c_b6);
-        sfpi::vFloat tail = E + 0.5f * inv_z;
+        sfpi::vFloat tail = E + half_scale * inv_z;
 
         // Scale by inv_z^n, taking advantage of inv_z^2's
         // computation above
@@ -123,8 +136,8 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
 
         sum += tail;
 
-        // Apply scale: (-1)^(n+1) * n!
-        sfpi::vFloat result = sum * scale;
+        // scale (-1)^(n+1) * n! is already folded into every term above
+        sfpi::vFloat result = sum;
 
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -61,10 +61,14 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
     float n4 = static_cast<float>(n + 4);
     float n5 = static_cast<float>(n + 5);
     float nf = static_cast<float>(n);
-    float inv_nf = 1.0f / nf;
-    float c_b2 = n1 / 12.0f;                           // B_2 term coefficient
-    float c_b4 = -(n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
-    float c_b6 = (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    // The scale (-1)^(n+1) * n! is folded into every term rather than applied to the final
+    // sum: the raw Hurwitz sum sits n! below the result (7.6 decades for n = 11) and flushes
+    // to zero on Tensix (no subnormals) while the result itself is still a normal fp32.
+    float inv_nf = scale / nf;
+    float c_b2 = scale * n1 / 12.0f;                           // B_2 term coefficient
+    float c_b4 = -scale * (n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
+    float c_b6 = scale * (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+    float half_scale = 0.5f * scale;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -72,7 +76,7 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
         sfpi::vFloat sum = sfpi::vFloat(0.0f);
 
         // Part 1: Exact summation of first NUM_TERMS terms
-        // Σ_{k=0}^{NUM_TERMS-1} 1/(x+k)^(n+1)
+        // Σ_{k=0}^{NUM_TERMS-1} scale/(x+k)^(n+1)
         for (int k = 0; k < NUM_TERMS; k++) {
             sfpi::vFloat xi = x + static_cast<float>(k);
 
@@ -86,7 +90,7 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
                 inv_xi = sfpu_reciprocal_iter<1>(xi);
             }
 
-            sfpi::vFloat inv_power = inv_xi;
+            sfpi::vFloat inv_power = inv_xi * scale;
             for (int j = 1; j < n_plus_1; j++) {
                 inv_power = inv_power * inv_xi;
             }
@@ -110,21 +114,20 @@ inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_pack
 
         sfpi::vFloat inv_z2 = inv_z * inv_z;
 
-        // Compute inv_z^n by repeated multiplication
-        sfpi::vFloat inv_z_n = inv_z;  // inv_z^1
-        for (int j = 1; j < n; j++) {
-            inv_z_n = inv_z_n * inv_z;  // inv_z^n
-        }
-
         // Use PolynomialEvaluator for the Bernoulli polynomial in the tail:
         // E = inv_nf + c_b2*inv_z2 + c_b4*inv_z2^2 + c_b6*inv_z2^3
         sfpi::vFloat E = PolynomialEvaluator::eval(inv_z2, inv_nf, c_b2, c_b4, c_b6);
-        sfpi::vFloat tail = inv_z_n * (E + 0.5f * inv_z);
+        // Scale by inv_z^n, multiplying into the (already scaled) tail so that every
+        // intermediate is >= the result and none flushes to zero before the result would
+        sfpi::vFloat tail = E + half_scale * inv_z;
+        for (int j = 0; j < n; j++) {
+            tail = tail * inv_z;  // tail * inv_z^n
+        }
 
         sum = sum + tail;
 
-        // Apply scale: (-1)^(n+1) * n!
-        sfpi::vFloat result = sum * scale;
+        // scale (-1)^(n+1) * n! is already folded into every term above
+        sfpi::vFloat result = sum;
 
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55105

`ttnn.polygamma` accumulated the raw Hurwitz sum Σ 1/(x+k)^(n+1) and multiplied by `(-1)^(n+1) * n!` only at the end. The accumulator sits `n!` below the result (7.6 decades for n = 11), so for large x it dropped below the fp32 normal range and Tensix flushed it to zero while ψ⁽ⁿ⁾(x) itself was still a perfectly normal number. Every order n ≥ 2 had a band of x returning exactly 0, not only n ≥ 7 as reported.

The fix folds the scale into the seed of each power chain and into the host-side tail coefficients (free), and keeps every intermediate of the power chains ≥ the result: the last squaring is applied as two multiplies into the seed instead of forming `x^n` on its own, which still flushed for n = 4 and n = 8 (`inv_z^8` alone underflows at z > 2^15.75 while `n!/n · inv_z^8` is normal). Net cost is +5 SFPU multiplies per element on both architectures (six seeded chains, one final multiply removed).

Exhaustive sweep, every bfloat16 in [0.5, bf16 max] for each n (17 k points per row), golden `torch.special.polygamma` in float64, ttsim v1.10.6. "zero band" = x where the kernel returns exactly 0 although the true value is a normal fp32.

| arch | dtype | n | before max ULP | before zero band | after max ULP (|ψ| ≥ 2⁻¹⁰⁰) | after zero band |
|---|---|---|---|---|---|---|
| Blackhole | bf16 | 4 | 705 | [2.1e9, 4.7e9] | **1** | none |
| Blackhole | bf16 | 8 | 2078 | [42496, 159744] | **1** | none |
| Blackhole | bf16 | 11 | 3353 | [2256, 11072] | **1** | none |
| Blackhole | bf16 | 1..11 | up to 3353 | n ≥ 2 | **1** | none |
| Blackhole | fp32 | 11 | 2.2e8 | [2256, 11072] | **21** | none |
| Blackhole | fp32 | 1..11 | up to 2.2e8 | n ≥ 2 | **≤ 21** | none |
| Wormhole | bf16 | 1..11 | (same kernel structure) | – | **1** | none |

Full before/after tables for all n and both dtypes: https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55105-polygamma.txt

![sweep](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-55105-polygamma.png)

Test: `test_unary_polygamma_large_x_all_bitpatterns` in `test_composite.py` sweeps every bf16 bit pattern in [0.5, bf16 max] for n = 1..11 in bfloat16 and float32, asserts no lane returns 0 where the true value is normal, and checks ULP (bf16 ≤ 2, fp32 ≤ 32) above 2⁻¹⁰⁰. It fails on main (278 zero lanes at n = 11, first x = 2256) and passes with this change. Existing polygamma tests in `test_composite.py` / `test_math.py` pass (ttsim Blackhole: 36 passed; ttsim Wormhole bf16: 29 passed).

### Notes for reviewers
- Only the results' magnitude changes; NaN/inf/negative x are outside the supported domain (x ≥ 0.5) and are untouched.
- Immediately above the fp32 flush floor (|ψ| < 2⁻¹⁰⁰) fp32 error grows to ~1% because the six exact terms, which are `n/x` smaller than the result, flush individually. That is inherent to flush-to-zero and was already the case on main; bf16 stays within 3 ULP there.
- Wormhole and Blackhole kernels differ in structure already (`power` lambda vs explicit loops, #47436); each is changed in its own style. Cycle counts were not measured on the LLK harness (no silicon here); the instruction delta is +5 `SFPMUL` per element.
- Verified on ttsim (Blackhole bf16 + fp32, Wormhole bf16); I have no hardware access, so a CI run on both archs is the real check.
