### PR TITLE
[Fix] Reject per_core_M greater than Mt in 2D and 1D mcast_in1 matmul configs

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -4474,11 +4474,12 @@ def test_matmul_mcast_in1_single_core_h_and_w_tail(device):
 @pytest.mark.parametrize(
     "m_tiles,n_tiles,grid,per_core_m,per_core_n,out_block_h,out_block_w,error",
     [
-        (1, 9, (2, 1), 2, 8, 2, 4, r"mcast_in1 requires N .*single per_core_N block"),
+        (1, 9, (2, 1), 1, 8, 1, 4, r"mcast_in1 requires N .*single per_core_N block"),
         (1, 3, (1, 1), 1, 8, 1, 4, r"logical N tail to be in the final internal W block"),
-        (3, 8, (1, 1), 8, 8, 4, 4, r"per_core_M \(8\) exceeds Mt \(3\)"),
+        # No case for the M-tail guards: they only fire when per_core_M exceeds Mt, which
+        # validation now rejects before reaching them.
     ],
-    ids=["multiple-x-blocks", "deep-w-tail", "per-core-m-exceeds-mt"],
+    ids=["multiple-x-blocks", "deep-w-tail"],
 )
 def test_matmul_mcast_in1_rejects_unsupported_distribution(
     device,
@@ -4507,6 +4508,31 @@ def test_matmul_mcast_in1_rejects_unsupported_distribution(
     )
 
     with expect_error(RuntimeError, error):
+        ttnn.matmul(in0, in1, program_config=program_config)
+
+
+@pytest.mark.parametrize("config_kind", ["2d", "1d_mcast_in1"])
+def test_matmul_per_core_m_exceeds_mt_rejected(device, expect_error, config_kind):
+    """per_core_M must not exceed Mt - the surplus rows have nowhere to land in the output."""
+    torch.manual_seed(0)
+    m, k, n = 128, 32, 64  # Mt = 4
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    if config_kind == "2d":
+        program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(1, 1),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=7,
+            per_core_N=2,
+            transpose_mcast=False,
+        )
+    else:
+        program_config = _mcast_in1_tail_config(grid=(1, 1), per_core_m=7, per_core_n=2, out_block_h=7, out_block_w=2)
+
+    with expect_error(RuntimeError, r"per_core_M \(7\) exceeds Mt \(4\)"):
         ttnn.matmul(in0, in1, program_config=program_config)
 
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -4475,11 +4475,10 @@ def test_matmul_mcast_in1_single_core_h_and_w_tail(device):
     "m_tiles,n_tiles,grid,per_core_m,per_core_n,out_block_h,out_block_w,error",
     [
         (1, 9, (2, 1), 2, 8, 2, 4, r"mcast_in1 requires N .*single per_core_N block"),
-        (1, 3, (1, 1), 2, 8, 2, 4, r"logical N tail to be in the final internal W block"),
-        (3, 7, (1, 1), 8, 8, 4, 4, r"single-Y mcast_in1 sender requires the logical M tail"),
-        (7, 7, (1, 1), 8, 8, 4, 4, r"partial final H block only when per_core_M contains one internal H block"),
+        (1, 3, (1, 1), 1, 8, 1, 4, r"logical N tail to be in the final internal W block"),
+        (3, 8, (1, 1), 8, 8, 4, 4, r"per_core_M \(8\) exceeds Mt \(3\)"),
     ],
-    ids=["multiple-x-blocks", "deep-w-tail", "single-y-deep-h-tail", "single-y-multi-block-h-tail"],
+    ids=["multiple-x-blocks", "deep-w-tail", "per-core-m-exceeds-mt"],
 )
 def test_matmul_mcast_in1_rejects_unsupported_distribution(
     device,

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -4465,7 +4465,7 @@ def test_matmul_mcast_in1_single_core_h_and_w_tail(device):
 
     in0 = ttnn.from_torch(torch_in0, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     in1 = ttnn.from_torch(torch_in1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    program_config = _mcast_in1_tail_config(grid=(1, 1), per_core_m=2, per_core_n=8, out_block_h=2, out_block_w=8)
+    program_config = _mcast_in1_tail_config(grid=(1, 1), per_core_m=1, per_core_n=8, out_block_h=1, out_block_w=8)
 
     output = ttnn.to_torch(ttnn.matmul(in0, in1, program_config=program_config))
     assert_with_pcc(torch_output, output, pcc=0.999)

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1314,14 +1314,23 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
+                // Cores here always cover the first H-block. If there's only one H-block total, this
+                // is also the last one, so clamp its write size to the real remaining rows — otherwise
+                // it always writes a full block's worth, even past the tensor's actual end.
+                bool is_last_h_block = in0_idx == in0_end_idx;
+                uint32_t out_num_nonzero_subblocks_h_arg =
+                    is_last_h_block ? last_block_num_nonzero_subblocks_h : (out_block_h / out_subblock_h);
+                uint32_t out_last_subblock_h_arg = is_last_h_block ? last_subblock_of_last_block_h : out_subblock_h;
+                uint32_t padded_block_tiles_h_skip_arg = is_last_h_block ? last_block_padded_block_tiles_h_skip : 0;
+
                 if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
                     // padding args (READER)
                     mm_in1_sender_writer_args.push_back(last_out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
+                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
+                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
                     mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
@@ -1332,9 +1341,9 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     mm_in1_sender_writer_args.push_back(out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
+                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
+                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_subblock_w);
@@ -2821,14 +2830,23 @@ create_program_mcast_in0_in1(
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
+                // Cores here always cover the first H-block. If there's only one H-block total, this
+                // is also the last one, so clamp its write size to the real remaining rows — otherwise
+                // it always writes a full block's worth, even past the tensor's actual end.
+                bool is_last_h_block = in0_idx == in0_end_idx;
+                uint32_t out_num_nonzero_subblocks_h_arg =
+                    is_last_h_block ? last_block_num_nonzero_subblocks_h : (out_block_h / out_subblock_h);
+                uint32_t out_last_subblock_h_arg = is_last_h_block ? last_subblock_of_last_block_h : out_subblock_h;
+                uint32_t padded_block_tiles_h_skip_arg = is_last_h_block ? last_block_padded_block_tiles_h_skip : 0;
+
                 if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
                     // padding args (READER)
                     mm_in1_sender_writer_args.push_back(last_out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
+                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
+                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
                     mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
@@ -2839,9 +2857,9 @@ create_program_mcast_in0_in1(
                     mm_in1_sender_writer_args.push_back(out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(out_subblock_h);
-                    mm_in1_sender_writer_args.push_back(0);
+                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
+                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
+                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_subblock_w);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
+#include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 
 #include <algorithm>
+#include <tuple>
 #include <utility>
 
 #include "hostdevcommon/common_values.hpp"
@@ -121,6 +123,14 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
     const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    if (!in0_is_sharded && !output_is_sharded && M < per_core_M) {
+        per_core_M = M;
+        if (out_block_h > per_core_M || per_core_M % out_block_h != 0) {
+            out_block_h = per_core_M;
+        }
+        std::tie(out_subblock_h, out_subblock_w) = operations::matmul::bmm_op_utils::get_matmul_subblock_params(
+            out_block_h, out_block_w, false, false, fp32_dest_acc_en);
+    }
 
     // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
     // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
@@ -1314,23 +1324,14 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
-                // Cores here always cover the first H-block. If there's only one H-block total, this
-                // is also the last one, so clamp its write size to the real remaining rows — otherwise
-                // it always writes a full block's worth, even past the tensor's actual end.
-                bool is_last_h_block = in0_idx == in0_end_idx;
-                uint32_t out_num_nonzero_subblocks_h_arg =
-                    is_last_h_block ? last_block_num_nonzero_subblocks_h : (out_block_h / out_subblock_h);
-                uint32_t out_last_subblock_h_arg = is_last_h_block ? last_subblock_of_last_block_h : out_subblock_h;
-                uint32_t padded_block_tiles_h_skip_arg = is_last_h_block ? last_block_padded_block_tiles_h_skip : 0;
-
                 if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
                     // padding args (READER)
                     mm_in1_sender_writer_args.push_back(last_out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
-                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
-                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
                     mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
@@ -1341,9 +1342,9 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
                     mm_in1_sender_writer_args.push_back(out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
-                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
-                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_subblock_w);
@@ -1663,6 +1664,14 @@ create_program_mcast_in0_in1(
     const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
     const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    if (!in0_is_sharded && !output_is_sharded && M < per_core_M) {
+        per_core_M = M;
+        if (out_block_h > per_core_M || per_core_M % out_block_h != 0) {
+            out_block_h = per_core_M;
+        }
+        std::tie(out_subblock_h, out_subblock_w) = operations::matmul::bmm_op_utils::get_matmul_subblock_params(
+            out_block_h, out_block_w, false, false, fp32_dest_acc_en);
+    }
 
     TT_FATAL(
         !(output_is_sharded && B > 1),
@@ -2830,23 +2839,14 @@ create_program_mcast_in0_in1(
                     ((std::uint32_t)in1_idx * per_core_N) + (in0_idx * per_core_M * N)  // out_tensor_start_tile_id
                 };
 
-                // Cores here always cover the first H-block. If there's only one H-block total, this
-                // is also the last one, so clamp its write size to the real remaining rows — otherwise
-                // it always writes a full block's worth, even past the tensor's actual end.
-                bool is_last_h_block = in0_idx == in0_end_idx;
-                uint32_t out_num_nonzero_subblocks_h_arg =
-                    is_last_h_block ? last_block_num_nonzero_subblocks_h : (out_block_h / out_subblock_h);
-                uint32_t out_last_subblock_h_arg = is_last_h_block ? last_subblock_of_last_block_h : out_subblock_h;
-                uint32_t padded_block_tiles_h_skip_arg = is_last_h_block ? last_block_padded_block_tiles_h_skip : 0;
-
                 if (in1_idx == in1_end_idx) {  // right cores when no transpose_mcast
                     // padding args (READER)
                     mm_in1_sender_writer_args.push_back(last_out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
-                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
-                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
                     mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
@@ -2857,9 +2857,9 @@ create_program_mcast_in0_in1(
                     mm_in1_sender_writer_args.push_back(out_block_w);
 
                     // padding args (WRITER)
-                    mm_in1_sender_writer_args.push_back(out_num_nonzero_subblocks_h_arg);
-                    mm_in1_sender_writer_args.push_back(out_last_subblock_h_arg);
-                    mm_in1_sender_writer_args.push_back(padded_block_tiles_h_skip_arg);
+                    mm_in1_sender_writer_args.push_back(out_block_h / out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(out_subblock_h);
+                    mm_in1_sender_writer_args.push_back(0);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_block_w / out_subblock_w);
                     mm_in1_sender_writer_args.push_back(out_subblock_w);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
-#include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 
 #include <algorithm>
-#include <tuple>
 #include <utility>
 
 #include "hostdevcommon/common_values.hpp"
@@ -123,14 +121,6 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
     const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
     const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-    if (!in0_is_sharded && !output_is_sharded && M < per_core_M) {
-        per_core_M = M;
-        if (out_block_h > per_core_M || per_core_M % out_block_h != 0) {
-            out_block_h = per_core_M;
-        }
-        std::tie(out_subblock_h, out_subblock_w) = operations::matmul::bmm_op_utils::get_matmul_subblock_params(
-            out_block_h, out_block_w, false, false, fp32_dest_acc_en);
-    }
 
     // Tiles whose size is not a multiple of the DRAM alignment (e.g. bfp8 32x16 = 544B on
     // Blackhole's 64B alignment) are padded to it in DRAM. The interleaved reader copies tiles at
@@ -1664,14 +1654,6 @@ create_program_mcast_in0_in1(
     const bool in1_is_height_sharded = in1_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
     const bool output_is_sharded = out_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-    if (!in0_is_sharded && !output_is_sharded && M < per_core_M) {
-        per_core_M = M;
-        if (out_block_h > per_core_M || per_core_M % out_block_h != 0) {
-            out_block_h = per_core_M;
-        }
-        std::tie(out_subblock_h, out_subblock_w) = operations::matmul::bmm_op_utils::get_matmul_subblock_params(
-            out_block_h, out_block_w, false, false, fp32_dest_acc_en);
-    }
 
     TT_FATAL(
         !(output_is_sharded && B > 1),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -781,8 +781,8 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                             num_blocks_x);
                         TT_FATAL(
                             per_core_M <= Mt,
-                            "{}: per_core_M ({}) exceeds Mt ({}). Computing more row tiles than are available "
-                            "overwrites memory beyond this tensor. Reduce per_core_M to at most Mt.",
+                            "{}: per_core_M ({}) exceeds Mt ({}). Each core would compute more output row tiles "
+                            "than the tensor has. Reduce per_core_M to at most Mt.",
                             config_name,
                             per_core_M,
                             Mt);
@@ -842,8 +842,8 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                     Nt);
                 TT_FATAL(
                     program_config.per_core_M <= Mt,
-                    "{}: per_core_M ({}) exceeds Mt ({}). Computing more row tiles than are available overwrites "
-                    "memory beyond this tensor. Reduce per_core_M to at most Mt.",
+                    "{}: per_core_M ({}) exceeds Mt ({}). Each core would compute more output row tiles "
+                    "than the tensor has. Reduce per_core_M to at most Mt.",
                     config_name,
                     program_config.per_core_M,
                     Mt);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -779,6 +779,13 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                             Nt,
                             per_core_N,
                             num_blocks_x);
+                        TT_FATAL(
+                            per_core_M <= Mt,
+                            "{}: per_core_M ({}) exceeds Mt ({}). Computing more row tiles than are available "
+                            "overwrites memory beyond this tensor. Reduce per_core_M to at most Mt.",
+                            config_name,
+                            per_core_M,
+                            Mt);
                         const uint32_t logical_blocks_w = ((Nt - 1) / program_config.out_block_w) + 1;
                         const uint32_t physical_blocks_w = per_core_N / program_config.out_block_w;
                         TT_FATAL(
@@ -833,6 +840,13 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                     config_name,
                     Mt,
                     Nt);
+                TT_FATAL(
+                    program_config.per_core_M <= Mt,
+                    "{}: per_core_M ({}) exceeds Mt ({}). Computing more row tiles than are available overwrites "
+                    "memory beyond this tensor. Reduce per_core_M to at most Mt.",
+                    config_name,
+                    program_config.per_core_M,
+                    Mt);
                 uint32_t num_blocks_y = ((Mt - 1) / program_config.per_core_M) + 1;
                 uint32_t num_blocks_x = ((Nt - 1) / program_config.per_core_N) + 1;
                 if (program_config.transpose_mcast) {


### PR DESCRIPTION
**Summary**
- Fixes: #51550
- `ttnn.matmul` now rejects `per_core_M > Mt` on the 2D reuse-mcast config and on 1D `mcast_in1`, so an oversized `per_core_M` fails at validation instead of writing past the output tensor.

**Problem Description**
- `per_core_M` is how many output tile-rows each core is told to produce. `Mt` is how many the output actually has.
- On 2D interleaved mcast, each core writes `per_core_M` rows even when that is more than `Mt`. The extra rows go past the output into the next DRAM tensor.
- Example: `a = [1, 1, 128, 2048]` (`Mt = 4`) with `per_core_M = 7`. A canary after the output drifted by `7296.0`. It should stay at `0.0`.
- 1D mcast already stops writing at `Mt`, so it does not hit the neighbour. Height- and width-sharded 2D output do not use this factory (they go to 1D, or an explicit 2D config must be `BLOCK_SHARDED`).

**What's Changed**
Added a `TT_FATAL(per_core_M <= Mt, ...)` check to both the 2D and 1D `mcast_in1` validation paths in `validate_matmul_work_distribution_and_gather_ring_topology` (`matmul_device_operation.cpp`), with the same message on both:

> `per_core_M ({}) exceeds Mt ({}). Each core would compute more output row tiles than the tensor has. Reduce per_core_M to at most Mt.`

- 2D (`MatmulMultiCoreReuseMultiCastProgramConfig`) - placed right after the existing `Mt > 0 && Nt > 0` check.
- 1D `mcast_in1` (`MatmulMultiCoreReuseMultiCast1DProgramConfig` with `mcast_in0 = false`) - placed right after the existing `num_blocks_x == 1` check.

1D is included even though its writer already clamps at `Mt` and never touches a neighbour: without this check, the same oversized config throws on 2D but passes quietly on 1D, with `program_config.per_core_M` still reporting the wrong value to anything else that reads it. Rejecting it here keeps both paths consistent instead of relying on that clamp staying intact.

The message is written to hold on every path it fires on, so it doesn't mention memory corruption - that's only true for 2D interleaved output (the case above). 2D `BLOCK_SHARDED` hits the same check but stays in-bounds regardless, since each core's shard is sized `per_core_M x per_core_N`; it's rejected anyway because it's still asking cores to compute rows the tensor doesn't have.

**Compatibility**
- A previous attempt at this fatal (#51627) was reverted after breaking sanity. Auto-config was sizing `per_core_M` from L1 capacity (`get_per_core_factor`, starting at `16x16` tiles) and never capping it to `Mt`, so the default path often produced `per_core_M > Mt` and the new check failed those tests.
- #53662 (Fixes #32435) added `per_core_M = std::min(per_core_M, Mt)` in `create_simple_matmul_program_config`. The auto-config `per_core_M` now stops at `Mt`, so this fatal only hits an explicit oversized program config, not the default path.

**Tests**
`tests/ttnn/unit_tests/operations/matmul/test_matmul.py`

- `test_matmul_per_core_m_exceeds_mt_rejected` (new) - parametrized over both affected configs (`2d`, `1d_mcast_in1`), same shapes (`Mt = 4`, `per_core_M = 7`) so one regex covers both. The `2d` case is the direct regression test for the load-bearing fix.
- `test_matmul_mcast_in1_rejects_unsupported_distribution` - both remaining cases (`multiple-x-blocks`, `deep-w-tail`) retuned to `per_core_M <= Mt` so neither depends on this check's position relative to the guard it's testing. The two internal H-block cases are gone: a comment at the parametrize list explains why - once `per_core_M <= Mt` holds, `per_core_M` is pinned to exactly `Mt` in the single-Y case, so those guards can no longer fire. The guards themselves are untouched, kept as defence in depth.
- `test_matmul_mcast_in1_single_core_h_and_w_tail` - `per_core_m` / `out_block_h` `2` -> `1` (`Mt = 1`), so the old hardcoded `2` is not itself the rejected pattern.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/matmul-mcast-oob-write-51550)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/matmul-mcast-oob-write-51550)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/matmul-mcast-oob-write-51550)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/matmul-mcast-oob-write-51550)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/matmul-mcast-oob-write-51550)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/matmul-mcast-oob-write-51550)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/matmul-mcast-oob-write-51550)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/matmul-mcast-oob-write-51550)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/matmul-mcast-oob-write-51550)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/matmul-mcast-oob-write-51550)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/matmul-mcast-oob-write-51550)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/matmul-mcast-oob-write-51550)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/matmul-mcast-oob-write-51550)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/matmul-mcast-oob-write-51550)