### PR TITLE
Declare unimplemented Quasar p_stall wait resources and STALL_XMOV as non-integers

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
@@ -184,18 +184,48 @@ struct p_mov_src_to_dest
 struct p_stall
 {
     // What to stall on
-    constexpr static std::uint32_t NOTHING         = 0;
-    constexpr static std::uint32_t THCON           = 1;
-    constexpr static std::uint32_t UNPACK0         = 2;
-    constexpr static std::uint32_t UNPACK0_DONE_RD = 3;
-    constexpr static std::uint32_t UNPACK1         = 4;
-    constexpr static std::uint32_t UNPACK1_DONE_RD = 5;
-    constexpr static std::uint32_t UNPACK2         = 6;
-    constexpr static std::uint32_t UNPACK2_DONE_RD = 7;
-    constexpr static std::uint32_t PACK0           = 8;
-    constexpr static std::uint32_t PACK0_DONE_WR   = 9;
-    constexpr static std::uint32_t PACK1           = 10;
-    constexpr static std::uint32_t PACK1_DONE_WR   = 11;
+    constexpr static std::uint32_t NOTHING = 0;
+    constexpr static std::uint32_t THCON   = 1;
+    constexpr static std::uint32_t UNPACK0 = 2;
+
+    // index 3 - not implemented; see the note below
+    constexpr static struct
+    {
+        int not_implemented;
+    } UNPACK0_DONE_RD = {0};
+
+    constexpr static std::uint32_t UNPACK1 = 4;
+
+    // index 5 - not implemented; see the note below
+    constexpr static struct
+    {
+        int not_implemented;
+    } UNPACK1_DONE_RD = {0};
+
+    constexpr static std::uint32_t UNPACK2 = 6;
+
+    // index 7 - not implemented; see the note below
+    constexpr static struct
+    {
+        int not_implemented;
+    } UNPACK2_DONE_RD = {0};
+
+    constexpr static std::uint32_t PACK0 = 8;
+
+    // index 9 - not implemented; see the note below
+    constexpr static struct
+    {
+        int not_implemented;
+    } PACK0_DONE_WR = {0};
+
+    constexpr static std::uint32_t PACK1 = 10;
+
+    // index 11 - not implemented; see the note below
+    constexpr static struct
+    {
+        int not_implemented;
+    } PACK1_DONE_WR = {0};
+
     constexpr static std::uint32_t MATH            = 12;
     constexpr static std::uint32_t SRCA_CLR        = 13;
     constexpr static std::uint32_t SRCB_CLR        = 14;
@@ -204,10 +234,25 @@ struct p_stall
     constexpr static std::uint32_t SRCA_VLD        = 17;
     constexpr static std::uint32_t SRCB_VLD        = 18;
     constexpr static std::uint32_t SFPU_SRCS_RDY   = 19;
-    constexpr static std::uint32_t XMOV            = 20;
-    constexpr static std::uint32_t TRISC_CFG       = 21;
-    constexpr static std::uint32_t SFPU1           = 22; // lol name collisions
-    constexpr static std::uint32_t CFGEXU          = 23;
+
+    // index 20 - not implemented; see the note below
+    constexpr static struct
+    {
+        int not_implemented;
+    } XMOV = {0};
+
+    constexpr static std::uint32_t TRISC_CFG = 21;
+    constexpr static std::uint32_t SFPU1     = 22; // lol name collisions
+    constexpr static std::uint32_t CFGEXU    = 23;
+
+    // Wait resources 3, 5, 7, 9, 11 and 20 above are decoded by the instruction but do
+    // not reach the live wait condition. Passing one yields an empty wait mask, which
+    // means "wait for every data-movement engine on this thread": used alone the stall
+    // is far broader than it reads, and combined with any implemented index it
+    // contributes nothing. They are declared as non-integers so that any use is a
+    // compile error, and kept named so the index numbering stays documented.
+    // For "the packer has finished" use PACK0 / PACK1; for a full data-movement drain
+    // pass no wait index.
 
     constexpr static std::uint32_t WAIT_SFPU = SFPU1;
     constexpr static std::uint32_t PACK      = PACK0;
@@ -222,8 +267,14 @@ struct p_stall
     constexpr static std::uint32_t STALL_SYNC   = 0x2;
     constexpr static std::uint32_t STALL_PACK   = 0x4;
     constexpr static std::uint32_t STALL_UNPACK = 0x8;
+
     // constexpr static uint STALL_XSEARCH     = 0x10;
-    constexpr static std::uint32_t STALL_XMOV   = 0x10;
+    // 0x10 - not implemented; a mask naming only this bit stalls no class
+    constexpr static struct
+    {
+        int not_implemented;
+    } STALL_XMOV = {0};
+
     constexpr static std::uint32_t STALL_THCON  = 0x20;
     constexpr static std::uint32_t STALL_MATH   = 0x40;
     constexpr static std::uint32_t STALL_CFG    = 0x80;


### PR DESCRIPTION
Declares the Quasar `p_stall` wait resources at indices 3, 5, 7, 9, 11 and 20 (`UNPACK0/1/2_DONE_RD`, `PACK0/1_DONE_WR`, `XMOV`) and the `STALL_XMOV` stall-class bit as non-integers, so that any use is a compile error.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/quasar-dead-pstall-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/quasar-dead-pstall-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-dead-pstall-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/quasar-dead-pstall-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/quasar-dead-pstall-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/quasar-dead-pstall-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/quasar-dead-pstall-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/quasar-dead-pstall-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/quasar-dead-pstall-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/quasar-dead-pstall-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/quasar-dead-pstall-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/quasar-dead-pstall-constants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/quasar-dead-pstall-constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/quasar-dead-pstall-constants)