### PR TITLE
[Bug fix] Fix traced chunked-prefill RoPE slicing

### DIFF
--- a/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
+++ b/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
@@ -10,7 +10,12 @@ import torch
 
 import ttnn
 from models.tt_transformers.tt.common import Mode
-from models.tt_transformers.tt.model import Transformer, _get_trace_rope_table_len, _pad_prefill_rope_tables
+from models.tt_transformers.tt.model import (
+    Transformer,
+    _get_trace_rope_table_len,
+    _pad_prefill_rope_tables,
+    _prefill_rope_setups_to_pad,
+)
 
 
 def test_resumed_prefill_rope_slice_matches_trace_length_near_context_limit(device):
@@ -117,3 +122,27 @@ def test_trace_rope_table_supports_every_bucket_and_dynamic_start():
 
     assert table_len >= max_seq_len + max(trace_prefill_seq_lens)
     assert all(table_len % seq_len == 0 for seq_len in trace_prefill_seq_lens)
+
+
+@pytest.mark.parametrize(
+    "rope_setup_class, has_local, expected",
+    [
+        (None, False, ["global"]),
+        (None, True, ["global", "local"]),
+        (object, False, []),
+        (object, True, ["local"]),
+    ],
+    ids=["builtin", "builtin_local", "custom", "custom_local"],
+)
+def test_only_setups_owning_shared_prefill_tables_are_padded(rope_setup_class, has_local, expected):
+    # A custom rope_setup_class, as Qwen2.5-VL and Qwen3-VL pass, has cos_matrix
+    # and sin_matrix but no cos_matrix_prefill, so padding it raises AttributeError.
+    rope_setup = SimpleNamespace(name="global", cos_matrix=object(), sin_matrix=object())
+    rope_local_setup = (
+        SimpleNamespace(name="local", cos_matrix_prefill=object(), sin_matrix_prefill=object()) if has_local else None
+    )
+
+    selected = _prefill_rope_setups_to_pad(rope_setup, rope_local_setup, rope_setup_class)
+
+    assert [setup.name for setup in selected] == expected
+    assert all(hasattr(setup, "cos_matrix_prefill") for setup in selected)

--- a/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
+++ b/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
@@ -135,9 +135,15 @@ def test_trace_rope_table_supports_every_bucket_and_dynamic_start():
     ids=["builtin", "builtin_local", "custom", "custom_local"],
 )
 def test_only_setups_owning_shared_prefill_tables_are_padded(rope_setup_class, has_local, expected):
-    # A custom rope_setup_class, as Qwen2.5-VL and Qwen3-VL pass, has cos_matrix
-    # and sin_matrix but no cos_matrix_prefill, so padding it raises AttributeError.
+    # Transformer builds rope_setup from rope_setup_class, so which attributes it
+    # owns follows that class: the built-in setups define cos_matrix_prefill, and
+    # the Qwen2.5-VL and Qwen3-VL setups define only cos_matrix and sin_matrix, so
+    # padding one of those raises AttributeError. rope_local_setup is always built
+    # in, so it always owns the prefill tables.
     rope_setup = SimpleNamespace(name="global", cos_matrix=object(), sin_matrix=object())
+    if rope_setup_class is None:
+        rope_setup.cos_matrix_prefill = object()
+        rope_setup.sin_matrix_prefill = object()
     rope_local_setup = (
         SimpleNamespace(name="local", cos_matrix_prefill=object(), sin_matrix_prefill=object()) if has_local else None
     )

--- a/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
+++ b/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
@@ -5,6 +5,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 
+import pytest
 import torch
 
 import ttnn
@@ -74,12 +75,18 @@ def test_resumed_prefill_rope_slice_matches_trace_length_near_context_limit(devi
     torch.testing.assert_close(ttnn.to_torch(rot_sin), -expected_positions)
 
 
-def test_prefill_forward_passes_trace_length_to_global_and_local_rope_slices():
+@pytest.mark.parametrize(
+    "batch_size, expected_prefill_seq_len",
+    [(1, 8192), (8, 1024)],
+    ids=["single_user", "batched"],
+)
+def test_prefill_forward_passes_per_user_length_to_global_and_local_rope_slices(batch_size, expected_prefill_seq_len):
     model = object.__new__(Transformer)
     model.prefetcher = None
     model.layers = []
     model._slice_prefill_rot_mats = MagicMock(side_effect=lambda rot_mats, *_: rot_mats)
 
+    # Batched prefill hands forward the flattened [1, 1, batch_size * S_per_user, dim] activation.
     x = SimpleNamespace(shape=(1, 1, 8192, 32))
     rot_mats_global = object()
     rot_mats_local = object()
@@ -92,12 +99,13 @@ def test_prefill_forward_passes_trace_length_to_global_and_local_rope_slices():
         rot_mats_local=rot_mats_local,
         mode=Mode.PREFILL,
         chunk_start_idx=chunk_start_idx,
+        batch_size=batch_size,
     )
 
     assert result is x
     assert model._slice_prefill_rot_mats.call_args_list == [
-        call(rot_mats_global, chunk_start_idx, 8192),
-        call(rot_mats_local, chunk_start_idx, 8192),
+        call(rot_mats_global, chunk_start_idx, expected_prefill_seq_len),
+        call(rot_mats_local, chunk_start_idx, expected_prefill_seq_len),
     ]
 
 

--- a/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
+++ b/models/tt_transformers/tests/test_traced_prefill_rope_slice.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import torch
+
+import ttnn
+from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.model import Transformer, _get_trace_rope_table_len, _pad_prefill_rope_tables
+
+
+def test_resumed_prefill_rope_slice_matches_trace_length_near_context_limit(device):
+    max_seq_len = 32768
+    prefill_seq_len = 8192
+    chunk_start_idx = 28672
+    head_dim = 32
+    trace_prefill_seq_lens = [128, 1024, 2048, 4096, prefill_seq_len]
+    trace_rope_table_len = _get_trace_rope_table_len(max_seq_len, trace_prefill_seq_lens)
+
+    valid_positions = (
+        torch.arange(max_seq_len, dtype=torch.float32)
+        .to(torch.bfloat16)
+        .reshape(1, 1, max_seq_len, 1)
+        .expand(1, 1, max_seq_len, head_dim)
+        .contiguous()
+    )
+    rope_setup = SimpleNamespace()
+    rope_setup.cos_matrix_prefill = ttnn.from_torch(
+        valid_positions,
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    rope_setup.sin_matrix_prefill = ttnn.from_torch(
+        -valid_positions,
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    _pad_prefill_rope_tables([rope_setup], max_seq_len, trace_prefill_seq_lens)
+    full_rot_cos = rope_setup.cos_matrix_prefill
+    full_rot_sin = rope_setup.sin_matrix_prefill
+    positions = torch.nn.functional.pad(valid_positions, (0, 0, 0, trace_rope_table_len - max_seq_len))
+
+    model = object.__new__(Transformer)
+    # Simulate the eight-device mesh width that the old code passed as the partition count.
+    model.args = SimpleNamespace(max_seq_len=max_seq_len, num_devices=8)
+    model._tt_seq_len_buffer = ttnn.from_torch(
+        torch.tensor([1, 1, max_seq_len, head_dim], dtype=torch.int32),
+        device=device,
+    )
+    model._tt_slice_start_zeros_4 = ttnn.from_torch(
+        torch.zeros(4, dtype=torch.int32),
+        device=device,
+    )
+    tt_chunk_start_idx = ttnn.from_torch(
+        torch.tensor([chunk_start_idx], dtype=torch.int32),
+        device=device,
+    )
+
+    rot_cos, rot_sin = model._slice_prefill_rot_mats(
+        (full_rot_cos, full_rot_sin),
+        tt_chunk_start_idx,
+        prefill_seq_len,
+    )
+
+    expected_positions = positions[:, :, chunk_start_idx : chunk_start_idx + prefill_seq_len, :]
+    assert rot_cos.shape[2] == prefill_seq_len
+    assert rot_sin.shape[2] == prefill_seq_len
+    torch.testing.assert_close(ttnn.to_torch(rot_cos), expected_positions)
+    torch.testing.assert_close(ttnn.to_torch(rot_sin), -expected_positions)
+
+
+def test_prefill_forward_passes_trace_length_to_global_and_local_rope_slices():
+    model = object.__new__(Transformer)
+    model.prefetcher = None
+    model.layers = []
+    model._slice_prefill_rot_mats = MagicMock(side_effect=lambda rot_mats, *_: rot_mats)
+
+    x = SimpleNamespace(shape=(1, 1, 8192, 32))
+    rot_mats_global = object()
+    rot_mats_local = object()
+    chunk_start_idx = object()
+
+    result = model.forward(
+        x,
+        current_pos=None,
+        rot_mats_global=rot_mats_global,
+        rot_mats_local=rot_mats_local,
+        mode=Mode.PREFILL,
+        chunk_start_idx=chunk_start_idx,
+    )
+
+    assert result is x
+    assert model._slice_prefill_rot_mats.call_args_list == [
+        call(rot_mats_global, chunk_start_idx, 8192),
+        call(rot_mats_local, chunk_start_idx, 8192),
+    ]
+
+
+def test_trace_rope_table_supports_every_bucket_and_dynamic_start():
+    max_seq_len = 30000
+    trace_prefill_seq_lens = [128, 1024, 2048, 4096, 8192]
+
+    table_len = _get_trace_rope_table_len(max_seq_len, trace_prefill_seq_lens)
+
+    assert table_len >= max_seq_len + max(trace_prefill_seq_lens)
+    assert all(table_len % seq_len == 0 for seq_len in trace_prefill_seq_lens)

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -1015,10 +1015,14 @@ class Transformer(LightweightModule):
 
         if mode == Mode.PREFILL:
             # For traced prefill, keep RoPE slicing in-graph and driven by the
-            # on-device chunk_start_idx input.
-            rot_mats_global = self._slice_prefill_rot_mats(rot_mats_global, chunk_start_idx, x.shape[2])
+            # on-device chunk_start_idx input. Batched prefill arrives flattened
+            # to [1, 1, batch_size * S_per_user, dim] and each TransformerBlock
+            # restores the batch dimension before attention, so the RoPE slice
+            # width is the per-user length, not the flattened one.
+            prefill_seq_len = x.shape[2] // batch_size
+            rot_mats_global = self._slice_prefill_rot_mats(rot_mats_global, chunk_start_idx, prefill_seq_len)
             if rot_mats_local is not None:
-                rot_mats_local = self._slice_prefill_rot_mats(rot_mats_local, chunk_start_idx, x.shape[2])
+                rot_mats_local = self._slice_prefill_rot_mats(rot_mats_local, chunk_start_idx, prefill_seq_len)
 
         if page_tables_per_layer is not None and len(page_tables_per_layer) != len(self.layers):
             raise ValueError(

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -32,6 +32,21 @@ def _get_trace_rope_table_len(max_seq_len, trace_prefill_seq_lens):
     return ((min_table_len + slice_alignment - 1) // slice_alignment) * slice_alignment
 
 
+def _prefill_rope_setups_to_pad(rope_setup, rope_local_setup, rope_setup_class):
+    """Select the RoPE setups whose shared prefill tables Transformer slices.
+
+    A caller-supplied rope_setup_class builds its prefill cosine and sine mats
+    per request on the host, inside its own prepare_inputs_prefill, and its
+    forward never calls Transformer._slice_prefill_rot_mats. Such a setup owns
+    no cos_matrix_prefill to pad. rope_local_setup always comes from the
+    built-in classes, so it always owns one.
+    """
+    rope_setups = [] if rope_setup_class is not None else [rope_setup]
+    if rope_local_setup is not None:
+        rope_setups.append(rope_local_setup)
+    return rope_setups
+
+
 def _pad_prefill_rope_tables(rope_setups, max_seq_len, trace_prefill_seq_lens):
     table_len = _get_trace_rope_table_len(max_seq_len, trace_prefill_seq_lens)
     pad_len = table_len - max_seq_len
@@ -121,11 +136,12 @@ class Transformer(LightweightModule):
         # Dynamic starts share one table across fixed-width trace buckets. The
         # tail prevents out-of-range reads and the common multiple preserves
         # the tensor-bound slice partition geometry for every traced length.
-        rope_setups = [self.rope_setup]
-        if hasattr(self, "rope_local_setup"):
-            rope_setups.append(self.rope_local_setup)
         _pad_prefill_rope_tables(
-            rope_setups,
+            _prefill_rope_setups_to_pad(
+                self.rope_setup,
+                getattr(self, "rope_local_setup", None),
+                rope_setup_class,
+            ),
             args.max_seq_len,
             args.trace_prefill_supported_seq_lens,
         )

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import math
+
 import torch
 from tqdm import tqdm
 
@@ -19,6 +21,35 @@ from models.tt_transformers.tt.embedding import Embedding, ScaledEmbedding
 from models.tt_transformers.tt.lm_head import LMHead
 from models.tt_transformers.tt.model_config import TensorGroup
 from models.tt_transformers.tt.rope import HfRotarySetup, RotarySetup
+
+
+def _get_trace_rope_table_len(max_seq_len, trace_prefill_seq_lens):
+    if not trace_prefill_seq_lens:
+        return max_seq_len
+
+    slice_alignment = math.lcm(*trace_prefill_seq_lens)
+    min_table_len = max_seq_len + max(trace_prefill_seq_lens)
+    return ((min_table_len + slice_alignment - 1) // slice_alignment) * slice_alignment
+
+
+def _pad_prefill_rope_tables(rope_setups, max_seq_len, trace_prefill_seq_lens):
+    table_len = _get_trace_rope_table_len(max_seq_len, trace_prefill_seq_lens)
+    pad_len = table_len - max_seq_len
+    if pad_len == 0:
+        return
+
+    padding = [(0, 0), (0, 0), (0, pad_len), (0, 0)]
+    for rope_setup in rope_setups:
+        rope_setup.cos_matrix_prefill = ttnn.pad(
+            rope_setup.cos_matrix_prefill,
+            padding=padding,
+            value=0.0,
+        )
+        rope_setup.sin_matrix_prefill = ttnn.pad(
+            rope_setup.sin_matrix_prefill,
+            padding=padding,
+            value=0.0,
+        )
 
 
 class Transformer(LightweightModule):
@@ -86,6 +117,18 @@ class Transformer(LightweightModule):
                 use_qk_fused=args.use_qk_fused,
                 prefetcher=None,
             )
+
+        # Dynamic starts share one table across fixed-width trace buckets. The
+        # tail prevents out-of-range reads and the common multiple preserves
+        # the tensor-bound slice partition geometry for every traced length.
+        rope_setups = [self.rope_setup]
+        if hasattr(self, "rope_local_setup"):
+            rope_setups.append(self.rope_local_setup)
+        _pad_prefill_rope_tables(
+            rope_setups,
+            args.max_seq_len,
+            args.trace_prefill_supported_seq_lens,
+        )
 
         self.trans_mats_dict = self.rope_setup.get_both_trans_mats()
 
@@ -452,7 +495,8 @@ class Transformer(LightweightModule):
             tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
 
         # Slice the rot mats to the prefill seqlen
-        mat_len = self.rope_setup.cos_matrix_prefill.shape[2]
+        trace_mat_len = self.rope_setup.cos_matrix_prefill.shape[2]
+        mat_len = self.args.max_seq_len
         seq_len = last_token_idx + 1 if last_token_idx is not None else S
         assert mat_len >= seq_len, f"Sequence length {seq_len} exceeds max seq len {mat_len}"
 
@@ -462,7 +506,7 @@ class Transformer(LightweightModule):
         # We set the end_pos to max_seq_len so that we don't create a new tensor for the whole cos_matrix and sin_matrix
         # In case of trace, we will use the whole matrix for all seq_lens supported by trace
         prefill_start_pos = 0 if trace_enabled else start_pos
-        slice_end = self.args.max_seq_len if trace_enabled else min(mat_len, required_end)
+        slice_end = trace_mat_len if trace_enabled else min(mat_len, required_end)
 
         cos_slice = self.rope_setup.cos_matrix_prefill[:, :, prefill_start_pos:slice_end, :]
         sin_slice = self.rope_setup.sin_matrix_prefill[:, :, prefill_start_pos:slice_end, :]
@@ -477,10 +521,11 @@ class Transformer(LightweightModule):
         tt_rot_mats_prefill_global = [cos_slice, sin_slice]
 
         if hasattr(self, "rope_local_setup"):
-            local_mat_len = self.rope_local_setup.cos_matrix_prefill.shape[2]
+            local_trace_mat_len = self.rope_local_setup.cos_matrix_prefill.shape[2]
+            local_mat_len = self.args.max_seq_len
             local_required_end = start_pos + S
             local_pad_len = max(0, local_required_end - local_mat_len)
-            local_slice_end = self.args.max_seq_len if trace_enabled else min(local_mat_len, local_required_end)
+            local_slice_end = local_trace_mat_len if trace_enabled else min(local_mat_len, local_required_end)
 
             local_cos_slice = self.rope_local_setup.cos_matrix_prefill[:, :, prefill_start_pos:local_slice_end, :]
             local_sin_slice = self.rope_local_setup.sin_matrix_prefill[:, :, prefill_start_pos:local_slice_end, :]
@@ -825,15 +870,30 @@ class Transformer(LightweightModule):
         ttnn.plus_one(current_pos, skip_negative_entries=True)
         ttnn.plus_one(rot_mat_idxs)
 
-    def _slice_prefill_rot_mats(self, rot_mats, chunk_start_idx):
-        """Slices full prefill RoPE mats on device to [chunk_start_idx, max_seq_len)."""
+    def _slice_prefill_rot_mats(self, rot_mats, chunk_start_idx, prefill_seq_len):
+        """Slice full prefill RoPE mats to the traced prefill sequence length."""
         if rot_mats is None or chunk_start_idx is None or not isinstance(chunk_start_idx, ttnn.Tensor):
             return rot_mats
 
         full_rot_cos, full_rot_sin = rot_mats[0], rot_mats[1]
-        if full_rot_cos.shape[2] != self.args.max_seq_len:
-            # Already sliced in input prep path; leave as-is.
+        full_seq_len = full_rot_cos.shape[2]
+        if prefill_seq_len <= 0:
+            raise ValueError(f"Prefill sequence length must be positive, got {prefill_seq_len}")
+        if full_rot_sin.shape[2] != full_seq_len:
+            raise ValueError(
+                f"Prefill RoPE cosine and sine sequence lengths must match, got "
+                f"{full_seq_len} and {full_rot_sin.shape[2]}"
+            )
+        if full_seq_len == prefill_seq_len:
             return rot_mats
+        if full_seq_len % prefill_seq_len != 0:
+            raise ValueError(
+                f"Full RoPE sequence length {full_seq_len} must be evenly divisible by "
+                f"prefill sequence length {prefill_seq_len}"
+            )
+        # Tensor-bound slice fixes output geometry as input length divided by
+        # num_devices; this argument is a partition count, not the mesh width.
+        num_partitions = full_seq_len // prefill_seq_len
 
         z = self._tt_slice_start_zeros_4
         tt_slice_starts = ttnn.concat([z[0:2], chunk_start_idx, z[3:4]], dim=0)
@@ -843,14 +903,14 @@ class Transformer(LightweightModule):
             starts=tt_slice_starts,
             ends=self._tt_seq_len_buffer,
             slice_dim=2,
-            num_devices=self.args.num_devices,
+            num_devices=num_partitions,
         )
         rot_sin_slice = ttnn.slice(
             input_tensor=full_rot_sin,
             starts=tt_slice_starts,
             ends=self._tt_seq_len_buffer,
             slice_dim=2,
-            num_devices=self.args.num_devices,
+            num_devices=num_partitions,
         )
         return (rot_cos_slice, rot_sin_slice)
 
@@ -956,9 +1016,9 @@ class Transformer(LightweightModule):
         if mode == Mode.PREFILL:
             # For traced prefill, keep RoPE slicing in-graph and driven by the
             # on-device chunk_start_idx input.
-            rot_mats_global = self._slice_prefill_rot_mats(rot_mats_global, chunk_start_idx)
+            rot_mats_global = self._slice_prefill_rot_mats(rot_mats_global, chunk_start_idx, x.shape[2])
             if rot_mats_local is not None:
-                rot_mats_local = self._slice_prefill_rot_mats(rot_mats_local, chunk_start_idx)
+                rot_mats_local = self._slice_prefill_rot_mats(rot_mats_local, chunk_start_idx, x.shape[2])
 
         if page_tables_per_layer is not None and len(page_tables_per_layer) != len(self.layers):
             raise ValueError(

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -21,6 +21,7 @@
     # (variant-qualified markers, fail-closed unverifiable variants, sidecar single-load) that
     # every tt_transformers e2e leg depends on. See #45400.
     pytest --timeout 120 models/tt_transformers/tests/test_warm_cache_marker.py
+    pytest --timeout 300 models/tt_transformers/tests/test_traced_prefill_rope_slice.py
     pytest --timeout 300 models/tt_transformers/tests/test_embedding.py
     pytest --timeout 300 models/tt_transformers/tests/test_rms_norm.py
     pytest --timeout 600 models/tt_transformers/tests/test_mlp.py


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix traced chunked prefill corruption when a per-request prefill chunk is 4096 tokens or larger. This is the traced-path follow-up to #55630, which fixed the separate untraced page-table bug.

The tensor-bound `ttnn.slice` overload derives its output width as the input length divided by its `num_devices` argument. The traced RoPE path passed the physical mesh width there. On an 8-device mesh with a 32768-token RoPE table, that fixes the output at 4096 tokens regardless of the active trace bucket. An 8192-token trace therefore receives only 4096 RoPE rows, and the rotary kernel zero-fills the remaining positions, corrupting the output.

This change:

- derives the slice partition count from `full_rope_table_len / prefill_seq_len`, so every trace bucket gets exactly its requested width;
- pads the shared prefill RoPE table to a common multiple of all trace buckets, with enough tail space for a dynamic resume offset near the context limit;
- exposes the padded table only to traced input preparation while retaining `max_seq_len` as the valid eager-path bound;
- adds device regression coverage for production RoPE padding and a resumed 8192-token slice, plus caller and sizing tests;
- schedules the new test in `models_unit_tests.yaml`.

Before this fix, the 12452-token needle-recall reproducer from #55630 failed for traced 8192-token chunks even at concurrency 1. A 4096-token chunk passed alone but failed when concurrent prefills shared a step. 

### Notes for reviewers
The non-obvious part is that `num_devices` in this `ttnn.slice` overload is a partition count used to determine output geometry, not the physical mesh width. Please focus on the table-length calculation and the dynamic slice contract in `Transformer._slice_prefill_rot_mats`.

Validation:

- VLLM CI: https://github.com/tenstorrent/tt-metal/actions/runs/34472335981/attempts/2
- Models CI: https://github.com/tenstorrent/tt-metal/actions/runs/34479379273
- `pre-commit run` - passed
- `git diff --check` - passed
- `models/tt_transformers/tests/test_traced_prefill_rope_slice.py` - added to the device CI suite

test | max_model_len | budget | prompt | conc | before | after
-- | -- | -- | -- | -- | -- | --
1 | 32768 | 8192 | 16384 | 1 | 0/3 FAIL | 3/3 PASS
2 | 32768 | 4096 | 12288 | 1 | 3/3 | 3/3 PASS
3 | 65536 | 8192 | 16384 | 1 | 3/3 | 3/3 PASS
4 | 16384 | 4096 | 12288 | 1 | 0/3 FAIL | 3/3 PASS
5 | 32768 | 4096 | 12452 | 4 | 6/12 FAIL | 12/12 PASS

<br class="Apple-interchange-newline">

AI assistance was used for root-cause analysis, implementation, tests, and review. The submitter must review and validate the change before merge.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-traced-prefill-rope-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-traced-prefill-rope-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-traced-prefill-rope-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/fix-traced-prefill-rope-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-traced-prefill-rope-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-traced-prefill-rope-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/fix-traced-prefill-rope-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/fix-traced-prefill-rope-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-traced-prefill-rope-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-traced-prefill-rope-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-traced-prefill-rope-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-traced-prefill-rope-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-traced-prefill-rope-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-traced-prefill-rope-slice)