### PR TITLE
[Bug fix] binary_ng: pin Alignment and Tile in the program-cache key

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -14,8 +14,9 @@ operation_attributes_t::attribute_values(): binary_op_type, lhs/rhs/post_activat
            input_layout_a/b, output_layout, equal_nan, the shard volumes, and
            c_tensor_shape_in_pages (the sharded output's tensor shape in pages on the accessor path)
 
-tensor_args_t::to_hash(): input tensor dtypes and memory_configs, plus each
-           sharded input's tensor shape in pages (BufferDistributionSpec::tensor_shape_in_pages)
+tensor_args_t::to_hash(): input tensor dtypes, memory_configs, Alignment, and Tile,
+           plus each sharded input's tensor shape in pages
+           (BufferDistributionSpec::tensor_shape_in_pages)
 
 The default compute_program_hash() combines both of the above.
 
@@ -305,6 +306,30 @@ def test_ng_cache_miss_different_memory_configs(device, isolate_program_cache):
         device, ttnn.add, shape, shape, dtype=ttnn.float32, memory_config=ttnn.L1_MEMORY_CONFIG
     )
     assert_with_pcc(torch_ref2, tt_out2, 0.9999)
+
+    assert device.cache_entries_counter.total == 2
+
+
+def test_ng_cache_miss_different_alignment(device, isolate_program_cache):
+    """Different tensor alignments -> different cache entries.
+    Alignment is part of tensor_layout and is hashed in to_hash()."""
+    shape = [1, 1, 32, 32]
+    padded = [1, 1, 64, 32]  # > round_up(32, 32); produces Alignment{64,32} not {32,32}
+
+    torch_a = torch.rand(shape, dtype=torch.bfloat16)
+    torch_b = torch.rand(shape, dtype=torch.bfloat16)
+    tt_a = ttnn.tilize_with_val_padding(
+        ttnn.from_torch(torch_a, layout=ttnn.ROW_MAJOR_LAYOUT, device=device), padded, 0.0
+    )
+    tt_b = ttnn.tilize_with_val_padding(
+        ttnn.from_torch(torch_b, layout=ttnn.ROW_MAJOR_LAYOUT, device=device), padded, 0.0
+    )
+    with device.cache_entries_counter.measure():
+        tt_out1 = ttnn.add(tt_a, tt_b)
+    assert_with_pcc(torch.add(torch_a, torch_b), ttnn.to_torch(tt_out1), 0.999)
+
+    torch_ref2, tt_out2 = run_binary_ng_op(device, ttnn.add, shape, shape, dtype=ttnn.bfloat16)
+    assert_with_pcc(torch_ref2, tt_out2, 0.999)
 
     assert device.cache_entries_counter.total == 2
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -300,8 +300,13 @@ ttsl::hash::hash_t BinaryNgDeviceOperation::tensor_args_t::to_hash() const {
     return ttsl::hash::hash_objects_with_default_seed(
         input_tensor_a.dtype(),
         input_tensor_a.memory_config(),
+        input_tensor_a.tensor_spec().tensor_layout().get_alignment(),
+        input_tensor_a.tensor_spec().tile(),
         input_tensor_b.has_value() ? std::optional<DataType>{input_tensor_b->dtype()} : std::nullopt,
         input_tensor_b.has_value() ? std::optional<MemoryConfig>{input_tensor_b->memory_config()} : std::nullopt,
+        input_tensor_b.has_value() ? std::optional{input_tensor_b->tensor_spec().tensor_layout().get_alignment()}
+                                   : std::nullopt,
+        input_tensor_b.has_value() ? std::optional{input_tensor_b->tensor_spec().tile()} : std::nullopt,
         sharded_tensor_shape_in_pages(input_tensor_a),
         input_tensor_b.has_value() ? sharded_tensor_shape_in_pages(*input_tensor_b) : std::nullopt);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -125,8 +125,8 @@ struct BinaryNgDeviceOperation {
         std::optional<Tensor> input_tensor_b;
         std::optional<Tensor> output_tensor;
 
-        // Operand dtypes and memory configs, plus each sharded operand's shape in pages. Omits logical
-        // shape by design, so differently-shaped interleaved calls share one cache entry.
+        // Operand dtypes, memory configs, Alignment, and Tile, plus each sharded operand's shape in
+        // pages. Omits logical shape by design, so differently-shaped interleaved calls share one cache entry.
         ttsl::hash::hash_t to_hash() const;
     };
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #55414.

`binary_ng` `to_hash()` omitted Alignment and Tile, so two tensors that only differed there shared one program. Added those fields for A and B.

### Notes for reviewers
Did not hash optional output (would split in-place vs out-of-place). Rest of the key is unchanged.

Mixed-alignment workloads will compile more; that is expected.

Wormhole: `pytest tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py -v` — 28 passed, 1 existing xfail (#54138).