### PR TITLE
[LLK] fix relu min int negative threshold

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3158,44 +3158,19 @@ class UnarySFPUGolden:
         return torch.nn.functional.threshold(input_tensor, t, v).item()
 
     def _relu_max(self, x, threshold=RELU_MAX_THRESHOLD):
-        # _relu_max_body_ is `v_if (val > threshold) val = threshold` then
-        # `v_if (val < 0) val = 0`. The first is a two-vector compare and so uses the total
-        # order -- a NaN is greater than the threshold and is replaced by it, after which the
-        # relu clamp sees a finite value. Order matters: relu-then-min would keep the NaN.
         return sfpu_relu_max(float(x), float(threshold))
 
     def _relu_min(self, x, threshold=RELU_MIN_THRESHOLD):
         if isinstance(x, int):
-            # Integer dst. An exact integer max with no float round-trip, and
-            # deliberately blind to how either kernel gets there: Wormhole compares in
-            # sign+magnitude (a hand-encoded threshold in LREG2 against an input loaded
-            # under the non-converting InstrModLoadStore::INT32) and Blackhole compares in
-            # two's complement (DEST read through the converting DataLayout::SM32). Same
-            # answer, so the golden states the answer.
-            # Deliberately independent of self.dst_format: for an integer dst the max is
-            # exact, so the dest format cannot change the result, and nothing here should
-            # imply the golden tracks it.
-            #
-            # The threshold comes from _relu_min_int_threshold, not the float default: the
-            # int32 sweep drives negative thresholds to reach the wrapper's sign+magnitude
-            # re-encoding branch, and a negative value has no float-path equivalent here.
+            # Integer dst: an exact integer max, independent of both dst_format and of how
+            # each arch performs the compare, since none of those can change the result.
+            # The threshold comes from _relu_min_int_threshold because the int32 sweep drives
+            # negative values, which the float default cannot express.
             return max(x, int(self._relu_min_int_threshold))
-        # Float dst. The kernel is a single SFPSWAP fold, so this is a max under the SFPU's
-        # total order and not IEEE's -- see sfpu_total_order_key. Measured on n150, threshold
-        # 5.0, Float32 end to end:
-        #
-        #   -NaN (0xFFC00000) -> 5.0        +NaN (0x7FC00000) -> +NaN
-        #   -inf              -> 5.0        +inf              -> +inf
-        #
-        # torch.max agrees on four of those and not on -NaN, which it propagates: -NaN ranks
-        # below -inf under the total order, so the fold discards it for the threshold exactly
-        # as it does -inf. FLOAT_SPECIALS injects only +NaN, so no sweep reaches that lane
-        # today and switching to sfpu_max changes no sweep's outcome -- but the device answer
-        # is measured, so the golden may as well be right there rather than resting on which
-        # NaN sign the specials set happens to carry.
-        #
-        # ReluMax states the same thing through sfpu_relu_max, whose first compare is this
-        # fold; relu_min is that compare with no relu clamp after it.
+        # Float dst: a max under the SFPU's total order rather than IEEE's -- see
+        # sfpu_total_order_key. It diverges from torch.max only on -NaN, which the device
+        # discards in favour of the threshold exactly as it does -inf. No sweep injects -NaN
+        # today, so the choice changes no current result.
         return sfpu_max(float(x), float(threshold))
 
     def _lrelu(self, x, negative_slope=LRELU_NEGATIVE_SLOPE):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3166,10 +3166,12 @@ class UnarySFPUGolden:
 
     def _relu_min(self, x, threshold=RELU_MIN_THRESHOLD):
         if isinstance(x, int):
-            # Integer dst. The kernel takes the vInt branch of _relu_min_, which loads a
-            # hand-encoded sign+magnitude threshold into LREG2 and loads the input under
-            # InstrModLoadStore::INT32, so both operands reach SFPSWAP in sign+magnitude
-            # and the compare is an exact integer max with no float round-trip.
+            # Integer dst. An exact integer max with no float round-trip, and
+            # deliberately blind to how either kernel gets there: Wormhole compares in
+            # sign+magnitude (a hand-encoded threshold in LREG2 against an input loaded
+            # under the non-converting InstrModLoadStore::INT32) and Blackhole compares in
+            # two's complement (DEST read through the converting DataLayout::SM32). Same
+            # answer, so the golden states the answer.
             # Deliberately independent of self.dst_format: for an integer dst the max is
             # exact, so the dest format cannot change the result, and nothing here should
             # imply the golden tracks it.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3166,11 +3166,13 @@ class UnarySFPUGolden:
 
     def _relu_min(self, x, threshold=RELU_MIN_THRESHOLD):
         if isinstance(x, int):
-            # Integer dst. The kernel takes the vInt branch of _relu_min_, which loads an
-            # integer threshold into LREG2 and compares under INT32_2S_COMP, so the golden
-            # is an exact integer max with no float round-trip. Deliberately independent of
-            # self.dst_format: _call_integer returns before __call__ assigns it, so reading
-            # it here would pick up whatever the previous call left behind.
+            # Integer dst. The kernel takes the vInt branch of _relu_min_, which loads a
+            # hand-encoded sign+magnitude threshold into LREG2 and loads the input under
+            # InstrModLoadStore::INT32, so both operands reach SFPSWAP in sign+magnitude
+            # and the compare is an exact integer max with no float round-trip.
+            # Deliberately independent of self.dst_format: for an integer dst the max is
+            # exact, so the dest format cannot change the result, and nothing here should
+            # imply the golden tracks it.
             #
             # The threshold comes from _relu_min_int_threshold, not the float default: the
             # int32 sweep drives negative thresholds to reach the wrapper's sign+magnitude

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3158,6 +3158,8 @@ class UnarySFPUGolden:
         return torch.nn.functional.threshold(input_tensor, t, v).item()
 
     def _relu_max(self, x, threshold=RELU_MAX_THRESHOLD):
+        # Threshold first, then the relu clamp: that order turns a NaN into the threshold,
+        # where relu-then-threshold would keep it.
         return sfpu_relu_max(float(x), float(threshold))
 
     def _relu_min(self, x, threshold=RELU_MIN_THRESHOLD):

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1142,11 +1142,8 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     straight. Negative *inputs* alone are harmless where the compare is a sign+magnitude
     order: for a non-negative threshold that ordering cannot change the outcome, because a
     negative input loses under either encoding. Only once the *threshold* is negative too
-    does the encoding of the two operands have to actually agree. That is the Wormhole
-    defect in #55643: the kernel hand-encodes the threshold to sign+magnitude for SFPSWAP
-    and now loads the input under the non-converting InstrModLoadStore::INT32, so both
-    operands reach the compare in that same form. It previously used INT32_2S_COMP, the
-    *converting* mode, which handed SFPSWAP a two's-complement input instead.
+    does the encoding of the two operands have to actually agree -- on Wormhole, that both
+    reach SFPSWAP in sign+magnitude.
 
     The two range ends are here for a second, independent failure mode, and they matter on
     Blackhole rather than Wormhole. That kernel compares in two's complement, and the SFPU
@@ -1192,34 +1189,6 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     _skip_coverage_unsupported(MathOperation.ReluMin)
 
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
-
-    # The negative half of this sweep was broken on both arches until tt-metal #55643, from
-    # the same root cause -- the compare was handed its two operands in different
-    # representations -- reached by opposite mistakes:
-    #
-    #   Wormhole  hand-encodes the threshold to sign+magnitude for SFPSWAP, correctly, but
-    #             loaded the input under InstrModLoadStore::INT32_2S_COMP, the mode that
-    #             *converts* DEST's sign+magnitude to two's complement. So SFPSWAP compared a
-    #             sign+magnitude threshold against a two's-complement input, the threshold won
-    #             every lane, and it was stored back un-converted (threshold -5 returned
-    #             0x80000005). The fix is INT32, the mode that leaves DEST's encoding alone.
-    #   Blackhole is plain sfpi with no instruction mode to get wrong, but read DEST as a bare
-    #             sfpi::dst_reg[0], which for vInt defaults to the non-converting
-    #             DataLayout::I32 -- so its two's-complement compare saw raw sign+magnitude
-    #             bits. It now reads through DataLayout::SM32, the converting layout there.
-    #
-    # Both name pairs are the opposite way round to the intuition, which is what the original
-    # code walked into; both fixes carry the note at the call site.
-    #
-    # Keep the non-negative thresholds next to the negative ones. They exercise the
-    # straight-through path where sign+magnitude and two's complement coincide -- which is
-    # exactly why this defect stayed invisible -- and if it ever regresses, the split between
-    # the two halves is what says whether the encoding or the instruction mode moved.
-    #
-    # No xfail marker: the Blackhole half was unverified when it was written (no Blackhole
-    # part on the development bench) and carried a non-strict xfail for CI to judge, which it
-    # has -- all four negative thresholds report XPASS on bh_p150b in the llk-smoke job of
-    # PR gate run 34261984343. Wormhole is verified on n150. Both arches now gate.
 
     eltwise_unary_sfpu(
         "sources/eltwise_unary_sfpu_test.cpp",

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1091,13 +1091,19 @@ def test_eltwise_unary_sfpu_int(
     )
 
 
+_INT32_MAX = 2**31 - 1
+
 # relu_min's integer threshold, which is the last unreached branch of that kernel.
 #
-# The vInt branch of _relu_min_ re-encodes its threshold from two's complement into the
-# sign+magnitude order SFPSWAP compares in -- but only when the threshold is negative:
+# The vInt branch of _relu_min_ (Wormhole) re-encodes its threshold from two's complement
+# into the sign+magnitude order SFPSWAP compares in -- but only when the threshold is
+# negative:
 #
-#     int scalar = static_cast<int>(threshold);
-#     if (scalar < 0) { scalar = -scalar; scalar = 0x80000000 | (scalar & 0x7FFFFFFF); }
+#     const int scalar = static_cast<int>(threshold);
+#     if (scalar < 0) {
+#         const std::uint32_t magnitude = -static_cast<std::uint32_t>(scalar);
+#         sign_mag = 0x80000000u | (magnitude > 0x7FFFFFFFu ? 0x7FFFFFFFu : magnitude);
+#     }
 #
 # Nothing reaches that `if`. The harness's own dispatch hard-coded 5u, and no Compute API
 # entry point passes a negative integer threshold either (relu_tile_int32 passes 0, and
@@ -1107,17 +1113,22 @@ def test_eltwise_unary_sfpu_int(
 # Both signs are swept, because the negation is only meaningful against a control: the
 # non-negative thresholds take the straight-through path and must keep agreeing.
 #
-# The two extremes are the ends of the sign+magnitude-representable range, and they pass.
-# INT_MIN is deliberately absent, for two independent reasons: sign+magnitude has a 31-bit
-# magnitude field so -2^31 has no encoding at all (the kernel saturates it to -(2^31 - 1)),
-# and StimuliSpec.custom cannot deliver it either -- CustomStrategy clamps through
-# _get_integer_bounds, which returns info.min + 1. Including it would assert against a
-# golden built from clamped stimuli, which is a test artefact rather than kernel behaviour.
-_RELU_MIN_INT_THRESHOLDS = [-2147483647, -1000, -5, -1, 0, 5, 1000, 2147483647]
+# The negative extreme is deliberately one off the end of the range rather than on it.
+# -(2^31 - 1) is exactly the bound CustomStrategy clamps stimuli to (_get_integer_bounds
+# returns info.min + 1), so at that threshold every generated value lands on or above the
+# threshold and the clamp branch never fires -- the case would look extreme and assert
+# nothing. -(2^31 - 2) leaves the clamped stimuli one below it.
+#
+# INT_MIN is absent for the same clamping reason plus a representation one: sign+magnitude
+# has a 31-bit magnitude field, so Dst cannot hold -2^31 at all and neither arch can be
+# handed it as a stimulus. Both kernels do the mathematically right thing with it as a
+# *threshold* -- no representable input is below it, so the clamp correctly never fires --
+# which is not something this sweep can assert.
+_RELU_MIN_INT_THRESHOLDS = [-(_INT32_MAX - 1), -1000, -5, -1, 0, 5, 1000, _INT32_MAX]
 
 
 def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
-    """Values straddling *threshold*, so both sides of the clamp fire.
+    """Values straddling *threshold*, plus both ends of the range, so every compare fires.
 
     Built around the threshold rather than from a fixed span: at -1000 a positive-only
     spread would sit entirely on the pass-through side and the clamp would never fire,
@@ -1128,25 +1139,31 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     there is about ops that are also read as unsigned, which is a different constraint.)
 
     Negative inputs and a negative threshold matter independently, which is worth keeping
-    straight. Negative *inputs* alone are harmless: the compare orders operands as
-    sign+magnitude, but for a non-negative threshold that ordering cannot change the
-    outcome, because a negative input loses under either encoding. Only once the *threshold*
-    is negative too does the encoding of the two operands have to actually agree.
+    straight. Negative *inputs* alone are harmless where the compare is a sign+magnitude
+    order: for a non-negative threshold that ordering cannot change the outcome, because a
+    negative input loses under either encoding. Only once the *threshold* is negative too
+    does the encoding of the two operands have to actually agree. That is the Wormhole
+    defect in #55643: the kernel hand-encodes the threshold to sign+magnitude for SFPSWAP
+    and now loads the input under the non-converting InstrModLoadStore::INT32, so both
+    operands reach the compare in that same form. It previously used INT32_2S_COMP, the
+    *converting* mode, which handed SFPSWAP a two's-complement input instead.
 
-    On Wormhole they agree now: the kernel loads and stores under
-    InstrModLoadStore::INT32, the mode that converts DEST's two's complement into the
-    sign+magnitude SFPSWAP compares in, and back again on the store. It previously used
-    INT32_2S_COMP, which loads raw.
-
-    Blackhole reached the same place by a different route -- a bare DEST access defaulting
-    to the non-converting DataLayout::I32, now DataLayout::SM32 -- but that half is not
-    verified on silicon, so its negative cases stay xfailed. See the marker below and
-    https://github.com/tenstorrent/tt-metal/issues/55643.
+    The two range ends are here for a second, independent failure mode, and they matter on
+    Blackhole rather than Wormhole. That kernel compares in two's complement, and the SFPU
+    signed compare subtracts and tests the sign of the result, so it inverts its answer for
+    operands >= 2^31 apart. A stimulus set that only ever reaches threshold +/- 1000 cannot
+    see that: it takes an input at one end of int32 against a threshold at the other. Every
+    threshold therefore gets +/-(2^31 - 1) as well, which is a pass-through case under an
+    exact golden and so costs nothing to assert. Wormhole is immune by construction --
+    SFPSWAP orders operands instead of subtracting -- and passes the same cases.
     """
     straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
     # A decade either side, so the comparison is exercised well away from the boundary too.
     spread = [float(threshold + d) for d in (-1000, -100, -10, 10, 100, 1000)]
-    return StimuliSpec.custom(values=straddle + spread, seed=0)
+    # Both ends of int32, for the far-apart compare. CustomStrategy clamps to info.min + 1,
+    # so -2**31 would arrive as -(2**31 - 1) anyway; ask for what is representable.
+    extremes = [float(-_INT32_MAX), float(_INT32_MAX)]
+    return StimuliSpec.custom(values=straddle + spread + extremes, seed=0)
 
 
 @parametrize(
@@ -1155,7 +1172,6 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     input_dimensions=[[64, 64]],
 )
 def test_eltwise_unary_sfpu_relu_min_int_threshold(
-    request,
     threshold: int,
     dest_acc: DestAccumulation,
     input_dimensions: list[int],
@@ -1164,56 +1180,46 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
 
     The negative cases are the point: they are the only inputs that reach the
     sign+magnitude re-encoding in _relu_min_'s vInt branch, and the only ones whose result
-    depends on the load/store instruction mode agreeing with it. Exact integer golden, so a
-    mis-encoded threshold shows up as a wrong clamp value rather than a tolerance miss.
+    depends on the two operands reaching the compare in the same representation. Exact
+    integer golden, so a mis-encoded threshold shows up as a wrong clamp value rather than
+    a tolerance miss.
+
+    The stimuli reach both ends of int32 at every threshold, which is what covers the other
+    way this can go wrong -- a subtracting compare inverting for far-apart operands. See
+    _relu_min_int_stimuli_spec.
     """
     # ReluMin is hardcoded here rather than parametrized, so the guard takes it directly.
     _skip_coverage_unsupported(MathOperation.ReluMin)
 
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
 
-    # The negative half of this sweep was broken until tt-metal #55643. The vInt branch
-    # re-encoded its threshold to sign+magnitude for SFPSWAP, correctly, but loaded the input
-    # with InstrModLoadStore::INT32_2S_COMP, which loads *raw* -- so the compare saw a
-    # sign+magnitude threshold against a two's-complement input, and the threshold won every
-    # lane and was stored un-converted (threshold -5 returned 0x80000005). The fix was the
-    # instruction mode, not the encoding: INT32 is the mode that translates at the DEST
-    # boundary, and with it both operands reach SFPSWAP in the same form.
+    # The negative half of this sweep was broken on both arches until tt-metal #55643, from
+    # the same root cause -- the compare was handed its two operands in different
+    # representations -- reached by opposite mistakes:
+    #
+    #   Wormhole  hand-encodes the threshold to sign+magnitude for SFPSWAP, correctly, but
+    #             loaded the input under InstrModLoadStore::INT32_2S_COMP, the mode that
+    #             *converts* DEST's sign+magnitude to two's complement. So SFPSWAP compared a
+    #             sign+magnitude threshold against a two's-complement input, the threshold won
+    #             every lane, and it was stored back un-converted (threshold -5 returned
+    #             0x80000005). The fix is INT32, the mode that leaves DEST's encoding alone.
+    #   Blackhole is plain sfpi with no instruction mode to get wrong, but read DEST as a bare
+    #             sfpi::dst_reg[0], which for vInt defaults to the non-converting
+    #             DataLayout::I32 -- so its two's-complement compare saw raw sign+magnitude
+    #             bits. It now reads through DataLayout::SM32, the converting layout there.
+    #
+    # Both name pairs are the opposite way round to the intuition, which is what the original
+    # code walked into; both fixes carry the note at the call site.
     #
     # Keep the non-negative thresholds next to the negative ones. They exercise the
     # straight-through path where sign+magnitude and two's complement coincide -- which is
     # exactly why this defect stayed invisible -- and if it ever regresses, the split between
     # the two halves is what says whether the encoding or the instruction mode moved.
-
-    # Blackhole had the same symptom from a different cause, and the kernel side is now
-    # fixed too -- but unverified on silicon, so the marker stays until CI says otherwise.
     #
-    # Blackhole's _relu_min_impl_ has no instruction mode to get wrong (it is plain sfpi),
-    # but it read DEST as a bare sfpi::dst_reg[0]. Dst holds int32 as sign+magnitude (see
-    # _int_unary_stimuli_spec, which stays positive-only for exactly this reason), and a
-    # bare vInt access to dst_reg defaults to DataLayout::I32 on Blackhole, which does no
-    # conversion -- so the compare saw raw bits and -1000 came back as 0x800003E8, measured
-    # in CI on bh_p150b. It now accesses DEST through DataLayout::SM32, the *converting*
-    # layout on this arch; the two names are the opposite way round to the intuition, which
-    # is documented at the fix in ckernel_sfpu_relu.h.
-    #
-    # Marker kept because there is no Blackhole part on the bench this was developed
-    # against, so the fix is reasoned and compile-checked but not measured: the vInt
-    # instantiation gains sfpi's software smag_to_int / int_to_smag (an SFPSETSGN plus a
-    # predicated negate) and every float instantiation is byte-identical. Non-strict, so
-    # bh_p150b reports XPASS if it works and a plain xfail if it does not -- either way CI
-    # is the judge, and this whole block goes away once it reports XPASS.
-    if threshold < 0 and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE:
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Blackhole negative int32 relu_min threshold: kernel fixed to access "
-                "DEST through the converting sfpi DataLayout::SM32, but unverified on "
-                "silicon -- no Blackhole part on the development bench. Expect XPASS on "
-                "bh_p150b, at which point drop this marker. Wormhole is fixed and verified. "
-                "https://github.com/tenstorrent/tt-metal/issues/55643",
-                strict=False,
-            )
-        )
+    # No xfail marker: the Blackhole half was unverified when it was written (no Blackhole
+    # part on the development bench) and carried a non-strict xfail for CI to judge, which it
+    # has -- all four negative thresholds report XPASS on bh_p150b in the llk-smoke job of
+    # PR gate run 34261984343. Wormhole is verified on n150. Both arches now gate.
 
     eltwise_unary_sfpu(
         "sources/eltwise_unary_sfpu_test.cpp",
@@ -1264,8 +1270,6 @@ _UNARY_SHIFT_AMOUNTS = [n for n in SHIFT_EDGE_AMOUNTS if n >= 0] + [-1]
 # which cannot tell calculate_right_shift's `eff = 31` clamp from a clamp anywhere in that
 # range. The limit filter below drops it from every LeftShift variant that would overflow.
 _SHIFT_STIMULUS_MAGNITUDES = [0, 1, 2, 3, 7, 255, 256, 1023, 65535, 65536, 2**30]
-
-_INT32_MAX = 2**31 - 1
 
 
 def _shift_stimulus_values(mathop, shift_amount):

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1093,72 +1093,30 @@ def test_eltwise_unary_sfpu_int(
 
 _INT32_MAX = 2**31 - 1
 
-# relu_min's integer threshold, which is the last unreached branch of that kernel.
-#
-# The vInt branch of _relu_min_ (Wormhole) re-encodes its threshold from two's complement
-# into the sign+magnitude order SFPSWAP compares in -- but only when the threshold is
-# negative:
-#
-#     const int scalar = static_cast<int>(threshold);
-#     if (scalar < 0) {
-#         const std::uint32_t magnitude = -static_cast<std::uint32_t>(scalar);
-#         sign_mag = 0x80000000u | (magnitude > 0x7FFFFFFFu ? 0x7FFFFFFFu : magnitude);
-#     }
-#
-# Nothing reaches that `if`. The harness's own dispatch hard-coded 5u, and no Compute API
-# entry point passes a negative integer threshold either (relu_tile_int32 passes 0, and
-# relu_min_tile_int32 routes to a different kernel entirely). So the re-encoding shipped
-# untested. Overriding the threshold via SFPU_RELU_MIN_INT_THRESHOLD is what reaches it.
-#
-# Both signs are swept, because the negation is only meaningful against a control: the
-# non-negative thresholds take the straight-through path and must keep agreeing.
-#
-# The negative extreme is deliberately one off the end of the range rather than on it.
-# -(2^31 - 1) is exactly the bound CustomStrategy clamps stimuli to (_get_integer_bounds
-# returns info.min + 1), so at that threshold every generated value lands on or above the
-# threshold and the clamp branch never fires -- the case would look extreme and assert
-# nothing. -(2^31 - 2) leaves the clamped stimuli one below it.
-#
-# INT_MIN is absent for the same clamping reason plus a representation one: sign+magnitude
-# has a 31-bit magnitude field, so Dst cannot hold -2^31 at all and neither arch can be
-# handed it as a stimulus. Both kernels do the mathematically right thing with it as a
-# *threshold* -- no representable input is below it, so the clamp correctly never fires --
-# which is not something this sweep can assert.
+# relu_min's vInt branch is the last unreached path in that kernel and only a negative
+# threshold reaches it, so both signs are swept, the non-negative ones as the control.
+# The negative extreme sits one off the end of the range because -(2^31 - 1) is exactly the
+# bound CustomStrategy clamps stimuli to (_get_integer_bounds returns info.min + 1), which
+# would leave nothing below the threshold for the clamp to do. INT_MIN is absent for that
+# reason plus representation: Dst cannot hold -2^31, so it cannot be delivered as a stimulus
+# either.
 _RELU_MIN_INT_THRESHOLDS = [-(_INT32_MAX - 1), -1000, -5, -1, 0, 5, 1000, _INT32_MAX]
 
 
 def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
-    """Values straddling *threshold*, plus both ends of the range, so every compare fires.
+    """Values straddling *threshold*, plus both ends of int32.
 
-    Built around the threshold rather than from a fixed span: at -1000 a positive-only
-    spread would sit entirely on the pass-through side and the clamp would never fire,
-    which is the same way the float domain used to be vacuous.
-
-    Negatives are required here -- max(x, -5) only clamps for x < -5 -- so unlike
-    _int_unary_stimuli_spec this cannot stay positive-only. (The positive-only rule over
-    there is about ops that are also read as unsigned, which is a different constraint.)
-
-    Negative inputs and a negative threshold matter independently, which is worth keeping
-    straight. Negative *inputs* alone are harmless where the compare is a sign+magnitude
-    order: for a non-negative threshold that ordering cannot change the outcome, because a
-    negative input loses under either encoding. Only once the *threshold* is negative too
-    does the encoding of the two operands have to actually agree -- on Wormhole, that both
-    reach SFPSWAP in sign+magnitude.
-
-    The two range ends are here for a second, independent failure mode, and they matter on
-    Blackhole rather than Wormhole. That kernel compares in two's complement, and the SFPU
-    signed compare subtracts and tests the sign of the result, so it inverts its answer for
-    operands >= 2^31 apart. A stimulus set that only ever reaches threshold +/- 1000 cannot
-    see that: it takes an input at one end of int32 against a threshold at the other. Every
-    threshold therefore gets +/-(2^31 - 1) as well, which is a pass-through case under an
-    exact golden and so costs nothing to assert. Wormhole is immune by construction --
-    SFPSWAP orders operands instead of subtracting -- and passes the same cases.
+    Built around the threshold rather than a fixed span, because a positive-only spread
+    would sit entirely on the pass-through side of a negative threshold and the clamp would
+    never fire. Negatives are therefore required here, unlike _int_unary_stimuli_spec. The
+    range ends cover the compare between far-apart operands, which a set reaching only
+    threshold +/- 1000 cannot; they are pass-through cases under an exact golden, so they
+    cost nothing to assert.
     """
     straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
     # A decade either side, so the comparison is exercised well away from the boundary too.
     spread = [float(threshold + d) for d in (-1000, -100, -10, 10, 100, 1000)]
-    # Both ends of int32, for the far-apart compare. CustomStrategy clamps to info.min + 1,
-    # so -2**31 would arrive as -(2**31 - 1) anyway; ask for what is representable.
+    # CustomStrategy clamps to info.min + 1, so ask for what is representable.
     extremes = [float(-_INT32_MAX), float(_INT32_MAX)]
     return StimuliSpec.custom(values=straddle + spread + extremes, seed=0)
 
@@ -1175,15 +1133,8 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
 ):
     """relu_min on Int32 against both signs of threshold.
 
-    The negative cases are the point: they are the only inputs that reach the
-    sign+magnitude re-encoding in _relu_min_'s vInt branch, and the only ones whose result
-    depends on the two operands reaching the compare in the same representation. Exact
-    integer golden, so a mis-encoded threshold shows up as a wrong clamp value rather than
-    a tolerance miss.
-
-    The stimuli reach both ends of int32 at every threshold, which is what covers the other
-    way this can go wrong -- a subtracting compare inverting for far-apart operands. See
-    _relu_min_int_stimuli_spec.
+    The negative half is the point, and the golden is an exact integer max, so a wrong
+    threshold shows up as a wrong clamp value rather than a tolerance miss.
     """
     # ReluMin is hardcoded here rather than parametrized, so the guard takes it directly.
     _skip_coverage_unsupported(MathOperation.ReluMin)

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1094,8 +1094,8 @@ def test_eltwise_unary_sfpu_int(
 _INT32_MAX = 2**31 - 1
 
 # Only a negative threshold reaches relu_min's vInt branch, so both signs are swept, the
-# non-negative ones as the control. The negative extreme stops short of INT_MIN, which is
-# neither representable in Dst nor reachable as a stimulus.
+# non-negative ones as the control. The negative extreme stops short of INT_MIN: CustomStrategy
+# clamps stimuli at info.min + 1, so no input could straddle it.
 _RELU_MIN_INT_THRESHOLDS = [-(_INT32_MAX - 1), -1000, -5, -1, 0, 5, 1000, _INT32_MAX]
 
 
@@ -1106,8 +1106,8 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     negative threshold. The range ends exercise the compare between far-apart operands.
     """
     # Straddling the boundary, then a decade either side of it. Offsets that leave the
-    # representable range are dropped rather than folded onto its ends, which is what the
-    # thresholds at the extremes would otherwise turn most of them into.
+    # stimuli range are dropped rather than folded onto its ends, which is what the thresholds
+    # at the extremes would otherwise turn most of them into.
     offsets = (-1000, -100, -10, -2, -1, 0, 1, 2, 10, 100, 1000)
     candidates = [threshold + d for d in offsets] + [-_INT32_MAX, _INT32_MAX]
     values = sorted({v for v in candidates if -_INT32_MAX <= v <= _INT32_MAX})
@@ -1128,6 +1128,10 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
 
     The negative half is the point, and the golden is an exact integer max, so a wrong
     threshold shows up as a wrong clamp value rather than a tolerance miss.
+
+    Int32 stimuli are two's complement, which is how ttnn feeds the device -- see
+    use_int32_twos_complement in test_sfpu_reduce.py. Under this file's sign-magnitude
+    default a kernel that reads Dst in the other encoding would pass instead.
     """
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
 
@@ -1141,6 +1145,7 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
         input_dimensions,
         spec_A=_relu_min_int_stimuli_spec(threshold),
         relu_min_int_threshold=threshold,
+        twos_complement=True,
     )
 
 
@@ -1435,6 +1440,7 @@ def eltwise_unary_sfpu(
     custom_rtol=None,
     shift_amount=None,
     relu_min_int_threshold=None,
+    twos_complement=False,
 ):
     torch.manual_seed(0)
     torch.set_printoptions(precision=10)
@@ -1524,6 +1530,7 @@ def eltwise_unary_sfpu(
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_B,
             tile_count_res=tile_cnt_A,
+            twos_complement=twos_complement,
         ),
         dest_acc=dest_acc,
         # dest_acc off: Float32 unpacks to 16-bit in src regs (later copied to dest for SFPU op)

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1093,25 +1093,17 @@ def test_eltwise_unary_sfpu_int(
 
 _INT32_MAX = 2**31 - 1
 
-# relu_min's vInt branch is the last unreached path in that kernel and only a negative
-# threshold reaches it, so both signs are swept, the non-negative ones as the control.
-# The negative extreme sits one off the end of the range because -(2^31 - 1) is exactly the
-# bound CustomStrategy clamps stimuli to (_get_integer_bounds returns info.min + 1), which
-# would leave nothing below the threshold for the clamp to do. INT_MIN is absent for that
-# reason plus representation: Dst cannot hold -2^31, so it cannot be delivered as a stimulus
-# either.
+# Only a negative threshold reaches relu_min's vInt branch, so both signs are swept, the
+# non-negative ones as the control. The negative extreme stops short of INT_MIN, which is
+# neither representable in Dst nor reachable as a stimulus.
 _RELU_MIN_INT_THRESHOLDS = [-(_INT32_MAX - 1), -1000, -5, -1, 0, 5, 1000, _INT32_MAX]
 
 
 def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     """Values straddling *threshold*, plus both ends of int32.
 
-    Built around the threshold rather than a fixed span, because a positive-only spread
-    would sit entirely on the pass-through side of a negative threshold and the clamp would
-    never fire. Negatives are therefore required here, unlike _int_unary_stimuli_spec. The
-    range ends cover the compare between far-apart operands, which a set reaching only
-    threshold +/- 1000 cannot; they are pass-through cases under an exact golden, so they
-    cost nothing to assert.
+    Built around the threshold rather than a fixed span, so the clamp actually fires for a
+    negative threshold. The range ends exercise the compare between far-apart operands.
     """
     straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
     # A decade either side, so the comparison is exercised well away from the boundary too.
@@ -1136,10 +1128,7 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     The negative half is the point, and the golden is an exact integer max, so a wrong
     threshold shows up as a wrong clamp value rather than a tolerance miss.
     """
-    # No _skip_coverage_unsupported here, unlike the sweeps: this case is one Int32 format
-    # pair rather than a broad-profile matrix, and relu_min's kernels do build under coverage
-    # instrumentation on both arches -- the unroll pragma the exclusion list is about is in
-    # _calculate_lrelu_, a different op.
+
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
 
     eltwise_unary_sfpu(

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1105,12 +1105,13 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     Built around the threshold rather than a fixed span, so the clamp actually fires for a
     negative threshold. The range ends exercise the compare between far-apart operands.
     """
-    straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
-    # A decade either side, so the comparison is exercised well away from the boundary too.
-    spread = [float(threshold + d) for d in (-1000, -100, -10, 10, 100, 1000)]
-    # CustomStrategy clamps to info.min + 1, so ask for what is representable.
-    extremes = [float(-_INT32_MAX), float(_INT32_MAX)]
-    return StimuliSpec.custom(values=straddle + spread + extremes, seed=0)
+    # Straddling the boundary, then a decade either side of it. Offsets that leave the
+    # representable range are dropped rather than folded onto its ends, which is what the
+    # thresholds at the extremes would otherwise turn most of them into.
+    offsets = (-1000, -100, -10, -2, -1, 0, 1, 2, 10, 100, 1000)
+    candidates = [threshold + d for d in offsets] + [-_INT32_MAX, _INT32_MAX]
+    values = sorted({v for v in candidates if -_INT32_MAX <= v <= _INT32_MAX})
+    return StimuliSpec.custom(values=[float(v) for v in values], seed=0)
 
 
 @parametrize(
@@ -1128,7 +1129,6 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     The negative half is the point, and the golden is an exact integer max, so a wrong
     threshold shows up as a wrong clamp value rather than a tolerance miss.
     """
-
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
 
     eltwise_unary_sfpu(

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1093,9 +1093,10 @@ def test_eltwise_unary_sfpu_int(
 
 _INT32_MAX = 2**31 - 1
 
-# Only a negative threshold reaches relu_min's vInt branch, so both signs are swept, the
-# non-negative ones as the control. The negative extreme stops short of INT_MIN: CustomStrategy
-# clamps stimuli at info.min + 1, so no input could straddle it.
+# Both signs are swept. Every threshold reaches the vInt branch; what the negative half alone
+# reaches is the overflow-safe compare it is split on, and Wormhole's hand-built threshold
+# encoding. The negative extreme stops short of INT_MIN: CustomStrategy clamps stimuli at
+# info.min + 1, so no input could straddle it.
 _RELU_MIN_INT_THRESHOLDS = [-(_INT32_MAX - 1), -1000, -5, -1, 0, 5, 1000, _INT32_MAX]
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1136,8 +1136,11 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     On Wormhole they agree now: the kernel loads and stores under
     InstrModLoadStore::INT32, the mode that converts DEST's two's complement into the
     sign+magnitude SFPSWAP compares in, and back again on the store. It previously used
-    INT32_2S_COMP, which loads raw. Blackhole is still wrong here for its own reason, so
-    the negative cases stay xfailed there -- see the marker below and
+    INT32_2S_COMP, which loads raw.
+
+    Blackhole reached the same place by a different route -- a bare DEST access defaulting
+    to the non-converting DataLayout::I32, now DataLayout::SM32 -- but that half is not
+    verified on silicon, so its negative cases stay xfailed. See the marker below and
     https://github.com/tenstorrent/tt-metal/issues/55643.
     """
     straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
@@ -1182,20 +1185,31 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     # exactly why this defect stayed invisible -- and if it ever regresses, the split between
     # the two halves is what says whether the encoding or the instruction mode moved.
 
-    # Blackhole is not fixed. Its _relu_min_impl_ has no instruction mode to get wrong --
-    # it is plain sfpi -- but it reads DEST as a bare sfpi::dst_reg[0], with no
-    # .mode<sfpi::DataLayout::I32>() to request the converting layout. Dst holds int32 as
-    # sign+magnitude (see _int_unary_stimuli_spec, which stays positive-only for exactly
-    # this reason), so a negative threshold does not survive the round trip: -1000 comes
-    # back as 0x800003E8, measured in CI on bh_p150b. Same symptom as the Wormhole defect,
-    # different cause, and not fixed here because there is no Blackhole part on the bench
-    # this was developed against. Non-strict, so it reports XPASS as soon as it is.
+    # Blackhole had the same symptom from a different cause, and the kernel side is now
+    # fixed too -- but unverified on silicon, so the marker stays until CI says otherwise.
+    #
+    # Blackhole's _relu_min_impl_ has no instruction mode to get wrong (it is plain sfpi),
+    # but it read DEST as a bare sfpi::dst_reg[0]. Dst holds int32 as sign+magnitude (see
+    # _int_unary_stimuli_spec, which stays positive-only for exactly this reason), and a
+    # bare vInt access to dst_reg defaults to DataLayout::I32 on Blackhole, which does no
+    # conversion -- so the compare saw raw bits and -1000 came back as 0x800003E8, measured
+    # in CI on bh_p150b. It now accesses DEST through DataLayout::SM32, the *converting*
+    # layout on this arch; the two names are the opposite way round to the intuition, which
+    # is documented at the fix in ckernel_sfpu_relu.h.
+    #
+    # Marker kept because there is no Blackhole part on the bench this was developed
+    # against, so the fix is reasoned and compile-checked but not measured: the vInt
+    # instantiation gains sfpi's software smag_to_int / int_to_smag (an SFPSETSGN plus a
+    # predicated negate) and every float instantiation is byte-identical. Non-strict, so
+    # bh_p150b reports XPASS if it works and a plain xfail if it does not -- either way CI
+    # is the judge, and this whole block goes away once it reports XPASS.
     if threshold < 0 and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE:
         request.node.add_marker(
             pytest.mark.xfail(
-                reason="Blackhole _relu_min_impl_ reads DEST without a converting sfpi "
-                "DataLayout, so a negative int32 threshold returns its sign+magnitude "
-                "encoding instead of its value (-1000 -> 0x800003E8). Wormhole is fixed. "
+                reason="Blackhole negative int32 relu_min threshold: kernel fixed to access "
+                "DEST through the converting sfpi DataLayout::SM32, but unverified on "
+                "silicon -- no Blackhole part on the development bench. Expect XPASS on "
+                "bh_p150b, at which point drop this marker. Wormhole is fixed and verified. "
                 "https://github.com/tenstorrent/tt-metal/issues/55643",
                 strict=False,
             )

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1106,7 +1106,14 @@ def test_eltwise_unary_sfpu_int(
 #
 # Both signs are swept, because the negation is only meaningful against a control: the
 # non-negative thresholds take the straight-through path and must keep agreeing.
-_RELU_MIN_INT_THRESHOLDS = [-1000, -5, -1, 0, 5, 1000]
+#
+# The two extremes are the ends of the sign+magnitude-representable range, and they pass.
+# INT_MIN is deliberately absent, for two independent reasons: sign+magnitude has a 31-bit
+# magnitude field so -2^31 has no encoding at all (the kernel saturates it to -(2^31 - 1)),
+# and StimuliSpec.custom cannot deliver it either -- CustomStrategy clamps through
+# _get_integer_bounds, which returns info.min + 1. Including it would assert against a
+# golden built from clamped stimuli, which is a test artefact rather than kernel behaviour.
+_RELU_MIN_INT_THRESHOLDS = [-2147483647, -1000, -5, -1, 0, 5, 1000, 2147483647]
 
 
 def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
@@ -1126,10 +1133,12 @@ def _relu_min_int_stimuli_spec(threshold: int) -> StimuliSpec:
     outcome, because a negative input loses under either encoding. Only once the *threshold*
     is negative too does the encoding of the two operands have to actually agree.
 
-    On both arches it currently does not, which is the unsupported path this sweep
-    deliberately drives and why the negative cases below are xfailed -- the mechanism
-    differs per arch and is tabulated at that marker.
-    See https://github.com/tenstorrent/tt-metal/issues/55643.
+    On Wormhole they agree now: the kernel loads and stores under
+    InstrModLoadStore::INT32, the mode that converts DEST's two's complement into the
+    sign+magnitude SFPSWAP compares in, and back again on the store. It previously used
+    INT32_2S_COMP, which loads raw. Blackhole is still wrong here for its own reason, so
+    the negative cases stay xfailed there -- see the marker below and
+    https://github.com/tenstorrent/tt-metal/issues/55643.
     """
     straddle = [float(threshold + d) for d in (-2, -1, 0, 1, 2)]
     # A decade either side, so the comparison is exercised well away from the boundary too.
@@ -1151,64 +1160,42 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     """relu_min on Int32 against both signs of threshold.
 
     The negative cases are the point: they are the only inputs that reach the
-    sign+magnitude re-encoding in _relu_min_'s vInt branch. Exact integer golden, so a
+    sign+magnitude re-encoding in _relu_min_'s vInt branch, and the only ones whose result
+    depends on the load/store instruction mode agreeing with it. Exact integer golden, so a
     mis-encoded threshold shows up as a wrong clamp value rather than a tolerance miss.
-
-    The non-negative cases are the control and pass: they take the straight-through path
-    where sign+magnitude and two's complement coincide.
     """
     # ReluMin is hardcoded here rather than parametrized, so the guard takes it directly.
     _skip_coverage_unsupported(MathOperation.ReluMin)
 
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
 
-    # First execution of this branch, and it does not work. Measured on n300 at
-    # thresholds -1, -5 and -1000, against stimuli straddling each:
+    # The negative half of this sweep was broken until tt-metal #55643. The vInt branch
+    # re-encoded its threshold to sign+magnitude for SFPSWAP, correctly, but loaded the input
+    # with InstrModLoadStore::INT32_2S_COMP, which loads *raw* -- so the compare saw a
+    # sign+magnitude threshold against a two's-complement input, and the threshold won every
+    # lane and was stored un-converted (threshold -5 returned 0x80000005). The fix was the
+    # instruction mode, not the encoding: INT32 is the mode that translates at the DEST
+    # boundary, and with it both operands reach SFPSWAP in the same form.
     #
-    #   as shipped      the threshold wins every lane, including against inputs that are
-    #                   larger than it, and is stored as the raw re-encoding: threshold -5
-    #                   returns 0x80000005 (-2147483643) rather than -5, and -1000 returns
-    #                   0x800003E8. The magnitude is right, the representation is not.
-    #   re-encode       the opposite failure -- a plain two's-complement negative threshold
-    #     removed       never wins, so every input passes through unclamped.
-    #
-    # So it is not a matter of deleting the conversion: neither representation makes SFPSWAP
-    # and the INT32_2S_COMP store agree for a negative threshold, and settling it needs the
-    # ISA semantics for that pair rather than a guess. Recorded as a non-strict xfail rather
-    # than skipped so the case still *executes* and reports XPASS the moment it is fixed.
-    #
-    # Tracked as tt-metal issue #55643. Drop this marker as part of fixing the kernel.
-    #
-    # Nothing ships on this path: no Compute API entry point passes a negative integer
-    # threshold (relu_tile_int32 passes 0, relu_min_tile_int32 routes to relu_clamp_int), and
-    # the harness itself hard-coded 5u until this test parametrized it.
-    #
-    # Both arches fail, for different reasons, and both return the *sign+magnitude* encoding
-    # of the threshold instead of its two's-complement value:
-    #
-    #   Wormhole   raw TTI. The vInt branch hand-re-encodes the threshold to sign+magnitude
-    #              for SFPSWAP, correctly, but loads the input with
-    #              InstrModLoadStore::INT32_2S_COMP, which loads raw -- so the compare comes
-    #              out against a two's-complement input. Threshold -5 returns 0x80000005.
-    #   Blackhole  plain sfpi, and no instruction mode to get wrong -- but _relu_min_impl_
-    #              reads DEST as a bare sfpi::dst_reg[0], with no .mode<DataLayout::I32>()
-    #              to request the converting layout. Dst holds int32 as sign+magnitude (see
-    #              _int_unary_stimuli_spec, which stays positive-only for exactly this
-    #              reason), so a negative threshold does not survive the round trip.
-    #              Threshold -1000 returns 0x800003E8, measured in CI on bh_p150b.
-    #
-    # Non-strict, so the case still executes and reports XPASS per arch as each is fixed.
-    if threshold < 0 and TestConfig.CHIP_ARCH in (
-        ChipArchitecture.WORMHOLE,
-        ChipArchitecture.BLACKHOLE,
-    ):
+    # Keep the non-negative thresholds next to the negative ones. They exercise the
+    # straight-through path where sign+magnitude and two's complement coincide -- which is
+    # exactly why this defect stayed invisible -- and if it ever regresses, the split between
+    # the two halves is what says whether the encoding or the instruction mode moved.
+
+    # Blackhole is not fixed. Its _relu_min_impl_ has no instruction mode to get wrong --
+    # it is plain sfpi -- but it reads DEST as a bare sfpi::dst_reg[0], with no
+    # .mode<sfpi::DataLayout::I32>() to request the converting layout. Dst holds int32 as
+    # sign+magnitude (see _int_unary_stimuli_spec, which stays positive-only for exactly
+    # this reason), so a negative threshold does not survive the round trip: -1000 comes
+    # back as 0x800003E8, measured in CI on bh_p150b. Same symptom as the Wormhole defect,
+    # different cause, and not fixed here because there is no Blackhole part on the bench
+    # this was developed against. Non-strict, so it reports XPASS as soon as it is.
+    if threshold < 0 and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE:
         request.node.add_marker(
             pytest.mark.xfail(
-                reason="relu_min's vInt branch returns the sign+magnitude encoding of a "
-                "negative threshold instead of its value: Wormhole 0x80000005 for -5 "
-                "(wrong SFPLOAD instruction mode), Blackhole 0x800003E8 for -1000 (no "
-                "converting sfpi DataLayout on the DEST access). Unreached before this "
-                "test; no shipping op passes a negative integer threshold. "
+                reason="Blackhole _relu_min_impl_ reads DEST without a converting sfpi "
+                "DataLayout, so a negative int32 threshold returns its sign+magnitude "
+                "encoding instead of its value (-1000 -> 0x800003E8). Wormhole is fixed. "
                 "https://github.com/tenstorrent/tt-metal/issues/55643",
                 strict=False,
             )

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -1136,9 +1136,10 @@ def test_eltwise_unary_sfpu_relu_min_int_threshold(
     The negative half is the point, and the golden is an exact integer max, so a wrong
     threshold shows up as a wrong clamp value rather than a tolerance miss.
     """
-    # ReluMin is hardcoded here rather than parametrized, so the guard takes it directly.
-    _skip_coverage_unsupported(MathOperation.ReluMin)
-
+    # No _skip_coverage_unsupported here, unlike the sweeps: this case is one Int32 format
+    # pair rather than a broad-profile matrix, and relu_min's kernels do build under coverage
+    # instrumentation on both arches -- the unroll pragma the exclusion list is about is in
+    # _calculate_lrelu_, a different op.
     formats = InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
 
     eltwise_unary_sfpu(

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -85,6 +85,9 @@ inline void _relu_max_(T threshold)
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
     VectorType v_threshold;
+    // Only the integer path reads this; the sign of the threshold picks the overflow-safe
+    // compare in _relu_min_impl_.
+    bool threshold_is_negative = false;
     if constexpr (std::is_same_v<T, float>)
     {
         static_assert(
@@ -130,20 +133,89 @@ inline void _relu_max_(T threshold)
 template <typename VecType>
 inline constexpr sfpi::DataLayout relu_dest_layout_v = std::is_same_v<VecType, sfpi::vInt> ? sfpi::DataLayout::SM32 : sfpi::DataLayout::Default;
 
+// threshold_is_negative selects which of the two integer forms below runs. A plain runtime
+// bool rather than a template parameter, because the threshold is a runtime scalar; it is
+// uniform across lanes, so the branch sits outside the loop and costs nothing per element.
+// Unused on the float path, which is why it defaults.
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_min_impl_(const int iterations, VecType threshold)
+inline void _relu_min_impl_(const int iterations, VecType threshold, const bool threshold_is_negative = false)
 {
     constexpr sfpi::DataLayout LAYOUT = relu_dest_layout_v<VecType>;
 
-    for (int d = 0; d < iterations; d++)
+    if constexpr (std::is_same_v<VecType, sfpi::vInt>)
     {
-        VecType a = sfpi::dst_reg[0].mode<LAYOUT>();
-        v_if (a < threshold)
+        // Once SM32 has converted DEST, `a` is a full-range two's-complement int32 -- and a
+        // plain `a < threshold` is then not a safe compare. The SFPU signed compare subtracts
+        // and tests the sign of the result, so it inverts its answer whenever the two operands
+        // are >= 2^31 apart: at threshold -(2^31 - 1) every input >= 1 would be wrongly clamped
+        // down to the threshold, and at a small positive threshold inputs near INT32_MIN would
+        // wrongly pass through. Splitting on the sign of the threshold leaves only same-sign
+        // operands to the subtracting compare, whose difference cannot overflow.
+        //
+        // Wormhole is immune without this: SFPSWAP orders its operands as sign+magnitude
+        // instead of subtracting. metal's relu_clamp_int guards the same way on this arch
+        // (hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h) and calls the
+        // guard "NOT redundant" for exactly this reason.
+        //
+        // An INT_MIN threshold needs no saturating clamp here, unlike the hand-built
+        // sign+magnitude encoding on Wormhole: DEST cannot represent -2^31 either, so no input
+        // is ever below such a threshold, and with the guard above the clamp correctly never
+        // fires. It is only the overflowing compare that made it look like it clamped
+        // everything.
+        if (threshold_is_negative)
         {
-            sfpi::dst_reg[0].mode<LAYOUT>() = threshold;
+            for (int d = 0; d < iterations; d++)
+            {
+                sfpi::vInt a = sfpi::dst_reg[0].mode<LAYOUT>();
+                // a >= 0 > threshold keeps a, so only the negative lanes can lose, and there
+                // both operands are negative.
+                v_if (a < 0)
+                {
+                    v_if (a < threshold)
+                    {
+                        a = threshold;
+                    }
+                    v_endif;
+                }
+                v_endif;
+                sfpi::dst_reg[0].mode<LAYOUT>() = a;
+                sfpi::dst_reg++;
+            }
         }
-        v_endif;
-        sfpi::dst_reg++;
+        else
+        {
+            for (int d = 0; d < iterations; d++)
+            {
+                sfpi::vInt a = sfpi::dst_reg[0].mode<LAYOUT>();
+                // Lifting the negative lanes to a non-negative threshold first is the whole
+                // answer for them, and it leaves only non-negative operands to the compare.
+                v_if (a < 0)
+                {
+                    a = threshold;
+                }
+                v_endif;
+                v_if (a < threshold)
+                {
+                    a = threshold;
+                }
+                v_endif;
+                sfpi::dst_reg[0].mode<LAYOUT>() = a;
+                sfpi::dst_reg++;
+            }
+        }
+    }
+    else
+    {
+        for (int d = 0; d < iterations; d++)
+        {
+            VecType a = sfpi::dst_reg[0].mode<LAYOUT>();
+            v_if (a < threshold)
+            {
+                sfpi::dst_reg[0].mode<LAYOUT>() = threshold;
+            }
+            v_endif;
+            sfpi::dst_reg++;
+        }
     }
 }
 
@@ -154,6 +226,9 @@ inline void _relu_min_(T threshold)
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
     VectorType v_threshold;
+    // Only the integer path reads this; the sign of the threshold picks the overflow-safe
+    // compare in _relu_min_impl_.
+    bool threshold_is_negative = false;
     if constexpr (std::is_same_v<T, float>)
     {
         static_assert(
@@ -166,7 +241,9 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            v_threshold = static_cast<int>(threshold);
+            const int scalar      = static_cast<int>(threshold);
+            v_threshold           = scalar;
+            threshold_is_negative = scalar < 0;
         }
         else
         {
@@ -178,7 +255,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
+    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold, threshold_is_negative);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -107,13 +107,6 @@ inline void _relu_max_(T threshold)
     _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
-// The layout DEST is accessed through. Only the integer datapath needs a non-default one, and
-// the two names are the opposite way round to the intuition: I32 is the raw one and SM32 is
-// the converting one. Wormhole already defaults vInt to SM32, which is why only Blackhole was
-// wrong.
-template <typename VecType>
-inline constexpr sfpi::DataLayout relu_dest_layout_v = std::is_same_v<VecType, sfpi::vInt> ? sfpi::DataLayout::SM32 : sfpi::DataLayout::Default;
-
 // Sign of an integer threshold. It is uniform across lanes, so it picks which of the integer
 // forms below runs from outside the loop.
 enum class ThresholdSign
@@ -131,8 +124,6 @@ inline constexpr ThresholdSign threshold_sign_of(const int scalar)
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_impl_(const int iterations, VecType threshold, const ThresholdSign threshold_sign)
 {
-    constexpr sfpi::DataLayout LAYOUT = relu_dest_layout_v<VecType>;
-
     if constexpr (std::is_same_v<VecType, sfpi::vInt>)
     {
         // A plain `a < threshold` is not a safe compare over the full int32 range: the signed
@@ -143,7 +134,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
         {
             for (int d = 0; d < iterations; d++)
             {
-                sfpi::vInt a = sfpi::dst_reg[0].mode<LAYOUT>();
+                sfpi::vInt a = sfpi::dst_reg[0];
                 // a >= 0 > threshold keeps a, so only the negative lanes can lose, and there
                 // both operands are negative.
                 v_if (a < 0)
@@ -155,7 +146,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
                     v_endif;
                 }
                 v_endif;
-                sfpi::dst_reg[0].mode<LAYOUT>() = a;
+                sfpi::dst_reg[0] = a;
                 sfpi::dst_reg++;
             }
         }
@@ -164,13 +155,13 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
             // The sign test is the whole compare, which is the form relu_tile_int32 takes.
             for (int d = 0; d < iterations; d++)
             {
-                sfpi::vInt a = sfpi::dst_reg[0].mode<LAYOUT>();
+                sfpi::vInt a = sfpi::dst_reg[0];
                 v_if (a < 0)
                 {
                     a = threshold;
                 }
                 v_endif;
-                sfpi::dst_reg[0].mode<LAYOUT>() = a;
+                sfpi::dst_reg[0] = a;
                 sfpi::dst_reg++;
             }
         }
@@ -178,7 +169,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
         {
             for (int d = 0; d < iterations; d++)
             {
-                sfpi::vInt a = sfpi::dst_reg[0].mode<LAYOUT>();
+                sfpi::vInt a = sfpi::dst_reg[0];
                 // Lifting the negative lanes to a positive threshold first is the whole answer
                 // for them, and it leaves only non-negative operands to the compare.
                 v_if (a < 0)
@@ -191,7 +182,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
                     a = threshold;
                 }
                 v_endif;
-                sfpi::dst_reg[0].mode<LAYOUT>() = a;
+                sfpi::dst_reg[0] = a;
                 sfpi::dst_reg++;
             }
         }
@@ -200,10 +191,10 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
     {
         for (int d = 0; d < iterations; d++)
         {
-            VecType a = sfpi::dst_reg[0].mode<LAYOUT>();
+            VecType a = sfpi::dst_reg[0];
             v_if (a < threshold)
             {
-                sfpi::dst_reg[0].mode<LAYOUT>() = threshold;
+                sfpi::dst_reg[0] = threshold;
             }
             v_endif;
             sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -107,6 +107,11 @@ inline void _relu_max_(T threshold)
     _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
+// Dst holds int32 in whatever encoding the caller put there, and ttnn's is two's complement,
+// which is what the compares below assume. Named rather than left to sfpi's default, because
+// that default is per-arch -- I32 here, SM32 (converting) on Wormhole.
+inline constexpr sfpi::DataLayout INT_DEST_LAYOUT = sfpi::DataLayout::I32;
+
 // Sign of an integer threshold. It is uniform across lanes, so it picks which of the integer
 // forms below runs from outside the loop.
 enum class ThresholdSign
@@ -134,7 +139,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
         {
             for (int d = 0; d < iterations; d++)
             {
-                sfpi::vInt a = sfpi::dst_reg[0];
+                sfpi::vInt a = sfpi::dst_reg[0].mode<INT_DEST_LAYOUT>();
                 // a >= 0 > threshold keeps a, so only the negative lanes can lose, and there
                 // both operands are negative.
                 v_if (a < 0)
@@ -146,7 +151,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
                     v_endif;
                 }
                 v_endif;
-                sfpi::dst_reg[0] = a;
+                sfpi::dst_reg[0].mode<INT_DEST_LAYOUT>() = a;
                 sfpi::dst_reg++;
             }
         }
@@ -155,13 +160,13 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
             // The sign test is the whole compare, which is the form relu_tile_int32 takes.
             for (int d = 0; d < iterations; d++)
             {
-                sfpi::vInt a = sfpi::dst_reg[0];
+                sfpi::vInt a = sfpi::dst_reg[0].mode<INT_DEST_LAYOUT>();
                 v_if (a < 0)
                 {
                     a = threshold;
                 }
                 v_endif;
-                sfpi::dst_reg[0] = a;
+                sfpi::dst_reg[0].mode<INT_DEST_LAYOUT>() = a;
                 sfpi::dst_reg++;
             }
         }
@@ -169,7 +174,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
         {
             for (int d = 0; d < iterations; d++)
             {
-                sfpi::vInt a = sfpi::dst_reg[0];
+                sfpi::vInt a = sfpi::dst_reg[0].mode<INT_DEST_LAYOUT>();
                 // Lifting the negative lanes to a positive threshold first is the whole answer
                 // for them, and it leaves only non-negative operands to the compare.
                 v_if (a < 0)
@@ -182,7 +187,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const Thres
                     a = threshold;
                 }
                 v_endif;
-                sfpi::dst_reg[0] = a;
+                sfpi::dst_reg[0].mode<INT_DEST_LAYOUT>() = a;
                 sfpi::dst_reg++;
             }
         }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -85,9 +85,6 @@ inline void _relu_max_(T threshold)
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
     VectorType v_threshold;
-    // Only the integer path reads this; the sign of the threshold picks the overflow-safe
-    // compare in _relu_min_impl_.
-    bool threshold_is_negative = false;
     if constexpr (std::is_same_v<T, float>)
     {
         static_assert(

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -114,11 +114,22 @@ inline void _relu_max_(T threshold)
 template <typename VecType>
 inline constexpr sfpi::DataLayout relu_dest_layout_v = std::is_same_v<VecType, sfpi::vInt> ? sfpi::DataLayout::SM32 : sfpi::DataLayout::Default;
 
-// threshold_is_negative selects which of the two integer forms below runs; it is uniform
-// across lanes, so the branch sits outside the loop. Unused on the float path, which is why
-// it defaults.
+// Sign of an integer threshold. It is uniform across lanes, so it picks which of the integer
+// forms below runs from outside the loop.
+enum class ThresholdSign
+{
+    Negative,
+    Zero,
+    Positive
+};
+
+inline constexpr ThresholdSign threshold_sign_of(const int scalar)
+{
+    return scalar < 0 ? ThresholdSign::Negative : scalar == 0 ? ThresholdSign::Zero : ThresholdSign::Positive;
+}
+
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _relu_min_impl_(const int iterations, VecType threshold, const bool threshold_is_negative = false)
+inline void _relu_min_impl_(const int iterations, VecType threshold, const ThresholdSign threshold_sign)
 {
     constexpr sfpi::DataLayout LAYOUT = relu_dest_layout_v<VecType>;
 
@@ -128,7 +139,7 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const bool 
         // compare subtracts, so it inverts its answer once the operands are 2^31 or more apart.
         // Splitting on the sign of the threshold leaves only same-sign operands to it, whose
         // difference cannot overflow. Wormhole compares differently and needs no split.
-        if (threshold_is_negative)
+        if (threshold_sign == ThresholdSign::Negative)
         {
             for (int d = 0; d < iterations; d++)
             {
@@ -148,13 +159,28 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const bool 
                 sfpi::dst_reg++;
             }
         }
+        else if (threshold_sign == ThresholdSign::Zero)
+        {
+            // The sign test is the whole compare, which is the form relu_tile_int32 takes.
+            for (int d = 0; d < iterations; d++)
+            {
+                sfpi::vInt a = sfpi::dst_reg[0].mode<LAYOUT>();
+                v_if (a < 0)
+                {
+                    a = threshold;
+                }
+                v_endif;
+                sfpi::dst_reg[0].mode<LAYOUT>() = a;
+                sfpi::dst_reg++;
+            }
+        }
         else
         {
             for (int d = 0; d < iterations; d++)
             {
                 sfpi::vInt a = sfpi::dst_reg[0].mode<LAYOUT>();
-                // Lifting the negative lanes to a non-negative threshold first is the whole
-                // answer for them, and it leaves only non-negative operands to the compare.
+                // Lifting the negative lanes to a positive threshold first is the whole answer
+                // for them, and it leaves only non-negative operands to the compare.
                 v_if (a < 0)
                 {
                     a = threshold;
@@ -192,9 +218,8 @@ inline void _relu_min_(T threshold)
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
     VectorType v_threshold;
-    // Only the integer path reads this; the sign of the threshold picks the overflow-safe
-    // compare in _relu_min_impl_.
-    bool threshold_is_negative = false;
+    // The integer path alone reads this; its compare is the one that splits on the sign.
+    ThresholdSign threshold_sign = ThresholdSign::Zero;
     if constexpr (std::is_same_v<T, float>)
     {
         static_assert(
@@ -207,9 +232,9 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            const int scalar      = static_cast<int>(threshold);
-            v_threshold           = scalar;
-            threshold_is_negative = scalar < 0;
+            const int scalar = static_cast<int>(threshold);
+            v_threshold      = scalar;
+            threshold_sign   = threshold_sign_of(scalar);
         }
         else
         {
@@ -221,7 +246,7 @@ inline void _relu_min_(T threshold)
         static_assert(std::is_same_v<T, float> || std::is_same_v<T, std::uint32_t>, "Threshold type must be float or uint32_t");
     }
 
-    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold, threshold_is_negative);
+    _relu_min_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold, threshold_sign);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -20,12 +20,6 @@ constexpr bool is_supported_relu_type_v = std::is_same_v<T, float> || std::is_sa
 template <bool APPROXIMATION_MODE>
 inline void _calculate_lrelu_(const int iterations, std::uint32_t slope)
 {
-    // Pure sfpi: `v_if (v < 0) v *= slope` lowers to the same per-element
-    // sfpload/sfpsetcc/sfpmul/sfpencc/sfpstore the raw path emitted (the raw code was
-    // already the natural predicate-multiply pattern, with no fused condition-code or
-    // SFPSWAP trick to lose), so the executed instruction stream is identical while the
-    // sfpi backend records it into a replay buffer and shrinks the static code size.
-    // This mirrors the Wormhole _calculate_lrelu_, which already ships this exact sfpi form.
     const sfpi::vFloat slope_v = Converter::as_float(slope);
 #pragma GCC unroll 8
     for (int d = 0; d < iterations; d++)
@@ -113,27 +107,16 @@ inline void _relu_max_(T threshold)
     _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
-// The layout DEST is accessed through. Only the integer datapath needs a non-default one:
-// Dest holds int32 as sign+magnitude, and on Blackhole a bare vInt access to dst_reg
-// defaults to DataLayout::I32, which does *no* conversion -- so the compare below would see
-// the raw bits and a negative operand would lose against a positive one. DataLayout::SM32 is
-// the converting layout here; it emits sfpi's software smag_to_int / int_to_smag around the
-// access (Blackhole's INT32_2S_COMP load/store mode has no effect -- see the note in
-// ckernel_sfpu_sub_int.h).
-//
-// Read the two layout names carefully, they are the opposite way round to the intuition:
-// I32 is the raw one and SM32 is the converting one. On Wormhole the bare default for vInt is
-// already SM32 (sfpi_funcs.h picks it per-arch), which is why only Blackhole was wrong.
-//
-// Default for vFloat, where .mode<Default>() is a no-op and SM32 would not even be a valid
-// layout for the type.
+// The layout DEST is accessed through. Only the integer datapath needs a non-default one, and
+// the two names are the opposite way round to the intuition: I32 is the raw one and SM32 is
+// the converting one. Wormhole already defaults vInt to SM32, which is why only Blackhole was
+// wrong.
 template <typename VecType>
 inline constexpr sfpi::DataLayout relu_dest_layout_v = std::is_same_v<VecType, sfpi::vInt> ? sfpi::DataLayout::SM32 : sfpi::DataLayout::Default;
 
-// threshold_is_negative selects which of the two integer forms below runs. A plain runtime
-// bool rather than a template parameter, because the threshold is a runtime scalar; it is
-// uniform across lanes, so the branch sits outside the loop and costs nothing per element.
-// Unused on the float path, which is why it defaults.
+// threshold_is_negative selects which of the two integer forms below runs; it is uniform
+// across lanes, so the branch sits outside the loop. Unused on the float path, which is why
+// it defaults.
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_impl_(const int iterations, VecType threshold, const bool threshold_is_negative = false)
 {
@@ -141,24 +124,10 @@ inline void _relu_min_impl_(const int iterations, VecType threshold, const bool 
 
     if constexpr (std::is_same_v<VecType, sfpi::vInt>)
     {
-        // Once SM32 has converted DEST, `a` is a full-range two's-complement int32 -- and a
-        // plain `a < threshold` is then not a safe compare. The SFPU signed compare subtracts
-        // and tests the sign of the result, so it inverts its answer whenever the two operands
-        // are >= 2^31 apart: at threshold -(2^31 - 1) every input >= 1 would be wrongly clamped
-        // down to the threshold, and at a small positive threshold inputs near INT32_MIN would
-        // wrongly pass through. Splitting on the sign of the threshold leaves only same-sign
-        // operands to the subtracting compare, whose difference cannot overflow.
-        //
-        // Wormhole is immune without this: SFPSWAP orders its operands as sign+magnitude
-        // instead of subtracting. metal's relu_clamp_int guards the same way on this arch
-        // (hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h) and calls the
-        // guard "NOT redundant" for exactly this reason.
-        //
-        // An INT_MIN threshold needs no saturating clamp here, unlike the hand-built
-        // sign+magnitude encoding on Wormhole: DEST cannot represent -2^31 either, so no input
-        // is ever below such a threshold, and with the guard above the clamp correctly never
-        // fires. It is only the overflowing compare that made it look like it clamped
-        // everything.
+        // A plain `a < threshold` is not a safe compare over the full int32 range: the signed
+        // compare subtracts, so it inverts its answer once the operands are 2^31 or more apart.
+        // Splitting on the sign of the threshold leaves only same-sign operands to it, whose
+        // difference cannot overflow. Wormhole compares differently and needs no split.
         if (threshold_is_negative)
         {
             for (int d = 0; d < iterations; d++)

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -113,15 +113,34 @@ inline void _relu_max_(T threshold)
     _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
+// The layout DEST is accessed through. Only the integer datapath needs a non-default one:
+// Dest holds int32 as sign+magnitude, and on Blackhole a bare vInt access to dst_reg
+// defaults to DataLayout::I32, which does *no* conversion -- so the compare below would see
+// the raw bits and a negative operand would lose against a positive one. DataLayout::SM32 is
+// the converting layout here; it emits sfpi's software smag_to_int / int_to_smag around the
+// access (Blackhole's INT32_2S_COMP load/store mode has no effect -- see the note in
+// ckernel_sfpu_sub_int.h).
+//
+// Read the two layout names carefully, they are the opposite way round to the intuition:
+// I32 is the raw one and SM32 is the converting one. On Wormhole the bare default for vInt is
+// already SM32 (sfpi_funcs.h picks it per-arch), which is why only Blackhole was wrong.
+//
+// Default for vFloat, where .mode<Default>() is a no-op and SM32 would not even be a valid
+// layout for the type.
+template <typename VecType>
+inline constexpr sfpi::DataLayout relu_dest_layout_v = std::is_same_v<VecType, sfpi::vInt> ? sfpi::DataLayout::SM32 : sfpi::DataLayout::Default;
+
 template <typename VecType, bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _relu_min_impl_(const int iterations, VecType threshold)
 {
+    constexpr sfpi::DataLayout LAYOUT = relu_dest_layout_v<VecType>;
+
     for (int d = 0; d < iterations; d++)
     {
-        VecType a = sfpi::dst_reg[0];
+        VecType a = sfpi::dst_reg[0].mode<LAYOUT>();
         v_if (a < threshold)
         {
-            sfpi::dst_reg[0] = threshold;
+            sfpi::dst_reg[0].mode<LAYOUT>() = threshold;
         }
         v_endif;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -107,20 +107,10 @@ inline void _relu_max_(T threshold)
     _relu_max_impl_<VectorType, APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, v_threshold);
 }
 
-// Contract: the threshold is an *implicit input in LREG2*, not a parameter. Every caller must
-// load it with _sfpu_load_imm32_(p_sfpu::LREG2, ...) before calling. The body is raw TTI, so
-// this dependency cannot be expressed in the signature -- keep it out of the parameter list
-// rather than carrying an argument the body never reads.
-//
-// SFPLOAD_INSTR_MOD is a template parameter rather than a function argument because it feeds
-// the "n" (immediate) operand of TTI_SFPLOAD/TTI_SFPSTORE. Passed by value it compiles only
-// for as long as the optimiser folds the constant into the asm, which makes a hard build
-// requirement out of an optimisation. Measured on this toolchain (sfpi 7.74.0, gcc 15.1.0),
-// both instantiations in one TU: as a runtime argument -O1/-O2/-O3 fold it and -O0 fails with
-// "impossible constraint in 'asm'"; as a template parameter all four levels compile.
-// ComputeConfig::opt_level is user-settable, so that is worth not relying on. Every sibling
-// integer kernel declares the mode constexpr for the same reason (see ckernel_sfpu_add_int.h,
-// ckernel_sfpu_sub_int.h, ckernel_sfpu_topk.h).
+// Contract: the threshold is an implicit input in LREG2, not a parameter -- every caller must
+// load it with _sfpu_load_imm32_ first, which the raw-TTI body cannot express in its signature.
+// SFPLOAD_INSTR_MOD has to stay a template parameter because it feeds an immediate asm operand:
+// as a runtime argument it compiles only while the optimiser folds it, and fails at -O0.
 template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore SFPLOAD_INSTR_MOD>
 inline void _relu_min_impl_(const int iterations)
 {
@@ -182,11 +172,8 @@ inline void _relu_min_(T threshold)
             if (scalar < 0)
             {
                 // Negate in unsigned: -INT_MIN is signed overflow. INT_MIN has no
-                // sign+magnitude form either -- the magnitude field is 31 bits -- so its
-                // magnitude saturates and the threshold lands on -(2^31 - 1) rather than
-                // round-tripping. The clamp is what makes that happen: masking instead
-                // would take INT_MIN's magnitude of 0x80000000 down to 0, i.e. encode
-                // sign+magnitude negative zero and clamp at 0 instead of at the low end.
+                // sign+magnitude form, so it saturates to -(2^31 - 1); the clamp is what
+                // saturates it, where a mask would encode negative zero and clamp at 0.
                 const std::uint32_t magnitude = -static_cast<std::uint32_t>(scalar);
                 sign_mag                      = 0x80000000u | (magnitude > 0x7FFFFFFFu ? 0x7FFFFFFFu : magnitude);
             }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -167,6 +167,9 @@ inline void _relu_min_(T threshold)
             // name that sounds otherwise. The threshold does not arrive through a load and so
             // passes through no mode at all, which is why it is re-encoded by hand here to
             // match, and why that is scoped to the integer branch.
+            constexpr std::uint32_t SIGN_MAG_SIGN_BIT      = 0x80000000u;
+            constexpr std::uint32_t SIGN_MAG_MAX_MAGNITUDE = 0x7FFFFFFFu;
+
             const int scalar       = static_cast<int>(threshold);
             std::uint32_t sign_mag = static_cast<std::uint32_t>(scalar);
             if (scalar < 0)
@@ -175,7 +178,7 @@ inline void _relu_min_(T threshold)
                 // sign+magnitude form, so it saturates to -(2^31 - 1); the clamp is what
                 // saturates it, where a mask would encode negative zero and clamp at 0.
                 const std::uint32_t magnitude = -static_cast<std::uint32_t>(scalar);
-                sign_mag                      = 0x80000000u | (magnitude > 0x7FFFFFFFu ? 0x7FFFFFFFu : magnitude);
+                sign_mag                      = SIGN_MAG_SIGN_BIT | (magnitude > SIGN_MAG_MAX_MAGNITUDE ? SIGN_MAG_MAX_MAGNITUDE : magnitude);
             }
             _sfpu_load_imm32_(p_sfpu::LREG2, sign_mag);
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -194,9 +194,13 @@ inline void _relu_min_(T threshold)
             if (scalar < 0)
             {
                 // Negate in unsigned: -INT_MIN is signed overflow. INT_MIN has no
-                // sign+magnitude form either (the magnitude field is 31 bits), so it
-                // necessarily saturates to -(2^31 - 1) rather than round-tripping.
-                sign_mag = 0x80000000u | (-static_cast<std::uint32_t>(scalar) & 0x7FFFFFFFu);
+                // sign+magnitude form either -- the magnitude field is 31 bits -- so its
+                // magnitude saturates and the threshold lands on -(2^31 - 1) rather than
+                // round-tripping. The clamp is what makes that happen: masking instead
+                // would take INT_MIN's magnitude of 0x80000000 down to 0, i.e. encode
+                // sign+magnitude negative zero and clamp at 0 instead of at the low end.
+                const std::uint32_t magnitude = -static_cast<std::uint32_t>(scalar);
+                sign_mag                      = 0x80000000u | (magnitude > 0x7FFFFFFFu ? 0x7FFFFFFFu : magnitude);
             }
             _sfpu_load_imm32_(p_sfpu::LREG2, sign_mag);
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -149,7 +149,8 @@ inline void _relu_min_(T threshold)
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
     // The load/store mode the branches below encode the threshold for. Only the integer
-    // datapath needs a non-default mode, and which branch runs is fixed by <T, VectorType>,
+    // datapath needs a non-default mode -- INT32, the non-converting one, for the reason
+    // spelled out in the vInt branch -- and which branch runs is fixed by <T, VectorType>,
     // so this is a compile-time constant rather than a variable the branches assign -- see
     // the note on _relu_min_impl_'s SFPLOAD_INSTR_MOD parameter.
     constexpr InstrModLoadStore SFPLOAD_INSTR_MOD =
@@ -174,18 +175,26 @@ inline void _relu_min_(T threshold)
             // that form before the compare. They get there by different routes, and the two
             // have to agree:
             //
-            //   the input      arrives through SFPLOAD, so the *instruction mode* converts
-            //                  it. InstrModLoadStore::INT32 (SFP format I32) is the mode
-            //                  that translates DEST's two's complement into sign+magnitude
-            //                  on the way in, and back again on the SFPSTORE.
-            //   the threshold  is written straight into LREG2 by _sfpu_load_imm32_, which
-            //                  bypasses any load conversion, so it is re-encoded by hand
-            //                  here to match what the input will look like.
+            //   the input      arrives through SFPLOAD from a DEST that already holds int32
+            //                  as sign+magnitude, so what is wanted is the mode that leaves
+            //                  it alone. InstrModLoadStore::INT32 (SFP format I32, mod0 4)
+            //                  is that mode -- it copies the bits, and the SFPSTORE puts the
+            //                  sign+magnitude result straight back.
+            //   the threshold  is written into LREG2 by _sfpu_load_imm32_, which is not a
+            //                  load from DEST and so passes through no mode at all. It is
+            //                  re-encoded by hand below to match the input.
             //
-            // Selecting INT32_2S_COMP (SFP format SM32) above instead is what tt-metal #55643
-            // was: that mode loads raw, so the input stayed two's complement while the
-            // threshold was sign+magnitude, and SFPSWAP compared two different encodings.
-            // It is the right mode only where DEST already holds sign+magnitude.
+            // Selecting INT32_2S_COMP (SFP format SM32, mod0 12) above instead is what
+            // tt-metal #55643 was. Read those two names carefully, because they are the
+            // opposite way round to the intuition and the inversion is what the original code
+            // walked into: INT32_2S_COMP is the *converting* mode -- it exists to hand an
+            // integer datapath the two's complement it needs, so on load it turns DEST's
+            // sign+magnitude into two's complement and on store turns it back. Under it the
+            // input reached SFPSWAP in two's complement while the threshold was
+            // sign+magnitude, and the compare saw two different encodings. So the fix is to
+            // stop converting, not to start: INT32_2S_COMP is the right mode for the integer
+            // add/sub kernels next door, which do want two's-complement LREGs, and the wrong
+            // one here where SFPSWAP wants sign+magnitude.
             //
             // Scoped to this branch because the re-encoding is only meaningful for an
             // integer threshold -- applying it to a float would reinterpret, not convert.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -115,8 +115,8 @@ template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore SFPLOAD_INS
 inline void _relu_min_impl_(const int iterations)
 {
     static_assert(
-        SFPLOAD_INSTR_MOD == InstrModLoadStore::DEFAULT || SFPLOAD_INSTR_MOD == InstrModLoadStore::INT32,
-        "SFPLOAD_INSTR_MOD must be DEFAULT (fp32 datapath) or INT32 (integer datapath)");
+        SFPLOAD_INSTR_MOD == InstrModLoadStore::DEFAULT || SFPLOAD_INSTR_MOD == InstrModLoadStore::INT32_2S_COMP,
+        "SFPLOAD_INSTR_MOD must be DEFAULT (fp32 datapath) or INT32_2S_COMP (integer datapath)");
 
     for (int d = 0; d < iterations; d++)
     {
@@ -139,12 +139,11 @@ inline void _relu_min_(T threshold)
     static_assert(std::is_same_v<VectorType, sfpi::vFloat> || std::is_same_v<VectorType, sfpi::vInt>, "VectorType must be sfpi::vFloat or sfpi::vInt");
 
     // The load/store mode the branches below encode the threshold for. Only the integer
-    // datapath needs a non-default mode -- INT32, the non-converting one, for the reason
-    // spelled out in the vInt branch -- and which branch runs is fixed by <T, VectorType>,
+    // datapath needs a non-default mode, and which branch runs is fixed by <T, VectorType>,
     // so this is a compile-time constant rather than a variable the branches assign -- see
     // the note on _relu_min_impl_'s SFPLOAD_INSTR_MOD parameter.
     constexpr InstrModLoadStore SFPLOAD_INSTR_MOD =
-        (std::is_same_v<T, std::uint32_t> && std::is_same_v<VectorType, sfpi::vInt>) ? InstrModLoadStore::INT32 : InstrModLoadStore::DEFAULT;
+        (std::is_same_v<T, std::uint32_t> && std::is_same_v<VectorType, sfpi::vInt>) ? InstrModLoadStore::INT32_2S_COMP : InstrModLoadStore::DEFAULT;
 
     // Invariant every branch below must uphold: leave the threshold in LREG2, in the encoding
     // SFPLOAD_INSTR_MOD selects. A branch that sets only a local vector compiles clean and then
@@ -161,12 +160,10 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            // SFPSWAP orders its operands as sign+magnitude and DEST already holds int32 in
-            // that form, so the load and store use InstrModLoadStore::INT32, the mode that
-            // leaves the bits alone -- INT32_2S_COMP is the converting one, despite being the
-            // name that sounds otherwise. The threshold does not arrive through a load and so
-            // passes through no mode at all, which is why it is re-encoded by hand here to
-            // match, and why that is scoped to the integer branch.
+            // SFPSWAP orders its operands as sign+magnitude, and INT32_2S_COMP is the load
+            // mode that converts a two's-complement DEST word into that form. The threshold
+            // does not arrive through a load, so it is re-encoded by hand here to match --
+            // scoped to this branch, since on a float the same bits mean something else.
             constexpr std::uint32_t SIGN_MAG_SIGN_BIT      = 0x80000000u;
             constexpr std::uint32_t SIGN_MAG_MAX_MAGNITUDE = 0x7FFFFFFFu;
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -125,8 +125,8 @@ template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore SFPLOAD_INS
 inline void _relu_min_impl_(const int iterations)
 {
     static_assert(
-        SFPLOAD_INSTR_MOD == InstrModLoadStore::DEFAULT || SFPLOAD_INSTR_MOD == InstrModLoadStore::INT32_2S_COMP,
-        "SFPLOAD_INSTR_MOD must be DEFAULT (fp32 datapath) or INT32_2S_COMP (integer datapath)");
+        SFPLOAD_INSTR_MOD == InstrModLoadStore::DEFAULT || SFPLOAD_INSTR_MOD == InstrModLoadStore::INT32,
+        "SFPLOAD_INSTR_MOD must be DEFAULT (fp32 datapath) or INT32 (integer datapath)");
 
     for (int d = 0; d < iterations; d++)
     {
@@ -153,7 +153,7 @@ inline void _relu_min_(T threshold)
     // so this is a compile-time constant rather than a variable the branches assign -- see
     // the note on _relu_min_impl_'s SFPLOAD_INSTR_MOD parameter.
     constexpr InstrModLoadStore SFPLOAD_INSTR_MOD =
-        (std::is_same_v<T, std::uint32_t> && std::is_same_v<VectorType, sfpi::vInt>) ? InstrModLoadStore::INT32_2S_COMP : InstrModLoadStore::DEFAULT;
+        (std::is_same_v<T, std::uint32_t> && std::is_same_v<VectorType, sfpi::vInt>) ? InstrModLoadStore::INT32 : InstrModLoadStore::DEFAULT;
 
     // Invariant every branch below must uphold: leave the threshold in LREG2, in the encoding
     // SFPLOAD_INSTR_MOD selects. A branch that sets only a local vector compiles clean and then
@@ -170,18 +170,35 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            // SFPSWAP orders operands as sign+magnitude, so a 2's complement integer
-            // threshold has to be re-encoded before it is loaded. Scoped to this branch
-            // because it is only meaningful for an integer threshold -- applying it to a
-            // float would reinterpret the value, not convert it.
-            int scalar = static_cast<int>(threshold);
+            // SFPSWAP orders its operands as sign+magnitude, so both of them have to be in
+            // that form before the compare. They get there by different routes, and the two
+            // have to agree:
+            //
+            //   the input      arrives through SFPLOAD, so the *instruction mode* converts
+            //                  it. InstrModLoadStore::INT32 (SFP format I32) is the mode
+            //                  that translates DEST's two's complement into sign+magnitude
+            //                  on the way in, and back again on the SFPSTORE.
+            //   the threshold  is written straight into LREG2 by _sfpu_load_imm32_, which
+            //                  bypasses any load conversion, so it is re-encoded by hand
+            //                  here to match what the input will look like.
+            //
+            // Selecting INT32_2S_COMP (SFP format SM32) above instead is what tt-metal #55643
+            // was: that mode loads raw, so the input stayed two's complement while the
+            // threshold was sign+magnitude, and SFPSWAP compared two different encodings.
+            // It is the right mode only where DEST already holds sign+magnitude.
+            //
+            // Scoped to this branch because the re-encoding is only meaningful for an
+            // integer threshold -- applying it to a float would reinterpret, not convert.
+            const int scalar       = static_cast<int>(threshold);
+            std::uint32_t sign_mag = static_cast<std::uint32_t>(scalar);
             if (scalar < 0)
             {
-                scalar  = -scalar;
-                int res = 0x80000000 | (scalar & 0x7FFFFFFF);
-                scalar  = res;
+                // Negate in unsigned: -INT_MIN is signed overflow. INT_MIN has no
+                // sign+magnitude form either (the magnitude field is 31 bits), so it
+                // necessarily saturates to -(2^31 - 1) rather than round-tripping.
+                sign_mag = 0x80000000u | (-static_cast<std::uint32_t>(scalar) & 0x7FFFFFFFu);
             }
-            _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
+            _sfpu_load_imm32_(p_sfpu::LREG2, sign_mag);
         }
         else
         {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -171,33 +171,12 @@ inline void _relu_min_(T threshold)
     {
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            // SFPSWAP orders its operands as sign+magnitude, so both of them have to be in
-            // that form before the compare. They get there by different routes, and the two
-            // have to agree:
-            //
-            //   the input      arrives through SFPLOAD from a DEST that already holds int32
-            //                  as sign+magnitude, so what is wanted is the mode that leaves
-            //                  it alone. InstrModLoadStore::INT32 (SFP format I32, mod0 4)
-            //                  is that mode -- it copies the bits, and the SFPSTORE puts the
-            //                  sign+magnitude result straight back.
-            //   the threshold  is written into LREG2 by _sfpu_load_imm32_, which is not a
-            //                  load from DEST and so passes through no mode at all. It is
-            //                  re-encoded by hand below to match the input.
-            //
-            // Selecting INT32_2S_COMP (SFP format SM32, mod0 12) above instead is what
-            // tt-metal #55643 was. Read those two names carefully, because they are the
-            // opposite way round to the intuition and the inversion is what the original code
-            // walked into: INT32_2S_COMP is the *converting* mode -- it exists to hand an
-            // integer datapath the two's complement it needs, so on load it turns DEST's
-            // sign+magnitude into two's complement and on store turns it back. Under it the
-            // input reached SFPSWAP in two's complement while the threshold was
-            // sign+magnitude, and the compare saw two different encodings. So the fix is to
-            // stop converting, not to start: INT32_2S_COMP is the right mode for the integer
-            // add/sub kernels next door, which do want two's-complement LREGs, and the wrong
-            // one here where SFPSWAP wants sign+magnitude.
-            //
-            // Scoped to this branch because the re-encoding is only meaningful for an
-            // integer threshold -- applying it to a float would reinterpret, not convert.
+            // SFPSWAP orders its operands as sign+magnitude and DEST already holds int32 in
+            // that form, so the load and store use InstrModLoadStore::INT32, the mode that
+            // leaves the bits alone -- INT32_2S_COMP is the converting one, despite being the
+            // name that sounds otherwise. The threshold does not arrive through a load and so
+            // passes through no mode at all, which is why it is re-encoded by hand here to
+            // match, and why that is scoped to the integer branch.
             const int scalar       = static_cast<int>(threshold);
             std::uint32_t sign_mag = static_cast<std::uint32_t>(scalar);
             if (scalar < 0)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sub_int.h
@@ -36,7 +36,7 @@ inline void _sub_int_(const std::uint32_t dst_index_in0, const std::uint32_t dst
     // out = in0 - in1. sfpi's `a - b` lowers to the same SFPIADD that 2's-complements the subtrahend,
     // matching the original TTI_SFPIADD(..., imod 6). The load/store DataLayout is chosen so its SFP
     // load/store format byte equals the original InstrModLoadStore value:
-    //   INT32 (4) -> I32 (sign-mag<->2's-comp conversion), LO16 (6) -> U16, INT32_2S_COMP (12) -> SM32 (raw).
+    //   INT32 (4) -> I32 (raw), LO16 (6) -> U16, INT32_2S_COMP (12) -> SM32 (sign-mag<->2's-comp conversion).
     constexpr sfpi::DataLayout layout = (sfpload_instr_mod == InstrModLoadStore::LO16)             ? sfpi::DataLayout::U16
                                         : (sfpload_instr_mod == InstrModLoadStore::INT32_2S_COMP)  ? sfpi::DataLayout::SM32
                                                                                                   : sfpi::DataLayout::I32;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/55643

`relu_min` on Int32 gives a wrong answer on Blackhole whenever the input and the threshold are 2^31 or more apart. The SFPU's signed compare subtracts and tests the sign, so it inverts on overflow: `relu_min(2147483647, -1)` returned `-1`, and at threshold `-(2^31 - 2)` inputs near `INT32_MAX` were clamped down to the threshold instead of passing through.

**Blackhole.** Split the compare on the sign of the threshold, so it only ever sees same-sign operands, whose difference cannot overflow. That is the same shape metal's `relu_clamp_int` already uses, for the same reason. A zero threshold takes a sign-test-only path: that is what `relu_tile_int32` -- the one shipping `vInt` caller -- hits, and it saves a SETCC plus a predicated move per element against the general non-negative form, whose second region is provably dead there. The integer path also names `DataLayout::I32` rather than leaning on sfpi's `vInt` default, which is per-arch (`I32` here, the converting `SM32` on Wormhole).

**Wormhole.** The body is raw-TTI `SFPSWAP`, which orders its operands as sign+magnitude, and `InstrModLoadStore::INT32_2S_COMP` is the load mode that converts a two's-complement DEST word into that form. Both are unchanged. What changed is the threshold encoding, which the kernel builds by hand because the threshold does not arrive through a load: the negation is now done in unsigned (`-INT_MIN` was signed overflow) and `INT_MIN` saturates to `-(2^31 - 1)` instead of encoding negative zero and clamping at 0. The two sign+magnitude constants are named so the saturation bound and the value it saturates to cannot drift apart.

### Int32 in DEST is a caller convention, not a hardware format
Worth stating plainly, because an earlier revision of this PR had it backwards and "fixed" both arches against the wrong convention. There is no hardware answer to what encoding DEST holds for Int32 -- it holds whatever the caller put there:

- **ttnn writes two's complement.** Nothing on the host re-encodes an int32 tensor. `use_int32_twos_complement` in `tests/python_tests/test_sfpu_reduce.py` states this, and the reduce and binary int32 suites opt into it.
- **tt-llk's python_tests pack sign+magnitude by default** (`helpers/pack.py:pack_int32`), unless a suite passes `twos_complement=True`.

So a sweep left on the harness default will pass a kernel that reads DEST in *either* encoding, which is exactly how the inverted revision stayed green. This sweep now drives two's-complement stimuli, matching ttnn.

Measured on bh_p150b: with two's-complement stimuli the raw layout passes 8/8 and the converting one fails all four negative thresholds (`-5` returning `0x80000005`); flip the stimuli encoding and the results flip with it. `relu_clamp_int`'s `DataLayout::I32` is correct as written.

### Tests
`test_eltwise_unary_sfpu_relu_min_int_threshold` sweeps both signs of threshold over `[-(2^31 - 2) .. 2^31 - 1]`, with stimuli straddling each threshold, a decade either side, and both ends of int32, against an exact integer golden. Offsets that leave the stimuli range are dropped rather than silently folded onto its ends, which is what the two extreme thresholds would otherwise turn most of them into.

Blackhole (bh_p150b), kernel cache wiped so everything JIT-compiles from the branch:

- the sweep: **8/8**. Negative controls, so the sweep is not passing vacuously: `main`'s plain compare fails 7/8, and flipping the layout constant to `SM32` fails 4/8.
- tt-llk `-k relu`: 329 passed, 64 skipped
- ttnn eltwise `-k relu`: 294 passed, 32 skipped; `unit_tests_ttnn *Relu*`: 7 passed
- `unit_tests_llk *elu*` (incl. 32-bit dest and approx fixtures): 20 passed; `unit_tests_integration` SFPU relu at 1/4/20 tiles: 5 passed
- ttnn `relu` / `relu_min` / `relu_max` on Int32 over the full range including `INT32_MIN`: pass

**No production behaviour change.** The only shipping `vInt` instantiation is `relu_tile_int32`, which passes threshold `0`, and that is correct under either encoding: the sign bit is in the same place and non-negative values are identical in both, so negatives clamp to 0 and non-negatives pass through either way. Verified directly with `ttnn.relu` on int32 across the full range. `relu_min_tile_int32`, the entry point that can carry a negative threshold, routes to `relu_clamp_int` and is untouched.

### Notes for reviewers
**Wormhole needs a silicon re-run before merge.** The n150 numbers quoted in this description's earlier revision (8/8 thresholds, 561 Relu-family cases) were measured against sign+magnitude stimuli and the `INT32` load mode, both of which have since been reverted; there is no Wormhole part on this bench to re-run them, and the LREG2 regression test is Wormhole-only so it skips on Blackhole. The Blackhole XPASS cited from PR gate run 34261984343 is from that same earlier revision.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/relu_min_int_negative_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/relu_min_int_negative_threshold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/relu_min_int_negative_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/relu_min_int_negative_threshold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/relu_min_int_negative_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/relu_min_int_negative_threshold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/relu_min_int_negative_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/relu_min_int_negative_threshold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/relu_min_int_negative_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/relu_min_int_negative_threshold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/relu_min_int_negative_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/relu_min_int_negative_threshold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/relu_min_int_negative_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/relu_min_int_negative_threshold)

