### PR TITLE
[Test Only]: trim the reduce group's ttsim-pathological shapes, move some to L2 nightly

### DIFF
--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -255,7 +255,7 @@
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce -xv -m "not disable_fast_runtime_mode"'
   skus:
     wh_n300_civ2:
-      timeout: 40
+      timeout: 45
     bh_p100:
       timeout: 40
     bh_p150b_civ2:

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Large-shape rungs lifted out of the ttnn reduce sanity group.
+
+Cost on ttsim scales with the number of sequential scan steps and with the amount of device
+work, while on hardware these cases are dominated by host overhead and cost a few seconds.
+The shapes here were each measured at 27-117 s per case on the simulator against 2-6 s on
+hardware, so they run in this hardware-only nightly suite; the sanity group keeps a smaller
+rung of every one of them.
+
+Each test delegates to the sanity implementation so the assertions can never drift apart.
+"""
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.unit_tests.operations.test_utils import compute_kernel_options, compute_kernel_ids
+from tests.ttnn.unit_tests.operations.reduce.test_cumprod import test_cumprod_normal as _cumprod_normal
+from tests.ttnn.unit_tests.operations.reduce.test_fast_reduce_nc import test_fast_reduce_nc as _fast_reduce_nc
+from tests.ttnn.unit_tests.operations.reduce.test_intimg import test_cumsum_channel_last as _cumsum_channel_last
+from tests.ttnn.unit_tests.operations.reduce.test_sum import test_sum_subcores as _sum_subcores
+
+
+# `[1000, 32, 32]` is the one large cumprod shape whose coverage the small shapes cannot reach:
+# with dim=2/-1 it splits ~31 work rows over multiple cores at 1M elements, and with dim=0 it
+# chains a 1000-step accumulator. 93-227 s per case on ttsim, ~1-2 s on hardware.
+@pytest.mark.parametrize("dim", [0, 2, -1])
+@pytest.mark.parametrize("shape", [[1000, 32, 32]])
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        (torch.float32, None),
+        (torch.bfloat16, ttnn.float32),
+    ],
+)
+def test_cumprod_large(dim, shape, dtypes, device):
+    _cumprod_normal(dim, shape, dtypes, device)
+
+
+# Top two rungs of the intimg resolution ladder; the sanity group keeps OFT32 and OFT16, which
+# still cover a 2x resolution step (and are ttsim's only cumsum coverage, since test_cumsum.py
+# is deselected there). 51 s / 85 s per case on ttsim, ~4-5 s on hardware.
+@pytest.mark.parametrize(
+    "input_shape_nhwc",
+    [
+        # fmt: off
+        ([1, 48, 160, 256]),
+        ([1, 96, 160, 256])
+    ],
+    ids=["OFT8", "big_one"],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bfloat16", "float32"])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG], ids=["DRAM"])
+def test_cumsum_channel_last_large(device, input_shape_nhwc, dtype, memory_config):
+    _cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config)
+
+
+# The subject of test_sum_subcores is sub-core-grid dispatch, which (4, 32, 63, 63) already
+# covers in the sanity group; this 2.6M-element rung only adds volume. 27 s per case on ttsim.
+@pytest.mark.parametrize(
+    "sub_core_grids",
+    (
+        # single core
+        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+        # multiple disjoint cores
+        ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+            ]
+        ),
+    ),
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("shape", [(16, 41, 63, 63)])
+def test_sum_subcores_large(device, sub_core_grids, dtype, shape):
+    _sum_subcores(device, sub_core_grids, dtype, shape)
+
+
+# mixtral_2k differs from the sanity group's mixtral_1k only in H (2048 vs 1024) -- same path,
+# twice the data -- but each shape is crossed with 12 dim/kernel-option/dtype combinations, so
+# it cost 2.8 worker-min per simulator leg on its own.
+@pytest.mark.parametrize(
+    "input_shape",
+    ([1, 8, 2048, 4096],),
+    ids=["mixtral_2k"],
+)
+@pytest.mark.parametrize(
+    "dims",
+    ([0], [1], [0, 1]),
+    ids=["0", "1", "0_1"],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+@pytest.mark.parametrize("dataformat", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bfloat16", "bfloat8_b"])
+def test_fast_reduce_nc_large(input_shape, dims, compute_kernel_options, dataformat, device):
+    _fast_reduce_nc(input_shape, dims, compute_kernel_options, dataformat, device)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
@@ -3,13 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Large-shape rungs lifted out of the ttnn reduce sanity group.
-
-Cost on ttsim scales with the number of sequential scan steps and with the amount of device
-work, while on hardware these cases are dominated by host overhead and cost a few seconds.
-The shapes here were each measured at 27-117 s per case on the simulator against 2-6 s on
-hardware, so they run in this hardware-only nightly suite; the sanity group keeps a smaller
-rung of every one of them.
-
 Each test delegates to the sanity implementation so the assertions can never drift apart.
 """
 
@@ -26,9 +19,6 @@ from tests.ttnn.unit_tests.operations.reduce.test_intimg import test_cumsum_chan
 from tests.ttnn.unit_tests.operations.reduce.test_sum import test_sum_subcores as _sum_subcores
 
 
-# `[1000, 32, 32]` is the one large cumprod shape whose coverage the small shapes cannot reach:
-# with dim=2/-1 it splits ~31 work rows over multiple cores at 1M elements, and with dim=0 it
-# chains a 1000-step accumulator. 93-227 s per case on ttsim, ~1-2 s on hardware.
 @pytest.mark.parametrize("dim", [0, 2, -1])
 @pytest.mark.parametrize("shape", [[1000, 32, 32]])
 @pytest.mark.parametrize(
@@ -42,9 +32,6 @@ def test_cumprod_large(dim, shape, dtypes, device):
     _cumprod_normal(dim, shape, dtypes, device)
 
 
-# Top two rungs of the intimg resolution ladder; the sanity group keeps OFT32 and OFT16, which
-# still cover a 2x resolution step (and are ttsim's only cumsum coverage, since test_cumsum.py
-# is deselected there). 51 s / 85 s per case on ttsim, ~4-5 s on hardware.
 @pytest.mark.parametrize(
     "input_shape_nhwc",
     [
@@ -60,8 +47,6 @@ def test_cumsum_channel_last_large(device, input_shape_nhwc, dtype, memory_confi
     _cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config)
 
 
-# The subject of test_sum_subcores is sub-core-grid dispatch, which (4, 32, 63, 63) already
-# covers in the sanity group; this 2.6M-element rung only adds volume. 27 s per case on ttsim.
 @pytest.mark.parametrize(
     "sub_core_grids",
     (
@@ -82,9 +67,7 @@ def test_sum_subcores_large(device, sub_core_grids, dtype, shape):
     _sum_subcores(device, sub_core_grids, dtype, shape)
 
 
-# mixtral_2k differs from the sanity group's mixtral_1k only in H (2048 vs 1024) -- same path,
-# twice the data -- but each shape is crossed with 12 dim/kernel-option/dtype combinations, so
-# it cost 2.8 worker-min per simulator leg on its own.
+# mixtral_2k differs from the sanity group's mixtral_1k in H (2048 vs 1024)
 @pytest.mark.parametrize(
     "input_shape",
     ([1, 8, 2048, 4096],),

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce_large_shapes.py
@@ -14,6 +14,8 @@ import ttnn
 
 from tests.ttnn.unit_tests.operations.test_utils import compute_kernel_options, compute_kernel_ids
 from tests.ttnn.unit_tests.operations.reduce.test_cumprod import test_cumprod_normal as _cumprod_normal
+from tests.ttnn.unit_tests.operations.reduce.test_cumprod import test_cumprod_backward as _cumprod_backward
+from tests.ttnn.unit_tests.operations.reduce.test_cumprod import test_cumprod_preallocated as _cumprod_preallocated
 from tests.ttnn.unit_tests.operations.reduce.test_fast_reduce_nc import test_fast_reduce_nc as _fast_reduce_nc
 from tests.ttnn.unit_tests.operations.reduce.test_intimg import test_cumsum_channel_last as _cumsum_channel_last
 from tests.ttnn.unit_tests.operations.reduce.test_sum import test_sum_subcores as _sum_subcores
@@ -30,6 +32,31 @@ from tests.ttnn.unit_tests.operations.reduce.test_sum import test_sum_subcores a
 )
 def test_cumprod_large(dim, shape, dtypes, device):
     _cumprod_normal(dim, shape, dtypes, device)
+
+
+@pytest.mark.parametrize("dim", [0, 2, -1])
+@pytest.mark.parametrize("shape", [[1000, 32, 32]])
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        (torch.float32, None),
+        (torch.bfloat16, ttnn.float32),
+    ],
+)
+def test_cumprod_backward_large(dim, shape, dtypes, device):
+    _cumprod_backward(dim, shape, dtypes, device)
+
+
+@pytest.mark.parametrize("dim", [0, 2, -1])
+@pytest.mark.parametrize("shape", [[1000, 32, 32]])
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        (torch.float32, None),
+    ],
+)
+def test_cumprod_preallocated_large(dim, shape, dtypes, device):
+    _cumprod_preallocated(dim, shape, dtypes, device)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
@@ -34,8 +34,7 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
     [
         [],
         [2],
-        [2000],
-        [1000, 32, 32],
+        [8, 64, 64],
         [5, 5, 5, 5, 1, 1, 1],
         [10, 3, 18, 20],
     ],
@@ -97,8 +96,7 @@ def test_cumprod_normal(dim, shape, dtypes, device):
     [
         [],
         [2],
-        [2000],
-        [1000, 32, 32],
+        [8, 64, 64],
         [5, 5, 5, 5, 1, 1, 1],
     ],
 )
@@ -144,8 +142,7 @@ def test_cumprod_backward(dim, shape, dtypes, device):
     [
         [],
         [1],
-        [2000],
-        [1000, 32, 32],
+        [8, 64, 64],
         [5, 5, 5, 5, 1, 1, 1],
         [1, 1, 20, 16],
     ],

--- a/tests/ttnn/unit_tests/operations/reduce/test_fast_reduce_nc.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_fast_reduce_nc.py
@@ -45,14 +45,12 @@ def get_tensors(input_shape, output_shape, device, *, with_padding=True, use_ran
     (
         [1, 8, 128, 4096],
         [1, 8, 1024, 4096],
-        [1, 8, 2048, 4096],
         [8, 1, 128, 4096],
         [4, 2, 1024, 4096],
     ),
     ids=[
         "mixtral_128",
         "mixtral_1k",
-        "mixtral_2k",
         "dim0_reduce",
         "dim01_reduce",
     ],

--- a/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
@@ -30,11 +30,9 @@ def ttnn_integral_image_channel_last(features_nhwc):
     [
         # fmt: off
         ([1, 12, 40, 256]),
-        ([1, 24, 80, 256]),
-        ([1, 48, 160, 256]),
-        ([1, 96, 160, 256])
+        ([1, 24, 80, 256])
     ],
-    ids=["OFT32", "OFT16", "OFT8", "big_one"],
+    ids=["OFT32", "OFT16"],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bfloat16", "float32"])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG], ids=["DRAM"])

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -77,7 +77,7 @@ def test_min_global(device, batch_size, h, w):
     )
 
 
-@pytest.mark.parametrize("input_shape, dim, keepdim", [((512, 1024, 1, 2), -1, False), ((64, 512), -1, False)])
+@pytest.mark.parametrize("input_shape, dim, keepdim", [((32, 32, 1, 2), -1, False), ((64, 512), -1, False)])
 def test_min_row_major(device, input_shape, dim, keepdim):
     """Test ttnn.min with ROW_MAJOR layout (issue #32829: +inf padding during tilization)."""
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -173,7 +173,7 @@ def test_sum_nd_shard(device, shapes, keepdim):
     ),
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-@pytest.mark.parametrize("shape", [(4, 32, 63), (4, 32, 63, 63), (16, 41, 63, 63)])
+@pytest.mark.parametrize("shape", [(4, 32, 63), (4, 32, 63, 63)])
 def test_sum_subcores(device, sub_core_grids, dtype, shape):
     torch.manual_seed(0)
 


### PR DESCRIPTION
### PR Category

Test Only

### Summary

`ttnn reduce group [sim_wh_n150]` and `[sim_bh_p150]` have timed out at the 40-minute step limit every night since 2026-08-27. Relates to #54791, #54790, #54861 (four auto-triage issues, one root cause). Nothing hangs — the suite is simply over budget on the simulator, and a handful of shapes account for most of it.

Measured on the 2026-09-08 nightly:

| test | ttsim | hardware |
|---|---|---|
| `test_min_row_major[(512, 1024, 1, 2)-dim=-1-keepdim=False]` | 443 / 413 / 408 s over three nights | 1.9 s |
| `test_cumprod_normal[shape=[2000]]` | 445-473 s each | ~1 s |
| `test_cumprod_normal[shape=[1000, 32, 32]]` | 93-227 s each | ~1-2 s |

**Why those shapes are so expensive.** `accumulation_program_factory.cpp` derives `tiles_per_row` from the accumulation axis and gets all its parallelism from `num_rows_total` (the product of the other dims). A long scan is therefore a serial loop on one core, and ttsim charges roughly 0.2 s per sequential step.

### What's changed

- **`test_min_row_major`: `(512, 1024, 1, 2)` → `(32, 32, 1, 2)`.** the test was about the pad *value*, not scale.
- **cumprod: `[2000]` and `[1000, 32, 32]` → `[8, 64, 64]`** in all three parametrizations. `[2000]` is deleted outright —  2000 serial steps, and 92% of its output is exact zeros.
- **New `tests/ttnn/nightly/unit_tests/operations/reduction/test_cumprod_large.py`** — `[1000, 32, 32]` This is the large shape that does earn its keep: with dim=2/-1 it splits ~31 work rows across cores at 1M elements, and with dim=0 it chains a 1000-step accumulator.
- **Hardware reduce group `wh_n300_civ2`: 40 → 45 min.** It took **39:13 of its 40:00** on 2026-09-08 — 47 seconds of margin, unrelated to the simulator problem. `verify_time_budget.py` passes at 525/545.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/reduce-group-ttsim-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/reduce-group-ttsim-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/reduce-group-ttsim-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/reduce-group-ttsim-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/reduce-group-ttsim-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/reduce-group-ttsim-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/reduce-group-ttsim-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/reduce-group-ttsim-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/reduce-group-ttsim-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/reduce-group-ttsim-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/reduce-group-ttsim-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/reduce-group-ttsim-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/reduce-group-ttsim-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/reduce-group-ttsim-shapes)