### PR TITLE
Performance: cap xdist's chunk size on the ttnn sim legs (--maxschedchunk=16)

### DIFF
--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -394,7 +394,8 @@ jobs:
             export OMP_NUM_THREADS=2
             export MKL_NUM_THREADS=2
             export OMP_WAIT_POLICY=passive
-            export PYTEST_ADDOPTS="-p no:timeout -n 4 ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
+            # Cap xdist chunks: unbounded load hands out huge chunks, so finished workers idle while another lags.
+            export PYTEST_ADDOPTS="-p no:timeout -n 4 --maxschedchunk=16 ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
             # Strip the per-test `pytest --timeout N` from the cmd: the simulator is ~10-50x slower than
             # HW, so that per-op limit kills slow-but-correct ops (the job timeout-minutes is the backstop;
             # PYTEST_ADDOPTS also sets -p no:timeout). Run that cmd with xdist; if a worker crashes (xdist


### PR DESCRIPTION
### PR Category

Performance

### Summary

Relates to #54791, #54790, #54861. `ttnn reduce group [sim_wh_n150]` times out at its 40-minute step limit every night, and not because it has 40 minutes of work: on the 2026-09-08 run the four xdist workers were *busy* for a combined 110 worker-min — about 28 minutes if spread evenly — yet the step was killed at 39.7 min with 98 tests never started. The rest of the capacity went to workers sitting idle.

Measured from that job's log:

| worker | tests completed | idle before the kill |
|---|---|---|
| gw0 | 821 (and ~102 still queued) | 0 s |
| gw1 | 235 | **1763 s** |
| gw2 | 603 | 400 s |
| gw3 | 457 | 376 s |

### What's changed

`--maxschedchunk=16` on the ttnn sim legs. In consequence, any worker's queue can never run more than one chunk ahead of the others, reducing the skew among the workers.

### Notes for reviewers

- **Scope is wider than the reduce group.**  this changes scheduling for **every `sim_*` leg of every group in `ttnn_sanity_tests.yaml`**
- That breadth is arguably the point: **`ttnn fused group 1 [sim_wh_n150]` is at 58 of its 60 minutes** under the identical scheduler, so it is next in line to file this same auto-triage issue.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ttnn-sim-worksteal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ttnn-sim-worksteal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ttnn-sim-worksteal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ttnn-sim-worksteal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ttnn-sim-worksteal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ttnn-sim-worksteal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ttnn-sim-worksteal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ttnn-sim-worksteal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ttnn-sim-worksteal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ttnn-sim-worksteal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ttnn-sim-worksteal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ttnn-sim-worksteal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ttnn-sim-worksteal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ttnn-sim-worksteal)