### PR TITLE
[Bug fix] Fix LLK perf-report test isolation on CI reruns

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -426,6 +426,7 @@ def test_combine_perf_reports_emits_parquet_alongside_csv(tmp_path, monkeypatch)
     monkeypatch.setenv("CHIP_ARCH", "wormhole")
     monkeypatch.setenv("GITHUB_SHA", "testsha")
     monkeypatch.setenv("GITHUB_RUN_ID", "testrun")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "1")
     monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)  # -> pipeline "nightly"
 
     # one raw per-worker CSV (the .gw* pattern combine globs for)


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fix a hardware-free LLK perf-report test that fails on GitHub Actions reruns.

The test expects an attempt-1 run_id but inherits GITHUB_RUN_ATTEMPT from CI. Explicitly set it to "1" alongside the other mocked environment variables. Production reporting behaviour is unchanged.

Closes https://github.com/tenstorrent/tt-metal/issues/55703

### Notes for reviewers
