### PR TITLE
sparse_mla: declare the sparse test modules explicitly chunked

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -293,6 +293,7 @@ def run_sparse_mla_accuracy_case(
     )
 
     logger.info(f"[{variant.name}] sparse MLA accuracy: running TT inference")
+    # Sparse has no single-shot path: one chunk, spanning the whole sequence, at offset 0.
     tt_output, hidden_states, _, shard_dims = run_mla_inference(
         config=config,
         weights=weights,
@@ -304,12 +305,15 @@ def run_sparse_mla_accuracy_case(
         is_balanced=False,
         topology=topology,
         tt_kvpe_cache=tt_kvpe_cache,
+        is_chunked=True,
+        active_seq_len=seq_len,
+        actual_start=0,
     )
 
     cache_dir = cpu_ref_cache_dir(variant)
     logger.info(f"[{variant.name}] sparse MLA accuracy: running CPU reference")
-    # accuracy runs the indexer's natural single-shot path (no block-cyclic index_kv_cache to read
-    # back), so the index-cache reference is unused here — chunked/rotated cover the block-cyclic cache.
+    # ref_index (the indexer key-cache truth) is dropped: one full-sequence chunk fills a single
+    # block-cyclic slab, so chunked/rotated are where that cache is asserted (SPARSE_INDEX_PCC).
     ref_output, ref_kvpe, _ = run_cpu_reference(
         config, weights, hidden_states, seq_len, cache_dir, cache_tag=f"{src_tag}_funcidx"
     )
@@ -364,6 +368,7 @@ def run_sparse_mla_determinism_case(
             sp_axis=sp_axis,
             num_kvpe_cache_layers=1,
         )
+        # Sparse has no single-shot path: one chunk, spanning the whole sequence, at offset 0.
         tt_output, _, _, shard_dims = run_mla_inference(
             config=config,
             weights=dict(weights),
@@ -375,6 +380,9 @@ def run_sparse_mla_determinism_case(
             is_balanced=False,
             topology=topology,
             tt_kvpe_cache=tt_kvpe_cache,
+            is_chunked=True,
+            active_seq_len=seq_len,
+            actual_start=0,
         )
         logger.debug(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}: collecting TT output")
         current = ttnn.to_torch(
@@ -614,7 +622,7 @@ def run_sparse_mla_pad_overflow_case(
     # NOT global position actual_start + j -- feeding natural order only happens to work when every start
     # is slab-aligned (what test_sparse_mla_chunked does). Every start here is drifted, so gather the
     # chunk in rotated chip-major order and scatter the output back by the same map, exactly as
-    # test_sparse_mla_rotated does.
+    # test_sparse_mla_rotated_chunked does.
     sp = mesh_device.shape[0]
     chunk_local = chunk // sp
     hid = hidden[0]  # [seq, hidden]
@@ -933,7 +941,7 @@ def run_sparse_mla_rotated_case(
 @pytest.mark.parametrize("tp_shard_kv", [False, True], ids=["sp_only", "tp_sharded"])
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
-def test_sparse_mla_rotated(
+def test_sparse_mla_rotated_chunked(
     mesh_device, seq_len, iters_isl, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo, tp_shard_kv
 ):
     run_sparse_mla_rotated_case(
@@ -949,35 +957,8 @@ def test_sparse_mla_rotated(
     )
 
 
-# None of these tests cover the chunked+non_balanced case, which is the only path production
-# runs — so they are all CI-skipped (still runnable locally).
-def _ci_unsupported_param_combos_sparse_mla_accuracy(**params):
-    on_ci = params["is_ci_env"] or params["is_ci_v2_env"]
-
-    if not on_ci:
-        return False
-    return True
-
-
-def _ci_unsupported_param_combos_sparse_mla_indexer_reuse(**params):
-    on_ci = params["is_ci_env"] or params["is_ci_v2_env"]
-
-    if not on_ci:
-        return False
-    return True
-
-
-def _ci_unsupported_param_combos_sparse_mla_determinism(**params):
-    on_ci = params["is_ci_env"] or params["is_ci_v2_env"]
-
-    if not on_ci:
-        return False
-    return True
-
-
 # One combined parametrization instead of independent variant/mesh/sequence/format axes. BF16 retains
 # both sparsity regimes; scaled FP8 is restricted to the real-pruning sequence to avoid redundant CI work.
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_sparse_mla_accuracy)
 @pytest.mark.parametrize(
     "variant, mesh_device, seq_len, device_params, cache_format",
     SPARSE_ACCURACY_CASES,
@@ -985,7 +966,7 @@ def _ci_unsupported_param_combos_sparse_mla_determinism(**params):
 )
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
-def test_sparse_mla_accuracy(
+def test_sparse_mla_accuracy_chunked(
     mesh_device,
     seq_len,
     device_params,
@@ -1022,7 +1003,6 @@ def test_sparse_mla_accuracy(
 SPARSE_REUSE_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_2" in c.id]
 
 
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_sparse_mla_indexer_reuse)
 @pytest.mark.parametrize(
     "variant, mesh_device, seq_len, device_params",
     SPARSE_REUSE_CASES,
@@ -1030,7 +1010,7 @@ SPARSE_REUSE_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_2" in c.id]
 )
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
-def test_sparse_mla_indexer_reuse(
+def test_sparse_mla_indexer_reuse_chunked(
     mesh_device, seq_len, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
 ):
     """GLM-5.2 indexer reuse: a layer fed a prior layer's top-k indices (indexer_indices=...) must
@@ -1054,6 +1034,7 @@ def test_sparse_mla_indexer_reuse(
             num_kvpe_cache_layers=1,
         )
 
+    # Sparse has no single-shot path: one chunk, spanning the whole sequence, at offset 0.
     common = dict(
         config=config,
         weights=weights,
@@ -1064,6 +1045,9 @@ def test_sparse_mla_indexer_reuse(
         tp_axis=tp_axis,
         is_balanced=False,
         topology=topology,
+        is_chunked=True,
+        active_seq_len=seq_len,
+        actual_start=0,
     )
     # A: compute the indexer, capture its top-k selection + output.
     out_a, _, _, shard_dims, idx = run_mla_inference(tt_kvpe_cache=_kvpe(), return_indices=True, **common)
@@ -1081,7 +1065,6 @@ def test_sparse_mla_indexer_reuse(
 
 
 # Anchor cases (per-variant prod-closest mesh, seq=4096); collected == run.
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_sparse_mla_determinism)
 @pytest.mark.parametrize(
     "variant, mesh_device, seq_len, device_params",
     SPARSE_ANCHOR_CASES,
@@ -1090,7 +1073,7 @@ def test_sparse_mla_indexer_reuse(
 @pytest.mark.parametrize("n_runs", [3], ids=["x3"])
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
-def test_sparse_mla_determinism(
+def test_sparse_mla_determinism_chunked(
     mesh_device, seq_len, n_runs, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
 ):
     topology = per_axis_topology(device_params["fabric_config"])
@@ -1150,7 +1133,7 @@ SPARSE_PAD_OVERFLOW_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_2" in c.id
 )
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
-def test_sparse_mla_pad_overflow(
+def test_sparse_mla_pad_overflow_chunked(
     mesh_device,
     seq_len,
     chunk,
@@ -1180,7 +1163,7 @@ SPARSE_KV_ONLY_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_1" in c.id]
 @pytest.mark.parametrize("chunk", [1024], ids=["c1k"])
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
-def test_sparse_mla_kv_only(
+def test_sparse_mla_kv_only_chunked(
     mesh_device, seq_len, chunk, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
 ):
     run_sparse_mla_kv_only_case(variant, config_only, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo)

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -202,7 +202,7 @@ def cleanup_cache():
 
 
 def _forward(mla, mesh_device, rope_tensors, kvpe_cache, index_kv_cache, hidden):
-    """Single-shot sparse MLA forward, mirroring run_mla_inference's SP×TP input sharding."""
+    """One full-sequence chunk at offset 0, mirroring run_mla_inference's SP×TP input sharding."""
     shard_dims = [None, None]
     shard_dims[TP_AXIS], shard_dims[SP_AXIS] = -1, -2
     tt_hidden = ttnn.from_torch(
@@ -214,7 +214,11 @@ def _forward(mla, mesh_device, rope_tensors, kvpe_cache, index_kv_cache, hidden)
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
     out = mla.forward(
-        hidden_states=tt_hidden, rope_tensors=rope_tensors, kvpe_cache=kvpe_cache, index_kv_cache=index_kv_cache
+        hidden_states=tt_hidden,
+        rope_tensors=rope_tensors,
+        kvpe_cache=kvpe_cache,
+        actual_start=0,  # the modules here are built chunked; one chunk spans the whole sequence
+        index_kv_cache=index_kv_cache,
     )
     return ttnn.to_torch(
         out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
@@ -236,7 +240,7 @@ def _new_kvpe(config, mesh_device, mesh_shape):
 
 
 def _new_index_kv(config, mesh_device, mesh_shape):
-    # Caller-owned indexer key cache for the folded single-shot (block-cyclic) path: 1 layer / 1 user, so
+    # Caller-owned indexer key cache for the block-cyclic path: 1 layer / 1 user, so
     # update_padded_kv_cache's num_slots = cache_batch / layer_num stays >= 1 with the MLA's layer_num=1.
     return init_kvpe_cache(
         kvpe_cache_head_dim=config.index_head_dim,
@@ -251,6 +255,8 @@ def _new_index_kv(config, mesh_device, mesh_shape):
 
 
 def _build_mla(config, state_dict, mesh_device, weight_cache_path):
+    # Sparse has no single-shot path (ttMLA binds the block-cyclic ops from _has_indexer alone), so
+    # build chunked explicitly: one full-sequence chunk, hence active_seq_len == SEQ_LEN.
     return ttMLA(
         config,
         state_dict,
@@ -260,9 +266,8 @@ def _build_mla(config, state_dict, mesh_device, weight_cache_path):
         sp_axis=SP_AXIS,
         tp_axis=TP_AXIS,
         weight_cache_path=weight_cache_path,
-        # Single-shot folds onto block-cyclic: the sparse indexer/KVPE write goes through
-        # update_padded_kv_cache (num_slots = cache_batch / layer_num). The test caches are 1 layer / 1 user,
-        # so layer_num must be 1 (matches test_mla.py) or num_slots collapses to 0 and the write asserts.
+        is_chunked=True,
+        active_seq_len=SEQ_LEN,
         layer_num=1,
     )
 
@@ -292,8 +297,8 @@ def test_sparse_mla_cache_only_stays_sparse(mesh_device, device_params, variant,
     weights = random_mla_weights(config)  # device-vs-device round-trip: config-shaped weights suffice
     mesh_shape = list(mesh_device.shape)
 
-    # Sparse single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0): indexed rope
-    # tables + a caller-owned indexer key cache, exactly like the chunked path.
+    # Sparse always runs block-cyclic; these modules are built chunked with one full-seq chunk at offset 0,
+    # so the rope tables are the indexed ones and the indexer key cache is caller-owned.
     rope_tensors = RotarySetup(config, mesh_device, sp_axis=SP_AXIS, is_balanced=False).get_rope_tensors_indexed(
         cache_seq_len_global=SEQ_LEN, chunk_size_global=SEQ_LEN
     )
@@ -393,6 +398,8 @@ def test_glm52_shared_layer_cache_skips_indexer(mesh_device, device_params, vari
         sp_axis=SP_AXIS,
         tp_axis=TP_AXIS,
         weight_cache_path=CACHE_DIR,
+        is_chunked=True,  # sparse is always block-cyclic; construction must say so
+        active_seq_len=SEQ_LEN,
     )
     assert mla_c._has_indexer and mla_c._indexer_reuse, f"{variant.name}: shared layer must be sparse + reuse"
     assert type(mla_c._indexer).__name__ == "ReuseIndexer", "shared layer must bind ReuseIndexer"
@@ -448,6 +455,8 @@ def _build_mla_tp(config, state_dict, mesh_device, *, tp_shard_kv):
         sp_axis=SP_AXIS,
         tp_axis=TP_AXIS,
         weight_cache_path=None,
+        is_chunked=True,  # sparse is always block-cyclic; SEQ_LEN is a single full-sequence chunk
+        active_seq_len=SEQ_LEN,
         layer_num=1,
         tp_shard_kv=tp_shard_kv,
     )

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
@@ -282,9 +282,11 @@ def _skip_unsupported(model: str, mesh_device) -> None:
         pytest.skip(f"GLM sparse_sdpa needs per-chip H=64/tp≥32 → tp≤2 (mesh tp={mesh_device.shape[1]})")
 
 
-def _make_mla(model, config, layer, mesh_device, is_chunked=False):
+def _make_mla(model, config, layer, mesh_device):
     config.max_seq_len = SEQ_LEN  # rope-table length (same hack as v3 run_model / test_mla)
     weights = _weights_for(model, config, layer)  # canonical dict — same tensors the CPU truth uses
+    # Sparse has no single-shot path (ttMLA binds the block-cyclic ops from _has_indexer alone), so
+    # build chunked explicitly: the reference capture is one full-sequence chunk at offset 0.
     return ttMLA(
         config,
         weights,
@@ -293,7 +295,8 @@ def _make_mla(model, config, layer, mesh_device, is_chunked=False):
         seq_len=SEQ_LEN,
         sp_axis=0,
         tp_axis=1,
-        is_chunked=is_chunked,
+        is_chunked=True,
+        active_seq_len=SEQ_LEN,
         layer_num=1,
     )
 
@@ -377,12 +380,12 @@ def test_indexer_device_vs_reference(mesh_device, model, layer, device_params, m
 
 
 def _run_device_forward(model, config, layer, mesh_device):
-    """Single-shot ttMLA forward over the reference input; returns (ref, output[1,S,hidden], kvpe[S,576])."""
+    """One full-sequence ttMLA chunk over the reference input; returns (ref, output[1,S,hidden], kvpe[S,576])."""
     ref = load_reference(model, layer)
     mla = _make_mla(model, config, layer, mesh_device)
     sp_axis, tp_axis = 0, 1
     # Sparse: uncompressed bf16/ROW_MAJOR KVPE cache + indexed rope + a caller-owned indexer key cache.
-    # Single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0).
+    # The module is built chunked; the capture is one full-seq chunk at offset 0.
     kvpe_cache = init_mla_kv_cache(
         cache_format=MlaKvCacheFormat.BF16_RM,
         hf_config=config,
@@ -416,7 +419,7 @@ def _run_device_forward(model, config, layer, mesh_device):
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
-    out = mla.forward(tt_x, rope_tensors, kvpe_cache, index_kv_cache=index_kv_cache)
+    out = mla.forward(tt_x, rope_tensors, kvpe_cache, actual_start=0, index_kv_cache=index_kv_cache)
     out_t = ttnn.to_torch(
         out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
     ).to(torch.bfloat16)[

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -65,6 +65,9 @@ def run_mla_inference(
     tt_kvpe_cache,
     return_indices=False,
     inject_indices=None,
+    is_chunked=False,
+    active_seq_len=None,
+    actual_start=None,
 ):
     """
     Utility function to run MLA inference without host comparison.
@@ -80,12 +83,25 @@ def run_mla_inference(
         is_balanced: Whether to use balanced chunk ordering
         topology: Topology (Linear or Ring)
         tt_kvpe_cache: Initialized KVPE cache on device
+        is_chunked / active_seq_len / actual_start: prefill mode, passed straight to ttMLA and
+            forward(). No chunk loop here -- one forward over the whole sequence -- so only two
+            triples fit: single-shot (False/None/None) or one chunk (True/seq_len/0). Sparse must chunk.
 
     Returns:
         Tuple of (tt_output, hidden_states, chunk_order, shard_dims)
     """
     # Create TT MLA
     logger.info("Creating TT MLA...")
+
+    # The mode is the caller's, not derived: dense chunked prefill is real (test_mla_chunked_prefill,
+    # tt_prefill_runtime.py), so sparsity cannot decide it -- it only decides what a sparse caller may
+    # declare, since ttMLA binds _apply_rope_padded + _sparse_chunked_attn from _has_indexer alone.
+    has_indexer = resolve_has_indexer(config)
+    assert not has_indexer or is_chunked, (
+        "sparse (DSA) MLA has no single-shot path -- it is block-cyclic by construction. Pass "
+        "is_chunked=True: this helper's single forward is then declared as one full-length chunk at "
+        "offset 0, which is what actually executes."
+    )
 
     mla_tt = ttMLA(
         config,
@@ -97,17 +113,12 @@ def run_mla_inference(
         tp_axis=tp_axis,
         is_balanced=is_balanced,
         topology=topology,
-        # Match the single-layer test cache (num_kvpe_cache_layers=1): the sparse single-shot write now
-        # goes through update_padded_kv_cache, which asserts cache_batch % layer_num == 0. Dense is
-        # unaffected (its single-shot write uses fill_cache_for_user_, which ignores layer_num).
+        is_chunked=is_chunked,
+        active_seq_len=active_seq_len,
         layer_num=1,
         sparse_kv_cache_format=tt_kvpe_cache.format,
     )
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
-    # Sparse (DSA) single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0):
-    # it uses the indexed rope tables and a caller-owned indexer key cache, exactly like the chunked
-    # path. Dense keeps natural rope + no index cache.
-    has_indexer = resolve_has_indexer(config)
     index_kv_cache = None
     if has_indexer:
         rope_tensors = rope_setup.get_rope_tensors_indexed(cache_seq_len_global=seq_len, chunk_size_global=seq_len)
@@ -159,11 +170,12 @@ def run_mla_inference(
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
     # GLM-5.2 indexer reuse (return_indices / inject_indices): capture this layer's top-k selection, or
-    # feed a prior layer's to skip the indexer. Defaults leave the single-shot forward unchanged.
+    # feed a prior layer's to skip the indexer. Defaults leave the forward unchanged.
     mla_out = mla_tt.forward(
         hidden_states=tt_hidden_states,
         rope_tensors=rope_tensors,
         kvpe_cache=tt_kvpe_cache,
+        actual_start=actual_start,
         indexer_indices=inject_indices,
         return_indexer_indices=return_indices,
         index_kv_cache=index_kv_cache,


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/53363

### Description

Sparse MLA always runs chunked MLA, but the tests were configured in such a way that they initialize the MLA module with `is_chunked=False`, but then, later in MLA it falls to the chunked codepath. This PR changes that the tests explicitly set the flags when creating the MLA module to run the chunked variant, instead on implicitly falling to the chunked path.

### CI runs

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:nostojic/sparse_mla_refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nostojic/sparse_mla_refactor)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/sparse_mla_refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/sparse_mla_refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/sparse_mla_refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/sparse_mla_refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/sparse_mla_refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/sparse_mla_refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/sparse_mla_refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/sparse_mla_refactor)