### PR TITLE
[Bug fix] round: keep integral inputs finite instead of overflowing the 10**decimals rescale

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -9,6 +9,8 @@ import ttnn
 from functools import partial
 from models.common.utility_functions import torch_random
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+from tests.ttnn.unit_tests.operations.eltwise.eltwise_test_utils import to_tt_tensor
+from tests.ttnn.utils_for_testing import flush_subnormal_values_to_zero, generate_all_bfloat16_bitpatterns
 
 pytestmark = pytest.mark.use_module_device
 
@@ -54,3 +56,35 @@ def test_round_new(shape, dtypes, decimal, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
+
+
+@pytest.mark.parametrize("decimals", [-3, -1, 0, 1, 2, 3, 5, 7])
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+def test_round_all_bitpatterns(dtypes, decimals, device):
+    """Every bfloat16 bit pattern through ttnn.round.
+
+    The kernel scales by 10**decimals before rounding, which overflows for
+    |x| > FLT_MAX / 10**decimals; the inverse scale cannot bring +/-inf back. Every such
+    input is already an integer, so the result must be the input itself.
+    """
+    torch_dtype, tt_dtype = dtypes
+    torch_input_tensor = flush_subnormal_values_to_zero(generate_all_bfloat16_bitpatterns(torch_dtype))
+    finite = torch.isfinite(torch_input_tensor)
+
+    input_tensor = to_tt_tensor(torch_input_tensor, device, dtype=tt_dtype)
+    output_tensor = ttnn.to_torch(ttnn.round(input_tensor, decimals=decimals))
+
+    # a finite input must never come back infinite
+    assert torch.equal(torch.isfinite(output_tensor) & finite, finite)
+
+    if decimals >= 0:
+        # |x| >= 2**23 has no fractional part, so rounding to any number of decimal places
+        # returns it unchanged
+        integral = finite & (torch_input_tensor.abs() >= 2.0**23)
+        assert torch.equal(output_tensor[integral], torch_input_tensor[integral])

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -163,11 +163,24 @@ void _calculate_round_(const int decimals)
     const sfpi::vFloat coeff   = exp10i(decimals);
     const sfpi::vFloat inverse = exp10i(-decimals);
 
+    // v * coeff overflows to +/-inf for |v| > FLT_MAX / 10**decimals, and inverse * inf is inf,
+    // so large finite inputs come back infinite. Every |v| >= 2**23 is already an integer, so for
+    // decimals >= 0 the answer is v itself and the rescale can be skipped. Negative decimals do
+    // change such values (round to tens, hundreds, ...) and coeff < 1 cannot overflow there, so
+    // the shortcut is disabled by making its threshold +inf, which then only selects v = +/-inf --
+    // where returning v is also correct.
+    const sfpi::vFloat integral_threshold = decimals >= 0 ? 0x1.0p23F : 1.0F / 0.0F;
+
     for (int d = 0; d < ITERATIONS; ++d)
     {
         sfpi::vFloat v      = sfpi::dst_reg[0];
         sfpi::vFloat result = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[0]    = result;
+        v_if (sfpi::setsgn(v, 0) >= integral_threshold)
+        {
+            result = v;
+        }
+        v_endif;
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -175,11 +175,24 @@ void _calculate_round_(const int decimals)
     const sfpi::vFloat coeff   = exp10i(decimals);
     const sfpi::vFloat inverse = exp10i(-decimals);
 
+    // v * coeff overflows to +/-inf for |v| > FLT_MAX / 10**decimals, and inverse * inf is inf,
+    // so large finite inputs come back infinite. Every |v| >= 2**23 is already an integer, so for
+    // decimals >= 0 the answer is v itself and the rescale can be skipped. Negative decimals do
+    // change such values (round to tens, hundreds, ...) and coeff < 1 cannot overflow there, so
+    // the shortcut is disabled by making its threshold +inf, which then only selects v = +/-inf --
+    // where returning v is also correct.
+    const sfpi::vFloat integral_threshold = decimals >= 0 ? 0x1.0p23F : 1.0F / 0.0F;
+
     for (int d = 0; d < ITERATIONS; ++d)
     {
         sfpi::vFloat v      = sfpi::dst_reg[0];
         sfpi::vFloat result = inverse * _round_even_(v * coeff);
-        sfpi::dst_reg[0]    = result;
+        v_if (sfpi::setsgn(v, 0) >= integral_threshold)
+        {
+            result = v;
+        }
+        v_endif;
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55709

`_calculate_round_` scales by `10**decimals` before rounding and by `10**-decimals` after. The first multiply overflows for `|x| > FLT_MAX / 10**decimals`, and multiplying `inf` by the inverse scale cannot bring it back, so a finite input comes back infinite. Every such input is already an integer (`|x| >= 2**23`), so for `decimals >= 0` the answer is the input itself and the rescale can be skipped. Negative `decimals` do change large values (rounding to tens, hundreds, ...) and the scale is `< 1` there so it cannot overflow, so the shortcut's threshold is set to `+inf` in that case, which then only selects `x = +/-inf` — where returning `x` is also correct.

All 65,536 bfloat16 bit patterns, as `bfloat16` and as `float32`, on ttsim Blackhole:

| decimals | finite inputs returning ±inf (before) | (after) | max ULP bf16 (before → after) | max ULP fp32 (before → after) |
|---|---|---|---|---|
| -6 | 0 | **0** | 1 → **1** | 122 → **122** |
| -2 | 0 | **0** | 1 → **1** | 13 → **13** |
| -1 | 0 | **0** | 1 → **1** | 2 → **2** |
| 0 | 0 | **0** | 1 → **1** | 0 → **0** |
| 1 | 870 | **0** | 1 → **1** | 1 → **1** |
| 2 | 1720 | **0** | 1 → **1** | 1 → **1** |
| 3 | 2552 | **0** | 1 → **1** | 1 → **1** |
| 5 | 4272 | **0** | 1 → **1** | 1 → **1** |
| 7 | 5970 | **0** | 1 → **1** | 215 → **215** |

Accuracy is unchanged everywhere; only the infinities go away.

![round(decimals) before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-round-decimals.png)

### Notes for reviewers

- Both archs: `tt_llk_blackhole` and `tt_llk_wormhole_b0` carry identical copies of `_calculate_round_`; both are patched the same way.
- `integral_threshold` is a loop-invariant `vFloat`, so the guard costs one compare and one predicated move per element; there is no extra work for `decimals <= 0` beyond that.
- `2**23` is the fp32 threshold above which no float has a fractional part. For `bfloat16` the true threshold is `2**8`, so the guard is conservative for bf16 inputs — values in `[2**8, 2**23)` still take the rescale, which is correct there and cannot overflow.
- NaN is unaffected either way: `setsgn(NaN, 0) >= 2**23` selects `result = NaN`, and the unguarded path also produced NaN.
- `test_round_all_bitpatterns` sweeps every bfloat16 bit pattern for `decimals` in `{-3, -1, 0, 1, 2, 3, 5, 7}` and asserts (a) no finite input produces a non-finite output, and (b) for `decimals >= 0`, every `|x| >= 2**23` comes back bit-identical. It fails 10 of 16 cases on `main`.
- Existing `test_round.py` passes today only because `test_round_new` uses PCC on a `[-100, 100]` random tensor, which never reaches the overflow band. All 40 cases in that file pass with this change.
- Verified on ttsim Blackhole v1.10.6 (slow dispatch); no silicon.
