### PR TITLE
[Bug fix] softcap: small inputs no longer vanish in the 1/beta rescale

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -10,7 +10,14 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_with_ulp, assert_allclose
+from tests.ttnn.utils_for_testing import (
+    assert_with_pcc,
+    assert_equal,
+    assert_with_ulp,
+    assert_allclose,
+    flush_subnormal_values_to_zero,
+    generate_all_bfloat16_bitpatterns,
+)
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import (
     data_gen_with_range,
     data_gen_with_range_dtype,
@@ -2747,6 +2754,35 @@ def test_softcap_bfloat16_full_domain(device):
 
     tiny_max = result[~mask].to(torch.float32).abs().max().item()
     assert tiny_max <= 4.0 * SOFTCAP_FLUSH_FLOOR, f"negligible-reference region returned {tiny_max:.4e}"
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="softcap is implemented for Blackhole only")
+@pytest.mark.parametrize("beta", [SOFTCAP_BETA, 30.0, 50.0, 3.0, 1.0])
+def test_softcap_small_magnitude_all_bitpatterns(beta, device):
+    """Every representable bfloat16 value, checking that small inputs survive the rescale.
+
+    The kernel evaluates beta * tanh(x * (1/beta)). x * (1/beta) flushes to zero for
+    |x| < beta * 2**-126 and beta * tanh(0) is exactly 0, so the whole input was discarded
+    over a band that grows with beta (1250 of the 65,536 bfloat16 patterns at beta = 30),
+    although softcap(x) = x there. tanh(y) = y to under half an fp32 ULP for |y| <= 2**-12,
+    so the result must be the input itself over that range.
+    """
+    input_tensor = flush_subnormal_values_to_zero(generate_all_bfloat16_bitpatterns(torch.bfloat16))
+    # NaN does not propagate through min(., 1.0); see test_softcap_bfloat16_full_domain.
+    input_tensor = torch.where(torch.isnan(input_tensor), torch.zeros_like(input_tensor), input_tensor)
+
+    tt_in = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    result = ttnn.to_torch(ttnn.softcap(tt_in, beta))
+    golden = ttnn.get_golden_function(ttnn.softcap)(input_tensor, beta=beta, device=device)
+
+    linear = input_tensor.abs() <= beta * 2.0**-13
+    assert torch.equal(result[linear], input_tensor[linear])
+
+    # no normal reference value may come back as exactly zero
+    normal = (golden.abs() >= 2.0**-126) & torch.isfinite(golden)
+    assert not (result[normal] == 0).any()
+
+    assert_with_ulp(golden[normal], result[normal], ulp_threshold=SOFTCAP_ULP)
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="softcap is implemented for Blackhole only")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -2782,7 +2782,7 @@ def test_softcap_small_magnitude_all_bitpatterns(beta, device):
     normal = (golden.abs() >= 2.0**-126) & torch.isfinite(golden)
     assert not (result[normal] == 0).any()
 
-    assert_with_ulp(golden[normal], result[normal], ulp_threshold=SOFTCAP_ULP)
+    assert_with_ulp(expected_result=golden[normal], actual_result=result[normal], ulp_threshold=SOFTCAP_ULP)
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="softcap is implemented for Blackhole only")

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softcap.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softcap.h
@@ -23,7 +23,18 @@ namespace ckernel::sfpu {
 // both matching stock calculate_tanh / tanh_tile rather than torch. Leaves rounding to the
 // caller, so fused callers can round once at the end.
 sfpi_inline sfpi::vFloat _sfpu_softcap_(sfpi::vFloat x, sfpi::vFloat beta, sfpi::vFloat inv_beta) {
-    return _sfpu_tanh_polynomial_(x * inv_beta) * beta;
+    sfpi::vFloat y = x * inv_beta;
+    sfpi::vFloat result = _sfpu_tanh_polynomial_(y) * beta;
+
+    // x * inv_beta flushes to zero for |x| < beta * 2^-126, and beta * tanh(0) = 0 throws the
+    // input away even though softcap(x) = x - x^3/(3 beta^2) + ... is still a normal float there
+    // (beta = 30 loses every |x| < 3.53e-37). tanh(y) = y to under half an fp32 ULP for
+    // |y| <= 2^-12, so beta * tanh(y) = x over that whole range: return x unchanged, which also
+    // drops the two roundings the rescale would otherwise introduce.
+    v_if(sfpi::setsgn(y, 0) <= 0x1.0p-12f) { result = x; }
+    v_endif;
+
+    return result;
 }
 
 inline void softcap_init() { tanh_init</*APPROXIMATION_MODE=*/false, /*is_fp32_dest_acc_en=*/false>(); }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55710

`_sfpu_softcap_` evaluates `beta * tanh(x * (1/beta))`. The rescale flushes to zero for `|x| < beta * 2^-126`, and `beta * tanh(0)` is exactly 0, so the input was discarded over a band that widens with `beta` — at `beta = 30` every `|x|` below `3.53e-37` came back as `0`, 1250 of the 65,536 bfloat16 bit patterns, although `softcap(x) = x` there.

`tanh(y) = y` to under half an fp32 ULP for `|y| <= 2^-12`, so the kernel now returns `x` unchanged over that range. That covers the whole underflow band and also drops the two roundings the rescale would otherwise introduce, so the near-linear region gets slightly more accurate rather than less.

All 65,536 bfloat16 bit patterns on ttsim Blackhole, golden `beta * tanh(x / beta)` in float64:

| beta | zeros where golden is normal (before → after) | max ULP (before → after) | mean ULP (before → after) |
|---|---|---|---|
| 50 | 1426 → **0** | 841 → **1** | 10.6276 → **0.0030** |
| 30 | 1250 → **0** | 753 → **1** | 8.4702 → **0.0027** |
| 25 | 1170 → **0** | 713 → **1** | 7.5687 → **0.0030** |
| 3 | 386 → **0** | 321 → **1** | 1.3357 → **0.0031** |
| 1 | 2 → **0** | 129 → **1** | 0.0072 → **0.0033** |
| 0.5 | 2 → **0** | 129 → **1** | 0.0072 → **0.0033** |
| 0.001 | 2 → **0** | 129 → **1** | 0.0069 → **0.0030** |

![softcap before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-softcap.png)

### Notes for reviewers

- Blackhole only — `softcap` has no Wormhole kernel.
- `situ_glu` calls `_sfpu_softcap_` for both halves and inherits the fix; `test_binary_composite.py -k situ_glu` still passes (9 passed, 1 skipped).
- The threshold is on `y = x * inv_beta`, not on `x`, so it needs no extra multiply and stays correct for any `beta` including the ones where `beta * 2^-12` itself would overflow or underflow.
- `tanh(y) - y = -y^3/3 + O(y^5)`, so at `|y| = 2^-12` the relative difference is `2^-24 / 3`, below half an fp32 ULP; returning `x` is at least as accurate as the polynomial over the whole selected range, which is why the mean ULP drops.
- Edge cases are unchanged: `±inf` still clamps to `±beta`, NaN still does not propagate (the guard's ordered compare is false for NaN, so NaN keeps the existing path), `-0.0` still comes back as `+0.0`. All as documented in the file header.
- `test_softcap_small_magnitude_all_bitpatterns` sweeps every bfloat16 bit pattern for `beta` in `{1, 3, 25, 30, 50}` and asserts the result is bit-identical to the input for `|x| <= beta * 2^-13`, that no normal golden comes back as zero, and 2 ULP overall. It fails all 5 cases on `main`.
- `test_softcap_bfloat16_full_domain` did not catch this: it masks out `|golden| <= 1e-30` and only asserts that region stays below `4e-30`, which returning zero satisfies. That test is left as is.
- Verified on ttsim Blackhole v1.10.6 (slow dispatch); no silicon.
