### PR TITLE
[Bug fix] silu / mish: keep the deep negative tail instead of flushing it to zero

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -641,3 +641,40 @@ def test_lgamma_fp32(device, shapes):
     tt_out = ttnn.to_torch(z_tt)
 
     assert_with_pcc(z_torch, tt_out, 0.999)
+
+
+@pytest.mark.parametrize(
+    "ttnn_function, torch_function",
+    [(ttnn.silu, torch.nn.functional.silu), (ttnn.mish, torch.nn.functional.mish)],
+)
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+def test_silu_mish_negative_tail_all_bitpatterns(ttnn_function, torch_function, dtypes, device):
+    """Every bfloat16 bit pattern through silu / mish, checking the deep negative tail.
+
+    Both ops route through exp: silu as x / (1 + exp(-x)), mish as x * u(u+2)/(u^2+2u+2)
+    with u = exp(x). exp underflows (for silu, the reciprocal flushes) at x = ln(2**-126) =
+    -87.3365, which sent the result to exactly 0 even though f(x) -> x * exp(x) is a normal
+    float down to x = -91.83 and is still -1.02e-36 at the threshold.
+
+    The reference is evaluated in float64: the registered mish golden casts to float32 first
+    and is itself tens of ULP off at the bottom of the normal range.
+    """
+    torch_dtype, tt_dtype = dtypes
+    torch_input_tensor = flush_subnormal_values_to_zero(generate_all_bfloat16_bitpatterns(torch_dtype))
+
+    reference = torch_function(torch_input_tensor.to(torch.float64))
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=tt_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    result = ttnn.to_torch(ttnn_function(input_tensor))
+
+    # the whole band whose exact result is still a normal float must survive; below it the
+    # true value is subnormal and the device is right to flush it
+    tail = (torch_input_tensor.to(torch.float64) < -80.0) & (reference.abs() >= 2.0**-126)
+    assert tail.any()
+    assert not (result[tail] == 0).any()
+    assert_with_ulp(reference[tail].to(torch_dtype), result[tail].to(torch_dtype), ulp_threshold=4)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -677,4 +677,6 @@ def test_silu_mish_negative_tail_all_bitpatterns(ttnn_function, torch_function, 
     tail = (torch_input_tensor.to(torch.float64) < -80.0) & (reference.abs() >= 2.0**-126)
     assert tail.any()
     assert not (result[tail] == 0).any()
-    assert_with_ulp(reference[tail].to(torch_dtype), result[tail].to(torch_dtype), ulp_threshold=4)
+    assert_with_ulp(
+        expected_result=reference[tail].to(torch_dtype), actual_result=result[tail].to(torch_dtype), ulp_threshold=4
+    )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
@@ -34,7 +34,21 @@ namespace ckernel::sfpu {
  * WH does not need this rearrangement since we use Sollya quadratic (~1e-5 relative error).
  *
  * Saturation: For x >= 8.0, mish(x) is approximated as x.
+ *
+ * Deep negative tail: exp(x) flushes to zero at x = ln(2^-126) = -87.3365 and the whole
+ * expression then collapses to mish(x) = 0, although mish(x) -> x*exp(x) is still a normal
+ * float down to x = -91.83 and is -1.02e-36 at the threshold. Below the threshold the
+ * exponential is evaluated at x + 44 instead, i.e. exp(x)*e^44, and the e^-44 is applied
+ * after multiplying by x, so nothing leaves the normal range. 44 is used because |x| lies in
+ * [64, 128) over the whole affected band, where adding an exact integer is itself exact, so
+ * the only new error is the single rounding of the e^-44 constant (5e-9 relative).
+ * u(u+2)/(u^2+2u+2) equals u to far below fp32 resolution there (u < 2^-126), so the tail is
+ * exactly x*exp(x).
  */
+constexpr float MISH_TAIL_THRESHOLD = -87.3365f;  // ln(2^-126), where exp(x) underflows
+constexpr float MISH_TAIL_SHIFT = 44.0f;
+constexpr float MISH_TAIL_SCALE = 7.78113228e-20f;  // e^-44
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_mish() {
     constexpr float SAT_HI = 8.0f;
@@ -47,11 +61,15 @@ inline void calculate_mish() {
         sfpi::vFloat result = x;
 
         v_if(x < SAT_HI) {
+            sfpi::vFloat arg = x;
+            v_if(x < MISH_TAIL_THRESHOLD) { arg = x + MISH_TAIL_SHIFT; }
+            v_endif;
+
             sfpi::vFloat u;
             if constexpr (APPROXIMATION_MODE) {
-                u = _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(x);
+                u = _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(arg);
             } else {
-                u = _sfpu_exp_accurate_<is_fp32_dest_acc_en>(x);
+                u = _sfpu_exp_accurate_<is_fp32_dest_acc_en>(arg);
             }
 
             // denominator = (1 + u)^2 + 1 = u^2 + 2u + 2
@@ -76,6 +94,10 @@ inline void calculate_mish() {
                 sfpi::vFloat numer = u * (u + 2.0f);
                 result = x * (numer * inv_denom);
             }
+            v_endif;
+
+            // u here is exp(x) * e^44; undo the scale after multiplying by x
+            v_if(x < MISH_TAIL_THRESHOLD) { result = (x * u) * MISH_TAIL_SCALE; }
             v_endif;
         }
         v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -6,9 +6,28 @@
 
 #include "cmath_common.h"  // math::reset_counters, p_setrwc
 #include "ckernel_sfpu_sigmoid.h"
+#include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
 
 namespace ckernel::sfpu {
+
+// silu(x) = x * sigmoid(x) = x / (1 + exp(-x)).
+//
+// Evaluating sigmoid first throws the deep negative tail away: exp(-x) reaches 2^126 at
+// x = ln(2^-126) = -87.3365 (and overflows to +inf below x = -88.72), so the reciprocal
+// flushes to zero and x * 0 is exactly 0 -- although x * exp(x) is a normal float all the
+// way down to x = -91.83, and silu is -1.02e-36 at the threshold itself.
+//
+// Below the threshold the exponential is evaluated at -x - 44 instead, i.e. exp(-x) * e^-44,
+// and the numerator is scaled by the same e^-44, which keeps both operands of the reciprocal
+// inside the normal range. 44 is chosen because -x lies in [64, 128) over the whole affected
+// band, where subtracting an exact integer is itself exact, so the only new error is the one
+// rounding of the e^-44 constant (5e-9 relative). The 1 in the denominator is then a
+// 1.5e-19 relative perturbation of a quantity >= 6.6e18 and disappears in the fp32 rounding,
+// which is exactly the 1/(1+exp(-x)) -> exp(x) limit the tail is in.
+constexpr float SILU_TAIL_THRESHOLD = -87.3365f;  // ln(2^-126), where 1 + exp(-x) hits 2^126
+constexpr float SILU_TAIL_SHIFT = 44.0f;
+constexpr float SILU_TAIL_SCALE = 7.78113228e-20f;  // e^-44
 
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
@@ -16,8 +35,29 @@ inline void calculate_silu() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
-        // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        sfpi::vFloat arg = -x;
+        sfpi::vFloat numerator = x;
+        v_if(x < SILU_TAIL_THRESHOLD) {
+            arg = -x - SILU_TAIL_SHIFT;
+            numerator = x * SILU_TAIL_SCALE;
+        }
+        v_endif;
+
+        // sigmoid's body, with the argument and numerator above rather than -x and x
+        sfpi::vFloat exp_neg_x;
+        if constexpr (is_fp32_dest_acc_en) {
+            exp_neg_x = _sfpu_exp_accurate_<true>(arg);
+        } else {
+            exp_neg_x = _sfpu_exp_21f_bf16_<true>(arg);
+        }
+        sfpi::vFloat denominator = 1.0f + exp_neg_x;
+
+        sfpi::vFloat result;
+        if constexpr (is_fp32_dest_acc_en) {
+            result = numerator * sfpu_reciprocal_iter<2>(denominator);
+        } else {
+            result = numerator * sfpu_reciprocal_iter<1>(denominator);
+        }
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
@@ -32,7 +72,7 @@ inline void calculate_silu() {
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
-    // calculate_silu uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must use non-approx sigmoid_init
+    // calculate_silu inlines the non-approx sigmoid path, so we must use non-approx sigmoid_init
     sigmoid_init<false>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mish.h
@@ -29,7 +29,21 @@ namespace ckernel::sfpu {
  * cancellation through its lower-precision approx_recip.
  *
  * Saturation: For x >= 8.0, mish(x) is approximated as x.
+ *
+ * Deep negative tail: exp(x) flushes to zero at x = ln(2^-126) = -87.3365 and the whole
+ * expression then collapses to mish(x) = 0, although mish(x) -> x*exp(x) is still a normal
+ * float down to x = -91.83 and is -1.02e-36 at the threshold. Below the threshold the
+ * exponential is evaluated at x + 44 instead, i.e. exp(x)*e^44, and the e^-44 is applied
+ * after multiplying by x, so nothing leaves the normal range. 44 is used because |x| lies in
+ * [64, 128) over the whole affected band, where adding an exact integer is itself exact, so
+ * the only new error is the single rounding of the e^-44 constant (5e-9 relative).
+ * u(u+2)/(u^2+2u+2) equals u to far below fp32 resolution there (u < 2^-126), so the tail is
+ * exactly x*exp(x).
  */
+constexpr float MISH_TAIL_THRESHOLD = -87.3365f;  // ln(2^-126), where exp(x) underflows
+constexpr float MISH_TAIL_SHIFT = 44.0f;
+constexpr float MISH_TAIL_SCALE = 7.78113228e-20f;  // e^-44
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_mish() {
     constexpr float SAT_HI = 8.0f;
@@ -42,11 +56,15 @@ inline void calculate_mish() {
         sfpi::vFloat result = x;
 
         v_if(x < SAT_HI) {
+            sfpi::vFloat arg = x;
+            v_if(x < MISH_TAIL_THRESHOLD) { arg = x + MISH_TAIL_SHIFT; }
+            v_endif;
+
             sfpi::vFloat u;
             if constexpr (APPROXIMATION_MODE) {
-                u = _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(x);
+                u = _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(arg);
             } else {
-                u = _sfpu_exp_accurate_<is_fp32_dest_acc_en>(x);
+                u = _sfpu_exp_accurate_<is_fp32_dest_acc_en>(arg);
             }
 
             // numerator = u * (u + 2)
@@ -66,6 +84,10 @@ inline void calculate_mish() {
             }
 
             result = x * (numer * inv_denom);
+
+            // u here is exp(x) * e^44; undo the scale after multiplying by x
+            v_if(x < MISH_TAIL_THRESHOLD) { result = (x * u) * MISH_TAIL_SCALE; }
+            v_endif;
         }
         v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -6,9 +6,28 @@
 
 #include "cmath_common.h"  // math::reset_counters, p_setrwc
 #include "ckernel_sfpu_sigmoid.h"
+#include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
 
 namespace ckernel::sfpu {
+
+// silu(x) = x * sigmoid(x) = x / (1 + exp(-x)).
+//
+// Evaluating sigmoid first throws the deep negative tail away: exp(-x) reaches 2^126 at
+// x = ln(2^-126) = -87.3365 (and overflows to +inf below x = -88.72), so the reciprocal
+// flushes to zero and x * 0 is exactly 0 -- although x * exp(x) is a normal float all the
+// way down to x = -91.83, and silu is -1.02e-36 at the threshold itself.
+//
+// Below the threshold the exponential is evaluated at -x - 44 instead, i.e. exp(-x) * e^-44,
+// and the numerator is scaled by the same e^-44, which keeps both operands of the reciprocal
+// inside the normal range. 44 is chosen because -x lies in [64, 128) over the whole affected
+// band, where subtracting an exact integer is itself exact, so the only new error is the one
+// rounding of the e^-44 constant (5e-9 relative). The 1 in the denominator is then a
+// 1.5e-19 relative perturbation of a quantity >= 6.6e18 and disappears in the fp32 rounding,
+// which is exactly the 1/(1+exp(-x)) -> exp(x) limit the tail is in.
+constexpr float SILU_TAIL_THRESHOLD = -87.3365f;  // ln(2^-126), where 1 + exp(-x) hits 2^126
+constexpr float SILU_TAIL_SHIFT = 44.0f;
+constexpr float SILU_TAIL_SCALE = 7.78113228e-20f;  // e^-44
 
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
@@ -16,8 +35,29 @@ inline void calculate_silu() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
-        // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        sfpi::vFloat arg = -x;
+        sfpi::vFloat numerator = x;
+        v_if(x < SILU_TAIL_THRESHOLD) {
+            arg = -x - SILU_TAIL_SHIFT;
+            numerator = x * SILU_TAIL_SCALE;
+        }
+        v_endif;
+
+        // sigmoid's body, with the argument and numerator above rather than -x and x
+        sfpi::vFloat exp_neg_x;
+        if constexpr (is_fp32_dest_acc_en) {
+            exp_neg_x = _sfpu_exp_accurate_<true>(arg);
+        } else {
+            exp_neg_x = _sfpu_exp_21f_bf16_<true>(arg);
+        }
+        sfpi::vFloat denominator = 1.0f + exp_neg_x;
+
+        sfpi::vFloat result;
+        if constexpr (is_fp32_dest_acc_en) {
+            result = numerator * sfpu_reciprocal_iter<2>(denominator);
+        } else {
+            result = numerator * sfpu_reciprocal_iter<1>(denominator);
+        }
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
@@ -32,8 +72,8 @@ inline void calculate_silu() {
 template <bool APPROXIMATION_MODE>
 inline void silu_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
-    // calculate_silu always uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must
-    // use non-approx sigmoid_init regardless of APPROXIMATION_MODE.
+    // calculate_silu always inlines the non-approx sigmoid path, so we must use non-approx
+    // sigmoid_init regardless of APPROXIMATION_MODE.
     sigmoid_init<false>();
 }
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55711

Both ops go through `exp` and lose everything below `x = ln(2^-126) = -87.3365`:

* `silu` evaluates `x / (1 + exp(-x))`; `exp(-x)` reaches `2^126` there (and overflows to `+inf` below `x = -88.72`), so the reciprocal flushes to zero and `x * 0` is exactly `0`.
* `mish` evaluates `x * u(u+2)/(u^2+2u+2)` with `u = exp(x)`; `u` itself flushes to zero.

`f(x) -> x * exp(x)` is still a normal float down to `x = -91.83`, so the whole band returned `0` where the answer is as large as `-1.02e-36`.

Below the threshold the exponential is now evaluated at `-x - 44` (silu) or `x + 44` (mish), i.e. scaled by `e^∓44`, and the same `e^-44` is applied to the numerator / to `x*u`. `44` is used because `|x|` lies in `[64, 128)` over the whole affected band, where adding an exact integer is itself exact, so the only new error is the single rounding of the `e^-44` constant (5e-9 relative). Everything at or above the threshold is bit-identical to before.

All 65,536 bfloat16 bit patterns on ttsim Blackhole, golden in float64:

| op | dtype | zeros where golden is normal (before → after) | max ULP (before → after) | mean ULP (before → after) |
|---|---|---|---|---|
| silu | float32 | 9 → **0** | 60,071,006 → **2** | 4994.658 → **0.0518** |
| mish | float32 | 9 → **0** | 60,071,006 → **4** | 4994.861 → **0.2547** |
| silu | bfloat16 | 11 → **2** | 918 → **129** | 0.0872 → **0.0109** |
| mish | bfloat16 | 9 → **0** | 918 → **1** | 0.0884 → **0.0121** |

Restricted to `x > -87` (everything outside the band this PR touches), before and after are byte-identical: silu fp32 2 ULP, mish fp32 4 ULP, silu bf16 129 ULP, mish bf16 1 ULP in both builds.

![silu/mish before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-silu-mish.png)

### Notes for reviewers

- Both archs, one file each per op; the changes are identical apart from mish's existing positive-side rearrangement, which is untouched.
- `calculate_silu` no longer calls `_sfpu_sigmoid_`; it inlines the same body so the exponential's argument can be selected per lane. That is one `exp` and one reciprocal, as before — the tail costs a compare and two predicated multiplies, not a second exponential.
- The `1 +` in silu's denominator is left in place on the tail path. Scaled, the exact denominator would be `e^-44 + exp(-x)*e^-44`; the `1` differs from `e^-44` by 7.8e-20 against a term that is at least 6.6e18, a 1.5e-19 relative perturbation that disappears in the fp32 rounding. That is exactly the `1/(1+exp(-x)) -> exp(x)` limit the tail is in.
- Same for mish: `u(u+2)/(u^2+2u+2) = u` to far below fp32 resolution once `u < 2^-126`, so the tail is exactly `x*exp(x)`.
- `-87.3365f` is used as the threshold rather than the exactly-rounded `ln(2^-126) = -87.33654475`, so the tail path starts a hair before the old path breaks rather than a hair after. The sweep confirms nothing above the threshold changed.
- The two remaining bfloat16 silu residuals are `x = ±2^-125`, whose exact result is the smallest normal and which the bf16 pack rounds to zero. That is a separate pre-existing boundary case, unrelated to the tail, and unchanged by this PR (it was 2 of the 11 before).
- `silu(-inf)` / `mish(-inf)` return NaN before and after, matching `torch`.
- `test_silu_mish_negative_tail_all_bitpatterns` sweeps every bfloat16 bit pattern in both dtypes and asserts no zero survives where the float64 reference is normal, plus 4 ULP over the band. It fails all 4 cases on `main`. It compares against float64 on purpose: the registered `mish` golden casts to float32 first (`torch.nn.functional.mish(_x.to(torch.float))`) and is itself ~60 ULP off at the bottom of the normal range.
- `test_activation.py` (110 passed, 3 skipped) and `test_unary_fp32.py -k silu` pass with the change.
- Verified on ttsim Blackhole v1.10.6 (slow dispatch); no silicon.
