### PR TITLE
Bug fix: centralize prefill MoE fabric payload sizing

### DIFF
--- a/models/demos/common/prefill/docs/ADDING_A_PREFILL_MODEL.md
+++ b/models/demos/common/prefill/docs/ADDING_A_PREFILL_MODEL.md
@@ -89,6 +89,13 @@ That is the entire adapter contract — four methods plus the attributes. The ad
 a factory + descriptor; it performs no device work or comms itself, and it does not
 hold the cache (the engine does).
 
+For models using the shared MoE dispatch/combine path, set `FABRIC_PAYLOAD_SIZE` with
+`moe_fabric_payload_size(EMB_SIZE)` from `models.demos.common.prefill.fabric`. The
+helper reserves two bytes per embedding element because transport uses BF16,
+independently of expert weight precision, plus the 64-byte routing header required by
+`combine_fabric2d`. The common router-config helper caps this requested size at the
+architecture's fabric limit; larger ordinary dispatch/combine rows are fragmented.
+
 Test-only metadata (HF download coordinates, reference-model classes, PCC
 thresholds) is optional and only needed if you wire pytest coverage; see the
 attributes and lazy `reference_*_cls` properties on `PrefillModelAdapter`. Keep the

--- a/models/demos/common/prefill/fabric.py
+++ b/models/demos/common/prefill/fabric.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Payload sizing for prefill MoE dispatch/combine.
+
+Keep dimension calculations import-safe: model configs are also imported by host-only
+producers. Architecture detection is deferred until the fabric router is configured.
+"""
+
+
+MOE_FABRIC_DTYPE_SIZE_BYTES = 2
+MOE_FABRIC_HEADER_SIZE_BYTES = 64
+FABRIC_MAX_PAYLOAD_SIZE_BYTES = {"wormhole_b0": 7616, "blackhole": 15232}
+
+
+def moe_fabric_payload_size(embedding_size: int) -> int:
+    """Bytes needed for one BF16 embedding row and its routing header.
+
+    Every prefill MoE model and test derives its router payload from this formula
+    so dispatch, ordinary combine, and combine_fabric2d use one consistent size.
+    """
+    if embedding_size <= 0:
+        raise ValueError("Embedding size must be positive")
+    return embedding_size * MOE_FABRIC_DTYPE_SIZE_BYTES + MOE_FABRIC_HEADER_SIZE_BYTES
+
+
+def limit_fabric_payload_size(payload_size: int, arch: str) -> int:
+    """Cap a requested payload at Metal's architecture-specific fabric limit.
+
+    Limits mirror FabricEriscDatamoverBuilder in
+    tt_metal/fabric/erisc_datamover_builder.hpp. Larger rows are fragmented by
+    the ordinary dispatch/combine send helpers.
+    """
+    if payload_size <= 0:
+        raise ValueError("Fabric payload size must be positive")
+    return min(payload_size, FABRIC_MAX_PAYLOAD_SIZE_BYTES[arch])
+
+
+def create_fabric_router_config(max_payload_size: int):
+    """Create a router config for the requested bytes on the current architecture."""
+    import ttnn
+
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = limit_fabric_payload_size(max_payload_size, ttnn.get_arch_name())
+    return config

--- a/models/demos/common/prefill/runners/runner_utils.py
+++ b/models/demos/common/prefill/runners/runner_utils.py
@@ -8,12 +8,7 @@ from pathlib import Path
 from loguru import logger
 
 import ttnn
-
-
-def _create_fabric_router_config(max_payload_size):
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
+from models.demos.common.prefill.fabric import create_fabric_router_config
 
 
 def open_mesh_device(
@@ -37,7 +32,7 @@ def open_mesh_device(
         fabric_config = ttnn.FabricConfig.FABRIC_1D if sp <= 8 else ttnn.FabricConfig.FABRIC_2D
     logger.info(f"Fabric config: {fabric_config} (sp={sp}, PREFILL_FABRIC_MODE={fabric_mode or 'unset'})")
 
-    fabric_router_config = _create_fabric_router_config(
+    fabric_router_config = create_fabric_router_config(
         max_payload_size=model_cfg.FABRIC_PAYLOAD_SIZE,
     )
 

--- a/models/demos/common/prefill/tests/test_fabric_payload.py
+++ b/models/demos/common/prefill/tests/test_fabric_payload.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Host-only sizing checks; runnable with pytest --noconftest without TTNN."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from models.demos.common.prefill.fabric import (
+    FABRIC_MAX_PAYLOAD_SIZE_BYTES,
+    MOE_FABRIC_DTYPE_SIZE_BYTES,
+    MOE_FABRIC_HEADER_SIZE_BYTES,
+    create_fabric_router_config,
+    moe_fabric_payload_size,
+)
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_2_config import DeepseekV32Config
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
+from models.demos.deepseek_v3_d_p.reference.gpt_oss_20b_config import GptOss20BConfig
+from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_7_config import KimiK27Config
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.reference.minimax_m3_config import MiniMaxM3Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
+
+MODEL_CONFIGS = [
+    DeepseekV32Config,
+    DeepSeekV3Config,
+    DeepSeekV4FlashConfig,
+    DeepSeekV4ProConfig,
+    GLM51Config,
+    GLM52Config,
+    GptOss20BConfig,
+    GptOss120BConfig,
+    KimiK26Config,
+    KimiK27Config,
+    KimiK3Config,
+    MiniMaxM27Config,
+    MiniMaxM3Config,
+    MistralSmall4Config,
+]
+
+
+@pytest.mark.parametrize("model_config", MODEL_CONFIGS, ids=lambda config: config.__name__)
+def test_model_payload_fits_one_bf16_embedding_row_and_header(model_config):
+    expected = model_config.EMB_SIZE * MOE_FABRIC_DTYPE_SIZE_BYTES + MOE_FABRIC_HEADER_SIZE_BYTES
+    assert model_config.FABRIC_PAYLOAD_SIZE == expected
+
+
+@pytest.mark.parametrize("model_config", MODEL_CONFIGS, ids=lambda config: config.__name__)
+def test_payload_helper_uses_shared_transport_constants(model_config):
+    assert moe_fabric_payload_size(model_config.EMB_SIZE) == model_config.FABRIC_PAYLOAD_SIZE
+
+
+@pytest.mark.parametrize("model_config", MODEL_CONFIGS, ids=lambda config: config.__name__)
+@pytest.mark.parametrize("arch", FABRIC_MAX_PAYLOAD_SIZE_BYTES)
+def test_router_config_applies_architecture_limit(monkeypatch, arch, model_config):
+    # Exercise the entry point shared by the runner and operator fixtures without opening hardware.
+    monkeypatch.setitem(
+        sys.modules,
+        "ttnn",
+        SimpleNamespace(
+            get_arch_name=lambda: arch,
+            _ttnn=SimpleNamespace(fabric=SimpleNamespace(FabricRouterConfig=SimpleNamespace)),
+        ),
+    )
+    config = create_fabric_router_config(model_config.FABRIC_PAYLOAD_SIZE)
+    assert config.max_packet_payload_size_bytes == min(
+        model_config.FABRIC_PAYLOAD_SIZE, FABRIC_MAX_PAYLOAD_SIZE_BYTES[arch]
+    )

--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v3_2_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v3_2_config.py
@@ -16,12 +16,15 @@ the HF config.json: https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp/blob/ma
 
 import types
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
 
 class DeepseekV32Config:
     """DeepSeek-V3.2-Exp model dimensions (from HF config.json)."""
 
     # Core dimensions
     EMB_SIZE = 7168  # hidden_size
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     INTERMEDIATE_SIZE = 18432  # dense FFN hidden dimension
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
 

--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v3_config.py
@@ -10,12 +10,15 @@ Values from HuggingFace config.json for DeepSeek-V3.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class DeepSeekV3Config:
     """DeepSeek V3/R1 671B model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 7168  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
     INTERMEDIATE_SIZE = 18432  # Dense FFN hidden dimension
 

--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v4_flash_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v4_flash_config.py
@@ -10,12 +10,15 @@ Values from HuggingFace config.json for DeepSeek-V4-Flash.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class DeepSeekV4FlashConfig:
     """DeepSeek V4 Flash model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 4096  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
     # Routed-expert hybrid split: experts with <= this many active tokens go to
     # moe_fused_swiglu, the rest to unified_routed_expert_moe. Measured crossover on the

--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v4_pro_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v4_pro_config.py
@@ -10,12 +10,15 @@ Values from HuggingFace config.json for DeepSeek-V4-Pro.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class DeepSeekV4ProConfig:
     """DeepSeek V4 Pro model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 7168  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 3072  # MoE FFN hidden dimension
     # Routed-expert hybrid split. moe_fused_swiglu beat the composite at EVERY measured
     # token count on the 7168x3072 routed-expert shape (1.24-3.14x across 0-5120 tokens),

--- a/models/demos/deepseek_v3_d_p/reference/glm_5_1_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/glm_5_1_config.py
@@ -11,13 +11,15 @@ Values from HuggingFace config.json for GLM-5.1.
 
 import types
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
 
 class GLM51Config:
     """GLM 5.1 model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 6144  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
     # Routed-expert hybrid split: experts with <= this many active tokens go to
     # moe_fused_swiglu, the rest to unified_routed_expert_moe. Measured crossover on the

--- a/models/demos/deepseek_v3_d_p/reference/glm_5_2_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/glm_5_2_config.py
@@ -16,13 +16,15 @@ recent full layer's top-k selection. The full/shared map is ``indexer_types``.
 
 import types
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
 
 class GLM52Config:
     """GLM 5.2 model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 6144  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
     # Routed-expert hybrid split: experts with <= this many active tokens go to
     # moe_fused_swiglu, the rest to unified_routed_expert_moe. Inherited from GLM 5.1 rather than

--- a/models/demos/deepseek_v3_d_p/reference/gpt_oss_120b_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/gpt_oss_120b_config.py
@@ -10,12 +10,15 @@ Values from HuggingFace config.json for gpt-oss-120b.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class GptOss120BConfig:
     """GPT-OSS 120B model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 2880  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2880  # MoE FFN hidden dimension
     # Routed-expert hybrid split: experts with <= this many active tokens go to
     # moe_fused_swiglu, the rest to unified_routed_expert_moe. Measured under SwiGLU-OAI WITH the

--- a/models/demos/deepseek_v3_d_p/reference/gpt_oss_20b_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/gpt_oss_20b_config.py
@@ -10,6 +10,9 @@ Values from HuggingFace config.json for gpt-oss-20b.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class GptOss20BConfig:
     """GPT-OSS 20B model configuration."""
 
@@ -90,4 +93,4 @@ class GptOss20BConfig:
     QUANT_METHOD = "mxfp4"
 
     # Implementation-specific, not from the HF model config
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k2_6_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k2_6_config.py
@@ -10,12 +10,15 @@ Values from HuggingFace config.json for Kimi-K2.6 (text_config).
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class KimiK26Config:
     """Kimi K2.6 model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 7168  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
     # Routed-expert hybrid split. moe_fused_swiglu beat the composite at EVERY measured
     # token count on the 7168x2048 routed-expert shape (1.02-2.37x across 0-5120 tokens),

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k2_7_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k2_7_config.py
@@ -14,12 +14,15 @@ K2.6 silently moved K2.7, and it would hide which values K2.7 actually asserts.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class KimiK27Config:
     """Kimi K2.7-Code model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 7168  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension
     # Routed-expert hybrid split. moe_fused_swiglu beat the composite at EVERY measured
     # token count on the 7168x2048 routed-expert shape (1.02-1.81x across 0-5120 tokens),

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -31,13 +31,14 @@ included, is plain bf16. Only the MoE routed experts are quantized.
 
 import types
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
 
 class KimiK3Config:
     """Kimi K3 model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 7168  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
     MOE_INTERMEDIATE_SIZE = 3072  # MoE FFN hidden dimension
     INTERMEDIATE_SIZE = 33792  # Dense FFN hidden dimension
 
@@ -58,6 +59,7 @@ class KimiK3Config:
     # The measured crossover is kept under _MEASURED so it is not re-derived; rename it back to
     # ROUTED_EXPERT_HYBRID_TOKEN_THRESHOLD to turn the split on, which is all the readers look for.
     ROUTED_EXPERT_HYBRID_TOKEN_THRESHOLD_MEASURED = 768
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
 
     # Above this, moe_grouped_topk's circular buffers (sized from NUM_ROUTED_EXPERTS/32) no longer fit
     # L1 alongside the height-sharded gate input, and the program fails to validate. Enforced by

--- a/models/demos/deepseek_v3_d_p/reference/minimax_m2_7_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/minimax_m2_7_config.py
@@ -10,12 +10,15 @@ Values from HuggingFace config.json for MiniMax-M2.7.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class MiniMaxM27Config:
     """MiniMax M2.7 model dimensions."""
 
     # Core dimensions
     EMB_SIZE = 3072  # embedding dimension
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 1536  # MoE FFN hidden dimension
     INTERMEDIATE_SIZE = 1536  # Dense FFN hidden dimension (same as MoE)
 

--- a/models/demos/deepseek_v3_d_p/reference/minimax_m3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/minimax_m3_config.py
@@ -10,12 +10,15 @@ Values from HuggingFace config.json for MiniMax-M3.
 """
 
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
+
 class MiniMaxM3Config:
     """MiniMax-M3 text-backbone model dimensions and hyperparameters."""
 
     # Core dimensions
     EMB_SIZE = 6144
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # Implementation-specific; keep in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
 
     # FFN dimensions
     MOE_INTERMEDIATE_SIZE = 3072  # Routed-expert FFN hidden dimension

--- a/models/demos/deepseek_v3_d_p/reference/mistral_small_4_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/mistral_small_4_config.py
@@ -29,13 +29,15 @@ device code reads:
    and their query path is unchanged.
 """
 
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
+
 
 class MistralSmall4Config:
     """Mistral-Small-4-119B model dimensions (text_config)."""
 
     # Core dimensions
     EMB_SIZE = 4096  # hidden_size
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension (also the shared expert's)
     INTERMEDIATE_SIZE = 12288  # Dense FFN hidden dimension; unused - NUM_DENSE_LAYERS is 0
 

--- a/models/demos/deepseek_v3_d_p/tests/attn_res/model/harness.py
+++ b/models/demos/deepseek_v3_d_p/tests/attn_res/model/harness.py
@@ -19,6 +19,7 @@ import torch
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     torus_x_device_params,
@@ -49,7 +50,7 @@ L1_SMALL_SIZE = 1152
 # to drop out rather than open a submesh and stall in the ethernet handshake.
 EXACT_BOX = {"require_exact_physical_num_devices": True}
 
-FABRIC = {"fabric_config": ttnn.FabricConfig.FABRIC_2D, "l1_small_size": L1_SMALL_SIZE, **EXACT_BOX}
+FABRIC = fabric2d_device_params(model_config=KimiK3Config, l1_small_size=L1_SMALL_SIZE, **EXACT_BOX)
 
 
 def placements():
@@ -78,17 +79,17 @@ def placements():
         pytest.param((2, 4), FABRIC, id="mesh-2x4"),
         pytest.param(
             (8, 4),
-            fabric2d_device_params(l1_small_size=L1_SMALL_SIZE, **EXACT_BOX),
+            fabric2d_device_params(model_config=KimiK3Config, l1_small_size=L1_SMALL_SIZE, **EXACT_BOX),
             id="mesh-8x4",
         ),
         pytest.param(
             (8, 4),
-            torus_x_device_params(l1_small_size=L1_SMALL_SIZE, **EXACT_BOX),
+            torus_x_device_params(model_config=KimiK3Config, l1_small_size=L1_SMALL_SIZE, **EXACT_BOX),
             id="torusx-mesh-8x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(l1_small_size=L1_SMALL_SIZE, **EXACT_BOX),
+            torus_xy_device_params(model_config=KimiK3Config, l1_small_size=L1_SMALL_SIZE, **EXACT_BOX),
             id="torusxy-mesh-8x4",
         ),
     ]

--- a/models/demos/deepseek_v3_d_p/tests/attn_res/model/test_attn_res_contract.py
+++ b/models/demos/deepseek_v3_d_p/tests/attn_res/model/test_attn_res_contract.py
@@ -32,6 +32,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.kimi_k3.attn_res.attn_res import EPS
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.tests.attn_res.assertions import assert_bit_identical
 from models.demos.deepseek_v3_d_p.tests.attn_res.model.harness import (
     FABRIC,
@@ -82,17 +83,17 @@ on_traced_mesh = pytest.mark.parametrize(
         pytest.param((2, 4), TRACED, id="mesh-2x4"),
         pytest.param(
             (8, 4),
-            fabric2d_device_params(l1_small_size=L1_SMALL_SIZE, **_TRACED_BOX),
+            fabric2d_device_params(model_config=KimiK3Config, l1_small_size=L1_SMALL_SIZE, **_TRACED_BOX),
             id="mesh-8x4",
         ),
         pytest.param(
             (8, 4),
-            torus_x_device_params(l1_small_size=L1_SMALL_SIZE, **_TRACED_BOX),
+            torus_x_device_params(model_config=KimiK3Config, l1_small_size=L1_SMALL_SIZE, **_TRACED_BOX),
             id="torusx-mesh-8x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(l1_small_size=L1_SMALL_SIZE, **_TRACED_BOX),
+            torus_xy_device_params(model_config=KimiK3Config, l1_small_size=L1_SMALL_SIZE, **_TRACED_BOX),
             id="torusxy-mesh-8x4",
         ),
     ],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -32,7 +33,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -32,7 +33,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_gate_weights, get_sp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
@@ -67,7 +68,9 @@ def _ci_unsupported_param_combos(**params):
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
@@ -43,7 +43,9 @@ def _ci_unsupported_param_combos(**params):
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
@@ -39,12 +40,16 @@ def _ci_unsupported_param_combos(**params):
 
 
 @pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
+# This mesh axis is crossed with DeepSeek V3, Kimi K3, and Mistral. DeepSeek is
+# one of the tested variants and has the largest payload (tied with Kimi K3).
 @pytest.mark.parametrize(
     "mesh_device, device_params",
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),
@@ -53,7 +58,9 @@ def _ci_unsupported_param_combos(**params):
         # executable there, which is where the Kimi weight caches are exercised.
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         ),
@@ -62,7 +69,9 @@ def _ci_unsupported_param_combos(**params):
         # that executes on Blackhole, and so the only one that covers mistral_small_4 at all.
         pytest.param(
             (8, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="fabric2d-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -56,7 +56,9 @@ def _ci_unsupported_param_combos(**params):
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -32,7 +33,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
@@ -41,7 +42,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -32,7 +33,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -25,6 +25,7 @@ from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.common.prefill.adapter import ADAPTER_PATHS, PrefillModelAdapter, get_adapter
 from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.test_utils import load_state_dict
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 
 # The per-model registry now lives in models/demos/common/prefill/adapter.py and is shared by the
 # runner and the tests. These aliases keep the existing fixture/test references (TestVariant /
@@ -64,14 +65,18 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
 FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS = [
     pytest.param(
         (4, 2),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         1,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
         id="fabric2d-mesh-4x2",
     ),
     pytest.param(
         (2, 4),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         1,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
         id="fabric2d-mesh-2x4",
@@ -80,7 +85,9 @@ FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS = [
     # Ring-4). SP-axis MoE dispatch/combine ride #48225's ring-aware kernels; TP-axis collectives ring.
     pytest.param(
         (8, 4),
-        torus_xy_device_params(),
+        torus_xy_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         2,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
         id="torus-xy-8x4",
@@ -89,21 +96,27 @@ FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS = [
     # they are a distinct workload and are not substitutes for production 8x4 TorusXY coverage.
     pytest.param(
         (4, 4),
-        torus_y_device_params(),
+        torus_y_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         2,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
         id="torus-y-4x4",
     ),
     pytest.param(
         (4, 4),
-        torus_x_device_params(),
+        torus_x_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         2,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
         id="torus-x-4x4",
     ),
     pytest.param(
         (4, 4),
-        torus_xy_device_params(),
+        torus_xy_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         2,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
         id="torus-xy-4x4",

--- a/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py
+++ b/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py
@@ -85,7 +85,7 @@ def _read_cache_natural(cache, mesh_device, mesh_shape, sp: int, chunk_global: i
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -196,7 +196,7 @@ _MULTITURN_ITERS = [
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash_prefill_integration.py
+++ b/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash_prefill_integration.py
@@ -74,7 +74,7 @@ MAX_RANDOM_LAYERS = 12
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK27Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
+++ b/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
@@ -10,62 +10,54 @@ import re
 from pathlib import Path
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 
 
-def fabric2d_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+def fabric2d_device_params(*, model_config, **overrides) -> dict:
     """Unwrapped local Fabric2D profile for 2x2/2x4/4x2 Blackhole tests."""
     params = {
         "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-        "fabric_router_config": create_fabric_router_config(
-            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
-        ),
+        "fabric_router_config": create_fabric_router_config(max_payload_size=model_config.FABRIC_PAYLOAD_SIZE),
         "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     }
     params.update(overrides)
     return params
 
 
-def fabric_1d_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+def fabric_1d_device_params(*, model_config, **overrides) -> dict:
     """Unwrapped 1D fabric profile."""
     params = {
         "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        "fabric_router_config": create_fabric_router_config(
-            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
-        ),
+        "fabric_router_config": create_fabric_router_config(max_payload_size=model_config.FABRIC_PAYLOAD_SIZE),
         "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     }
     params.update(overrides)
     return params
 
 
-def torus_y_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+def torus_y_device_params(*, model_config, **overrides) -> dict:
     """Fabric2D Ring/Linear profile for an Nx1 mesh."""
     params = {
         "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-        "fabric_router_config": create_fabric_router_config(
-            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
-        ),
+        "fabric_router_config": create_fabric_router_config(max_payload_size=model_config.FABRIC_PAYLOAD_SIZE),
         "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     }
     params.update(overrides)
     return params
 
 
-def torus_x_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+def torus_x_device_params(*, model_config, **overrides) -> dict:
     """Fabric2D Linear/Ring profile for a 1xN mesh."""
     params = {
         "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-        "fabric_router_config": create_fabric_router_config(
-            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
-        ),
+        "fabric_router_config": create_fabric_router_config(max_payload_size=model_config.FABRIC_PAYLOAD_SIZE),
         "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     }
     params.update(overrides)
     return params
 
 
-def torus_xy_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+def torus_xy_device_params(*, model_config, **overrides) -> dict:
     """Production 8x4 Ring/Ring profile.
 
     Leave `TT_MESH_GRAPH_DESC_PATH` unset. A torus descriptor declares its channel counts
@@ -77,9 +69,7 @@ def torus_xy_device_params(*, fabric_payload_size=None, **overrides) -> dict:
     """
     params = {
         "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        "fabric_router_config": create_fabric_router_config(
-            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
-        ),
+        "fabric_router_config": create_fabric_router_config(max_payload_size=model_config.FABRIC_PAYLOAD_SIZE),
         "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     }
     params.update(overrides)

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_convolution.py
@@ -9,6 +9,8 @@ import torch
 
 import ttnn
 from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import collect_mesh_accuracy_and_determinism_results
 from models.demos.deepseek_v3_d_p.tt.kda.convolution import exchange_convolution_carry
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_equal
@@ -18,7 +20,7 @@ pytestmark = [
     pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
     pytest.mark.parametrize(
         "device_params",
-        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        [fabric_1d_device_params(model_config=KimiK3Config)],
         indirect=True,
     ),
 ]

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_recurrence.py
@@ -11,6 +11,8 @@ import torch
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda.ops import kda_recurrent_reference
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     collect_mesh_accuracy_and_determinism_results,
     compare_cpu_device,
@@ -297,7 +299,7 @@ def _run_distributed_recurrence(
 @pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric_1d_device_params(model_config=KimiK3Config)],
     indirect=True,
 )
 @pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
@@ -333,7 +335,7 @@ def test_distributed_recurrence_matches_serial_and_is_deterministic(
 @pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric_1d_device_params(model_config=KimiK3Config)],
     indirect=True,
 )
 @pytest.mark.parametrize("tensor_parallel_axis", [0, 1])

--- a/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/components/test_weights.py
@@ -9,6 +9,8 @@ import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
 from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import random_weights
 from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
 from models.demos.deepseek_v3_d_p.tt.kda.weights import load_kda_weights
@@ -38,7 +40,7 @@ def _tp_rank(physical_index: int, mesh_columns: int, tensor_parallel_axis: int) 
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric_1d_device_params(model_config=KimiK3Config)],
     indirect=True,
 )
 def test_device_weight_placement(
@@ -133,7 +135,7 @@ def test_device_weight_placement(
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric_1d_device_params(model_config=KimiK3Config)],
     indirect=True,
 )
 def test_tp_layer_with_nonsquare_state_matches_reference(mesh_device: ttnn.MeshDevice) -> None:

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_acceptance.py
@@ -13,6 +13,7 @@ import pytest
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     check_kimi_k3_accuracy,
@@ -35,13 +36,17 @@ _PCC_THRESHOLD = 0.9995
         pytest.param(
             (2, 4),
             1,
-            fabric_1d_device_params(),
+            fabric_1d_device_params(
+                model_config=KimiK3Config,
+            ),
             id="SP2xTP4-fabric-1d",
         ),
         pytest.param(
             (8, 4),
             1,
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=KimiK3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="SP8xTP4-torus-xy",
         ),
@@ -116,13 +121,39 @@ def test_synthetic_kimi_k3_accuracy_and_determinism(
 @pytest.mark.parametrize(
     "mesh_device,tensor_parallel_axis,device_params,sequence",
     [
-        pytest.param((1, 8), 1, fabric_1d_device_params(), 128, id="SP1xTP8"),
-        pytest.param((2, 4), 1, fabric_1d_device_params(), 128, id="SP2xTP4"),
-        pytest.param((2, 4), 0, fabric_1d_device_params(), 128, id="SP4xTP2"),
+        pytest.param(
+            (1, 8),
+            1,
+            fabric_1d_device_params(
+                model_config=KimiK3Config,
+            ),
+            128,
+            id="SP1xTP8",
+        ),
+        pytest.param(
+            (2, 4),
+            1,
+            fabric_1d_device_params(
+                model_config=KimiK3Config,
+            ),
+            128,
+            id="SP2xTP4",
+        ),
+        pytest.param(
+            (2, 4),
+            0,
+            fabric_1d_device_params(
+                model_config=KimiK3Config,
+            ),
+            128,
+            id="SP4xTP2",
+        ),
         pytest.param(
             (8, 4),
             1,
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=KimiK3Config,
+            ),
             512,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="SP8xTP4",

--- a/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/layer/test_distributed.py
@@ -11,6 +11,8 @@ import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
 from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
     collect_mesh_accuracy_and_determinism_results,
     random_weights,
@@ -28,7 +30,7 @@ pytestmark = [
     pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
     pytest.mark.parametrize(
         "device_params",
-        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        [fabric_1d_device_params(model_config=KimiK3Config)],
         indirect=True,
     ),
 ]

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
@@ -23,6 +23,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from models.demos.deepseek_v3_d_p.reference.kda import KDAReferenceState, kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric_1d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import KIMI_K3_FIRST_KDA_LAYER
 from models.demos.deepseek_v3_d_p.tests.kda.utils import (
@@ -405,9 +406,7 @@ def _trace_wall_samples_ms(
         # Ethernet-core recovery. SP2xTP4/SP4xTP2 were correct but 0.05%/0.10%
         # slower than FABRIC_1D; do not enable 2D until the SP1 failure is fixed.
         pytest.param(
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            },
+            fabric_1d_device_params(model_config=KimiK3Config),
             id="fabric_1d",
         ),
     ],
@@ -514,11 +513,20 @@ def test_kimi_k3_layer_1_perf(
 @pytest.mark.parametrize(
     "mesh_device,tensor_parallel_axis,device_params",
     [
-        pytest.param((2, 4), 1, fabric_1d_device_params(), id="SP2xTP4-fabric-1d"),
+        pytest.param(
+            (2, 4),
+            1,
+            fabric_1d_device_params(
+                model_config=KimiK3Config,
+            ),
+            id="SP2xTP4-fabric-1d",
+        ),
         pytest.param(
             (8, 4),
             1,
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=KimiK3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="SP8xTP4-torus-xy",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import rotate_half
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_d_p.tt.mla.utils import block_cyclic_reorder
@@ -265,7 +266,9 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     torus_x_device_params,
@@ -429,19 +430,25 @@ def test_update_padded_kv_cache_full_mesh_rejects_axis_topology(mesh_device, exp
     [
         pytest.param(
             (1, 4),
-            torus_x_device_params(),
+            torus_x_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),
@@ -815,7 +822,9 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -20,6 +20,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_y_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
@@ -205,7 +206,7 @@ def run_combine_op(
     [
         pytest.param(
             (4, 1),
-            torus_y_device_params(l1_small_size=512),
+            torus_y_device_params(model_config=DeepSeekV3Config, l1_small_size=512),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
             id="torus-y-4x1",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
@@ -16,7 +16,8 @@ import torch
 import ttnn
 from models.common.utility_functions import is_blackhole
 from models.demos.common.prefill.adapter import PrefillRunParams
-from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config, glm_hf_config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1 import GLM51Adapter
 from models.demos.deepseek_v3_d_p.tt.runners.kv_chunk_table import (
     _dram_chunk_size_bytes,
@@ -28,7 +29,7 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import PREFILL_CHUNK_TOKE
 
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    [fabric2d_device_params(model_config=GLM51Config)],
     indirect=True,
 )
 @pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
@@ -14,6 +14,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, extract_mesh_config, get_ep_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import compare_exact, validate_composed
@@ -56,13 +57,17 @@ def torch_masked_bincount(
         ),
         pytest.param(
             (1, 4),
-            torus_x_device_params(),
+            torus_x_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
@@ -22,6 +22,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.utils import rotated_chip_real_token_counts
 from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
@@ -32,13 +33,17 @@ from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 _MESHES = [
     pytest.param(
         (8, 4),
-        torus_xy_device_params(),
+        torus_xy_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
         id="torus-xy-8x4",
     ),
     pytest.param(
         (2, 4),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
         id="fabric2d-2x4",
     ),
@@ -155,7 +160,9 @@ def test_moe_padding_config_left_padding(mesh_device):
     [
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         )

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_offset_cumsum.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_offset_cumsum.py
@@ -14,6 +14,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_y_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import extract_mesh_config
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
@@ -75,21 +76,27 @@ def torch_offset_cumsum(
     [
         pytest.param(
             (4, 1),
-            torus_y_device_params(),
+            torus_y_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
             id="torus-y-4x1",
         ),
         pytest.param(
             (4, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -433,7 +433,7 @@ def _cross_product_conflated_cmb_test_dimensions():
     params = []
     for model_name, model_config_class, test_meshes in COMBINE_MODELS:
         for target_mesh, fabric_cfg in test_meshes.target_meshes.items():
-            device_params = fabric_to_device_params(fabric_cfg)
+            device_params = fabric_to_device_params(fabric_cfg, model_config_class)
             topo_marker = _topo_marker(target_mesh, fabric_cfg)
             marks = pytest.mark.requires_mesh_topology(mesh_shape=target_mesh, topology=topo_marker)
             test_scenarios = [
@@ -579,7 +579,7 @@ def _all_externally_owned_test_cases():
         model_name = model.__class__.__name__.removesuffix("Config")
         return pytest.param(
             mesh,
-            fabric_to_device_params(fabric_cfg),
+            fabric_to_device_params(fabric_cfg, model),
             seq_len_per_chip,
             model.EMB_SIZE,
             model.NUM_ROUTED_EXPERTS,
@@ -668,7 +668,7 @@ def _cmb_fabric2d_dimensions():
         params.append(
             pytest.param(
                 mesh,
-                fabric_to_device_params(fabric_cfg),
+                fabric_to_device_params(fabric_cfg, DeepSeekV3Config),
                 per_axis_topology(fabric_cfg)[0],  # sp axis; the op rings along cluster_axis=sp_axis
                 seq_len_per_chip,
                 model_config.EMB_SIZE,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
@@ -40,13 +40,17 @@ from tests.ttnn.utils_for_testing import comp_pcc
 REDUCE_MESH_PARAMS = [
     pytest.param(
         (4, 1),
-        torus_y_device_params(),
+        torus_y_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
         id="torus-y-4x1",
     ),
     pytest.param(
         (4, 2),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
         id="fabric2d-mesh-4x2",
     ),
@@ -55,7 +59,9 @@ REDUCE_MESH_PARAMS = [
     # so the only one covering mistral_small_4 (or any model) on Blackhole.
     pytest.param(
         (8, 4),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
         id="fabric2d-mesh-8x4",
     ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -9,6 +9,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
@@ -505,7 +506,9 @@ def _ci_unsupported_param_combos_mla_sdpa_perf(**params):
 @pytest.mark.parametrize(
     "device_params",
     [
-        fabric2d_device_params(trace_region_size=1000000, worker_l1_size=_WORKER_L1_SIZE),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config, trace_region_size=1000000, worker_l1_size=_WORKER_L1_SIZE
+        ),
     ],
     indirect=["device_params"],
     ids=["fabric2d"],
@@ -874,19 +877,19 @@ def run_ring_joint_sdpa_perf(
     [
         pytest.param(
             (32, 4),
-            fabric2d_device_params(worker_l1_size=_WORKER_L1_SIZE),
+            fabric2d_device_params(model_config=DeepSeekV3Config, worker_l1_size=_WORKER_L1_SIZE),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(32, 4), topology="mesh-32x4"),
             id="fabric2d-32x4",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(worker_l1_size=_WORKER_L1_SIZE),
+            fabric2d_device_params(model_config=DeepSeekV3Config, worker_l1_size=_WORKER_L1_SIZE),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(worker_l1_size=_WORKER_L1_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config, worker_l1_size=_WORKER_L1_SIZE),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py
@@ -10,6 +10,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.reference.modeling_deepseek import rotate_half
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, get_cos_sin_matrix
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
@@ -42,7 +43,11 @@ def _ci_unsupported_param_combos(**params):
 )
 @pytest.mark.parametrize(
     "device_params",
-    [fabric2d_device_params()],
+    [
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        )
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize("seq_len", [128 * 1024], ids=["seq128k"])

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_sub_device_load_clear_timing.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_sub_device_load_clear_timing.py
@@ -37,6 +37,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 
 # Path the test writes its host-profiler samples to so the wrapper can include
@@ -93,7 +94,9 @@ def _two_ops_subdevice(mesh_device, x, w, sd_id, core_grid, ckc):
     [
         pytest.param(
             (4, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-mesh-4x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
@@ -530,7 +530,9 @@ def test_ttnn_dispatch_combine(
     [
         pytest.param(
             (8, 1),
-            torus_y_device_params(),
+            torus_y_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
             id="fabric2d-torus-y-8x1-1link",
@@ -693,7 +695,9 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, device_params, num_links, o
     [
         pytest.param(
             (8, 1),
-            torus_y_device_params(),
+            torus_y_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
             id="fabric2d-torus-y-8x1-1link",

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     torus_xy_device_params,
@@ -51,13 +52,17 @@ _FORMAT_IDS = ["bfp8_tile", "bf16_rm", "fp8_rm"]
 _MESHES = [
     pytest.param(
         (8, 1),
-        torus_y_device_params(),
+        torus_y_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
         id="torus-y-8x1",
     ),
     pytest.param(
         (8, 4),
-        torus_xy_device_params(),
+        torus_xy_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
         id="torus-xy-8x4",
     ),
@@ -169,7 +174,9 @@ def _assert_cache_windows(
     [
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -23,6 +23,7 @@ Test-id naming convention
 import pytest
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     fabric_1d_device_params,
@@ -30,10 +31,9 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     torus_xy_device_params,
     torus_y_device_params,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_max_payload_size
 
 
-def _mesh_param(shape, fabric, payload, nlinks, topo_marker, test_id, reliability_mode=None):
+def _mesh_param(shape, fabric, model_config, nlinks, topo_marker, test_id, reliability_mode=None):
     """Build a single pytest.param for the mesh_device parametrize axis.
 
     `topo_marker` is the CI hardware-class string consumed by the `requires_mesh_topology`
@@ -45,7 +45,7 @@ def _mesh_param(shape, fabric, payload, nlinks, topo_marker, test_id, reliabilit
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y: torus_y_device_params,
         ttnn.FabricConfig.FABRIC_2D_TORUS_XY: torus_xy_device_params,
     }[fabric]
-    device_params = profile(fabric_payload_size=payload)
+    device_params = profile(model_config=model_config)
     if reliability_mode is not None:
         device_params["reliability_mode"] = reliability_mode
     return pytest.param(
@@ -57,12 +57,14 @@ def _mesh_param(shape, fabric, payload, nlinks, topo_marker, test_id, reliabilit
     )
 
 
+# These topology-only fixtures are shared across model tests. DeepSeek has the largest
+# payload of the supported configs (tied with Kimi), so it is the safe dominant profile.
 ALL_MESH_CONFIGS = [
     # Local policy: one 2x2 QuietBox case, canonical 2x4 LoudBox, and one 4x2 axis diagnostic.
     _mesh_param(
         (2, 2),
         ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         1,
         "mesh-4x2",
         "fabric2d-mesh-2x2",
@@ -71,7 +73,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (4, 2),
         ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         1,
         "mesh-4x2",
         "fabric2d-mesh-4x2",
@@ -80,7 +82,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (4, 2),
         ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         2,
         "mesh-4x2",
         "fabric2d-mesh-4x2-2link",
@@ -89,7 +91,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (2, 4),
         ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         1,
         "mesh-4x2",
         "fabric2d-mesh-2x4",
@@ -99,7 +101,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (4, 1),
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         1,
         "ring",
         "fabric2d-torus-y-4x1-1link",
@@ -108,7 +110,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (4, 1),
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         2,
         "ring",
         "fabric2d-torus-y-4x1-2link",
@@ -118,7 +120,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (8, 1),
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         1,
         "ring",
         "fabric2d-torus-y-8x1-1link",
@@ -127,7 +129,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (8, 1),
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         2,
         "ring",
         "fabric2d-torus-y-8x1-2link",
@@ -137,7 +139,7 @@ ALL_MESH_CONFIGS = [
     _mesh_param(
         (8, 4),
         ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        get_max_payload_size(),
+        DeepSeekV3Config,
         2,
         "mesh-8x4",
         "fabric2d-torus-xy-8x4-2link",
@@ -146,7 +148,7 @@ ALL_MESH_CONFIGS = [
 ]
 
 
-def fabric_to_device_params(fabric_cfg):
+def fabric_to_device_params(fabric_cfg, model_config):
     assert fabric_cfg in (
         ttnn.FabricConfig.FABRIC_1D,
         ttnn.FabricConfig.FABRIC_2D,
@@ -155,11 +157,11 @@ def fabric_to_device_params(fabric_cfg):
         ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
     )
     if fabric_cfg == ttnn.FabricConfig.FABRIC_1D:
-        return fabric_1d_device_params()
+        return fabric_1d_device_params(model_config=model_config)
     if fabric_cfg == ttnn.FabricConfig.FABRIC_2D:
-        return fabric2d_device_params()
+        return fabric2d_device_params(model_config=model_config)
     if fabric_cfg == ttnn.FabricConfig.FABRIC_2D_TORUS_X:
-        return torus_x_device_params()
+        return torus_x_device_params(model_config=model_config)
     if fabric_cfg == ttnn.FabricConfig.FABRIC_2D_TORUS_Y:
-        return torus_y_device_params()
-    return torus_xy_device_params()
+        return torus_y_device_params(model_config=model_config)
+    return torus_xy_device_params(model_config=model_config)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
@@ -16,6 +16,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params, torus_xy_device_params
@@ -38,12 +39,16 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
     ids=["isl_5k", "isl_5k-k3-33792-situ"],
 )
+# The model-shape and mesh axes are crossed independently. DeepSeek and Kimi K3
+# have the same embedding size and therefore the same fabric payload.
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links",
     [
         pytest.param(
             (1, 4),
-            torus_x_device_params(),
+            torus_x_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
@@ -52,7 +57,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         # only param where the SiTU case can run at all -- SiTU needs ttnn.softcap, Blackhole-only.
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -102,28 +102,36 @@ def _ci_unsupported_param_combos_global_to_local_token_id(**params):
     [
         pytest.param(
             (1, 4),
-            torus_x_device_params(),
+            torus_x_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -31,7 +31,6 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     GATE_KEY_PREFIX_KIMI_K3,
     create_fabric_router_config,
     create_gate_weights,
-    get_max_payload_size,
     get_sp_mesh_composer,
     load_gate_weights_from_hf,
 )
@@ -198,25 +197,33 @@ def _try_load_real_gate_input(max_seq_len: int, dim: int) -> torch.Tensor | None
     return load_trace_gate_input(trace_dir, layer_idx=_MOE_LAYER_IDX, max_seq_len=max_seq_len, dim=dim)
 
 
-# Mesh topologies shared by the regular-gate and hash-gate PCC tests.
+# Mesh topologies shared by every model in the regular-gate and hash-gate PCC tests.
+# DeepSeek's payload is the largest supported value (tied with Kimi), so it is the
+# safe dominant config for this independent pytest axis.
 MESH_CONFIGS = [
     pytest.param(
         (2, 2),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         2,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
         id="fabric2d-mesh-2x2",
     ),
     pytest.param(
         (2, 4),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         2,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
         id="fabric2d-mesh-2x4",
     ),
     pytest.param(
         (8, 4),
-        torus_xy_device_params(),
+        torus_xy_device_params(
+            model_config=DeepSeekV3Config,
+        ),
         2,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
         id="torus-xy-8x4",
@@ -228,7 +235,7 @@ LOUDBOX_TP1_MESH_CONFIG = pytest.param(
     (8, 1),
     {
         "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+        "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
     },
     1,
     ttnn.Topology.Linear,
@@ -243,7 +250,7 @@ GALAXY_TP4_MESH_CONFIG = pytest.param(
     (8, 4),
     {
         "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+        "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
     },
     2,
     ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -16,6 +16,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 
 # from models.demos.deepseek_v3_d_p.reference.moe.dispatch import TorchDispatchModule
@@ -55,14 +56,14 @@ from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
     [
         pytest.param(
             (2, 2),
-            fabric2d_device_params(fabric_payload_size=7 * 1024),
+            fabric2d_device_params(model_config=DeepSeekV3Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-mesh-2x2",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(fabric_payload_size=7 * 1024),
+            fabric2d_device_params(model_config=DeepSeekV3Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -42,13 +42,17 @@ from tests.ttnn.utils_for_testing import comp_pcc
     [
         pytest.param(
             (1, 4),
-            torus_x_device_params(),
+            torus_x_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         ),
@@ -56,7 +60,9 @@ from tests.ttnn.utils_for_testing import comp_pcc
         # the embedding at the mesh it actually runs on.
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -19,6 +19,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params, torus_y_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
@@ -48,7 +49,9 @@ def _ci_unsupported_param_combos(**params):
     [
         pytest.param(
             (1, 4),
-            torus_x_device_params(),
+            torus_x_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
@@ -162,7 +165,7 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
     [
         pytest.param(
             (8, 1),
-            torus_y_device_params(fabric_payload_size=7 * 1024),
+            torus_y_device_params(model_config=DeepSeekV3Config),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
             id="torus-y-8x1",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -92,19 +92,25 @@ def shared_expert_sub_device(mesh_device):
     # v4_pro shape).
     ids=["isl_5k", "isl_5k-k3-6144", "isl_5k-k3-6144-situ", "isl_5k-v4pro-3072"],
 )
+# The model-shape and mesh axes are crossed independently. Every model above has
+# EMB_SIZE=7168, so Kimi K2.7's payload is also the exact payload for all cases.
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links",
     [
         pytest.param(
             (1, 4),
-            torus_x_device_params(),
+            torus_x_device_params(
+                model_config=KimiK27Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=KimiK27Config,
+            ),
             1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
@@ -113,7 +119,7 @@ def shared_expert_sub_device(mesh_device):
         # only param where the SiTU cases can run at all -- SiTU needs ttnn.softcap, Blackhole-only.
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK27Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py
@@ -96,24 +96,32 @@ _MODEL_CONFIGS_FORWARD = [pytest.param(cfg, fwd, id=name) for name, cfg, _, _, f
 
 
 # Blackhole runs a mesh config only when it uses every chip, so one shape per box class.
+# The mesh axis is shared by Flash and Pro; Pro is the tested model with the larger
+# payload, so its router config safely covers both variants.
 _MESH_CONFIGS = [
     pytest.param(
         (2, 2),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV4ProConfig,
+        ),
         ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
         id="fabric2d-mesh-2x2",
     ),
     pytest.param(
         (4, 2),
-        fabric2d_device_params(),
+        fabric2d_device_params(
+            model_config=DeepSeekV4ProConfig,
+        ),
         ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
         id="fabric2d-mesh-4x2",
     ),
     pytest.param(
         (8, 4),
-        torus_xy_device_params(),
+        torus_xy_device_params(
+            model_config=DeepSeekV4ProConfig,
+        ),
         ttnn.Topology.Ring,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
         id="torus-xy-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -762,28 +762,28 @@ def _ci_unsupported_param_combos_ds_moe(**params):
         # its non-TP ops on the assumption that this slot is an SP=8 run.
         pytest.param(
             (8, 1),
-            torus_y_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_y_device_params(model_config=DeepSeekV3Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
             id="torus-y-8x1",
         ),
         pytest.param(
             (4, 2),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=DeepSeekV3Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=DeepSeekV3Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -857,28 +857,28 @@ def test_ds_moe(
     [
         pytest.param(
             (8, 1),
-            torus_y_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_y_device_params(model_config=GLM52Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
             id="torus-y-8x1",
         ),
         pytest.param(
             (4, 2),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=GLM52Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=GLM52Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=GLM52Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -989,21 +989,21 @@ def _run_moe_case(
     [
         pytest.param(
             (4, 2),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=KimiK27Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (2, 4),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=KimiK27Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK27Config),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -1071,14 +1071,14 @@ def test_kimi_moe(
         # at TP=1 the shared expert is unsharded and its gate matmul's CBs exceed L1.
         pytest.param(
             (2, 4),
-            fabric2d_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=KimiK3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -1190,7 +1190,7 @@ def test_kimi_k3_moe(
             # reports green. FABRIC_2D is what this test ran under on ssalice/mistral4-119b-prefill,
             # where it genuinely passed on CI. Revert once bh_sc1 is ring-cabled.
             fabric2d_device_params(
-                fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE,
+                model_config=MistralSmall4Config,
             ),
             2 if is_blackhole() else 1,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
@@ -57,9 +57,6 @@ _SEQ_LEN_PER_CHIP = PREFILL_CHUNK_TOKENS_PER_CHIP
 # slots (top-8 -> top-16), so per-chip dispatch bytes are roughly unchanged.
 _DISPATCH_BUFFER_CAPACITY_FACTOR = 5
 
-# Both generations carry FABRIC_PAYLOAD_SIZE = 7168, so one device_params axis serves both.
-_FABRIC_PAYLOAD_SIZE = KimiK27Config.FABRIC_PAYLOAD_SIZE
-
 # The profiler's default 1s collection deadline is sized for a single block's programs. The MoE
 # forward at 896 experts dispatches far more, and records arrive asynchronously from the receiver
 # thread: a record still in flight when the window closes is NOT counted as dropped, so a short
@@ -146,8 +143,16 @@ _K3 = _MoEPerfCase(
 # "k2_7" / "k3", not "kimi_k2_7" / "kimi_k3": pytest -k is substring-based, so the ids must stay
 # disjoint -- a bare "kimi" id would match both generations and widen every `-k` selector.
 _CASES = [
-    pytest.param("kimi_k2_7", _K2_7, id="k2_7"),
-    pytest.param("kimi_k3", _K3, id="k3"),
+    pytest.param(
+        variant,
+        case,
+        (8, 4),
+        torus_xy_device_params(model_config=case.config),
+        2,
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+        id=f"{label}-torus-xy-8x4",
+    )
+    for variant, case, label in [("kimi_k2_7", _K2_7, "k2_7"), ("kimi_k3", _K3, "k3")]
 ]
 
 
@@ -159,19 +164,10 @@ _CASES = [
 )
 @pytest.mark.timeout(0)
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links",
-    [
-        pytest.param(
-            (8, 4),
-            torus_xy_device_params(fabric_payload_size=_FABRIC_PAYLOAD_SIZE),
-            2,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="torus-xy-8x4",
-        ),
-    ],
-    indirect=["mesh_device", "device_params"],
+    "variant, case, mesh_device, device_params, num_links",
+    _CASES,
+    indirect=["variant", "mesh_device", "device_params"],
 )
-@pytest.mark.parametrize("variant, case", _CASES, indirect=["variant"])
 def test_kimi_moe_perf_galaxy(variant, case, config_only, mesh_device, device_params, num_links, request):
     """Device time of one MoE forward at the 5k production chunk, per Kimi generation."""
     require_realtime_profiler(f"the {case.label} MoE perf gate")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_mesh.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_mesh.py
@@ -30,6 +30,7 @@ import os
 import pytest
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     torus_x_device_params,
@@ -114,19 +115,19 @@ def parametrize_mesh_and_device_params(*, worker_l1_size, torus_xy_certified=Fal
             marker = None
             profile = "disabled"
         elif shape[1] == 1 and shape[0] > 2:
-            device_params = torus_y_device_params(worker_l1_size=worker_l1_size)
+            device_params = torus_y_device_params(model_config=GLM51Config, worker_l1_size=worker_l1_size)
             marker = "ring"
             profile = "torus-y"
         elif shape[0] == 1 and shape[1] > 2:
-            device_params = torus_x_device_params(worker_l1_size=worker_l1_size)
+            device_params = torus_x_device_params(model_config=GLM51Config, worker_l1_size=worker_l1_size)
             marker = "ring"
             profile = "torus-x"
         elif shape == (8, 4) and torus_xy_certified:
-            device_params = torus_xy_device_params(worker_l1_size=worker_l1_size)
+            device_params = torus_xy_device_params(model_config=GLM51Config, worker_l1_size=worker_l1_size)
             marker = "mesh-8x4"
             profile = "torus-xy"
         else:
-            device_params = fabric2d_device_params(worker_l1_size=worker_l1_size)
+            device_params = fabric2d_device_params(model_config=GLM51Config, worker_l1_size=worker_l1_size)
             marker = f"mesh-{shape[0]}x{shape[1]}"
             profile = "fabric2d"
         marks = [] if marker is None else pytest.mark.requires_mesh_topology(mesh_shape=shape, topology=marker)
@@ -142,7 +143,7 @@ def parametrize_mesh_and_device_params(*, worker_l1_size, torus_xy_certified=Fal
         params.append(
             pytest.param(
                 (2, 2),
-                fabric2d_device_params(worker_l1_size=worker_l1_size),
+                fabric2d_device_params(model_config=GLM51Config, worker_l1_size=worker_l1_size),
                 marks=pytest.mark.skip(reason=f"unsupported device count {detect_num_devices()}"),
                 id="unsupported",
             )

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -16,6 +16,7 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     torus_x_device_params,
@@ -94,10 +95,10 @@ def _worker_l1_size():
 def _device_params_for_mesh(mesh):
     """Assign one fabric to each existing mesh; topology is not a separate test axis."""
     if mesh == (1, 4):
-        return torus_x_device_params(worker_l1_size=_worker_l1_size())
+        return torus_x_device_params(model_config=GLM51Config, worker_l1_size=_worker_l1_size())
     if mesh == (8, 4):
-        return torus_xy_device_params(worker_l1_size=_worker_l1_size())
-    return fabric2d_device_params(worker_l1_size=_worker_l1_size())
+        return torus_xy_device_params(model_config=GLM51Config, worker_l1_size=_worker_l1_size())
+    return fabric2d_device_params(model_config=GLM51Config, worker_l1_size=_worker_l1_size())
 
 
 def _seq_ok_for_mesh(seq_len, mesh):
@@ -121,7 +122,7 @@ def _sparse_cases(seqs, anchor_only):
                 SPARSE_VARIANTS[0],
                 (2, 2),
                 seqs[-1],
-                fabric2d_device_params(worker_l1_size=_worker_l1_size()),
+                fabric2d_device_params(model_config=GLM51Config, worker_l1_size=_worker_l1_size()),
                 marks=pytest.mark.skip(reason=f"unsupported device count {num_devices}"),
                 id="unsupported-fabric2d",
             )

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -24,8 +24,14 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import random_mla_weights
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_2_config import DeepseekV32Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config, glm_5_2_hf_config
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    fabric_1d_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
     ReuseIndexer,
@@ -359,7 +365,8 @@ def _build_mla(config, state_dict, mesh_device, weight_cache_path):
         pytest.param(
             (4, 2),
             fabric2d_device_params(
-                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+                model_config=GLM51Config,
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
             ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-4x2",
@@ -439,7 +446,8 @@ def test_sparse_mla_cache_only_stays_sparse(mesh_device, device_params, variant,
         pytest.param(
             (8, 4),
             torus_xy_device_params(
-                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+                model_config=GLM52Config,
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
             ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -493,10 +501,10 @@ def test_glm52_shared_layer_cache_skips_indexer(mesh_device, device_params, vari
     [
         pytest.param(
             (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
+            fabric_1d_device_params(
+                model_config=DeepseekV32Config,
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="linear"),
             id="linear-4x2",
         ),
@@ -548,10 +556,10 @@ def _build_mla_tp(config, state_dict, mesh_device, *, tp_shard_kv):
     [
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
+            fabric_1d_device_params(
+                model_config=GLM51Config,
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="mesh-2x4",
         ),
@@ -651,10 +659,10 @@ def _run_chunked(mla, mesh_device, rope_tensors, kvpe_cache, index_kv_cache, hid
     [
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
+            fabric_1d_device_params(
+                model_config=GLM51Config,
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="mesh-2x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_ccl_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_ccl_perf.py
@@ -23,7 +23,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config, glm_hf_config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     torus_xy_device_params,
@@ -260,14 +260,14 @@ def ccl_mesh_param(collective_axis: int):
     to TorusY for SP-axis collectives, or the existing 2x4 Fabric2D proxy for TP collectives.
     """
     num_devices = detect_num_devices()
-    fabric_2d = fabric2d_device_params(trace_region_size=100000)
-    torus_xy = torus_xy_device_params(trace_region_size=100000)
+    fabric_2d = fabric2d_device_params(model_config=GLM51Config, trace_region_size=100000)
+    torus_xy = torus_xy_device_params(model_config=GLM51Config, trace_region_size=100000)
     if num_devices == 32:
         system, mesh_shape, mesh_topology, device_params = "galaxy_torus_xy", (8, 4), "mesh-8x4", torus_xy
     elif num_devices == 8:
         if collective_axis == SP_AXIS:
             system, mesh_shape, mesh_topology = "loudbox_torus_y", (8, 1), "ring"
-            device_params = torus_y_device_params(trace_region_size=100000)
+            device_params = torus_y_device_params(model_config=GLM51Config, trace_region_size=100000)
         else:
             system, device_params = "loudbox_fabric2d", fabric_2d
             mesh_shape, mesh_topology = (2, 4), "mesh-2x4"

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -130,7 +130,7 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import random_mla_weights
-from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config, glm_hf_config
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import glm_5_2_hf_config
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import detect_num_devices
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_marker_explicitly_selected
@@ -138,7 +138,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import m
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
@@ -692,7 +692,7 @@ PERF_CASES = [
     [
         {
             "fabric_config": PERF_FABRIC,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+            "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
         }

--- a/models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py
@@ -20,6 +20,7 @@ import torch
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 
 _TOKENS_PER_ROW = 640  # tokens of the chunk carried per mesh row (the realistic knob)
@@ -62,7 +63,9 @@ def _to_device(torch_u32, mesh, mapper):
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),
@@ -71,7 +74,9 @@ def _to_device(torch_u32, mesh, mapper):
         # small multi-card box (no 32-chip Galaxy needed).
         pytest.param(
             (2, 2),
-            fabric2d_device_params(),
+            fabric2d_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
             id="fabric2d-2x2",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
@@ -28,7 +28,9 @@ from tests.ttnn.utils_for_testing import comp_pcc
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/test_h2d_socket_sync.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_h2d_socket_sync.py
@@ -26,7 +26,9 @@ _METADATA_SIZE_BYTES = 12
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(),
+            torus_xy_device_params(
+                model_config=DeepSeekV3Config,
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -12,7 +12,16 @@ from loguru import logger
 from ttnn.device import is_blackhole
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_7_config import KimiK27Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    fabric_1d_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import build_weights
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
@@ -42,7 +51,11 @@ from tests.ttnn.utils_for_testing import assert_equal
 )
 @pytest.mark.parametrize(
     "device_params",
-    [torus_xy_device_params()],
+    [
+        torus_xy_device_params(
+            model_config=KimiK27Config,
+        )
+    ],
     ids=["torus-xy"],
     indirect=True,
 )
@@ -168,7 +181,11 @@ def test_kimi_kv_cache_table(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [torus_xy_device_params()],
+    [
+        torus_xy_device_params(
+            model_config=KimiK27Config,
+        )
+    ],
     ids=["torus-xy"],
     indirect=True,
 )
@@ -275,7 +292,11 @@ def test_kimi_kv_cache_mock(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [torus_xy_device_params()],
+    [
+        torus_xy_device_params(
+            model_config=DeepSeekV3Config,
+        )
+    ],
     ids=["torus-xy"],
     indirect=True,
 )
@@ -436,9 +457,7 @@ def test_dflash_kv_cache_mock(
 @pytest.mark.parametrize(
     "device_params",
     [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        },
+        fabric_1d_device_params(model_config=GLM51Config),
     ],
     ids=["line"],
     indirect=True,
@@ -662,12 +681,8 @@ def test_glm_kv_cache_table(
 @pytest.mark.parametrize(
     "device_params",
     [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-        },
+        fabric_1d_device_params(model_config=GLM52Config),
+        fabric_1d_device_params(model_config=GLM52Config, fabric_config=ttnn.FabricConfig.FABRIC_1D_RING),
     ],
     ids=["line", "ring"],
     indirect=True,
@@ -802,8 +817,20 @@ def test_glm52_tp_sharded_kv_cache_mock(
 @pytest.mark.parametrize(
     "mesh_device,device_params",
     [
-        pytest.param((2, 4), fabric2d_device_params(), id="fabric2d-2x4"),
-        pytest.param((8, 4), torus_xy_device_params(), id="torus-xy-8x4"),
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(
+                model_config=GLM52Config,
+            ),
+            id="fabric2d-2x4",
+        ),
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(
+                model_config=GLM52Config,
+            ),
+            id="torus-xy-8x4",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -1174,7 +1201,7 @@ def test_glm52_tp_sharded_pipeline_stage_addresses():
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric_1d_device_params(model_config=MistralSmall4Config)],
     ids=["line"],
     indirect=True,
 )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -19,8 +19,15 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.common.utility_functions import comp_pcc, hf_cache_layer_kv
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_7_config import KimiK27Config
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    fabric_1d_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_mla
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
@@ -441,11 +448,7 @@ def run_model(
 @pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-        },
-    ],
+    [fabric2d_device_params(model_config=MistralSmall4Config)],
     ids=["fabric2d"],
     indirect=True,
 )
@@ -965,7 +968,7 @@ def _run_chunked_prefill(
 @pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric_1d_device_params(model_config=MistralSmall4Config)],
     ids=["line"],
     indirect=True,
 )
@@ -1085,7 +1088,7 @@ def test_llama4_query_scale_matches_rotated_positions(request, mesh_device, kv_a
 @pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [fabric_1d_device_params(model_config=MistralSmall4Config)],
     ids=["line"],
     indirect=True,
 )
@@ -1195,7 +1198,7 @@ def test_llama4_query_scale_is_applied_in_q_stem(request, mesh_device, kv_actual
 @pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 16 * 1024 * 1024}],
+    [fabric_1d_device_params(model_config=MistralSmall4Config, trace_region_size=16 * 1024 * 1024)],
     ids=["line"],
     indirect=True,
 )
@@ -1306,15 +1309,18 @@ _CHUNKED_SCENARIOS = (
 )
 
 
+# This mesh axis is crossed independently with Kimi K2.7, Kimi K3, and Mistral.
+# Kimi K2.7 has the largest payload among those variants (tied with Kimi K3), so
+# it safely covers every variant while keeping the axes independent.
 @pytest.mark.parametrize(
     "mesh_device,device_params",
     [
-        pytest.param((2, 2), fabric2d_device_params(l1_small_size=1152), id="fabric2d-2x2"),
-        pytest.param((2, 4), fabric2d_device_params(l1_small_size=1152), id="fabric2d-2x4"),
+        pytest.param((2, 2), fabric2d_device_params(model_config=KimiK27Config, l1_small_size=1152), id="fabric2d-2x2"),
+        pytest.param((2, 4), fabric2d_device_params(model_config=KimiK27Config, l1_small_size=1152), id="fabric2d-2x4"),
         # high_bw_all_gather parks readiness/completion semaphores in L1_SMALL. On 8x4 the
         # fallback fragments general L1 enough that a later op's static circular buffers collide.
         #
-        pytest.param((8, 4), torus_xy_device_params(l1_small_size=1152), id="torus-xy-8x4"),
+        pytest.param((8, 4), torus_xy_device_params(model_config=KimiK27Config, l1_small_size=1152), id="torus-xy-8x4"),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -1408,7 +1414,7 @@ def test_mla_chunked_prefill(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(l1_small_size=1152),
+            torus_xy_device_params(model_config=KimiK3Config, l1_small_size=1152),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -590,35 +590,35 @@ def _ci_unsupported_param_combos(**params):
     [
         pytest.param(
             (2, 4),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),
         pytest.param(
             (4, 4),
-            torus_y_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_y_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
             id="torus-y-4x4",
         ),
         pytest.param(
             (4, 4),
-            torus_x_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_x_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
             id="torus-x-4x4",
         ),
         pytest.param(
             (4, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
             id="torus-xy-4x4",
@@ -713,7 +713,7 @@ def test_ds_prefill_block(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK27Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -810,7 +810,7 @@ def test_kimi_prefill_block(
     [
         pytest.param(
             (8, 4),
-            fabric2d_device_params(fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=MistralSmall4Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="fabric2d-mesh-8x4",
@@ -985,7 +985,7 @@ def _glm_pretrained_weights(config, model_dir, layer_idx, is_moe):
         pytest.param(
             (8, 4),
             torus_xy_device_params(
-                fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE,
+                model_config=GLM51Config,
                 worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE,
             ),
             2,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
@@ -365,7 +365,7 @@ def run_chunked_block(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -540,7 +540,7 @@ def run_chunked_block_multiuser(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -822,7 +822,7 @@ def run_chunked_block_padded(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -872,7 +872,7 @@ def test_ds_prefill_block_chunked_padded(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK27Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -919,7 +919,7 @@ def test_kimi_prefill_block_chunked(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK27Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -1125,7 +1125,7 @@ def run_chunked_block_glm_indexer(
         pytest.param(
             (8, 4),
             # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
-            torus_xy_device_params(fabric_payload_size=GLM52Config.FABRIC_PAYLOAD_SIZE, l1_small_size=768),
+            torus_xy_device_params(model_config=GLM52Config, l1_small_size=768),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
@@ -113,7 +113,7 @@ def _ci_unsupported_param_combos(**params):
             ),
             pytest.param(
                 (2, 4),
-                fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.EMB_SIZE),
+                fabric2d_device_params(model_config=DeepSeekV3Config),
                 2,
                 marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
                 id="fabric2d-mesh-2x4-2link",

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -1074,7 +1074,7 @@ def test_ds_prefill_transformer(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=KimiK27Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -1178,7 +1178,7 @@ def test_kimi_prefill_transformer(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=GLM51Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -1318,7 +1318,7 @@ MISTRAL4_THRESHOLDS = PrefillTransformerThresholds(
     [
         pytest.param(
             (8, 4),
-            fabric2d_device_params(fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE),
+            fabric2d_device_params(model_config=MistralSmall4Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="fabric2d-mesh-8x4",

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1072,7 +1072,7 @@ def run_chunked_transformer(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -1114,7 +1114,7 @@ def test_ds_prefill_transformer_chunked(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -1172,7 +1172,7 @@ _PADDED_MODES = ["notrace", "traced"]
             (8, 4),
             # L1_SMALL holds the routing semaphores plus sparse-MLA high-bandwidth-gather semaphores.
             torus_xy_device_params(
-                fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE,
+                model_config=KimiK27Config,
                 l1_small_size=768,
                 trace_region_size=256 * 1024 * 1024,
             ),
@@ -1241,7 +1241,7 @@ def test_kimi_prefill_transformer_chunked_padded(
         pytest.param(
             (8, 4),
             torus_xy_device_params(
-                fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE,
+                model_config=MistralSmall4Config,
                 l1_small_size=768,
                 trace_region_size=256 * 1024 * 1024,
             ),
@@ -1309,7 +1309,7 @@ def test_mistral4_prefill_transformer_chunked_padded(
             # trace_region_size: without it the captured buffers fall back to general DRAM and
             # trace_bytes() reads 0.
             torus_xy_device_params(
-                fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE,
+                model_config=MistralSmall4Config,
                 l1_small_size=768,
                 trace_region_size=256 * 1024 * 1024,
             ),
@@ -1399,7 +1399,7 @@ def test_mistral4_prefill_transformer_chunked_no_pcc(
         pytest.param(
             (8, 4),
             torus_xy_device_params(
-                fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE,
+                model_config=GLM51Config,
                 l1_small_size=GLM_L1_SMALL_SIZE,
                 trace_region_size=GLM_TRACE_REGION_SIZE,
             ),
@@ -2313,7 +2313,7 @@ def glm_chunked_perf_gate(variant, use_trace, num_layers, n_chunks, num_iters, p
         pytest.param(
             (8, 4),
             torus_xy_device_params(
-                fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE,
+                model_config=KimiK27Config,
                 l1_small_size=768,
                 trace_region_size=256 * 1024 * 1024,
             ),
@@ -2405,7 +2405,7 @@ def test_kimi_prefill_transformer_chunked_perf(
         pytest.param(
             (8, 4),
             torus_xy_device_params(
-                fabric_payload_size=KimiK27Config.FABRIC_PAYLOAD_SIZE,
+                model_config=KimiK27Config,
                 l1_small_size=768,
                 trace_region_size=256 * 1024 * 1024,
             ),
@@ -2482,7 +2482,7 @@ def test_kimi_prefill_transformer_chunked(
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
+            torus_xy_device_params(model_config=DeepSeekV3Config),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
@@ -2554,7 +2554,7 @@ def test_ds_prefill_transformer_chunked_no_pcc(
         pytest.param(
             (8, 4),
             torus_xy_device_params(
-                fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE,
+                model_config=GLM51Config,
                 l1_small_size=GLM_L1_SMALL_SIZE,
                 trace_region_size=GLM_TRACE_REGION_SIZE,
             ),
@@ -2567,7 +2567,7 @@ def test_ds_prefill_transformer_chunked_no_pcc(
         pytest.param(
             (8, 4),
             fabric2d_device_params(
-                fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE, l1_small_size=GLM_L1_SMALL_SIZE
+                model_config=GLM51Config, l1_small_size=GLM_L1_SMALL_SIZE
             ),
             2,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -19,17 +19,7 @@ from loguru import logger
 from tqdm import tqdm
 
 import ttnn
-from models.common.utility_functions import is_blackhole
-
-# Fabric packet payload limits (conservative round values below hardware maximums).
-MAX_PAYLOAD_SIZE_BH = 14 * 1024  # Blackhole hardware max ~15232 B
-MAX_PAYLOAD_SIZE_WH = 7 * 1024  # Wormhole hardware max ~7616 B
-CMB_FABRIC2D_ROUTING_INFO_BYTES = 64
-
-
-def get_max_payload_size() -> int:
-    """Return the arch-appropriate fabric payload size. Deferred to avoid probing hardware at import time."""
-    return (MAX_PAYLOAD_SIZE_BH if is_blackhole() else MAX_PAYLOAD_SIZE_WH) + CMB_FABRIC2D_ROUTING_INFO_BYTES
+from models.demos.common.prefill.fabric import create_fabric_router_config as _create_fabric_router_config
 
 
 @dataclass
@@ -846,18 +836,8 @@ def load_captured_routing(
 
 
 def create_fabric_router_config(max_payload_size):
-    """
-    Helper to create FabricRouterConfig with custom max payload size.
-
-    Args:
-        max_payload_size: Maximum packet payload size in bytes
-
-    Returns:
-        FabricRouterConfig configured with the specified payload size
-    """
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
+    """Compatibility entry point for the shared, architecture-aware router config."""
+    return _create_fabric_router_config(max_payload_size)
 
 
 def get_dispatch_input_mesh_mapper(mesh_device, sp_axis: int):

--- a/models/demos/deepseek_v3_d_p/utils/test_mla_matmuls.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_mla_matmuls.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS, PREFILL_CHUNK_TOKENS_PER_CHIP
 
@@ -131,7 +132,7 @@ prog_config_mm5_bh = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [torus_xy_device_params()],
+    [torus_xy_device_params(model_config=DeepSeekV3Config)],
     ids=["torus-xy"],
     indirect=True,
 )

--- a/models/demos/minimax_m3/tests/perf/test_model_perf.py
+++ b/models/demos/minimax_m3/tests/perf/test_model_perf.py
@@ -36,6 +36,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.minimax_m3_config import MiniMaxM3Config
 
 _THIS = "models/demos/minimax_m3/tests/perf/test_model_perf.py"
 
@@ -122,7 +123,7 @@ def _build_real_model(mesh, seq):
 def test_model_fwd():
     from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 
-    fabric_payload_size = 6144  # M3 hidden_size (max fabric packet payload)
+    fabric_payload_size = MiniMaxM3Config.FABRIC_PAYLOAD_SIZE
 
     seq = int(os.getenv("PERF_SEQ", "512"))
     layers = int(os.getenv("PERF_LAYERS", "4"))

--- a/models/demos/minimax_m3/tt/runners/adapters/minimax_m3.py
+++ b/models/demos/minimax_m3/tt/runners/adapters/minimax_m3.py
@@ -43,6 +43,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.common.prefill.adapter import PrefillModelAdapter, PrefillRunParams
+from models.demos.common.prefill.fabric import moe_fabric_payload_size
 
 # The common runner reads PREFILL_NUM_LAYERS with a hardcoded default of 61 (DeepSeek's layer count).
 # M3 has 60 decoder layers. This adapter module is imported (via get_adapter) BEFORE the runner reads
@@ -53,11 +54,11 @@ os.environ.setdefault("PREFILL_NUM_LAYERS", "60")
 
 class MiniMaxM3Config:
     """Static model-dimension constants the common runner reads. The runner uses only
-    ``FABRIC_PAYLOAD_SIZE`` (the fabric router's max packet payload, mirrored from the embedding dim as
-    in the DeepSeek config); the rest document M3's dimensions for readers."""
+    ``FABRIC_PAYLOAD_SIZE`` (one BF16 embedding row plus routing header, capped at mesh open);
+    the rest document M3's dimensions for readers."""
 
     EMB_SIZE = 6144  # hidden_size
-    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload (mirrors DeepSeekV3Config convention)
+    FABRIC_PAYLOAD_SIZE = moe_fabric_payload_size(EMB_SIZE)
     NUM_LAYERS = 60
     NUM_ATTENTION_HEADS = 64
     NUM_KEY_VALUE_HEADS = 4


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Centralize prefill MoE fabric payload sizing so every supported model config derives `FABRIC_PAYLOAD_SIZE` from the same invariant: `EMB_SIZE * 2 + 64`. The shared helper owns the BF16 transport width (2 bytes), the 64-byte routing header, and the architecture payload caps.

Runners and tests now consume `model_config.FABRIC_PAYLOAD_SIZE` directly. Fabric test profiles require an explicit model config—there is no fallback/default packet size—and dedicated Kimi, GLM, Mistral, MiniMax, GPT-OSS, and DeepSeek cases use their own configs. Shared cross-model topology axes use the largest payload among the models actually exercised by that test; the code comments identify the dominant model for each shared axis.

The host sizing test imports each config directly and computes expectations from the centralized constants, removing both hardcoded expected packet sizes and the dynamic imports flagged by scanning.

### Notes for reviewers

- Kimi K3 now sizes from the full `EMB_SIZE`, not its latent routed-expert width, for consistency with every model.
- Architecture detection remains deferred until router creation; model-config imports stay hardware-independent. Wormhole caps requests at 7,616 bytes and Blackhole at 15,232 bytes.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python_env/bin/python -m pytest --noconftest -o addopts='' -q models/demos/common/prefill/tests/test_fabric_payload.py` passed all 56 host tests. Pre-commit, Python compileall, and `git diff --check` also passed.
- After syncing submodules, `./build_metal.sh --release` completed successfully on the final rebased tree, including the install step. Device correctness and performance remain unverified locally; no performance improvement is claimed.

### Prefill validation workflows

Manually maintained badges, outside the autogenerated CI section. Click a badge to filter runs by this branch.

- [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing) — `model=disaggregated_prefill`, all systems and test selections.
- [![Blaze Models Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing) — `test-type=all`, full prefill suite.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/prefill-moe-fabric-payload-sizing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/prefill-moe-fabric-payload-sizing)