### PR TITLE
common/prefill: resolve the KV chunk table path in one place

### DIFF
--- a/models/demos/common/prefill/runners/migration.py
+++ b/models/demos/common/prefill/runners/migration.py
@@ -24,6 +24,24 @@ class KvCacheStage(NamedTuple):
     count: int
 
 
+_PER_HOST_FS_PREFIXES = ("/tmp", "/dev/shm", "/run", "/var/tmp")
+
+
+def migration_table_path_is_explicit() -> bool:
+    return bool(os.environ.get("PREFILL_MIGRATION_TABLE_PATH"))
+
+
+def migration_table_path() -> str:
+    if migration_table_path_is_explicit():
+        return os.environ["PREFILL_MIGRATION_TABLE_PATH"]
+    return f"/tmp/prefill_kv_chunk_table_{os.environ.get('PREFILL_H2D_SERVICE_ID', 'ds_prefill')}.pb"
+
+
+def is_per_host_storage(path: str) -> bool:
+    abs_path = os.path.abspath(path)
+    return any(abs_path == p or abs_path.startswith(p + "/") for p in _PER_HOST_FS_PREFIXES)
+
+
 def migration_file_export_enabled() -> bool:
     return os.environ.get("PREFILL_MIGRATION_EXPORT_TO_FILE", "0") == "1"
 

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -19,6 +19,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.common.prefill.adapter import DEFAULT_MODEL, get_adapter
+from models.demos.common.prefill.runners.migration import is_per_host_storage, migration_table_path
 from models.demos.common.prefill.runners.runner_utils import load_trace_token_ids, resolve_trace_dir
 
 
@@ -108,16 +109,13 @@ def _chunk_to_host_array(chunk_token_ids):
     )
 
 
-_PER_HOST_FS_PREFIXES = ("/tmp", "/dev/shm", "/run", "/var/tmp")
-
-
 def _require_shared_table_path(world_size: int) -> None:
     if world_size <= 1:
         return
-    table_path = os.path.abspath(os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb"))
-    if any(table_path == p or table_path.startswith(p + "/") for p in _PER_HOST_FS_PREFIXES):
+    table_path = os.path.abspath(migration_table_path())
+    if is_per_host_storage(table_path):
         logger.error(
-            f"[producer] PREFILL_MIGRATION_TABLE_PATH={table_path!r} is on per-host storage; multi-rank "
+            f"[producer] KV chunk table {table_path!r} is on per-host storage; multi-rank "
             f"(world_size={world_size}) validators on other hosts cannot read rank 0's table. Point it at "
             "shared/NFS storage (e.g. /data/...)."
         )
@@ -125,7 +123,7 @@ def _require_shared_table_path(world_size: int) -> None:
 
 
 def _read_kv_chunk_table(timeout_s: int):
-    table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
+    table_path = migration_table_path()
     deadline = time.perf_counter() + timeout_s
     while not os.path.exists(table_path):
         if time.perf_counter() > deadline:

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -16,7 +16,10 @@ import ttnn
 from models.common.utility_functions import is_blackhole
 from models.demos.common.prefill.adapter import DEFAULT_MODEL, PrefillRunParams, get_adapter
 from models.demos.common.prefill.runners.migration import (
+    is_per_host_storage,
     migration_file_export_enabled,
+    migration_table_path,
+    migration_table_path_is_explicit,
     remove_stale_device_map_sidecars,
     serialize_device_map,
 )
@@ -414,10 +417,7 @@ def _print_config() -> None:
         ("PREFILL_TRACE_DIR", os.environ.get("PREFILL_TRACE_DIR", ADAPTER.prefill_trace_default)),
         ("PREFILL_ENABLE_MIGRATION", os.environ.get("PREFILL_ENABLE_MIGRATION", "0")),
         ("PREFILL_MOCK_MIGRATION", os.environ.get("PREFILL_MOCK_MIGRATION", "0")),
-        (
-            "PREFILL_MIGRATION_TABLE_PATH",
-            os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb"),
-        ),
+        ("PREFILL_MIGRATION_TABLE_PATH", migration_table_path()),
         ("PREFILL_MIGRATION_WAIT_READY_MS", os.environ.get("PREFILL_MIGRATION_WAIT_READY_MS", "120000")),
         ("PREFILL_MIGRATION_EXPORT_TO_FILE", os.environ.get("PREFILL_MIGRATION_EXPORT_TO_FILE", "0")),
         (
@@ -583,7 +583,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     _file_export = migration_file_export_enabled()
 
     if _mock_migration and not _migration_enabled:
-        _mock_table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
+        _mock_table_path = migration_table_path()
         _mock_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
         runtime.build_kv_chunk_table(kv_caches, path=_mock_table_path)
         remove_stale_device_map_sidecars(_mock_map_path)
@@ -607,17 +607,21 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         first_layer_idx, num_my_layers = compute_layer_split(
             NUM_LAYERS, num_ranks, ADAPTER.layer_split_boundaries(NUM_LAYERS)
         )[rank]
-        table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
+        table_path = migration_table_path()
         wait_ready_ms = int(os.environ.get("PREFILL_MIGRATION_WAIT_READY_MS", "120000"))
 
-        if num_ranks > 1:
-            _abs_table = os.path.abspath(table_path)
-            if any(_abs_table == p or _abs_table.startswith(p + "/") for p in ("/tmp", "/dev/shm", "/run", "/var/tmp")):
+        if num_ranks > 1 and is_per_host_storage(table_path):
+            if migration_table_path_is_explicit():
                 raise ValueError(
-                    f"PREFILL_MIGRATION_TABLE_PATH={_abs_table} is on per-host storage; with num_ranks="
-                    f"{num_ranks} the table rank 0 writes is invisible to the other hosts' readers. Point "
-                    "it at shared/NFS storage (e.g. /data/...)."
+                    f"PREFILL_MIGRATION_TABLE_PATH={os.path.abspath(table_path)} is on per-host storage; "
+                    f"with num_ranks={num_ranks} the table rank 0 writes is invisible to the other hosts' "
+                    "readers. Point it at shared/NFS storage (e.g. /data/...)."
                 )
+            logger.warning(
+                f"[migration] KV chunk table defaults to per-host {table_path} at num_ranks={num_ranks}; "
+                "readers on other hosts cannot see it. Set PREFILL_MIGRATION_TABLE_PATH to shared storage "
+                "if one is expected."
+            )
 
         if is_first_rank and os.path.exists(table_path):
             logger.warning(f"[migration] removing stale KV chunk table {table_path} from a prior run")
@@ -713,7 +717,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                 "publish a table covering only its own layer slice; a merged mock table is not "
                 "implemented); run single-rank or unset PREFILL_MOCK_MIGRATION."
             )
-        table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
+        table_path = migration_table_path()
         runtime.build_kv_chunk_table(kv_caches, path=table_path)
         device_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
         serialize_device_map(mesh_device, device_map_path)


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/actions/runs/34364510139


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/migration_table_path_guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/migration_table_path_guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/migration_table_path_guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/migration_table_path_guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/migration_table_path_guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/migration_table_path_guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/migration_table_path_guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/migration_table_path_guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/migration_table_path_guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/migration_table_path_guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/migration_table_path_guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/migration_table_path_guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/migration_table_path_guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/migration_table_path_guard)
