### PR TITLE
[Bug fix] sigmoid_bw: use sigmoid(x) * sigmoid(-x) instead of s * (1 - s)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_sigmoid.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_sigmoid.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
+from tests.ttnn.utils_for_testing import assert_with_ulp, generate_all_bfloat16_bitpatterns
 
 
 @pytest.mark.parametrize(
@@ -27,3 +28,48 @@ def test_bw_sigmoid(input_shapes, device):
 
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor, 0.90)
     assert comp_pass
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_bw_sigmoid_all_bitpatterns(device, dtype):
+    """Exhaustive: every bfloat16 bit pattern as the input, with an all-ones gradient.
+
+    d/dx sigmoid(x) is sigmoid(x) * sigmoid(-x), which is a normal float out to |x| = 87.34,
+    so no finite input in the swept set has a zero gradient.  Building it as s * (1 - s) lost
+    the whole x >= 6.25 (bfloat16) / x >= 16.75 (float32) tail: s rounds to exactly 1 there
+    and the subtraction cancels to 0.
+
+    The reference is evaluated in float64 rather than through the registered golden so that
+    the comparison is not limited by the reference's own float32 rounding.
+
+    Excluded: subnormal inputs (hardware flushes them to zero), NaN and +/-inf (covered by
+    the special-value tests), and inputs whose exact gradient is itself subnormal.
+    """
+    x2d = generate_all_bfloat16_bitpatterns(dtype)
+    x = x2d.flatten()
+    tt_dtype = ttnn.bfloat16 if dtype == torch.bfloat16 else ttnn.float32
+
+    tt_in = ttnn.from_torch(
+        x2d, dtype=tt_dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt_grad = ttnn.from_torch(
+        torch.ones_like(x2d),
+        dtype=tt_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    result = ttnn.to_torch(ttnn.sigmoid_bw(tt_grad, tt_in)[0]).flatten().to(dtype)
+    x64 = x.double()
+    golden64 = torch.sigmoid(x64) * torch.sigmoid(-x64)
+    golden = golden64.to(dtype)
+
+    tiny = torch.finfo(torch.float32).tiny
+    finite_in = torch.isfinite(x) & ((x == 0) | (x.abs() >= tiny))
+    normal_out = (golden64.abs() >= tiny) & torch.isfinite(golden64)
+    checked = finite_in & normal_out
+
+    lost = checked & (result == 0)
+    assert lost.sum() == 0, f"{int(lost.sum())} inputs returned a zero gradient, first at x={float(x[lost][0])}"
+    assert_with_ulp(golden[checked], result[checked], ulp_threshold=8)

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_sigmoid.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_sigmoid.py
@@ -72,4 +72,4 @@ def test_bw_sigmoid_all_bitpatterns(device, dtype):
 
     lost = checked & (result == 0)
     assert lost.sum() == 0, f"{int(lost.sum())} inputs returned a zero gradient, first at x={float(x[lost][0])}"
-    assert_with_ulp(golden[checked], result[checked], ulp_threshold=8)
+    assert_with_ulp(expected_result=golden[checked], actual_result=result[checked], ulp_threshold=8)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -464,6 +464,12 @@ std::vector<Tensor> tan_bw(
 }
 
 // grad(sigmoid) = grad*(1 - sigmoid(x))*sigmoid(x)
+// bw(sigmoid) = grad * sigmoid(input) * sigmoid(-input)
+// s * (1 - s) is the same quantity only in exact arithmetic: s rounds to exactly 1 as soon as
+// 1 - s drops below half an ULP of 1, so the subtraction cancels to 0 and the gradient is lost
+// for every input above about 6.25 (bfloat16) / 16.75 (float32). sigmoid(-x) is that same
+// 1 - s evaluated directly, with no cancellation, and sigmoid(x) * sigmoid(-x) is the identical
+// function elsewhere, so nothing inside the previously accurate range changes.
 std::vector<Tensor> sigmoid_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
@@ -473,8 +479,12 @@ std::vector<Tensor> sigmoid_bw(
         (int)ttnn::operations::unary::VecMode::RC,
         ttnn::operations::unary::SigmoidMode::ACCURATE,
         output_mem_config);
-    Tensor rsub_term = ttnn::rsub(sig_result, 1.0f, std::nullopt, output_mem_config);
-    Tensor prod_term_1 = ttnn::multiply(sig_result, rsub_term, std::nullopt, output_mem_config);
+    Tensor sig_neg = ttnn::sigmoid(
+        ttnn::neg(input, output_mem_config),
+        (int)ttnn::operations::unary::VecMode::RC,
+        ttnn::operations::unary::SigmoidMode::ACCURATE,
+        output_mem_config);
+    Tensor prod_term_1 = ttnn::multiply(sig_result, sig_neg, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(ttnn::multiply(prod_term_1, grad, std::nullopt, output_mem_config));
     return grad_tensor;
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55724

`sigmoid_bw` formed the derivative as `s * (1 - s)`. `s = sigmoid(x)` rounds to exactly `1` once `1 - s` falls below half an ULP of `1`, so `rsub(s, 1)` is exactly `0` and the gradient with it — for every input above `6.25` in bfloat16 and `16.75` in float32, where the true gradient is still a normal float out to `1.2e-37`.

`sigmoid'(x) = sigmoid(x) * sigmoid(-x)` is the same function with the subtraction removed: `sigmoid(-x)` **is** `1 - s`, evaluated directly instead of by cancellation.

All 65,536 bfloat16 bit patterns as the input with an all-ones gradient, golden `sigmoid(x) * sigmoid(-x)` in float64, on ttsim Blackhole:

| dtype | zeros where the golden is normal | max ULP | mean ULP |
|---|---|---|---|
| bfloat16 | 487 → **0** | 15,100 → **2** | 80.0844 → **0.0218** |
| float32 | 297 → **0** | 862,212,012 → **4** | 2,511,838.31 → **0.0668** |

Spot values, float32:

| input | before | after | exact |
|---|---|---|---|
| 5 | 0.006648033 | **0.006648056** | 0.006648057 |
| 10 | 4.535708e-05 | **4.539581e-05** | 4.539581e-05 |
| 16.75 | 0 | **5.315785e-08** | 5.315785e-08 |
| 30 | 0 | **9.357624e-14** | 9.357623e-14 |
| 85 | 0 | **1.216099e-37** | 1.216099e-37 |

![sigmoid_bw before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-sigmoid-bw.png)

### Notes for reviewers

- Host composite, so both Wormhole and Blackhole are covered by the one change.
- Costs one extra dispatch (`neg` plus a second `sigmoid`, replacing the `rsub`). That is the price of the identity; there is no way to recover the lost bits from `s` alone, because `s` is exactly `1.0` there.
- Both `sigmoid` calls keep `SigmoidMode::ACCURATE` and `VecMode::RC`, unchanged from before.
- Independent of the SFPU sigmoid work in #53258 / #55061 / #54602 — the loss was in the composite's algebra, not in the LUT, and the fix does not touch any kernel.
- `silu_bw` uses the same `rsub(sigmoid(x), 1)` shape but is **not** affected: there the term appears as `(1 - s) * x + 1`, which tends to `1` rather than to `0`, so cancellation there loses nothing. Left alone deliberately.
- `test_bw_sigmoid_all_bitpatterns` sweeps every bfloat16 bit pattern in both bfloat16 and float32, asserts no normal gradient comes back as zero, and holds 8 ULP. It fails both parametrisations on `main` ("487 inputs returned a zero gradient, first at x=6.25" / "297 ... first at x=16.75"). The reference is evaluated in float64 rather than through the registered golden, so the assertion is not limited by the reference's own float32 rounding.
- The pre-existing `test_bw_sigmoid` PCC cases still pass; they did not catch this because they draw inputs from `[-1, 1]` and assert PCC at 0.90.
- Verified on ttsim Blackhole v1.10.6 (slow dispatch); no silicon.
