### PR TITLE
[Bug fix] asinh_bw: keep the gradient finite once x*x overflows

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_asinh.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_asinh.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
+from tests.ttnn.utils_for_testing import assert_with_ulp, generate_all_bfloat16_bitpatterns
 
 
 @pytest.mark.parametrize(
@@ -27,3 +28,48 @@ def test_bw_asinh(input_shapes, device):
 
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_bw_asinh_all_bitpatterns(device, dtype):
+    """Exhaustive: every bfloat16 bit pattern as the input, with an all-ones gradient.
+
+    d/dx asinh(x) is 1/sqrt(1 + x^2), a normal float for every |x| up to 2^126, but squaring
+    overflows above 2^64 and rsqrt(inf) is 0, so the gradient used to vanish over the whole
+    2^64 < |x| <= FLT_MAX band - 15,874 of the 65,536 bit patterns.
+
+    The reference is evaluated in float64 rather than through the registered golden so that
+    the comparison is not limited by the reference's own float32 rounding.
+
+    Excluded: subnormal inputs (hardware flushes them to zero), NaN and +/-inf (covered by
+    the special-value tests), and gradients whose exact value is below 2^-100, where the
+    accuracy is that of ttnn.reciprocal at the bottom of the normal range rather than
+    anything this derivative does (ttnn.reciprocal(2^126) is itself 0, not FLT_MIN).
+    """
+    x2d = generate_all_bfloat16_bitpatterns(dtype)
+    x = x2d.flatten()
+    tt_dtype = ttnn.bfloat16 if dtype == torch.bfloat16 else ttnn.float32
+
+    tt_in = ttnn.from_torch(
+        x2d, dtype=tt_dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt_grad = ttnn.from_torch(
+        torch.ones_like(x2d),
+        dtype=tt_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    result = ttnn.to_torch(ttnn.asinh_bw(tt_grad, tt_in)[0]).flatten().to(dtype)
+    x64 = x.double()
+    golden64 = 1.0 / torch.sqrt(1.0 + x64 * x64)
+    golden = golden64.to(dtype)
+
+    tiny = torch.finfo(torch.float32).tiny
+    finite_in = torch.isfinite(x) & ((x == 0) | (x.abs() >= tiny))
+    checked = finite_in & (golden64 >= 2.0**-100)
+
+    lost = checked & (result == 0)
+    assert lost.sum() == 0, f"{int(lost.sum())} inputs returned a zero gradient, first at x={float(x[lost][0])}"
+    assert_with_ulp(golden[checked], result[checked], ulp_threshold=4)

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_asinh.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_asinh.py
@@ -72,4 +72,4 @@ def test_bw_asinh_all_bitpatterns(device, dtype):
 
     lost = checked & (result == 0)
     assert lost.sum() == 0, f"{int(lost.sum())} inputs returned a zero gradient, first at x={float(x[lost][0])}"
-    assert_with_ulp(golden[checked], result[checked], ulp_threshold=4)
+    assert_with_ulp(expected_result=golden[checked], actual_result=result[checked], ulp_threshold=4)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1042,17 +1042,31 @@ std::vector<Tensor> asin_bw(
 
 // Asinh
 // result: grad * (self * self + 1).rsqrt()
+// d/dx asinh(x) = 1 / sqrt(1 + x^2)
+// The square overflows for |x| > 2^64 and rsqrt(inf) is 0, so the derivative used to vanish
+// over the whole band 2^64 < |x| <= FLT_MAX even though 1/sqrt(1 + x^2) tends to 1/|x| and
+// stays a normal float down to 2.9e-39. Past kAsinhReciprocalCutoff = 2^62, 1/x^2 is below
+// 2^-124, so 1/sqrt(1 + x^2) and 1/|x| agree to far under half a float32 ULP and the
+// reciprocal can be taken directly. Below the cutoff the square is finite and the chain is
+// unchanged, so no previously correct value moves.
 std::vector<Tensor> asinh_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
+    constexpr float kAsinhReciprocalCutoff = 4611686018427387904.0f;  // 2^62
     std::vector<EltwiseUnaryWithParam> ops_chain = {
         EltwiseUnaryWithParam{UnaryOpType::SQUARE},
         EltwiseUnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
         EltwiseUnaryWithParam{UnaryOpType::RSQRT}};
-    Tensor grad_result =
-        ttnn::multiply(grad, ttnn::unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
+    std::vector<EltwiseUnaryWithParam> abs_recip = {
+        EltwiseUnaryWithParam{UnaryOpType::ABS}, EltwiseUnaryWithParam{UnaryOpType::RECIP}};
+    Tensor derivative = ttnn::where(
+        ttnn::gt(ttnn::abs(input, output_mem_config), kAsinhReciprocalCutoff, std::nullopt, output_mem_config),
+        ttnn::unary_chain(input, abs_recip, output_mem_config),
+        ttnn::unary_chain(input, ops_chain, output_mem_config),
+        output_mem_config);
+    Tensor grad_result = ttnn::multiply(grad, derivative, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_result);
     return grad_tensor;
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #55725

`asinh_bw` evaluates `1/sqrt(1 + x*x)` as a `SQUARE -> ADD 1 -> RSQRT` chain. `x * x` overflows to `+inf` for `|x| > sqrt(FLT_MAX)`, and `rsqrt(inf)` is `0`, so the gradient vanished over the whole `2^64 < |x| <= FLT_MAX` band — 15,874 of the 65,536 bfloat16 bit patterns, 24% of the domain — even though `1/sqrt(1 + x^2)` tends to `1/|x|` and is still `1.18e-38`, a normal float, at `x = 2^126`.

Past `2^62` the two agree: `1/x^2` is below `2^-124` there, so `1/sqrt(1 + x^2)` and `1/|x|` differ by far under half a float32 ULP. The chain is kept for `|x| <= 2^62` and the reciprocal is taken above it, so nothing that was already correct moves.

All 65,536 bfloat16 bit patterns as the input with an all-ones gradient, golden `1/sqrt(1 + x^2)` in float64, on ttsim Blackhole:

| dtype | zeros where the golden is normal | max ULP | mean ULP |
|---|---|---|---|
| bfloat16 | 15,874 → **2** | 8,064 → **128** | 996.3788 → **0.0639** |
| float32 | 15,874 → **2** | 528,482,304 → **8,388,608** | 65,295,045.59 → **1,221.687** |

Spot values, float32:

| input | before | after | exact |
|---|---|---|---|
| 1 | 0.7071068 | 0.7071068 | 0.7071068 |
| 1e10 | 9.999999e-11 | 9.999999e-11 | 1e-10 |
| 2^64 | 0 | **5.421011e-20** | 5.421011e-20 |
| 1e25 | 0 | **1e-25** | 1e-25 |
| 1e30 | 0 | **1e-30** | 1e-30 |
| 2^126 | 0 | 0 | 1.175494e-38 |

![asinh_bw before/after](https://raw.githubusercontent.com/badnikhil/tt-metal/pr-assets/tt-metal-asinh-bw.png)

### Notes for reviewers

- Host composite, so both Wormhole and Blackhole are covered by the one change.
- The two residual zeros and the residual ULP are `ttnn.reciprocal`'s own profile at the bottom of the normal range, reproduced exactly: sweeping all 65,536 bit patterns through `ttnn.reciprocal` alone gives the same 2 zeros (at `x = ±2^126`, where `1/x` is `FLT_MIN` and the op returns `0`), the same max ULP of 8,388,608, and mean 1,221.70 against this PR's 1,221.687. Nothing in this change makes them worse, and fixing them belongs in `reciprocal`.
- Cutoff is `2^62`, not the `2^64` where the overflow actually starts, so the branch is not sitting on the boundary. Over `2^62 < |x| <= 2^64` both expressions are correct and the reciprocal is chosen; the relative difference there is at most `2^-125`.
- Costs three extra dispatches (`abs`, `gt`, a two-step `ABS -> RECIP` chain) plus the `where`. A branch is unavoidable: float32 has no scale factor that keeps `x^2` finite for `|x| = FLT_MAX` while keeping `1` representable, since `2^-64 * 2^-64` is subnormal.
- Special values are unchanged. `|±inf| > 2^62` selects `1/inf = 0`, which is the correct limit; NaN fails the ordered `gt` and takes the chain, which yields NaN as before; `±0` takes the chain and yields `1`.
- `acosh_bw` (`rsqrt(x*x - 1)`) and, much more narrowly, `atan_bw` / `atanh_bw` (`1/(1 ± x^2)`, only 2 bit patterns because the true result is subnormal past `2^63`) carry the same overflow. `acosh_bw` is being rewritten by #53885, so this PR deliberately leaves all three alone rather than conflict with it.
- `test_bw_asinh_all_bitpatterns` sweeps every bfloat16 bit pattern in both bfloat16 and float32, asserts no gradient above `2^-100` comes back as zero, and holds 4 ULP over that range. It fails both parametrisations on `main` ("9218 inputs returned a zero gradient, first at x=1.8446744073709552e+19"). The `2^-100` floor keeps the assertion off the `ttnn.reciprocal` boundary described above; the reference is evaluated in float64 rather than through the registered golden.
- The pre-existing `test_bw_asinh` PCC cases still pass; they did not catch this because they draw inputs from `[-100, 100]`, twenty orders of magnitude below the overflow.
- Verified on ttsim Blackhole v1.10.6 (slow dispatch); no silicon.
