### PR TITLE
[Quasar] op_slicing: call the Quasar to_memory_config, not the mainline one

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/op_slicing/op_slicing.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/operations/experimental/quasar/to_memory_config/to_memory_config_op.hpp"
 #include "op_slicing.hpp"
 #include <tuple>
 #include <ttnn/operations/core/core.hpp>
@@ -128,7 +129,7 @@ void run_sliced_op(
         }
         auto op_output_tensors = op_slice_attr->run_L1_op(input_tensor, {0, 0}, {output_height, output_width});
         for (uint32_t i = 0; i < num_output_tensors; i++) {
-            output_tensors[i].get() = ttnn::to_memory_config(
+            output_tensors[i].get() = ttnn::operations::experimental::quasar::to_memory_config(
                 op_output_tensors[i],
                 tt::tt_metal::MemoryConfig{
                     TensorMemoryLayout::INTERLEAVED,
@@ -267,7 +268,7 @@ void run_sliced_op(
             if (sliced_output_tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED &&
                 sliced_output_tensor.memory_config().memory_layout() != TensorMemoryLayout::BLOCK_SHARDED &&
                 output_layout == Layout::ROW_MAJOR) {
-                sliced_output_tensor = ttnn::to_memory_config(
+                sliced_output_tensor = ttnn::operations::experimental::quasar::to_memory_config(
                     sliced_output_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
             }
             if (sliced_output_tensor.layout() != Layout::ROW_MAJOR && output_layout == Layout::ROW_MAJOR) {


### PR DESCRIPTION
## What

`ttnn/cpp/ttnn/operations/experimental/quasar/op_slicing/op_slicing.cpp` calls
mainline `ttnn::to_memory_config` in two places. Both call sites are inside
Quasar's own op-slicing path, so they should be calling
`ttnn::operations::experimental::quasar::to_memory_config`.

Three lines: the include, and the two calls.

## Why it matters

Mainline ops are refused on Quasar, not merely slower — their program factories
construct `DataMovementKernel`, whose constructor `TT_FATAL`s
(`tt_metal/impl/kernels/kernel.hpp`). So a Quasar op that delegates to a mainline
op takes the whole path down with it.

Because the failure surfaces inside the *called* op, it is easy to misattribute
to whichever op is under test. That is what happened to us: a conv2d test failed
and the blame initially landed on conv2d's compute config, when the actual throw
came from further up the call chain.

## How it was found

Reached while bringing Quasar up through tt-forge-onnx / tt-mlir
(tenstorrent/tt-mlir#9287). `run_sliced_op` is on the path to
`prim::qsr::halo`, which conv2d needs.

## Testing

Found and exercised on a craq-sim virtual Quasar in bf16. I have **not** been
able to run the tt-metal test suites against this change — the machine it was
developed on is no longer available to me — so please treat CI as the gate. The
change is a like-for-like substitution within the Quasar namespace, and touches
no other architecture.

## Note

There are two further genuine bugs in this area which this PR does **not**
address, both reached once conv2d gets past the above:

1. `halo_gather.cpp` declares `config_read_index` `constexpr` while
   `untilize_with_halo_program_factory.cpp` passes it as a runtime arg — will not
   compile. `const` fixes it. Only on the `CONFIG_TENSOR_IN_DRAM` path, which is
   presumably why the upstream Quasar conv tests do not hit it.
2. `dataflow_buffer.cpp` — "producer_risc_mask and consumer_risc_mask must not
   overlap", via `quasar::op_slicing::run_sliced_op` -> `prim::qsr::halo`.

Happy to file those separately with reproductions if that is useful.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=quasar-op-slicing-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:quasar-op-slicing-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=quasar-op-slicing-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:quasar-op-slicing-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=quasar-op-slicing-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:quasar-op-slicing-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=quasar-op-slicing-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:quasar-op-slicing-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=quasar-op-slicing-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:quasar-op-slicing-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=quasar-op-slicing-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:quasar-op-slicing-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=quasar-op-slicing-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:quasar-op-slicing-to-memory-config)