### PR TITLE
kernel_lib sanity: deselect the device-profiler tests that need a Tracy build

### DIFF
--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -268,7 +268,14 @@
   owner_id: U084B1CES7M # Borys Bradel
 
 - name: "ttnn llk helper library tests"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/kernel_lib -xv -m "not disable_fast_runtime_mode"'
+  # The device-perf tests in this directory shell out to `python3 -m tracy`, which needs a
+  # Tracy-enabled build; this job runs from the wheel, so they fail on a missing profiler
+  # rather than on anything they measure. The nightly entry in ops_unit_tests.yaml drops the
+  # same tests by --ignore'ing both files; deselecting the marker instead keeps the
+  # functional cases in test_chain_perf.py, which do run here.
+  cmd: >-
+    pytest --timeout 300 tests/ttnn/unit_tests/kernel_lib -xv
+    -m "not disable_fast_runtime_mode and not models_device_performance_bare_metal"
   skus:
     wh_n300_civ2:
       timeout: 20


### PR DESCRIPTION
## Problem

The `ttnn llk helper library tests` sanity entry has failed on every commit since it was added, including all three retry attempts:

- [run 34211842282](https://github.com/tenstorrent/tt-metal/actions/runs/34211842282) — `132690373`, attempts 1/2/3 all failure
- [run 34213944156](https://github.com/tenstorrent/tt-metal/actions/runs/34213944156) — `11de68c4a` (an unrelated UMD bump), identical failure

It is one test, and it is the environment rather than the code:

```
tests/ttnn/unit_tests/kernel_lib/test_chain_perf.py::test_perf_hoisting_device[n=64]
ERROR | tracy:run_report_setup:119 - Tracy tools were not found. Please make sure you are on a Tracy-enabled build (default).
=================== 1 failed, 188 passed in 81.40s ===================
```

`tests/ttnn/unit_tests/kernel_lib` holds device-profiler tests alongside the functional ones: three `models_device_performance_bare_metal` cases in `test_chain_perf.py`, and all of `test_chain_skip_compute_perf.py` via its module-level `pytestmark`. They shell out to `python3 -m tracy`, which needs a Tracy-enabled build. This job runs from the installed wheel (`/opt/venv/.../site-packages/ttnn`), which ships no profiler tools, so the test fails on the missing profiler rather than on anything it measures — and `-x` stops the job there.

The nightly entry for the same directory already excludes exactly these two files (`tests/pipeline_reorg/ops_unit_tests.yaml`, `ttnn kernel-lib eltwise chain tests`):

```yaml
    pytest tests/ttnn/unit_tests/kernel_lib -xv
    --ignore=tests/ttnn/unit_tests/kernel_lib/test_chain_perf.py
    --ignore=tests/ttnn/unit_tests/kernel_lib/test_chain_skip_compute_perf.py
```

The sanity entry, added later, did not carry that over.

## Change

One line: add `and not models_device_performance_bare_metal` to the sanity entry's `-m` expression.

Deselecting the marker rather than copying the two `--ignore` flags keeps the functional cases in `test_chain_perf.py` — `test_func_block`, `test_func_hoist`, `test_func_lifecycle`, `test_setup_placements_are_bit_identical` — which all pass in this job today, and it covers any future device-perf test added to the directory without another yaml edit.

Verified the expression selects what is intended, against files mirroring both marker styles (per-function marks and a module-level `pytestmark`):

```
$ pytest . -m "not disable_fast_runtime_mode and not models_device_performance_bare_metal" --collect-only
test_chain_perf.py::test_func_block
test_chain_perf.py::test_func_hoist
2/7 tests collected (5 deselected)
```

## Not fixed here

Nothing runs the kernel_lib device-perf tests at all — they are absent from `models_device_perf_tests.yaml`, and the nightly entry `--ignore`s them. This PR only stops them from failing a sanity job they cannot pass; giving them a home on a profiler build is a separate change and a call for the entry owner.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/kernel-lib-sanity-skip-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/kernel-lib-sanity-skip-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/kernel-lib-sanity-skip-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/kernel-lib-sanity-skip-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/kernel-lib-sanity-skip-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/kernel-lib-sanity-skip-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/kernel-lib-sanity-skip-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/kernel-lib-sanity-skip-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/kernel-lib-sanity-skip-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/kernel-lib-sanity-skip-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/kernel-lib-sanity-skip-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/kernel-lib-sanity-skip-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/kernel-lib-sanity-skip-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/kernel-lib-sanity-skip-device-perf)