### PR TITLE
[Bug fix] Fix Quasar SDPA with fp32 dest accumulation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -1683,10 +1683,14 @@ ttnn::device_operation::ProgramArtifacts SDPAOperation::SDPAProgramFactory::crea
         // qk_im / sum_A / sum_B are Float32 when enable_32_bit_dest is on; the validator requires an
         // explicit unpack_modes entry for each Float32 DFB the compute consumes. Legacy defaulted to
         // UnpackToSrc (no explicit unpack_to_dest_mode), preserved here.
-        auto& gen1 = std::get<ComputeGen1Config>(compute_hw);
-        gen1.unpack_modes.insert({QK_IM, tt::tt_metal::UnpackMode::UnpackToSrc});
-        gen1.unpack_modes.insert({SUM_A, tt::tt_metal::UnpackMode::UnpackToSrc});
-        gen1.unpack_modes.insert({SUM_B, tt::tt_metal::UnpackMode::UnpackToSrc});
+        // Reach unpack_modes through the generation-neutral accessor rather than
+        // std::get<ComputeGen1Config>: the helper above builds the config from device->arch(), so on
+        // Quasar it returns the Gen2 alternative and naming Gen1 here throws std::bad_variant_access.
+        // TODO(#52269): Quasar unpack_modes are copied from Gen1 and not yet optimized for Quasar.
+        auto& dfb_unpack_modes = unpack_modes(compute_hw);
+        dfb_unpack_modes.insert({QK_IM, tt::tt_metal::UnpackMode::UnpackToSrc});
+        dfb_unpack_modes.insert({SUM_A, tt::tt_metal::UnpackMode::UnpackToSrc});
+        dfb_unpack_modes.insert({SUM_B, tt::tt_metal::UnpackMode::UnpackToSrc});
     }
 
     KernelSpec compute{


### PR DESCRIPTION
Issue - https://github.com/tenstorrent/tt-metal/issues/55733

### PR Category

Bug fix

### Summary

This factory reached `unpack_modes` via `std::get<ComputeGen1Config>` on the variant returned by `ttnn::to_compute_hardware_config`. That helper returns the **Gen2** alternative on `ARCH::QUASAR`, so on Quasar the `std::get` cannot succeed — it throws `std::bad_variant_access`. The branch is gated on the caller-supplied `fp32_dest_acc_en` (a supported setting here), and the op is compiled and exposed to Python, so the path is reachable rather than dead.

Fixed with the generation-neutral accessor `unpack_modes(config)`, which resolves whichever alternative the helper chose. Entries unchanged; no `arch` branch needed.

Fixes #55733.

### Notes for reviewers

**No Quasar test was run for this change, on either side of it.** The failure above is established by reading the code — the variant provably cannot hold `ComputeGen1Config` on Quasar — not by reproducing it, and the fix is correspondingly unvalidated on Gen2. There is no Quasar-arch coverage for sdpa to run: the simulator path (`ARCH_NAME=quasar`) is wired up only for `binary_ng` and the TM ops.

What *is* measured is that Gen1 is unaffected: on Wormhole the op runs with `fp32_dest_acc_en=True`, and its output is bitwise identical to the pre-change build for a fixed seed (max abs diff 0.0).

The existing Gen1 tests that drive this factory with `fp32_dest_acc_en=True` — 13 across `models/experimental/llama32_1b_quasar/tests/{ops,prototype_ops,graph_ops}/` — skip on a 2-device host, since the conftest's `_CANDIDATE_REQ_SHAPES` has no entry for a system reporting `(2,1)`. They want an N150 `(1,1)`, N300 `(1,2)`, T3K `(2,4)` or Galaxy `(8,4)`.

`gen1` is renamed to `dfb_unpack_modes` because it no longer refers to a Gen1 config.

### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Test
- [x] Nightly for sdpa Category

---

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/sdpa_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/sdpa_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/sdpa_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/sdpa_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/sdpa_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/sdpa_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/sdpa_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/sdpa_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/sdpa_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/sdpa_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/sdpa_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/sdpa_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/sdpa_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/sdpa_quasar)

