### PR TITLE
Remove p300 op_unit_tests from blackhole_e2e + remove 2chip tests

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -189,14 +189,10 @@ def pytest_collection_modifyitems(config, items):
     FC = ttnn.FabricConfig
     DEFAULT_ALLOWED_FABRICS = frozenset({FC.DISABLED, FC.FABRIC_1D, FC.FABRIC_2D})
     # DISABLED is listed only on shapes that already own fabric-irrelevant diagnostics
-    # (currently single-chip and the P300 1x2 masked-bincount row). Do not expand it into
+    # (currently single-chip). Do not expand it into
     # communicating-test matrices merely to make this table visually symmetric.
     CI_ALLOWED_FABRICS = {
         CT.P150: {(1, 1): [FC.DISABLED, FC.FABRIC_2D]},  # single chip
-        CT.P300: {
-            (2, 1): [FC.FABRIC_2D],
-            (1, 2): [FC.DISABLED, FC.FABRIC_2D],
-        },  # 2 chips
         CT.P300_X2: {  # 4-chip QuietBox
             (4, 1): [FC.FABRIC_1D, FC.FABRIC_2D_TORUS_Y],
             (2, 2): [FC.FABRIC_2D],

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
@@ -13,8 +13,8 @@ lines (plus the None default) and checks the output still matches the torch refe
 exercising both the row-oriented and the new column-oriented core layouts.
 
 This file MUST NOT run in CI.  It is collected by every "Disaggregated prefill op tests"
-job (some of which run the op_unit_tests/ folder unfiltered, e.g. [bh_p150b_civ2] /
-[bh_p300]), so a ``-k`` filter cannot exclude it.  Instead it skips itself in CI via
+job (some of which run the op_unit_tests/ folder unfiltered, e.g. [bh_p150b_civ2]),
+so a ``-k`` filter cannot exclude it.  Instead it skips itself in CI via
 the is_ci_env / is_ci_v2_env fixtures (same mechanism as
 test_sub_device_load_clear_timing.py): all CI jobs collect it but report it as skipped,
 while it still runs locally with no env var.
@@ -155,7 +155,7 @@ def test_combine_subdevice_placement(
     """
     topology = per_axis_topology(device_params["fabric_config"])[0]
     # Local-only: this file is collected by every "Disaggregated prefill op tests" job
-    # (some unfiltered, e.g. [bh_p150b_civ2]/[bh_p300]), so a -k filter cannot exclude
+    # (some unfiltered, e.g. [bh_p150b_civ2]), so a -k filter cannot exclude
     # it. Skip in CI the same way test_sub_device_load_clear_timing.py does; runs
     # locally with no env var.
     if is_ci_env or is_ci_v2_env:

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -1302,9 +1302,7 @@ def test_update_padded_kv_cache_multihead_head_stride(mesh_device, case):
 
 # KV dedup: the op gets a TP-REPLICATED input and each chip persists only its own 1/tp window, so the two
 # mesh axes linearize into one block-cyclic axis of sp*tp with per-chip chunk Cl = chunk_local/tp.
-@pytest.mark.parametrize(
-    "mesh_device", [(1, 2), (1, 4), (2, 2), (2, 4)], ids=["1x2", "1x4", "2x2", "2x4"], indirect=True
-)
+@pytest.mark.parametrize("mesh_device", [(1, 4), (2, 2), (2, 4)], ids=["1x4", "2x2", "2x4"], indirect=True)
 @pytest.mark.parametrize("dtype, layout", DTYPE_LAYOUT_CASES, ids=DTYPE_LAYOUT_IDS)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, cl_tiles_per_dev, cache_tokens_per_dev",

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
@@ -55,12 +55,6 @@ def torch_masked_bincount(
             id="single",
         ),
         pytest.param(
-            (1, 2),
-            {"fabric_config": ttnn.FabricConfig.DISABLED},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 2), topology="linear"),
-            id="disabled-1x2",
-        ),
-        pytest.param(
             (1, 4),
             torus_x_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_offset_cumsum.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_offset_cumsum.py
@@ -74,13 +74,6 @@ def torch_offset_cumsum(
     "mesh_device, device_params, num_links",
     [
         pytest.param(
-            (2, 1),
-            fabric2d_device_params(),
-            1,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="fabric2d-2x1",
-        ),
-        pytest.param(
             (4, 1),
             torus_y_device_params(),
             1,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
@@ -476,7 +476,6 @@ def dispatch_shape_params():
 # Two-link subset of the shared dispatch/combine mesh table. The 1-link rows are redundant
 # coverage here; everything else about the profiles stays owned by ALL_MESH_CONFIGS.
 _MESH_IDS = (
-    "fabric2d-2x1-2link",
     "fabric2d-torus-y-4x1-2link",
     "fabric2d-torus-y-8x1-2link",
     "fabric2d-torus-xy-8x4-2link",

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
@@ -409,7 +409,6 @@ def dispatch_combine_shape_params():
 # Two-link subset of the shared dispatch/combine mesh table. The 1-link rows are redundant
 # coverage here; everything else about the profiles stays owned by ALL_MESH_CONFIGS.
 _MESH_IDS = (
-    "fabric2d-2x1-2link",
     "fabric2d-torus-y-4x1-2link",
     "fabric2d-torus-y-8x1-2link",
     "fabric2d-mesh-4x2-2link",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -58,25 +58,6 @@ def _mesh_param(shape, fabric, payload, nlinks, topo_marker, test_id, reliabilit
 
 
 ALL_MESH_CONFIGS = [
-    # Existing two-chip rows cannot form a useful ring; migrate them one-for-one to Fabric2D.
-    _mesh_param(
-        (2, 1),
-        ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
-        1,
-        "linear",
-        "fabric2d-2x1-1link",
-        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
-    ),
-    _mesh_param(
-        (2, 1),
-        ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
-        2,
-        "linear",
-        "fabric2d-2x1-2link",
-        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
-    ),
     # Local policy: one 2x2 QuietBox case, canonical 2x4 LoudBox, and one 4x2 axis diagnostic.
     _mesh_param(
         (2, 2),

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -253,19 +253,6 @@
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
-- id: bh-p300-disaggregated-prefill-op-tests
-  name: Disaggregated prefill op tests
-  model-name: disaggregated_prefill
-  cmd: |
-    exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or fabric2d) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
-    exit $exit_code
-  skus:
-    bh_p300:
-      timeout: 10
-  owner_id: U094PKWHNJ0 # Petar Milojevic
-  team: models
-
 - id: bh-qb2-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
   model-name: disaggregated_prefill


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-metal/issues/53656

### Summary
Removes the P300 disaggregated-prefill op-tests row from the Blackhole e2e pipeline.

That row was the only CI job running the DeepSeek `op_unit_tests/` on a 2-chip machine, so the
2x1 / 1x2 parametrizations in those tests (and the matching rows in `pcc/mesh_configs.py` and
`conftest.py`) became unreachable in CI. This PR deletes them too. All other cases stay covered
by the LoudBox, P150 and QuietBox 2 rows.

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/remove_p300_op_tests_from_bhe2e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/remove_p300_op_tests_from_bhe2e)