### PR TITLE
#55439: keep the dispatch program out of the Kimi MoE perf gate

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
@@ -7,11 +7,15 @@ Kimi MoE device-perf gate on the 8x4 galaxy, one test parametrized over the Kimi
 (K2.7 dense-expert MoE and K3 LatentMoE), measured with the real-time program profiler -- same
 mechanism as ``test_ttnn_hca_perf.py``, which already gates HCA perf on this SKU.
 
-What the number is: over the programs the MoE forward dispatched, the sum of each program's
-critical path (max duration across the 32 chips). Close to but NOT the same as the tracy
-baseline it replaces -- ``merge_device_rows`` averages CCL ops across devices where this takes
-their max -- so these baselines were measured with the real-time profiler and must not be
+What the number is: over the programs the MoE forward dispatched EXCEPT the dispatch program, the
+sum of each program's critical path (max duration across the 32 chips). Close to but NOT the same as
+the tracy baseline it replaces -- ``merge_device_rows`` averages CCL ops across devices where this
+takes their max -- so these baselines were measured with the real-time profiler and must not be
 back-ported to the tracy path.
+
+The dispatch program is excluded because its record does not consistently bracket its own work,
+which made this gate bimodal (#55439). ``_split_off_dispatch`` carries the measurements; read it
+before re-cutting any baseline here, and do not re-add that program without re-cutting both.
 
 What the number excludes, verified on an 8x4 galaxy (warm caches, 58 programs x 32 chips =
 1856 records, 0 dropped, no program dispatched more than once per chip):
@@ -93,9 +97,12 @@ class _MoEPerfCase:
 # gated total, so the two clusters collapse into one and the midpoint describes every run.
 #
 # The six samples that measured the dispatch program async -- and so were already measuring today's
-# metric -- were 5,404,540 / 5,413,674 / 5,443,696 / 5,484,610 / 5,495,657 / 5,512,248 (runs
-# 33787697384, 33871578406, 33871606089, 33871618241, 33946052498). Median 5,464,153, 2.0% peak to
-# peak. Nine local runs of the dispatch-excluded metric agreed at 5,445,011 mean, 0.60% sd.
+# metric -- with the run each came from:
+#   5,404,540  run 33946052498 att1        5,484,610  run 33871606089 att1
+#   5,413,674  run 33787697384 att3        5,495,657  run 33787697384 att2
+#   5,443,696  run 33871578406 att3        5,512,248  run 33871618241 att3
+# Median 5,464,153, 2.0% peak to peak. Nine local runs of the dispatch-excluded metric agreed at
+# 5,445,011 mean, 0.60% sd.
 #
 # Previous history: 5,413,674 from 2026-09-03 (one sample, run 33787697384); 6,260,834 from
 # 2026-09-02; 6,574,780 from run 33194039175.
@@ -184,8 +191,13 @@ def _split_off_dispatch(per_program: dict, label: str) -> tuple[float, float]:
     from one run that happened to land in the async state.
 
     Excluding it leaves the other 23 programs, which are tight: nine runs on one box spanned 1.97%
-    peak to peak (sd 0.60%) against the 3-4% bands here. The dispatch op keeps its own deterministic
-    per-op gate in ``test_dispatch_combine_perf.py``; this gate does not cover it on 8x4.
+    peak to peak (sd 0.60%) against the 3-4% bands here.
+
+    What this gives up. ``test_dispatch_combine_perf.py`` gates DispatchDeviceOperation per-op, but
+    only for the K2.6/K2.7 shape (its ``_MODELS`` has no K3 entry) and only on torus-y 8x1. So the
+    K2.7 dispatch op keeps a gate on a different SKU, and K3's dispatch op is now gated nowhere --
+    it was only ever covered here, and only in whichever of the two states a run happened to land
+    in, which is not coverage. Closing that needs a K3 case in the per-op gate; tracked on #55439.
     """
     dispatch = [
         entry
@@ -272,8 +284,12 @@ def test_kimi_moe_perf_galaxy(variant, case, config_only, mesh_device, device_pa
     assert per_program, f"real-time profiler produced no program records for the {case.label} MoE forward"
 
     dispatch_ns, total_ns = _split_off_dispatch(per_program, case.label)
+    gated_programs = len(per_program) - 1
     tag = f"{case.label} moe 8x4 realtime perf ({case.shape_note})"
-    logger.info(
+    # WARNING, not info, on the bracketed state: it is the state whose 1.10 ms this gate used to
+    # swallow, so it must be greppable in a job log that is otherwise green.
+    dispatch_log = logger.warning if dispatch_ns >= _DISPATCH_BRACKETED_NS else logger.info
+    dispatch_log(
         f"{tag}: dispatch program {dispatch_ns:,.0f} ns, "
         f"{'BRACKETED (workers waited for the transfer)' if dispatch_ns >= _DISPATCH_BRACKETED_NS else 'ASYNC (workers returned first)'}"
         " -- excluded from the gated total, see _split_off_dispatch"
@@ -281,8 +297,9 @@ def test_kimi_moe_perf_galaxy(variant, case, config_only, mesh_device, device_pa
 
     if case.expected_ns is None:
         logger.warning(
-            f"{tag}: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms) over {len(per_program)} programs "
-            f"-- REPORT ONLY, this run does NOT gate perf. Set expected_ns = {total_ns:,.0f} for "
+            f"{tag}: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms) over {gated_programs} gated programs "
+            f"(+1 dispatch, excluded) -- REPORT ONLY, this run does NOT gate perf. "
+            f"Set expected_ns = {total_ns:,.0f} for "
             f"{case.label} in {os.path.basename(__file__)} to start gating."
         )
         return
@@ -290,8 +307,8 @@ def test_kimi_moe_perf_galaxy(variant, case, config_only, mesh_device, device_pa
     margin = adjust_margin_for_ddr_speed(case.margin)
     lower, upper = case.expected_ns * (1 - margin), case.expected_ns * (1 + margin)
     logger.info(
-        f"{tag}: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms) over {len(per_program)} programs, "
-        f"expected {case.expected_ns:,} ns, band [{lower:,.0f}, {upper:,.0f}] "
+        f"{tag}: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms) over {gated_programs} gated programs "
+        f"(+1 dispatch, excluded), expected {case.expected_ns:,} ns, band [{lower:,.0f}, {upper:,.0f}] "
         f"(margin +/- {margin * 100:.1f}%)"
     )
     assert lower <= total_ns <= upper, (

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
@@ -86,28 +86,31 @@ class _MoEPerfCase:
 
 # K2.7: 384 experts / top-8 over the 7168 embedding, no LatentMoE plumbing.
 #
-# Re-centred 2026-09-03: device time came in at 5,413,674 ns, 9.9% below the old band's lower edge
-# (previous midpoint 6,260,834). Per the repo's rule that is fixed by lowering the midpoint, never by
-# widening the margin. ONE sample, from the failing gate run itself.
+# Re-cut 2026-09-08 for #55439, from the MEDIAN of the six runs that measured today's metric rather
+# than from one sample. The previous 5,413,674 was one sample of a number that was bimodal: it came
+# from a run where the dispatch program measured ~0.7 us, while runs of the same commit measured it
+# at ~1.12 ms and read 1.10 ms higher. ``_split_off_dispatch`` now keeps that program out of the
+# gated total, so the two clusters collapse into one and the midpoint describes every run.
 #
-# This drop is an order of magnitude larger than the previous re-centre (13.5% vs 0.8%), so it is a
-# real change in the work rather than drift: it is a SPEEDUP, and this branch reorders the shared
-# expert against dispatch, which is exactly the kind of change that moves this number. If a later
-# run does not reproduce ~5.41 ms, treat that as evidence this sample caught something transient and
-# re-cut from the median of several runs rather than re-lowering again.
+# The six samples that measured the dispatch program async -- and so were already measuring today's
+# metric -- were 5,404,540 / 5,413,674 / 5,443,696 / 5,484,610 / 5,495,657 / 5,512,248 (runs
+# 33787697384, 33871578406, 33871606089, 33871618241, 33946052498). Median 5,464,153, 2.0% peak to
+# peak. Nine local runs of the dispatch-excluded metric agreed at 5,445,011 mean, 0.60% sd.
 #
-# Previous history: re-centred 2026-09-02 to 6,260,834 from 6,574,780 (run 33194039175).
+# Previous history: 5,413,674 from 2026-09-03 (one sample, run 33787697384); 6,260,834 from
+# 2026-09-02; 6,574,780 from run 33194039175.
 #
 # K2.7-Code is architecturally identical to K2.6 (61 layers, 384 routed experts, same dims), so the
 # MoE shapes are unchanged; only the label moved.
 _K2_7 = _MoEPerfCase(
     label="kimi-k2.7",
     config=KimiK27Config,
-    expected_ns=5_413_674,
+    expected_ns=5_464_153,
     # 4%, not 3%: K2.7 runs FIRST in the merged job, so it absorbs the warm-up variability that K3,
-    # running second on an already-warm device, does not -- five samples on the previous shape spanned
-    # 7.12% peak to peak against K3's 0.44%. Do NOT tighten this to match K3; the asymmetry is a
-    # property of the job order, not of the midpoint. Sub-nominal DDR doubles it to 8%.
+    # running second on an already-warm device, does not. Do NOT tighten this to match K3; the
+    # asymmetry is a property of the job order, not of the midpoint. Sub-nominal DDR doubles it to 8%.
+    # The 1.10 ms swing this margin used to be blamed for was the dispatch program, not warm-up, and
+    # is gone -- the remaining spread is 2.0% across the six CI samples above.
     margin=0.04,
     shape_note="384 experts / top-8, 7168 emb",
 )
@@ -125,6 +128,12 @@ _K2_7 = _MoEPerfCase(
 # over the same 35 programs -- that count is what separates a real drop from a record window closing
 # early and under-reporting the sum. ONE sample, against the four-sample 0.44% spread that set the
 # margin below.
+#
+# Unchanged by the #55439 dispatch exclusion. K3 carries the same bimodal dispatch program (measured
+# locally at ~0.74 us async and ~1.55 ms bracketed), but every CI sample of this case has been async:
+# K3 runs SECOND, on a host the K2.7 case has already warmed, and 24 CI samples span 8,166,412 to
+# 8,601,784 with no second cluster. So this midpoint was already measuring the dispatch-excluded
+# number to within the ~0.74 us the exclusion removes.
 _K3 = _MoEPerfCase(
     label="kimi-k3",
     config=KimiK3Config,
@@ -149,6 +158,49 @@ _CASES = [
     pytest.param("kimi_k2_7", _K2_7, id="k2_7"),
     pytest.param("kimi_k3", _K3, id="k3"),
 ]
+
+
+# A dispatch record at or above this is one that waited for its own fabric transfer; a record below
+# it is one that returned before the transfer landed. Measured states are ~0.7 us and ~1.12 ms, so
+# anything in this range is decisive and the exact threshold does not matter.
+_DISPATCH_BRACKETED_NS = 100_000
+
+# The MoE dispatch op's kernels. Matched on the sender writer alone: it is the kernel that owns the
+# fabric writes, and it appears in no other program in this forward.
+_DISPATCH_KERNEL = "writer_sender_dispatch.cpp"
+
+
+def _split_off_dispatch(per_program: dict, label: str) -> tuple[float, float]:
+    """Return (dispatch program ns, summed ns of every other program).
+
+    Why dispatch is not in the gated number (#55439). This metric is a sum of per-program critical
+    paths, and the dispatch program's record does not consistently bracket its own work: its workers
+    hand the payload to the fabric mux and, depending on whether they return before or after the
+    transfer lands, the SAME code measures the program at ~0.7 us or ~1.12 ms. The state is fixed for
+    the life of a process -- five measured passes in one process all agree -- so it cannot be averaged
+    out by sampling, and it moved the gated total between two clusters 1.10 ms apart (5.46 ms vs
+    6.56 ms) with nothing else in the forward changing by more than ~45 us. That is what made this
+    gate flaky, and it is why the midpoint must never be cut from a single sample: 5,413,674 was cut
+    from one run that happened to land in the async state.
+
+    Excluding it leaves the other 23 programs, which are tight: nine runs on one box spanned 1.97%
+    peak to peak (sd 0.60%) against the 3-4% bands here. The dispatch op keeps its own deterministic
+    per-op gate in ``test_dispatch_combine_perf.py``; this gate does not cover it on 8x4.
+    """
+    dispatch = [
+        entry
+        for entry in per_program.values()
+        if any(_DISPATCH_KERNEL in source.replace("\\", "/") for source in entry["kernel_sources"])
+    ]
+    # One match, or the number silently changes meaning: no match would fold nothing out (and put the
+    # bimodality straight back), several would mean this forward no longer has a single dispatch.
+    assert len(dispatch) == 1, (
+        f"{label}: expected exactly one program with {_DISPATCH_KERNEL}, got {len(dispatch)}. The "
+        "gated total excludes that program, so a rename or a second dispatch has to be handled here "
+        "rather than change the number underneath the baseline."
+    )
+    dispatch_ns = dispatch[0]["duration_ns"]
+    return dispatch_ns, sum(entry["duration_ns"] for entry in per_program.values()) - dispatch_ns
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="Kimi prefill MoE requires Blackhole")
@@ -219,8 +271,13 @@ def test_kimi_moe_perf_galaxy(variant, case, config_only, mesh_device, device_pa
     # i.e. the forward was not the thing profiled. Never report green off that.
     assert per_program, f"real-time profiler produced no program records for the {case.label} MoE forward"
 
-    total_ns = sum(entry["duration_ns"] for entry in per_program.values())
+    dispatch_ns, total_ns = _split_off_dispatch(per_program, case.label)
     tag = f"{case.label} moe 8x4 realtime perf ({case.shape_note})"
+    logger.info(
+        f"{tag}: dispatch program {dispatch_ns:,.0f} ns, "
+        f"{'BRACKETED (workers waited for the transfer)' if dispatch_ns >= _DISPATCH_BRACKETED_NS else 'ASYNC (workers returned first)'}"
+        " -- excluded from the gated total, see _split_off_dispatch"
+    )
 
     if case.expected_ns is None:
         logger.warning(

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
@@ -90,19 +90,24 @@ class _MoEPerfCase:
 
 # K2.7: 384 experts / top-8 over the 7168 embedding, no LatentMoE plumbing.
 #
-# Re-cut 2026-09-08 for #55439, from the MEDIAN of the six runs that measured today's metric rather
+# Re-cut 2026-09-08 for #55439, from the MEDIAN of the nine runs that measured today's metric rather
 # than from one sample. The previous 5,413,674 was one sample of a number that was bimodal: it came
 # from a run where the dispatch program measured ~0.7 us, while runs of the same commit measured it
 # at ~1.12 ms and read 1.10 ms higher. ``_split_off_dispatch`` now keeps that program out of the
 # gated total, so the two clusters collapse into one and the midpoint describes every run.
 #
-# The six samples that measured the dispatch program async -- and so were already measuring today's
-# metric -- with the run each came from:
-#   5,404,540  run 33946052498 att1        5,484,610  run 33871606089 att1
-#   5,413,674  run 33787697384 att3        5,495,657  run 33787697384 att2
-#   5,443,696  run 33871578406 att3        5,512,248  run 33871618241 att3
-# Median 5,464,153, 2.0% peak to peak. Nine local runs of the dispatch-excluded metric agreed at
-# 5,445,011 mean, 0.60% sd.
+# Nine CI measurements of the gated metric. Six predate the fix but measured the dispatch program
+# async, so their total already WAS this metric (less the ~720 ns async record):
+#   5,403,820  run 33946052498 att1        5,483,890  run 33871606089 att1
+#   5,412,954  run 33787697384 att3        5,494,937  run 33787697384 att2
+#   5,442,976  run 33871578406 att3        5,511,528  run 33871618241 att3
+# Three measure it directly, on runs that all landed BRACKETED and so would have failed on the old
+# metric at 6,377,518 / 6,502,417 / 6,551,469:
+#   5,280,196  run 34224607638             5,434,881  run 34224698012
+#   5,389,948  run 34224663346
+# Median 5,434,881, 4.26% peak to peak. Centred on the median rather than the mean so the lowest
+# sample keeps 1.20% inside the lower edge instead of 0.66%. Nine local runs on a single box agreed
+# at 5,445,011 mean, 0.60% sd -- the CI spread is across hosts, the local one is not.
 #
 # Previous history: 5,413,674 from 2026-09-03 (one sample, run 33787697384); 6,260,834 from
 # 2026-09-02; 6,574,780 from run 33194039175.
@@ -112,12 +117,12 @@ class _MoEPerfCase:
 _K2_7 = _MoEPerfCase(
     label="kimi-k2.7",
     config=KimiK27Config,
-    expected_ns=5_464_153,
+    expected_ns=5_434_881,
     # 4%, not 3%: K2.7 runs FIRST in the merged job, so it absorbs the warm-up variability that K3,
     # running second on an already-warm device, does not. Do NOT tighten this to match K3; the
     # asymmetry is a property of the job order, not of the midpoint. Sub-nominal DDR doubles it to 8%.
     # The 1.10 ms swing this margin used to be blamed for was the dispatch program, not warm-up, and
-    # is gone -- the remaining spread is 2.0% across the six CI samples above.
+    # is gone -- the remaining spread is 4.26% across the nine CI samples above, all cross-host.
     margin=0.04,
     shape_note="384 experts / top-8, 7168 emb",
 )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf_diag.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf_diag.py
@@ -45,7 +45,9 @@ from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import get_ddr_speed, get_tdp_limit_max
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program, require_realtime_profiler
 
-_ITERS = int(os.environ.get("KIMI_MOE_DIAG_ITERS", "3"))
+# Clamped: _ITERS is a divisor below, and a 0 from the environment would crash only after the full
+# device forward had already run.
+_ITERS = max(1, int(os.environ.get("KIMI_MOE_DIAG_ITERS", "3")))
 # Generous: this harness cares about a complete record set, not about finishing fast.
 _RECORD_TIMEOUT_S = 30.0
 
@@ -130,7 +132,9 @@ def test_kimi_moe_perf_diag(variant, case, config_only, mesh_device, device_para
         entry["by_chip"][record["chip_id"]] = record["duration_ns"]
         entry["spans"][record["chip_id"]] = (record["start_ns"], record["end_ns"])
 
-    ordered = list(per_program.items())
+    # runtime_id increments per dispatch, so sorting by it gives dispatch order. Record arrival
+    # order does not: the receiver interleaves 32 chips and can deliver a later program first.
+    ordered = sorted(per_program.items())
     counts = sorted(len(entry["by_chip"]) for _, entry in ordered)
     mesh_size = mesh_device.get_num_devices()
     logger.info(
@@ -147,7 +151,11 @@ def test_kimi_moe_perf_diag(variant, case, config_only, mesh_device, device_para
         chunk = ordered[iteration * per_iter : (iteration + 1) * per_iter]
         total = sum(max(entry["by_chip"].values()) for _, entry in chunk)
         dispatch = [max(entry["by_chip"].values()) for _, entry in chunk if _DISPATCH_KERNEL in entry["kernels"]]
-        dispatch_ns = dispatch[0] if dispatch else 0.0
+        if len(dispatch) != 1:
+            # 0 would print as "dispatch 0 ns", indistinguishable from a healthy async record and so
+            # from "there is no bimodality here" -- the one conclusion this harness must not fake.
+            logger.error(f"DIAG {case.label} iter {iteration}: {len(dispatch)} programs match {_DISPATCH_KERNEL}")
+        dispatch_ns = dispatch[0] if len(dispatch) == 1 else float("nan")
         logger.info(
             f"DIAG {case.label} iter {iteration}: total {total:,.0f} ns | dispatch {dispatch_ns:,.0f} ns | "
             f"total without dispatch {total - dispatch_ns:,.0f} ns"
@@ -155,9 +163,20 @@ def test_kimi_moe_perf_diag(variant, case, config_only, mesh_device, device_para
 
     # One chip's timeline for the first iteration. The gap column is what shows a record closing
     # before its work is done: the time leaves the record and turns up in the gap behind it.
-    ref_chip = min(chip for _, entry in ordered for chip in entry["spans"])
-    timeline = [(entry["spans"][ref_chip], entry["kernels"]) for _, entry in ordered[:per_iter]]
-    origin = min(start for (start, _), _ in timeline)
+    # A chip every program in the slice reported. The global minimum would KeyError on exactly the
+    # partial record sets the short= count above exists to report.
+    common = set.intersection(*(set(entry["spans"]) for _, entry in ordered[:per_iter]))
+    if not common:
+        logger.warning(f"DIAG {case.label}: no chip reported every program in iteration 0, skipping timeline")
+        return
+    ref_chip = min(common)
+    # Sorted by start, not by dispatch order: the gap column is only meaningful on a start-ordered
+    # sequence, and a program whose record closed early can start after one dispatched later.
+    timeline = sorted(
+        ((entry["spans"][ref_chip], entry["kernels"]) for _, entry in ordered[:per_iter]),
+        key=lambda item: item[0][0],
+    )
+    origin = timeline[0][0][0]
     logger.info(f"DIAG {case.label} chip-{ref_chip} timeline (offset, duration, gap to next):")
     for idx, ((start, end), kernels) in enumerate(timeline):
         gap = timeline[idx + 1][0][0] - end if idx + 1 < len(timeline) else 0

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf_diag.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf_diag.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reproduction harness for #55439, the MoE perf gate's 1.10 ms bimodality.
+
+Not a gate -- it asserts nothing about time. It runs the same forward ``test_kimi_moe_perf.py``
+measures, N times in one profiler window, and reports per iteration the summed critical path, the
+dispatch program's own record, and one chip's program timeline.
+
+What it showed. The dispatch program's record is binary: ~0.7 us when its workers return before the
+fabric transfer lands, ~1.12 ms (K2.7) / ~1.55 ms (K3) when they wait for it. The gated total tracks
+that 1:1 and nothing else in the forward moves by more than ~45 us, which is the whole flakiness.
+The chip timeline is what distinguishes the two: in the async state the record closes in <1 us and
+the transfer time reappears as the gap before the next program, so a duration alone cannot tell them
+apart. The state is per forward but strongly autocorrelated -- one process measured 4 async and 1
+bracketed, another 3 bracketed in a row -- so sampling within a process does not average it out.
+
+Record loss was ruled out here too: every program came back with all 32 chip records, and dropping
+any single chip's records costs at most 2.2% of the total, against a 1.10 ms (20%) gap.
+
+Run it as the gate runs, one measured pass:
+    KIMI_MOE_DIAG_ITERS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf_diag.py -k k2_7
+"""
+
+import os
+import statistics
+
+import pytest
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.pcc.test_ttnn_moe import run_model
+from models.demos.deepseek_v3_d_p.tests.perf.test_kimi_moe_perf import (
+    _CASES,
+    _DISPATCH_BUFFER_CAPACITY_FACTOR,
+    _DISPATCH_KERNEL,
+    _FABRIC_PAYLOAD_SIZE,
+    _SEQ_LEN_PER_CHIP,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import get_ddr_speed, get_tdp_limit_max
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program, require_realtime_profiler
+
+_ITERS = int(os.environ.get("KIMI_MOE_DIAG_ITERS", "3"))
+# Generous: this harness cares about a complete record set, not about finishing fast.
+_RECORD_TIMEOUT_S = 30.0
+
+
+def _kernel_tag(sources):
+    return ",".join(sorted({source.rsplit("/", 1)[-1] for source in sources}))
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="Kimi prefill MoE requires Blackhole")
+@pytest.mark.timeout(0)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links",
+    [
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(fabric_payload_size=_FABRIC_PAYLOAD_SIZE),
+            2,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant, case", _CASES, indirect=["variant"])
+def test_kimi_moe_perf_diag(variant, case, config_only, mesh_device, device_params, num_links, request):
+    require_realtime_profiler(f"the {case.label} MoE perf diagnostic")
+    topology = per_axis_topology(device_params["fabric_config"])
+    logger.info(f"DIAG env: tdp_limit_max={get_tdp_limit_max()} ddr_speed={get_ddr_speed()}")
+
+    collected = {}
+
+    def measure(forward):
+        warm = forward()
+        ttnn.synchronize_device(mesh_device)
+        del warm
+
+        def run_all():
+            last = None
+            for _ in range(_ITERS):
+                last = forward()
+            return last
+
+        result, records = profile_realtime_program(
+            mesh_device, run_all, collect_all=True, record_timeout_seconds=_RECORD_TIMEOUT_S
+        )
+        collected["records"] = records
+        return result
+
+    run_model(
+        variant,
+        config_only,
+        mesh_device,
+        device_params,
+        _SEQ_LEN_PER_CHIP,
+        case.config.EMB_SIZE,
+        case.config.MOE_INTERMEDIATE_SIZE,
+        case.config.NUM_ROUTED_EXPERTS,
+        case.config.NUM_EXPERTS_PER_TOKEN,
+        _DISPATCH_BUFFER_CAPACITY_FACTOR,
+        False,
+        num_links,
+        topology,
+        GateComputeMode.DEVICE_FP32,
+        request,
+        **case.extra,
+        measure=measure,
+    )
+
+    records = collected.get("records")
+    assert records, "real-time profiler returned no records"
+
+    # runtime_id is unique per dispatch, and records arrive in dispatch order, so the programs of
+    # iteration k are the k-th slice of equal length.
+    per_program = {}
+    for record in records:
+        runtime_id = record["runtime_id"]
+        if not runtime_id:
+            continue
+        entry = per_program.setdefault(
+            runtime_id, {"by_chip": {}, "spans": {}, "kernels": _kernel_tag(record["kernel_sources"])}
+        )
+        entry["by_chip"][record["chip_id"]] = record["duration_ns"]
+        entry["spans"][record["chip_id"]] = (record["start_ns"], record["end_ns"])
+
+    ordered = list(per_program.items())
+    counts = sorted(len(entry["by_chip"]) for _, entry in ordered)
+    mesh_size = mesh_device.get_num_devices()
+    logger.info(
+        f"DIAG {case.label}: {len(ordered)} programs, {len(records)} records, chip records per program "
+        f"min={counts[0]} max={counts[-1]} short={sum(1 for c in counts if c < mesh_size)} (mesh={mesh_size})"
+    )
+
+    if len(ordered) % _ITERS:
+        logger.warning(f"DIAG {case.label}: {len(ordered)} programs is not a multiple of {_ITERS} iters")
+        return
+    per_iter = len(ordered) // _ITERS
+
+    for iteration in range(_ITERS):
+        chunk = ordered[iteration * per_iter : (iteration + 1) * per_iter]
+        total = sum(max(entry["by_chip"].values()) for _, entry in chunk)
+        dispatch = [max(entry["by_chip"].values()) for _, entry in chunk if _DISPATCH_KERNEL in entry["kernels"]]
+        dispatch_ns = dispatch[0] if dispatch else 0.0
+        logger.info(
+            f"DIAG {case.label} iter {iteration}: total {total:,.0f} ns | dispatch {dispatch_ns:,.0f} ns | "
+            f"total without dispatch {total - dispatch_ns:,.0f} ns"
+        )
+
+    # One chip's timeline for the first iteration. The gap column is what shows a record closing
+    # before its work is done: the time leaves the record and turns up in the gap behind it.
+    ref_chip = min(chip for _, entry in ordered for chip in entry["spans"])
+    timeline = [(entry["spans"][ref_chip], entry["kernels"]) for _, entry in ordered[:per_iter]]
+    origin = min(start for (start, _), _ in timeline)
+    logger.info(f"DIAG {case.label} chip-{ref_chip} timeline (offset, duration, gap to next):")
+    for idx, ((start, end), kernels) in enumerate(timeline):
+        gap = timeline[idx + 1][0][0] - end if idx + 1 < len(timeline) else 0
+        logger.info(
+            f"DIAG   [{idx:>2}] t+{start - origin:>12,.0f} dur {end - start:>10,.0f} gap {gap:>12,.0f}  "
+            f"{kernels.split(',')[0]}"
+        )
+
+    spread = [max(entry["by_chip"].values()) - statistics.median(entry["by_chip"].values()) for _, entry in ordered]
+    logger.info(
+        f"DIAG {case.label} per-program chip skew (max - median), worst {max(spread):,.0f} ns, "
+        f"summed {sum(spread):,.0f} ns -- how much of this metric is straggler chips"
+    )

--- a/tests/ttnn/profiling/realtime_profiler_utils.py
+++ b/tests/ttnn/profiling/realtime_profiler_utils.py
@@ -48,6 +48,12 @@ def profile_realtime_program(
                     "runtime_id": int(record.runtime_id),
                     "chip_id": int(record.chip_id),
                     "duration_ns": (end_timestamp - start_timestamp) / frequency,
+                    # Start/end in ns on the recording chip's own clock, comparable only within that
+                    # chip. Enough to place a program on its chip's timeline -- which is how a program
+                    # whose record closes before its work lands gets caught, since the duration alone
+                    # cannot show that the time went into the following gap.
+                    "start_ns": start_timestamp / frequency,
+                    "end_ns": end_timestamp / frequency,
                     "kernel_sources": tuple(str(source) for source in record.kernel_sources),
                 }
             )


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/55439

### Problem description

`test_kimi_moe_perf_galaxy[blackhole-k2_7-torus-xy-8x4]` was bimodal, not noisy. CI samples from Aug 28 to Sep 8 fall in two clusters 1.10 ms apart, 5.46 ms (n=6) and 6.56 ms (n=22), with an empty 634k ns band between them. The gate's 4% margin admits only the lower cluster.

Root cause: the metric sums per-program critical paths, and the dispatch program's record is binary. Its workers hand the payload to the fabric mux; if they return before the transfer lands the record reads ~0.7 us, if they wait for it the record reads ~1.12 ms (K2.7) / ~1.55 ms (K3). Nothing else in the forward moves by more than ~45 us. The chip-0 timeline separates the two: in the async state the record closes in under 1 us and the transfer time reappears as the gap before the next program, so the duration alone cannot tell them apart.

The state is per forward and autocorrelated within a process (one process measured 4 async and 1 bracketed, another 3 bracketed in a row), so sampling within a process does not average it out.

Ruled out:

- Record loss. Every program returned all 32 chip records; the worst leave-one-chip-out deficit is 2.2% against a 20% gap.
- Program overlap double-counting. Measured overlap is zero; programs are serialized on device.
- A commit. `172d28fa8ed` produced both 5,443,696 and 6,509,689 across attempts of the same code.

The 5,413,674 midpoint came from one sample, #55188 attempt 3. Attempt 1 of the same commit read 6,726,711.

### What's changed

- `_split_off_dispatch` keeps the dispatch program out of the gated total, asserts exactly one match so a rename cannot silently change the number, and logs which state it measured (WARNING when bracketed).
- K2.7 midpoint re-cut to 5,434,881, the median of the nine CI runs that measured this metric. Margin unchanged at 4%.
- K3 unchanged: it runs second on a host K2.7 has warmed, and all 24 CI samples were async, so it was already measuring this number.
- Adds `test_kimi_moe_perf_diag.py`, the repro harness, and `start_ns`/`end_ns` on profiler records, which is what the timeline needs.

Coverage given up: `test_dispatch_combine_perf.py` gates DispatchDeviceOperation per-op but has no K3 entry and runs torus-y 8x1, so K3's dispatch op is now gated nowhere. It was previously covered here only in whichever state a run landed in, which is not coverage either. Follow-up tracked on #55439.

### Perf

10 runs of the gate on one 8x4 BH galaxy (bh-glx-110-c10u20):

| | before | after |
|---|---|---|
| pass | 5/10 | 10/10 |
| min / max | 5,412,103 / 6,654,451 | 5,361,665 / 5,473,288 |
| sd | 495,582 (8.29%) | 32,455 (0.60%) |
| peak to peak | 1,242,348 (20.78%) | 111,623 (2.05%) |
| largest adjacent gap | 672,865 (bimodal) | 44,165 (unimodal) |

One further run landed in the bracketed state (dispatch 1,126,795 ns) and read 5,511,059 ns, passing; on main that run reads ~6.64 ms and fails. The K3 leg also passes locally at 8,480,122 ns with 34 gated programs + 1 dispatch, so the single-match assert holds for both generations.

That box reports TDP_LIMIT_MAX 75 W, so the gate skips there without `KIMI_MOE_PERF_IGNORE_POWER=1`. Both clusters still reproduced at CI's values.

### CI

Three `kimi_moe_perf` runs on `bh_sc1_high_power`, all green. All three landed BRACKETED, so all three are runs that fail on main:

| run | K2.7 gated | dispatch | state | old metric |
|---|---|---|---|---|
| [34224607638](https://github.com/tenstorrent/tt-metal/actions/runs/34224607638) | 5,280,196 | 1,097,322 | BRACKETED | 6,377,518 -> fail |
| [34224663346](https://github.com/tenstorrent/tt-metal/actions/runs/34224663346) | 5,389,948 | 1,112,469 | BRACKETED | 6,502,417 -> fail |
| [34224698012](https://github.com/tenstorrent/tt-metal/actions/runs/34224698012) | 5,434,881 | 1,116,588 | BRACKETED | 6,551,469 -> fail |

K3 was ASYNC on all three (741 / 743 / 745 ns), as the K3 comment predicts. CI's bracketed dispatch (1,097,322 to 1,116,588 ns) matches the 1,103,162 ns separating the two historical clusters and the 1,113,237 to 1,126,795 ns measured locally.

Those three ran at 5efd7e9b4b8, before the midpoint moved from 5,464,153 to 5,434,881. Confirmation runs on c9008d53923:

- https://github.com/tenstorrent/tt-metal/actions/runs/34229264519
- https://github.com/tenstorrent/tt-metal/actions/runs/34229296191
- https://github.com/tenstorrent/tt-metal/actions/runs/34229332460
