### PR TITLE
[Test Only] permute: sweep block-float dtypes and expose the bfloat4_b gap

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_permute.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_permute.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Full block-float permutation sweep for ttnn.permute (see #48813).
+
+ttnn::permute typecasts bfloat8_b to bfloat16 and back when a permutation has no native
+block-float pattern; bfloat4_b never gets that fallback. This sweeps every 4-D permutation
+for both block-float types, on an aligned and an unaligned shape.
+"""
+
+import itertools
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+_PERMS = list(itertools.permutations(range(4)))
+
+_SHAPES = [(2, 3, 32, 64), (2, 3, 32, 60)]
+
+# PCC floor per dtype. bfloat4_b carries a 3-bit mantissa, so even a perfectly ordered
+# result sits well below the bfloat8_b floor; both values are measured, not guessed.
+_PCC = {ttnn.bfloat8_b: 0.9999, ttnn.bfloat4_b: 0.99}
+
+# bfloat4_b permutations that abort with a misaligned NoC read instead of returning a wrong
+# result. They cannot be xfail: the process dies and takes the rest of the session with it.
+_BFP4_MISALIGNED = {
+    (0, 2, 3, 1),
+    (0, 3, 2, 1),
+    (1, 2, 3, 0),
+    (1, 3, 2, 0),
+    (2, 0, 3, 1),
+    (2, 1, 3, 0),
+    (2, 3, 0, 1),
+    (2, 3, 1, 0),
+    (3, 0, 2, 1),
+    (3, 1, 2, 0),
+    (3, 2, 0, 1),
+    (3, 2, 1, 0),
+}
+
+# bfloat4_b permutations that stay within the PCC floor without the bfloat16 fallback.
+_BFP4_EXPECTED_PASS = {(0, 1, 2, 3), (1, 0, 2, 3)}
+
+
+def _params():
+    for dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b):
+        for shape in _SHAPES:
+            for perm in _PERMS:
+                marks = ()
+                if dtype == ttnn.bfloat4_b and perm not in _BFP4_MISALIGNED and perm not in _BFP4_EXPECTED_PASS:
+                    marks = (pytest.mark.xfail(reason="#48813: bfloat4_b has no bfloat16 permute fallback"),)
+                name = "bfloat8_b" if dtype == ttnn.bfloat8_b else "bfloat4_b"
+                pid = f"{name}-{'x'.join(map(str, shape))}-{''.join(map(str, perm))}"
+                yield pytest.param(dtype, shape, perm, marks=marks, id=pid)
+
+
+@pytest.mark.parametrize("dtype, shape, perm", list(_params()))
+def test_permute_block_float(device, dtype, shape, perm):
+    if dtype == ttnn.bfloat4_b and perm in _BFP4_MISALIGNED:
+        pytest.skip("#48813: bfloat4_b permute aborts on a misaligned NoC read for this permutation")
+
+    torch.manual_seed(2005)
+    torch_input = torch.randn(*shape)
+    torch_output = torch.permute(torch_input, perm)
+
+    tt_input = ttnn.from_torch(torch_input, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
+    tt_output = ttnn.to_torch(ttnn.permute(tt_input, perm))
+
+    assert_with_pcc(torch_output, tt_output, _PCC[dtype])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_permute.py
@@ -158,15 +158,48 @@ def test_permute_negative_dim(device, h, w, dtype):
     assert_equal(torch_output_tensor, output_tensor)
 
 
-def test_permute_bfloat8(device):
+# PCC floor per block-float type. bfloat4_b carries a 3-bit mantissa, so a correctly ordered
+# result sits well below the bfloat8_b floor; 0.99 is the contract a bfloat16 fallback meets.
+_BLOCK_FLOAT_PCC = {ttnn.bfloat8_b: 0.9999, ttnn.bfloat4_b: 0.99}
+
+_BFP4_NO_FALLBACK = "#48813: bfloat4_b has no bfloat16 permute fallback"
+
+
+@pytest.mark.parametrize(
+    "dtype, perm",
+    [
+        pytest.param(ttnn.bfloat8_b, (0, 2, 3, 1), id="bfloat8_b-0231"),
+        pytest.param(ttnn.bfloat8_b, (1, 0, 2, 3), id="bfloat8_b-1023-cn"),
+        pytest.param(ttnn.bfloat8_b, (0, 1, 3, 2), id="bfloat8_b-0132-wh"),
+        pytest.param(ttnn.bfloat8_b, (0, 2, 1, 3), id="bfloat8_b-0213"),
+        pytest.param(ttnn.bfloat8_b, (2, 0, 1, 3), id="bfloat8_b-2013"),
+        pytest.param(
+            ttnn.bfloat4_b,
+            (0, 2, 3, 1),
+            marks=pytest.mark.skip(reason="#48813: bfloat4_b permute aborts on a misaligned NoC read here"),
+            id="bfloat4_b-0231",
+        ),
+        pytest.param(ttnn.bfloat4_b, (1, 0, 2, 3), id="bfloat4_b-1023-cn"),
+        pytest.param(
+            ttnn.bfloat4_b, (0, 1, 3, 2), marks=pytest.mark.xfail(reason=_BFP4_NO_FALLBACK), id="bfloat4_b-0132-wh"
+        ),
+        pytest.param(
+            ttnn.bfloat4_b, (0, 2, 1, 3), marks=pytest.mark.xfail(reason=_BFP4_NO_FALLBACK), id="bfloat4_b-0213"
+        ),
+        pytest.param(
+            ttnn.bfloat4_b, (2, 0, 1, 3), marks=pytest.mark.xfail(reason=_BFP4_NO_FALLBACK), id="bfloat4_b-2013"
+        ),
+    ],
+)
+def test_permute_block_float(device, dtype, perm):
     torch.manual_seed(2005)
     input_a = torch.randn(1, 160, 32, 32)
-    torch_output = torch.permute(input_a, (0, 2, 3, 1))
+    torch_output = torch.permute(input_a, perm)
 
-    tt_input = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
-    tt_output = ttnn.permute(tt_input, (0, 2, 3, 1))
+    tt_input = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
+    tt_output = ttnn.permute(tt_input, perm)
     tt_output = ttnn.to_torch(tt_output)
-    assert_with_pcc(torch_output, tt_output, 0.9999)
+    assert_with_pcc(torch_output, tt_output, _BLOCK_FLOAT_PCC[dtype])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### PR Category

Test Only

### Summary

Relates to #48813.

- Extend the existing block-float unit test to cover both `bfloat8_b` and `bfloat4_b` over
  five permutations.
- Add a nightly test covering all 24 4D permutations, both block-float types, and shapes
  `(2, 3, 32, 64)` and `(2, 3, 32, 60)`.

No production code changes.

### Notes for reviewers

`bfloat4_b` currently fails in two ways:

- 12 permutations abort on a misaligned NoC read. They are skipped because `xfail` cannot
  contain a process abort. One of them is `(0, 2, 3, 1)`, the permutation the existing unit
  test used, so that case is kept for `bfloat8_b` and skipped for `bfloat4_b`.
- All other failing `bfloat4_b` cases are marked `xfail` with #48813.

The PCC thresholds are `0.9999` for `bfloat8_b` and `0.99` for `bfloat4_b`. The lower
threshold accounts for normal `bfloat4_b` quantization.

Are skips acceptable for the aborting cases, or should they use another nightly marker?

### Test results

Blackhole ttsim, no hardware:

- Nightly: 52 passed, 24 skipped, 20 xfailed.
- Unit: 6 passed, 1 skipped, 3 xfailed.

No failures or unexpected passes.

The abort has not been observed on silicon. It is structural — it depends on the shape and
the permutation, not on the values — but if a card hangs instead of aborting cleanly, the
skip list matters more than I can show from a simulator.
