### PR TITLE
[Test Infra] [Test Only] Add Quasar support to the SFPU accuracy sweep

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/accuracy_harness.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import torch
 from helpers.accuracy_metrics import compute_pointwise_metrics
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
     UnarySFPUGolden,
@@ -20,14 +21,19 @@ from helpers.golden_generators import (
 )
 from helpers.llk_params import (
     ApproximationMode,
+    DataCopyType,
     DestAccumulation,
+    DestSync,
     FastMode,
+    ImpliedMathFormat,
     MathOperation,
     PerfRunType,
     StableSort,
     Transpose,
+    UnpackerEngine,
     format_dict,
 )
+from helpers.param_config import QuasarSfpuVariant, resolve_quasar_sfpu_variant
 from helpers.perf.core import PerfConfig
 from helpers.sfpu_domains import for_op
 from helpers.stimuli_config import StimuliConfig
@@ -41,16 +47,23 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     APPROX_MODE,
     CLAMP_NEGATIVE,
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
     FAST_MODE,
+    IMPLIED_MATH_FORMAT,
     ITERATIONS,
     LOOP_FACTOR,
     MATH_OP,
     NUM_FACES,
     PERF_RUN_TYPE,
     STABLE_SORT,
+    TEST_FACE_DIMS,
     TILE_COUNT,
+    TYPECAST_FORMATS,
     UNPACK_TRANS_FACES,
     UNPACK_TRANS_WITHIN_FACE,
+    UNPACKER_ENGINE_SEL,
 )
 
 _THIS_DIR = Path(__file__).resolve().parent
@@ -114,6 +127,82 @@ FLOAT_FORMAT = "%.9g"
 
 # How many input points each op's curve is sampled at.
 DEFAULT_SWEEP_POINTS = 2048
+
+# ── Per-arch kernel selection ──────────────────────────────────────────────────
+WH_BH_KERNEL = "sources/eltwise_unary_sfpu_perf.cpp"
+QUASAR_KERNEL = "sources/quasar/eltwise_unary_sfpu_quasar_test.cpp"
+
+# Quasar-only knobs the accuracy sweep pins rather than sweeps. DestSync is a
+# synchronisation mode and should not change numerics. ImpliedMathFormat does
+# (it decides whether Float16 lives in Dest as FP16A or BF16), but the shard
+# schema has no column for it; sweeping it is a separate schema decision.
+QUASAR_DEST_SYNC = DestSync.Half
+QUASAR_IMPLIED_MATH_FORMAT = ImpliedMathFormat.Yes
+
+
+def kernel_source_for(arch: ChipArchitecture) -> str:
+    """Kernel source path for *arch* (relative to tests/)."""
+    return QUASAR_KERNEL if arch == ChipArchitecture.QUASAR else WH_BH_KERNEL
+
+
+def resolve_quasar_variant(
+    op: MathOperation, formats: InputOutputFormat, dest_acc: DestAccumulation
+) -> QuasarSfpuVariant:
+    """Resolve the Quasar data route for one (op, formats, dest_acc).
+
+    Quasar cannot take an arbitrary triple: the resolver picks the Dest,
+    SFPU and packer formats and rejects routes the hardware cannot execute.
+    Raises ValueError (rather than returning None) so a bad sweep entry fails
+    loudly instead of silently producing no shard.
+    """
+    variant = resolve_quasar_sfpu_variant(op, formats, dest_acc)
+    if variant is None:
+        raise ValueError(
+            f"{op.name}: Quasar cannot execute {formats.input_format.name} -> "
+            f"{formats.output_format.name} with dest_acc={dest_acc.name}"
+        )
+    return variant
+
+
+def quasar_templates(
+    op: MathOperation,
+    approx_mode: ApproximationMode,
+    fast_mode: FastMode,
+    unpack_to_dest: bool,
+) -> list:
+    """Compile-time parameters for the Quasar unary SFPU kernel.
+
+    Mirrors the template list in quasar/test_eltwise_unary_sfpu_quasar.py for
+    a non-typecast op, with the Quasar-only knobs pinned (see module constants).
+    """
+    if fast_mode == FastMode.Yes:
+        raise ValueError(
+            f"{op.name}: the Quasar unary SFPU kernel has no fast mode; "
+            "sweep FastMode.No only"
+        )
+    return [
+        PERF_RUN_TYPE(PerfRunType.L1_TO_L1),
+        MATH_OP(mathop=op),
+        APPROX_MODE(approx_mode),
+        IMPLIED_MATH_FORMAT(QUASAR_IMPLIED_MATH_FORMAT),
+        DATA_COPY_TYPE(DataCopyType.A2D),
+        UNPACKER_ENGINE_SEL(
+            UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+        ),
+        DEST_SYNC(QUASAR_DEST_SYNC),
+        TYPECAST_FORMATS(),
+    ]
+
+
+def quasar_runtimes(tile_cnt: int, num_faces: int) -> list:
+    """Runtime parameters for the Quasar unary SFPU kernel: one pass over the data."""
+    return [
+        TILE_COUNT(tile_cnt),
+        NUM_FACES(num_faces=num_faces),
+        TEST_FACE_DIMS(),
+        DEST_INDEX(0),
+        LOOP_FACTOR(1),
+    ]
 
 
 def _write_op_file(df: "pd.DataFrame", stem: str, output_format: str) -> Path:
@@ -420,17 +509,38 @@ def run_case(
         tile_count_res=tile_cnt_A,
     )
 
-    unpack_to_dest = (
-        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
-    )
-
     _, _, faces_to_generate = calculate_tile_and_face_counts(
         input_dimensions, input_dimensions, face_r_dim=16, num_faces=4
     )
 
-    if run_mode == RunMode.ACCURACY:
+    arch = get_chip_architecture()
+    if arch == ChipArchitecture.QUASAR:
+        if run_mode != RunMode.ACCURACY:
+            raise NotImplementedError(
+                f"run_mode={run_mode.value} is not supported on Quasar; "
+                "only RunMode.ACCURACY"
+            )
+        # On Quasar the data route (and therefore unpack_to_dest) is decided by
+        # the resolver, not by the WH/BH "32-bit input + dest_acc" rule.
+        quasar_variant = resolve_quasar_variant(op, formats, dest_acc)
+        unpack_to_dest = quasar_variant.unpack_to_dest
         configuration = TestConfig(
-            "sources/eltwise_unary_sfpu_perf.cpp",
+            QUASAR_KERNEL,
+            formats,
+            templates=quasar_templates(op, approx_mode, fast_mode, unpack_to_dest),
+            runtimes=quasar_runtimes(tile_cnt_A, faces_to_generate),
+            variant_stimuli=variant_stimuli,
+            dest_acc=dest_acc,
+            unpack_to_dest=unpack_to_dest,
+        )
+        quasar_variant.apply_formats(configuration.formats_config)
+        res_from_L1 = configuration.run().result
+    elif run_mode == RunMode.ACCURACY:
+        unpack_to_dest = (
+            formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+        )
+        configuration = TestConfig(
+            WH_BH_KERNEL,
             formats,
             templates=[
                 PERF_RUN_TYPE(PerfRunType.L1_TO_L1),
@@ -454,6 +564,9 @@ def run_case(
         )
         res_from_L1 = configuration.run().result
     else:
+        unpack_to_dest = (
+            formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+        )
         run_types = (
             _ACCURACY_CAPABLE_RUN_TYPES
             if run_mode == RunMode.BOTH

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/conftest.py
@@ -20,12 +20,15 @@ import os
 
 from helpers.logger import logger
 
-_MODE_TO_FUNC = {
-    "accuracy": "test_sfpu_accuracy_sweep",
-    "perf": "test_sfpu_perf_sweep",
-    "both": "test_sfpu_accuracy_and_perf_sweep",
+# Sweep functions per --mode. The Quasar sibling is accuracy-only (run_case
+# rejects PERF/BOTH on Quasar), so it is selected by "accuracy" and deselected
+# by the other modes.
+_MODE_TO_FUNCS = {
+    "accuracy": {"test_sfpu_accuracy_sweep", "test_sfpu_accuracy_sweep_quasar"},
+    "perf": {"test_sfpu_perf_sweep"},
+    "both": {"test_sfpu_accuracy_and_perf_sweep"},
 }
-_SWEEP_FUNCS = set(_MODE_TO_FUNC.values())
+_SWEEP_FUNCS = set().union(*_MODE_TO_FUNCS.values())
 
 
 def pytest_collection_modifyitems(config, items):
@@ -33,13 +36,13 @@ def pytest_collection_modifyitems(config, items):
     mode = config.getoption("--mode", default=None)
     if not mode:
         return
-    target = _MODE_TO_FUNC[mode]
+    targets = _MODE_TO_FUNCS[mode]
     deselected = [
         it
         for it in items
         if getattr(it, "function", None) is not None
         and it.function.__name__ in _SWEEP_FUNCS
-        and it.function.__name__ != target
+        and it.function.__name__ not in targets
     ]
     if deselected:
         drop = {id(it) for it in deselected}

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
@@ -12,7 +12,7 @@ shards into one CSV per op. Sanity-assert only (no ULP threshold gating).
 from itertools import product
 
 import pytest
-from conftest import skip_for_coverage
+from conftest import skip_for_coverage, skip_for_quasar
 from helpers.chip_architecture import ChipArchitecture
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.llk_params import (
@@ -119,6 +119,7 @@ def _skip_if_unsupported(
         pytest.skip(reason="This combination is not supported on BH architecture")
 
 
+@skip_for_quasar
 @skip_for_coverage
 @pytest.mark.accuracy
 @pytest.mark.parametrize(
@@ -138,6 +139,7 @@ def test_sfpu_accuracy_sweep(
     run_case(mathop, formats, approx_mode, fast_mode, dest_acc)
 
 
+@skip_for_quasar
 @skip_for_coverage
 @pytest.mark.perf
 @pytest.mark.parametrize(
@@ -169,6 +171,7 @@ def test_sfpu_perf_sweep(
     )
 
 
+@skip_for_quasar
 @skip_for_coverage
 @pytest.mark.perf
 @pytest.mark.accuracy

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy_quasar.py
@@ -21,7 +21,7 @@ Runs only against the Quasar simulator (no silicon): from tests/python_tests
 """
 
 import pytest
-from conftest import skip_for_coverage
+from conftest import quasar_only, skip_for_coverage
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.llk_params import (
     ApproximationMode,
@@ -98,6 +98,7 @@ def _quasar_accuracy_params():
 QUASAR_ACCURACY_PARAMS = _quasar_accuracy_params()
 
 
+@quasar_only
 @skip_for_coverage
 @pytest.mark.quasar
 @pytest.mark.accuracy

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy_quasar.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+SFPU accuracy sweep for Quasar.
+
+Sibling of test_sfpu_accuracy.py (the WH/BH sweep) sharing run_case, the
+shard->merge pipeline and the output schema. It lives here rather than in
+quasar/ because the merge hooks are in accuracy/conftest.py.
+
+The parameter list is resolver-driven, not a cartesian product: on Quasar the
+(input, output, dest_acc) route is decided by resolve_quasar_sfpu_variant, so
+only executable routes appear. The op list is the subset of the WH/BH
+transcendentals the Quasar unary SFPU kernel dispatches, the approx axis
+follows Quasar's own approx-capable list, and there is no fast-mode axis
+(the Quasar kernel has none). DestSync and ImpliedMathFormat are pinned in
+accuracy_harness (QUASAR_DEST_SYNC / QUASAR_IMPLIED_MATH_FORMAT).
+
+Runs only against the Quasar simulator (no silicon): from tests/python_tests
+    CHIP_ARCH=quasar pytest --run-simulator -m "accuracy and quasar" \
+        accuracy/test_sfpu_accuracy_quasar.py --maxfail=5000
+"""
+
+import pytest
+from conftest import skip_for_coverage
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.llk_params import (
+    ApproximationMode,
+    DestAccumulation,
+    FastMode,
+    MathOperation,
+)
+from helpers.param_config import (
+    generate_quasar_sfpu_format_variants,
+    input_output_formats,
+)
+
+# WH/BH transcendentals that the Quasar unary SFPU test kernel dispatches
+# (see tests/helpers/include/sfpu_operations_quasar.h). Missing vs WH/BH:
+# Exp2, Log, Log1p, Elu, Celu, Hardsigmoid, Erfinv.
+QUASAR_TRANSCENDENTAL_OPS = [
+    MathOperation.Exp,
+    MathOperation.Sqrt,
+    MathOperation.Rsqrt,
+    MathOperation.Reciprocal,
+    MathOperation.Sin,
+    MathOperation.Cos,
+    MathOperation.Tanh,
+    MathOperation.Gelu,
+    MathOperation.Silu,
+    MathOperation.Atanh,
+    MathOperation.Asinh,
+    MathOperation.Acosh,
+]
+
+# Ops with a real approx kernel on Quasar (mirrors quasar/test_eltwise_unary_sfpu_quasar.py).
+# Differs from WH/BH: Sqrt, Sin and Cos have no approx path here.
+QUASAR_APPROX_CAPABLE_OPS = [
+    MathOperation.Exp,
+    MathOperation.Gelu,
+    MathOperation.Reciprocal,
+    MathOperation.Rsqrt,
+]
+
+FORMATS = input_output_formats(
+    [
+        DataFormat.Float32,
+        DataFormat.Float16,
+        DataFormat.Float16_b,
+    ]
+)
+
+
+def _get_approx_modes(mathop):
+    if mathop in QUASAR_APPROX_CAPABLE_OPS:
+        return [ApproximationMode.No, ApproximationMode.Yes]
+    return [ApproximationMode.No]
+
+
+def _quasar_accuracy_params():
+    """(formats, approx, op, dest_acc) for every executable Quasar route.
+
+    full_format_route_sweep keeps every valid (input, output, dest_acc) route
+    rather than one representative per SFPU-visible state: the input format
+    changes the sampled x values, so routes the functional suite treats as
+    duplicates are distinct accuracy curves.
+    """
+    params = []
+    for op in QUASAR_TRANSCENDENTAL_OPS:
+        variants = generate_quasar_sfpu_format_variants(
+            op, FORMATS, full_format_route_sweep=True
+        )
+        for variant in variants:
+            for approx in _get_approx_modes(op):
+                params.append((variant.formats, approx, op, variant.dest_acc))
+    return params
+
+
+QUASAR_ACCURACY_PARAMS = _quasar_accuracy_params()
+
+
+@skip_for_coverage
+@pytest.mark.quasar
+@pytest.mark.accuracy
+@pytest.mark.parametrize("formats,approx_mode,mathop,dest_acc", QUASAR_ACCURACY_PARAMS)
+def test_sfpu_accuracy_sweep_quasar(
+    formats: InputOutputFormat,
+    approx_mode: ApproximationMode,
+    mathop: MathOperation,
+    dest_acc: DestAccumulation,
+):
+    from accuracy.accuracy_harness import run_case
+
+    run_case(mathop, formats, approx_mode, FastMode.No, dest_acc)


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The SFPU accuracy harness (`tests/python_tests/accuracy/`) only ran on Wormhole and Blackhole. This adds Quasar so the same per-element accuracy data can be collected there too.

- `run_case` now picks the kernel by architecture. WH/BH keep `eltwise_unary_sfpu_perf.cpp`; Quasar uses `eltwise_unary_sfpu_quasar_test.cpp` with its own template list.
- New `test_sfpu_accuracy_quasar.py` sweeps 12 of the 19 transcendental ops (the ones the Quasar kernel dispatches) over 240 executable format/dest_acc routes. It shares the shard/merge pipeline and schema, output lands in `_csv_output/qsr/`.
- The WH/BH sweeps are marked `skip_for_quasar`; their behaviour is otherwise unchanged. Rerunning the Exp sweep on Wormhole before and after gives byte-identical Parquet.
- Off-device unit tests cover the new helpers and the sweep's parameter list.
- README gets a Quasar section.

### Notes for reviewers
- **Pinned knobs.** `DestSync.Half` and `ImpliedMathFormat.Yes` are fixed constants in the harness, not swept. Implied math format does affect numerics (Float16 in Dest as FP16A vs BF16), but the shard schema has no column for it. Sweeping it later means adding a column and extending the shard name. I kept it pinned to match what the Quasar perf sweep uses.
- **Resolver-driven matrix.** Quasar can't take an arbitrary (input, output, dest_acc) triple, so the sweep is built from `generate_quasar_sfpu_format_variants(..., full_format_route_sweep=True)`. The full route sweep is deliberate: the functional suite's default dedup drops routes that differ only in input format, which for an accuracy curve changes the sampled x values.
- **Accuracy only on Quasar.** `RunMode.PERF` and `BOTH` raise `NotImplementedError`. Perf on Quasar needs its own run types and config factory and is out of scope here.
- **Not executed on a simulator yet.** Verified by compile-only build of the Exp variants (30 tests, 6 distinct ELF sets) and by unit tests. First real run should be one op, one format, before the full 240.
- **Pre-existing, not from this PR.** The WH `--mode both` sweep exits 1 at session end with `PerfSchemaError` (duplicate keys after dest_acc promotion on Float16_b→Float16). Confirmed identical on the original code. Worth a separate fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-tests-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/accuracy-tests-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-tests-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/accuracy-tests-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/accuracy-tests-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/accuracy-tests-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/accuracy-tests-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/accuracy-tests-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/accuracy-tests-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/accuracy-tests-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/accuracy-tests-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/accuracy-tests-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/accuracy-tests-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/accuracy-tests-quasar)