### PR TITLE
fix(kv_cache): visit every user when update_cache batch is odd

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -177,6 +177,31 @@ class TestUpdateCache:
 
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
+@pytest.mark.parametrize("num_users", [3, 5])
+def test_update_cache_decode_odd_num_users(num_users, device):
+    """Odd Bcache must update every user; u_count = u_range / 2 used to skip the last."""
+    num_heads = 2
+    head_dim = 64
+    max_seq_len = 64
+    cache_idx = 1
+    input_shape = [num_users, num_heads, 1, head_dim]
+    cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+    cache = torch.randn(cache_shape).bfloat16().float()
+    cachett = ttnn.Tensor(cache, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    x = torch.randn(input_shape).bfloat16().float()
+    x_new = torch.cat((x, torch.zeros(32 - num_users, num_heads, 1, head_dim)), dim=0)
+    xt = ttnn.Tensor(x_new.permute(2, 1, 0, 3), ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    cachett = ttnn.update_cache(cachett, xt, cache_idx)
+    cache[0:num_users, 0:num_heads, cache_idx : cache_idx + 1, 0:head_dim] = x
+
+    tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    eq_cache, output_cache = comp_equal(cache, tt_got_back)
+    logger.info(output_cache)
+    assert eq_cache
+
+
+@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("in_sharded", [False, True])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
 def test_update_cache_decode_program_cache_hits(in_sharded, input_dtype, device):

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -198,7 +198,7 @@ def test_update_cache_decode_odd_num_users(num_users, device):
     tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     eq_cache, output_cache = comp_equal(cache, tt_got_back)
     logger.info(output_cache)
-    assert eq_cache
+    assert eq_cache, output_cache
 
 
 @skip_for_blackhole("Mismatching on BH, see #12349")

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
@@ -171,8 +171,11 @@ ttnn::device_operation::ProgramArtifacts UpdateCacheMultiCoreProgramFactory::cre
 
     std::uint32_t B = input_tensor.padded_shape()[-2];
     std::uint32_t Bcache = cache_tensor.padded_shape()[0];
-    const std::uint32_t granularity =
-        std::min(static_cast<std::uint32_t>(2), Bcache);  // granularity = 2 best for performance
+    // Kernels visit u_count * granularity users per head; that product must equal
+    // min(32, Bcache). 2 is faster but only when it divides (odd Bcache >= 3).
+    const std::uint32_t u_range = std::min(static_cast<std::uint32_t>(32), Bcache);
+    const std::uint32_t granularity = (u_range % 2 == 0) ? 2u : 1u;
+    const std::uint32_t u_count = u_range / granularity;
     std::uint32_t num_batched_heads = input_tensor.padded_shape()[1] * B / tt::constants::TILE_HEIGHT;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -267,9 +270,6 @@ ttnn::device_operation::ProgramArtifacts UpdateCacheMultiCoreProgramFactory::cre
 
     const TensorParameter cache_param{.unique_id = CACHE, .spec = cache_tensor.tensor_spec()};
     const TensorParameter input_param{.unique_id = INPUT, .spec = input_tensor.tensor_spec()};
-
-    const std::uint32_t u_range = std::min(static_cast<std::uint32_t>(32), Bcache);
-    const std::uint32_t u_count = u_range / granularity;
 
     // ---- Reader ----
     KernelSpec::CompilerOptions::Defines reader_defines;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Relates to #51227 (item 2).

`update_cache` set `u_count = min(32, Bcache) / granularity` with `granularity = min(2, Bcache)`. Odd `Bcache >= 3` truncated, so the kernels skipped the last user and later heads wrote into the wrong slots. Use granularity 2 only when `min(32, Bcache)` is even.

### Notes for reviewers

Kernels unchanged. Even batches stay at granularity 2.

Does not cover `Bcache > 32` (#52671 / #52789).

Wormhole:

```
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py::test_update_cache_decode_odd_num_users -v
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py::TestUpdateCache::test_update_cache_decode -v
```