### PR TITLE
[Performance] Restore TP-ring all-to-all balance with opt-in Fabric routes

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/equal_cost_unicast.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/equal_cost_unicast.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Experimental API; subject to change without notice.
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+#include <hostdevcommon/fabric_common.h>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+
+namespace tt::tt_metal::experimental::fabric {
+
+// Opaque route arguments produced by Fabric. A default object requests canonical routing.
+class UnicastRoute {
+public:
+    UnicastRoute() = default;
+    tt::tt_fabric::eth_chan_directions initial_direction() const {
+        return static_cast<tt::tt_fabric::eth_chan_directions>(args_[0]);
+    }
+    uint32_t num_hops() const { return args_[1]; }
+    const std::vector<uint32_t>& runtime_args() const { return args_; }
+
+private:
+    friend std::optional<std::array<UnicastRoute, 2>> get_equal_cost_unicast_routes(
+        const tt::tt_fabric::FabricNodeId&,
+        const tt::tt_fabric::FabricNodeId&,
+        const std::array<tt::tt_fabric::FabricNodeId, 2>&);
+    std::vector<uint32_t> args_{tt::tt_fabric::eth_chan_directions::COUNT, 0};
+};
+
+// Opt-in load balancing for an intra-mesh unicast. Return two supported routes, one
+// through each supplied direct neighbor, only when both use distinct physical egresses
+// and match the canonical route's hop count. Fabric owns path selection, validation,
+// header capacity checks, and encoding. Unsupported paths return nullopt; retain
+// canonical routing in that case. Routes are valid until Fabric is closed.
+std::optional<std::array<UnicastRoute, 2>> get_equal_cost_unicast_routes(
+    const tt::tt_fabric::FabricNodeId& source,
+    const tt::tt_fabric::FabricNodeId& destination,
+    const std::array<tt::tt_fabric::FabricNodeId, 2>& neighbors);
+
+}  // namespace tt::tt_metal::experimental::fabric

--- a/tt_metal/fabric/equal_cost_unicast.cpp
+++ b/tt_metal/fabric/equal_cost_unicast.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/fabric/equal_cost_unicast.hpp>
+
+#include <set>
+#include <utility>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include "fabric_context.hpp"
+#include "impl/context/metal_context.hpp"
+
+namespace tt::tt_metal::experimental::fabric {
+
+std::optional<std::array<UnicastRoute, 2>> get_equal_cost_unicast_routes(
+    const tt::tt_fabric::FabricNodeId& source,
+    const tt::tt_fabric::FabricNodeId& destination,
+    const std::array<tt::tt_fabric::FabricNodeId, 2>& neighbors) {
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& context = control_plane.get_fabric_context();
+    if (!context.is_2D_routing_enabled() || source.mesh_id != destination.mesh_id || source == destination ||
+        neighbors[0] == neighbors[1]) {
+        return std::nullopt;
+    }
+    // Resolve paths using the same live routing tables as canonical unicast. The
+    // application cannot request detours or supply packet-header instructions.
+    auto shortest_path = [&](const tt::tt_fabric::FabricNodeId& start) {
+        std::vector<tt::tt_fabric::FabricNodeId> path;
+        if (start == destination) {
+            return std::vector<tt::tt_fabric::FabricNodeId>{start};
+        }
+        for (const auto channel : control_plane.get_forwarding_eth_chans_to_chip(start, destination)) {
+            const auto candidate = control_plane.get_fabric_route(start, destination, channel);
+            std::vector<tt::tt_fabric::FabricNodeId> nodes{start};
+            for (const auto& [node, _] : candidate) {
+                if (node != nodes.back()) {
+                    nodes.push_back(node);
+                }
+            }
+            if (nodes.back() == destination && (path.empty() || nodes.size() < path.size())) {
+                path = std::move(nodes);
+            }
+        }
+        return path;
+    };
+    const auto canonical_path = shortest_path(source);
+    if (canonical_path.empty()) {
+        return std::nullopt;
+    }
+    auto route_via = [&](const tt::tt_fabric::FabricNodeId& neighbor) -> std::optional<UnicastRoute> {
+        if (source.mesh_id != neighbor.mesh_id || source == neighbor ||
+            tt::tt_fabric::get_neighbor_eth_directions(source, neighbor).empty()) {
+            return std::nullopt;
+        }
+
+        auto path = shortest_path(neighbor);
+        if (path.empty()) {
+            return std::nullopt;
+        }
+        path.insert(path.begin(), source);
+        if (path.size() != canonical_path.size()) {
+            return std::nullopt;
+        }
+        if (path.size() < 2 || path.size() - 1 > context.get_2d_pkt_hdr_route_buffer_size()) {
+            return std::nullopt;
+        }
+
+        std::set<tt::tt_fabric::FabricNodeId> visited{source};
+        std::vector<tt::tt_fabric::eth_chan_directions> directions;
+        for (size_t hop = 1; hop < path.size(); ++hop) {
+            const auto& from = path[hop - 1];
+            const auto& to = path[hop];
+            if (to.mesh_id != source.mesh_id || !visited.insert(to).second) {
+                return std::nullopt;
+            }
+            const auto direction = control_plane.get_forwarding_direction(from, to);
+            if (!direction) {
+                return std::nullopt;
+            }
+            const auto eth_direction = control_plane.routing_direction_to_eth_direction(*direction);
+            if (eth_direction >= tt::tt_fabric::eth_chan_directions::Z) {
+                return std::nullopt;
+            }
+            const auto channels = control_plane.get_active_fabric_eth_routing_planes_in_direction(from, *direction);
+            if (channels.empty()) {
+                return std::nullopt;
+            }
+            // Every plane on this egress must reach the same physical neighbor. Express links
+            // require a route representation that also selects an edge, rather than a direction.
+            for (const auto channel : channels) {
+                const auto peer = control_plane.try_get_connected_mesh_chip_chan_ids(from, channel);
+                if (!peer || peer->first != to) {
+                    return std::nullopt;
+                }
+            }
+            // The header has one branch offset per EW direction. Keep canonical routing for
+            // paths requiring an NS-to-EW transition until this API can represent those turns.
+            if (!directions.empty() &&
+                (directions.back() == tt::tt_fabric::NORTH || directions.back() == tt::tt_fabric::SOUTH) &&
+                (eth_direction == tt::tt_fabric::EAST || eth_direction == tt::tt_fabric::WEST)) {
+                return std::nullopt;
+            }
+            directions.push_back(eth_direction);
+        }
+
+        constexpr uint32_t commands_per_word = 8;
+        UnicastRoute route;
+        route.args_ = {directions.front(), static_cast<uint32_t>(directions.size())};
+        route.args_.resize(2 + (directions.size() + commands_per_word - 1) / commands_per_word, 0);
+        for (size_t hop = 0; hop < directions.size(); ++hop) {
+            // Injection performs the first hop. The final command drains through the ingress.
+            const bool terminal = hop + 1 == directions.size();
+            const auto direction = terminal ? directions.back() : directions[hop + 1];
+            const bool ns = direction == tt::tt_fabric::NORTH || direction == tt::tt_fabric::SOUTH;
+            // Reuse Fabric's canonical encoder for a one-hop segment with its forward
+            // command prepended: [forward, drain]. Selecting the appropriate command
+            // also supports folded physical paths without duplicating opcode mappings.
+            uint8_t segment[2];
+            tt::tt_fabric::routing_encoding::encode_2d_unicast(
+                ns ? 1 : 0,
+                ns ? 0 : 1,
+                direction == tt::tt_fabric::SOUTH,
+                direction == tt::tt_fabric::EAST,
+                segment,
+                2,
+                true);
+            route.args_[2 + hop / commands_per_word] |= static_cast<uint32_t>(segment[terminal ? 1 : 0])
+                                                        << (4 * (hop % commands_per_word));
+        }
+        return route;
+    };
+    const auto first = route_via(neighbors[0]);
+    const auto second = route_via(neighbors[1]);
+    if (!first || !second || first->initial_direction() == second->initial_direction()) {
+        return std::nullopt;
+    }
+    return std::array<UnicastRoute, 2>{*first, *second};
+}
+
+}  // namespace tt::tt_metal::experimental::fabric

--- a/tt_metal/fabric/hw/inc/equal_cost_unicast.h
+++ b/tt_metal/fabric/hw/inc/equal_cost_unicast.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Experimental API; subject to change without notice.
+
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+
+namespace tt::tt_metal::experimental::fabric {
+
+// Worker-side view of the opaque arguments produced by get_equal_cost_unicast_routes.
+class UnicastRouteView {
+public:
+    constexpr UnicastRouteView() = default;
+    explicit constexpr UnicastRouteView(size_t arg_index) : arg_index_(arg_index), canonical_(false) {}
+    uint32_t num_hops() const { return canonical_ ? 0 : get_arg_val<uint32_t>(arg_index_ + 1); }
+    tt::tt_fabric::eth_chan_directions initial_direction() const {
+        return static_cast<tt::tt_fabric::eth_chan_directions>(get_arg_val<uint32_t>(arg_index_));
+    }
+
+private:
+    friend bool fabric_set_equal_cost_unicast_route(
+        volatile tt_l1_ptr tt::tt_fabric::HybridMeshPacketHeader*, uint16_t, uint16_t, const UnicastRouteView&);
+
+    uint32_t command(uint32_t hop) const {
+        return (get_arg_val<uint32_t>(arg_index_ + 2 + hop / 8) >> (4 * (hop % 8))) & 0xf;
+    }
+
+    size_t arg_index_ = 0;
+    bool canonical_ = true;
+};
+
+FORCE_INLINE UnicastRouteView get_unicast_route_from_args(size_t arg_index) { return UnicastRouteView(arg_index); }
+
+FORCE_INLINE tt::tt_fabric::eth_chan_directions get_unicast_route_direction(
+    const UnicastRouteView& route, uint16_t dst_mesh_id, uint16_t dst_dev_id) {
+    return route.num_hops() == 0 ? tt::tt_fabric::get_next_hop_router_direction(dst_mesh_id, dst_dev_id)
+                                 : route.initial_direction();
+}
+
+// Only Fabric writes packet routing fields. The host validates every physical hop and
+// capacity; recheck the device header specialization before using a noncanonical route.
+FORCE_INLINE bool fabric_set_equal_cost_unicast_route(
+    volatile tt_l1_ptr tt::tt_fabric::HybridMeshPacketHeader* packet_header,
+    uint16_t dst_dev_id,
+    uint16_t dst_mesh_id,
+    const UnicastRouteView& route) {
+    const uint32_t hops = route.num_hops();
+    if (hops == 0) {
+        return tt::tt_fabric::fabric_set_unicast_route(packet_header, dst_dev_id, dst_mesh_id);
+    }
+    if (route.initial_direction() >= tt::tt_fabric::eth_chan_directions::Z ||
+        hops > tt::tt_fabric::FabricHeaderConfig::MESH_ROUTE_BUFFER_SIZE) {
+        return false;
+    }
+    packet_header->dst_start_node_id = (static_cast<uint32_t>(dst_mesh_id) << 16) | dst_dev_id;
+    packet_header->mcast_params_64 = 0;
+    packet_header->is_mcast_active = 0;
+    packet_header->routing_fields.value = 0;
+    for (uint32_t hop = 0; hop < tt::tt_fabric::FabricHeaderConfig::MESH_ROUTE_BUFFER_SIZE; ++hop) {
+        packet_header->route_buffer[hop] = hop < hops ? route.command(hop) : 0;
+    }
+    return true;
+}
+
+}  // namespace tt::tt_metal::experimental::fabric

--- a/tt_metal/fabric/sources.cmake
+++ b/tt_metal/fabric/sources.cmake
@@ -1,4 +1,5 @@
 set(FABRIC_JIT_API_HEADERS
+    hw/inc/equal_cost_unicast.h
     hw/inc/tt_fabric_api.h
     hw/inc/tt_fabric_mux.hpp
     hw/inc/tt_fabric_mux_interface.hpp
@@ -41,6 +42,7 @@ set(FABRIC_SOURCES
     channel_trimming_import.cpp
     channel_trimming_io.cpp
     channel_trimming_report.cpp
+    equal_cost_unicast.cpp
     fabric.cpp
     fabric_vc2_connection.cpp
     fabric_init.cpp

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -37,6 +37,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/dispatch_context.hpp
     api/tt-metalium/experimental/fabric/control_plane.hpp
     api/tt-metalium/experimental/fabric/edm_fabric_counters.hpp
+    api/tt-metalium/experimental/fabric/equal_cost_unicast.hpp
     api/tt-metalium/experimental/fabric/fabric.hpp
     api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
     api/tt-metalium/experimental/fabric/fabric_switch_manager.hpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/experimental/fabric/equal_cost_unicast.hpp>
 #include <algorithm>
 #include <cstddef>
 #include <set>
@@ -512,9 +513,40 @@ AllToAllAsyncGenericProgram::create_at(
     }
     const uint32_t num_direction_groups = static_cast<uint32_t>(direction_group_to_physical_direction.size());
     TT_FATAL(num_direction_groups > 0, "All-to-all collective has no remote direction groups");
-    // Fabric2D route selection and encoding are owned by Fabric. Until Fabric exposes an arc-constrained routing API,
-    // send each antipodal destination through canonical unicast routing instead of constructing a route in TTNN.
-    const bool split_antipode_across_arcs = is_ring && !is_fabric_2d;
+    // TTNN names the two neighbors and divides the transfer. Fabric only returns a
+    // pair when both routes are supported and have canonical unicast's hop count.
+    auto antipodal_routes = [&](const MeshCoordinate& source_coord, int32_t half_ring) {
+        auto node_at_offset = [&](int32_t offset) {
+            const auto coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+                tensor_args.input_tensor, source_coord, offset, effective_topology, operation_attributes.cluster_axis);
+            TT_FATAL(coord, "Missing all-to-all ring coordinate");
+            return device->get_fabric_node_id(*coord);
+        };
+        return tt::tt_metal::experimental::fabric::get_equal_cost_unicast_routes(
+            device->get_fabric_node_id(source_coord),
+            node_at_offset(half_ring),
+            {node_at_offset(1), node_at_offset(-1)});
+    };
+    bool split_antipode_across_arcs = is_ring && !is_fabric_2d;
+    tt::tt_metal::experimental::fabric::UnicastRoute positive_antipode_route;
+    tt::tt_metal::experimental::fabric::UnicastRoute negative_antipode_route;
+    if (is_ring && is_fabric_2d && operation_attributes.num_devices > 2 && operation_attributes.num_devices % 2 == 0) {
+        const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
+        split_antipode_across_arcs = true;
+        for (uint32_t source_device = 0; source_device < operation_attributes.num_devices; ++source_device) {
+            MeshCoordinate source_coord = mesh_coordinate;
+            source_coord[cluster_axis] = source_device;
+            const auto routes = antipodal_routes(source_coord, half_ring);
+            if (!routes || (*routes)[0].num_hops() != half_ring) {
+                split_antipode_across_arcs = false;
+                break;
+            }
+            if (source_coord == mesh_coordinate) {
+                positive_antipode_route = (*routes)[0];
+                negative_antipode_route = (*routes)[1];
+            }
+        }
+    }
 
     const uint32_t max_useful_workers_per_direction =
         is_ring ? preferred_workers_per_direction
@@ -554,6 +586,13 @@ AllToAllAsyncGenericProgram::create_at(
         workers_per_direction = 0;
     }
     const bool use_direction_owned_schedule = workers_per_direction > 0;
+    if (is_fabric_2d && !use_direction_owned_schedule) {
+        split_antipode_across_arcs = false;
+    }
+    const uint32_t fabric_route_args =
+        is_fabric_2d && split_antipode_across_arcs
+            ? std::max(positive_antipode_route.runtime_args().size(), negative_antipode_route.runtime_args().size())
+            : 0;
     const bool use_worker_mux = workers_per_direction > 1;
     const uint32_t mux_cores_per_direction = workers_per_direction + 1;
     const uint32_t direction_senders_per_link = num_direction_groups * workers_per_direction + 1;
@@ -908,6 +947,7 @@ AllToAllAsyncGenericProgram::create_at(
             is_fabric_2d,                                // is_fabric_2d
             sender_stream_direction_masks[stream],       // fabric_direction_mask
             number_pages_per_packet,                     // max_pages_per_packet
+            fabric_route_args,                           // fabric_route_args
             use_multicast_initialization                 // use_multicast_initialization
         };
 
@@ -997,6 +1037,14 @@ AllToAllAsyncGenericProgram::create_at(
                 // The low-latency 1D header uses the second route field as a hop count.
                 sender_writer_rt_args.push_back(0);
                 sender_writer_rt_args.push_back(std::abs(device_offset));
+            }
+            if (fabric_route_args > 0) {
+                const auto route = std::abs(device_offset) * 2 == operation_attributes.num_devices
+                                       ? (device_offset > 0 ? positive_antipode_route : negative_antipode_route)
+                                       : tt::tt_metal::experimental::fabric::UnicastRoute{};
+                auto args = route.runtime_args();
+                args.resize(fabric_route_args, 0);
+                sender_writer_rt_args.insert(sender_writer_rt_args.end(), args.begin(), args.end());
             }
         }
         const bool is_remote_sender = sender_stream != local_sender_stream || num_senders_per_link == 1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -13,6 +13,7 @@
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_mux_v2_sender.hpp"
+#include "tt_metal/fabric/hw/inc/equal_cost_unicast.h"
 #include "ckernel.h"
 #include <cstdint>
 
@@ -40,8 +41,9 @@ constexpr uint16_t source_mesh_id = get_compile_time_arg_val(14);
 constexpr bool is_fabric_2d = get_compile_time_arg_val(15);
 constexpr uint32_t fabric_direction_mask = get_compile_time_arg_val(16);
 constexpr uint32_t max_pages_per_packet = get_compile_time_arg_val(17);
-constexpr bool use_multicast_initialization = get_compile_time_arg_val(18);
-constexpr auto output_tensor_args = TensorAccessorArgs<19>();
+constexpr uint32_t target_route_args = get_compile_time_arg_val(18);
+constexpr bool use_multicast_initialization = get_compile_time_arg_val(19);
+constexpr auto output_tensor_args = TensorAccessorArgs<20>();
 constexpr uint32_t mux_ct_base = output_tensor_args.next_compile_time_args_offset();
 // This flag is specialized per stream by the host. Endpoint streams without a physical egress compile against the
 // routing-plane-manager ABI even when other streams in the same program use a worker mux.
@@ -52,7 +54,8 @@ constexpr bool has_fabric_connections = fabric_direction_mask != 0;
 // Base record: offset, block range/stride, completion, mesh and chip. Fabric2D adds the destination's harvested drain
 // coordinate.
 constexpr uint32_t target_drain_args = is_fabric_2d ? 2 : 0;
-constexpr uint32_t target_runtime_args = 7 + target_drain_args;
+constexpr uint32_t target_route_args_idx = 7 + target_drain_args;
+constexpr uint32_t target_runtime_args = target_route_args_idx + target_route_args;
 constexpr uint32_t target_drain_args_idx = 7;
 constexpr auto fabric_directions =
     ttnn::operations::ccl::common::fabric_direction_mask_to_directions(fabric_direction_mask);
@@ -74,11 +77,34 @@ constexpr bool fabric2d_multicast_initialization_is_safe = is_fabric_2d && use_m
     }
 }
 
+FORCE_INLINE tt::tt_metal::experimental::fabric::UnicastRouteView get_target_route(size_t target_arg_idx) {
+    if constexpr (target_route_args > 0) {
+        return tt::tt_metal::experimental::fabric::get_unicast_route_from_args(target_arg_idx + target_route_args_idx);
+    }
+    return {};
+}
+
+template <typename PacketHeader>
+FORCE_INLINE void set_target_route(
+    volatile PacketHeader* packet_header,
+    const ccl_routing_utils::line_unicast_route_info_t& route_info,
+    const tt::tt_metal::experimental::fabric::UnicastRouteView& route) {
+    if constexpr (std::is_same_v<PacketHeader, tt::tt_fabric::HybridMeshPacketHeader>) {
+        if (!tt::tt_metal::experimental::fabric::fabric_set_equal_cost_unicast_route(
+                packet_header, route_info.dst_chip_id, route_info.dst_mesh_id, route)) {
+            fail_stop_invalid_fabric_route();
+        }
+    } else {
+        ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
+    }
+}
+
 inline FabricMuxSender& select_connection(
     FabricMuxConnection& fabric_connection,
     [[maybe_unused]] int device_offset,
     [[maybe_unused]] uint16_t dest_mesh_id,
-    [[maybe_unused]] uint16_t dest_chip_id) {
+    [[maybe_unused]] uint16_t dest_chip_id,
+    [[maybe_unused]] const tt::tt_metal::experimental::fabric::UnicastRouteView& route) {
     return fabric_connection.sender;
 }
 
@@ -96,8 +122,10 @@ inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     Fabric2DConnections& fabric_connections,
     [[maybe_unused]] int device_offset,
     uint16_t dest_mesh_id,
-    uint16_t dest_chip_id) {
-    const uint32_t direction = static_cast<uint32_t>(get_next_hop_router_direction(dest_mesh_id, dest_chip_id));
+    uint16_t dest_chip_id,
+    const tt::tt_metal::experimental::fabric::UnicastRouteView& route) {
+    const uint32_t direction = static_cast<uint32_t>(
+        tt::tt_metal::experimental::fabric::get_unicast_route_direction(route, dest_mesh_id, dest_chip_id));
     return select_connection_by_direction(fabric_connections, direction);
 }
 
@@ -105,7 +133,8 @@ inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     FabricConnectionManager& fabric_connections,
     int device_offset,
     [[maybe_unused]] uint16_t dest_mesh_id,
-    [[maybe_unused]] uint16_t dest_chip_id) {
+    [[maybe_unused]] uint16_t dest_chip_id,
+    [[maybe_unused]] const tt::tt_metal::experimental::fabric::UnicastRouteView& route) {
     return (device_offset > 0) ? fabric_connections.get_forward_connection()
                                : fabric_connections.get_backward_connection();
 }
@@ -183,7 +212,7 @@ void send_initialization(
             auto* packet_header = device_offset > 0 ? pkt_hdr_sema_forward : pkt_hdr_sema_backward;
             const uint32_t packet_header_address =
                 device_offset > 0 ? packet_header_buffer_addr_sema_forward : packet_header_buffer_addr_sema_backward;
-            ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
+            set_target_route(packet_header, route_info, get_target_route(target_arg_idx));
             packet_header->to_noc_unicast_atomic_inc(
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{target_init_semaphore_noc_addr, 1});
             send_mux_packet_blocking(fabric_connection, packet_header_address, sizeof(PacketHeader));
@@ -323,11 +352,15 @@ void send_initialization(
         auto* packet_header = device_offset > 0 ? pkt_hdr_sema_forward : pkt_hdr_sema_backward;
         const uint32_t packet_header_address =
             device_offset > 0 ? packet_header_buffer_addr_sema_forward : packet_header_buffer_addr_sema_backward;
-        ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
+        set_target_route(packet_header, route_info, get_target_route(target_arg_idx));
         packet_header->to_noc_unicast_atomic_inc(
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{target_init_semaphore_noc_addr, 1});
-        auto& connection =
-            select_connection(fabric_connections, device_offset, route_info.dst_mesh_id, route_info.dst_chip_id);
+        auto& connection = select_connection(
+            fabric_connections,
+            device_offset,
+            route_info.dst_mesh_id,
+            route_info.dst_chip_id,
+            get_target_route(target_arg_idx));
         connection.wait_for_empty_write_slot();
         connection.send_payload_flush_blocking_from_address(packet_header_address, sizeof(PacketHeader));
     }
@@ -597,6 +630,8 @@ void kernel_main() {
                 target_drain_sync_core_x = get_arg_val<uint32_t>(device_offsets_idx++);
                 target_drain_sync_core_y = get_arg_val<uint32_t>(device_offsets_idx++);
             }
+            const auto route = get_target_route(device_offsets_idx - target_route_args_idx);
+            device_offsets_idx += target_route_args;
             const uint64_t target_output_semaphore_noc_addr =
                 is_fabric_2d
                     ? safe_get_noc_addr(target_drain_sync_core_x, target_drain_sync_core_y, global_semaphore_addr)
@@ -610,13 +645,13 @@ void kernel_main() {
                 pkt_hdr = pkt_hdr_backward;
             }
             if (device_offset != 0) {
-                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, route_info);
+                set_target_route(pkt_hdr, route_info, route);
             }
             auto* target_connection =
                 device_offset == 0
                     ? nullptr
                     : &select_connection(
-                          fabric_connections, device_offset, route_info.dst_mesh_id, route_info.dst_chip_id);
+                          fabric_connections, device_offset, route_info.dst_mesh_id, route_info.dst_chip_id, route);
 
             auto calculate_params = [&](int b) {
                 const uint32_t o = b / (concat_num_tiles * inner_dims_size);


### PR DESCRIPTION
### PR Category

Performance / Bug fix

### Summary

GLM 5.2 sparse MLA redistributes tensors from head sharding to sequence sharding and back across TP4 groups. PR #55403 removed TTNN-owned Fabric2D routing but also disabled splitting opposite-chip traffic between equal-length ring arcs, overloading one egress.

Add an opt-in Fabric API that returns two opaque routes through requested direct neighbors only when both match canonical hop counts and use distinct egresses. Selecting another egress requires a matching packet route: Fabric validates the live links and header capacity and reuses its existing encoder, while TTNN splits destination banks and passes opaque route arguments.

Reverting only #55403 reduced the all-to-all pair from **0.553 ms to 0.397 ms (about 30%)**, confirming the regression. This change measured **0.392 ms** on the GLM 5.2 TP4 workload on Blackhole Galaxy with Fabric2D TorusXY.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fabric-equal-cost-unicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fabric-equal-cost-unicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fabric-equal-cost-unicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fabric-equal-cost-unicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fabric-equal-cost-unicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fabric-equal-cost-unicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fabric-equal-cost-unicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fabric-equal-cost-unicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fabric-equal-cost-unicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fabric-equal-cost-unicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fabric-equal-cost-unicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fabric-equal-cost-unicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fabric-equal-cost-unicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fabric-equal-cost-unicast)