### PR TITLE
#45821: fold op identity and length into program-cache hashes

### DIFF
--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_hash.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_hash.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt_stl/reflection.hpp>
+
+#include <functional>
+#include <set>
+
+#include "gtest/gtest.h"
+
+namespace basic_tests::core_coord_hash {
+using tt::tt_metal::CoreRange;
+using tt::tt_metal::CoreRangeSet;
+
+TEST(CoreRangeHashTest, CPU_DistinctRangesDoNotCollide) {
+    const CoreRange a({3, 0}, {3, 0});
+    const CoreRange b({1, 1}, {1, 1});
+    EXPECT_NE(std::hash<CoreRange>{}(a), std::hash<CoreRange>{}(b));
+    EXPECT_NE(ttsl::hash::canonical_key(a), ttsl::hash::canonical_key(b));
+}
+
+TEST(CoreRangeHashTest, CPU_OrderAndExtentMatter) {
+    const CoreRange a({0, 0}, {1, 2});
+    const CoreRange b({0, 0}, {2, 1});
+    EXPECT_NE(std::hash<CoreRange>{}(a), std::hash<CoreRange>{}(b));
+}
+
+TEST(CoreRangeSetHashTest, CPU_DistinctGridsDoNotCollide) {
+    const CoreRangeSet a(std::set<CoreRange>{CoreRange({0, 0}, {1, 1})});
+    const CoreRangeSet b(std::set<CoreRange>{CoreRange({3, 3}, {5, 4})});
+    EXPECT_NE(std::hash<CoreRangeSet>{}(a), std::hash<CoreRangeSet>{}(b));
+    EXPECT_NE(ttsl::hash::canonical_key(a), ttsl::hash::canonical_key(b));
+}
+
+TEST(CoreRangeSetHashTest, CPU_LengthMatters) {
+    const CoreRangeSet a(std::set<CoreRange>{CoreRange({0, 0}, {0, 0})});
+    const CoreRangeSet b(std::set<CoreRange>{CoreRange({0, 0}, {0, 0}), CoreRange({2, 2}, {2, 2})});
+    EXPECT_NE(std::hash<CoreRangeSet>{}(a), std::hash<CoreRangeSet>{}(b));
+}
+
+}  // namespace basic_tests::core_coord_hash

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -12,6 +12,7 @@ set(UNIT_TESTS_API_SOURCES
     circular_buffer/test_CircularBuffer_wrapping.cpp
     core_coord/test_CoreRange_adjacent.cpp
     core_coord/test_CoreRange_contains.cpp
+    core_coord/test_CoreRange_hash.cpp
     core_coord/test_CoreRange_intersects.cpp
     core_coord/test_CoreRange_iterator.cpp
     core_coord/test_CoreRange_merge.cpp

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <tuple>
 #include <vector>
 
 // UMD: re-exports tt_xy_pair, aliased as CoreCoord in this header.
@@ -88,6 +89,11 @@ public:
     CoreIterator begin() const;
 
     CoreIterator end() const;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("start_x", "start_y", "end_x", "end_y");
+    auto attribute_values() const {
+        return std::forward_as_tuple(start_coord.x, start_coord.y, end_coord.x, end_coord.y);
+    }
 };
 
 constexpr bool operator==(const CoreRange& a, const CoreRange& b) {
@@ -148,6 +154,9 @@ public:
     bool contains(const CoreRangeSet& other) const;
 
     const std::vector<CoreRange>& ranges() const;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("ranges");
+    auto attribute_values() const { return std::forward_as_tuple(this->ranges()); }
 
     std::string str() const;
 

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -687,7 +687,7 @@ std::size_t hash<RelativeCoreCoord>::operator()(const RelativeCoreCoord& o) cons
 }
 
 std::size_t hash<CoreRange>::operator()(const CoreRange& core_range) const {
-    // Hash x/y, not CoreCoord: UMD's std::hash<CoreCoord> is x ^ (y << 1) (issue #45821).
+    // Hash x/y, not CoreCoord: UMD's std::hash<CoreCoord> is x ^ (y << 1)
     std::size_t seed = 0;
     ttsl::hash::hash_combine(seed, core_range.start_coord.x);
     ttsl::hash::hash_combine(seed, core_range.start_coord.y);

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -681,29 +681,27 @@ using tt::tt_metal::RelativeCoreCoord;
 
 std::size_t hash<RelativeCoreCoord>::operator()(const RelativeCoreCoord& o) const {
     std::size_t seed = 0;
-    seed ^= std::hash<std::size_t>()(o.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    seed ^= std::hash<std::size_t>()(o.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    ttsl::hash::hash_combine(seed, o.x);
+    ttsl::hash::hash_combine(seed, o.y);
     return seed;
 }
 
 std::size_t hash<CoreRange>::operator()(const CoreRange& core_range) const {
-    // Hash x and y components individually using boost-style hash combine to avoid
-    // collisions from the weak std::hash<CoreCoord> (x ^ (y << 1)) in UMD.
-    // E.g. CoreCoord(3,0) and CoreCoord(1,1) both hash to 3 with the weak hash.
-    // TODO: Roll back to std::hash<CoreCoord> once we have a strong hash for xy_pair in UMD.
+    // Hash x/y, not CoreCoord: UMD's std::hash<CoreCoord> is x ^ (y << 1) (issue #45821).
     std::size_t seed = 0;
-    seed ^= std::hash<std::size_t>{}(core_range.start_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    seed ^= std::hash<std::size_t>{}(core_range.start_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    seed ^= std::hash<std::size_t>{}(core_range.end_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    seed ^= std::hash<std::size_t>{}(core_range.end_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    ttsl::hash::hash_combine(seed, core_range.start_coord.x);
+    ttsl::hash::hash_combine(seed, core_range.start_coord.y);
+    ttsl::hash::hash_combine(seed, core_range.end_coord.x);
+    ttsl::hash::hash_combine(seed, core_range.end_coord.y);
     return seed;
 }
 
 std::size_t hash<CoreRangeSet>::operator()(const CoreRangeSet& core_range_set) const {
     std::size_t seed = 0;
-    for (const auto& core_range : core_range_set.ranges()) {
-        seed = std::hash<CoreRange>{}(core_range) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    }
+    ttsl::hash::hash_combine(seed, core_range_set.ranges().size());
+    std::for_each(core_range_set.ranges().begin(), core_range_set.ranges().end(), [&](const auto& core_range) {
+        ttsl::hash::hash_combine(seed, core_range);
+    });
     return seed;
 }
 

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -55,6 +55,12 @@ TEST(HashCollisionTest, CPU_Issue45821_TruncatedPrefixDoesNotCollide) {
 
 // --- Order sensitivity ---------------------------------------------------------------------
 
+TEST(HashCollisionTest, CPU_LengthMatters) {
+    EXPECT_NE(hash_shape({1, 2, 3}), hash_shape({1, 2}));
+    EXPECT_NE(hash_shape({1, 1}), hash_shape({1}));
+    EXPECT_NE(hash_shape({}), hash_shape({0}));
+}
+
 TEST(HashCollisionTest, CPU_OrderMatters) {
     // A hash used as a cache key must distinguish permutations of the same multiset of dims;
     // otherwise e.g. a [2, 3] tensor and a [3, 2] tensor would share a program.

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -55,12 +55,6 @@ TEST(HashCollisionTest, CPU_Issue45821_TruncatedPrefixDoesNotCollide) {
 
 // --- Order sensitivity ---------------------------------------------------------------------
 
-TEST(HashCollisionTest, CPU_LengthMatters) {
-    EXPECT_NE(hash_shape({1, 2, 3}), hash_shape({1, 2}));
-    EXPECT_NE(hash_shape({1, 1}), hash_shape({1}));
-    EXPECT_NE(hash_shape({}), hash_shape({0}));
-}
-
 TEST(HashCollisionTest, CPU_OrderMatters) {
     // A hash used as a cache key must distinguish permutations of the same multiset of dims;
     // otherwise e.g. a [2, 3] tensor and a [3, 2] tensor would share a program.

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -62,6 +62,15 @@ TEST(HashCollisionTest, CPU_OrderMatters) {
     EXPECT_NE(hash_shape({1, 2}), hash_shape({2, 1}));
 }
 
+TEST(HashCollisionTest, CPU_SequenceLengthPrefixMatters) {
+    // Sequences that differ only in length must hash differently; otherwise a shorter key can
+    // alias a longer one. This pair collides under an element-only fold of mix_into, so it
+    // specifically requires the size prefix in hash_sized_range.
+    const std::vector<uint64_t> shorter{0};
+    const std::vector<uint64_t> longer{0, 0x1ddf'57c6'84e2'3251ULL};
+    EXPECT_NE(hash_objects_with_default_seed(shorter), hash_objects_with_default_seed(longer));
+}
+
 // --- Determinism ---------------------------------------------------------------------------
 
 TEST(HashCollisionTest, CPU_Deterministic) {

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1265,6 +1265,13 @@ struct is_std_hashable<T, std::void_t<decltype(std::declval<std::hash<T>>()(std:
 template <typename T>
 constexpr bool is_std_hashable_v = is_std_hashable<T>::value;
 
+template <typename Range>
+inline hash_t hash_sized_range(const Range& range) noexcept {
+    hash_t hash = hash_objects(hash_t{0}, range.size());
+    std::for_each(std::begin(range), std::end(range), [&](const auto& element) { hash = hash_objects(hash, element); });
+    return hash;
+}
+
 template <typename T, std::size_t N>
 inline hash_t hash_object(const std::array<T, N>& array) noexcept {
     if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
@@ -1357,37 +1364,24 @@ inline hash_t hash_object(const T& object) noexcept {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing std::vector of type {}: {}\n", get_type_name<T>(), object);
         }
-        hash_t hash = 0;
-        for (const auto& element : object) {
-            hash = hash_objects(hash, element);
-        }
-        return hash;
+        return hash_sized_range(object);
     } else if constexpr (is_span_v<T>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing std::span of type {}\n", get_type_name<T>());
         }
-        hash_t hash = 0;
-        for (const auto& element : object) {
-            hash = hash_objects(hash, element);
-        }
-        return hash;
+        return hash_sized_range(object);
     } else if constexpr (is_specialization_v<T, std::set>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing std::set of type {}: {}\n", get_type_name<T>(), object);
         }
-        hash_t hash = 0;
-        for (const auto& element : object) {
-            hash = hash_objects(hash, element);
-        }
-        return hash;
+        return hash_sized_range(object);
     } else if constexpr (is_specialization_v<T, std::map>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing std::map of type {}: {}\n", get_type_name<T>(), object);
         }
-        hash_t hash = 0;
-        for (const auto& [key, value] : object) {
-            hash = hash_objects(hash, key, value);
-        }
+        hash_t hash = hash_objects(hash_t{0}, object.size());
+        std::for_each(
+            object.begin(), object.end(), [&](const auto& kv) { hash = hash_objects(hash, kv.first, kv.second); });
         return hash;
     } else if constexpr (is_specialization_v<T, std::unordered_map>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
@@ -1401,10 +1395,10 @@ inline hash_t hash_object(const T& object) noexcept {
         }
         std::sort(iterators.begin(), iterators.end(), [](const auto& a, const auto& b) { return a->first < b->first; });
 
-        hash_t hash = 0;
-        for (const auto& it : iterators) {
+        hash_t hash = hash_objects(hash_t{0}, object.size());
+        std::for_each(iterators.begin(), iterators.end(), [&](const auto& it) {
             hash = hash_objects(hash, it->first, it->second);
-        }
+        });
         return hash;
     } else if constexpr (is_specialization_v<T, std::optional>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
@@ -1602,11 +1596,7 @@ void hash_combine(std::size_t& seed, const T& value) {
 template <typename T, size_t PREALLOCATED_SIZE>
 struct std::hash<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
     size_t operator()(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vec) const noexcept {
-        size_t hash = 0;
-        for (const auto& element : vec) {
-            hash = ttsl::hash::detail::hash_objects(hash, element);
-        }
-        return hash;
+        return static_cast<size_t>(ttsl::hash::detail::hash_sized_range(vec));
     }
 };
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -74,7 +74,10 @@ auto compute_program_hash(
     const typename device_operation_t::tensor_args_t& tensor_args) {
     if constexpr (DeviceOperationWithCustomProgramCacheConcept<device_operation_t>) {
         ZoneScopedN("Compute custom program hash");
-        return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
+        // Fold type_hash so distinct ops cannot alias on a custom-hash collision (issue #45821).
+        return ttsl::hash::hash_objects_with_default_seed(
+            ttsl::hash::type_hash<device_operation_t>,
+            device_operation_t::compute_program_hash(operation_attributes, tensor_args));
     } else {
         ZoneScopedN("Compute default program hash");
         return ttsl::hash::hash_objects_with_default_seed(

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -74,7 +74,7 @@ auto compute_program_hash(
     const typename device_operation_t::tensor_args_t& tensor_args) {
     if constexpr (DeviceOperationWithCustomProgramCacheConcept<device_operation_t>) {
         ZoneScopedN("Compute custom program hash");
-        // Fold type_hash so distinct ops cannot alias on a custom-hash collision (issue #45821).
+        // Fold type_hash so distinct ops cannot alias on a custom-hash collision
         return ttsl::hash::hash_objects_with_default_seed(
             ttsl::hash::type_hash<device_operation_t>,
             device_operation_t::compute_program_hash(operation_attributes, tensor_args));

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -251,7 +251,7 @@ public:
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
         if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            // Fold type_hash so distinct ops cannot alias on a custom-hash collision (issue #45821).
+            // Fold type_hash so distinct ops cannot alias on a custom-hash collision
             return ttsl::hash::hash_objects_with_default_seed(
                 ttsl::hash::type_hash<DeviceOperation>, DeviceOperation::compute_program_hash(attrs, tensor_args));
         } else {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -251,7 +251,9 @@ public:
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
         if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            return DeviceOperation::compute_program_hash(attrs, tensor_args);
+            // Fold type_hash so distinct ops cannot alias on a custom-hash collision (issue #45821).
+            return ttsl::hash::hash_objects_with_default_seed(
+                ttsl::hash::type_hash<DeviceOperation>, DeviceOperation::compute_program_hash(attrs, tensor_args));
         } else {
             return ttsl::hash::hash_objects_with_default_seed(
                 ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
@@ -1137,19 +1139,10 @@ public:
         tt::tt_metal::distributed::MeshDevice* mesh_device,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
-        ttsl::hash::hash_t hash;
-
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            hash = DeviceOperation::compute_program_hash(attrs, tensor_args);
-        } else {
-            hash =
-                ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
-        }
-
-        // Combine with the mesh coordinates the workload is targeting.
-        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
-            hash = ttsl::hash::hash_objects(hash, coord);
-        }
+        ttsl::hash::hash_t hash = compute_program_hash(attrs, tensor_args);
+        const auto coords = mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device);
+        std::for_each(
+            coords.begin(), coords.end(), [&](const auto& coord) { hash = ttsl::hash::hash_objects(hash, coord); });
         return hash;
     }
 
@@ -1173,10 +1166,9 @@ public:
             return key;  // custom hash -> opt out beyond the op-identity prefix
         } else {
             key += ttsl::hash::canonical_key(attrs, tensor_args);
-            for (const auto& coord :
-                 mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
-                key += ttsl::hash::canonical_key(coord);
-            }
+            const auto coords = mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device);
+            std::for_each(
+                coords.begin(), coords.end(), [&](const auto& coord) { key += ttsl::hash::canonical_key(coord); });
             return key;
         }
     }


### PR DESCRIPTION
Custom hashes could still alias across ops, and CoreRange/span keys still used the weak boost-style combiner. Mix type_hash into every custom hash, prefix sequence hashes with length, and hash shard grids with the splitmix64 mixer

### PR Category
Bug fix
Closes [#45821](https://github.com/tenstorrent/tt-metal/issues/45821) for the remaining framework-level hash paths. Per-op migrations that drop a redundant custom `compute_program_hash` (so those ops get a full canonical key) are still separate.

### Summary
Follow-up to the #45821 mixer + canonical-key work ([#46385](https://github.com/tenstorrent/tt-metal/pull/46385)). The original `[3, 17, 1, 1]` vs `[1, 152, 1, 1]` permute collision is already fixed on main; this PR closes remaining program-cache holes of the same class.

- Fold `type_hash<Op>` into **every** custom `compute_program_hash`, so two different ops cannot alias on a 64-bit collision. Matches the review note that the cache key must include the operation identity.
- Prefix sequence hashes (span / vector / set / map / `SmallVector`) with length via `std::for_each`, so a shorter shape cannot alias a longer one.
- Replace the boost-style combiner on `CoreRange` / `CoreRangeSet` with `ttsl::hash::hash_combine` (same splitmix64 mixer). Shard grids sit on the program-cache path through `ShardSpec`. `attribute_values` on both types make the canonical key encode x/y integers instead of a lossy `std::hash`.

### Notes for reviewers
- Custom hashes that already call `hash_operation<Op>(...)` now mix `type_hash` twice. Harmless: the cache is in-memory only and rebuilt each run.
- Custom hashes still opt out of attribute-level canonical-key resolution (RNG seed, L1-dependent factory index, etc.). This PR only makes a wrong *cross-op* hit impossible; same-op collisions on those ops still rely on the strong mixer.
- Tests run locally:
  - `unit_tests_stl` hash/canonical tests — 20/20 (includes the original #45821 shape pair)
  - `unit_tests_api --gtest_filter='CoreRangeHashTest.*:CoreRangeSetHashTest.*'` — 4/4
- On-device `batch_norm` / permute repro was not re-run here (no accelerator on this host).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/45821_hash_collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/45821_hash_collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/45821_hash_collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/45821_hash_collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/45821_hash_collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/issue/45821_hash_collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/45821_hash_collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/45821_hash_collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/45821_hash_collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/issue/45821_hash_collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/45821_hash_collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/issue/45821_hash_collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/45821_hash_collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/issue/45821_hash_collision)