### PR TITLE
Replace ETH_TEST_EXPECTED_LINKS with per-chip ETH_TEST_EXPECTED_LINKS_MAP

### DIFF
--- a/tests/tt_metal/tt_metal/deployment/eth/README.md
+++ b/tests/tt_metal/tt_metal/deployment/eth/README.md
@@ -29,6 +29,10 @@ This test suite is meant for testing the functionality of the Ethernet subsystem
 ## Environment variables
 
 - `ETH_TEST_TRANSFER_SIZE`: Controls the size of transfers initiated through metal
+- `ETH_TEST_EXPECTED_LINKS_MAP`: Path to a JSON object of expected trained ETH
+  channel counts per ASIC, keyed by `"{tray_id}:{asic_id}"` (same IDs as
+  `get_ubb_id`). Example: `{"1:1": 6, "1:2": 8, "4:8": 10}`. When unset, the
+  count check is skipped. A single global expected-link count is not used.
 
 ### Tests using DRAM:
 - `ETH_TEST_START_ADDR`: Starting address of DRAM to copy over

--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -6,6 +6,11 @@
 #define _ETH_COMMON_HPP
 
 #include <chrono>
+#include <fstream>
+#include <optional>
+#include <unordered_map>
+
+#include <nlohmann/json.hpp>
 
 #include "tt_metal/tt_metal/deployment/deployment_common.hpp"
 #include "impl/program/program_impl.hpp"
@@ -908,21 +913,85 @@ static std::string get_locinfo(
         get_connector(sdev, score));
 }
 
+// ETH_TEST_EXPECTED_LINKS_MAP is a JSON object path keyed by "{tray_id}:{asic_id}"
+// (same IDs as tt::tt_fabric::get_ubb_id). A global ETH_TEST_EXPECTED_LINKS scalar
+// is not applied — mixed per-chip degrees cannot be expressed as one integer.
+[[maybe_unused]]
+static std::optional<std::unordered_map<std::string, uint32_t>> load_expected_links_map(bool* load_failed) {
+    *load_failed = false;
+    const char* path = std::getenv("ETH_TEST_EXPECTED_LINKS_MAP");
+    if (path == nullptr || path[0] == '\0') {
+        return std::nullopt;
+    }
+
+    std::ifstream in(path);
+    if (!in) {
+        *load_failed = true;
+        log_critical(tt::LogTest, "failed to open ETH_TEST_EXPECTED_LINKS_MAP {}", path);
+        return std::nullopt;
+    }
+
+    nlohmann::json parsed;
+    try {
+        in >> parsed;
+    } catch (const std::exception& ex) {
+        *load_failed = true;
+        log_critical(tt::LogTest, "failed to parse ETH_TEST_EXPECTED_LINKS_MAP {}: {}", path, ex.what());
+        return std::nullopt;
+    }
+    if (!parsed.is_object()) {
+        *load_failed = true;
+        log_critical(tt::LogTest, "ETH_TEST_EXPECTED_LINKS_MAP {} is not a JSON object", path);
+        return std::nullopt;
+    }
+
+    std::unordered_map<std::string, uint32_t> expected;
+    for (auto it = parsed.begin(); it != parsed.end(); ++it) {
+        if (!it.value().is_number_unsigned() && !it.value().is_number_integer()) {
+            *load_failed = true;
+            log_critical(
+                tt::LogTest, "ETH_TEST_EXPECTED_LINKS_MAP {} has non-integer value for key {}", path, it.key());
+            return std::nullopt;
+        }
+        expected[it.key()] = it.value().get<uint32_t>();
+    }
+    log_info(tt::LogTest, "ETH_TEST_EXPECTED_LINKS_MAP {} ({} chips)", path, expected.size());
+    return expected;
+}
+
 static bool ensure_links(std::span<std::shared_ptr<distributed::MeshDevice>> devices) {
     bool pass = true;
-
-    TEST_PARAM(uint32_t, expected_links, 0, "ETH_TEST_EXPECTED_LINKS");
-
-    if (!expected_links) {
+    bool load_failed = false;
+    const auto expected_map = load_expected_links_map(&load_failed);
+    if (load_failed) {
+        return false;
+    }
+    if (!expected_map.has_value()) {
         return pass;
     }
 
+    const auto& cluster = MetalContext::instance().get_cluster();
+    umd::ClusterDescriptor* cluster_desc = cluster.get_cluster_desc();
+
     for (const auto& device : devices) {
         auto* const dev = device->get_devices()[0];
-        int numlinks = dev->get_active_ethernet_cores().size();
-        if (numlinks != expected_links) {
+        int numlinks = static_cast<int>(dev->get_active_ethernet_cores().size());
+        auto ubb = tt::tt_fabric::get_ubb_id(*cluster_desc, dev->id());
+        const std::string key = fmt::format("{}:{}", ubb.tray_id, ubb.asic_id);
+        auto it = expected_map->find(key);
+        if (it == expected_map->end()) {
             pass = false;
-
+            log_critical(
+                tt::LogTest,
+                "no expected count for ubb {} chip {} (map key {})",
+                ubb.tray_id,
+                ubb.asic_id,
+                key);
+            continue;
+        }
+        const uint32_t expected_links = it->second;
+        if (static_cast<uint32_t>(numlinks) != expected_links) {
+            pass = false;
             log_critical(
                 tt::LogTest,
                 "missing links: chip[{} ({}), {}]: expected {} links, got {}",

--- a/tests/tt_metal/tt_metal/deployment/eth/test_runner.py
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_runner.py
@@ -832,7 +832,8 @@ async def main():
         args = [f"--gtest_filter={filters}"]
 
         env = os.environ.copy()
-        env["ETH_TEST_EXPECTED_LINKS"] = str(10)
+        # Per-chip expected counts come from ETH_TEST_EXPECTED_LINKS_MAP (FSD-derived).
+        # Do not invent a global ETH_TEST_EXPECTED_LINKS=10.
         if not opts.v:
             env["TT_LOGGER_TYPES"] = "Test"
 


### PR DESCRIPTION
## Summary
- Replace the global `ETH_TEST_EXPECTED_LINKS` scalar in deployment eth `ensure_links` with `ETH_TEST_EXPECTED_LINKS_MAP`, a JSON object keyed by `"{tray_id}:{asic_id}"` (same IDs as `get_ubb_id`).
- Stop hardcoding `ETH_TEST_EXPECTED_LINKS=10` in `test_runner.py` so mixed FSD topologies (e.g. some ASICs at 8 links, others at 10) can be validated instead of fail-closing as unsupported.
- Document the new env var in the eth deployment README.

## Test plan
- [ ] Build `unit_tests_deployment` and run eth suite with `ETH_TEST_EXPECTED_LINKS_MAP` unset (count check skipped; suite should proceed as before when map is optional).
- [ ] Run with a valid map JSON matching cluster topology; confirm per-chip expected vs actual logging and pass/fail.
- [ ] Run with missing key / bad path / non-object JSON; confirm fail-closed load errors.
- [ ] Confirm syseng triage / StackStorm path that writes FSD-derived map can pass the eth link gate on mixed-degree hosts (e.g. bh-glx).


Made with [Cursor](https://cursor.com)