### PR TITLE
Add core counts to real-time profiler records

### DIFF
--- a/tech_reports/real_time_profiler/getting-started.md
+++ b/tech_reports/real_time_profiler/getting-started.md
@@ -1,6 +1,6 @@
 # Real-time profiler — getting started
 
-The **real-time profiler** (RT profiler) streams per-program timing from the device over the existing fast-dispatch path (D2H socket). Each completed program yields a `ProgramRealtimeRecord`: `runtime_id`, raw `start_timestamp` / `end_timestamp`, device `frequency` (cycles per ns), `chip_id`, and `kernel_sources` (paths for that program).
+The **real-time profiler** (RT profiler) streams per-program timing from the device over the existing fast-dispatch path (D2H socket). Each completed program yields a `ProgramRealtimeRecord`: `runtime_id`, raw `start_timestamp` / `end_timestamp`, device `frequency` (cycles per ns), `chip_id`, `core_count`, and `kernel_sources` (paths for that program).
 
 You can register **multiple** callbacks; they are invoked concurrently. If a callback shares a resource with other callbacks or across multiple meshes, access it in a thread-safe way (e.g. with a lock). Use `UnregisterProgramRealtimeProfilerCallback(handle)` when done (Python: `ttnn.device.UnregisterProgramRealtimeProfilerCallback`).
 
@@ -30,6 +30,7 @@ def on_record_batch(batch):
             "start_timestamp": record.start_timestamp,
             "end_timestamp": record.end_timestamp,
             "frequency": record.frequency,
+            "core_count": record.core_count,
             "kernel_sources": list(record.kernel_sources),
         }
         out.write(json.dumps(row) + "\n")

--- a/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_broadcast_ring.cpp
@@ -38,6 +38,7 @@ ProgramRealtimeRecord make_record(uint32_t runtime_id, std::span<const std::stri
         .end_timestamp = 200 + runtime_id,
         .frequency = 1.5,
         .kernel_sources = sources,
+        .core_count = runtime_id * 3,
     };
 }
 
@@ -116,6 +117,7 @@ TEST(BroadcastRing, RecordsBroadcastToAllReadersWithSpanFieldsIntact) {
             EXPECT_EQ(record->start_timestamp, 100 + record->runtime_id);
             EXPECT_EQ(record->end_timestamp, 200 + record->runtime_id);
             EXPECT_DOUBLE_EQ(record->frequency, 1.5);
+            EXPECT_EQ(record->core_count, record->runtime_id * 3);
             ASSERT_EQ(record->kernel_sources.size(), 2u);
             EXPECT_EQ(record->kernel_sources[0], "kernel_a.cpp");
             EXPECT_EQ(record->kernel_sources[1], "kernel_b.cpp");
@@ -353,6 +355,7 @@ ProgramRealtimeRecord make_seq_record(uint32_t seq) {
         .end_timestamp = static_cast<uint64_t>(seq) * 7 + 9,
         .frequency = 1.0 + static_cast<double>(seq) * 0.001,
         .kernel_sources = {},
+        .core_count = (seq % 127) + 1,
     };
 }
 
@@ -369,6 +372,7 @@ void verify_seq_records(const std::vector<ProgramRealtimeRecord>& received, uint
             << "torn/stale record: end_timestamp mismatch at seq " << seq;
         ASSERT_DOUBLE_EQ(r.frequency, 1.0 + static_cast<double>(seq) * 0.001)
             << "torn/stale record: frequency mismatch at seq " << seq;
+        ASSERT_EQ(r.core_count, (seq % 127) + 1) << "torn/stale record: core_count mismatch at seq " << seq;
         if (has_prev) {
             ASSERT_GT(seq, prev_seq) << "non-monotonic or duplicate delivery at seq " << seq;
         }
@@ -467,7 +471,7 @@ bool seq_record_ok(const ProgramRealtimeRecord& r) {
     const uint32_t seq = r.runtime_id - 1;
     return r.chip_id == (seq % 31) + 1 && r.start_timestamp == static_cast<uint64_t>(seq) * 7 + 3 &&
            r.end_timestamp == static_cast<uint64_t>(seq) * 7 + 9 &&
-           r.frequency == 1.0 + static_cast<double>(seq) * 0.001;
+           r.frequency == 1.0 + static_cast<double>(seq) * 0.001 && r.core_count == (seq % 127) + 1;
 }
 
 TEST(BroadcastRing, ConcurrentManyReadersMixedRates) {

--- a/tests/ttnn/profiling/realtime_profiler_utils.py
+++ b/tests/ttnn/profiling/realtime_profiler_utils.py
@@ -47,6 +47,7 @@ def profile_realtime_program(
                 {
                     "runtime_id": int(record.runtime_id),
                     "chip_id": int(record.chip_id),
+                    "core_count": int(record.core_count),
                     "duration_ns": (end_timestamp - start_timestamp) / frequency,
                     "kernel_sources": tuple(str(source) for source in record.kernel_sources),
                 }
@@ -118,8 +119,12 @@ def profile_realtime_program_merged(
         runtime_id = record["runtime_id"]
         if not runtime_id:
             continue
-        entry = per_program.setdefault(runtime_id, {"duration_ns": 0.0, "kernel_sources": record["kernel_sources"]})
+        entry = per_program.setdefault(
+            runtime_id,
+            {"duration_ns": 0.0, "core_count": 0, "kernel_sources": record["kernel_sources"]},
+        )
         entry["duration_ns"] = max(entry["duration_ns"], record["duration_ns"])
+        entry["core_count"] = max(entry["core_count"], record["core_count"])
 
     assert per_program, "real-time profiler returned no valid program records for the measured region"
     return result, per_program

--- a/tests/ttnn/tracy/cross_reference_workload.py
+++ b/tests/ttnn/tracy/cross_reference_workload.py
@@ -120,6 +120,7 @@ def main():
                     "start_timestamp": record.start_timestamp,
                     "end_timestamp": record.end_timestamp,
                     "frequency_ghz": record.frequency,
+                    "core_count": record.core_count,
                 }
             )
 
@@ -155,6 +156,7 @@ def main():
                         "chip_id": chip_id,
                         "runtime_id": runtime_id,
                         "duration_ns": duration_ns,
+                        "core_count": program.core_count,
                     }
                 )
 

--- a/tests/ttnn/tracy/matmul_workload.py
+++ b/tests/ttnn/tracy/matmul_workload.py
@@ -84,6 +84,7 @@ def main():
                     "start_timestamp": record.start_timestamp,
                     "end_timestamp": record.end_timestamp,
                     "frequency_ghz": record.frequency,
+                    "core_count": record.core_count,
                     "kernel_sources": list(record.kernel_sources),
                 }
             )

--- a/tests/ttnn/tracy/test_realtime_profiler.py
+++ b/tests/ttnn/tracy/test_realtime_profiler.py
@@ -236,6 +236,7 @@ def test_callback(tmp_path):
     for rec in snapshot:
         assert rec["end_timestamp"] >= rec["start_timestamp"], "end_timestamp < start_timestamp"
         assert rec["frequency_ghz"] > 0, "frequency_ghz must be positive"
+        assert rec["core_count"] > 0, "core_count must be positive"
         assert isinstance(rec["kernel_sources"], list), "kernel_sources must be list-like"
         assert all(
             isinstance(source, str) and source for source in rec["kernel_sources"]
@@ -403,6 +404,8 @@ def _cross_reference_impl(
     # Build duration maps.
     dev_by_raw = defaultdict(list)
     dev_by_decoded = defaultdict(list)
+    dev_cores_by_raw = defaultdict(list)
+    dev_cores_by_decoded = defaultdict(list)
     for entry in dev_flat:
         duration_ns = entry["duration_ns"]
         if duration_ns <= 0:
@@ -410,10 +413,13 @@ def _cross_reference_impl(
         runtime_id = entry["runtime_id"]
         dev_by_raw[runtime_id].append(duration_ns)
         dev_by_decoded[_decode_runtime_id(runtime_id)].append(duration_ns)
+        dev_cores_by_raw[runtime_id].append(entry["core_count"])
+        dev_cores_by_decoded[_decode_runtime_id(runtime_id)].append(entry["core_count"])
 
     assert dev_by_raw or dev_by_decoded, "No device profiler programs with kernel duration data"
 
     rt_by_id = defaultdict(list)
+    rt_cores_by_id = defaultdict(list)
     for rec in rt_snapshot:
         runtime_id = rec["runtime_id"]
         freq = rec["frequency_ghz"]
@@ -423,6 +429,7 @@ def _cross_reference_impl(
         if dur_ns <= 0:
             continue
         rt_by_id[runtime_id].append(dur_ns)
+        rt_cores_by_id[runtime_id].append(rec["core_count"])
 
     assert rt_by_id, "No valid real-time profiler records"
 
@@ -430,13 +437,14 @@ def _cross_reference_impl(
     raw_matches = sum(1 for runtime_id in rt_by_id if runtime_id in dev_by_raw)
     decoded_matches = sum(1 for runtime_id in rt_by_id if runtime_id in dev_by_decoded)
     if raw_matches >= decoded_matches:
-        dev_durations, match_strategy = dev_by_raw, "raw"
+        dev_durations, dev_core_counts, match_strategy = dev_by_raw, dev_cores_by_raw, "raw"
     else:
-        dev_durations, match_strategy = dev_by_decoded, "decoded"
+        dev_durations, dev_core_counts, match_strategy = dev_by_decoded, dev_cores_by_decoded, "decoded"
 
     # Cross-reference.
     matched = 0
     within = 0
+    core_count_matches = 0
     skipped_short = 0
     details = []
     for runtime_id, rt_durs in sorted(rt_by_id.items()):
@@ -446,6 +454,8 @@ def _cross_reference_impl(
         for i in range(min(len(rt_durs), len(dev_durs))):
             rt_ns = rt_durs[i]
             dev_ns = dev_durs[i]
+            rt_core_count = rt_cores_by_id[runtime_id][i]
+            dev_core_count = dev_core_counts[runtime_id][i]
             rel_err = abs(rt_ns - dev_ns) / dev_ns if dev_ns > 0 else float("inf")
             short = dev_ns < MIN_DEVICE_KERNEL_DURATION_NS
             if short:
@@ -455,6 +465,8 @@ def _cross_reference_impl(
                 matched += 1
                 if ok:
                     within += 1
+                if rt_core_count == dev_core_count:
+                    core_count_matches += 1
             details.append(
                 {
                     "runtime_id": runtime_id,
@@ -463,6 +475,9 @@ def _cross_reference_impl(
                     "dev_duration_ns": round(dev_ns, 1),
                     "relative_error": round(rel_err, 4),
                     "within_tolerance": ok,
+                    "rt_core_count": rt_core_count,
+                    "dev_core_count": dev_core_count,
+                    "core_count_matches": rt_core_count == dev_core_count,
                     "below_threshold": short,
                 }
             )
@@ -476,6 +491,7 @@ def _cross_reference_impl(
         "matched_pairs": matched,
         "skipped_short": skipped_short,
         "within_tolerance": within,
+        "core_count_matches": core_count_matches,
         "tolerance": RELATIVE_TOLERANCE,
         "min_device_kernel_duration_ns": MIN_DEVICE_KERNEL_DURATION_NS,
         "comparisons": details,
@@ -491,6 +507,7 @@ def _cross_reference_impl(
     print(f"  Dev unique runtime IDs:  {len(dev_by_raw)} (raw) / {len(dev_by_decoded)} (decoded)")
     print(f"  Matched (>={MIN_DEVICE_KERNEL_DURATION_NS}ns): {matched} (skipped {skipped_short} short)")
     print(f"  Within {RELATIVE_TOLERANCE*100:.0f}% tolerance:  {within}/{matched}")
+    print(f"  Matching core counts:    {core_count_matches}/{matched}")
     print(f"  Diagnostics:             {out_file}")
 
     _save_artifacts(test_name, **{"cross_reference.json": out_file, "workload_output.log": workload_log})
@@ -504,6 +521,10 @@ def _cross_reference_impl(
     assert pass_rate >= CROSS_REF_PASS_RATE, (
         f"Only {within}/{matched} ({pass_rate*100:.1f}%) pairs within "
         f"{RELATIVE_TOLERANCE*100:.0f}% tolerance (need >= {CROSS_REF_PASS_RATE*100:.0f}%); see {out_file}"
+    )
+    assert core_count_matches == matched, (
+        f"Only {core_count_matches}/{matched} matched runtime IDs reported the same core count in the real-time and "
+        f"standard profilers. See {out_file} for per-program details."
     )
 
     if expected_multi_chip:

--- a/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
+++ b/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
@@ -20,6 +20,7 @@ struct ProgramRealtimeRecord {
     double frequency;                                  // Device clock frequency (cycles per ns)
     std::span<const std::string_view> kernel_sources;  // Kernel source paths; valid until
                                                        // MetalContext teardown or reinitialization.
+    uint32_t core_count = 0;                           // Distinct programmable cores used by the program.
 };
 
 struct ProgramRealtimeRecordBatch {

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -354,7 +354,8 @@ void RealtimeProfilerManager::publish_pages(
             (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
             (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
             sync_frequency,
-            data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])));
+            data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])),
+            data_collector->GetProgramCoreCountForRuntimeId(static_cast<uint16_t>(rp[2])));
     }
     if (records.empty()) {
         return;

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -151,6 +151,14 @@ void DataCollector::RecordProgramMetadata(ProgramImpl& program) {
         }
     }
     runtime_id_to_kernel_sources_[runtime_id].store(&it->second, std::memory_order_release);
+
+    auto [core_count_it, core_count_inserted] = program_id_to_core_count_.try_emplace(program_id, 0);
+    if (core_count_inserted) {
+        for (const auto& cores : program.logical_cores()) {
+            core_count_it->second += cores.size();
+        }
+    }
+    runtime_id_to_core_count_[runtime_id].store(core_count_it->second, std::memory_order_release);
 }
 
 void DataCollector::RecordProgramSubDevice(

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -71,6 +71,9 @@ public:
         const auto* sources = runtime_id_to_kernel_sources_[runtime_id].load(std::memory_order_acquire);
         return sources != nullptr ? std::span<const std::string_view>(*sources) : std::span<const std::string_view>{};
     }
+    uint32_t GetProgramCoreCountForRuntimeId(uint16_t runtime_id) const noexcept {
+        return runtime_id_to_core_count_[runtime_id].load(std::memory_order_acquire);
+    }
     // Register a callback to be invoked when real-time profiler data arrives.
     // Returns a handle that can be used to unregister the callback.
     tt::ProgramRealtimeProfilerCallbackHandle RegisterProgramRealtimeProfilerCallback(
@@ -115,7 +118,9 @@ private:
     mutable std::mutex kernel_source_mutex_;
     std::unordered_set<std::string> unique_kernel_sources_;
     std::unordered_map<uint64_t, std::vector<std::string_view>> program_id_to_kernel_sources_;
+    std::unordered_map<uint64_t, uint32_t> program_id_to_core_count_;
     std::array<std::atomic<const std::vector<std::string_view>*>, kRuntimeIdSlots> runtime_id_to_kernel_sources_{};
+    std::array<std::atomic<uint32_t>, kRuntimeIdSlots> runtime_id_to_core_count_{};
     std::map<std::pair<tt::ChipId, uint64_t>, tt::ProgramSubDeviceInfo> runtime_id_to_sub_device;
     mutable std::mutex runtime_id_to_sub_device_mutex_;
     mutable std::mutex program_realtime_profiler_callbacks_mutex_;

--- a/tt_metal/programming_examples/profiler/test_realtime_profiler_csv/test_realtime_profiler_csv.cpp
+++ b/tt_metal/programming_examples/profiler/test_realtime_profiler_csv/test_realtime_profiler_csv.cpp
@@ -46,14 +46,15 @@ static void WriteRealtimeRecordsToCsv(const tt::tt_metal::experimental::ProgramR
 
         fmt::format_to(
             out,
-            FMT_COMPILE("{},{},{},{},{},{:.6g},{:.6g},\""),
+            FMT_COMPILE("{},{},{},{},{},{:.6g},{:.6g},{},\""),
             record.runtime_id,
             record.chip_id,
             record.start_timestamp,
             record.end_timestamp,
             duration_cycles,
             duration_ns,
-            record.frequency);
+            record.frequency,
+            record.core_count);
 
         for (size_t i = 0; i < record.kernel_sources.size(); i++) {
             const std::string_view source = record.kernel_sources[i];
@@ -133,6 +134,7 @@ int main(int argc, char** argv) {
             return 1;
         }
         g_csv_file << "runtime_id,chip_id,start_timestamp,end_timestamp,duration_cycles,duration_ns,frequency_ghz,"
+                   << "core_count,"
                    << "kernel_sources\n";
 
         tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle callback_handle =

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -173,6 +173,10 @@ void py_device_module_types(nb::module_& m_device) {
             &tt::tt_metal::experimental::ProgramRealtimeRecord::frequency,
             "Device clock frequency (cycles per ns)")
         .def_ro("chip_id", &tt::tt_metal::experimental::ProgramRealtimeRecord::chip_id, "Device chip ID")
+        .def_ro(
+            "core_count",
+            &tt::tt_metal::experimental::ProgramRealtimeRecord::core_count,
+            "Number of distinct programmable cores used by the program")
         .def_prop_ro(
             "kernel_sources",
             [](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {


### PR DESCRIPTION
## Problem

`ProgramRealtimeRecord` does not expose the number of programmable cores used by a program, which prevents consumers such as the eval golden-test profiler from replacing the standard profiler while preserving `device_num_cores`.

## Implementation

Record the program's distinct programmable-core count alongside its kernel-source metadata, associate it with each runtime ID, and include it in streamed real-time profiler records. The Python binding exposes the value as `record.core_count`; the documentation, CSV example, and profiler tests cover the new field. The cross-reference test also checks the value against the standard profiler.

This is the tt-metal dependency for [tt_ops_code_gen #185](https://github.com/tenstorrent/tt_ops_code_gen/pull/185).

## Validation

- `pre-commit run --files <all changed files>` — passed.
- `.github/scripts/copilot-build.sh --build-metal-tests --build-ttnn-tests --build-programming-examples` — could not run in this worktree because Docker is unavailable on the host, so this checkout's build is unverified.
- The identical implementation was previously compiled from [investigation commit 61746dad](https://github.com/tenstorrent/tt-metal/commit/61746dad381b2f54b9a078d11f1edef17aac626f) with `cmake --build build_Release --target ttnn/_ttnn.so -j 8`.
- On a Blackhole quietbox, `scripts/run_safe_pytest.sh --no-precompile tests/ttnn/tracy/test_realtime_profiler.py::test_callback -q` passed. A 50-case RMSNorm cross-reference also matched the standard profiler's core count for all 50 records.
