### PR TITLE
[Test Only] Penalties1D: cover release()/cleanup paths so the sampling coverage gate passes

### DIFF
--- a/models/common/tests/modules/sampling/test_penalties_1d.py
+++ b/models/common/tests/modules/sampling/test_penalties_1d.py
@@ -9,6 +9,8 @@ import pytest
 import torch
 
 import ttnn
+from models.common.modules.lazy_buffer import LazyBuffer
+from models.common.modules.sampling import penalties_1d as penalties_module
 from models.common.modules.sampling.penalties_1d import (
     Penalties1D,
     Penalties1DConfig,
@@ -785,6 +787,234 @@ class TestConfigUnitMore:
     def test_buf_resolved_returns_false_for_none(self):
         """_buf_resolved returns False for None (baseline, complements line 95/97 tests)."""
         assert not Penalties1DConfig._buf_resolved(None)
+
+
+# ==============================================================================
+# release() / cleanup contract (no device)
+# ==============================================================================
+
+# Module-owned buffer fields, in the order Penalties1D.release() walks them.
+_OWNED_BUFFER_NAMES = (
+    "prompt_mask",
+    "output_mask",
+    "output_counts",
+    "output_counts_gathered",
+    "zeros",
+    "decode_src",
+    "presence_penalties",
+    "frequency_penalties",
+    "repetition_penalties",
+    "inverse_repetition_penalties",
+)
+
+
+class _NotingError(RuntimeError):
+    """RuntimeError with an add_note() on every interpreter, so the note branch of the
+    cleanup helpers is exercised on Python 3.10 (CI) as well as 3.11+."""
+
+    def __init__(self, message):
+        super().__init__(message)
+        self.notes = ()
+
+    def add_note(self, note):
+        self.notes = self.notes + (note,)
+
+
+def _loaded_penalties_with_fake_buffers():
+    """A Penalties1D that looks loaded: ten owned LazyBuffers and two slice tensors hold
+    fake device handles. Returns (penalties, buffers, handles-in-release-order)."""
+    buffers = {}
+    values = []
+    for name in _OWNED_BUFFER_NAMES:
+        buffer = LazyBuffer(source=torch.zeros(1))
+        value = object()
+        buffer._value = value
+        buffers[name] = buffer
+        values.append(value)
+
+    penalties = object.__new__(Penalties1D)
+    penalties.config = SimpleNamespace(**buffers)
+    penalties._slice_start = object()
+    penalties._slice_end = object()
+    values.extend((penalties._slice_start, penalties._slice_end))
+    penalties._decode_src = buffers["decode_src"]._value
+    penalties._zeros = buffers["zeros"]._value
+    penalties._device_buffers_loaded = True
+    return penalties, buffers, values
+
+
+def test_penalties_release_deallocates_owned_lazy_buffers_and_slice_tensors(monkeypatch):
+    released = []
+    monkeypatch.setattr(penalties_module.ttnn, "deallocate", released.append)
+    penalties, buffers, values = _loaded_penalties_with_fake_buffers()
+
+    penalties.release()
+    penalties.release()  # idempotent: nothing left to deallocate
+
+    assert released == values
+    assert all(buffer._value is None for buffer in buffers.values())
+    assert penalties._slice_start is None and penalties._slice_end is None
+    assert penalties._decode_src is None and penalties._zeros is None
+    assert not penalties._device_buffers_loaded
+
+
+def test_penalties_release_is_best_effort_and_retries_only_failed_buffers(monkeypatch, expect_error):
+    penalties, buffers, values = _loaded_penalties_with_fake_buffers()
+    counts_handle = buffers["output_counts"]._value
+    slice_handle = penalties._slice_start
+    counts_error = _NotingError("output_counts deallocate failed once")
+    slice_error = RuntimeError("slice_start deallocate failed once")
+    failures = {counts_handle: counts_error, slice_handle: slice_error}
+    attempts = []
+
+    def deallocate(value):
+        attempts.append(value)
+        if value in failures and attempts.count(value) == 1:
+            raise failures[value]
+
+    monkeypatch.setattr(penalties_module.ttnn, "deallocate", deallocate)
+
+    with expect_error(RuntimeError, "output_counts deallocate failed once") as caught:
+        penalties.release()
+
+    # First failure is raised; later failures ride along on it.
+    assert caught.value is counts_error
+    assert caught.value.cleanup_failures == (slice_error,)
+    assert counts_error.notes == ("cleanup also encountered 1 additional failure(s)",)
+    # Every buffer was attempted once; only the failed ones keep their handles.
+    assert attempts == values
+    assert buffers["output_counts"]._value is not None
+    assert all(buffer._value is None for name, buffer in buffers.items() if name != "output_counts")
+    assert penalties._slice_start is not None
+    assert penalties._slice_end is None
+    assert penalties._decode_src is None and penalties._zeros is None
+    assert not penalties._device_buffers_loaded
+
+    penalties.release()
+
+    # Retry touches only the two buffers that failed, and now clears them.
+    assert attempts == values + [counts_handle, slice_handle]
+    assert all(buffer._value is None for buffer in buffers.values())
+    assert penalties._slice_start is None
+
+
+def test_load_device_buffers_failure_releases_partial_state_and_attaches_cleanup_failures(monkeypatch, expect_error):
+    decode_src = LazyBuffer(source=torch.zeros(1))
+    decode_src._value = object()
+    zeros = LazyBuffer(source=torch.zeros(1))
+    zeros._value = object()
+
+    penalties = object.__new__(Penalties1D)
+    penalties.config = SimpleNamespace(
+        decode_src=decode_src,
+        zeros=zeros,
+        mesh_device=SimpleNamespace(shape=(1, 8)),
+        sub_core_grids=None,
+        is_resolved=lambda: True,
+    )
+    penalties._device_buffers_loaded = False
+
+    allocation_error = _NotingError("slice tensors failed")
+    cleanup_error = RuntimeError("zeros deallocate failed once")
+    deallocated = []
+
+    def deallocate(value):
+        deallocated.append(value)
+        if value is zeros._value and deallocated.count(value) == 1:
+            raise cleanup_error
+
+    def build_slice_tensors_and_fail():
+        raise allocation_error
+
+    monkeypatch.setattr(penalties_module.ttnn, "ShardTensor2dMesh", lambda *args, **kwargs: object())
+    monkeypatch.setattr(penalties_module.ttnn, "deallocate", deallocate)
+    monkeypatch.setattr(penalties, "_build_slice_tensors", build_slice_tensors_and_fail)
+
+    with expect_error(RuntimeError, "slice tensors failed") as caught:
+        penalties.load_device_buffers()
+
+    # The allocation failure is what propagates; the cleanup failure is attached, not raised.
+    assert caught.value is allocation_error
+    assert caught.value.cleanup_failures == (cleanup_error,)
+    assert allocation_error.notes == ("cleanup also encountered 1 failure(s)",)
+    assert not penalties._device_buffers_loaded
+    assert decode_src._value is None  # released during cleanup
+    assert zeros._value is not None  # deallocate failed once, handle retained for retry
+
+    penalties.release()
+    assert zeros._value is None
+    assert deallocated.count(decode_src._value) == 0 and len(deallocated) == 3
+
+    # A later load succeeds and repopulates the module-owned state.
+    slices = (object(), object())
+    monkeypatch.setattr(penalties, "_build_slice_tensors", lambda: slices)
+    monkeypatch.setattr(penalties_module, "_materialize", lambda buf: object())
+    penalties.load_device_buffers()
+    assert penalties._device_buffers_loaded
+    assert (penalties._slice_start, penalties._slice_end) == slices
+    assert penalties._cluster_shape == (1, 8) and penalties._num_devices == 8
+
+
+def test_cleanup_failure_helpers_tolerate_exceptions_without_add_note(expect_error):
+    """Plain exceptions (no add_note on Python 3.10) still carry cleanup_failures."""
+    primary = RuntimeError("primary")
+
+    penalties_module._attach_cleanup_failures(primary, ())
+    assert not hasattr(primary, "cleanup_failures")
+
+    penalties_module._attach_cleanup_failures(primary, (ValueError("first"),))
+    penalties_module._attach_cleanup_failures(primary, (ValueError("second"),))
+    assert [str(error) for error in primary.cleanup_failures] == ["first", "second"]
+
+    lone = RuntimeError("lone failure")
+    with expect_error(RuntimeError, "lone failure") as caught:
+        penalties_module._raise_cleanup_failures([lone])
+    assert caught.value is lone
+    assert not hasattr(lone, "cleanup_failures")
+
+    head, tail = RuntimeError("head failure"), ValueError("tail failure")
+    with expect_error(RuntimeError, "head failure") as caught:
+        penalties_module._raise_cleanup_failures([head, tail])
+    assert caught.value is head
+    assert head.cleanup_failures == (tail,)
+
+
+def test_build_slice_tensors_releases_first_slice_when_second_allocation_fails(monkeypatch, expect_error):
+    penalties = object.__new__(Penalties1D)
+    penalties.config = SimpleNamespace(vocab_size=1024, max_batch_size=32, mesh_device=object())
+    penalties._cluster_shape = (1, 8)
+    penalties._num_devices = 8
+
+    first_slice = object()
+    allocation_error = _NotingError("slice_end allocation failed")
+    cleanup_error = RuntimeError("slice_start deallocate failed")
+    host_tensors = []
+    deallocated = []
+
+    def from_torch(tensor, **_kwargs):
+        host_tensors.append(tensor)
+        if len(host_tensors) == 1:
+            return first_slice
+        raise allocation_error
+
+    def deallocate(value):
+        deallocated.append(value)
+        raise cleanup_error
+
+    monkeypatch.setattr(penalties_module.ttnn, "ShardTensor2dMesh", lambda *args, **kwargs: object())
+    monkeypatch.setattr(penalties_module.ttnn, "from_torch", from_torch)
+    monkeypatch.setattr(penalties_module.ttnn, "deallocate", deallocate)
+
+    with expect_error(RuntimeError, "slice_end allocation failed") as caught:
+        penalties._build_slice_tensors()
+
+    assert caught.value is allocation_error
+    assert deallocated == [first_slice]  # the half-built pair is torn down before re-raising
+    assert caught.value.cleanup_failures == (cleanup_error,)
+    assert allocation_error.notes == ("cleanup also encountered 1 failure(s)",)
+    # Per-device vocab slice bounds for 1024 / 8 devices, padded batch 32.
+    assert host_tensors[0].tolist() == [v for d in range(8) for v in (0, 128 * d)]
+    assert host_tensors[1].tolist() == [v for d in range(8) for v in (32, 128 * (d + 1))]
 
 
 # ==============================================================================


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`TT-Transformers sampling module unit tests [wh_llmbox]` (Tier 1 Models unit, scheduled) has been red on every run since 2026-09-05 with **no failing test** — only:

```
ERROR: Coverage failure: total of 79 is less than fail-under=80
```

Root cause: #53575 added `Penalties1D.release()`, the cleanup-on-failure paths in `load_device_buffers()` / `_build_slice_tensors()` and the `_attach_cleanup_failures` / `_raise_cleanup_failures` helpers to `models/common/modules/sampling/penalties_1d.py` with no tests for them. The file's branch coverage dropped from 98.51% (last green run, 2026-09-04 20:39 UTC) to 78.76% (first red run, 2026-09-05 04:34 UTC), under the `fail_under = 80` gate in `models/common/tests/setup.cfg`. 51 of the 53 uncovered statements are from that commit; the other two (lines 450, 604) are the tall-mesh `else` branches this 1xN job cannot reach and were uncovered before as well.

This PR adds host-only tests (no device; `ttnn.deallocate` / `ttnn.from_torch` monkeypatched) to `test_penalties_1d.py` that pin the cleanup contract:

- `release()` deallocates the ten owned `LazyBuffer`s and both slice tensors, clears the derived handles, and is idempotent.
- `release()` is best-effort: a failing deallocate is recorded, the remaining buffers are still released, the first failure is raised with the rest attached as `cleanup_failures`, and a retry touches only the buffers that failed.
- A failure inside `load_device_buffers()` releases the partially built state, attaches cleanup failures to the primary error, re-raises it, and a later load succeeds.
- A failure allocating the second slice tensor deallocates the first.
- The cleanup helpers work on exceptions without `add_note` (CI runs Python 3.10).

Expected result on CI: `penalties_1d.py` back to ~98% (only lines 450/604 uncovered), gate passes.

### Notes for reviewers
- The first test is the one #53575 already wrote as `test_penalties_release_deallocates_owned_lazy_buffers_and_slice_tensors` in `test_sampling_state_1d.py:881` — that file is not collected by any CI job, so it never counted towards the gate. It is reproduced here (slightly refactored into a shared helper) rather than moved, to keep this PR to one file.
- Tests use the `expect_error` fixture (pre-commit `prefer-expect-error` hook) and a `RuntimeError` subclass with `add_note` so the note branch is exercised on Python 3.10 as well as 3.11+.
- Verified locally with a `ttnn` stub (no hardware here): the 14 host-only tests in the file pass and the new tests cover every range in the CI "Missing" list except 450/604. The real check is the CI run linked below.
- Follow-ups deliberately **not** in this PR: (1) `test_sampling_1d_release.py`, `test_params.py`, `test_sampling_state_1d.py`, `test_seed_manager_1d.py` in the same directory are collected by no CI job (68 tests never run); (2) `sampling_1d.py` sits at 81.12%, 8 items above the same gate; (3) `penalties_1d.py:191` passes the whole cleanup exception to `_attach_cleanup_failures` instead of flattening its own `cleanup_failures` the way `sampling_1d.py:219` does.

### CI
- Targeted run (`(Tier 1) Models Unit Tests`, model=`tt-transformers-common`, sku=`wh_llmbox (T3000)`): https://github.com/tenstorrent/tt-metal/actions/runs/34236956564
  - **Passed.** [`TT-Transformers sampling module unit tests [wh_llmbox]`](https://github.com/tenstorrent/tt-metal/actions/runs/34236956564/job/102099781381): `penalties_1d.py 304 stmts, 2 miss, 68 branch, 3 partial, 99%  Missing: 450, 482->487, 604` — `Required test coverage of 80.0% reached. Total coverage: 98.66%`, 95 passed (was 90 passed / 78.76% on main). `sampling_1d.py` unchanged at 81.12%, 124 passed.

