### PR TITLE
Add attention sink support to sparse SDPA

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -8,6 +8,8 @@ case on the production shape. The fast post-commit smoke is in
 tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py (shared helpers in sparse_sdpa_test_utils.py).
 """
 
+import statistics
+
 import pytest
 import torch
 from loguru import logger
@@ -16,6 +18,8 @@ import ttnn
 from models.common.utility_functions import run_for_blackhole, skip_with_llk_assert, skip_with_watcher
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import (
+    ATTENTION_SINK_SHAPES,
+    make_attention_sink_inputs,
     make_inputs,
     golden,
     to_dev,
@@ -351,4 +355,80 @@ def test_sparse_sdpa_indexed_cache_hit_host_dispatch_is_cheap(device):
     assert min_us < 1000.0, (
         f"indexed cache-hit host dispatch {min_us:.0f}us: override_runtime_arguments is rebuilding the full "
         f"descriptor on every hit instead of patching the runtime-arg slots in place"
+    )
+
+
+def _attention_sink_op(device, H, S, TOPK, dim, kc):
+    q, kv, indices, sink, scale = make_attention_sink_inputs(H, S, TOPK, dim)
+    tt_q = to_dev(q, device, ttnn.bfloat16)
+    tt_kv = to_dev(kv, device, ttnn.bfloat16)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    tt_sink = to_dev(sink, device, ttnn.bfloat16)
+
+    def run():
+        return ttnn.transformer.sparse_sdpa(
+            tt_q,
+            tt_kv,
+            tt_idx,
+            dim,
+            kv_format=ttnn.transformer.SparseKVFormat.BF16,
+            scale=scale,
+            k_chunk_size=kc,
+            attention_sink=tt_sink,
+        )
+
+    return run
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H,S,TOPK,dim,kc", ATTENTION_SINK_SHAPES)
+def test_sparse_sdpa_attention_sink_determinism(device, H, S, TOPK, dim, kc):
+    run = _attention_sink_op(device, H, S, TOPK, dim, kc)
+    reference = ttnn.to_torch(run())
+    assert torch.isfinite(reference).all()
+    entries = device.num_program_cache_entries()
+    # Compare BF16 storage bits, including signed zero, across ten cache-hit executions.
+    for iteration in range(10):
+        actual = ttnn.to_torch(run())
+        assert torch.equal(
+            reference.view(torch.int16), actual.view(torch.int16)
+        ), f"Attention sink output changed on repeat {iteration + 1}"
+    assert device.num_program_cache_entries() == entries, "Repeated sink calls must reuse the cached program"
+
+
+# Blackhole BF16 baselines measured 2026-09-12: median of five warmed device executions.
+# Keys are (H, S, TOPK, dim, kc), matching ATTENTION_SINK_SHAPES.
+_ATTENTION_SINK_EXPECTED_MS = {
+    (128, 4, 128, 64, 32): 0.028223,
+    (64, 640, 640, 512, 128): 1.270069,
+    (128, 640, 1152, 512, 128): 2.547384,
+}
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H,S,TOPK,dim,kc", ATTENTION_SINK_SHAPES)
+@pytest.mark.requires_host_iommu
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_sparse_sdpa_attention_sink_perf(device, H, S, TOPK, dim, kc):
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.fail("Real-time profiler must be active for attention sink perf checks (needs IOMMU)")
+    run = _attention_sink_op(device, H, S, TOPK, dim, kc)
+    run()  # Compile and warm the program cache before measuring device execution.
+    ttnn.synchronize_device(device)
+    entries = device.num_program_cache_entries()
+    samples = []
+    for _ in range(5):
+        out, record = profile_realtime_program(device, run)
+        assert tuple(out.shape) == (1, H, S, dim)
+        samples.append(record["duration_ns"] / 1e6)
+    assert device.num_program_cache_entries() == entries
+    duration_ms = statistics.median(samples)
+    logger.info(f"Attention sink H={H} S={S} TOPK={TOPK} dim={dim} kc={kc}: {duration_ms:.6f} ms; {samples=}")
+    expected_ms = _ATTENTION_SINK_EXPECTED_MS[H, S, TOPK, dim, kc]
+    lower = expected_ms * (1 - SPARSE_PERF_MARGIN)
+    upper = expected_ms * (1 + SPARSE_PERF_MARGIN)
+    assert lower <= duration_ms <= upper, (
+        f"Attention sink device duration {duration_ms:.6f} ms outside band [{lower:.6f}, {upper:.6f}] ms "
+        f"(expected {expected_ms:.6f} ms, margin +/- {SPARSE_PERF_MARGIN * 100:.0f}%)"
     )

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
@@ -15,7 +15,7 @@ import ttnn
 MASKED_INDEX = 0xFFFFFFFF  # sentinel: a masked slot (scores -inf, contributes 0); a contiguous tail per row
 
 
-def sparse_mla(q, kvpe, indices, scale, v_dim):
+def sparse_mla(q, kvpe, indices, scale, v_dim, attention_sink=None):
     """Torch reference for the sparse-MLA prefill op. Absorbed MQA over the top-k selected latents named by
     `indices` (one shared latent KV head); masking is baked into `indices` (index == MASKED_INDEX scores -inf).
     Dims are derived from the inputs; V is the leading `v_dim` cols of the K_DIM-wide kvpe.
@@ -33,7 +33,12 @@ def sparse_mla(q, kvpe, indices, scale, v_dim):
     )
     scores = torch.einsum("bhsd,bsjd->bhsj", q, sel) * scale  # full-K_DIM scores [B,H,S,k]
     scores = scores.masked_fill(masked.view(B, 1, S, k), float("-inf"))
+    if attention_sink is not None:
+        sink_scores = attention_sink.float().expand(B, H, S, 1) * scale
+        scores = torch.cat([scores, sink_scores], dim=-1)
     probs = scores.softmax(dim=-1, dtype=torch.float32).to(q.dtype)
+    if attention_sink is not None:
+        probs = probs[..., :-1]
     return torch.einsum("bhsj,bsjd->bhsd", probs, sel[..., :v_dim])  # weighted sum of V views [B,H,S,v_dim]
 
 
@@ -50,8 +55,8 @@ def make_inputs(H, S, T, TOPK, k_dim, n_valid_fn, seed=0):
     return q, kv, indices
 
 
-def golden(q, kv, indices, scale, v_dim):
-    return sparse_mla(q, kv[0, 0], indices.to(torch.int64), scale, v_dim)  # [1,H,S,v_dim]
+def golden(q, kv, indices, scale, v_dim, attention_sink=None):
+    return sparse_mla(q, kv[0, 0], indices.to(torch.int64), scale, v_dim, attention_sink)  # [1,H,S,v_dim]
 
 
 def to_dev(t, device, dtype):

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
@@ -7,6 +7,7 @@ Correctness uses SMALL parametric shapes (the golden gathers sel[S,k,D]; the ful
 640/2048/56320 shape is ~2.8 GiB and is only exercised by the perf-only test in the nightly suite).
 """
 
+import pytest
 import torch
 
 import ttnn
@@ -103,3 +104,20 @@ def run_op(
 
 def pcc(out, golden_t):
     return torch.corrcoef(torch.stack([out.flatten().float(), golden_t.flatten().float()]))[0, 1].item()
+
+
+# DeepSeek-V4 CSA geometries, shared by correctness, determinism, and performance tests.
+ATTENTION_SINK_SHAPES = [
+    pytest.param(128, 4, 128, 64, 32, id="small-boundaries"),
+    pytest.param(64, 640, 128 + 512, 512, 128, id="v4-flash-full-selection"),
+    pytest.param(128, 640, 128 + 1024, 512, 128, id="v4-pro-full-selection"),
+]
+
+
+def make_attention_sink_inputs(H, S, TOPK, dim):
+    # Keep the boundary smoke's partial chunks; CSA cases use every selected key.
+    q, kv, indices = make_inputs(H, S, 2 * TOPK, TOPK, dim, lambda s: [1, 31, 65, TOPK][s] if S == 4 else TOPK)
+    scale = dim**-0.5
+    # Span negligible to dominant sinks in the scaled-logit domain for every head dimension.
+    sink = (torch.linspace(-4, 8, H) / scale).reshape(1, 1, 1, H).to(torch.bfloat16)
+    return q.to(torch.bfloat16), kv.to(torch.bfloat16), indices, sink, scale

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -560,3 +560,121 @@ def test_sparse_sdpa_bad_layout_rejected_on_hit(device, expect_error):
     tt_q_tile = ttnn.to_layout(tt_q, ttnn.TILE_LAYOUT)  # same shape+dtype (same hash) but wrong layout -> HIT
     with expect_error(RuntimeError, "ROW_MAJOR"):
         ttnn.transformer.sparse_sdpa(tt_q_tile, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, k_chunk_size=kc)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("sink_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
+def test_sparse_sdpa_attention_sink(device, sink_dtype):
+    # One multi-chunk shape covers masks, head/face boundaries, and all accepted sink dtypes.
+    H, S, T, TOPK, dim, kc, scale = 128, 4, 256, 128, 64, 32, 0.125
+    q, kv, indices = make_inputs(H, S, T, TOPK, dim, lambda s: [1, 31, 65, TOPK][s])
+    tt_q = to_dev(q, device, ttnn.bfloat16)
+    tt_kv = to_dev(kv, device, ttnn.bfloat16)
+    tt_indices = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    sinks = torch.linspace(-32, 64, H).reshape(1, H, 1, 1)
+    tt_sink = ttnn.from_torch(sinks, dtype=sink_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.transformer.sparse_sdpa(
+        tt_q, tt_kv, tt_indices, dim, kv_format=BF16_KV, scale=scale, k_chunk_size=kc, attention_sink=tt_sink
+    )
+    expected = golden(
+        ttnn.to_torch(tt_q).float(),
+        ttnn.to_torch(tt_kv).float(),
+        indices,
+        scale,
+        dim,
+        attention_sink=ttnn.to_torch(tt_sink).float(),
+    )
+    actual = ttnn.to_torch(out).float()
+    # Correlation alone would miss the sink's suppression of the output magnitude.
+    torch.testing.assert_close(actual, expected, atol=0.035, rtol=0.08)
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_attention_sink_cache(device):
+    device.clear_program_cache()
+    grid = device.compute_with_storage_grid_size()
+    H, S, dim, scale = 64, grid.x * grid.y + 1, 64, 0.25
+    # Zero scores and unit values give the exact output nv / (nv + exp(scale * sink)).
+    tt_q = to_dev(torch.zeros(1, H, S, dim), device, ttnn.bfloat16)
+    tt_kv = to_dev(torch.ones(1, 1, 32, dim), device, ttnn.bfloat16)
+    indices = torch.arange(32).reshape(1, 1, 1, 32).expand(1, 1, S, 32).contiguous()
+    tt_indices = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    sink_tensors = []  # keep allocations alive to guarantee distinct addresses on cache hits
+    for value in (None, 0.0, 16.0, -32.0, None):
+        sink = None
+        if value is not None:
+            sink = ttnn.from_torch(
+                torch.full((1, H, 1, 1), value), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device
+            )
+            sink_tensors.append(sink)
+        out = ttnn.transformer.sparse_sdpa(
+            tt_q, tt_kv, tt_indices, dim, kv_format=BF16_KV, scale=scale, k_chunk_size=32, attention_sink=sink
+        )
+        expected = 1.0 if value is None else 32 / (32 + torch.exp(torch.tensor(scale * value)).item())
+        torch.testing.assert_close(
+            ttnn.to_torch(out).float(), torch.full((1, H, S, dim), expected), atol=0.012, rtol=0.01
+        )
+        assert device.num_program_cache_entries() == (1 if not sink_tensors else 2)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("invalid", ["heads", "layout", "memory", "dtype"])
+def test_sparse_sdpa_attention_sink_validation(device, expect_error, invalid):
+    q, kv, indices = make_inputs(32, 1, 64, 32, 64, lambda s: 32)
+    sink = ttnn.from_torch(
+        torch.zeros(1, 64 if invalid == "heads" else 32, 1, 1),
+        dtype=ttnn.float32 if invalid == "dtype" else ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT if invalid == "layout" else ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG if invalid == "memory" else ttnn.DRAM_MEMORY_CONFIG,
+        device=device,
+    )
+    with expect_error(RuntimeError, "Attention sink"):
+        ttnn.transformer.sparse_sdpa(
+            to_dev(q, device, ttnn.bfloat16),
+            to_dev(kv, device, ttnn.bfloat16),
+            to_dev(indices.to(torch.int32), device, ttnn.uint32),
+            64,
+            kv_format=BF16_KV,
+            k_chunk_size=32,
+            attention_sink=sink,
+        )
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_attention_sink_dense_parity(device):
+    # Selecting every key must match classic SDPA, including its sink scaling convention.
+    H, S, T, dim, scale = 64, 32, 32, 64, 0.25
+    torch.manual_seed(0)
+    q = torch.randn(1, H, S, dim, dtype=torch.bfloat16)
+    kv = torch.randn(1, 1, T, dim, dtype=torch.bfloat16)
+    indices = torch.arange(T).reshape(1, 1, 1, T).expand(1, 1, S, T).contiguous()
+    sink = ttnn.from_torch(
+        torch.linspace(-16, 32, H).reshape(1, H, 1, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+    sparse = ttnn.transformer.sparse_sdpa(
+        to_dev(q, device, ttnn.bfloat16),
+        to_dev(kv, device, ttnn.bfloat16),
+        to_dev(indices.to(torch.int32), device, ttnn.uint32),
+        dim,
+        kv_format=BF16_KV,
+        scale=scale,
+        k_chunk_size=T,
+        attention_sink=sink,
+    )
+    tiled_q = ttnn.from_torch(q, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    tiled_kv = ttnn.from_torch(kv, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    dense = ttnn.transformer.scaled_dot_product_attention(
+        tiled_q,
+        tiled_kv,
+        tiled_kv,
+        is_causal=False,
+        scale=scale,
+        attention_sink=sink,
+        program_config=ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(), q_chunk_size=S, k_chunk_size=T
+        ),
+    )
+    torch.testing.assert_close(ttnn.to_torch(sparse).float(), ttnn.to_torch(dense).float(), atol=0.035, rtol=0.08)

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -563,16 +563,15 @@ def test_sparse_sdpa_bad_layout_rejected_on_hit(device, expect_error):
 
 
 @run_for_blackhole()
-@pytest.mark.parametrize("sink_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_sparse_sdpa_attention_sink(device, sink_dtype):
-    # One multi-chunk shape covers masks, head/face boundaries, and all accepted sink dtypes.
+def test_sparse_sdpa_attention_sink(device):
+    # One multi-chunk shape covers masks, head/face boundaries, and an idle-core tail.
     H, S, T, TOPK, dim, kc, scale = 128, 4, 256, 128, 64, 32, 0.125
     q, kv, indices = make_inputs(H, S, T, TOPK, dim, lambda s: [1, 31, 65, TOPK][s])
     tt_q = to_dev(q, device, ttnn.bfloat16)
     tt_kv = to_dev(kv, device, ttnn.bfloat16)
     tt_indices = to_dev(indices.to(torch.int32), device, ttnn.uint32)
-    sinks = torch.linspace(-32, 64, H).reshape(1, H, 1, 1)
-    tt_sink = ttnn.from_torch(sinks, dtype=sink_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    sinks = torch.linspace(-32, 64, H).reshape(1, 1, 1, H)
+    tt_sink = ttnn.from_torch(sinks, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
     out = ttnn.transformer.sparse_sdpa(
         tt_q, tt_kv, tt_indices, dim, kv_format=BF16_KV, scale=scale, k_chunk_size=kc, attention_sink=tt_sink
     )
@@ -582,7 +581,7 @@ def test_sparse_sdpa_attention_sink(device, sink_dtype):
         indices,
         scale,
         dim,
-        attention_sink=ttnn.to_torch(tt_sink).float(),
+        attention_sink=ttnn.to_torch(tt_sink).float().reshape(1, H, 1, 1),
     )
     actual = ttnn.to_torch(out).float()
     # Correlation alone would miss the sink's suppression of the output magnitude.
@@ -604,7 +603,7 @@ def test_sparse_sdpa_attention_sink_cache(device):
         sink = None
         if value is not None:
             sink = ttnn.from_torch(
-                torch.full((1, H, 1, 1), value), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device
+                torch.full((1, 1, 1, H), value), dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
             )
             sink_tensors.append(sink)
         out = ttnn.transformer.sparse_sdpa(
@@ -618,13 +617,16 @@ def test_sparse_sdpa_attention_sink_cache(device):
 
 
 @run_for_blackhole()
-@pytest.mark.parametrize("invalid", ["heads", "layout", "memory", "dtype"])
+@pytest.mark.parametrize("invalid", ["heads", "layout", "memory", "dtype", "shape", "bfp8", "bfp4"])
 def test_sparse_sdpa_attention_sink_validation(device, expect_error, invalid):
     q, kv, indices = make_inputs(32, 1, 64, 32, 64, lambda s: 32)
+    heads = 64 if invalid == "heads" else 32
+    sink_shape = (1, heads, 1, 1) if invalid == "shape" else (1, 1, 1, heads)
+    dtype = {"dtype": ttnn.float32, "bfp8": ttnn.bfloat8_b, "bfp4": ttnn.bfloat4_b}.get(invalid, ttnn.bfloat16)
     sink = ttnn.from_torch(
-        torch.zeros(1, 64 if invalid == "heads" else 32, 1, 1),
-        dtype=ttnn.float32 if invalid == "dtype" else ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT if invalid == "layout" else ttnn.TILE_LAYOUT,
+        torch.zeros(sink_shape),
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT if invalid in ("layout", "bfp8", "bfp4") else ttnn.ROW_MAJOR_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG if invalid == "memory" else ttnn.DRAM_MEMORY_CONFIG,
         device=device,
     )
@@ -648,8 +650,15 @@ def test_sparse_sdpa_attention_sink_dense_parity(device):
     q = torch.randn(1, H, S, dim, dtype=torch.bfloat16)
     kv = torch.randn(1, 1, T, dim, dtype=torch.bfloat16)
     indices = torch.arange(T).reshape(1, 1, 1, T).expand(1, 1, S, T).contiguous()
-    sink = ttnn.from_torch(
-        torch.linspace(-16, 32, H).reshape(1, H, 1, 1),
+    sink_values = torch.linspace(-16, 32, H)
+    sparse_sink = ttnn.from_torch(
+        sink_values.reshape(1, 1, 1, H),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    dense_sink = ttnn.from_torch(
+        sink_values.reshape(1, H, 1, 1),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -662,7 +671,7 @@ def test_sparse_sdpa_attention_sink_dense_parity(device):
         kv_format=BF16_KV,
         scale=scale,
         k_chunk_size=T,
-        attention_sink=sink,
+        attention_sink=sparse_sink,
     )
     tiled_q = ttnn.from_torch(q, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     tiled_kv = ttnn.from_torch(kv, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -672,9 +681,45 @@ def test_sparse_sdpa_attention_sink_dense_parity(device):
         tiled_kv,
         is_causal=False,
         scale=scale,
-        attention_sink=sink,
+        attention_sink=dense_sink,
         program_config=ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=device.compute_with_storage_grid_size(), q_chunk_size=S, k_chunk_size=T
         ),
     )
     torch.testing.assert_close(ttnn.to_torch(sparse).float(), ttnn.to_torch(dense).float(), atol=0.035, rtol=0.08)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("scale", [None, 0.25])
+def test_sparse_sdpa_deepseek_attention_sink(device, scale):
+    # DeepSeek-V4 appends the learned sink AFTER scaling QK. Verify caller conversion against that
+    # convention directly, rather than a reference that scales the sink along with QK.
+    H, S, T, dim = 64, 4, 32, 64
+    resolved_scale = dim**-0.5 if scale is None else scale
+    # Constant key/value rows and binary-fraction queries make QK exact, isolating sink scaling
+    # from random-matmul rounding. Nonzero QK scores still exercise the supplied/default scale.
+    q = (torch.arange(H, dtype=torch.float32) - H // 2).reshape(1, H, 1, 1) / 256
+    q = q.expand(1, H, S, dim).to(torch.bfloat16).contiguous()
+    kv = torch.ones(1, 1, T, dim, dtype=torch.bfloat16)
+    indices = torch.arange(T).reshape(1, 1, 1, T).expand(1, 1, S, T).contiguous()
+    model_sink = torch.linspace(-4, 8, H).reshape(1, H, 1, 1).to(torch.bfloat16).float()
+    sink = ttnn.from_torch(
+        (model_sink / resolved_scale).reshape(1, 1, 1, H),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    out = ttnn.transformer.sparse_sdpa(
+        to_dev(q, device, ttnn.bfloat16),
+        to_dev(kv, device, ttnn.bfloat16),
+        to_dev(indices.to(torch.int32), device, ttnn.uint32),
+        dim,
+        kv_format=BF16_KV,
+        scale=scale,
+        k_chunk_size=T,
+        attention_sink=sink,
+    )
+    logits = q.float() @ kv.float().transpose(-1, -2) * resolved_scale
+    probs = torch.cat([logits, model_sink.expand(1, H, S, 1)], dim=-1).softmax(dim=-1)[..., :-1]
+    expected = probs @ kv.float()
+    torch.testing.assert_close(ttnn.to_torch(out).float(), expected, atol=0.012, rtol=0.01)

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -15,6 +15,8 @@ import torch
 import ttnn
 from models.common.utility_functions import run_for_blackhole
 from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import (
+    ATTENTION_SINK_SHAPES,
+    make_attention_sink_inputs,
     make_inputs,
     golden,
     to_dev,
@@ -563,27 +565,37 @@ def test_sparse_sdpa_bad_layout_rejected_on_hit(device, expect_error):
 
 
 @run_for_blackhole()
-def test_sparse_sdpa_attention_sink(device):
-    # One multi-chunk shape covers masks, head/face boundaries, and an idle-core tail.
-    H, S, T, TOPK, dim, kc, scale = 128, 4, 256, 128, 64, 32, 0.125
-    q, kv, indices = make_inputs(H, S, T, TOPK, dim, lambda s: [1, 31, 65, TOPK][s])
+@pytest.mark.parametrize("H,S,TOPK,dim,kc", ATTENTION_SINK_SHAPES)
+def test_sparse_sdpa_attention_sink(device, H, S, TOPK, dim, kc):
+    q, kv, indices, sinks, scale = make_attention_sink_inputs(H, S, TOPK, dim)
     tt_q = to_dev(q, device, ttnn.bfloat16)
     tt_kv = to_dev(kv, device, ttnn.bfloat16)
     tt_indices = to_dev(indices.to(torch.int32), device, ttnn.uint32)
-    sinks = torch.linspace(-32, 64, H).reshape(1, 1, 1, H)
-    tt_sink = ttnn.from_torch(sinks, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_sink = to_dev(sinks, device, ttnn.bfloat16)
     out = ttnn.transformer.sparse_sdpa(
         tt_q, tt_kv, tt_indices, dim, kv_format=BF16_KV, scale=scale, k_chunk_size=kc, attention_sink=tt_sink
     )
-    expected = golden(
-        ttnn.to_torch(tt_q).float(),
-        ttnn.to_torch(tt_kv).float(),
-        indices,
-        scale,
-        dim,
-        attention_sink=ttnn.to_torch(tt_sink).float().reshape(1, H, 1, 1),
-    )
     actual = ttnn.to_torch(out).float()
+    # Compute the PyTorch reference in batches of query positions to limit host memory use.
+    # This batch size is independent of hardware tiles and the device k_chunk_size.
+    # Concatenating along the query axis restores the full expected output for every head.
+    reference_query_batch_size = 32
+    expected = torch.cat(
+        [
+            golden(
+                q[:, :, start : start + reference_query_batch_size].float(),
+                kv.float(),
+                indices[:, :, start : start + reference_query_batch_size],
+                scale,
+                dim,
+                attention_sink=sinks.float().reshape(1, H, 1, 1),
+            )
+            for start in range(0, S, reference_query_batch_size)
+        ],
+        dim=2,
+    )
+    score = pcc(actual, expected)
+    assert score >= 0.99, f"Attention sink PCC {score:.5f}"
     # Correlation alone would miss the sink's suppression of the output magnitude.
     torch.testing.assert_close(actual, expected, atol=0.035, rtol=0.08)
 
@@ -686,7 +698,10 @@ def test_sparse_sdpa_attention_sink_dense_parity(device):
             compute_with_storage_grid_size=device.compute_with_storage_grid_size(), q_chunk_size=S, k_chunk_size=T
         ),
     )
-    torch.testing.assert_close(ttnn.to_torch(sparse).float(), ttnn.to_torch(dense).float(), atol=0.035, rtol=0.08)
+    actual, expected = ttnn.to_torch(sparse).float(), ttnn.to_torch(dense).float()
+    score = pcc(actual, expected)
+    assert score >= 0.99, f"Sparse/dense attention sink PCC {score:.5f}"
+    torch.testing.assert_close(actual, expected, atol=0.035, rtol=0.08)
 
 
 @run_for_blackhole()

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -704,17 +704,18 @@ template <
     uint32_t normalized_out_cb,
     uint32_t scale_fp32 = 0,
     bool use_attention_sink = false,
-    uint32_t cb_attention_sink = INVALID_CB>
+    uint32_t cb_attention_sink = INVALID_CB,
+    bool sink_per_row = false>
 static __attribute__((noinline, noclone)) void normalize_row_streaming(
     uint32_t cur_sum_cb,
     uint32_t cur_out_cb,
     uint32_t sbh,
     [[maybe_unused]] uint32_t cur_max_cb_rt = 0,
     [[maybe_unused]] uint32_t sink_row_offset = 0) {
-    // Attention sink: cb_attention_sink holds one raw per-head scalar tile. Broadcast it for each
-    // row, compute exp((sink - max)*scale), and fold it into the col-reduced denominator (DST[0]).
+    // Dense SDPA supplies one scalar tile; sparse SDPA supplies a first-column vector of head
+    // scalars per tile row. Fold exp((sink - max)*scale) into the col-reduced denominator (DST[0]).
     if constexpr (use_attention_sink) {
-        CircularBuffer(cb_attention_sink).wait_front(1);
+        CircularBuffer(cb_attention_sink).wait_front(sink_per_row ? sink_row_offset + sbh : 1);
         CircularBuffer(cur_max_cb_rt).wait_front(sink_row_offset + sbh);
     }
     configure_single_tile_pack(scratch_cb);
@@ -739,8 +740,14 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
                 // DST[1] = exp((sink[s] - max[row_offset+s]) * scale); DST[0] += DST[1].
                 // max - sink with a negated scale is equivalent and avoids expanding the sink
                 // scalar to a first-column vector for every Q tile.
-                sub_bcast_scalar_init(cur_max_cb_rt, cb_attention_sink);
-                sub_tiles_bcast_scalar(cur_max_cb_rt, cb_attention_sink, sink_row_offset + s, 0, 1);
+                if constexpr (sink_per_row) {
+                    // Sparse SDPA packs different heads in each row; both inputs hold a first-column vector.
+                    sub_init(cur_max_cb_rt, cb_attention_sink);
+                    sub_tiles(cur_max_cb_rt, cb_attention_sink, sink_row_offset + s, sink_row_offset + s, 1);
+                } else {
+                    sub_bcast_scalar_init(cur_max_cb_rt, cb_attention_sink);
+                    sub_tiles_bcast_scalar(cur_max_cb_rt, cb_attention_sink, sink_row_offset + s, 0, 1);
+                }
                 // The custom first-column exp needs generic unary SFPU addrmod state, but not the
                 // Blackhole approximate exp_init macro/replay setup used by exp_tile<true>.
                 MATH((llk_math_eltwise_unary_sfpu_init<SfpuType::exponential, DST_ACCUM_MODE>()));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -90,6 +90,8 @@ ALWI void tilize_packed_field() {
 }
 
 void kernel_main() {
+    constexpr bool use_attention_sink = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::USE_ATTENTION_SINK) != 0;
+    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_ATTENTION_SINK);
     constexpr uint32_t H = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::H);
     constexpr uint32_t DHt = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::DHT);
     constexpr uint32_t vDHt = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::V_DHT);
@@ -498,7 +500,10 @@ void kernel_main() {
                     cb_col_identity,
                     cb_recip_scratch,
                     cb_out_im,
-                    scale_fp32>(sum_cur.get_cb_id(), out_cur.get_cb_id(), Sqt);
+                    scale_fp32,
+                    use_attention_sink,
+                    cb_attention_sink,
+                    /*sink_per_row=*/true>(sum_cur.get_cb_id(), out_cur.get_cb_id(), Sqt, max_cur.get_cb_id());
                 max_cur.pop_front(Sqt);  // running max no longer needed
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -90,6 +90,7 @@ ALWI void tilize_packed_field() {
 }
 
 void kernel_main() {
+    constexpr bool sink_per_row = true;  // sparse query rows represent different heads
     constexpr bool use_attention_sink = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::USE_ATTENTION_SINK) != 0;
     constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_ATTENTION_SINK);
     constexpr uint32_t H = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::H);
@@ -503,7 +504,7 @@ void kernel_main() {
                     scale_fp32,
                     use_attention_sink,
                     cb_attention_sink,
-                    /*sink_per_row=*/true>(sum_cur.get_cb_id(), out_cur.get_cb_id(), Sqt, max_cur.get_cb_id());
+                    sink_per_row>(sum_cur.get_cb_id(), out_cur.get_cb_id(), Sqt, max_cur.get_cb_id());
                 max_cur.pop_front(Sqt);  // running max no longer needed
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
@@ -62,6 +62,10 @@ void kernel_main() {
     constexpr uint32_t cb_kreq = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_KREQ);
     constexpr uint32_t cb_kack = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_KACK);
 
+    constexpr bool use_attention_sink = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::USE_ATTENTION_SINK) != 0;
+    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_ATTENTION_SINK);
+    constexpr uint32_t cb_sink_scratch = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_SINK_SCRATCH);
+
     // kv carries a RUNTIME tensor shape (its T dim is common runtime args, not compile-time), so its accessor
     // spans both the compile-time AND common-runtime arg streams. Thread both offsets through all three.
     constexpr auto q_args = TensorAccessorArgs<sparse_sdpa::reader_ct_arg::END, 0>();
@@ -95,6 +99,37 @@ void kernel_main() {
     idx_cb.reserve_back(1);
     const uint32_t idx_l1 = idx_cb.get_write_ptr();
     volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
+
+    if constexpr (use_attention_sink) {
+        if (tok_count > 0) {
+            constexpr auto sink_args = TensorAccessorArgs<
+                idx_args.next_compile_time_args_offset(),
+                idx_args.next_common_runtime_args_offset()>();
+            const auto sink = TensorAccessor(sink_args, get_arg_val<uint32_t>(6));
+            experimental::CB sink_cb(cb_attention_sink), scratch(cb_sink_scratch);
+            constexpr uint32_t sink_tiles = H / tt::constants::TILE_HEIGHT;
+            const uint32_t tile_bytes = get_tile_size(cb_attention_sink);
+            constexpr uint32_t faces_per_row = tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH;
+            sink_cb.reserve_back(sink_tiles);
+            scratch.reserve_back(1);
+            noc.async_write_zeros(sink_cb, sink_tiles * tile_bytes);
+            noc.write_zeros_l1_barrier();
+            auto* dst = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(sink_cb.get_write_ptr());
+            auto* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scratch.get_write_ptr());
+            for (uint32_t h = 0; h < H; ++h) {
+                // [1,H,1,1] TILE stores each head in a separate tile. Read the first aligned
+                // segment, then put its scalar in the head's row of a packed first-column tile.
+                noc.async_read(sink, scratch, NOC_DRAM_READ_ALIGNMENT_BYTES, {.page_id = h}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                const uint32_t row = h % tt::constants::TILE_HEIGHT;
+                const uint32_t offset = (h / tt::constants::TILE_HEIGHT) * tt::constants::TILE_HW +
+                                        (row / tt::constants::FACE_HEIGHT) * faces_per_row * tt::constants::FACE_HW +
+                                        (row % tt::constants::FACE_HEIGHT) * tt::constants::FACE_WIDTH;
+                dst[offset] = src[0];
+            }
+            sink_cb.push_back(sink_tiles);  // reused by every token on this core
+        }
+    }
 
     for (uint32_t tok = tok_start; tok < tok_start + tok_count; ++tok) {
         // Q: H head-rows -> cb_q_rm.  Q is [1,H,S,576] row-major: row (h,tok) = page h*S+tok.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
@@ -62,10 +62,6 @@ void kernel_main() {
     constexpr uint32_t cb_kreq = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_KREQ);
     constexpr uint32_t cb_kack = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_KACK);
 
-    constexpr bool use_attention_sink = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::USE_ATTENTION_SINK) != 0;
-    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_ATTENTION_SINK);
-    constexpr uint32_t cb_sink_scratch = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_SINK_SCRATCH);
-
     // kv carries a RUNTIME tensor shape (its T dim is common runtime args, not compile-time), so its accessor
     // spans both the compile-time AND common-runtime arg streams. Thread both offsets through all three.
     constexpr auto q_args = TensorAccessorArgs<sparse_sdpa::reader_ct_arg::END, 0>();
@@ -99,37 +95,6 @@ void kernel_main() {
     idx_cb.reserve_back(1);
     const uint32_t idx_l1 = idx_cb.get_write_ptr();
     volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
-
-    if constexpr (use_attention_sink) {
-        if (tok_count > 0) {
-            constexpr auto sink_args = TensorAccessorArgs<
-                idx_args.next_compile_time_args_offset(),
-                idx_args.next_common_runtime_args_offset()>();
-            const auto sink = TensorAccessor(sink_args, get_arg_val<uint32_t>(6));
-            experimental::CB sink_cb(cb_attention_sink), scratch(cb_sink_scratch);
-            constexpr uint32_t sink_tiles = H / tt::constants::TILE_HEIGHT;
-            const uint32_t tile_bytes = get_tile_size(cb_attention_sink);
-            constexpr uint32_t faces_per_row = tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH;
-            sink_cb.reserve_back(sink_tiles);
-            scratch.reserve_back(1);
-            noc.async_write_zeros(sink_cb, sink_tiles * tile_bytes);
-            noc.write_zeros_l1_barrier();
-            auto* dst = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(sink_cb.get_write_ptr());
-            auto* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scratch.get_write_ptr());
-            for (uint32_t h = 0; h < H; ++h) {
-                // [1,H,1,1] TILE stores each head in a separate tile. Read the first aligned
-                // segment, then put its scalar in the head's row of a packed first-column tile.
-                noc.async_read(sink, scratch, NOC_DRAM_READ_ALIGNMENT_BYTES, {.page_id = h}, {.offset_bytes = 0});
-                noc.async_read_barrier();
-                const uint32_t row = h % tt::constants::TILE_HEIGHT;
-                const uint32_t offset = (h / tt::constants::TILE_HEIGHT) * tt::constants::TILE_HW +
-                                        (row / tt::constants::FACE_HEIGHT) * faces_per_row * tt::constants::FACE_HW +
-                                        (row % tt::constants::FACE_HEIGHT) * tt::constants::FACE_WIDTH;
-                dst[offset] = src[0];
-            }
-            sink_cb.push_back(sink_tiles);  // reused by every token on this core
-        }
-    }
 
     for (uint32_t tok = tok_start; tok < tok_start + tok_count; ++tok) {
         // Q: H head-rows -> cb_q_rm.  Q is [1,H,S,576] row-major: row (h,tok) = page h*S+tok.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -5,7 +5,8 @@
 // sparse_sdpa writer: per token, drain the untilized [H, V_DIM] row-major block from compute (Sqt*vDHt
 // tile-sized pages, row-major bytes inside) and write each head-row to the ROW-MAJOR [1,H,S,V_DIM] output.
 // Also builds the three persistent compute-input tiles once at startup (the reader is busier): the reduce
-// identity scaler, the col-identity (row-sum finalize), and the all-(-inf) mask tile.
+// identity scaler, the col-identity (row-sum finalize), and the all-(-inf) mask tile. Optional per-head
+// attention sinks are gathered once here too, while the reader loads Q and indices.
 // Uses the object-based NoC + circular-buffer APIs.
 
 #include <stdint.h>
@@ -43,6 +44,9 @@ void kernel_main() {
     constexpr uint32_t cb_kreq = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_KREQ);
     constexpr uint32_t cb_kack = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_KACK);
     constexpr uint32_t packed_row_bytes = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::PACKED_ROW_BYTES);
+    constexpr bool use_attention_sink = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::USE_ATTENTION_SINK) != 0;
+    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_ATTENTION_SINK);
+    constexpr uint32_t cb_sink_scratch = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_SINK_SCRATCH);
     constexpr auto out_args = TensorAccessorArgs<sparse_sdpa::writer_ct_arg::END, 0>();
     // kv carries a RUNTIME tensor shape (T dim in common runtime args), so its accessor spans both arg streams.
     constexpr auto kv_args =
@@ -95,6 +99,40 @@ void kernel_main() {
             p[tt::constants::FACE_HW + c] = neg_inf_bf16;
         }
         neginf_cb.push_back(1);
+    }
+
+    if constexpr (use_attention_sink) {
+        if (tok_count > 0) {
+            constexpr auto sink_args = TensorAccessorArgs<
+                kv_args.next_compile_time_args_offset(),
+                kv_args.next_common_runtime_args_offset()>();
+            const auto sink = TensorAccessor(sink_args, get_arg_val<uint32_t>(5));
+            experimental::CB sink_cb(cb_attention_sink), scratch(cb_sink_scratch);
+            constexpr uint32_t sink_bytes = H * sizeof(uint16_t);
+            constexpr uint32_t tile_bytes = tt::constants::TILE_HW * sizeof(uint16_t);
+            constexpr uint32_t faces_per_row = tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH;
+            static_assert(H % tt::constants::TILE_HEIGHT == 0);
+            static_assert(sink_bytes % NOC_DRAM_READ_ALIGNMENT_BYTES == 0);
+            constexpr uint32_t sink_tiles = H / tt::constants::TILE_HEIGHT;
+            sink_cb.reserve_back(sink_tiles);
+            scratch.reserve_back(1);
+            noc.async_write_zeros(sink_cb, sink_tiles * tile_bytes);
+            // [1,1,1,H] BF16 stores all heads in one row. Read once, then pack the scalars
+            // into the first column of the compute tiles (one head per row).
+            noc.async_read(sink, scratch, sink_bytes, {.page_id = 0}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            noc.write_zeros_l1_barrier();
+            auto* dst = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(sink_cb.get_write_ptr());
+            auto* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scratch.get_write_ptr());
+            for (uint32_t h = 0; h < H; ++h) {
+                const uint32_t row = h % tt::constants::TILE_HEIGHT;
+                const uint32_t offset = (h / tt::constants::TILE_HEIGHT) * tt::constants::TILE_HW +
+                                        (row / tt::constants::FACE_HEIGHT) * faces_per_row * tt::constants::FACE_HW +
+                                        (row % tt::constants::FACE_HEIGHT) * tt::constants::FACE_WIDTH;
+                dst[offset] = src[h];
+            }
+            sink_cb.push_back(sink_tiles);  // reused by every token on this core
+        }
     }
 
     for (uint32_t tok = tok_start; tok < tok_start + tok_count; ++tok) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
@@ -82,6 +82,9 @@ enum : uint32_t {
     PACKED_ROW_BYTES,
     CB_KREQ,
     CB_KACK,
+    USE_ATTENTION_SINK,
+    CB_ATTENTION_SINK,
+    CB_SINK_SCRATCH,
     END,
 };
 }  // namespace reader_ct_arg
@@ -147,6 +150,8 @@ enum : uint32_t {
     MATH_APPROX_MODE,
     QUERY_SUBBLOCK,
     PACKED_ROW_BYTES,
+    USE_ATTENTION_SINK,
+    CB_ATTENTION_SINK,
     END,
 };
 }  // namespace compute_ct_arg

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
@@ -82,9 +82,6 @@ enum : uint32_t {
     PACKED_ROW_BYTES,
     CB_KREQ,
     CB_KACK,
-    USE_ATTENTION_SINK,
-    CB_ATTENTION_SINK,
-    CB_SINK_SCRATCH,
     END,
 };
 }  // namespace reader_ct_arg
@@ -111,6 +108,9 @@ enum : uint32_t {
     CB_KREQ,
     CB_KACK,
     PACKED_ROW_BYTES,
+    USE_ATTENTION_SINK,
+    CB_ATTENTION_SINK,
+    CB_SINK_SCRATCH,
     END,
 };
 }  // namespace writer_ct_arg

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -27,6 +27,20 @@ void validate_non_hashed(const SparseSDPAParams& attrs, const SparseSDPAInputs& 
     const auto& idx = t.indices;
     TT_FATAL(
         q.device() == kv.device() && q.device() == idx.device(), "sparse_sdpa: all inputs must be on the same device");
+    if (t.attention_sink.has_value()) {
+        const auto& sink = t.attention_sink.value();
+        TT_FATAL(
+            sink.storage_type() == StorageType::DEVICE && sink.buffer() != nullptr,
+            "Attention sink tensor must be on device");
+        TT_FATAL(sink.device() == q.device(), "Attention sink must be on the same device as Q");
+        TT_FATAL(
+            sink.layout() == Layout::TILE && sink.dtype() == DataType::BFLOAT16,
+            "Sparse SDPA device attention sink must be tiled BF16");
+        TT_FATAL(sink.memory_config().buffer_type() == BufferType::DRAM, "Attention sink must be in DRAM");
+        TT_FATAL(
+            sink.logical_shape() == ttnn::Shape({1, q.logical_shape()[1], 1, 1}),
+            "Attention sink must have shape [1, H, 1, 1] matching Q heads");
+    }
     // q and indices: ROW_MAJOR, DRAM, interleaved, unpadded (row-major paged-accessor assumptions).
     for (const Tensor* tp : {&q, &idx}) {
         TT_FATAL(tp->layout() == Layout::ROW_MAJOR, "sparse_sdpa q/indices must be ROW_MAJOR");
@@ -250,7 +264,8 @@ ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAPar
         attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
         attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
         t.indices.logical_shape(),
-        t.indices.dtype());
+        t.indices.dtype(),
+        t.attention_sink);
 }
 
 Tensor sparse_sdpa(
@@ -263,7 +278,8 @@ Tensor sparse_sdpa(
     uint32_t k_chunk_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
-    std::optional<BlockCyclicLayout> block_cyclic) {
+    std::optional<BlockCyclicLayout> block_cyclic,
+    const std::optional<Tensor>& attention_sink) {
     using OperationType = ttnn::prim::SparseSDPAOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -279,6 +295,7 @@ Tensor sparse_sdpa(
             .q = q,
             .kv = kv,
             .indices = indices,
+            .attention_sink = attention_sink,
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -33,14 +33,16 @@ void validate_non_hashed(const SparseSDPAParams& attrs, const SparseSDPAInputs& 
             sink.storage_type() == StorageType::DEVICE && sink.buffer() != nullptr,
             "Attention sink tensor must be on device");
         TT_FATAL(sink.device() == q.device(), "Attention sink must be on the same device as Q");
-        TT_FATAL(
-            sink.layout() == Layout::TILE && sink.dtype() == DataType::BFLOAT16,
-            "Sparse SDPA device attention sink must be tiled BF16");
+        TT_FATAL(sink.dtype() == DataType::BFLOAT16, "Attention sink must be BF16");
+        TT_FATAL(sink.layout() == Layout::ROW_MAJOR, "Attention sink must be ROW_MAJOR");
         TT_FATAL(sink.memory_config().buffer_type() == BufferType::DRAM, "Attention sink must be in DRAM");
+        TT_FATAL(!sink.memory_config().is_sharded(), "Attention sink must be interleaved");
         TT_FATAL(
-            sink.logical_shape() == ttnn::Shape({1, q.logical_shape()[1], 1, 1}),
-            "Attention sink must have shape [1, H, 1, 1] matching Q heads");
+            sink.logical_shape() == ttnn::Shape({1, 1, 1, q.logical_shape()[1]}),
+            "Attention sink must have shape [1, 1, 1, H] matching Q heads");
+        TT_FATAL(sink.padded_shape() == sink.logical_shape(), "Attention sink must not be padded");
     }
+
     // q and indices: ROW_MAJOR, DRAM, interleaved, unpadded (row-major paged-accessor assumptions).
     for (const Tensor* tp : {&q, &idx}) {
         TT_FATAL(tp->layout() == Layout::ROW_MAJOR, "sparse_sdpa q/indices must be ROW_MAJOR");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -59,6 +59,7 @@ Tensor sparse_sdpa(
     uint32_t k_chunk_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
-    std::optional<BlockCyclicLayout> block_cyclic = std::nullopt);
+    std::optional<BlockCyclicLayout> block_cyclic = std::nullopt,
+    const std::optional<Tensor>& attention_sink = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -34,6 +34,7 @@ struct SparseSDPAInputs {
     Tensor q;        // [1, H, S, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
     Tensor kv;       // Plain [B,1,T,K_DIM] or packed scaled-FP8 rows; format is explicit in SparseSDPAParams
     Tensor indices;  // [1, 1, S, TOPK] uint32 ROW_MAJOR  (0xFFFFFFFF = masked)
+    std::optional<Tensor> attention_sink;  // [1, H, 1, 1] tiled BF16; scaled like QK, as in classic SDPA
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -34,7 +34,8 @@ struct SparseSDPAInputs {
     Tensor q;        // [1, H, S, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
     Tensor kv;       // Plain [B,1,T,K_DIM] or packed scaled-FP8 rows; format is explicit in SparseSDPAParams
     Tensor indices;  // [1, 1, S, TOPK] uint32 ROW_MAJOR  (0xFFFFFFFF = masked)
-    std::optional<Tensor> attention_sink;  // [1, H, 1, 1] tiled BF16; scaled like QK, as in classic SDPA
+    // [1, 1, 1, H] ROW_MAJOR BF16; scaled like QK.
+    std::optional<Tensor> attention_sink;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -34,19 +34,21 @@ enum SparseCB : uint32_t {
     cb_sum_b,
     cb_out_a,  // running out ping-pong [Sqt, vDHt] (single-buffered for L1 accumulation)
     cb_out_b,
-    cb_corr,           // exp(prev_max - cur_max) correction [Sqt, 1]
-    cb_out_im,         // fixed pre-untilize copy of the final out [Sqt, vDHt]
-    cb_out_rm,         // untilized row-major out (compute -> writer)
-    cb_idx,            // reader-internal: one token's index row (uint32)
-    cb_ctrl,           // reader -> compute: [active chunk count (=ceil(valid_keys/k_chunk)), valid_keys] per token
-    cb_col_identity,   // ones-in-col0 (writer-built): finalizes the partial row-sum via matmul_reduce
-    cb_recip_scratch,  // 1-tile reciprocal scratch for normalize_row_streaming
-    cb_kreq,           // reader->writer K-gather handoff (dual-NoC split)
-    cb_kack,           // writer->reader ack that its half of the chunk landed in cb_k_rm
-    cb_k_rope_rm,      // scaled FP8 only: format-only BF16 view of one packed row slab
-    cb_k_scale_bcast,  // scaled FP8 only: one FP32 per-row broadcast tile per scale block
-    cb_k_latent_tile,  // scaled FP8 only: one TILE_HEIGHT-row BFP8 latent slab
-    cb_k_rope_tile,    // scaled FP8 only: one K chunk's BF16 RoPE tiles
+    cb_corr,            // exp(prev_max - cur_max) correction [Sqt, 1]
+    cb_out_im,          // fixed pre-untilize copy of the final out [Sqt, vDHt]
+    cb_out_rm,          // untilized row-major out (compute -> writer)
+    cb_idx,             // reader-internal: one token's index row (uint32)
+    cb_ctrl,            // reader -> compute: [active chunk count (=ceil(valid_keys/k_chunk)), valid_keys] per token
+    cb_col_identity,    // ones-in-col0 (writer-built): finalizes the partial row-sum via matmul_reduce
+    cb_recip_scratch,   // 1-tile reciprocal scratch for normalize_row_streaming
+    cb_kreq,            // reader->writer K-gather handoff (dual-NoC split)
+    cb_kack,            // writer->reader ack that its half of the chunk landed in cb_k_rm
+    cb_k_rope_rm,       // scaled FP8 only: format-only BF16 view of one packed row slab
+    cb_k_scale_bcast,   // scaled FP8 only: one FP32 per-row broadcast tile per scale block
+    cb_k_latent_tile,   // scaled FP8 only: one TILE_HEIGHT-row BFP8 latent slab
+    cb_k_rope_tile,     // scaled FP8 only: one K chunk's BF16 RoPE tiles
+    cb_attention_sink,  // persistent first-column vector: one sink scalar per head
+    cb_sink_scratch,    // reader scratch for gathering tiled sink scalars
     cb_count
 };
 
@@ -54,6 +56,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     const SparseSDPAParams& attrs, const SparseSDPAInputs& t, Tensor& output) {
     tt::tt_metal::ProgramDescriptor desc;
 
+    const bool use_attention_sink = t.attention_sink.has_value();
     const uint32_t H = t.q.logical_shape()[1];  // head count, from the tensor (any multiple of TILE_HEIGHT)
     const uint32_t S = t.q.logical_shape()[2];
     const uint32_t topk = t.indices.logical_shape()[3];
@@ -171,6 +174,11 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
         cb(cb_k_rope_tile, tile_bytes, Skt * (DHt - vDHt), bf);
     }
 
+    if (use_attention_sink) {
+        cb(cb_attention_sink, tile_bytes, Sqt, bf);
+        cb(cb_sink_scratch, tile_bytes, 1, bf);
+    }
+
     // ---- compile-time args ----
     // CB ids are passed to each kernel as compile-time args (the SparseCB enum is the single source).
     // Keep each block's order in sync with the kernel's reads. Layout: scalars, then CB ids, then the
@@ -204,6 +212,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     reader_ct.insert(
         reader_ct.end(),
         {static_cast<uint32_t>(scaled_kv), v_dim, cb_k_scale_bcast, packed_page_bytes, cb_kreq, cb_kack});
+    reader_ct.insert(reader_ct.end(), {static_cast<uint32_t>(use_attention_sink), cb_attention_sink, cb_sink_scratch});
     TT_FATAL(
         reader_ct.size() == ::sparse_sdpa::reader_ct_arg::END,
         "sparse_sdpa reader compile-time argument layout is out of sync");
@@ -216,6 +225,8 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_ct, reader_crt);
     tt::tt_metal::TensorAccessorArgs(t.indices.buffer()).append_to(reader_ct, reader_crt);
+    tt::tt_metal::TensorAccessorArgs(use_attention_sink ? t.attention_sink->buffer() : nullptr)
+        .append_to(reader_ct, reader_crt);
     // The writer is the lighter dataflow kernel, so it builds the three persistent compute-input tiles.
     std::vector<uint32_t> writer_ct = {H, S, vDHt, cb_out_rm, cb_scale, cb_col_identity, cb_neginf, out_elem_bytes};
     writer_ct.insert(writer_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
@@ -299,6 +310,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     compute_ct.push_back(static_cast<uint32_t>(math_approx));
     compute_ct.push_back(qsb);
     compute_ct.push_back(packed_page_bytes);
+    compute_ct.insert(compute_ct.end(), {static_cast<uint32_t>(use_attention_sink), cb_attention_sink});
     TT_FATAL(
         compute_ct.size() == ::sparse_sdpa::compute_ct_arg::END,
         "sparse_sdpa compute compile-time argument layout is out of sync");
@@ -336,7 +348,15 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t tok_start = i * base + std::min(i, extra);
         uint32_t tok_count = base + (i < extra ? 1u : 0u);
-        reader_desc.emplace_runtime_args(core, {q_buf, kv_buf, idx_buf, tok_start, tok_count, kv_batch_page_offset});
+        reader_desc.emplace_runtime_args(
+            core,
+            {q_buf,
+             kv_buf,
+             idx_buf,
+             tok_start,
+             tok_count,
+             kv_batch_page_offset,
+             use_attention_sink ? t.attention_sink->buffer() : nullptr});
         writer_desc.emplace_runtime_args(core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});
         compute_desc.emplace_runtime_args(core, {tok_start, tok_count});
     }
@@ -368,6 +388,7 @@ void SparseSDPAOperation::SparseSDPAProgramFactory::override_runtime_arguments(
         r[1] = kv;
         r[2] = idx;
         r[5] = offset;
+        r[6] = t.attention_sink.has_value() ? t.attention_sink->buffer()->address() : 0u;
         w[0] = out;
         w[3] = kv;
         w[4] = offset;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -48,7 +48,7 @@ enum SparseCB : uint32_t {
     cb_k_latent_tile,   // scaled FP8 only: one TILE_HEIGHT-row BFP8 latent slab
     cb_k_rope_tile,     // scaled FP8 only: one K chunk's BF16 RoPE tiles
     cb_attention_sink,  // persistent first-column vector: one sink scalar per head
-    cb_sink_scratch,    // reader scratch for gathering tiled sink scalars
+    cb_sink_scratch,    // writer scratch for gathering sink scalars
     cb_count
 };
 
@@ -176,7 +176,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
 
     if (use_attention_sink) {
         cb(cb_attention_sink, tile_bytes, Sqt, bf);
-        cb(cb_sink_scratch, tile_bytes, 1, bf);
+        cb(cb_sink_scratch, H * sizeof(uint16_t), 1, bf);
     }
 
     // ---- compile-time args ----
@@ -212,7 +212,6 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     reader_ct.insert(
         reader_ct.end(),
         {static_cast<uint32_t>(scaled_kv), v_dim, cb_k_scale_bcast, packed_page_bytes, cb_kreq, cb_kack});
-    reader_ct.insert(reader_ct.end(), {static_cast<uint32_t>(use_attention_sink), cb_attention_sink, cb_sink_scratch});
     TT_FATAL(
         reader_ct.size() == ::sparse_sdpa::reader_ct_arg::END,
         "sparse_sdpa reader compile-time argument layout is out of sync");
@@ -225,20 +224,21 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_ct, reader_crt);
     tt::tt_metal::TensorAccessorArgs(t.indices.buffer()).append_to(reader_ct, reader_crt);
-    tt::tt_metal::TensorAccessorArgs(use_attention_sink ? t.attention_sink->buffer() : nullptr)
-        .append_to(reader_ct, reader_crt);
     // The writer is the lighter dataflow kernel, so it builds the three persistent compute-input tiles.
     std::vector<uint32_t> writer_ct = {H, S, vDHt, cb_out_rm, cb_scale, cb_col_identity, cb_neginf, out_elem_bytes};
     writer_ct.insert(writer_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
     writer_ct.insert(
         writer_ct.end(),
         {static_cast<uint32_t>(scaled_kv), k_dim, kv_elem_bytes, cb_idx, cb_kreq, cb_kack, packed_page_bytes});
+    writer_ct.insert(writer_ct.end(), {static_cast<uint32_t>(use_attention_sink), cb_attention_sink, cb_sink_scratch});
     TT_FATAL(
         writer_ct.size() == ::sparse_sdpa::writer_ct_arg::END,
         "sparse_sdpa writer compile-time argument layout is out of sync");
     std::vector<uint32_t> writer_crt;
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_ct, writer_crt);
     tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_ct, writer_crt);
+    tt::tt_metal::TensorAccessorArgs(use_attention_sink ? t.attention_sink->buffer() : nullptr)
         .append_to(writer_ct, writer_crt);
 
     std::vector<uint32_t> compute_ct = {H,
@@ -348,16 +348,15 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t tok_start = i * base + std::min(i, extra);
         uint32_t tok_count = base + (i < extra ? 1u : 0u);
-        reader_desc.emplace_runtime_args(
+        reader_desc.emplace_runtime_args(core, {q_buf, kv_buf, idx_buf, tok_start, tok_count, kv_batch_page_offset});
+        writer_desc.emplace_runtime_args(
             core,
-            {q_buf,
-             kv_buf,
-             idx_buf,
+            {out_buf,
              tok_start,
              tok_count,
+             kv_buf,
              kv_batch_page_offset,
              use_attention_sink ? t.attention_sink->buffer() : nullptr});
-        writer_desc.emplace_runtime_args(core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});
         compute_desc.emplace_runtime_args(core, {tok_start, tok_count});
     }
 
@@ -383,15 +382,15 @@ void SparseSDPAOperation::SparseSDPAProgramFactory::override_runtime_arguments(
     for (uint32_t i = 0; i < grid.x * grid.y; ++i) {
         const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         auto& r = tt::tt_metal::GetRuntimeArgs(program, 0, core);  // {q, kv, idx, tok_start, tok_count, offset}
-        auto& w = tt::tt_metal::GetRuntimeArgs(program, 1, core);  // {out, tok_start, tok_count, kv, offset}
+        auto& w = tt::tt_metal::GetRuntimeArgs(program, 1, core);  // {out, tok_start, tok_count, kv, offset, sink}
         r[0] = q;
         r[1] = kv;
         r[2] = idx;
         r[5] = offset;
-        r[6] = t.attention_sink.has_value() ? t.attention_sink->buffer()->address() : 0u;
         w[0] = out;
         w[3] = kv;
         w[4] = offset;
+        w[5] = t.attention_sink.has_value() ? t.attention_sink->buffer()->address() : 0u;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -381,6 +381,9 @@ void bind_sdpa(nb::module_& mod) {
 
         Keyword args:
             kv_format (SparseKVFormat): explicit physical/logical format of `kv`.
+            attention_sink (ttnn.Tensor, optional): [1, H, 1, 1] tiled DRAM tensor, BF16/BFP8/BFP4.
+                One scalar per head, shared across tokens. As in classic SDPA, the sink is multiplied by
+                scale and contributes only to the softmax denominator. Defaults to None.
             scale (float, optional): defaults to K_DIM**-0.5.
             k_chunk_size (int): defaults to 128 (must divide TOPK, multiple of 32).
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional).
@@ -413,7 +416,8 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("cache_batch_idx") = nb::none(),
         nb::arg("block_cyclic_sp_axis") = nb::none(),
         nb::arg("block_cyclic_chunk_local") = nb::none(),
-        nb::arg("block_cyclic_cache_tp_sharded") = false);
+        nb::arg("block_cyclic_cache_tp_sharded") = false,
+        nb::arg("attention_sink") = nb::none());
 
     ttnn::bind_function<"sparse_sdpa_msa", "ttnn.transformer.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -381,9 +381,11 @@ void bind_sdpa(nb::module_& mod) {
 
         Keyword args:
             kv_format (SparseKVFormat): explicit physical/logical format of `kv`.
-            attention_sink (ttnn.Tensor, optional): [1, H, 1, 1] tiled DRAM tensor, BF16/BFP8/BFP4.
-                One scalar per head, shared across tokens. As in classic SDPA, the sink is multiplied by
-                scale and contributes only to the softmax denominator. Defaults to None.
+            attention_sink (ttnn.Tensor, optional): [1, 1, 1, H] unpadded interleaved ROW_MAJOR BF16
+                tensor in DRAM. One scalar per head, shared across tokens. As in classic SDPA, the sink
+                is multiplied by scale and contributes only to the softmax denominator. DeepSeek-V4
+                sinks are already scaled logits: pass (model_sink / scale).reshape(1, 1, 1, H)
+                (scale != 0) to contribute exp(model_sink). Defaults to None.
             scale (float, optional): defaults to K_DIM**-0.5.
             k_chunk_size (int): defaults to 128 (must divide TOPK, multiple of 32).
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional).

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <cmath>
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 
 namespace ttnn::transformer {
 
@@ -22,7 +23,8 @@ ttnn::Tensor sparse_sdpa(
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local,
-    bool block_cyclic_cache_tp_sharded) {
+    bool block_cyclic_cache_tp_sharded,
+    const std::optional<ttnn::Tensor>& attention_sink) {
     const uint32_t k_dim = q.logical_shape()[3];  // head dim, from the tensor
     const float resolved_scale = scale.value_or(1.0f / std::sqrt(static_cast<float>(k_dim)));
 
@@ -82,8 +84,39 @@ ttnn::Tensor sparse_sdpa(
         /*default_fp32_acc=*/any_fp8,
         /*default_l1_acc=*/false);
 
+    // Match classic SDPA's sink contract. Convert block-float sinks once per invocation so the
+    // sparse reader can gather their scalars into a BF16 column (one row per head).
+    std::optional<ttnn::Tensor> sink = attention_sink;
+    if (sink.has_value()) {
+        TT_FATAL(
+            sink->storage_type() == StorageType::DEVICE && sink->buffer() != nullptr,
+            "Attention sink tensor must be on device");
+        TT_FATAL(sink->device() == q.device(), "Attention sink must be on the same device as Q");
+        TT_FATAL(sink->layout() == Layout::TILE, "Attention sink must be tilized");
+        TT_FATAL(sink->memory_config().buffer_type() == BufferType::DRAM, "Attention sink must be in DRAM");
+        TT_FATAL(
+            sink->logical_shape() == ttnn::Shape({1, q.logical_shape()[1], 1, 1}),
+            "Attention sink must have shape [1, H, 1, 1] matching Q heads");
+        TT_FATAL(
+            sink->dtype() == DataType::BFLOAT16 || sink->dtype() == DataType::BFLOAT8_B ||
+                sink->dtype() == DataType::BFLOAT4_B,
+            "Attention sink must be in BF16, BFP8, or BFP4 dataformat");
+        if (sink->dtype() != DataType::BFLOAT16) {
+            sink = ttnn::typecast(sink.value(), DataType::BFLOAT16);
+        }
+    }
     return ttnn::prim::sparse_sdpa(
-        q, kv, indices, resolved_scale, v_dim, kv_format, k_chunk_size, kernel_config, cache_batch_idx, block_cyclic);
+        q,
+        kv,
+        indices,
+        resolved_scale,
+        v_dim,
+        kv_format,
+        k_chunk_size,
+        kernel_config,
+        cache_batch_idx,
+        block_cyclic,
+        sink);
 }
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <cmath>
-#include "ttnn/operations/copy/typecast/typecast.hpp"
 
 namespace ttnn::transformer {
 
@@ -84,27 +83,6 @@ ttnn::Tensor sparse_sdpa(
         /*default_fp32_acc=*/any_fp8,
         /*default_l1_acc=*/false);
 
-    // Match classic SDPA's sink contract. Convert block-float sinks once per invocation so the
-    // sparse reader can gather their scalars into a BF16 column (one row per head).
-    std::optional<ttnn::Tensor> sink = attention_sink;
-    if (sink.has_value()) {
-        TT_FATAL(
-            sink->storage_type() == StorageType::DEVICE && sink->buffer() != nullptr,
-            "Attention sink tensor must be on device");
-        TT_FATAL(sink->device() == q.device(), "Attention sink must be on the same device as Q");
-        TT_FATAL(sink->layout() == Layout::TILE, "Attention sink must be tilized");
-        TT_FATAL(sink->memory_config().buffer_type() == BufferType::DRAM, "Attention sink must be in DRAM");
-        TT_FATAL(
-            sink->logical_shape() == ttnn::Shape({1, q.logical_shape()[1], 1, 1}),
-            "Attention sink must have shape [1, H, 1, 1] matching Q heads");
-        TT_FATAL(
-            sink->dtype() == DataType::BFLOAT16 || sink->dtype() == DataType::BFLOAT8_B ||
-                sink->dtype() == DataType::BFLOAT4_B,
-            "Attention sink must be in BF16, BFP8, or BFP4 dataformat");
-        if (sink->dtype() != DataType::BFLOAT16) {
-            sink = ttnn::typecast(sink.value(), DataType::BFLOAT16);
-        }
-    }
     return ttnn::prim::sparse_sdpa(
         q,
         kv,
@@ -116,7 +94,7 @@ ttnn::Tensor sparse_sdpa(
         kernel_config,
         cache_batch_idx,
         block_cyclic,
-        sink);
+        attention_sink);
 }
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
@@ -46,6 +46,9 @@ enum class SparseKVFormat : uint8_t {
 //   block_cyclic_cache_tp_sharded : true = the cache is striped across ALL sp*tp devices (linear chip = sp_coord*tp
 //                             + tp_coord), so stripes = sp*tp and per-stripe chunk = chunk_local/tp.
 //
+// attention_sink: optional [1,H,1,1] tiled DRAM BF16/BFP8/BFP4 tensor. Like classic SDPA,
+// its per-head scalar is multiplied by scale and added only to the softmax denominator.
+//
 // Producer preconditions (NOT validated per-element): sentinels are a contiguous tail, every row has >= 1
 // valid key, and all non-sentinel indices are < T.
 //
@@ -65,6 +68,7 @@ ttnn::Tensor sparse_sdpa(
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
     std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt,
-    bool block_cyclic_cache_tp_sharded = false);
+    bool block_cyclic_cache_tp_sharded = false,
+    const std::optional<ttnn::Tensor>& attention_sink = std::nullopt);
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
@@ -46,8 +46,10 @@ enum class SparseKVFormat : uint8_t {
 //   block_cyclic_cache_tp_sharded : true = the cache is striped across ALL sp*tp devices (linear chip = sp_coord*tp
 //                             + tp_coord), so stripes = sp*tp and per-stripe chunk = chunk_local/tp.
 //
-// attention_sink: optional [1,H,1,1] tiled DRAM BF16/BFP8/BFP4 tensor. Like classic SDPA,
-// its per-head scalar is multiplied by scale and added only to the softmax denominator.
+// attention_sink: optional [1,1,1,H] unpadded interleaved ROW_MAJOR BF16 tensor in DRAM.
+// Like classic SDPA, the sink is multiplied by scale and contributes only to the softmax denominator.
+// DeepSeek-V4 stores sinks in the already-scaled logit domain: pass model_sink / scale (scale != 0),
+// reshaped to [1,1,1,H], so the denominator receives exp(model_sink), not exp(scale * model_sink).
 //
 // Producer preconditions (NOT validated per-element): sentinels are a contiguous tail, every row has >= 1
 // valid key, and all non-sentinel indices are < T.


### PR DESCRIPTION
Add optional per-head attention sinks to `ttnn.transformer.sparse_sdpa` for DeepSeek-V4 CSA prefill. Matches classic SDPA semantics by including the sink in softmax normalization without contributing to the output numerator.

Closes #54173.

| Pipeline | Status |
| --- | --- |
| Sanity | [![Workflow status](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic%2Fsparse-sdpa-attention-sink&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/34689630227) |
| L2 nightly · SDPA | [![Workflow status](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic%2Fsparse-sdpa-attention-sink&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/34689632384) |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sparse-sdpa-attention-sink)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sparse-sdpa-attention-sink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/sparse-sdpa-attention-sink)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/sparse-sdpa-attention-sink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sparse-sdpa-attention-sink)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sparse-sdpa-attention-sink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/sparse-sdpa-attention-sink)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/sparse-sdpa-attention-sink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sparse-sdpa-attention-sink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sparse-sdpa-attention-sink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sparse-sdpa-attention-sink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sparse-sdpa-attention-sink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sparse-sdpa-attention-sink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sparse-sdpa-attention-sink)