### PR TITLE
[Test Only] Match MLA performance harness topology to the fabric

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -139,6 +139,7 @@ from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
@@ -764,6 +765,8 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_fo
         config,
         dict(weights),
         mesh_device,
+        # Match production CCL topology: Ring only on fabric-wrapped axes.
+        topology=per_axis_topology(PERF_FABRIC),
         layer_idx=mla_layer_idx,
         seq_len=total,
         sp_axis=sp_axis,


### PR DESCRIPTION
### PR Category

Test Only

### Summary

The standalone MLA performance test omitted `topology` when constructing `ttMLA`, so TP reduce-scatter inherited Linear even on TorusXY. Pass `per_axis_topology(PERF_FABRIC)` to match production: wrapped axes use Ring and unwrapped axes retain Linear.

### Notes for reviewers

Only the performance harness changes; model defaults, MoE overlap safeguards, and CCL implementations are unchanged. This PR is independent of the Fabric equal-cost unicast change.

Pre-commit and the warm GLM 5.2 scaled-FP8 performance test passed on a 32-chip Blackhole Galaxy with SP8 × TP4 TorusXY. The release build was also refreshed successfully with `./build_metal.sh --release` on the clean main base.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/mla-ring-reduce-scatter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/mla-ring-reduce-scatter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/mla-ring-reduce-scatter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/mla-ring-reduce-scatter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/mla-ring-reduce-scatter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/mla-ring-reduce-scatter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/mla-ring-reduce-scatter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/mla-ring-reduce-scatter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/mla-ring-reduce-scatter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/mla-ring-reduce-scatter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/mla-ring-reduce-scatter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/mla-ring-reduce-scatter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/mla-ring-reduce-scatter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/mla-ring-reduce-scatter)