### PR TITLE
[Test Only] deepseek_r1_distill_qwen_14b: align prefill-signature contract test with the planner

### DIFF
--- a/models/common/tests/models/deepseek_r1_distill_qwen_14b/test_demo_contract.py
+++ b/models/common/tests/models/deepseek_r1_distill_qwen_14b/test_demo_contract.py
@@ -160,7 +160,7 @@ def test_demo_warmup_uses_lane_group_capacity_and_lane_trace_policy():
     assert all(kwargs["kv_cache"] is kv_cache for _, kwargs in calls)
 
 
-def test_eval_prefill_signature_multiset_is_rotation_invariant_and_not_static_warmup_shaped():
+def test_eval_prefill_signature_multiset_is_rotation_invariant_and_keeps_each_bucket_as_one_wave():
     tokens = torch.zeros((32, 700), dtype=torch.long)
     prompt_lens = torch.tensor([64] * 30 + [400, 700])
     page_table = torch.zeros((32, 64), dtype=torch.int32)
@@ -178,7 +178,7 @@ def test_eval_prefill_signature_multiset_is_rotation_invariant_and_not_static_wa
             max_batch_size=32,
             max_prefill_chunk_size=1024,
             supports_batched_prefill=True,
-            max_prefill_batch_size=8,
+            max_prefill_batch_size=32,
             max_actual_page_table_width=32,
             canonical_page_table_width=64,
         )
@@ -187,7 +187,11 @@ def test_eval_prefill_signature_multiset_is_rotation_invariant_and_not_static_wa
             for request in requests
         )
 
-    expected = [(128, 8, 6), (128, 8, 8), (128, 8, 8), (128, 8, 8), (1024, 2, 2)]
+    # The current planner rounds one whole length bucket to one supported
+    # physical batch. It does not split a 30-row bucket into smaller waves,
+    # which would create extra TT invocations and trace identities. The cap
+    # matches this model's shipped policy (hf_adaptor.py: max_prefill_batch_size=32).
+    expected = [(128, 32, 30), (1024, 2, 2)]
     assert planned_shapes(0) == expected
     assert planned_shapes(1) == expected
     assert planned_shapes(2) == expected


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`TT-Transformers common unit tests [wh_llmbox]` (Tier 1 Models unit, scheduled) has failed every run since 2026-08-25 on exactly one host-only test:

```
models/common/tests/models/deepseek_r1_distill_qwen_14b/test_demo_contract.py::test_eval_prefill_signature_multiset_is_rotation_invariant_and_not_static_warmup_shaped
assert planned_shapes(0) == expected
E   assert [(128, 1, 1), (128, 1, 1), ...] == [(128, 8, 6), (128, 8, 8), (128, 8, 8), (128, 8, 8), (1024, 2, 2)]
```

This is a stale expectation, not a planner regression:

- `models/common/llm_runtime/prefill/plan.py` is byte-identical to #52724, the commit that added the test. The test was merged red.
- The expected `8, 8, 8, 6` split is the quasar planner's policy (`models/experimental/llama32_1b_quasar/models/executor.py`: "32 users with the default cap of 8 therefore run as 4 batched passes of 8"). The common planner instead rounds a whole length bucket to one supported wave and falls back to sequential single-row requests when that wave exceeds `max_prefill_batch_size` (`plan.py`, `_batched_prefill_size`). Its own unit test `test_batched_prefill_model_cap_falls_back_instead_of_splitting_wave` (`test_prefill_runtime.py`) asserts that behaviour.
- #53575 updated the qwen2_7b and qwen25_7b copies of this same test to the shipped policy and renamed them; the deepseek copy was missed. Since then the repo has held two tests with identical inputs asserting opposite multisets (qwen25_7b green, deepseek red).

Fix mirrors the qwen2_7b version: use this model's shipped cap (`models/common/models/deepseek_r1_distill_qwen_14b/hf_adaptor.py:53`, `max_prefill_batch_size: int = 32`), so the 30 x 64-token prompts plan as one padded 32-wide wave; expect `[(128, 32, 30), (1024, 2, 2)]`; rename to `..._keeps_each_bucket_as_one_wave`.

### Notes for reviewers
- Test-only. No planner change. A planner change would flip the currently green qwen2_7b / qwen25_7b tests and change trace identities for every TTTv2 model.
- Verified locally (host-only, torch): `_plan_prefill_requests` with these arguments returns `{(128, 32, 30): 1, (1024, 2, 2): 1}` for offsets 0, 1, 2; all 22 tests in the file pass.
- Design note for the planner owner, out of scope here: `max_prefill_batch_size` acts as a veto, not a wave size. Models with cap 8 (qwen25_7b, phi4, single-device mistral_7b) get no batched prefill for 9+ equal-length users, while their model comments describe folding into waves. Worth a separate decision.

### CI
- Targeted run (`(Tier 1) Models Unit Tests`, model=`tt-transformers-common`, sku=`wh_llmbox (T3000)`): https://github.com/tenstorrent/tt-metal/actions/runs/34244192022
  - **Passed** (attempt 2; attempt 1 died at `Setup Job` with an artifact-download 403 before any test ran). [`TT-Transformers common unit tests [wh_llmbox]`](https://github.com/tenstorrent/tt-metal/actions/runs/34244192022/job/102137377301): `3002 passed, 257 skipped, 3 deselected, 81 subtests passed in 1353s`, including `deepseek_r1_distill_qwen_14b/test_demo_contract.py::test_eval_prefill_signature_multiset_is_rotation_invariant_and_keeps_each_bucket_as_one_wave`. Same job fails on main on this test every run.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/deepseek-prefill-signature-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/deepseek-prefill-signature-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/deepseek-prefill-signature-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/deepseek-prefill-signature-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/deepseek-prefill-signature-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/deepseek-prefill-signature-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/deepseek-prefill-signature-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/deepseek-prefill-signature-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/deepseek-prefill-signature-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/deepseek-prefill-signature-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/deepseek-prefill-signature-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/deepseek-prefill-signature-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/deepseek-prefill-signature-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/deepseek-prefill-signature-contract)

