### PR TITLE
Fix topk_scores comparison in test_moe_gate_prefill2d.py to prevent significant PCC drop on all models (especially Kimi K3)

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v3_config.py
@@ -26,6 +26,11 @@ class DeepSeekV3Config:
     NUM_EXPERT_GROUPS = 8
     NUM_LIMITED_GROUPS = 4
 
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 256 experts, top-8, group-limited floors at
+    # 0.9950 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.985
+
     # Model architecture
     NUM_LAYERS = 61
     NUM_DENSE_LAYERS = 3

--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v4_flash_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v4_flash_config.py
@@ -38,6 +38,11 @@ class DeepSeekV4FlashConfig:
     # V4 replaces V3/Kimi's sigmoid router affinity with sqrt(softplus(.)).
     SCORE_FUNC = "sqrtsoftplus"
 
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 256 experts, top-6, sqrtsoftplus floors at
+    # 0.9956 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.985
+
     # Model architecture
     NUM_LAYERS = 43
     NUM_HASH_LAYERS = 3

--- a/models/demos/deepseek_v3_d_p/reference/deepseek_v4_pro_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/deepseek_v4_pro_config.py
@@ -38,6 +38,11 @@ class DeepSeekV4ProConfig:
     # V4 replaces V3/Kimi's sigmoid router affinity with sqrt(softplus(.)).
     SCORE_FUNC = "sqrtsoftplus"
 
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 384 experts, top-6, sqrtsoftplus floors at
+    # 0.9927 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.982
+
     # Model architecture
     NUM_LAYERS = 61
     NUM_HASH_LAYERS = 3

--- a/models/demos/deepseek_v3_d_p/reference/glm_5_2_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/glm_5_2_config.py
@@ -39,6 +39,11 @@ class GLM52Config:
     NUM_EXPERT_GROUPS = 1
     NUM_LIMITED_GROUPS = 1
 
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 160 experts, top-8 floors at
+    # 0.9941 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.984
+
     # Model architecture
     NUM_LAYERS = 78
     NUM_DENSE_LAYERS = 3  # first_k_dense_replace

--- a/models/demos/deepseek_v3_d_p/reference/gpt_oss_120b_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/gpt_oss_120b_config.py
@@ -45,6 +45,11 @@ class GptOss120BConfig:
     # Weights are a softmax over the selected top-k logits; no extra route scaling.
     ROUTE_SCALE = 1.0
 
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 128 experts, top-4 floors at
+    # 0.9909 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.98
+
     # Model architecture
     NUM_LAYERS = 36
     VOCAB_SIZE = 201088

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k2_7_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k2_7_config.py
@@ -37,14 +37,10 @@ class KimiK27Config:
     NUM_LIMITED_GROUPS = 1
     ROUTE_SCALE = 2.827
 
-    # Gate-test device-mode scores bar, relaxing the shared 0.93. 384 experts under sigmoid near-tie
-    # the top-8 boundary at 640 tokens/chip: every device/reference disagreement sits at an fp64
-    # selection-score margin below the bf16 matmul's own logit error, so the two sides order tied
-    # slots differently. The weights themselves are right (0.8% relative L2 vs an fp64 golden); it is
-    # the position-wise PCC that lands at 0.926-0.941 across the 8 SP chips of a Blackhole Galaxy 8x4.
-    # A test tolerance, not a checkpoint field: it follows from the expert count and the 8x4 mesh, both
-    # of which K2.7 shares, which is why the number carries over unchanged.
-    GATE_SCORES_PCC_DEVICE = 0.92
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 384 experts, top-8 floors at
+    # 0.9935 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.983
 
     # Model architecture
     NUM_LAYERS = 61

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -64,10 +64,11 @@ class KimiK3Config:
     # TtMoEGateConfig as both the default per-chip depth and a ceiling on any explicit sp_dim.
     MAX_GATE_SEQ_LEN_PER_CHIP = 3200
 
-    # Gate-test device-mode scores bar, relaxing the shared 0.93; see #52569. 896 experts under sigmoid
-    # near-tie the 16th and 17th scores often enough that device precision swaps a pick, and the
-    # spread across Blackhole Galaxies (0.886 - 0.952) straddles the shared bar.
-    GATE_SCORES_PCC_DEVICE = 0.87
+    # Gate-test device-mode scores bar, tightening the shared 0.93; see #52569. 896 experts under
+    # sigmoid near-tie the 16th and 17th scores often enough that device precision swaps a pick, and
+    # the spread across Blackhole Galaxies is 0.886 - 0.952, so this bar sits inside that spread
+    # rather than below it.
+    GATE_SCORES_PCC_DEVICE = 0.94
     # Upstream KimiSparseMoeBlock builds ONE KimiMLP for the shared expert, not num_shared_experts of
     # them: shared_experts.gate_proj.weight is [6144, 7168].
     SHARED_EXPERT_INTERMEDIATE_SIZE = MOE_INTERMEDIATE_SIZE * NUM_SHARED_EXPERTS  # 6144

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -64,14 +64,14 @@ class KimiK3Config:
     # TtMoEGateConfig as both the default per-chip depth and a ceiling on any explicit sp_dim.
     MAX_GATE_SEQ_LEN_PER_CHIP = 3200
 
-    # Gate-test device-mode scores bar, tightening the shared 0.93; see #52569. 896 experts under
-    # sigmoid near-tie the 16th and 17th scores often enough that device precision swaps a pick, and
-    # the spread across Blackhole Galaxies is 0.886 - 0.952, so this bar sits inside that spread
-    # rather than below it.
-    GATE_SCORES_PCC_DEVICE = 0.94
     # Upstream KimiSparseMoeBlock builds ONE KimiMLP for the shared expert, not num_shared_experts of
     # them: shared_experts.gate_proj.weight is [6144, 7168].
     SHARED_EXPERT_INTERMEDIATE_SIZE = MOE_INTERMEDIATE_SIZE * NUM_SHARED_EXPERTS  # 6144
+
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 896 experts, top-16 floors at
+    # 0.9989 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.988
 
     # Model architecture
     NUM_LAYERS = 93

--- a/models/demos/deepseek_v3_d_p/reference/minimax_m2_7_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/minimax_m2_7_config.py
@@ -29,6 +29,11 @@ class MiniMaxM27Config:
     # Reference route_tokens_to_experts sum-normalizes with no extra scaling.
     ROUTE_SCALE = 1.0
 
+    # Gate-test device-mode scores bar. pcc_scores sorts both sides, so this measures the
+    # selected-weight distribution rather than slot alignment; 256 experts, top-8 floors at
+    # 0.9977 on a 2x4 Blackhole mesh, the tightest reachable shape.
+    GATE_SCORES_PCC_DEVICE = 0.987
+
     # Model architecture
     NUM_LAYERS = 62
     VOCAB_SIZE = 200064

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -383,9 +383,15 @@ def _validate_gate(
         broadcast_groups=n_tp_devices,
     )
 
+    # Compare the selected-weight distributions, not their slot alignment. The top-k slot is a write
+    # offset that tt_reduce's weighted sum collapses, so a device order differing from torch's near a
+    # selection tie leaves the routed output unchanged -- and the slots are ordered by score+bias while
+    # the values are the unbiased scores, so transposing two near-tied slots writes two materially
+    # different weights and costs a position-wise PCC as much as a genuine mis-route does. Membership
+    # is covered above by recall_topk_indices, which pairs every expert with its own weight.
     pcc_scores = validate_composed(
-        host_tt_topk_scores,
-        reference_topk_scores,
+        host_tt_topk_scores.sort(dim=-1, descending=True).values,
+        reference_topk_scores.sort(dim=-1, descending=True).values,
         1,
         n_sp_devices,
         compare_pcc(scores_pcc_threshold, label="pcc_scores"),
@@ -568,9 +574,9 @@ def test_forward_pass(
     else:
         recall_threshold = 0.95
         logits_pcc_threshold = 0.997
-        scores_pcc_threshold = 0.93
-        # Device-mode scores only: at high expert counts sigmoid near-ties the top-k boundary, so a
-        # small matmul difference swaps a pick and moves the weight vector. Others keep 0.93.
+        # Order-insensitive since pcc_scores sorts both sides, so near-tie slot swaps no longer cost
+        # anything and every model clears this without a per-model relaxation.
+        scores_pcc_threshold = 0.98
         scores_pcc_threshold = getattr(GATE_MODELS[gate_model], "GATE_SCORES_PCC_DEVICE", scores_pcc_threshold)
 
     _validate_gate(
@@ -751,5 +757,5 @@ def test_forward_pass_interleaved(mesh_device, num_links, topology, gate_model, 
         reference_logits,
         0.95,
         0.997,
-        getattr(GATE_MODELS[gate_model], "GATE_SCORES_PCC_DEVICE", 0.93),
+        getattr(GATE_MODELS[gate_model], "GATE_SCORES_PCC_DEVICE", 0.98),
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/52569

### Problem

Current problem is that we are comparing `topk_scores` tensor on host and device by classic PCC comparison. That causes PCC drop, because `topk_scores` is actual result of `sigmoid(logits)`, but `topk_indices` and `topk_scores` have elements order ordered in descending order based on result of `sigmoid(logits)+bias`, which can cause that best score of `sigmoid(logits)` on host and device doesn't have to be from exact same expert, but we are comparing it as it's from exactly same expert. Order of experts for each token (which expert is best, which is second best and so on) isn't important in E2E prefill scenario, only which `topK` experts are chosen for each token is important and we already compare that good using `recall` comparison instead of `PCC` for `topk_indices` tensor on host and device.

### What's changed

- sort `topk_scores` tensor in descending order, because exact order of experts for each chip isn't important so this is best way to compare best expert on host with best expert on device and other places in order too
- increase threshold for `GATE_SCORES_PCC_DEVICE` for models.

### CI

- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/52569)
- [x] [![(Galaxy) Blaze Models Prefill tests ](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pmilojevic/52569)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/52569)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/52569)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/52569)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/52569)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/52569)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/52569)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/52569)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/52569)