### PR TITLE
[Bug fix] Fix Quasar fused INIT collisions and pack/datacopy perf CSV keys

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/compute_pipeline.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/compute_pipeline.py
@@ -224,7 +224,7 @@ class ComputePipeline:
         uninit_code = ""
         if hoist and not unpack_ops[0].unpacker.per_block_init:
             uninit_code += unpack_ops[0].unpack_uninit(operation, config, None)
-        code += self._zone(config, "INIT", uninit_code)
+        code += self._zone(config, "UNINIT", uninit_code)
 
         return code
 
@@ -278,7 +278,7 @@ class ComputePipeline:
         uninit_code = ""
         if hoist and not fpu_ops[0].fpu.per_block_init:
             uninit_code += fpu_ops[0].fpu_uninit(operation, config, None)
-        code += self._zone(config, "INIT", uninit_code)
+        code += self._zone(config, "UNINIT", uninit_code)
 
         return code
 
@@ -347,7 +347,7 @@ class ComputePipeline:
         if hoist and not pack_only[0].packer.per_block_init:
             uninit_code += pack_only[0].uninit(operation, config)
         uninit_code += pack_common.pack_reduce_mask_clear(operation)
-        code += self._zone(config, "INIT", uninit_code)
+        code += self._zone(config, "UNINIT", uninit_code)
 
         return code
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/test_schemas.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/test_schemas.py
@@ -904,8 +904,10 @@ PERF_TEST_SCHEMAS_QSR = {
         },
     },
     "perf_eltwise_unary_datacopy_quasar": {
-        "version": 3,
+        "version": 4,
         "columns": [
+            "block_ct_dim",
+            "block_rt_dim",
             "data_copy_type",
             "dest_acc",
             "dest_sync",
@@ -919,6 +921,8 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.register_B",
             "formats.sfpu_src",
             "formats.sfpu_dst",
+            "full_ct_dim",
+            "full_rt_dim",
             "implied_math_format",
             "loop_factor",
             "marker",
@@ -1051,8 +1055,10 @@ PERF_TEST_SCHEMAS_QSR = {
         "test_name_aliases": {"perf_pack_l1_acc_quasar": "perf_pack_l1_acc_quasar"},
     },
     "perf_pack_quasar": {
-        "version": 3,
+        "version": 4,
         "columns": [
+            "block_ct_dim",
+            "block_rt_dim",
             "dest_acc",
             "dest_sync",
             "face_c_dim",
@@ -1064,6 +1070,8 @@ PERF_TEST_SCHEMAS_QSR = {
             "formats.register_B",
             "formats.sfpu_src",
             "formats.sfpu_dst",
+            "full_ct_dim",
+            "full_rt_dim",
             "implied_math_format",
             "loop_factor",
             "marker",

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -43,6 +43,7 @@ from helpers.test_variant_parameters import (
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
+    generate_input_dim,
 )
 from helpers.tile_constants import SUPPORTED_TILE_SIZES, is_mx_unsupported_tile_dims
 from helpers.tile_shape import construct_tile_shape
@@ -249,6 +250,9 @@ def test_eltwise_unary_datacopy_quasar(
             NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
             DEST_INDEX(dest_index),
             LOOP_FACTOR(loop_factor),
+            generate_input_dim(
+                input_dimensions, input_dimensions, tile_dimensions=tile_dimensions
+            ),
         ],
         "variant_stimuli": StimuliConfig(
             src_A,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -45,6 +45,7 @@ from helpers.test_variant_parameters import (
     RELU_CONFIG,
     TEST_FACE_DIMS,
     TILE_COUNT,
+    generate_input_dim,
 )
 from helpers.tile_constants import (
     MX_SUPPORTED_TILE_SIZES,
@@ -312,6 +313,9 @@ def test_pack_quasar(
             NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
             NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
             LOOP_FACTOR(loop_factor),
+            generate_input_dim(
+                input_dimensions, input_dimensions, tile_dimensions=tile_dimensions
+            ),
         ],
         "variant_stimuli": StimuliConfig(
             src_A,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes three Quasar LLK perf-report failures: fused profiler `INIT` hash collisions, and duplicate CSV keys in pack and unary datacopy.

**Fused INIT hash collision.** Marker IDs are a 16-bit FNV of `LLK_PROFILER:file:line:marker`. The fuser wrapped both setup and teardown in `ZONE_SCOPED("INIT")`. Multi-op graphs (`conv_silu`, `quasar/conv_bn_relu`) emitted many INIT zones in one cpp, so empty uninit shells collided. Unpack/math/pack teardown zones are now `"UNINIT"`; real init zones stay `"INIT"`. Generated fused cpp is rewritten on the next compile unless `--skip-codegen`.

**Pack and unary datacopy duplicate CSV keys.** `generate_perf_input_dimensions()` always emits tall and wide dest-fill matrices with the same `tile_cnt` / face dims (`[256,32]` vs `[32,256]`). These two tests did not record `full_rt_dim` / `full_ct_dim` / `block_*`, so those pairs collapsed (datacopy 960 keys / 1920 rows; pack 2532 / 5064). Both tests now record `generate_input_dim(...)` on **runtimes** (kernels do not read `FULL_RT_DIM`; templates would 2x ELFs for no kernel reason). Schemas `perf_eltwise_unary_datacopy_quasar` and `perf_pack_quasar` bump v3 → v4 and add `block_ct_dim`, `block_rt_dim`, `full_ct_dim`, `full_rt_dim`.

### Notes for reviewers
- Only the three **uninit** `_zone(..., "INIT", ...)` calls in `compute_pipeline.py` change. Do not hand-edit generated fused cpp.
- Unary SFPU (`Asinh`/`Atanh`) is **not** in this change.
- Local Quasar simulator reruns after this change: fused 40 passed / 11 skipped (non-Quasar YAMLs), unary datacopy 640 passed, pack 1688 passed; all wrote Parquet with no `Hash collision` / `PerfSchemaError`.

### Test plan
- [x] `perf_fused_quasar.py` — simulate all passed (skips for non-Quasar YAMLs), Parquet written, no hash collision; `conv_silu` and `quasar/conv_bn_relu` pass with separate `INIT`/`UNINIT` markers
- [x] `perf_eltwise_unary_datacopy_quasar.py` — 640 passed, Parquet written, no `PerfSchemaError`
- [x] `perf_pack_quasar.py` — 1688 passed, Parquet written, no `PerfSchemaError`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_quasar_perf_test_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_quasar_perf_test_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_quasar_perf_test_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_quasar_perf_test_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_quasar_perf_test_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_quasar_perf_test_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_quasar_perf_test_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_quasar_perf_test_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_quasar_perf_test_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_quasar_perf_test_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_quasar_perf_test_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_quasar_perf_test_failures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_quasar_perf_test_failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_quasar_perf_test_failures)