### PR TITLE
[Bug fix] nlp_create_qkv_heads_decode: stop reading one past the NoC coordinate varargs

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -128,8 +128,13 @@ void kernel_main() {
                     qkv_x = 0;
                     qkv_y++;
                 }
-                qkv_noc_x = get_vararg(qkv_x);
-                qkv_noc_y = get_vararg(num_x + qkv_y);
+                // After the last tile of the last input core qkv_y == num_y: the coordinate
+                // tables have no entry for it and the coordinates are never used again, so skip
+                // the read (the watcher flags it as a runtime-arg out-of-bounds access).
+                if (qkv_y < num_y) {
+                    qkv_noc_x = get_vararg(qkv_x);
+                    qkv_noc_y = get_vararg(num_x + qkv_y);
+                }
                 qkv_read_addr = q_start_addr + in_tile_offset_by_batch;
                 num_tiles_read_cur_core = 0;
             }
@@ -187,8 +192,13 @@ void kernel_main() {
                         qkv_x = 0;
                         qkv_y++;
                     }
-                    qkv_noc_x = get_vararg(qkv_x);
-                    qkv_noc_y = get_vararg(num_x + qkv_y);
+                    // After the last tile of the last input core qkv_y == num_y: the coordinate
+                    // tables have no entry for it and the coordinates are never used again, so skip
+                    // the read (the watcher flags it as a runtime-arg out-of-bounds access).
+                    if (qkv_y < num_y) {
+                        qkv_noc_x = get_vararg(qkv_x);
+                        qkv_noc_y = get_vararg(num_x + qkv_y);
+                    }
                     qkv_read_addr = q_start_addr + in_tile_offset_by_batch;
                     num_tiles_read_cur_core = 0;
                 }
@@ -247,8 +257,13 @@ void kernel_main() {
                         qkv_x = 0;
                         qkv_y++;
                     }
-                    qkv_noc_x = get_vararg(qkv_x);
-                    qkv_noc_y = get_vararg(num_x + qkv_y);
+                    // After the last tile of the last input core qkv_y == num_y: the coordinate
+                    // tables have no entry for it and the coordinates are never used again, so skip
+                    // the read (the watcher flags it as a runtime-arg out-of-bounds access).
+                    if (qkv_y < num_y) {
+                        qkv_noc_x = get_vararg(qkv_x);
+                        qkv_noc_y = get_vararg(num_x + qkv_y);
+                    }
                     qkv_read_addr = q_start_addr + in_tile_offset_by_batch;
                     num_tiles_read_cur_core = 0;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
@@ -120,8 +120,13 @@ void kernel_main() {
 
             if (num_tiles_read_cur_core == num_tiles_per_core) {
                 cur_core_idx++;
-                qkv_noc_x = get_vararg(cur_core_idx);
-                qkv_noc_y = get_vararg(in_num_cores + cur_core_idx);
+                // After the last tile of the last input core cur_core_idx == in_num_cores: the
+                // coordinate tables have no entry for it and the coordinates are never used again,
+                // so skip the read (the watcher flags it as a runtime-arg out-of-bounds access).
+                if (cur_core_idx < in_num_cores) {
+                    qkv_noc_x = get_vararg(cur_core_idx);
+                    qkv_noc_y = get_vararg(in_num_cores + cur_core_idx);
+                }
                 qkv_read_addr = q_start_addr + in_tile_offset_by_batch;
                 num_tiles_read_cur_core = 0;
             }
@@ -174,8 +179,13 @@ void kernel_main() {
 
                 if (num_tiles_read_cur_core == num_tiles_per_core) {
                     cur_core_idx++;
-                    qkv_noc_x = get_vararg(cur_core_idx);
-                    qkv_noc_y = get_vararg(in_num_cores + cur_core_idx);
+                    // After the last tile of the last input core cur_core_idx == in_num_cores: the
+                    // coordinate tables have no entry for it and the coordinates are never used again,
+                    // so skip the read (the watcher flags it as a runtime-arg out-of-bounds access).
+                    if (cur_core_idx < in_num_cores) {
+                        qkv_noc_x = get_vararg(cur_core_idx);
+                        qkv_noc_y = get_vararg(in_num_cores + cur_core_idx);
+                    }
                     qkv_read_addr = q_start_addr + in_tile_offset_by_batch;
                     num_tiles_read_cur_core = 0;
                 }
@@ -229,8 +239,13 @@ void kernel_main() {
 
                 if (num_tiles_read_cur_core == num_tiles_per_core) {
                     cur_core_idx++;
-                    qkv_noc_x = get_vararg(cur_core_idx);
-                    qkv_noc_y = get_vararg(in_num_cores + cur_core_idx);
+                    // After the last tile of the last input core cur_core_idx == in_num_cores: the
+                    // coordinate tables have no entry for it and the coordinates are never used again,
+                    // so skip the read (the watcher flags it as a runtime-arg out-of-bounds access).
+                    if (cur_core_idx < in_num_cores) {
+                        qkv_noc_x = get_vararg(cur_core_idx);
+                        qkv_noc_y = get_vararg(in_num_cores + cur_core_idx);
+                    }
                     qkv_read_addr = q_start_addr + in_tile_offset_by_batch;
                     num_tiles_read_cur_core = 0;
                 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`GPT-OSS 120B unit tests` (Tier 1 Models unit, scheduled, runs with `TT_METAL_WATCHER=15`) has aborted on every run since 2026-09-02 20:14 UTC on all three watcher-enabled SKUs (`wh_llmbox`, `wh_galaxy`, `bh_galaxy`), in `test_modules.py::test_decoder[...-unpaged-layer_0-decode_low_latency-...]`:

```
Device 0 worker core(x= 0,y= 0): NCRISC accessed unique runtime arg index out of bounds. Current kernel: ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
TT_THROW: Watcher detected tripped assert and stopped device. (assert.hpp:104)
Fatal Python error: Aborted   (exit 134)
```

Green on the 2026-09-02 04:19 UTC run, red from 20:14. #54633 merged at 19:08 UTC that day and ported `nlp_create_qkv_heads_decode` to Metal 2.0 ProgramSpec factories. The port moved the per-input-core NoC coordinate tables from raw L1 pointers (`get_arg_addr(3 + ...)`) to bounds-checked `get_vararg()` reads, with `num_runtime_varargs = 2 * in_num_cores` (subcoregrid factory) and `num_x + num_y` (sharded factory).

Both reader kernels step to the "next" input core after the last tile of every core, including the last one. On the final core this leaves `cur_core_idx == in_num_cores` (subcoregrid) / `qkv_y == num_y` (sharded), and the unconditional fetch of the next coordinates reads vararg index `2 * in_num_cores` / `num_x + num_y`, one past the table. Pre-#54633 the same read went through a raw L1 pointer and returned garbage that was never used. Post-#54633 the watcher's runtime-arg bounds check catches it and halts the device.

Fix: skip the coordinate fetch once the walk has passed the last input core (3 loops in each reader). The coordinates are never used after that point, so the data path is unchanged; only the out-of-bounds read goes away. Interleaved reader has no varargs and is untouched.

### Notes for reviewers
- Off-by-one is latent in every configuration of both sharded factories, but only visible with the watcher on. Jobs that run this op with the watcher off (demos, e2e, most module unit suites which `unset TT_METAL_WATCHER`) pass, which is why only the GPT-OSS unit job went red.
- No host/factory change. `num_runtime_varargs` sizing in `nlp_create_qkv_heads_decode_sharded_subcoregrid_program_factory.cpp:261` and `..._sharded_program_factory.cpp:252` is correct; the kernels were reading past what they declared.
- Not fixed here: `GPT-OSS 120B unit tests [bh_quietbox_2]` is red for a different reason (`test_rope_vs_hf_reference[blackhole-batch_1-seq_16384-1x4]` device timeout, red since before 2026-08-27).
- No open PR touches these kernels; #55589 changes `gpt_oss/tt/attention/decode.py` but not the op.
- Cannot compile RISC-V kernels locally; `clang-format --style=file` clean. Verification is the CI run below (watcher on, same test that aborts on main).
- Only the section that runs last can actually overrun (V for the overlap and Q/V kernels; the K-only kernel lands in bounds). Guarding all three loops is for uniformity, not required for the reported failure.
- **Coordination:** `8e4b941cedd` on `origin/vsureshTT/llama_quasar_uplift` ("nlp_*_decode readers: don't read the NoC-coordinate varargs one past the end", 2026-09-04, not on main) fixes the same class in the flat sharded reader and in `nlp_concat_heads_decode`, but **not** in `..._on_subcoregrids.cpp`, which is the kernel GPT-OSS runs. Landing that branch alone would not turn this job green; landing both will conflict trivially in `reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp`. cc @vsureshTT.
- Follow-ups, out of scope here:
  1. `reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp` `#else` of `PROCESS_K`: `qkv_x += num_kv_cores % num_x; qkv_y += num_kv_cores / num_x;` has no wrap normalisation. When `(num_q_cores % num_x) + (num_kv_cores % num_x) >= num_x` the Q/V kernel of a non-overlapping grid reads V from the wrong input core (silent, pre-existing, not reachable from current callers which feed interleaved input).
  2. `nlp_concat_heads_decode` reader has the same end-of-walk over-advance on a raw pointer today; it will trip the watcher the moment that op is ported to Metal 2.0 (`8e4b941cedd` already carries the guard).
  3. Regression gate: `test_create_min_width_shard_subcoregrid` in `tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py` exercises exactly this kernel but runs watcher-off (`runtime-integration-tests-impl.yaml` does not pass `enable-watcher`), so the assert is compiled out. A watcher-enabled run of that file would have caught this at PR time.

### CI
- Targeted run (`(Tier 1) Models Unit Tests`, model=`gpt-oss-120b`, sku=`wh_llmbox (T3000)`): https://github.com/tenstorrent/tt-metal/actions/runs/34246292177
  - **Passed.** [`GPT-OSS 120B unit tests [wh_llmbox]`](https://github.com/tenstorrent/tt-metal/actions/runs/34246292177/job/102132071156): `48 passed, 24 skipped in 876s`, watcher on (`TT_METAL_WATCHER=15`), all 8 `test_decoder[...]` cases passed including `unpaged-layer_0-decode_low_latency`, no `runtime arg index out of bounds`, no abort. Same job aborts on main on every run since 2026-09-02.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/qkv-heads-decode-vararg-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/qkv-heads-decode-vararg-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/qkv-heads-decode-vararg-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/qkv-heads-decode-vararg-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/qkv-heads-decode-vararg-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/qkv-heads-decode-vararg-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/qkv-heads-decode-vararg-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/qkv-heads-decode-vararg-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/qkv-heads-decode-vararg-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/qkv-heads-decode-vararg-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/qkv-heads-decode-vararg-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/qkv-heads-decode-vararg-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/qkv-heads-decode-vararg-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/qkv-heads-decode-vararg-oob)


