### PR TITLE
[LLK] tests: fix mutable dataclass default in fuser L1Operation

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/l1_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/l1_operation.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
 from helpers.llk_params import (

--- a/tt_metal/tt-llk/tests/python_tests/fuser/l1_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/l1_operation.py
@@ -22,8 +22,10 @@ from .compute_pipeline import ComputePipeline
 class L1Operation:
     math: ComputePipeline
     max_output_dimensions: Tuple[int, int]
-    tile_shape: TileShape = construct_tile_shape(
-        (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
+    tile_shape: TileShape = field(
+        default_factory=lambda: construct_tile_shape(
+            (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
+        )
     )
     stage_id: int = 0
     needs_pack_sync: bool = False


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`L1Operation.tile_shape` uses a call to construct_tile_shape() as its dataclass default, so one TileShape instance built at class-creation time is shared by every L1Operation that does not pass one. TileShape is itself a dataclass, which means it defines __eq__ and is therefore unhashable, and from Python 3.11 on dataclasses reads unhashability as a proxy for mutability.

So this passes on 3.10 and raises `ValueError: mutable default <class TileShape> for field tile_shape is not allowed: use default_factory` on 3.11 and later, at class-creation time -- which makes fuser/l1_operation.py unimportable, so python_tests/quasar/test_fused_quasar.py and perf_fused_quasar.py both fail at collection.

Nothing in the tree mutates a TileShape, so the shared default is only a hazard, not a live bug. default_factory has been available since 3.7, and Operand in the same package (fuser/operand.py) already declares its own tile_shape exactly this way, so the fix is what the file next door already does. Making TileShape frozen would also satisfy 3.11 (frozen dataclasses are hashable) and is arguably the better description of a shape, but it constrains every other holder of one.

Found while bringing up the Quasar LLK suite on ttsim; not simulator-specific, it fails identically on silicon, on any Python >= 3.11.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-fuser-dataclass)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-fuser-dataclass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-fuser-dataclass)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-fuser-dataclass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-fuser-dataclass)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-fuser-dataclass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-fuser-dataclass)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-fuser-dataclass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-fuser-dataclass)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-fuser-dataclass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-fuser-dataclass)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-fuser-dataclass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-fuser-dataclass)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-fuser-dataclass)