### PR TITLE
[LLK] tests: golden fixes for math fidelity phases and Dest flush to zero

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -110,6 +110,18 @@ def _apply_ftz(result: torch.Tensor, data_format: DataFormat) -> torch.Tensor:
     ).to(result.dtype)
 
 
+def _flush_subnormals_of_dtype(result: torch.Tensor) -> torch.Tensor:
+    """Flush values that are subnormal in *result*'s own floating-point dtype to zero.
+
+    Used where the value being modelled still lives in Dest, whose precision the
+    dtype stands in for, rather than in an L1 format.
+    """
+    if not result.dtype.is_floating_point:
+        return result
+    tiny = torch.finfo(result.dtype).tiny
+    return torch.where(result.abs() < tiny, torch.zeros_like(result), result)
+
+
 def saturate_integer(result: torch.Tensor, data_format, torch_format) -> torch.Tensor:
     """Apply integer saturation during format conversion.
 
@@ -3563,10 +3575,14 @@ class EltwiseBinaryGolden(FidelityMasking):
         if op == MathOperation.Elwmul:
             result = None
             for fidelity_iter in range(fidelity_iter_count + 1):
-                t1, t2 = self._apply_fidelity_masking(
+                # Each phase masks the *original* operands: the phases decompose one
+                # multiply into high/low mantissa halves, so feeding a phase the
+                # already-masked operands zeroes every phase past the first and makes
+                # HiFi2/3/4 silently degrade to LoFi.
+                masked_1, masked_2 = self._apply_fidelity_masking(
                     math_format_for_fidelity, t1, t2, fidelity_iter
                 )
-                phase_result = self.ops[op](t1, t2)
+                phase_result = self.ops[op](masked_1, masked_2)
                 if fidelity_iter == 0:
                     result = phase_result
                 else:
@@ -3765,6 +3781,12 @@ class EltwiseBinaryGolden(FidelityMasking):
             # an extra bfloat16 cast before MX quantization; quantize from the current
             # result dtype so the golden follows the active pack-source path more
             # closely.
+            #
+            # Hardware flushes subnormals where the math unit writes Dest, which is
+            # before the packer's MX conversion. The final _apply_ftz below uses the
+            # MX threshold, so a value that is subnormal for Dest but normal for the
+            # MX block would survive it; flush against Dest's own precision here.
+            result = _flush_subnormals_of_dtype(result)
             result = quantize_mx_tensor_chunked(result, data_format)
         else:
             if data_format.is_integer():

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -331,6 +331,10 @@ def test_eltwise_binary_reuse_dest_quasar(
                     else:
                         dest = srcA * srcB
 
+            # Hardware flushes subnormals as the math unit writes Dest, so a product the
+            # Dest format can only hold as a subnormal reads back as zero.
+            tiny = torch.finfo(internal_dtype).tiny
+            dest = torch.where(dest.abs() < tiny, torch.zeros_like(dest), dest)
             golden_tensor[out_start : out_start + tile_elements] = dest.to(golden_dtype)
 
     if is_perf and perf_report is None:


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Three independent fixes.

1. EltwiseBinaryGolden._compute_eltwise, the Elwmul fidelity loop. It reassigns t1/t2 from _apply_fidelity_masking each iteration, so every phase after the first masks the already-masked operands. The masks are disjoint mantissa slices (0b11111111000 and 0b00000000111 on Quasar), so phases 1..3 AND to zero and the loop returns the LoFi result bit for bit -- confirmed: with fp16 operands `buggy == LoFi-only` is exactly True, and against an fp32 reference the mean relative error is 4.7e-3 where the summed phases give 2.7e-4. HiFi2/3/4 are therefore not tested at all today: the Float16 tolerance is atol=rtol=0.05, so both goldens pass, and a simulator that ignored math fidelity entirely would pass too. No test flips either way (measured on 120 Float16->Float16 and 60 Float16->* Elwmul HiFi cases). The matmul golden in the same file (_matmul_fidelity_faces) already masks the originals, so this hunk brings Elwmul in line with it.

2. The Dest flush before MX quantization. Hardware flushes what Dest cannot hold as a normal, at the Dest format's own exponent width, and that happens before the packer's MX conversion; the final _apply_ftz uses the MX threshold and so lets a value through that Dest itself would have zeroed. Verified directly against the RTL: 2^-8 x 2^-8 with a five-bit-exponent Dest returns zero with the underflow flag set, the same product with fp32 accumulation is kept, and 2^-7 x 2^-7 - exactly the smallest normal - is kept. Measured: 4 of 11 failures fixed and 0 broken on a 60-case Float16 Elwmul HiFi sample; it is this fix, not fix (1), that flips those tests.

3. The same flush in test_eltwise_binary_reuse_dest_quasar.py, whose golden is computed inline in the test rather than by the generator. The hardware premise is the one verified in (2), but no test has been observed to flip: the failures remaining in that file are MX block-quantization differences (golden 0.0212 vs result 0.0195, and small datums quantizing to zero inside a block), not subnormals. Correct by the same argument as (2).

Found while bringing up the Quasar LLK suite on ttsim; none of it is simulator-specific.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-llk-golden-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/qsr-llk-golden-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-llk-golden-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/qsr-llk-golden-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/qsr-llk-golden-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/qsr-llk-golden-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/qsr-llk-golden-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/qsr-llk-golden-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/qsr-llk-golden-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/qsr-llk-golden-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/qsr-llk-golden-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/qsr-llk-golden-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/qsr-llk-golden-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/qsr-llk-golden-fixes)