### PR TITLE
[LLK] tests: read buffer C from the Tensix the test ran on

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_add_parallel_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_add_parallel_matmul_quasar.py
@@ -313,7 +313,10 @@ def test_sfpu_add_parallel_matmul_quasar(format_dest_acc_sync_implied_math):
     outcome = configuration.run()
 
     res_add = torch.tensor(outcome.result, dtype=torch_format)
-    res_matmul = torch.tensor(stimuli.collect_buffer_c_results(), dtype=torch_format)
+    res_matmul = torch.tensor(
+        stimuli.collect_buffer_c_results(TestConfig.TENSIX_LOCATION),
+        dtype=torch_format,
+    )
 
     assert len(res_add) == len(golden_add), "add"
     assert len(res_matmul) == len(golden_matmul), "matmul"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_exp_parallel_matmul_quasar.py
@@ -276,7 +276,10 @@ def test_sfpu_exp_parallel_matmul_quasar(
     outcome = configuration.run()
 
     res_exp = torch.tensor(outcome.result, dtype=torch_format)
-    res_matmul = torch.tensor(stimuli.collect_buffer_c_results(), dtype=torch_format)
+    res_matmul = torch.tensor(
+        stimuli.collect_buffer_c_results(TestConfig.TENSIX_LOCATION),
+        dtype=torch_format,
+    )
 
     assert len(res_exp) == len(golden_exp), "exp"
     assert len(res_matmul) == len(golden_matmul), "matmul"


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Both Quasar parallel-matmul tests collect the SFPU result with StimuliConfig.collect_results(TestConfig.TENSIX_LOCATION) (TestConfig.run does that for them) but collect the matmul result with `stimuli.collect_buffer_c_results()`, whose `location` parameter defaults to "0,0". Under xdist every worker is bound to a Tensix of its own (device.tensix_location_for_worker), so on every worker but the one that owns 0,0 the matmul half of the comparison reads an untouched core: buffer C comes back as its initial zeros and the test fails its `assert passed_test(golden_matmul, res_matmul, formats.output_format), "matmul"` while the SFPU half passes. Serially the whole file passes; at -n 4 roughly three quarters of it fails, and which cases fail changes from run to run because xdist hands tests to workers dynamically.

Reproduced on ttsim with `pytest --run-simulator --forked -n 4 --dist each quasar/test_sfpu_add_parallel_matmul_quasar.py::test_sfpu_add_parallel_matmul_quasar'[...]'`, which passes on gw0 and fails on gw1, gw2 and gw3. Nothing here is simulator-specific; a multi-core silicon run should behave the same way.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-parallel-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-parallel-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-parallel-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-parallel-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-parallel-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-parallel-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-parallel-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-parallel-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-parallel-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-parallel-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-parallel-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-parallel-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-parallel-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-parallel-matmul)