### PR TITLE
[CI] BGE-M3 e2e: raise the wh_n150 job timeout to fit the 10-case benchmark

### DIFF
--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -1751,7 +1751,10 @@
   model: bge_m3
   skus:
     wh_n150:
-      timeout: 4
+      # #54669 (2026-08-31) grew the benchmark from 5 to 10 parametrisations (5 single-request
+      # ISLs + a batch-25 sweep of 50 requests each). Model download + the first 5 cases already
+      # take ~4 min on N150, so the job was wall-clock killed every day from 2026-09-01.
+      timeout: 10
       tier: 2
   owner_id: U082LLYBLSW # Gabriel Tobar (CODEOWNERS @gtobarTT)
   team: models


### PR DESCRIPTION
### PR Category
Bug fix (CI config)

### Summary
`BGE-M3 e2e tests [wh_n150]` (Tier 2 Models e2e, scheduled) has failed every run since 2026-09-01 with only `The action has timed out.` and no test failure. Last green run: 2026-08-31 (job 99372093504).

Cause: #54669 (`bc294789ec3`, merged 2026-08-31, "BGE-M3: Data Parallel Optimization on N300") rewrote `models/demos/wormhole/bge_m3/demo/demo.py` and grew `test_bge_benchmark` from 5 single-request ISL cases to 10 (adds a batch-25 sweep of 50 requests per ISL). The job's `timeout: 4` (minutes, applied as `timeout-minutes` on the test step) was sized for the old file. On 2026-09-08 (job 101927675994): pytest started 03:32:50, model download until 03:34:03, cases 1-5 finished 03:36:28 (23-36 s each), killed 03:36:52 with cases 6-10 never started. The last green run needed 3.2 min for the whole old file.

Fix: `timeout: 10` for the `wh_n150` leg in `tests/pipeline_reorg/models_e2e_tests.yaml`, with a comment.

### Notes for reviewers
- Config-only. If the batch-25 sweep is not wanted in the daily e2e leg, the alternative is trimming the parametrisation in `demo.py`; that is the model owner's call (@gtobarTT).
- Open PR #55499 (BGE-M3 vLLM DP serving path) does not touch this job definition.

### CI
- Targeted run (`(Tier 2) Models End-To-End Tests`, model=`bge_m3`, sku=`wh_n150 (N150)`): https://github.com/tenstorrent/tt-metal/actions/runs/34255315780
  - **Passed.** [`BGE-M3 e2e tests [wh_n150]`](https://github.com/tenstorrent/tt-metal/actions/runs/34255315780/job/102162100632): `12 passed in 389.85s (0:06:29)` for the pytest run (the full 10-case benchmark plus 2 other tests), well inside the new 10-minute step budget and well over the old 4.


